### PR TITLE
PLT-7535 Invalidate webhook cache after updating webhook

### DIFF
--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -503,6 +505,9 @@ func TestUpdateIncomingHook(t *testing.T) {
 		} else {
 			t.Fatal("should not be nil")
 		}
+
+		//updatedHook, _ = th.App.GetIncomingWebhook(createdHook.Id)
+		assert.Equal(t, updatedHook.ChannelId, createdHook.ChannelId)
 	})
 
 	t.Run("RetainCreateAt", func(t *testing.T) {

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -219,6 +219,7 @@ func (a *App) UpdateIncomingWebhook(oldHook, updatedHook *model.IncomingWebhook)
 	if result := <-a.Srv.Store.Webhook().UpdateIncoming(updatedHook); result.Err != nil {
 		return nil, result.Err
 	} else {
+		a.InvalidateCacheForWebhook(oldHook.Id)
 		return result.Data.(*model.IncomingWebhook), nil
 	}
 }


### PR DESCRIPTION
#### Summary
Invalidate webhook cache after updating webhook.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7535