### PR TITLE
PLT-7579: fix broken css after tutorial

### DIFF
--- a/webapp/components/channel_view.jsx
+++ b/webapp/components/channel_view.jsx
@@ -86,7 +86,9 @@ export default class ChannelView extends React.Component {
 
     render() {
         if (this.state.tutorialStep <= TutorialSteps.INTRO_SCREENS) {
-            return (<TutorialView/>);
+            return (<TutorialView
+                isRoot={false}
+            />);
         }
 
         return (

--- a/webapp/components/tutorial/tutorial_view.jsx
+++ b/webapp/components/tutorial/tutorial_view.jsx
@@ -7,6 +7,7 @@ import ChannelStore from 'stores/channel_store.jsx';
 import Constants from 'utils/constants.jsx';
 
 import $ from 'jquery';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export default class TutorialView extends React.Component {
@@ -22,12 +23,16 @@ export default class TutorialView extends React.Component {
     componentDidMount() {
         ChannelStore.addChangeListener(this.handleChannelChange);
 
-        $('body').addClass('app__body');
+        if (this.props.isRoot) {
+            $('body').addClass('app__body');
+        }
     }
     componentWillUnmount() {
         ChannelStore.removeChangeListener(this.handleChannelChange);
 
-        $('body').removeClass('app__body');
+        if (this.props.isRoot) {
+            $('body').removeClass('app__body');
+        }
     }
     handleChannelChange() {
         this.setState({
@@ -47,3 +52,11 @@ export default class TutorialView extends React.Component {
         );
     }
 }
+
+TutorialView.defaultProps = {
+    isRoot: true,
+};
+
+TutorialView.propTypes = {
+    isRoot: PropTypes.bool
+};


### PR DESCRIPTION
#### Summary

When the tutorial view was displayed by the channel view, after navigating through the tutorial, the tutorial view would leave the `<body>` without an `app__body` class.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7579

#### Checklist
N/A