### PR TITLE
PLT-6871: Sort at-mention autocomplete by username starting with search string

### DIFF
--- a/webapp/components/searchable_user_list/searchable_user_list.jsx
+++ b/webapp/components/searchable_user_list/searchable_user_list.jsx
@@ -168,6 +168,19 @@ export default class SearchableUserList extends React.Component {
 
         if (this.props.term || !this.props.users) {
             usersToDisplay = this.props.users;
+
+            if (this.props.term) {
+                const searchTerm = this.props.term.replace(/^@/, '');
+                usersToDisplay.sort((a, b) => {
+                    if (a.username.startsWith(searchTerm)) {
+                        return -1;
+                    }
+                    if (b.username.startsWith(searchTerm)) {
+                        return 1;
+                    }
+                    return 0;
+                });
+            }
         } else if (!this.props.term) {
             const pageStart = this.props.page * this.props.usersPerPage;
             const pageEnd = pageStart + this.props.usersPerPage;

--- a/webapp/stores/suggestion_store.jsx
+++ b/webapp/stores/suggestion_store.jsx
@@ -122,24 +122,24 @@ class SuggestionStore extends EventEmitter {
 
     addSuggestions(id, terms, items, component, matchedPretext) {
         const suggestion = this.getSuggestions(id);
+        const searchTerm = matchedPretext.replace(/^@/, '');
 
         // Sort suggestions
         terms.sort((a, b) => {
-            if (a.startsWith(matchedPretext)) {
+            if (a.startsWith(searchTerm)) {
                 return -1;
             }
-            if (b.startsWith(matchedPretext)) {
+            if (b.startsWith(searchTerm)) {
                 return 1;
             }
             return 0;
         });
 
-        const matchedUsernamePretext = matchedPretext.substring(1);
         items.sort((a, b) => {
-            if (a.username.startsWith(matchedUsernamePretext)) {
+            if (a.username.startsWith(searchTerm)) {
                 return -1;
             }
-            if (b.username.startsWith(matchedUsernamePretext)) {
+            if (b.username.startsWith(searchTerm)) {
                 return 1;
             }
             return 0;

--- a/webapp/stores/suggestion_store.jsx
+++ b/webapp/stores/suggestion_store.jsx
@@ -123,6 +123,28 @@ class SuggestionStore extends EventEmitter {
     addSuggestions(id, terms, items, component, matchedPretext) {
         const suggestion = this.getSuggestions(id);
 
+        // Sort suggestions
+        terms.sort((a, b) => {
+            if (a.startsWith(matchedPretext)) {
+                return -1;
+            }
+            if (b.startsWith(matchedPretext)) {
+                return 1;
+            }
+            return 0;
+        });
+
+        const matchedUsernamePretext = matchedPretext.substring(1);
+        items.sort((a, b) => {
+            if (a.username.startsWith(matchedUsernamePretext)) {
+                return -1;
+            }
+            if (b.username.startsWith(matchedUsernamePretext)) {
+                return 1;
+            }
+            return 0;
+        });
+
         suggestion.terms.push(...terms);
         suggestion.items.push(...items);
 


### PR DESCRIPTION
#### Summary
Change at-mention autocomplete to prioritize entries where the username starts with the search string

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6871

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

Fixes #6699 