### PR TITLE
PLT-7404 Return viewed at times in view channel API response

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -779,7 +779,7 @@ func viewChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := c.App.ViewChannel(view, c.Session.UserId, !c.Session.IsMobileApp()); err != nil {
+	if _, err := c.App.ViewChannel(view, c.Session.UserId, !c.Session.IsMobileApp()); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -709,12 +709,20 @@ func viewChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := c.App.ViewChannel(view, c.Params.UserId, !c.Session.IsMobileApp()); err != nil {
+	times, err := c.App.ViewChannel(view, c.Params.UserId, !c.Session.IsMobileApp())
+
+	if err != nil {
 		c.Err = err
 		return
 	}
 
-	ReturnStatusOK(w)
+	// Returning {"status": "OK", ...} for backwards compatability
+	resp := &model.ChannelViewResponse{
+		Status:            "OK",
+		LastViewedAtTimes: times,
+	}
+
+	w.Write([]byte(resp.ToJson()))
 }
 
 func updateChannelMemberRoles(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1375,11 +1375,17 @@ func TestViewChannel(t *testing.T) {
 		ChannelId: th.BasicChannel.Id,
 	}
 
-	pass, resp := Client.ViewChannel(th.BasicUser.Id, view)
+	viewResp, resp := Client.ViewChannel(th.BasicUser.Id, view)
 	CheckNoError(t, resp)
 
-	if !pass {
+	if viewResp.Status != "OK" {
 		t.Fatal("should have passed")
+	}
+
+	channel, _ := th.App.GetChannel(th.BasicChannel.Id)
+
+	if lastViewedAt := viewResp.LastViewedAtTimes[channel.Id]; lastViewedAt != channel.LastPostAt {
+		t.Fatal("LastPostAt does not match returned LastViewedAt time")
 	}
 
 	view.PrevChannelId = th.BasicChannel.Id
@@ -1396,7 +1402,7 @@ func TestViewChannel(t *testing.T) {
 
 	member, resp := Client.GetChannelMember(th.BasicChannel.Id, th.BasicUser.Id, "")
 	CheckNoError(t, resp)
-	channel, resp := Client.GetChannel(th.BasicChannel.Id, "")
+	channel, resp = Client.GetChannel(th.BasicChannel.Id, "")
 	CheckNoError(t, resp)
 
 	if member.MsgCount != channel.TotalMsgCount {

--- a/model/channel_view.go
+++ b/model/channel_view.go
@@ -32,3 +32,28 @@ func ChannelViewFromJson(data io.Reader) *ChannelView {
 		return nil
 	}
 }
+
+type ChannelViewResponse struct {
+	Status            string           `json:"status"`
+	LastViewedAtTimes map[string]int64 `json:"last_viewed_at_times"`
+}
+
+func (o *ChannelViewResponse) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func ChannelViewResponseFromJson(data io.Reader) *ChannelViewResponse {
+	decoder := json.NewDecoder(data)
+	var o ChannelViewResponse
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
+	} else {
+		return nil
+	}
+}

--- a/model/channel_view_test.go
+++ b/model/channel_view_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestChannelViewJson(t *testing.T) {
+	o := ChannelView{ChannelId: NewId(), PrevChannelId: NewId()}
+	json := o.ToJson()
+	ro := ChannelViewFromJson(strings.NewReader(json))
+
+	if o.ChannelId != ro.ChannelId {
+		t.Fatal("ChannelIdIds do not match")
+	}
+
+	if o.PrevChannelId != ro.PrevChannelId {
+		t.Fatal("PrevChannelIds do not match")
+	}
+}
+
+func TestChannelViewResponseJson(t *testing.T) {
+	id := NewId()
+	o := ChannelViewResponse{Status: "OK", LastViewedAtTimes: map[string]int64{id: 12345}}
+	json := o.ToJson()
+	ro := ChannelViewResponseFromJson(strings.NewReader(json))
+
+	if o.Status != ro.Status {
+		t.Fatal("ChannelIdIds do not match")
+	}
+
+	if o.LastViewedAtTimes[id] != ro.LastViewedAtTimes[id] {
+		t.Fatal("LastViewedAtTimes do not match")
+	}
+}

--- a/model/client4.go
+++ b/model/client4.go
@@ -1570,13 +1570,13 @@ func (c *Client4) GetChannelMembersForUser(userId, teamId, etag string) (*Channe
 }
 
 // ViewChannel performs a view action for a user. Synonymous with switching channels or marking channels as read by a user.
-func (c *Client4) ViewChannel(userId string, view *ChannelView) (bool, *Response) {
+func (c *Client4) ViewChannel(userId string, view *ChannelView) (*ChannelViewResponse, *Response) {
 	url := fmt.Sprintf(c.GetChannelsRoute()+"/members/%v/view", userId)
 	if r, err := c.DoApiPost(url, view.ToJson()); err != nil {
-		return false, BuildErrorResponse(r, err)
+		return nil, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
+		return ChannelViewResponseFromJson(r.Body), BuildResponse(r)
 	}
 }
 

--- a/store/sqlstore/channel_store_test.go
+++ b/store/sqlstore/channel_store_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 )
@@ -1258,15 +1260,44 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&m1))
 
-	result := <-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, m1.UserId)
-	if result.Err != nil {
+	o2 := model.Channel{}
+	o2.TeamId = model.NewId()
+	o2.DisplayName = "Channel1"
+	o2.Name = "zz" + model.NewId() + "c"
+	o2.Type = model.CHANNEL_OPEN
+	o2.TotalMsgCount = 26
+	o2.LastPostAt = 123456
+	store.Must(ss.Channel().Save(&o2))
+
+	m2 := model.ChannelMember{}
+	m2.ChannelId = o2.Id
+	m2.UserId = m1.UserId
+	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&m2))
+
+	if result := <-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, m1.UserId); result.Err != nil {
 		t.Fatal("failed to update", result.Err)
 	} else if result.Data.(map[string]int64)[o1.Id] != o1.LastPostAt {
 		t.Fatal("last viewed at time incorrect")
 	}
 
