### PR TITLE
Remove more global references

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -19,7 +19,7 @@ import (
 type CommandProvider interface {
 	GetTrigger() string
 	GetCommand(T goi18n.TranslateFunc) *model.Command
-	DoCommand(args *model.CommandArgs, message string) *model.CommandResponse
+	DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse
 }
 
 var commandProviders = make(map[string]CommandProvider)
@@ -140,7 +140,7 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 	provider := GetCommandProvider(trigger)
 
 	if provider != nil {
-		response := provider.DoCommand(args, message)
+		response := provider.DoCommand(a, args, message)
 		return a.HandleCommandResponse(provider.GetCommand(args.T), args, response, true)
 	} else {
 		if !*utils.Cfg.ServiceSettings.EnableCommands {

--- a/app/command_away.go
+++ b/app/command_away.go
@@ -32,8 +32,8 @@ func (me *AwayProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *AwayProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	Global().SetStatusAwayIfNeeded(args.UserId, true)
+func (me *AwayProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	a.SetStatusAwayIfNeeded(args.UserId, true)
 
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_away.success")}
 }

--- a/app/command_channel_header.go
+++ b/app/command_channel_header.go
@@ -34,17 +34,17 @@ func (me *HeaderProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *HeaderProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := Global().GetChannel(args.ChannelId)
+func (me *HeaderProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	channel, err := a.GetChannel(args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
@@ -57,7 +57,7 @@ func (me *HeaderProvider) DoCommand(args *model.CommandArgs, message string) *mo
 	}
 	*patch.Header = message
 
-	_, err = Global().PatchChannel(channel, patch, args.UserId)
+	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_header.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_channel_purpose.go
+++ b/app/command_channel_purpose.go
@@ -33,17 +33,17 @@ func (me *PurposeProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *PurposeProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := Global().GetChannel(args.ChannelId)
+func (me *PurposeProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	channel, err := a.GetChannel(args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
@@ -60,7 +60,7 @@ func (me *PurposeProvider) DoCommand(args *model.CommandArgs, message string) *m
 	}
 	*patch.Purpose = message
 
-	_, err = Global().PatchChannel(channel, patch, args.UserId)
+	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_channel_rename.go
+++ b/app/command_channel_rename.go
@@ -33,17 +33,17 @@ func (me *RenameProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *RenameProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	channel, err := Global().GetChannel(args.ChannelId)
+func (me *RenameProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	channel, err := a.GetChannel(args.ChannelId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_OPEN && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_PRIVATE && !Global().SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+	if channel.Type == model.CHANNEL_PRIVATE && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
@@ -64,7 +64,7 @@ func (me *RenameProvider) DoCommand(args *model.CommandArgs, message string) *mo
 	}
 	*patch.DisplayName = message
 
-	_, err = Global().PatchChannel(channel, patch, args.UserId)
+	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_channel_rename_test.go
+++ b/app/command_channel_rename_test.go
@@ -25,7 +25,7 @@ func TestRenameProviderDoCommand(t *testing.T) {
 		"1234567890123456789012":  "",
 		"12345678901234567890123": "api.command_channel_rename.too_long.app_error",
 	} {
-		actual := rp.DoCommand(args, msg).Text
+		actual := rp.DoCommand(th.App, args, msg).Text
 		assert.Equal(t, expected, actual)
 	}
 }

--- a/app/command_code.go
+++ b/app/command_code.go
@@ -35,7 +35,7 @@ func (me *CodeProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *CodeProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *CodeProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	if len(message) == 0 {
 		return &model.CommandResponse{Text: args.T("api.command_code.message.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_code_test.go
+++ b/app/command_code_test.go
@@ -18,7 +18,7 @@ func TestCodeProviderDoCommand(t *testing.T) {
 		"foo\nbar":   "    foo\n    bar",
 		"foo\nbar\n": "    foo\n    bar\n    ",
 	} {
-		actual := cp.DoCommand(args, msg).Text
+		actual := cp.DoCommand(nil, args, msg).Text
 		if actual != expected {
 			t.Errorf("expected `%v`, got `%v`", expected, actual)
 		}

--- a/app/command_echo.go
+++ b/app/command_echo.go
@@ -40,7 +40,7 @@ func (me *EchoProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *EchoProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *EchoProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	if len(message) == 0 {
 		return &model.CommandResponse{Text: args.T("api.command_echo.message.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
@@ -88,7 +88,7 @@ func (me *EchoProvider) DoCommand(args *model.CommandArgs, message string) *mode
 
 		time.Sleep(time.Duration(delay) * time.Second)
 
-		if _, err := Global().CreatePostMissingChannel(post, true); err != nil {
+		if _, err := a.CreatePostMissingChannel(post, true); err != nil {
 			l4g.Error(args.T("api.command_echo.create.app_error"), err)
 		}
 	}()

--- a/app/command_expand_collapse.go
+++ b/app/command_expand_collapse.go
@@ -52,12 +52,12 @@ func (me *CollapseProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *ExpandProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	return Global().setCollapsePreference(args, false)
+func (me *ExpandProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	return a.setCollapsePreference(args, false)
 }
 
-func (me *CollapseProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	return Global().setCollapsePreference(args, true)
+func (me *CollapseProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	return a.setCollapsePreference(args, true)
 }
 
 func (a *App) setCollapsePreference(args *model.CommandArgs, isCollapse bool) *model.CommandResponse {

--- a/app/command_help.go
+++ b/app/command_help.go
@@ -33,7 +33,7 @@ func (h *HelpProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (h *HelpProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (h *HelpProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	helpLink := *utils.Cfg.SupportSettings.HelpLink
 
 	if helpLink == "" {

--- a/app/command_invite_people.go
+++ b/app/command_invite_people.go
@@ -41,7 +41,7 @@ func (me *InvitePeopleProvider) GetCommand(T goi18n.TranslateFunc) *model.Comman
 	}
 }
 
-func (me *InvitePeopleProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *InvitePeopleProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	if !utils.Cfg.EmailSettings.SendEmailNotifications {
 		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command.invite_people.email_off")}
 	}
@@ -63,7 +63,7 @@ func (me *InvitePeopleProvider) DoCommand(args *model.CommandArgs, message strin
 		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command.invite_people.no_email")}
 	}
 
-	if err := Global().InviteNewUsersToTeam(emailList, args.TeamId, args.UserId); err != nil {
+	if err := a.InviteNewUsersToTeam(emailList, args.TeamId, args.UserId); err != nil {
 		l4g.Error(err.Error())
 		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command.invite_people.fail")}
 	}

--- a/app/command_join.go
+++ b/app/command_join.go
@@ -33,15 +33,15 @@ func (me *JoinProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *JoinProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	if result := <-Global().Srv.Store.Channel().GetByName(args.TeamId, message, true); result.Err != nil {
+func (me *JoinProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	if result := <-a.Srv.Store.Channel().GetByName(args.TeamId, message, true); result.Err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_join.list.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
 		channel := result.Data.(*model.Channel)
 
 		if channel.Name == message {
 			allowed := false
-			if (channel.Type == model.CHANNEL_PRIVATE && Global().SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_READ_CHANNEL)) || channel.Type == model.CHANNEL_OPEN {
+			if (channel.Type == model.CHANNEL_PRIVATE && a.SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_READ_CHANNEL)) || channel.Type == model.CHANNEL_OPEN {
 				allowed = true
 			}
 
@@ -49,11 +49,11 @@ func (me *JoinProvider) DoCommand(args *model.CommandArgs, message string) *mode
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 
-			if err := Global().JoinChannel(channel, args.UserId); err != nil {
+			if err := a.JoinChannel(channel, args.UserId); err != nil {
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 
-			team, err := Global().GetTeam(channel.TeamId)
+			team, err := a.GetTeam(channel.TeamId)
 			if err != nil {
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}

--- a/app/command_leave.go
+++ b/app/command_leave.go
@@ -32,21 +32,21 @@ func (me *LeaveProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *LeaveProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LeaveProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	var channel *model.Channel
 	var noChannelErr *model.AppError
-	if channel, noChannelErr = Global().GetChannel(args.ChannelId); noChannelErr != nil {
+	if channel, noChannelErr = a.GetChannel(args.ChannelId); noChannelErr != nil {
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 	if channel.Name == model.DEFAULT_CHANNEL {
 		return &model.CommandResponse{Text: args.T("api.channel.leave.default.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
-	err := Global().LeaveChannel(args.ChannelId, args.UserId)
+	err := a.LeaveChannel(args.ChannelId, args.UserId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	team, err := Global().GetTeam(args.TeamId)
+	team, err := a.GetTeam(args.TeamId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_loadtest.go
+++ b/app/command_loadtest.go
@@ -85,33 +85,33 @@ func (me *LoadTestProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *LoadTestProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LoadTestProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	//This command is only available when EnableTesting is true
 	if !utils.Cfg.ServiceSettings.EnableTesting {
 		return &model.CommandResponse{}
 	}
 
 	if strings.HasPrefix(message, "setup") {
-		return me.SetupCommand(args, message)
+		return me.SetupCommand(a, args, message)
 	}
 
 	if strings.HasPrefix(message, "users") {
-		return me.UsersCommand(args, message)
+		return me.UsersCommand(a, args, message)
 	}
 
 	if strings.HasPrefix(message, "channels") {
-		return me.ChannelsCommand(args, message)
+		return me.ChannelsCommand(a, args, message)
 	}
 
 	if strings.HasPrefix(message, "posts") {
-		return me.PostsCommand(args, message)
+		return me.PostsCommand(a, args, message)
 	}
 
 	if strings.HasPrefix(message, "url") {
-		return me.UrlCommand(args, message)
+		return me.UrlCommand(a, args, message)
 	}
 	if strings.HasPrefix(message, "json") {
-		return me.JsonCommand(args, message)
+		return me.JsonCommand(a, args, message)
 	}
 	return me.HelpCommand(args, message)
 }
@@ -120,7 +120,7 @@ func (me *LoadTestProvider) HelpCommand(args *model.CommandArgs, message string)
 	return &model.CommandResponse{Text: usage, ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
-func (me *LoadTestProvider) SetupCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LoadTestProvider) SetupCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	tokens := strings.Fields(strings.TrimPrefix(message, "setup"))
 	doTeams := contains(tokens, "teams")
 	doFuzz := contains(tokens, "fuzz")
@@ -161,7 +161,7 @@ func (me *LoadTestProvider) SetupCommand(args *model.CommandArgs, message string
 	client := model.NewClient(args.SiteURL)
 
 	if doTeams {
-		if err := Global().CreateBasicUser(client); err != nil {
+		if err := a.CreateBasicUser(client); err != nil {
 			return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 		client.Login(BTEST_USER_EMAIL, BTEST_USER_PASSWORD)
@@ -184,7 +184,7 @@ func (me *LoadTestProvider) SetupCommand(args *model.CommandArgs, message string
 	} else {
 
 		var team *model.Team
-		if tr := <-Global().Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
+		if tr := <-a.Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
 			return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		} else {
 			team = tr.Data.(*model.Team)
@@ -204,7 +204,7 @@ func (me *LoadTestProvider) SetupCommand(args *model.CommandArgs, message string
 	return &model.CommandResponse{Text: "Created enviroment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
-func (me *LoadTestProvider) UsersCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LoadTestProvider) UsersCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "users"))
 
 	doFuzz := false
@@ -219,7 +219,7 @@ func (me *LoadTestProvider) UsersCommand(args *model.CommandArgs, message string
 	}
 
 	var team *model.Team
-	if tr := <-Global().Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
+	if tr := <-a.Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
 		return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
 		team = tr.Data.(*model.Team)
@@ -234,7 +234,7 @@ func (me *LoadTestProvider) UsersCommand(args *model.CommandArgs, message string
 	return &model.CommandResponse{Text: "Added users", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
-func (me *LoadTestProvider) ChannelsCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LoadTestProvider) ChannelsCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "channels"))
 
 	doFuzz := false
@@ -249,7 +249,7 @@ func (me *LoadTestProvider) ChannelsCommand(args *model.CommandArgs, message str
 	}
 
 	var team *model.Team
-	if tr := <-Global().Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
+	if tr := <-a.Srv.Store.Team().Get(args.TeamId); tr.Err != nil {
 		return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
 		team = tr.Data.(*model.Team)
@@ -265,7 +265,7 @@ func (me *LoadTestProvider) ChannelsCommand(args *model.CommandArgs, message str
 	return &model.CommandResponse{Text: "Added channels", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
-func (me *LoadTestProvider) PostsCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LoadTestProvider) PostsCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	cmd := strings.TrimSpace(strings.TrimPrefix(message, "posts"))
 
 	doFuzz := false
@@ -288,7 +288,7 @@ func (me *LoadTestProvider) PostsCommand(args *model.CommandArgs, message string
 	}
 
 	var usernames []string
-	if result := <-Global().Srv.Store.User().GetProfiles(args.TeamId, 0, 1000); result.Err == nil {
+	if result := <-a.Srv.Store.User().GetProfiles(args.TeamId, 0, 1000); result.Err == nil {
 		profileUsers := result.Data.([]*model.User)
 		usernames = make([]string, len(profileUsers))
 		i := 0
@@ -315,7 +315,7 @@ func (me *LoadTestProvider) PostsCommand(args *model.CommandArgs, message string
 	return &model.CommandResponse{Text: "Added posts", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
-func (me *LoadTestProvider) UrlCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LoadTestProvider) UrlCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	url := strings.TrimSpace(strings.TrimPrefix(message, "url"))
 	if len(url) == 0 {
 		return &model.CommandResponse{Text: "Command must contain a url", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
@@ -357,7 +357,7 @@ func (me *LoadTestProvider) UrlCommand(args *model.CommandArgs, message string) 
 		post.ChannelId = args.ChannelId
 		post.UserId = args.UserId
 
-		if _, err := Global().CreatePostMissingChannel(post, false); err != nil {
+		if _, err := a.CreatePostMissingChannel(post, false); err != nil {
 			return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 	}
@@ -365,7 +365,7 @@ func (me *LoadTestProvider) UrlCommand(args *model.CommandArgs, message string) 
 	return &model.CommandResponse{Text: "Loaded data", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
-func (me *LoadTestProvider) JsonCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LoadTestProvider) JsonCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	url := strings.TrimSpace(strings.TrimPrefix(message, "json"))
 	if len(url) == 0 {
 		return &model.CommandResponse{Text: "Command must contain a url", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
@@ -396,7 +396,7 @@ func (me *LoadTestProvider) JsonCommand(args *model.CommandArgs, message string)
 		post.Message = message
 	}
 
-	if _, err := Global().CreatePostMissingChannel(post, false); err != nil {
+	if _, err := a.CreatePostMissingChannel(post, false); err != nil {
 		return &model.CommandResponse{Text: "Unable to create post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 	return &model.CommandResponse{Text: "Loaded data", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}

--- a/app/command_logout.go
+++ b/app/command_logout.go
@@ -33,13 +33,13 @@ func (me *LogoutProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *LogoutProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *LogoutProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	FAIL := &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_logout.fail_message")}
 	SUCCESS := &model.CommandResponse{GotoLocation: "/login"}
 
 	// We can't actually remove the user's cookie from here so we just dump their session and let the browser figure it out
 	if args.Session.Id != "" {
-		if err := Global().RevokeSessionById(args.Session.Id); err != nil {
+		if err := a.RevokeSessionById(args.Session.Id); err != nil {
 			return FAIL
 		}
 		return SUCCESS

--- a/app/command_me.go
+++ b/app/command_me.go
@@ -33,6 +33,6 @@ func (me *MeProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *MeProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *MeProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL, Text: "*" + message + "*"}
 }

--- a/app/command_msg.go
+++ b/app/command_msg.go
@@ -36,7 +36,7 @@ func (me *msgProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 
 	splitMessage := strings.SplitN(message, " ", 2)
 
@@ -51,7 +51,7 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 	targetUsername = strings.TrimPrefix(targetUsername, "@")
 
 	var userProfile *model.User
-	if result := <-Global().Srv.Store.User().GetByUsername(targetUsername); result.Err != nil {
+	if result := <-a.Srv.Store.User().GetByUsername(targetUsername); result.Err != nil {
 		l4g.Error(result.Err.Error())
 		return &model.CommandResponse{Text: args.T("api.command_msg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
@@ -66,9 +66,9 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 	channelName := model.GetDMNameFromIds(args.UserId, userProfile.Id)
 
 	targetChannelId := ""
-	if channel := <-Global().Srv.Store.Channel().GetByName(args.TeamId, channelName, true); channel.Err != nil {
+	if channel := <-a.Srv.Store.Channel().GetByName(args.TeamId, channelName, true); channel.Err != nil {
 		if channel.Err.Id == "store.sql_channel.get_by_name.missing.app_error" {
-			if directChannel, err := Global().CreateDirectChannel(args.UserId, userProfile.Id); err != nil {
+			if directChannel, err := a.CreateDirectChannel(args.UserId, userProfile.Id); err != nil {
 				l4g.Error(err.Error())
 				return &model.CommandResponse{Text: args.T("api.command_msg.dm_fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			} else {
@@ -89,7 +89,7 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 		post.Message = parsedMessage
 		post.ChannelId = targetChannelId
 		post.UserId = args.UserId
-		if _, err := Global().CreatePostMissingChannel(post, true); err != nil {
+		if _, err := a.CreatePostMissingChannel(post, true); err != nil {
 			return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 	}
@@ -101,7 +101,7 @@ func (me *msgProvider) DoCommand(args *model.CommandArgs, message string) *model
 		teamId = args.Session.TeamMembers[0].TeamId
 	}
 
-	team, err := Global().GetTeam(teamId)
+	team, err := a.GetTeam(teamId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/app/command_offline.go
+++ b/app/command_offline.go
@@ -32,8 +32,8 @@ func (me *OfflineProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *OfflineProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	Global().SetStatusOffline(args.UserId, true)
+func (me *OfflineProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	a.SetStatusOffline(args.UserId, true)
 
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_offline.success")}
 }

--- a/app/command_online.go
+++ b/app/command_online.go
@@ -32,8 +32,8 @@ func (me *OnlineProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *OnlineProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
-	Global().SetStatusOnline(args.UserId, args.Session.Id, true)
+func (me *OnlineProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
+	a.SetStatusOnline(args.UserId, args.Session.Id, true)
 
 	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_online.success")}
 }

--- a/app/command_search.go
+++ b/app/command_search.go
@@ -33,7 +33,7 @@ func (search *SearchProvider) GetCommand(T goi18n.TranslateFunc) *model.Command 
 	}
 }
 
-func (search *SearchProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (search *SearchProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_search.unsupported.app_error"),

--- a/app/command_settings.go
+++ b/app/command_settings.go
@@ -33,7 +33,7 @@ func (settings *SettingsProvider) GetCommand(T goi18n.TranslateFunc) *model.Comm
 	}
 }
 
-func (settings *SettingsProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (settings *SettingsProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_settings.unsupported.app_error"),

--- a/app/command_shortcuts.go
+++ b/app/command_shortcuts.go
@@ -33,7 +33,7 @@ func (me *ShortcutsProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *ShortcutsProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *ShortcutsProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
 		Text:         args.T("api.command_shortcuts.unsupported.app_error"),

--- a/app/command_shrug.go
+++ b/app/command_shrug.go
@@ -33,7 +33,7 @@ func (me *ShrugProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 	}
 }
 
-func (me *ShrugProvider) DoCommand(args *model.CommandArgs, message string) *model.CommandResponse {
+func (me *ShrugProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	rmsg := `¯\\\_(ツ)\_/¯`
 	if len(message) > 0 {
 		rmsg = message + " " + rmsg

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -128,8 +128,8 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 
 	var user, user2 *model.User
 	var gitlabUserObj oauthgitlab.GitLabUser
-	user, gitlabUserObj = createGitlabUser(t, username, email)
-	user2, _ = createGitlabUser(t, username2, email2)
+	user, gitlabUserObj = createGitlabUser(t, th.App, username, email)
+	user2, _ = createGitlabUser(t, th.App, username2, email2)
 
 	t.Run("UpdateUsername", func(t *testing.T) {
 		t.Run("NoExistingUserWithSameUsername", func(t *testing.T) {
@@ -137,9 +137,9 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 			gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
 			data := bytes.NewReader(gitlabUser)
 
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 			th.App.UpdateOAuthUserAttrs(data, user, gitlabProvider, "gitlab")
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 
 			if user.Username != gitlabUserObj.Username {
 				t.Fatal("user's username is not updated")
@@ -152,9 +152,9 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 			gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
 			data := bytes.NewReader(gitlabUser)
 
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 			th.App.UpdateOAuthUserAttrs(data, user, gitlabProvider, "gitlab")
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 
 			if user.Username == gitlabUserObj.Username {
 				t.Fatal("user's username is updated though there already exists another user with the same username")
@@ -168,9 +168,9 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 			gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
 			data := bytes.NewReader(gitlabUser)
 
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 			th.App.UpdateOAuthUserAttrs(data, user, gitlabProvider, "gitlab")
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 
 			if user.Email != gitlabUserObj.Email {
 				t.Fatal("user's email is not updated")
@@ -187,9 +187,9 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 			gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
 			data := bytes.NewReader(gitlabUser)
 
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 			th.App.UpdateOAuthUserAttrs(data, user, gitlabProvider, "gitlab")
-			user = getUserFromDB(user.Id, t)
+			user = getUserFromDB(th.App, user.Id, t)
 
 			if user.Email == gitlabUserObj.Email {
 				t.Fatal("user's email is updated though there already exists another user with the same email")
@@ -202,9 +202,9 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 		gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
 		data := bytes.NewReader(gitlabUser)
 
-		user = getUserFromDB(user.Id, t)
+		user = getUserFromDB(th.App, user.Id, t)
 		th.App.UpdateOAuthUserAttrs(data, user, gitlabProvider, "gitlab")
-		user = getUserFromDB(user.Id, t)
+		user = getUserFromDB(th.App, user.Id, t)
 
 		if user.FirstName != "Updated" {
 			t.Fatal("user's first name is not updated")
@@ -216,9 +216,9 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 		gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
 		data := bytes.NewReader(gitlabUser)
 
-		user = getUserFromDB(user.Id, t)
+		user = getUserFromDB(th.App, user.Id, t)
 		th.App.UpdateOAuthUserAttrs(data, user, gitlabProvider, "gitlab")
-		user = getUserFromDB(user.Id, t)
+		user = getUserFromDB(th.App, user.Id, t)
 
 		if user.LastName != "Lastname" {
 			t.Fatal("user's last name is not updated")
@@ -226,8 +226,7 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 	})
 }
 
-func getUserFromDB(id string, t *testing.T) *model.User {
-	a := Global()
+func getUserFromDB(a *App, id string, t *testing.T) *model.User {
 	if user, err := a.GetUser(id); err != nil {
 		t.Fatal("user is not found")
 		return nil
@@ -246,8 +245,7 @@ func getGitlabUserPayload(gitlabUser oauthgitlab.GitLabUser, t *testing.T) []byt
 	return payload
 }
 
-func createGitlabUser(t *testing.T, email string, username string) (*model.User, oauthgitlab.GitLabUser) {
-	a := Global()
+func createGitlabUser(t *testing.T, a *App, email string, username string) (*model.User, oauthgitlab.GitLabUser) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	gitlabUserObj := oauthgitlab.GitLabUser{Id: int64(r.Intn(1000)) + 1, Username: username, Login: "user1", Email: email, Name: "Test User"}
 	gitlabUser := getGitlabUserPayload(gitlabUserObj, t)

--- a/store/layered_store.go
+++ b/store/layered_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -26,8 +27,8 @@ type LayeredStore struct {
 func NewLayeredStore() Store {
 	store := &LayeredStore{
 		TmpContext:      context.TODO(),
-		DatabaseLayer:   NewSqlSupplier(),
-		LocalCacheLayer: NewLocalCacheSupplier(),
+		DatabaseLayer:   NewSqlSupplier(einterfaces.GetMetricsInterface()),
+		LocalCacheLayer: NewLocalCacheSupplier(einterfaces.GetMetricsInterface(), einterfaces.GetClusterInterface()),
 	}
 
 	store.ReactionStore = &LayeredReactionStore{store}

--- a/store/local_cache_supplier_reactions.go
+++ b/store/local_cache_supplier_reactions.go
@@ -18,23 +18,23 @@ func (s *LocalCacheSupplier) handleClusterInvalidateReaction(msg *model.ClusterM
 }
 
 func (s *LocalCacheSupplier) ReactionSave(ctx context.Context, reaction *model.Reaction, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
-	doInvalidateCacheCluster(s.reactionCache, reaction.PostId)
+	s.doInvalidateCacheCluster(s.reactionCache, reaction.PostId)
 	return s.Next().ReactionSave(ctx, reaction, hints...)
 }
 
 func (s *LocalCacheSupplier) ReactionDelete(ctx context.Context, reaction *model.Reaction, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
-	doInvalidateCacheCluster(s.reactionCache, reaction.PostId)
+	s.doInvalidateCacheCluster(s.reactionCache, reaction.PostId)
 	return s.Next().ReactionDelete(ctx, reaction, hints...)
 }
 
 func (s *LocalCacheSupplier) ReactionGetForPost(ctx context.Context, postId string, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
-	if result := doStandardReadCache(ctx, s.reactionCache, postId, hints...); result != nil {
+	if result := s.doStandardReadCache(ctx, s.reactionCache, postId, hints...); result != nil {
 		return result
 	}
 
 	result := s.Next().ReactionGetForPost(ctx, postId, hints...)
 
-	doStandardAddToCache(ctx, s.reactionCache, postId, result, hints...)
+	s.doStandardAddToCache(ctx, s.reactionCache, postId, result, hints...)
 
 	return result
 }
@@ -42,6 +42,6 @@ func (s *LocalCacheSupplier) ReactionGetForPost(ctx context.Context, postId stri
 func (s *LocalCacheSupplier) ReactionDeleteAllWithEmojiName(ctx context.Context, emojiName string, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
 	// This could be improved. Right now we just clear the whole
 	// cache because we don't have a way find what post Ids have this emoji name.
-	doClearCacheCluster(s.reactionCache)
+	s.doClearCacheCluster(s.reactionCache)
 	return s.Next().ReactionDeleteAllWithEmojiName(ctx, emojiName, hints...)
 }

--- a/store/sql_supplier.go
+++ b/store/sql_supplier.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/lib/pq"
 	"github.com/mattermost/gorp"
+	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -96,7 +97,7 @@ type SqlSupplier struct {
 	oldStores      SqlSupplierOldStores
 }
 
-func NewSqlSupplier() *SqlSupplier {
+func NewSqlSupplier(metrics einterfaces.MetricsInterface) *SqlSupplier {
 	supplier := &SqlSupplier{
 		rrCounter: 0,
 		srCounter: 0,
@@ -105,24 +106,24 @@ func NewSqlSupplier() *SqlSupplier {
 	supplier.initConnection()
 
 	supplier.oldStores.team = NewSqlTeamStore(supplier)
-	supplier.oldStores.channel = NewSqlChannelStore(supplier)
-	supplier.oldStores.post = NewSqlPostStore(supplier)
-	supplier.oldStores.user = NewSqlUserStore(supplier)
+	supplier.oldStores.channel = NewSqlChannelStore(supplier, metrics)
+	supplier.oldStores.post = NewSqlPostStore(supplier, metrics)
+	supplier.oldStores.user = NewSqlUserStore(supplier, metrics)
 	supplier.oldStores.audit = NewSqlAuditStore(supplier)
 	supplier.oldStores.cluster = NewSqlClusterDiscoveryStore(supplier)
 	supplier.oldStores.compliance = NewSqlComplianceStore(supplier)
 	supplier.oldStores.session = NewSqlSessionStore(supplier)
 	supplier.oldStores.oauth = NewSqlOAuthStore(supplier)
 	supplier.oldStores.system = NewSqlSystemStore(supplier)
-	supplier.oldStores.webhook = NewSqlWebhookStore(supplier)
+	supplier.oldStores.webhook = NewSqlWebhookStore(supplier, metrics)
 	supplier.oldStores.command = NewSqlCommandStore(supplier)
 	supplier.oldStores.commandWebhook = NewSqlCommandWebhookStore(supplier)
 	supplier.oldStores.preference = NewSqlPreferenceStore(supplier)
 	supplier.oldStores.license = NewSqlLicenseStore(supplier)
 	supplier.oldStores.token = NewSqlTokenStore(supplier)
-	supplier.oldStores.emoji = NewSqlEmojiStore(supplier)
+	supplier.oldStores.emoji = NewSqlEmojiStore(supplier, metrics)
 	supplier.oldStores.status = NewSqlStatusStore(supplier)
-	supplier.oldStores.fileInfo = NewSqlFileInfoStore(supplier)
+	supplier.oldStores.fileInfo = NewSqlFileInfoStore(supplier, metrics)
 	supplier.oldStores.job = NewSqlJobStore(supplier)
 	supplier.oldStores.userAccessToken = NewSqlUserAccessTokenStore(supplier)
 


### PR DESCRIPTION
#### Summary
This propagates an `app.App` through slash commands, an `einterfaces.MetricsInterface` through SQL stores, and a few other smaller things.