### PR TITLE
Avoid error linking client dist directory every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -374,7 +374,9 @@ run-cli: start-docker
 run-client:
 	@echo Running mattermost client for development
 
-	ln -s $(BUILD_WEBAPP_DIR)/dist client
+	@if [ ! -e client ]; then \
+		ln -s $(BUILD_WEBAPP_DIR)/dist client; \
+	fi
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) run
 
 run-client-fullmap:


### PR DESCRIPTION
Other option to solve this is use "ln -s -f" to force overwrite of client link, but the current approach allows you to link to your client in other place temporary without been overwritten accidentally.