-	result = <-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, "missing id")
-	if result.Err != nil {
+	if result := <-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId, m2.ChannelId}, m1.UserId); result.Err != nil {
+		t.Fatal("failed to update", result.Err)
+	} else if result.Data.(map[string]int64)[o2.Id] != o2.LastPostAt {
+		t.Fatal("last viewed at time incorrect")
+	}
+
+	rm1 := store.Must(ss.Channel().GetMember(m1.ChannelId, m1.UserId)).(*model.ChannelMember)
+	assert.Equal(t, rm1.LastViewedAt, o1.LastPostAt)
+	assert.Equal(t, rm1.LastUpdateAt, o1.LastPostAt)
+	assert.Equal(t, rm1.MsgCount, o1.TotalMsgCount)
+
+	rm2 := store.Must(ss.Channel().GetMember(m2.ChannelId, m2.UserId)).(*model.ChannelMember)
+	assert.Equal(t, rm2.LastViewedAt, o2.LastPostAt)
+	assert.Equal(t, rm2.LastUpdateAt, o2.LastPostAt)
+	assert.Equal(t, rm2.MsgCount, o2.TotalMsgCount)
+
+	if result := <-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, "missing id"); result.Err != nil {
 		t.Fatal("failed to update")
 	}
 }

--- a/store/sqlstore/channel_store_test.go
+++ b/store/sqlstore/channel_store_test.go
@@ -1249,6 +1249,7 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
 	o1.TotalMsgCount = 25
+	o1.LastPostAt = 12345
 	store.Must(ss.Channel().Save(&o1))
 
 	m1 := model.ChannelMember{}
@@ -1257,13 +1258,15 @@ func TestChannelStoreUpdateLastViewedAt(t *testing.T) {
 	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&m1))
 
-	err := (<-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, m1.UserId)).Err
-	if err != nil {
-		t.Fatal("failed to update", err)
+	result := <-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, m1.UserId)
+	if result.Err != nil {
+		t.Fatal("failed to update", result.Err)
+	} else if result.Data.(map[string]int64)[o1.Id] != o1.LastPostAt {
+		t.Fatal("last viewed at time incorrect")
 	}
 
-	err = (<-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, "missing id")).Err
-	if err != nil {
+	result = <-ss.Channel().UpdateLastViewedAt([]string{m1.ChannelId}, "missing id")
+	if result.Err != nil {
 		t.Fatal("failed to update")
 	}
 }


### PR DESCRIPTION
#### Summary
I used a transaction to select the LastPostAt times out of the database and then update the ChannelMembers. This might have perf implications because it adds a read on a hot route so if either of you can think of a better method that doesn't require an extra read let me know

API reference update: mattermost/mattermost-api-reference#288

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7404