### PR TITLE
[PLT-6973] Improve emoji first load performance

### DIFF
--- a/webapp/components/create_comment/create_comment.jsx
+++ b/webapp/components/create_comment/create_comment.jsx
@@ -17,7 +17,6 @@ import MsgTyping from 'components/msg_typing.jsx';
 import FileUpload from 'components/file_upload.jsx';
 import FilePreview from 'components/file_preview.jsx';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
-import * as EmojiPicker from 'components/emoji_picker/emoji_picker.jsx';
 import * as Utils from 'utils/utils.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
@@ -562,7 +561,6 @@ export default class CreateComment extends React.Component {
                     <span
                         className={'fa fa-smile-o icon--emoji-picker emoji-rhs'}
                         onClick={this.toggleEmojiPicker}
-                        onMouseOver={EmojiPicker.beginPreloading}
                     />
                 </span>
             );

--- a/webapp/components/create_post.jsx
+++ b/webapp/components/create_post.jsx
@@ -9,7 +9,6 @@ import FilePreview from './file_preview.jsx';
 import PostDeletedModal from './post_deleted_modal.jsx';
 import TutorialTip from './tutorial/tutorial_tip.jsx';
 import EmojiPickerOverlay from 'components/emoji_picker/emoji_picker_overlay.jsx';
-import * as EmojiPicker from 'components/emoji_picker/emoji_picker.jsx';
 
 import AppDispatcher from 'dispatcher/app_dispatcher.jsx';
 import * as GlobalActions from 'actions/global_actions.jsx';
@@ -734,7 +733,6 @@ export default class CreatePost extends React.Component {
                     <span
                         className={'fa fa-smile-o icon--emoji-picker emoji-main'}
                         onClick={this.toggleEmojiPicker}
-                        onMouseOver={EmojiPicker.beginPreloading}
                     />
                 </span>
             );

