### PR TITLE
[PLT-7577] Fix sorting of group channel display name

### DIFF
--- a/webapp/actions/notification_actions.jsx
+++ b/webapp/actions/notification_actions.jsx
@@ -7,7 +7,6 @@ import ChannelStore from 'stores/channel_store.jsx';
 import NotificationStore from 'stores/notification_store.jsx';
 
 import {isSystemMessage} from 'utils/post_utils.jsx';
-import {buildGroupChannelName} from 'utils/channel_utils.jsx';
 import {isWindowsApp, isMacApp, isMobileApp} from 'utils/user_agent.jsx';
 import * as Utils from 'utils/utils.jsx';
 
@@ -59,8 +58,6 @@ export function sendDesktopNotification(post, msgProps) {
         };
     } else if (channel.type === Constants.DM_CHANNEL) {
         title = Utils.localizeMessage('notification.dm', 'Direct Message');
-    } else if (channel.type === Constants.GM_CHANNEL) {
-        title = buildGroupChannelName(channel.id);
     } else {
         title = channel.display_name;
     }

--- a/webapp/components/channel_header.jsx
+++ b/webapp/components/channel_header.jsx
@@ -364,10 +364,6 @@ export default class ChannelHeader extends React.Component {
             }
         }
 
-        if (isGroup) {
-            channelTitle = ChannelUtils.buildGroupChannelName(channel.id);
-        }
-
         let popoverListMembers;
         if (!isDirect) {
             popoverListMembers = (

--- a/webapp/components/navbar.jsx
+++ b/webapp/components/navbar.jsx
@@ -786,18 +786,14 @@ export default class Navbar extends React.Component {
             );
 
             isChannelAdmin = ChannelStore.isChannelAdminForCurrentChannel();
+            channelTitle = channel.display_name;
 
-            if (channel.type === 'O') {
-                channelTitle = channel.display_name;
-            } else if (channel.type === 'P') {
-                channelTitle = channel.display_name;
-            } else if (channel.type === 'D') {
+            if (channel.type === Constants.DM_CHANNEL) {
                 isDirect = true;
                 const teammateId = Utils.getUserIdFromChannelName(channel);
                 channelTitle = Utils.displayUsername(teammateId);
             } else if (channel.type === Constants.GM_CHANNEL) {
                 isGroup = true;
-                channelTitle = ChannelUtils.buildGroupChannelName(channel.id);
             }
 
             if (channel.header.length === 0) {

--- a/webapp/components/sidebar.jsx
+++ b/webapp/components/sidebar.jsx
@@ -196,8 +196,6 @@ export default class Sidebar extends React.Component {
                 if (teammate != null) {
                     currentChannelName = teammate.username;
                 }
-            } else if (channel.type === Constants.GM_CHANNEL) {
-                currentChannelName = ChannelUtils.buildGroupChannelName(channel.id);
             }
 
             const unread = this.getTotalUnreadCount();
@@ -527,8 +525,6 @@ export default class Sidebar extends React.Component {
             rowClass += ' has-badge';
         }
 
-        let displayName = channel.display_name;
-
         var icon = null;
         const globeIcon = Constants.GLOBE_ICON_SVG;
         const lockIcon = Constants.LOCK_ICON_SVG;
@@ -547,7 +543,6 @@ export default class Sidebar extends React.Component {
                 />
             );
         } else if (channel.type === Constants.GM_CHANNEL) {
-            displayName = ChannelUtils.buildGroupChannelName(channel.id);
             icon = <div className='status status--group'>{UserStore.getProfileListInChannel(channel.id, true).length}</div>;
         } else {
             // set up status icon for direct message channels (status is null for other channel types)
@@ -609,6 +604,8 @@ export default class Sidebar extends React.Component {
         } else {
             link = '/' + this.state.currentTeam.name + '/channels/' + channel.name;
         }
+
+        const displayName = channel.display_name;
 
         return (
             <li

--- a/webapp/utils/channel_utils.jsx
+++ b/webapp/utils/channel_utils.jsx
@@ -247,23 +247,6 @@ export function canManageMembers(channel, isChannelAdmin, isTeamAdmin, isSystemA
     return true;
 }
 
-export function buildGroupChannelName(channelId) {
-    const locale = LocalizationStore.getLocale();
-    const profiles = UserStore.getProfileListInChannel(channelId, true);
-    if (!profiles) {
-        return '';
-    }
-
-    const groupDisplayName = [];
-    for (let i = 0; i < profiles.length; i++) {
-        groupDisplayName.push(Utils.displayUsernameForUser(profiles[i]));
-    }
-
-    return groupDisplayName.sort((a, b) => {
-        return a.toLowerCase().localeCompare(b.toLowerCase(), locale, {numeric: true});
-    }).join(', ');
-}
-
 export function getCountsStateFromStores(team = TeamStore.getCurrent(), teamMembers = TeamStore.getMyTeamMembers(), unreadCounts = ChannelStore.getUnreadCounts()) {
     let mentionCount = 0;
     let messageCount = 0;

--- a/webapp/utils/channel_utils.jsx
+++ b/webapp/utils/channel_utils.jsx
@@ -248,16 +248,20 @@ export function canManageMembers(channel, isChannelAdmin, isTeamAdmin, isSystemA
 }
 
 export function buildGroupChannelName(channelId) {
+    const locale = LocalizationStore.getLocale();
     const profiles = UserStore.getProfileListInChannel(channelId, true);
-    let displayName = '';
-    for (let i = 0; i < profiles.length; i++) {
-        displayName += Utils.displayUsernameForUser(profiles[i]);
-        if (i !== profiles.length - 1) {
-            displayName += ', ';
-        }
+    if (!profiles) {
+        return '';
     }
 
-    return displayName;
+    const groupDisplayName = [];
+    for (let i = 0; i < profiles.length; i++) {
+        groupDisplayName.push(Utils.displayUsernameForUser(profiles[i]));
+    }
+
+    return groupDisplayName.sort((a, b) => {
+        return a.toLowerCase().localeCompare(b.toLowerCase(), locale, {numeric: true});
+    }).join(', ');
 }
 
 export function getCountsStateFromStores(team = TeamStore.getCurrent(), teamMembers = TeamStore.getMyTeamMembers(), unreadCounts = ChannelStore.getUnreadCounts()) {


### PR DESCRIPTION
#### Summary
Fix sorting of group channel display name
#### Ticket Link
Jira ticket: [PLT-7577](https://mattermost.atlassian.net/browse/PLT-7577)

UPDATE:
Make use of channel.display_name (for group channel) which is already sorted from mattermost-redux. Just realized after the comment made by @enahum on PR submitted to master.