### PR TITLE
[PLT-7574] Update and Simplify Compatibility Check and Replace UA Dependency

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -65,7 +65,7 @@ func pluginHandler(config model.ConfigFunc, handler http.Handler) http.Handler {
 	})
 }
 
-// Due to the complexities of UA detection and the ramifications of a misdetection only older Safari and IE browsers throw incopatability errors.
+// Due to the complexities of UA detection and the ramifications of a misdetection only older Safari and IE browsers throw incompatibility errors.
 
 // Map should be of minimum required browser version.
 var browserMinimumSupported = map[string]int{

--- a/web/web.go
+++ b/web/web.go
@@ -84,7 +84,14 @@ func CheckBrowserCompatability(c *api.Context, r *http.Request) bool {
 }
 
 func root(c *api.Context, w http.ResponseWriter, r *http.Request) {
-	if !CheckBrowserCompatability(c, r) {
+	agentString := r.UserAgent()
+	ua := user_agent.New(agentString)
+
+	if strings.Contains(agentString, "Mattermost") {
+		l4g.Debug("Detected Browser: Mattermost App")
+	} else if ua.Mobile() {
+		l4g.Debug("Detected Browser: Mobile Browser")
+	} else if !CheckBrowserCompatability(ua) {
 		w.Header().Set("Cache-Control", "no-store")
 		page := utils.NewHTMLTemplate(c.App.HTMLTemplates(), "unsupported_browser")
 		page.Props["Title"] = c.T("web.error.unsupported_browser.title")

--- a/web/web.go
+++ b/web/web.go
@@ -65,7 +65,15 @@ func pluginHandler(config model.ConfigFunc, handler http.Handler) http.Handler {
 	})
 }
 
-var browsersNotSupported string = "MSIE/8;MSIE/9;MSIE/10;Internet Explorer/8;Internet Explorer/9;Internet Explorer/10;Safari/7;Safari/8"
+// Older Versions of Chrome, FF, and Edge and other lesser known browsers may also have bugs.
+// Due to the complexities of UA detection and teh eamifications of a misdetection only these older browsers throw incopatability errors.
+
+// Map should be of minimum required browser version.
+var browserMinimumSupported = map[string]int{
+	"MSIE":              11,
+	"Internet Explorer": 11,
+	"Safari":            9,
+}
 
 func CheckBrowserCompatability(c *api.Context, r *http.Request) bool {
 	ua := user_agent.New(r.UserAgent())

--- a/web/web.go
+++ b/web/web.go
@@ -65,8 +65,7 @@ func pluginHandler(config model.ConfigFunc, handler http.Handler) http.Handler {
 	})
 }
 
-// Older Versions of Chrome, FF, and Edge and other lesser known browsers may also have bugs.
-// Due to the complexities of UA detection and teh eamifications of a misdetection only these older browsers throw incopatability errors.
+// Due to the complexities of UA detection and the ramifications of a misdetection only older Safari and IE browsers throw incopatability errors.
 
 // Map should be of minimum required browser version.
 var browserMinimumSupported = map[string]int{

--- a/web/web.go
+++ b/web/web.go
@@ -86,7 +86,7 @@ func CheckClientCompatability(agentString string) bool {
 		return false
 	}
 
-	l4g.Debug("Client not version controlled.")
+	l4g.Debug("Client allowed or not version controlled.")
 	return true
 }
 

--- a/web/web.go
+++ b/web/web.go
@@ -7,9 +7,8 @@ import (
 	"net/http"
 	"strings"
 
-	"xojoc.pw/useragent"
-
 	"github.com/NYTimes/gziphandler"
+	"github.com/avct/uasurfer"
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-server/api"
@@ -71,22 +70,17 @@ func pluginHandler(config model.ConfigFunc, handler http.Handler) http.Handler {
 
 // Map should be of minimum required browser version.
 var browserMinimumSupported = map[string]int{
-	"MSIE":   11,
-	"Safari": 9,
+	"BrowserIE":     11,
+	"BrowserSafari": 9,
 }
 
 func CheckClientCompatability(agentString string) bool {
-	ua := useragent.Parse(agentString)
+	ua := uasurfer.Parse(agentString)
 
-	l4g.Debug("User Agent: %v", agentString)
-	l4g.Debug("Detected Client: %v %v", ua.Name, ua.Version)
-
-	if version, exist := browserMinimumSupported[ua.Name]; exist && int(ua.Version.Major) < version {
-		l4g.Debug("Client not supported.")
+	if version, exist := browserMinimumSupported[ua.Browser.Name.String()]; exist && ua.Browser.Version.Major < version {
 		return false
 	}
 
-	l4g.Debug("Client allowed or not version controlled.")
 	return true
 }
 

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -156,4 +156,104 @@ func TestMain(m *testing.M) {
 	}()
 
 	status = m.Run()
+
+}
+
+func TestCheckClientCompatability(t *testing.T) {
+
+	//Firefox 40.1
+	ua := "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Friefox User Agent passed browser incompatibility!")
+	} else {
+		t.Error("Fail: Firefox should have passed browser compatibility")
+	}
+
+	//Chrome 60
+	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Chrome User Agent passed browser compatibility!")
+	} else {
+		t.Error("Fail: Chrome should have passed browser compatibility")
+	}
+
+	//Chrome Mobile
+	ua = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Mobile Safari/537.36"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Chrome Mobile passed browser compatibility.")
+	} else {
+		t.Error("Fail: Chrome Mobile User Agent Test failed!")
+	}
+
+	//Classic app
+	ua = "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.81 Mobile Safari/537.36 Web-Atoms-Mobile-WebView"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Mattermost Classic App passed browser compatibility.")
+	} else {
+		t.Error("Fail: Mattermost Classic App User Agent Test failed!")
+	}
+
+	//Mattermost App 3.7.1
+	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.7.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Mattermost App passed browser compatibility.")
+	} else {
+		t.Error("Fail: Mattermost App User Agent Test failed!")
+	}
+
+	//Franz
+	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Franz/4.0.4 Chrome/52.0.2743.82 Electron/1.3.1 Safari/537.36"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Franz App passed browser compatibility.")
+	} else {
+		t.Error("Fail: Franz App User Agent Test failed!")
+	}
+
+	//Edge 14
+	ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Edge User Agent passed browser incompatibility!")
+	} else {
+		t.Error("Fail: Edge should have passed browser compatibility")
+	}
+
+	//IE 11
+	ua = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: IE 11 passed browser compatibility.")
+	} else {
+		t.Error("Fail: IE 11 User Agent Test failed!")
+	}
+
+	//IE 9
+	ua = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)"
+	if result := CheckClientCompatability(ua); result == false {
+		t.Log("Pass: IE 9 correctly failed browser compatibility.")
+	} else {
+		t.Error("Fail: IE 9 incorrectly passed browser compatibility!")
+	}
+
+	//Safari 9
+	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Safari/604.1.38"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: IE 11 passed browser compatibility.")
+	} else {
+		t.Error("Fail: IE 11 User Agent Test failed!")
+	}
+
+	//Safari 8
+	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12"
+	if result := CheckClientCompatability(ua); result == false {
+		t.Log("Pass: Safari 8 correctly failed browser compatibility.")
+	} else {
+		t.Error("Fail: Safari 8 incorrectly passed browser compatibility!")
+	}
+
+	//Safari Mobile Mobile
+	ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1"
+	if result := CheckClientCompatability(ua); result == true {
+		t.Log("Pass: Safari Mobile passed browser compatibility.")
+	} else {
+		t.Error("Fail: Safari Mobile User Agent Test failed!")
+	}
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -160,100 +160,31 @@ func TestMain(m *testing.M) {
 }
 
 func TestCheckClientCompatability(t *testing.T) {
-
-	//Firefox 40.1
-	ua := "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Friefox User Agent passed browser incompatibility!")
-	} else {
-		t.Error("Fail: Firefox should have passed browser compatibility")
+	//Browser Name, UA String, expected result (if the browser should fail the test false and if it should pass the true)
+	type uaTest struct {
+		Name      string // Name of Browser
+		UserAgent string // Useragent of Browser
+		Result    bool   // Expected result (true if browser should be compatible, false if browser shouldn't be compatible)
 	}
-
-	//Chrome 60
-	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Chrome User Agent passed browser compatibility!")
-	} else {
-		t.Error("Fail: Chrome should have passed browser compatibility")
+	var uaTestParameters = []uaTest{
+		{"Mozilla 40.1", "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1", true},
+		{"Chrome 60", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36", true},
+		{"Chrome Mobile", "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Mobile Safari/537.36", true},
+		{"MM Classic App", "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.81 Mobile Safari/537.36 Web-Atoms-Mobile-WebView", true},
+		{"MM App 3.7.1", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.7.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36", true},
+		{"Franz 4.0.4", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Franz/4.0.4 Chrome/52.0.2743.82 Electron/1.3.1 Safari/537.36", true},
+		{"Edge 14", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393", true},
+		{"Internet Explorer 11", "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko", true},
+		{"Internet Explorer 9", "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0", false},
+		{"Safari 9", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Safari/604.1.38", true},
+		{"Safari 8", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12", false},
+		{"Safari Mobile", "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1", true},
 	}
-
-	//Chrome Mobile
-	ua = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Mobile Safari/537.36"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Chrome Mobile passed browser compatibility.")
-	} else {
-		t.Error("Fail: Chrome Mobile User Agent Test failed!")
-	}
-
-	//Classic app
-	ua = "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.81 Mobile Safari/537.36 Web-Atoms-Mobile-WebView"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Mattermost Classic App passed browser compatibility.")
-	} else {
-		t.Error("Fail: Mattermost Classic App User Agent Test failed!")
-	}
-
-	//Mattermost App 3.7.1
-	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.7.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Mattermost App passed browser compatibility.")
-	} else {
-		t.Error("Fail: Mattermost App User Agent Test failed!")
-	}
-
-	//Franz 4.0.4
-	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Franz/4.0.4 Chrome/52.0.2743.82 Electron/1.3.1 Safari/537.36"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Franz App passed browser compatibility.")
-	} else {
-		t.Error("Fail: Franz App User Agent Test failed!")
-	}
-
-	//Edge 14
-	ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Edge User Agent passed browser incompatibility!")
-	} else {
-		t.Error("Fail: Edge should have passed browser compatibility")
-	}
-
-	//IE 11
-	ua = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: IE 11 passed browser compatibility.")
-	} else {
-		t.Error("Fail: IE 11 User Agent Test failed!")
-	}
-
-	//IE 9
-	ua = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)"
-	if result := CheckClientCompatability(ua); result == false {
-		t.Log("Pass: IE 9 correctly failed browser compatibility.")
-	} else {
-		t.Error("Fail: IE 9 incorrectly passed browser compatibility!")
-	}
-
-	//Safari 9
-	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Safari/604.1.38"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Safari 9 passed browser compatibility.")
-	} else {
-		t.Error("Fail: Safari 9 User Agent Test failed!")
-	}
-
-	//Safari 8
-	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12"
-	if result := CheckClientCompatability(ua); result == false {
-		t.Log("Pass: Safari 8 correctly failed browser compatibility.")
-	} else {
-		t.Error("Fail: Safari 8 incorrectly passed browser compatibility!")
-	}
-
-	//Safari Mobile
-	ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1"
-	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: Safari Mobile passed browser compatibility.")
-	} else {
-		t.Error("Fail: Safari Mobile User Agent Test failed!")
+	for _, browser := range uaTestParameters {
+		if result := CheckClientCompatability(browser.UserAgent); result == browser.Result {
+			t.Logf("Pass: %s passed browser test.", browser.Name)
+		} else {
+			t.Errorf("Fail: %s User Agent Test failed!", browser.Name)
+		}
 	}
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -236,9 +236,9 @@ func TestCheckClientCompatability(t *testing.T) {
 	//Safari 9
 	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Safari/604.1.38"
 	if result := CheckClientCompatability(ua); result == true {
-		t.Log("Pass: IE 11 passed browser compatibility.")
+		t.Log("Pass: Safari 9 passed browser compatibility.")
 	} else {
-		t.Error("Fail: IE 11 User Agent Test failed!")
+		t.Error("Fail: Safari 9 User Agent Test failed!")
 	}
 
 	//Safari 8

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -201,7 +201,7 @@ func TestCheckClientCompatability(t *testing.T) {
 		t.Error("Fail: Mattermost App User Agent Test failed!")
 	}
 
-	//Franz
+	//Franz 4.0.4
 	ua = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Franz/4.0.4 Chrome/52.0.2743.82 Electron/1.3.1 Safari/537.36"
 	if result := CheckClientCompatability(ua); result == true {
 		t.Log("Pass: Franz App passed browser compatibility.")
@@ -249,7 +249,7 @@ func TestCheckClientCompatability(t *testing.T) {
 		t.Error("Fail: Safari 8 incorrectly passed browser compatibility!")
 	}
 
-	//Safari Mobile Mobile
+	//Safari Mobile
 	ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1"
 	if result := CheckClientCompatability(ua); result == true {
 		t.Log("Pass: Safari Mobile passed browser compatibility.")


### PR DESCRIPTION
#### Summary
Changing to only check Safari and Edge, Updating UA check dependency to better library.

See: https://pre-release.mattermost.com/core/pl/xou45eqebtro3qx4euzm3nho5w

#### Ticket Link
Current:
https://mattermost.atlassian.net/browse/PLT-7574

Browser Compatibility Check Implementation:
https://github.com/mattermost/mattermost-server/pull/6945
https://mattermost.atlassian.net/browse/PLT-959