--- a/webapp/components/emoji_picker/components/emoji_picker_category.jsx
+++ b/webapp/components/emoji_picker/components/emoji_picker_category.jsx
@@ -9,7 +9,8 @@ export default class EmojiPickerCategory extends React.Component {
         category: PropTypes.string.isRequired,
         icon: PropTypes.node.isRequired,
         onCategoryClick: PropTypes.func.isRequired,
-        selected: PropTypes.bool.isRequired
+        selected: PropTypes.bool.isRequired,
+        enable: PropTypes.bool.isRequired
     }
 
     constructor(props) {
@@ -28,6 +29,10 @@ export default class EmojiPickerCategory extends React.Component {
         let className = 'emoji-picker__category';
         if (this.props.selected) {
             className += ' emoji-picker__category--selected';
+        }
+
+        if (!this.props.enable) {
+            className += ' disable';
         }
 
         return (

--- a/webapp/components/emoji_picker/components/emoji_picker_item.jsx
+++ b/webapp/components/emoji_picker/components/emoji_picker_item.jsx
@@ -13,9 +13,7 @@ export default class EmojiPickerItem extends React.PureComponent {
         onItemOver: PropTypes.func.isRequired,
         onItemOut: PropTypes.func.isRequired,
         onItemClick: PropTypes.func.isRequired,
-        onItemUnmount: PropTypes.func.isRequired,
-        category: PropTypes.string.isRequired,
-        isLoaded: PropTypes.bool.isRequired
+        onItemUnmount: PropTypes.func.isRequired
     }
 
     constructor(props) {
@@ -43,46 +41,18 @@ export default class EmojiPickerItem extends React.PureComponent {
     }
 
     render() {
-        let item = null;
-
-        if (this.props.emoji.category) {
-            let className;
-            if (this.props.isLoaded) {
-                className = 'emojisprite';
-            } else {
-                className = 'emojisprite-loading';
-            }
-
-            className += ' emoji-category-' + this.props.emoji.category;
-            className += ' emoji-' + this.props.emoji.filename;
-
-            item = (
-                <div>
-                    <img
-                        src='/static/images/img_trans.gif'
-                        className={className}
-                        onMouseOver={this.handleMouseOver}
-                        onMouseOut={this.handleMouseOut}
-                        onClick={this.handleClick}
-                    />
-                </div>
-            );
-        } else {
-            item = (
-                <span
-                    onMouseOver={this.handleMouseOver}
-                    onMouseOut={this.handleMouseOut}
-                    onClick={this.handleClick}
-                    className='emoji-picker__item-wrapper'
-                >
-                    <img
-                        className='emoji-picker__item emoticon'
-                        src={EmojiStore.getEmojiImageUrl(this.props.emoji)}
-                    />
-                </span>
-            );
-        }
-
-        return item;
+        return (
+            <span
+                onMouseOver={this.handleMouseOver}
+                onMouseOut={this.handleMouseOut}
+                onClick={this.handleClick}
+                className='emoji-picker__item-wrapper'
+            >
+                <img
+                    className='emoji-picker__item emoticon'
+                    src={EmojiStore.getEmojiImageUrl(this.props.emoji)}
+                />
+            </span>
+        );
     }
 }

--- a/webapp/components/emoji_picker/components/emoji_picker_preview.jsx
+++ b/webapp/components/emoji_picker/components/emoji_picker_preview.jsx
@@ -20,32 +20,23 @@ export default class EmojiPickerPreview extends React.Component {
         if (emoji) {
             let name;
             let aliases;
-            let previewImage;
 
             if (emoji.aliases && emoji.category) {
                 // This is a system emoji which only has a list of aliases
                 name = emoji.aliases[0];
                 aliases = emoji.aliases;
-
-                previewImage = (
-                    <span className='sprite-preview'>
-                        <img
-                            src='/static/images/img_trans.gif'
-                            className={'emojisprite-preview emoji-category-' + emoji.category + ' emoji-' + emoji.filename}
-                        />
-                    </span>
-                );
             } else {
                 // This is a custom emoji that matches the model on the server
                 name = emoji.name;
                 aliases = [emoji.name];
-                previewImage = (
-                    <img
-                        className='emoji-picker__preview-image'
-                        src={EmojiStore.getEmojiImageUrl(emoji)}
-                    />
-                );
             }
+
+            const previewImage = (
+                <img
+                    className='emoji-picker__preview-image'
+                    src={EmojiStore.getEmojiImageUrl(emoji)}
+                />
+            );
 
             return (
                 <div className='emoji-picker__preview'>

--- a/webapp/components/emoji_picker/emoji_list.jsx
+++ b/webapp/components/emoji_picker/emoji_list.jsx
@@ -1,0 +1,187 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+import React, {PureComponent} from 'react';
+import PropTypes from 'prop-types';
+import EmojiListManager from './emoji_list_manager';
+
+const STYLE_WRAPPER = {overflow: 'auto', willChange: 'transform', WebkitOverflowScrolling: 'touch'};
+const STYLE_INNER = {position: 'relative', overflow: 'hidden', width: '100%', minHeight: '100%'};
+const STYLE_ITEM = {position: 'absolute', left: 0, width: '100%'};
+
+export default class EmojiList extends PureComponent {
+    static defaultProps = {
+        width: '100%'
+    };
+
+    static propTypes = {
+        height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        itemCount: PropTypes.number.isRequired,
+        itemSize: PropTypes.oneOfType([PropTypes.number, PropTypes.array, PropTypes.func]).isRequired,
+        renderItem: PropTypes.func.isRequired,
+        scrollOffset: PropTypes.number,
+        onScroll: PropTypes.func.isRequired,
+        width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired
+    }
+
+    constructor(props) {
+        super(props);
+
+        this.emojiListManager = new EmojiListManager({
+            itemCount: props.itemCount,
+            itemSizeGetter: ({index}) => this.getSize(index),
+            itemSize: props.itemSize
+        });
+
+        this.state = {
+            offset: (props.scrollOffset || 0),
+            bottom: 0,
+            stop: 0
+        };
+
+        this.styleCache = {};
+    }
+
+    componentDidMount() {
+        const {scrollOffset} = this.props;
+
+        if (scrollOffset != null) {
+            this.scrollTo(scrollOffset);
+        }
+    }
+
+    componentWillReceiveProps(nextProps) {
+        const {
+            itemCount,
+            itemSize,
+            scrollOffset
+        } = this.props;
+
+        const itemPropsHaveChanged = (nextProps.itemCount !== itemCount || nextProps.itemSize !== itemSize);
+
+        if (nextProps.itemCount !== itemCount) {
+            this.emojiListManager.updateConfig({
+                itemCount: nextProps.itemCount,
+                itemSize: nextProps.itemSize
+            });
+        }
+
+        let recompute = false;
+        if (itemPropsHaveChanged) {
+            recompute = true;
+            this.recomputeSizes();
+        }
+
+        let offset = 0;
+        if (nextProps.scrollOffset !== scrollOffset) {
+            offset = nextProps.scrollOffset;
+            this.setState({offset});
+        }
+
+        this.setStopAndBottom(offset, recompute);
+    }
+
+    componentDidUpdate(nextProps, nextState) {
+        const {offset} = this.state;
+
+        if (nextState.offset !== offset) {
+            this.scrollTo(offset);
+        }
+    }
+
+    getRef = (node) => {
+        this.rootNode = node;
+    };
+
+    handleScroll = (e) => {
+        e.preventDefault();
+
+        const offset = this.getNodeOffset();
+        if (offset < 0 || this.state.offset === offset || e.target !== this.rootNode) {
+            return;
+        }
+
+        this.setState({offset});
+
+        this.setStopAndBottom(offset, false);
+
+        setTimeout(() => {
+            this.props.onScroll(offset);
+        }, 0);
+    };
+
+    setStopAndBottom(offset, recompute) {
+        const {stop, bottom} = this.state;
+        const containerSize = this.props.height;
+        const nextStop = this.emojiListManager.getNextStop({containerSize, offset, currentStop: stop});
+
+        this.setState({
+            stop: nextStop,
+            bottom: nextStop > bottom || recompute ? nextStop : bottom
+        });
+    }
+
+    getNodeOffset() {
+        return this.rootNode.scrollTop;
+    }
+
+    scrollTo(value) {
+        this.rootNode.scrollTop = value;
+    }
+
+    getSize(index) {
+        const {itemSize} = this.props;
+
+        if (typeof itemSize === 'function') {
+            return itemSize(index);
+        }
+
+        return Array.isArray(itemSize) ? itemSize[index] : itemSize;
+    }
+
+    getStyle(index) {
+        const style = this.styleCache[index];
+        if (style) {
+            return style;
+        }
+
+        const {size, offset} = this.emojiListManager.getSizeAndPositionForIndex(index);
+
+        this.styleCache[index] = {
+            ...STYLE_ITEM,
+            height: size,
+            top: offset
+        };
+
+        return this.styleCache[index];
+    }
+
+    recomputeSizes(startIndex = 0) {
+        this.styleCache = {};
+        this.emojiListManager.resetItem(startIndex);
+    }
+
+    render() {
+        const {height, renderItem, width} = this.props;
+        const items = [];
+        const {bottom} = this.state;
+
+        if (bottom) {
+            for (let index = 0; index <= bottom; index++) {
+                items.push(renderItem({index, style: this.getStyle(index)}));
+            }
+        }
+
+        return (
+            <div
+                ref={this.getRef}
+                onScroll={this.handleScroll}
+                style={{...STYLE_WRAPPER, height, width}}
+            >
+                <div style={{...STYLE_INNER, height: this.emojiListManager.getTotalSize()}}>
+                    {items}
+                </div>
+            </div>
+        );
+    }
+}

--- a/webapp/components/emoji_picker/emoji_list_manager.jsx
+++ b/webapp/components/emoji_picker/emoji_list_manager.jsx
@@ -1,0 +1,122 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+const OVERSCAN_COUNT = 3;
+
+export default class EmojiListManager {
+    constructor({itemCount, itemSizeGetter, itemSize}) {
+        this.itemSizeGetter = itemSizeGetter;
+        this.itemCount = itemCount;
+        this.itemSize = itemSize;
+        this.itemSizeAndPositionData = {};
+        this.lastMeasuredIndex = -1;
+    }
+
+    updateConfig({itemCount, itemSize}) {
+        this.itemCount = itemCount;
+        this.itemSize = itemSize;
+    }
+
+    getLastMeasuredIndex() {
+        return this.lastMeasuredIndex;
+    }
+
+    getSizeAndPositionForIndex(index) {
+        if (index < 0 || index >= this.itemCount) {
+            throw Error(`Requested index ${index} is outside of range 0..${this.itemCount}`);
+        }
+
+        if (index > this.lastMeasuredIndex) {
+            const lastMeasuredSizeAndPosition = this.getSizeAndPositionOfLastMeasuredItem();
+            let offset = lastMeasuredSizeAndPosition.offset + lastMeasuredSizeAndPosition.size;
+
+            for (var i = this.lastMeasuredIndex + 1; i <= index; i++) {
+                const size = this.itemSizeGetter({index: i});
+
+                if (size == null || isNaN(size)) {
+                    throw Error(`Invalid size returned for index ${i} of value ${size}`);
+                }
+
+                this.itemSizeAndPositionData[i] = {offset, size};
+
+                offset += size;
+            }
+
+            this.lastMeasuredIndex = index;
+        }
+
+        return this.itemSizeAndPositionData[index];
+    }
+
+    getSizeAndPositionOfLastMeasuredItem() {
+        return this.lastMeasuredIndex >= 0 ? this.itemSizeAndPositionData[this.lastMeasuredIndex] : {offset: 0, size: 0};
+    }
+
+    getTotalSize() {
+        const lastMeasuredSizeAndPosition = this.getSizeAndPositionOfLastMeasuredItem();
+        const remainSize = (this.itemCount - this.lastMeasuredIndex - 1) * this.itemSize;
+
+        return lastMeasuredSizeAndPosition.offset + lastMeasuredSizeAndPosition.size + remainSize;
+    }
+
+    getNextStop({containerSize, offset}) {
+        let nextOffset = offset;
+        const totalSize = this.getTotalSize();
+
+        if (totalSize === 0) {
+            return 0;
+        }
+
+        const maxOffset = nextOffset + containerSize;
+        const start = this.findNearestItem(nextOffset);
+        let stop = start;
+
+        const datum = this.getSizeAndPositionForIndex(start);
+        nextOffset = datum.offset + datum.size;
+
+        while (nextOffset < maxOffset && stop < this.itemCount - 1) {
+            stop++;
+            nextOffset += this.getSizeAndPositionForIndex(stop).size;
+        }
+
+        return Math.min(stop + OVERSCAN_COUNT, this.itemCount - 1);
+    }
+
+    resetItem(index) {
+        this.lastMeasuredIndex = Math.min(this.lastMeasuredIndex, index - 1);
+    }
+
+    searchIndex({low, high, offset}) {
+        let lowIndex = low;
+        let h = high;
+        const o = offset;
+        let middle;
+        let currentOffset;
+
+        while (lowIndex <= h) {
+            middle = lowIndex + Math.floor((h - lowIndex) / 2);
+            currentOffset = this.getSizeAndPositionForIndex(middle).offset;
+
+            if (currentOffset === o) {
+                return middle;
+            } else if (currentOffset < o) {
+                lowIndex = middle + 1;
+            } else if (currentOffset > o) {
+                h = middle - 1;
+            }
+        }
+
+        return lowIndex > 0 ? lowIndex - 1 : 0;
+    }
+
+    findNearestItem(offset) {
+        const maxOffset = Math.max(0, offset);
+        const lastMeasuredIndex = Math.max(0, this.lastMeasuredIndex);
+
+        return this.searchIndex({
+            high: lastMeasuredIndex,
+            low: 0,
+            offset: maxOffset
+        });
+    }
+}

--- a/webapp/components/emoji_picker/emoji_picker.jsx
+++ b/webapp/components/emoji_picker/emoji_picker.jsx
@@ -6,36 +6,16 @@ import PropTypes from 'prop-types';
 
 import * as Emoji from 'utils/emoji.jsx';
 import EmojiStore from 'stores/emoji_store.jsx';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
 import * as Utils from 'utils/utils.jsx';
 import {FormattedMessage} from 'react-intl';
 
 import EmojiPickerCategory from './components/emoji_picker_category.jsx';
 import EmojiPickerItem from './components/emoji_picker_item.jsx';
 import EmojiPickerPreview from './components/emoji_picker_preview.jsx';
+import EmojiList from './emoji_list.jsx';
 
-import PeopleSpriteSheet from 'images/emoji-sheets/people.png';
-import NatureSpriteSheet from 'images/emoji-sheets/nature.png';
-import FoodsSpriteSheet from 'images/emoji-sheets/foods.png';
-import ActivitySpriteSheet from 'images/emoji-sheets/activity.png';
-import PlacesSpriteSheet from 'images/emoji-sheets/places.png';
-import ObjectsSpriteSheet from 'images/emoji-sheets/objects.png';
-import SymbolsSpriteSheet from 'images/emoji-sheets/symbols.png';
-import FlagsSpriteSheet from 'images/emoji-sheets/flags.png';
-
-// This should include all the categories available in Emoji.CategoryNames
-const CATEGORIES = [
-    'recent',
-    'people',
-    'nature',
-    'foods',
-    'activity',
-    'places',
-    'objects',
-    'symbols',
-    'flags',
-    'custom'
-];
+const ROW_SIZE = 30;
+const EMOJI_PER_ROW = 9;
 
 export default class EmojiPicker extends React.Component {
     static propTypes = {
@@ -55,24 +35,33 @@ export default class EmojiPicker extends React.Component {
     constructor(props) {
         super(props);
 
-        // All props are primitives or treated as immutable
-        this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this);
-
-        this.handlePreload = this.handlePreload.bind(this);
         this.handleCategoryClick = this.handleCategoryClick.bind(this);
         this.handleFilterChange = this.handleFilterChange.bind(this);
         this.handleItemOver = this.handleItemOver.bind(this);
         this.handleItemOut = this.handleItemOut.bind(this);
         this.handleItemClick = this.handleItemClick.bind(this);
-        this.handleScroll = this.handleScroll.bind(this);
+        this.handleOnScroll = this.handleOnScroll.bind(this);
         this.handleItemUnmount = this.handleItemUnmount.bind(this);
-        this.renderCategory = this.renderCategory.bind(this);
+
+        this.categories = {
+            recent: {name: 'recent', className: 'fa fa-clock-o', id: 'emoji_picker.recent', message: 'Recently Used', offset: 0, enable: false},
+            people: {name: 'people', className: 'fa fa-smile-o', id: 'emoji_picker.people', message: 'People', offset: 0, enable: false},
+            nature: {name: 'nature', className: 'fa fa-leaf', id: 'emoji_picker.nature', message: 'Nature', offset: 0, enable: false},
+            foods: {name: 'foods', className: 'fa fa-cutlery', id: 'emoji_picker.foods', message: 'Foods', offset: 0, enable: false},
+            activity: {name: 'activity', className: 'fa fa-futbol-o', id: 'emoji_picker.activity', message: 'Activity', offset: 0, enable: false},
+            places: {name: 'places', className: 'fa fa-plane', id: 'emoji_picker.places', message: 'Places', offset: 0, enable: false},
+            objects: {name: 'objects', className: 'fa fa-lightbulb-o', id: 'emoji_picker.objects', message: 'Objects', offset: 0, enable: false},
+            symbols: {name: 'symbols', className: 'fa fa-heart-o', id: 'emoji_picker.symbols', message: 'Symbols', offset: 0, enable: false},
+            flags: {name: 'flags', className: 'fa fa-flag-o', id: 'emoji_picker.flags', message: 'Fags', offset: 0, enable: false},
+            custom: {name: 'custom', className: 'fa fa-at', id: 'emoji_picker.custom', message: 'Custom', offset: 0, enable: false}
+        };
 
         this.state = {
             category: 'recent',
             filter: '',
             selected: null,
-            preloaded: []
+            list: this.generateList(''),
+            scrollOffset: 0
         };
     }
 
@@ -82,39 +71,34 @@ export default class EmojiPicker extends React.Component {
         requestAnimationFrame(() => {
             this.searchInput.focus();
         });
-        beginPreloading();
-        subscribeToPreloads(this.handlePreload);
-        this.handlePreload();
-    }
-
-    componentWillUnmount() {
-        unsubscribeFromPreloads(this.handlePreload);
-    }
-
-    handlePreload() {
-        const preloaded = [];
-        for (const category of CATEGORIES) {
-            if (didPreloadCategory(category)) {
-                preloaded.push(category);
-            }
-        }
-        this.setState({preloaded});
     }
 
     handleCategoryClick(category) {
-        const items = this.refs.items;
+        const scrollOffset = this.categories[category].offset;
 
-        if (category === CATEGORIES[0]) {
-            // First category includes the search box so just scroll to the top
-            items.scrollTop = 0;
-        } else {
-            const cat = this.refs[category];
-            items.scrollTop = cat.offsetTop;
-        }
+        this.setState({
+            scrollOffset,
+            category
+        });
     }
 
     handleFilterChange(e) {
-        this.setState({filter: e.target.value});
+        e.preventDefault();
+
+        for (const category of Object.keys(this.categories)) {
+            this.categories[category].offset = 0;
+            this.categories[category].enable = false;
+        }
+
+        const filter = e.target.value;
+
+        this.setState({
+            category: 'recent',
+            selected: null,
+            scrollOffset: 0,
+            list: this.generateList(filter),
+            filter
+        });
     }
 
     handleItemOver(emoji) {
@@ -143,44 +127,65 @@ export default class EmojiPicker extends React.Component {
         this.props.onEmojiClick(emoji);
     }
 
-    handleScroll() {
-        const items = this.refs.items;
-        const contentTop = items.scrollTop;
-        const itemsPaddingTop = getComputedStyle(items).paddingTop;
-        const contentTopPadding = parseInt(itemsPaddingTop, 10);
-        const scrollPct = (contentTop / (items.scrollHeight - items.clientHeight)) * 100.0;
-
-        if (scrollPct > 99.0) {
-            this.setState({category: 'custom'});
-            return;
-        }
-
-        for (const category of CATEGORIES) {
-            const header = this.refs[category];
-            const headerStyle = getComputedStyle(header);
-            const headerBottomMargin = parseInt(headerStyle.marginBottom, 10);
-            const headerBottomPadding = parseInt(headerStyle.paddingBottom, 10);
-            const headerBottomSpace = headerBottomMargin + headerBottomPadding;
-            const headerBottom = header.offsetTop + header.offsetHeight + headerBottomSpace;
-
-            // If category is the first one visible, highlight it in the bar at the top
-            if (headerBottom - contentTopPadding >= contentTop) {
-                if (this.state.category !== category) {
-                    this.setState({category: String(category)});
-                }
-
+    handleOnScroll(offset) {
+        let category = 'recent';
+        for (const cat of Object.keys(this.categories)) {
+            if (offset < this.categories[cat].offset) {
                 break;
             }
+
+            category = this.categories[cat].name;
         }
+
+        this.setState({category});
     }
 
-    renderCategory(category, isLoaded, filter) {
-        let emojis;
-        if (category === 'recent') {
-            const recentEmojis = [...EmojiStore.getRecentEmojis()];
+    generateEmojiHeaderRow(category) {
+        return (
+            <div
+                id={'emojipickercat-' + category}
+                key={category}
+                className='emoji-picker__category-header'
+            >
+                <FormattedMessage id={'emoji_picker.' + category}/>
+            </div>
+        );
+    }
 
-            // Reverse so most recently added is first
-            recentEmojis.reverse();
+    generateEmojiRows(emojis, category) {
+        return emojis.map((emoji) => {
+            const name = emoji.name || emoji.aliases[0];
+            const key = category + '-' + name;
+
+            return (
+                <EmojiPickerItem
+                    key={key}
+                    emoji={emoji}
+                    onItemOver={this.handleItemOver}
+                    onItemOut={this.handleItemOut}
+                    onItemClick={this.handleItemClick}
+                    onItemUnmount={this.handleItemUnmount}
+                />
+            );
+        });
+    }
+
+    addEmojiRow(list, emojiRows) {
+        let arr = [];
+        for (let i = 0; i < emojiRows.length; i += EMOJI_PER_ROW) {
+            arr = emojiRows.slice(i, i + EMOJI_PER_ROW);
+            list.push(arr);
+        }
+
+        return list;
+    }
+
+    getEmojis(category, filter) {
+        // check to filter first before building emojis
+        let emojis = [];
+
+        if (category === 'recent') {
+            const recentEmojis = [...EmojiStore.getRecentEmojis()].reverse();
 
             emojis = recentEmojis.filter((name) => {
                 return EmojiStore.has(name);
@@ -197,8 +202,11 @@ export default class EmojiPicker extends React.Component {
             }
         }
 
-        // Apply filter
-        emojis = emojis.filter((emoji) => {
+        return filter ? this.filterEmojis(emojis, filter) : emojis;
+    }
+
+    filterEmojis(emojis, filter) {
+        return emojis.filter((emoji) => {
             if (emoji.name) {
                 return emoji.name.indexOf(filter) !== -1;
             }
@@ -211,67 +219,75 @@ export default class EmojiPicker extends React.Component {
 
             return false;
         });
+    }
 
-        const items = emojis.map((emoji) => {
-            const name = emoji.name || emoji.aliases[0];
-            let key;
-            if (category === 'recent') {
-                key = 'system_recent_' + name;
-            } else if (category === 'custom' && emoji.name) {
-                key = 'custom_' + name;
-            } else {
-                key = 'system_' + name;
+    generateList(filter) {
+        let list = [];
+
+        for (const category of Object.keys(this.categories)) {
+            const emojis = this.getEmojis(category, filter);
+
+            if (emojis.length) {
+                this.categories[category].offset = list.length * ROW_SIZE;
+                this.categories[category].enable = true;
+
+                const emojiHeaderRow = this.generateEmojiHeaderRow(category);
+                list.push(emojiHeaderRow);
+
+                const emojiRows = this.generateEmojiRows(emojis, category);
+                list = this.addEmojiRow(list, emojiRows);
             }
+        }
 
+        return list;
+    }
+
+    emojiCategories() {
+        const categories = this.categories;
+
+        const emojiPickerCategories = Object.keys(categories).map((category) => {
             return (
-                <EmojiPickerItem
-                    key={key}
-                    emoji={emoji}
-                    category={category}
-                    isLoaded={isLoaded}
-                    onItemOver={this.handleItemOver}
-                    onItemOut={this.handleItemOut}
-                    onItemClick={this.handleItemClick}
-                    onItemUnmount={this.handleItemUnmount}
+                <EmojiPickerCategory
+                    key={'header-' + categories[category].name}
+                    category={categories[category].name}
+                    icon={
+                        <i
+                            className={this.categories[category].className}
+                            title={Utils.localizeMessage(categories[category].id, categories[category].message)}
+                        />
+                    }
+                    onCategoryClick={this.handleCategoryClick}
+                    selected={this.state.category === categories[category].name}
+                    enable={categories[category].enable}
                 />
             );
         });
 
-        // Only render the header if there's any visible items
-        let header = null;
-        if (items.length > 0) {
-            header = (
-                <div className='emoji-picker__category-header'>
-                    <FormattedMessage id={'emoji_picker.' + category}/>
-                </div>
-            );
-        }
-
         return (
-            <div
-                key={'category_' + category}
-                id={'emojipickercat-' + category}
-                ref={category}
-            >
-                {header}
-                <div className='emoji-picker-items__container'>
-                    {items}
-                </div>
+            <div className='emoji-picker__categories'>
+                {emojiPickerCategories}
+            </div>
+        );
+    }
+
+    emojiSearch() {
+        return (
+            <div className='emoji-picker__search-container'>
+                <span className='fa fa-search emoji-picker__search-icon'/>
+                <input
+                    ref={(input) => {
+                        this.searchInput = input;
+                    }}
+                    className='emoji-picker__search'
+                    type='text'
+                    onChange={this.handleFilterChange}
+                    placeholder={Utils.localizeMessage('emoji_picker.search', 'search')}
+                />
             </div>
         );
     }
 
     render() {
-        const items = [];
-
-        for (const category of CATEGORIES) {
-            if (category === 'custom') {
-                items.push(this.renderCategory('custom', true, this.state.filter, this.props.customEmojis));
-            } else {
-                items.push(this.renderCategory(category, category === 'recent' || this.state.preloaded.indexOf(category) >= 0, this.state.filter));
-            }
-        }
-
         let pickerStyle;
         if (this.props.style && !(this.props.style.left === 0 || this.props.style.top === 0)) {
             if (this.props.placement === 'top' || this.props.placement === 'bottom') {
@@ -295,226 +311,28 @@ export default class EmojiPicker extends React.Component {
                 className='emoji-picker'
                 style={pickerStyle}
             >
-                <div className='emoji-picker__categories'>
-                    <EmojiPickerCategory
-                        category='recent'
-                        icon={
-                            <i
-                                className='fa fa-clock-o'
-                                title={Utils.localizeMessage('emoji_picker.recent', 'Recently Used')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'recent'}
-                    />
-                    <EmojiPickerCategory
-                        category='people'
-                        icon={
-                            <i
-                                className='fa fa-smile-o'
-                                title={Utils.localizeMessage('emoji_picker.people', 'People')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'people'}
-                    />
-                    <EmojiPickerCategory
-                        category='nature'
-                        icon={
-                            <i
-                                className='fa fa-leaf'
-                                title={Utils.localizeMessage('emoji_picker.nature', 'Nature')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'nature'}
-                    />
-                    <EmojiPickerCategory
-                        category='foods'
-                        icon={
-                            <i
-                                className='fa fa-cutlery'
-                                title={Utils.localizeMessage('emoji_picker.foods', 'Foods')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'foods'}
-                    />
-                    <EmojiPickerCategory
-                        category='activity'
-                        icon={
-                            <i
-                                className='fa fa-futbol-o'
-                                title={Utils.localizeMessage('emoji_picker.activity', 'Activity')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'activity'}
-                    />
-                    <EmojiPickerCategory
-                        category='places'
-                        icon={
-                            <i
-                                className='fa fa-plane'
-                                title={Utils.localizeMessage('emoji_picker.places', 'Places')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'places'}
-                    />
-                    <EmojiPickerCategory
-                        category='objects'
-                        icon={
-                            <i
-                                className='fa fa-lightbulb-o'
-                                title={Utils.localizeMessage('emoji_picker.objects', 'Objects')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'objects'}
-                    />
-                    <EmojiPickerCategory
-                        category='symbols'
-                        icon={
-                            <i
-                                className='fa fa-heart-o'
-                                title={Utils.localizeMessage('emoji_picker.symbols', 'Symbols')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'symbols'}
-                    />
-                    <EmojiPickerCategory
-                        category='flags'
-                        icon={
-                            <i
-                                className='fa fa-flag-o'
-                                title={Utils.localizeMessage('emoji_picker.flags', 'Flags')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'flags'}
-                    />
-                    <EmojiPickerCategory
-                        category='custom'
-                        icon={
-                            <i
-                                className='fa fa-at'
-                                title={Utils.localizeMessage('emoji_picker.custom', 'Custom')}
-                            />
-                        }
-                        onCategoryClick={this.handleCategoryClick}
-                        selected={this.state.category === 'custom'}
-                    />
-                </div>
-                <div className='emoji-picker__search-container'>
-                    <span className='fa fa-search emoji-picker__search-icon'/>
-                    <input
-                        ref={(input) => {
-                            this.searchInput = input;
-                        }}
-                        className='emoji-picker__search'
-                        type='text'
-                        onChange={this.handleFilterChange}
-                        placeholder={Utils.localizeMessage('emoji_picker.search', 'search')}
-                    />
-                </div>
-                <div
-                    ref='items'
-                    id='emojipickeritems'
-                    className='emoji-picker__items'
-                    onScroll={this.handleScroll}
-                >
-                    {items}
-                </div>
+                {this.emojiCategories()}
+                {this.emojiSearch()}
+                <EmojiList
+                    width='100%'
+                    height={300}
+                    itemCount={this.state.list.length}
+                    itemSize={ROW_SIZE}
+                    scrollOffset={this.state.scrollOffset}
+                    onScroll={this.handleOnScroll}
+                    renderItem={({index, style}) =>
+                        <div
+                            key={index}
+                            style={style}
+                        >
+                            {this.state.list[index]}
+                        </div>
+                    }
+                />
                 <EmojiPickerPreview
                     emoji={this.state.selected}
                 />
             </div>
         );
-    }
-}
-
-var preloads = {
-    people: {
-        src: PeopleSpriteSheet,
-        didPreload: false
-    },
-    nature: {
-        src: NatureSpriteSheet,
-        didPreload: false
-    },
-    foods: {
-        src: FoodsSpriteSheet,
-        didPreload: false
-    },
-    activity: {
-        src: ActivitySpriteSheet,
-        didPreload: false
-    },
-    places: {
-        src: PlacesSpriteSheet,
-        didPreload: false
-    },
-    objects: {
-        src: ObjectsSpriteSheet,
-        didPreload: false
-    },
-    symbols: {
-        src: SymbolsSpriteSheet,
-        didPreload: false
-    },
-    flags: {
-        src: FlagsSpriteSheet,
-        didPreload: false
-    }
-};
-
-var didBeginPreloading = false;
-
-var preloadCallback = null;
-
-export function beginPreloading() {
-    if (didBeginPreloading) {
-        return;
-    }
-    didBeginPreloading = true;
-    preloadNextCategory();
-}
-
-function preloadNextCategory() {
-    let sheet = null;
-    for (const category of CATEGORIES) {
-        const preload = preloads[category];
-        if (preload && !preload.didPreload) {
-            sheet = preload;
-            break;
-        }
-    }
-    if (sheet) {
-        const img = new Image();
-        img.onload = () => {
-            sheet.didPreload = true;
-            if (preloadCallback) {
-                preloadCallback();
-            }
-            preloadNextCategory();
-        };
-        img.src = sheet.src;
-    }
-}
-
-export function didPreloadCategory(category) {
-    const preload = preloads[category];
-    return preload && preload.didPreload;
-}
-
-function subscribeToPreloads(callback) {
-    preloadCallback = callback;
-}
-
-function unsubscribeFromPreloads(callback) {
-    if (callback === preloadCallback) {
-        preloadCallback = null;
     }
 }

--- a/webapp/sass/components/_emoticons.scss
+++ b/webapp/sass/components/_emoticons.scss
@@ -75,6 +75,10 @@
         &:hover {
             color: #666666;
         }
+
+        &.disable {
+            pointer-events: none;
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
Improve emoji first load performance by:
- Disabling emoji sprite sheets
- Lazy loading emojis only for those currently at viewing area (+ 3 emoji rows)

This PR also address the performance in handling/loading very large custom emojis

Note:
- this PR is for initial preview of emoji picker performance. Other emoji sprite related codes are still present.
- if performance is good to go, then I need help from @asaadmahmood with CSS styling.

#### Ticket Link
Jira ticket: [PLT-6973](https://mattermost.atlassian.net/browse/PLT-6973)

#### Checklist
- [x] Has UI changes