### PR TITLE
PLT-7207: Change from fulltext to LIKE search for user filtering

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1583,7 +1583,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 	result := store.StoreResult{}
 
 	// these chars have special meaning and can be treated as spaces
-	for _, c := range specialUserSearchChar {
+	for _, c := range ignoreUserSearchChar {
 		term = strings.Replace(term, c, " ", -1)
 	}
 

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1399,45 +1399,16 @@ func (us SqlUserStore) SearchInChannel(channelId string, term string, options ma
 }
 
 var specialUserSearchChar = []string{
-	"<",
-	">",
-	"+",
-	"-",
-	"(",
-	")",
-	"~",
-	":",
 	"*",
-	"\"",
-	"!",
-	"@",
-}
-
-var postgresSearchChar = []string{
-	"(",
-	")",
-	":",
-	"!",
+	"%",
 }
 
 func (us SqlUserStore) performSearch(searchQuery string, term string, options map[string]bool, parameters map[string]interface{}) store.StoreResult {
 	result := store.StoreResult{}
 
-	// Special handling for emails
-	originalTerm := term
-	postgresUseOriginalTerm := false
-	if strings.Contains(term, "@") && strings.Contains(term, ".") {
-		if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
-			postgresUseOriginalTerm = true
-		} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
-			lastIndex := strings.LastIndex(term, ".")
-			term = term[0:lastIndex]
-		}
-	}
-
-	// these chars have special meaning and can be treated as spaces
+	// These chars must be removed from the like query.
 	for _, c := range specialUserSearchChar {
-		term = strings.Replace(term, c, " ", -1)
+		term = strings.Replace(term, c, "", -1)
 	}
 
 	searchType := USER_SEARCH_TYPE_ALL
@@ -1457,44 +1428,25 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 
 	if term == "" {
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
-	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
-		if postgresUseOriginalTerm {
-			term = originalTerm
-			// these chars will break the query and must be removed
-			for _, c := range postgresSearchChar {
-				term = strings.Replace(term, c, "", -1)
-			}
-		} else {
-			splitTerm := strings.Fields(term)
-			for i, t := range strings.Fields(term) {
-				if i == len(splitTerm)-1 {
-					splitTerm[i] = t + ":*"
-				} else {
-					splitTerm[i] = t + ":* &"
-				}
-			}
+	} else {
+		splitTerms := strings.Fields(term)
+		splitFields := strings.Split(searchType, ", ")
 
-			term = strings.Join(splitTerm, " ")
+		terms := []string{}
+		for i, term := range splitTerms {
+			fields := []string{}
+			for _, field := range splitFields {
+				fields = append(fields, fmt.Sprintf("%s LIKE %s", field, fmt.Sprintf(":Term%d", i)))
+			}
+			terms = append(terms, fmt.Sprintf("(%s)", strings.Join(fields, " OR ")))
+			parameters[fmt.Sprintf("Term%d", i)] = fmt.Sprintf("%s%%", term)
 		}
 
-		searchType = convertMySQLFullTextColumnsToPostgres(searchType)
-		searchClause := fmt.Sprintf("AND (%s) @@  to_tsquery('simple', :Term)", searchType)
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
-	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
-		splitTerm := strings.Fields(term)
-		for i, t := range strings.Fields(term) {
-			splitTerm[i] = "+" + t + "*"
-		}
-
-		term = strings.Join(splitTerm, " ")
-
-		searchClause := fmt.Sprintf("AND MATCH(%s) AGAINST (:Term IN BOOLEAN MODE)", searchType)
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
+		term := strings.Join(terms, " AND ")
+		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", fmt.Sprintf(" AND %s ", term), 1)
 	}
 
 	var users []*model.User
-
-	parameters["Term"] = term
 
 	if _, err := us.GetReplica().Select(&users, searchQuery, parameters); err != nil {
 		result.Err = model.NewAppError("SqlUserStore.Search", "store.sql_user.search.app_error", nil, "term="+term+", "+"search_type="+searchType+", "+err.Error(), http.StatusInternalServerError)

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1401,6 +1401,7 @@ func (us SqlUserStore) SearchInChannel(channelId string, term string, options ma
 var specialUserSearchChar = []string{
 	"*",
 	"%",
+	"_",
 }
 
 func (us SqlUserStore) performSearch(searchQuery string, term string, options map[string]bool, parameters map[string]interface{}) store.StoreResult {
@@ -1408,7 +1409,7 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 
 	// These chars must be removed from the like query.
 	for _, c := range specialUserSearchChar {
-		term = strings.Replace(term, c, "", -1)
+		term = strings.Replace(term, c, "*"+c, -1)
 	}
 
 	searchType := USER_SEARCH_TYPE_ALL
@@ -1436,7 +1437,7 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 		for i, term := range splitTerms {
 			fields := []string{}
 			for _, field := range splitFields {
-				fields = append(fields, fmt.Sprintf("%s LIKE %s", field, fmt.Sprintf(":Term%d", i)))
+				fields = append(fields, fmt.Sprintf("%s LIKE %s escape '*' ", field, fmt.Sprintf(":Term%d", i)))
 			}
 			terms = append(terms, fmt.Sprintf("(%s)", strings.Join(fields, " OR ")))
 			parameters[fmt.Sprintf("Term%d", i)] = fmt.Sprintf("%s%%", term)

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1398,17 +1398,25 @@ func (us SqlUserStore) SearchInChannel(channelId string, term string, options ma
 	return storeChannel
 }
 
-var specialUserSearchChar = []string{
-	"*",
+var escapeUserSearchChar = []string{
 	"%",
 	"_",
+}
+
+var ignoreUserSearchChar = []string{
+	"*",
 }
 
 func (us SqlUserStore) performSearch(searchQuery string, term string, options map[string]bool, parameters map[string]interface{}) store.StoreResult {
 	result := store.StoreResult{}
 
 	// These chars must be removed from the like query.
-	for _, c := range specialUserSearchChar {
+	for _, c := range ignoreUserSearchChar {
+		term = strings.Replace(term, c, "", -1)
+	}
+
+	// These chars must be escaped in the like query.
+	for _, c := range escapeUserSearchChar {
 		term = strings.Replace(term, c, "*"+c, -1)
 	}
 

--- a/store/sqlstore/user_store_test.go
+++ b/store/sqlstore/user_store_test.go
@@ -1334,10 +1334,19 @@ func TestUserStoreSearch(t *testing.T) {
 	u3.DeleteAt = 1
 	store.Must(ss.User().Save(u3))
 
+	u5 := &model.User{}
+	u5.Username = "yu" + model.NewId()
+	u5.FirstName = "En"
+	u5.LastName = "Yu"
+	u5.Nickname = "enyu"
+	u5.Email = model.NewId() + "@simulator.amazonses.com"
+	store.Must(ss.User().Save(u5))
+
 	tid := model.NewId()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u1.Id}))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u2.Id}))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u3.Id}))
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u5.Id}))
 
 	searchOptions := map[string]bool{}
 	searchOptions[store.USER_SEARCH_OPTION_NAMES_ONLY] = true
