### PR TITLE
PLT-7569: More robust command response content-type checking

### DIFF
--- a/model/command_response.go
+++ b/model/command_response.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"strings"
 )
 
 const (
@@ -33,7 +34,7 @@ func (o *CommandResponse) ToJson() string {
 }
 
 func CommandResponseFromHTTPBody(contentType string, body io.Reader) *CommandResponse {
-	if contentType == "application/json" {
+	if strings.TrimSpace(strings.Split(contentType, ";")[0]) == "application/json" {
 		return CommandResponseFromJson(body)
 	}
 	if b, err := ioutil.ReadAll(body); err == nil {

--- a/model/command_response_test.go
+++ b/model/command_response_test.go
@@ -27,6 +27,7 @@ func TestCommandResponseFromHTTPBody(t *testing.T) {
 		{"", "foo", "foo"},
 		{"text/plain", "foo", "foo"},
 		{"application/json", `{"text": "foo"}`, "foo"},
+		{"application/json; charset=utf-8", `{"text": "foo"}`, "foo"},
 	} {
 		response := CommandResponseFromHTTPBody(test.ContentType, strings.NewReader(test.Body))
 		if response.Text != test.ExpectedText {


### PR DESCRIPTION
#### Summary
Ensures that content-types like `application/json; charset=utf-8` are handled correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7569

#### Checklist
- [x] Added or updated unit tests (required for all new features)