### PR TITLE
PLT-7561 Fixed crash when translated shortcuts don't include keys (4.2)

### DIFF
--- a/webapp/components/shortcuts_modal.jsx
+++ b/webapp/components/shortcuts_modal.jsx
@@ -376,14 +376,18 @@ function renderShortcut(text) {
 
     const shortcut = text.split('\t');
     const description = <span>{shortcut[0]}</span>;
-    const keys = shortcut[1].split('|').map((key) =>
-        <span
-            className='shortcut-key'
-            key={key}
-        >
-            {key}
-        </span>
-    );
+
+    let keys = null;
+    if (shortcut.length > 1) {
+        keys = shortcut[1].split('|').map((key) => (
+            <span
+                className='shortcut-key'
+                key={key}
+            >
+                {key}
+            </span>
+        ));
+    }
 
     return (
         <div className='shortcut-line'>


### PR DESCRIPTION
Fixes the crash on load for non-English languages that happened because we expected the shortcuts header to contain a tab character followed by a shortcut key. Since it was translated before the header included that, it was crashing

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7561
https://github.com/mattermost/mattermost-server/issues/7395