@@ -1364,6 +1373,22 @@ func TestUserStoreSearch(t *testing.T) {
 
 		if found2 {
 			t.Fatal("should not have found inactive user")
+		}
+	}
+
+	if r1 := <-ss.User().Search(tid, "en", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		found1 := false
+		for _, profile := range profiles {
+			if profile.Id == u5.Id {
+				found1 = true
+			}
+		}
+
+		if !found1 {
+			t.Fatal("should have found user")
 		}
 	}
 

--- a/store/sqlstore/user_store_test.go
+++ b/store/sqlstore/user_store_test.go
@@ -1342,11 +1342,20 @@ func TestUserStoreSearch(t *testing.T) {
 	u5.Email = model.NewId() + "@simulator.amazonses.com"
 	store.Must(ss.User().Save(u5))
 
+	u6 := &model.User{}
+	u6.Username = "underscore" + model.NewId()
+	u6.FirstName = "Du_"
+	u6.LastName = "_DE"
+	u6.Nickname = "lodash"
+	u6.Email = model.NewId() + "@simulator.amazonses.com"
+	store.Must(ss.User().Save(u6))
+
 	tid := model.NewId()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u1.Id}))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u2.Id}))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u3.Id}))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u5.Id}))
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u6.Id}))
 
 	searchOptions := map[string]bool{}
 	searchOptions[store.USER_SEARCH_OPTION_NAMES_ONLY] = true
@@ -1451,6 +1460,56 @@ func TestUserStoreSearch(t *testing.T) {
 
 		if found1 {
 			t.Fatal("should not have found user")
+		}
+	}
+
+	// % should be escaped and searched for.
+	if r1 := <-ss.User().Search(tid, "h%", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		if len(profiles) != 0 {
+			t.Fatal("shouldn't have found anything")
+		}
+	}
+
+	// "_" should be properly escaped and searched for.
+	if r1 := <-ss.User().Search(tid, "h_", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		if len(profiles) != 0 {
+			t.Fatal("shouldn't have found anything")
+		}
+	}
+	if r1 := <-ss.User().Search(tid, "Du_", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		found6 := false
+		for _, profile := range profiles {
+			if profile.Id == u6.Id {
+				found6 = true
+			}
+		}
+
+		if !found6 {
+			t.Fatal("should have found user")
+		}
+	}
+	if r1 := <-ss.User().Search(tid, "_dE", searchOptions); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else {
+		profiles := r1.Data.([]*model.User)
+		found6 := false
+		for _, profile := range profiles {
+			if profile.Id == u6.Id {
+				found6 = true
+			}
+		}
+
+		if !found6 {
+			t.Fatal("should have found user")
 		}
 	}
 


### PR DESCRIPTION
#### Summary
The current (fulltext based) implementation of user filtering search can't cope with <3 character long names. This is causing issues for some customers.

This PR fixes it to support searching names of any length, by switching to LIKE queries instead of fulltext. Given we don't really utilise any features of fulltext in these search queries, and we don't need any prefix wildcards, LIKE queries on these fields are indexed.

I have been testing locally on a DB with 100,000 users, and performance of the user filtering seems to actually be *better* than before after this change. It will need proper performance/load testing before it gets merged though.

I don't think this results in any feature loss, but it might, so we need to check the functionality of any user search/filtering features exhaustively too before considering it safe to merge.

It may be necessary to create some new indexes on the User table for this to work well. I haven't quite figured out how to get a proper query plan out of MySQL to investigate this yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7207