### PR TITLE
PLT-7622 Improvements to server handling of webapp plugins

### DIFF
--- a/api4/plugin.go
+++ b/api4/plugin.go
@@ -135,8 +135,8 @@ func getWebappPlugins(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	clientManifests := []*model.Manifest{}
 	for _, m := range manifests {
-		if m.IsClient() {
-			clientManifests = append(clientManifests, m.GetSanitizedForClient())
+		if m.HasClient() {
+			clientManifests = append(clientManifests, m.ClientManifest())
 		}
 	}
 

--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -17,14 +17,11 @@ import (
 func TestPlugin(t *testing.T) {
 	pluginDir, err := ioutil.TempDir("", "mm-plugin-test")
 	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(pluginDir)
-	}()
+	defer os.RemoveAll(pluginDir)
+
 	webappDir, err := ioutil.TempDir("", "mm-webapp-test")
 	require.NoError(t, err)
-	defer func() {
-		os.RemoveAll(webappDir)
-	}()
+	defer os.RemoveAll(webappDir)
 
 	th := SetupEnterprise().InitBasic().InitSystemAdmin()
 	defer TearDown()
@@ -50,9 +47,7 @@ func TestPlugin(t *testing.T) {
 
 	// Successful upload
 	manifest, resp := th.SystemAdminClient.UploadPlugin(file)
-	defer func() {
-		os.RemoveAll("plugins/testplugin")
-	}()
+	defer os.RemoveAll("plugins/testplugin")
 	CheckNoError(t, resp)
 
 	assert.Equal(t, "testplugin", manifest.Id)
@@ -90,6 +85,19 @@ func TestPlugin(t *testing.T) {
 	*utils.Cfg.PluginSettings.Enable = true
 	_, resp = th.Client.GetPlugins()
 	CheckForbiddenStatus(t, resp)
+
+	// Successful webapp get
+	manifests, resp = th.Client.GetWebappPlugins()
+	CheckNoError(t, resp)
+
+	found = false
+	for _, m := range manifests {
+		if m.Id == manifest.Id {
+			found = true
+		}
+	}
+
+	assert.True(t, found)
 
 	// Successful remove
 	ok, resp := th.SystemAdminClient.RemovePlugin(manifest.Id)

--- a/api4/system.go
+++ b/api4/system.go
@@ -244,7 +244,6 @@ func getClientConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	respCfg["NoAccounts"] = strconv.FormatBool(c.App.IsFirstUserAccount())
-	respCfg["Plugins"] = c.App.GetPluginsForClientConfig()
 
 	w.Write([]byte(model.MapToJson(respCfg)))
 }

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -332,7 +332,8 @@ func (a *App) InitPlugins(pluginPath, webappPath string) {
 
 	a.PluginEnv, err = pluginenv.New(
 		pluginenv.SearchPath(pluginPath),
-		pluginenv.WebappPath(webappPath), pluginenv.APIProvider(func(m *model.Manifest) (plugin.API, error) {
+		pluginenv.WebappPath(webappPath),
+		pluginenv.APIProvider(func(m *model.Manifest) (plugin.API, error) {
 			return &PluginAPI{
 				id:  m.Id,
 				app: a,

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -252,9 +252,9 @@ func (a *App) UnpackAndActivatePlugin(pluginFile io.Reader) (*model.Manifest, *m
 		return nil, model.NewAppError("UnpackAndActivatePlugin", "app.plugin.activate.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
-	if manifest.IsClient() {
+	if manifest.HasClient() {
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_PLUGIN_ACTIVATED, "", "", "", nil)
-		message.Add("manifest", manifest.GetSanitizedForClient())
+		message.Add("manifest", manifest.ClientManifest())
 		Publish(message)
 	}
 
@@ -300,9 +300,9 @@ func (a *App) RemovePlugin(id string) *model.AppError {
 		return model.NewAppError("RemovePlugin", "app.plugin.remove.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
-	if manifest.IsClient() {
+	if manifest.HasClient() {
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_PLUGIN_DEACTIVATED, "", "", "", nil)
-		message.Add("manifest", manifest.GetSanitizedForClient())
+		message.Add("manifest", manifest.ClientManifest())
 		Publish(message)
 	}
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -3088,3 +3088,14 @@ func (c *Client4) RemovePlugin(id string) (bool, *Response) {
 		return CheckStatusOK(r), BuildResponse(r)
 	}
 }
+
+// GetWebappPlugins will return a list of plugins that the webapp should download.
+// WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
+func (c *Client4) GetWebappPlugins() ([]*Manifest, *Response) {
+	if r, err := c.DoApiGet(c.GetPluginsRoute()+"/webapp", ""); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return ManifestListFromJson(r.Body), BuildResponse(r)
+	}
+}

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -67,11 +67,11 @@ func ManifestListFromJson(data io.Reader) []*Manifest {
 	}
 }
 
-func (m *Manifest) IsClient() bool {
+func (m *Manifest) HasClient() bool {
 	return m.Webapp != nil
 }
 
-func (m *Manifest) GetSanitizedForClient() *Manifest {
+func (m *Manifest) ClientManifest() *Manifest {
 	cm := new(Manifest)
 	*cm = *m
 	cm.Name = ""

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -12,8 +12,9 @@ import (
 
 type Manifest struct {
 	Id          string           `json:"id" yaml:"id"`
-	Name        string           `json:"name" yaml:"name"`
-	Description string           `json:"description" yaml:"description"`
+	Name        string           `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Version     string           `json:"version" yaml:"version"`
 	Backend     *ManifestBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
 	Webapp      *ManifestWebapp  `json:"webapp,omitempty" yaml:"webapp,omitempty"`
 }
@@ -64,6 +65,19 @@ func ManifestListFromJson(data io.Reader) []*Manifest {
 	} else {
 		return nil
 	}
+}
+
+func (m *Manifest) IsClient() bool {
+	return m.Webapp != nil
+}
+
+func (m *Manifest) GetSanitizedForClient() *Manifest {
+	cm := new(Manifest)
+	*cm = *m
+	cm.Name = ""
+	cm.Description = ""
+	cm.Backend = nil
+	return cm
 }
 
 // FindManifest will find and parse the manifest in a given directory.

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -129,3 +129,51 @@ func TestManifestJson(t *testing.T) {
 	assert.Equal(t, newManifestList, manifestList)
 	assert.Equal(t, ManifestListToJson(newManifestList), json)
 }
+
+func TestManifestIsClient(t *testing.T) {
+	manifest := &Manifest{
+		Id: "theid",
+		Backend: &ManifestBackend{
+			Executable: "theexecutable",
+		},
+		Webapp: &ManifestWebapp{
+			BundlePath: "thebundlepath",
+		},
+	}
+
+	assert.True(t, manifest.IsClient())
+
+	manifest.Webapp = nil
+	assert.False(t, manifest.IsClient())
+}
+
+func TestManifestGetSanitizedForClient(t *testing.T) {
+	manifest := &Manifest{
+		Id:          "theid",
+		Name:        "thename",
+		Description: "thedescription",
+		Version:     "0.0.1",
+		Backend: &ManifestBackend{
+			Executable: "theexecutable",
+		},
+		Webapp: &ManifestWebapp{
+			BundlePath: "thebundlepath",
+		},
+	}
+
+	sanitized := manifest.GetSanitizedForClient()
+
+	assert.NotEmpty(t, sanitized.Id)
+	assert.NotEmpty(t, sanitized.Version)
+	assert.NotEmpty(t, sanitized.Webapp)
+	assert.Empty(t, sanitized.Name)
+	assert.Empty(t, sanitized.Description)
+	assert.Empty(t, sanitized.Backend)
+
+	assert.NotEmpty(t, manifest.Id)
+	assert.NotEmpty(t, manifest.Version)
+	assert.NotEmpty(t, manifest.Webapp)
+	assert.NotEmpty(t, manifest.Name)
+	assert.NotEmpty(t, manifest.Description)
+	assert.NotEmpty(t, manifest.Backend)
+}

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -130,7 +130,7 @@ func TestManifestJson(t *testing.T) {
 	assert.Equal(t, ManifestListToJson(newManifestList), json)
 }
 
-func TestManifestIsClient(t *testing.T) {
+func TestManifestHasClient(t *testing.T) {
 	manifest := &Manifest{
 		Id: "theid",
 		Backend: &ManifestBackend{
@@ -141,13 +141,13 @@ func TestManifestIsClient(t *testing.T) {
 		},
 	}
 
-	assert.True(t, manifest.IsClient())
+	assert.True(t, manifest.HasClient())
 
 	manifest.Webapp = nil
-	assert.False(t, manifest.IsClient())
+	assert.False(t, manifest.HasClient())
 }
 
-func TestManifestGetSanitizedForClient(t *testing.T) {
+func TestManifestClientManifest(t *testing.T) {
 	manifest := &Manifest{
 		Id:          "theid",
 		Name:        "thename",
@@ -161,7 +161,7 @@ func TestManifestGetSanitizedForClient(t *testing.T) {
 		},
 	}
 
-	sanitized := manifest.GetSanitizedForClient()
+	sanitized := manifest.ClientManifest()
 
 	assert.NotEmpty(t, sanitized.Id)
 	assert.NotEmpty(t, sanitized.Version)

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -39,6 +39,8 @@ const (
 	WEBSOCKET_EVENT_RESPONSE            = "response"
 	WEBSOCKET_EVENT_EMOJI_ADDED         = "emoji_added"
 	WEBSOCKET_EVENT_CHANNEL_VIEWED      = "channel_viewed"
+	WEBSOCKET_EVENT_PLUGIN_ACTIVATED    = "plugin_activated"   // EXPERIMENTAL - SUBJECT TO CHANGE
+	WEBSOCKET_EVENT_PLUGIN_DEACTIVATED  = "plugin_deactivated" // EXPERIMENTAL - SUBJECT TO CHANGE
 )
 
 type WebSocketMessage interface {

--- a/plugin/pluginenv/environment.go
+++ b/plugin/pluginenv/environment.go
@@ -66,7 +66,7 @@ func (env *Environment) Plugins() ([]*model.BundleInfo, error) {
 }
 
 // Returns a list of all currently active plugins within the environment.
-func (env *Environment) ActivePlugins() ([]*model.BundleInfo, error) {
+func (env *Environment) ActivePlugins() []*model.BundleInfo {
 	env.mutex.RLock()
 	defer env.mutex.RUnlock()
 
@@ -75,7 +75,7 @@ func (env *Environment) ActivePlugins() ([]*model.BundleInfo, error) {
 		activePlugins = append(activePlugins, p.BundleInfo)
 	}
 
-	return activePlugins, nil
+	return activePlugins
 }
 
 // Returns the ids of the currently active plugins.

--- a/plugin/pluginenv/environment_test.go
+++ b/plugin/pluginenv/environment_test.go
@@ -127,8 +127,7 @@ func TestEnvironment(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, plugins, 3)
 
-	activePlugins, err := env.ActivePlugins()
-	assert.NoError(t, err)
+	activePlugins := env.ActivePlugins()
 	assert.Len(t, activePlugins, 0)
 
 	assert.Error(t, env.ActivatePlugin("x"))
@@ -150,8 +149,7 @@ func TestEnvironment(t *testing.T) {
 
 	assert.NoError(t, env.ActivatePlugin("foo"))
 	assert.Equal(t, env.ActivePluginIds(), []string{"foo"})
-	activePlugins, err = env.ActivePlugins()
-	assert.NoError(t, err)
+	activePlugins = env.ActivePlugins()
 	assert.Len(t, activePlugins, 1)
 	assert.Error(t, env.ActivatePlugin("foo"))
 


### PR DESCRIPTION
#### Summary
* Add new REST API endpoint for getting sanitized versions of webapp plugins to download
* Removed temporary code loading plugin manifest into client config
* Fix webapp plugin directory based on repo split and move webapp plugins into their own directory
* Add own HTTP handler for plugin js bundles, in developer mode disable caching of plugin js bundles
* Fix setting of EnableDeveloper to true for dev builds
* Add websocket events for plugin activation/deactivation

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7622