### PR TITLE
[PLT-7475] Set S3 region when empty

### DIFF
--- a/api/file_test.go
+++ b/api/file_test.go
@@ -875,12 +875,12 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 
 func cleanupTestFile(info *model.FileInfo) error {
 	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		region := utils.Cfg.FileSettings.AmazonS3Region
+		region := *utils.Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return err

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -690,12 +690,12 @@ func TestUserCreateImage(t *testing.T) {
 	}
 
 	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		region := utils.Cfg.FileSettings.AmazonS3Region
+		region := *utils.Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			t.Fatal(err)
@@ -796,12 +796,12 @@ func TestUserUploadProfileImage(t *testing.T) {
 		Client.DoApiGet("/users/"+user.Id+"/image", "", "")
 
 		if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-			endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+			endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 			accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 			secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 			secure := *utils.Cfg.FileSettings.AmazonS3SSL
 			signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-			region := utils.Cfg.FileSettings.AmazonS3Region
+			region := *utils.Cfg.FileSettings.AmazonS3Region
 			s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 			if err != nil {
 				t.Fatal(err)

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -637,12 +637,12 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 
 func cleanupTestFile(info *model.FileInfo) error {
 	if *utils.Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := utils.Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *utils.Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := utils.Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := utils.Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *utils.Cfg.FileSettings.AmazonS3SSL
 		signV2 := *utils.Cfg.FileSettings.AmazonS3SignV2
-		region := utils.Cfg.FileSettings.AmazonS3Region
+		region := *utils.Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return err

--- a/app/admin.go
+++ b/app/admin.go
@@ -155,7 +155,7 @@ func SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool) *model.A
 	}
 
 	if *cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		if len(*cfg.FileSettings.AmazonS3Region) == 0 || *cfg.FileSettings.AmazonS3Region == "" {
+		if *cfg.FileSettings.AmazonS3Region == "" {
 			region, err := utils.GetAmazonS3Region(cfg)
 			if err != nil {
 				return err

--- a/app/admin.go
+++ b/app/admin.go
@@ -154,6 +154,18 @@ func SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool) *model.A
 		return err
 	}
 
+	if *cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+		if len(*cfg.FileSettings.AmazonS3Region) == 0 || *cfg.FileSettings.AmazonS3Region == "" {
+			region, err := utils.GetAmazonS3Region(cfg)
+			if err != nil {
+				return err
+			}
+
+			*cfg.FileSettings.AmazonS3Region = region
+			l4g.Warn(utils.T("utils.config.set_amazon_region"), region)
+		}
+	}
+
 	if *utils.Cfg.ClusterSettings.Enable && *utils.Cfg.ClusterSettings.ReadOnlyConfig {
 		return model.NewAppError("saveConfig", "ent.cluster.save_config.error", nil, "", http.StatusForbidden)
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6480,6 +6480,10 @@
     "translation": "Unable to load mattermost configuration file:  Adding DefaultClientLocale to AvailableLocales."
   },
   {
+    "id": "utils.config.bad_connection_to_s3_or_minio.app_error",
+    "translation": "Bad connection to S3 or Minio cloud storage. Please try again."
+  },
+  {
     "id": "utils.config.load_config.decoding.panic",
     "translation": "Error decoding config file={{.Filename}}, err={{.Error}}"
   },
@@ -6498,6 +6502,10 @@
   {
     "id": "utils.config.save_config.saving.app_error",
     "translation": "An error occurred while saving the file to {{.Filename}}"
+  },
+  {
+    "id": "utils.config.set_amazon_region",
+    "translation": "Set Amazon S3 Region to '%v'."
   },
   {
     "id": "utils.config.supported_available_locales.app_error",

--- a/model/config.go
+++ b/model/config.go
@@ -88,6 +88,9 @@ const (
 
 	SQL_SETTINGS_DEFAULT_DATA_SOURCE = "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
 
+	FILE_SETTINGS_DEFAULT_AMAZON_S3_ENDPOINT = "s3.amazonaws.com"
+	FILE_SETTINGS_DEFAULT_AMAZON_S3_REGION   = "us-east-1"
+
 	EMAIL_SETTINGS_DEFAULT_FEEDBACK_ORGANIZATION = ""
 
 	SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK      = "https://about.mattermost.com/default-terms/"
@@ -269,8 +272,8 @@ type FileSettings struct {
 	AmazonS3AccessKeyId     string
 	AmazonS3SecretAccessKey string
 	AmazonS3Bucket          string
-	AmazonS3Region          string
-	AmazonS3Endpoint        string
+	AmazonS3Region          *string
+	AmazonS3Endpoint        *string
 	AmazonS3SSL             *bool
 	AmazonS3SignV2          *bool
 	AmazonS3SSE             *bool
@@ -598,9 +601,14 @@ func (o *Config) SetDefaults() {
 		*o.FileSettings.DriverName = IMAGE_DRIVER_LOCAL
 	}
 
-	if o.FileSettings.AmazonS3Endpoint == "" {
-		// Defaults to "s3.amazonaws.com"
-		o.FileSettings.AmazonS3Endpoint = "s3.amazonaws.com"
+	if o.FileSettings.AmazonS3Region == nil {
+		o.FileSettings.AmazonS3Region = new(string)
+		*o.FileSettings.AmazonS3Region = FILE_SETTINGS_DEFAULT_AMAZON_S3_REGION
+	}
+
+	if o.FileSettings.AmazonS3Endpoint == nil {
+		o.FileSettings.AmazonS3Endpoint = new(string)
+		*o.FileSettings.AmazonS3Endpoint = FILE_SETTINGS_DEFAULT_AMAZON_S3_ENDPOINT
 	}
 
 	if o.FileSettings.AmazonS3SSL == nil {

--- a/utils/file.go
+++ b/utils/file.go
@@ -48,12 +48,12 @@ func s3New(endpoint, accessKey, secretKey string, secure bool, signV2 bool, regi
 
 func TestFileConnection() *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 		bucket := Cfg.FileSettings.AmazonS3Bucket
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
@@ -91,12 +91,12 @@ func TestFileConnection() *model.AppError {
 
 func ReadFile(path string) ([]byte, *model.AppError) {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
 			return nil, model.NewLocAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error())
@@ -125,12 +125,12 @@ func ReadFile(path string) ([]byte, *model.AppError) {
 
 func MoveFile(oldPath, newPath string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 		encrypt := false
 		if *Cfg.FileSettings.AmazonS3SSE && IsLicensed() && *License().Features.Compliance {
 			encrypt = true
@@ -169,12 +169,12 @@ func MoveFile(oldPath, newPath string) *model.AppError {
 
 func WriteFile(f []byte, path string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 		encrypt := false
 		if *Cfg.FileSettings.AmazonS3SSE && IsLicensed() && *License().Features.Compliance {
 			encrypt = true
@@ -222,12 +222,12 @@ func writeFileLocally(f []byte, path string) *model.AppError {
 
 func RemoveFile(path string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
@@ -271,12 +271,12 @@ func getPathsFromObjectInfos(in <-chan s3.ObjectInfo) <-chan string {
 
 func RemoveDirectory(path string) *model.AppError {
 	if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
-		endpoint := Cfg.FileSettings.AmazonS3Endpoint
+		endpoint := *Cfg.FileSettings.AmazonS3Endpoint
 		accessKey := Cfg.FileSettings.AmazonS3AccessKeyId
 		secretKey := Cfg.FileSettings.AmazonS3SecretAccessKey
 		secure := *Cfg.FileSettings.AmazonS3SSL
 		signV2 := *Cfg.FileSettings.AmazonS3SignV2
-		region := Cfg.FileSettings.AmazonS3Region
+		region := *Cfg.FileSettings.AmazonS3Region
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {


### PR DESCRIPTION
Please make sure you've read the [pull request](http://docs.mattermost.com/developer/contribution-guide.html#preparing-a-pull-request) section of our [code contribution guidelines](http://docs.mattermost.com/developer/contribution-guide.html).
#### Summary
Set S3 region when empty, by:
- getting GetBucketLocation; or
- setting to default when not found.

Also, set S3 endpoint and region to default values whenever such are not included/defined in config.json.

#### Ticket Link
Jira ticket: [PLT-7475](https://mattermost.atlassian.net/browse/PLT-7475)

#### Checklist
- [x] Has UI changes (https://github.com/mattermost/mattermost-webapp/pull/40)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/platform/blob/master/i18n/en.json) and [.../webapp/i18n/en.json](https://github.com/mattermost/platform/tree/master/webapp/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (s3 storage)
