### PR TITLE
Add status codes to remaining errors in model package

### DIFF
--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -49,7 +49,7 @@ func TestCreateCommand(t *testing.T) {
 	newCmd.Method = "Wrong"
 	newCmd.Trigger = "testcommand"
 	_, resp = th.SystemAdminClient.CreateCommand(newCmd)
-	CheckInternalErrorStatus(t, resp)
+	CheckBadRequestStatus(t, resp)
 	CheckErrorMessage(t, resp, "model.command.is_valid.method.app_error")
 
 	*utils.Cfg.ServiceSettings.EnableCommands = false

--- a/model/access.go
+++ b/model/access.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 )
 
 const (
@@ -37,23 +38,23 @@ type AccessResponse struct {
 func (ad *AccessData) IsValid() *AppError {
 
 	if len(ad.ClientId) == 0 || len(ad.ClientId) > 26 {
-		return NewLocAppError("AccessData.IsValid", "model.access.is_valid.client_id.app_error", nil, "")
+		return NewAppError("AccessData.IsValid", "model.access.is_valid.client_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(ad.UserId) == 0 || len(ad.UserId) > 26 {
-		return NewLocAppError("AccessData.IsValid", "model.access.is_valid.user_id.app_error", nil, "")
+		return NewAppError("AccessData.IsValid", "model.access.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(ad.Token) != 26 {
-		return NewLocAppError("AccessData.IsValid", "model.access.is_valid.access_token.app_error", nil, "")
+		return NewAppError("AccessData.IsValid", "model.access.is_valid.access_token.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(ad.RefreshToken) > 26 {
-		return NewLocAppError("AccessData.IsValid", "model.access.is_valid.refresh_token.app_error", nil, "")
+		return NewAppError("AccessData.IsValid", "model.access.is_valid.refresh_token.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(ad.RedirectUri) == 0 || len(ad.RedirectUri) > 256 || !IsValidHttpUrl(ad.RedirectUri) {
-		return NewLocAppError("AccessData.IsValid", "model.access.is_valid.redirect_uri.app_error", nil, "")
+		return NewAppError("AccessData.IsValid", "model.access.is_valid.redirect_uri.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/authorize.go
+++ b/model/authorize.go
@@ -39,35 +39,35 @@ type AuthorizeRequest struct {
 func (ad *AuthData) IsValid() *AppError {
 
 	if len(ad.ClientId) != 26 {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.client_id.app_error", nil, "")
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.client_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(ad.UserId) != 26 {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.user_id.app_error", nil, "")
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(ad.Code) == 0 || len(ad.Code) > 128 {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.auth_code.app_error", nil, "client_id="+ad.ClientId)
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.auth_code.app_error", nil, "client_id="+ad.ClientId, http.StatusBadRequest)
 	}
 
 	if ad.ExpiresIn == 0 {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.expires.app_error", nil, "")
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.expires.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if ad.CreateAt <= 0 {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.create_at.app_error", nil, "client_id="+ad.ClientId)
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.create_at.app_error", nil, "client_id="+ad.ClientId, http.StatusBadRequest)
 	}
 
 	if len(ad.RedirectUri) == 0 || len(ad.RedirectUri) > 256 || !IsValidHttpUrl(ad.RedirectUri) {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.redirect_uri.app_error", nil, "client_id="+ad.ClientId)
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.redirect_uri.app_error", nil, "client_id="+ad.ClientId, http.StatusBadRequest)
 	}
 
 	if len(ad.State) > 128 {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.state.app_error", nil, "client_id="+ad.ClientId)
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.state.app_error", nil, "client_id="+ad.ClientId, http.StatusBadRequest)
 	}
 
 	if len(ad.Scope) > 128 {
-		return NewLocAppError("AuthData.IsValid", "model.authorize.is_valid.scope.app_error", nil, "client_id="+ad.ClientId)
+		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.scope.app_error", nil, "client_id="+ad.ClientId, http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/channel.go
+++ b/model/channel.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"net/http"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -110,39 +111,39 @@ func (o *Channel) StatsEtag() string {
 func (o *Channel) IsValid() *AppError {
 
 	if len(o.Id) != 26 {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.id.app_error", nil, "")
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if o.CreateAt == 0 {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.create_at.app_error", nil, "id="+o.Id)
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.create_at.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if o.UpdateAt == 0 {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.update_at.app_error", nil, "id="+o.Id)
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.update_at.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(o.DisplayName) > CHANNEL_DISPLAY_NAME_MAX_RUNES {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.display_name.app_error", nil, "id="+o.Id)
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.display_name.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if !IsValidChannelIdentifier(o.Name) {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.2_or_more.app_error", nil, "id="+o.Id)
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.2_or_more.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if !(o.Type == CHANNEL_OPEN || o.Type == CHANNEL_PRIVATE || o.Type == CHANNEL_DIRECT || o.Type == CHANNEL_GROUP) {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.type.app_error", nil, "id="+o.Id)
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.type.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(o.Header) > CHANNEL_HEADER_MAX_RUNES {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.header.app_error", nil, "id="+o.Id)
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.header.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(o.Purpose) > CHANNEL_PURPOSE_MAX_RUNES {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.purpose.app_error", nil, "id="+o.Id)
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.purpose.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if len(o.CreatorId) > 26 {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.creator_id.app_error", nil, "")
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.creator_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -101,36 +102,32 @@ func ChannelMemberFromJson(data io.Reader) *ChannelMember {
 func (o *ChannelMember) IsValid() *AppError {
 
 	if len(o.ChannelId) != 26 {
-		return NewLocAppError("ChannelMember.IsValid", "model.channel_member.is_valid.channel_id.app_error", nil, "")
+		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.channel_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.UserId) != 26 {
-		return NewLocAppError("ChannelMember.IsValid", "model.channel_member.is_valid.user_id.app_error", nil, "")
+		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	notifyLevel := o.NotifyProps[DESKTOP_NOTIFY_PROP]
 	if len(notifyLevel) > 20 || !IsChannelNotifyLevelValid(notifyLevel) {
-		return NewLocAppError("ChannelMember.IsValid", "model.channel_member.is_valid.notify_level.app_error",
-			nil, "notify_level="+notifyLevel)
+		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.notify_level.app_error", nil, "notify_level="+notifyLevel, http.StatusBadRequest)
 	}
 
 	markUnreadLevel := o.NotifyProps[MARK_UNREAD_NOTIFY_PROP]
 	if len(markUnreadLevel) > 20 || !IsChannelMarkUnreadLevelValid(markUnreadLevel) {
-		return NewLocAppError("ChannelMember.IsValid", "model.channel_member.is_valid.unread_level.app_error",
-			nil, "mark_unread_level="+markUnreadLevel)
+		return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.unread_level.app_error", nil, "mark_unread_level="+markUnreadLevel, http.StatusBadRequest)
 	}
 
 	if pushLevel, ok := o.NotifyProps[PUSH_NOTIFY_PROP]; ok {
 		if len(pushLevel) > 20 || !IsChannelNotifyLevelValid(pushLevel) {
-			return NewLocAppError("ChannelMember.IsValid", "model.channel_member.is_valid.push_level.app_error",
-				nil, "push_notification_level="+pushLevel)
+			return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.push_level.app_error", nil, "push_notification_level="+pushLevel, http.StatusBadRequest)
 		}
 	}
 
 	if sendEmail, ok := o.NotifyProps[EMAIL_NOTIFY_PROP]; ok {
 		if len(sendEmail) > 20 || !IsSendEmailValid(sendEmail) {
-			return NewLocAppError("ChannelMember.IsValid", "model.channel_member.is_valid.email_value.app_error",
-				nil, "push_notification_level="+sendEmail)
+			return NewAppError("ChannelMember.IsValid", "model.channel_member.is_valid.email_value.app_error", nil, "push_notification_level="+sendEmail, http.StatusBadRequest)
 		}
 	}
 

--- a/model/client.go
+++ b/model/client.go
@@ -144,7 +144,7 @@ func (c *Client) DoPost(url, data, contentType string) (*http.Response, *AppErro
 	rq.Close = true
 
 	if rp, err := c.HttpClient.Do(rq); err != nil {
-		return nil, NewLocAppError(url, "model.client.connecting.app_error", nil, err.Error())
+		return nil, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode >= 300 {
 		defer closeBody(rp)
 		return nil, AppErrorFromJson(rp.Body)
@@ -162,7 +162,7 @@ func (c *Client) DoApiPost(url string, data string) (*http.Response, *AppError) 
 	}
 
 	if rp, err := c.HttpClient.Do(rq); err != nil {
-		return nil, NewLocAppError(url, "model.client.connecting.app_error", nil, err.Error())
+		return nil, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode >= 300 {
 		defer closeBody(rp)
 		return nil, AppErrorFromJson(rp.Body)
@@ -184,7 +184,7 @@ func (c *Client) DoApiGet(url string, data string, etag string) (*http.Response,
 	}
 
 	if rp, err := c.HttpClient.Do(rq); err != nil {
-		return nil, NewLocAppError(url, "model.client.connecting.app_error", nil, err.Error())
+		return nil, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode == 304 {
 		return rp, nil
 	} else if rp.StatusCode >= 300 {
@@ -677,7 +677,7 @@ func (c *Client) login(m map[string]string) (*Result, *AppError) {
 		sessionToken := getCookie(SESSION_COOKIE_TOKEN, r)
 
 		if c.AuthToken != sessionToken.Value {
-			NewLocAppError("/users/login", "model.client.login.app_error", nil, "")
+			NewAppError("/users/login", "model.client.login.app_error", nil, "", 0)
 		}
 
 		defer closeBody(r)
@@ -1054,7 +1054,7 @@ func (c *Client) DownloadComplianceReport(id string) (*Result, *AppError) {
 	}
 
 	if rp, err := c.HttpClient.Do(rq); err != nil {
-		return nil, NewLocAppError("/admin/download_compliance_report", "model.client.connecting.app_error", nil, err.Error())
+		return nil, NewAppError("/admin/download_compliance_report", "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode >= 300 {
 		defer rp.Body.Close()
 		return nil, AppErrorFromJson(rp.Body)
@@ -1527,19 +1527,19 @@ func (c *Client) UploadPostAttachment(data []byte, channelId string, filename st
 	writer := multipart.NewWriter(body)
 
 	if part, err := writer.CreateFormFile("files", filename); err != nil {
-		return nil, NewLocAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error())
+		return nil, NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), 0)
 	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
-		return nil, NewLocAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error())
+		return nil, NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), 0)
 	}
 
 	if part, err := writer.CreateFormField("channel_id"); err != nil {
-		return nil, NewLocAppError("UploadPostAttachment", "model.client.upload_post_attachment.channel_id.app_error", nil, err.Error())
+		return nil, NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.channel_id.app_error", nil, err.Error(), 0)
 	} else if _, err = io.Copy(part, strings.NewReader(channelId)); err != nil {
-		return nil, NewLocAppError("UploadPostAttachment", "model.client.upload_post_attachment.channel_id.app_error", nil, err.Error())
+		return nil, NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.channel_id.app_error", nil, err.Error(), 0)
 	}
 
 	if err := writer.Close(); err != nil {
-		return nil, NewLocAppError("UploadPostAttachment", "model.client.upload_post_attachment.writer.app_error", nil, err.Error())
+		return nil, NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.writer.app_error", nil, err.Error(), 0)
 	}
 
 	if result, err := c.uploadFile(c.ApiUrl+c.GetTeamRoute()+"/files/upload", body.Bytes(), writer.FormDataContentType()); err != nil {
@@ -1559,7 +1559,7 @@ func (c *Client) uploadFile(url string, data []byte, contentType string) (*Resul
 	}
 
 	if rp, err := c.HttpClient.Do(rq); err != nil {
-		return nil, NewLocAppError(url, "model.client.connecting.app_error", nil, err.Error())
+		return nil, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode >= 300 {
 		return nil, AppErrorFromJson(rp.Body)
 	} else {
@@ -2175,17 +2175,17 @@ func (c *Client) CreateEmoji(emoji *Emoji, image []byte, filename string) (*Emoj
 	writer := multipart.NewWriter(body)
 
 	if part, err := writer.CreateFormFile("image", filename); err != nil {
-		return nil, NewLocAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error())
+		return nil, NewAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error(), 0)
 	} else if _, err = io.Copy(part, bytes.NewBuffer(image)); err != nil {
-		return nil, NewLocAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error())
+		return nil, NewAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error(), 0)
 	}
 
 	if err := writer.WriteField("emoji", emoji.ToJson()); err != nil {
-		return nil, NewLocAppError("CreateEmoji", "model.client.create_emoji.emoji.app_error", nil, err.Error())
+		return nil, NewAppError("CreateEmoji", "model.client.create_emoji.emoji.app_error", nil, err.Error(), 0)
 	}
 
 	if err := writer.Close(); err != nil {
-		return nil, NewLocAppError("CreateEmoji", "model.client.create_emoji.writer.app_error", nil, err.Error())
+		return nil, NewAppError("CreateEmoji", "model.client.create_emoji.writer.app_error", nil, err.Error(), 0)
 	}
 
 	rq, _ := http.NewRequest("POST", c.ApiUrl+c.GetEmojiRoute()+"/create", body)
@@ -2197,7 +2197,7 @@ func (c *Client) CreateEmoji(emoji *Emoji, image []byte, filename string) (*Emoj
 	}
 
 	if r, err := c.HttpClient.Do(rq); err != nil {
-		return nil, NewLocAppError("CreateEmoji", "model.client.connecting.app_error", nil, err.Error())
+		return nil, NewAppError("CreateEmoji", "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if r.StatusCode >= 300 {
 		return nil, AppErrorFromJson(r.Body)
 	} else {
@@ -2241,7 +2241,7 @@ func (c *Client) UploadCertificateFile(data []byte, contentType string) *AppErro
 	}
 
 	if rp, err := c.HttpClient.Do(rq); err != nil {
-		return NewLocAppError(url, "model.client.connecting.app_error", nil, err.Error())
+		return NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode >= 300 {
 		return AppErrorFromJson(rp.Body)
 	} else {

--- a/model/client4.go
+++ b/model/client4.go
@@ -327,7 +327,7 @@ func (c *Client4) DoApiRequest(method, url, data, etag string) (*http.Response, 
 	}
 
 	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
-		return nil, NewLocAppError(url, "model.client.connecting.app_error", nil, err.Error())
+		return nil, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
 	} else if rp.StatusCode == 304 {
 		return rp, nil
 	} else if rp.StatusCode >= 300 {
@@ -2867,17 +2867,17 @@ func (c *Client4) CreateEmoji(emoji *Emoji, image []byte, filename string) (*Emo
 	writer := multipart.NewWriter(body)
 
 	if part, err := writer.CreateFormFile("image", filename); err != nil {
-		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewLocAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error())}
+		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error(), 0)}
 	} else if _, err = io.Copy(part, bytes.NewBuffer(image)); err != nil {
-		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewLocAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error())}
+		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error(), 0)}
 	}
 
 	if err := writer.WriteField("emoji", emoji.ToJson()); err != nil {
-		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewLocAppError("CreateEmoji", "model.client.create_emoji.emoji.app_error", nil, err.Error())}
+		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewAppError("CreateEmoji", "model.client.create_emoji.emoji.app_error", nil, err.Error(), 0)}
 	}
 
 	if err := writer.Close(); err != nil {
-		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewLocAppError("CreateEmoji", "model.client.create_emoji.writer.app_error", nil, err.Error())}
+		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewAppError("CreateEmoji", "model.client.create_emoji.writer.app_error", nil, err.Error(), 0)}
 	}
 
 	return c.DoEmojiUploadFile(c.GetEmojisRoute(), body.Bytes(), writer.FormDataContentType())

--- a/model/cluster_discovery.go
+++ b/model/cluster_discovery.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"os"
 )
 
@@ -85,27 +86,27 @@ func FilterClusterDiscovery(vs []*ClusterDiscovery, f func(*ClusterDiscovery) bo
 
 func (o *ClusterDiscovery) IsValid() *AppError {
 	if len(o.Id) != 26 {
-		return NewLocAppError("Channel.IsValid", "model.channel.is_valid.id.app_error", nil, "")
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.ClusterName) == 0 {
-		return NewLocAppError("ClusterDiscovery.IsValid", "ClusterName must be set", nil, "")
+		return NewAppError("ClusterDiscovery.IsValid", "ClusterName must be set", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.Type) == 0 {
-		return NewLocAppError("ClusterDiscovery.IsValid", "Type must be set", nil, "")
+		return NewAppError("ClusterDiscovery.IsValid", "Type must be set", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.Hostname) == 0 {
-		return NewLocAppError("ClusterDiscovery.IsValid", "Hostname must be set", nil, "")
+		return NewAppError("ClusterDiscovery.IsValid", "Hostname must be set", nil, "", http.StatusBadRequest)
 	}
 
 	if o.CreateAt == 0 {
-		return NewLocAppError("ClusterDiscovery.IsValid", "CreateAt must be set", nil, "")
+		return NewAppError("ClusterDiscovery.IsValid", "CreateAt must be set", nil, "", http.StatusBadRequest)
 	}
 
 	if o.LastPingAt == 0 {
-		return NewLocAppError("ClusterDiscovery.IsValid", "LastPingAt must be set", nil, "")
+		return NewAppError("ClusterDiscovery.IsValid", "LastPingAt must be set", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/command.go
+++ b/model/command.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -79,51 +80,51 @@ func CommandListFromJson(data io.Reader) []*Command {
 func (o *Command) IsValid() *AppError {
 
 	if len(o.Id) != 26 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.id.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.Token) != 26 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.token.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.token.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if o.CreateAt == 0 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.create_at.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.create_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if o.UpdateAt == 0 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.update_at.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.update_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.CreatorId) != 26 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.user_id.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.TeamId) != 26 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.team_id.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.team_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.Trigger) < MIN_TRIGGER_LENGTH || len(o.Trigger) > MAX_TRIGGER_LENGTH || strings.Index(o.Trigger, "/") == 0 || strings.Contains(o.Trigger, " ") {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.trigger.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.trigger.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.URL) == 0 || len(o.URL) > 1024 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.url.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.url.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if !IsValidHttpUrl(o.URL) {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.url_http.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.url_http.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if !(o.Method == COMMAND_METHOD_GET || o.Method == COMMAND_METHOD_POST) {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.method.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.method.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.DisplayName) > 64 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.display_name.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.display_name.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.Description) > 128 {
-		return NewLocAppError("Command.IsValid", "model.command.is_valid.description.app_error", nil, "")
+		return NewAppError("Command.IsValid", "model.command.is_valid.description.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/compliance.go
+++ b/model/compliance.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -75,27 +76,27 @@ func (me *Compliance) JobName() string {
 func (me *Compliance) IsValid() *AppError {
 
 	if len(me.Id) != 26 {
-		return NewLocAppError("Compliance.IsValid", "model.compliance.is_valid.id.app_error", nil, "")
+		return NewAppError("Compliance.IsValid", "model.compliance.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if me.CreateAt == 0 {
-		return NewLocAppError("Compliance.IsValid", "model.compliance.is_valid.create_at.app_error", nil, "")
+		return NewAppError("Compliance.IsValid", "model.compliance.is_valid.create_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(me.Desc) > 512 || len(me.Desc) == 0 {
-		return NewLocAppError("Compliance.IsValid", "model.compliance.is_valid.desc.app_error", nil, "")
+		return NewAppError("Compliance.IsValid", "model.compliance.is_valid.desc.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if me.StartAt == 0 {
-		return NewLocAppError("Compliance.IsValid", "model.compliance.is_valid.start_at.app_error", nil, "")
+		return NewAppError("Compliance.IsValid", "model.compliance.is_valid.start_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if me.EndAt == 0 {
-		return NewLocAppError("Compliance.IsValid", "model.compliance.is_valid.end_at.app_error", nil, "")
+		return NewAppError("Compliance.IsValid", "model.compliance.is_valid.end_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if me.EndAt <= me.StartAt {
-		return NewLocAppError("Compliance.IsValid", "model.compliance.is_valid.start_end_at.app_error", nil, "")
+		return NewAppError("Compliance.IsValid", "model.compliance.is_valid.start_end_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/emoji.go
+++ b/model/emoji.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 )
 
 type Emoji struct {
@@ -19,23 +20,23 @@ type Emoji struct {
 
 func (emoji *Emoji) IsValid() *AppError {
 	if len(emoji.Id) != 26 {
-		return NewLocAppError("Emoji.IsValid", "model.emoji.id.app_error", nil, "")
+		return NewAppError("Emoji.IsValid", "model.emoji.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if emoji.CreateAt == 0 {
-		return NewLocAppError("Emoji.IsValid", "model.emoji.create_at.app_error", nil, "id="+emoji.Id)
+		return NewAppError("Emoji.IsValid", "model.emoji.create_at.app_error", nil, "id="+emoji.Id, http.StatusBadRequest)
 	}
 
 	if emoji.UpdateAt == 0 {
-		return NewLocAppError("Emoji.IsValid", "model.emoji.update_at.app_error", nil, "id="+emoji.Id)
+		return NewAppError("Emoji.IsValid", "model.emoji.update_at.app_error", nil, "id="+emoji.Id, http.StatusBadRequest)
 	}
 
 	if len(emoji.CreatorId) != 26 {
-		return NewLocAppError("Emoji.IsValid", "model.emoji.user_id.app_error", nil, "")
+		return NewAppError("Emoji.IsValid", "model.emoji.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(emoji.Name) == 0 || len(emoji.Name) > 64 || !IsValidAlphaNumHyphenUnderscore(emoji.Name, false) {
-		return NewLocAppError("Emoji.IsValid", "model.emoji.name.app_error", nil, "")
+		return NewAppError("Emoji.IsValid", "model.emoji.name.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/file_info.go
+++ b/model/file_info.go
@@ -10,6 +10,7 @@ import (
 	"image/gif"
 	"io"
 	"mime"
+	"net/http"
 	"path/filepath"
 	"strings"
 )
@@ -89,27 +90,27 @@ func (o *FileInfo) PreSave() {
 
 func (o *FileInfo) IsValid() *AppError {
 	if len(o.Id) != 26 {
-		return NewLocAppError("FileInfo.IsValid", "model.file_info.is_valid.id.app_error", nil, "")
+		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.CreatorId) != 26 {
-		return NewLocAppError("FileInfo.IsValid", "model.file_info.is_valid.user_id.app_error", nil, "id="+o.Id)
+		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.user_id.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if len(o.PostId) != 0 && len(o.PostId) != 26 {
-		return NewLocAppError("FileInfo.IsValid", "model.file_info.is_valid.post_id.app_error", nil, "id="+o.Id)
+		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.post_id.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if o.CreateAt == 0 {
-		return NewLocAppError("FileInfo.IsValid", "model.file_info.is_valid.create_at.app_error", nil, "id="+o.Id)
+		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.create_at.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if o.UpdateAt == 0 {
-		return NewLocAppError("FileInfo.IsValid", "model.file_info.is_valid.update_at.app_error", nil, "id="+o.Id)
+		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.update_at.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if o.Path == "" {
-		return NewLocAppError("FileInfo.IsValid", "model.file_info.is_valid.path.app_error", nil, "id="+o.Id)
+		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.path.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	return nil
@@ -147,7 +148,7 @@ func GetInfoForBytes(name string, data []byte) (*FileInfo, *AppError) {
 				if gifConfig, err := gif.DecodeAll(bytes.NewReader(data)); err != nil {
 					// Still return the rest of the info even though it doesn't appear to be an actual gif
 					info.HasPreviewImage = true
-					err = NewLocAppError("GetInfoForBytes", "model.file_info.get.gif.app_error", nil, "name="+name)
+					err = NewAppError("GetInfoForBytes", "model.file_info.get.gif.app_error", nil, "name="+name, http.StatusBadRequest)
 				} else {
 					info.HasPreviewImage = len(gifConfig.Image) == 1
 				}

--- a/model/license.go
+++ b/model/license.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 )
 
 const (
@@ -202,15 +203,15 @@ func LicenseFromJson(data io.Reader) *License {
 
 func (lr *LicenseRecord) IsValid() *AppError {
 	if len(lr.Id) != 26 {
-		return NewLocAppError("LicenseRecord.IsValid", "model.license_record.is_valid.id.app_error", nil, "")
+		return NewAppError("LicenseRecord.IsValid", "model.license_record.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if lr.CreateAt == 0 {
-		return NewLocAppError("LicenseRecord.IsValid", "model.license_record.is_valid.create_at.app_error", nil, "")
+		return NewAppError("LicenseRecord.IsValid", "model.license_record.is_valid.create_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(lr.Bytes) == 0 || len(lr.Bytes) > 10000 {
-		return NewLocAppError("LicenseRecord.IsValid", "model.license_record.is_valid.create_at.app_error", nil, "")
+		return NewAppError("LicenseRecord.IsValid", "model.license_record.is_valid.create_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/post.go
+++ b/model/post.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"unicode/utf8"
 )
 
@@ -118,47 +119,47 @@ func (o *Post) Etag() string {
 func (o *Post) IsValid() *AppError {
 
 	if len(o.Id) != 26 {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.id.app_error", nil, "")
+		return NewAppError("Post.IsValid", "model.post.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if o.CreateAt == 0 {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.create_at.app_error", nil, "id="+o.Id)
+		return NewAppError("Post.IsValid", "model.post.is_valid.create_at.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if o.UpdateAt == 0 {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.update_at.app_error", nil, "id="+o.Id)
+		return NewAppError("Post.IsValid", "model.post.is_valid.update_at.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if len(o.UserId) != 26 {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.user_id.app_error", nil, "")
+		return NewAppError("Post.IsValid", "model.post.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.ChannelId) != 26 {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.channel_id.app_error", nil, "")
+		return NewAppError("Post.IsValid", "model.post.is_valid.channel_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if !(len(o.RootId) == 26 || len(o.RootId) == 0) {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.root_id.app_error", nil, "")
+		return NewAppError("Post.IsValid", "model.post.is_valid.root_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if !(len(o.ParentId) == 26 || len(o.ParentId) == 0) {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.parent_id.app_error", nil, "")
+		return NewAppError("Post.IsValid", "model.post.is_valid.parent_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.ParentId) == 26 && len(o.RootId) == 0 {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.root_parent.app_error", nil, "")
+		return NewAppError("Post.IsValid", "model.post.is_valid.root_parent.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if !(len(o.OriginalId) == 26 || len(o.OriginalId) == 0) {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.original_id.app_error", nil, "")
+		return NewAppError("Post.IsValid", "model.post.is_valid.original_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(o.Message) > POST_MESSAGE_MAX_RUNES {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.msg.app_error", nil, "id="+o.Id)
+		return NewAppError("Post.IsValid", "model.post.is_valid.msg.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(o.Hashtags) > POST_HASHTAGS_MAX_RUNES {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.hashtags.app_error", nil, "id="+o.Id)
+		return NewAppError("Post.IsValid", "model.post.is_valid.hashtags.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	// should be removed once more message types are supported
@@ -167,19 +168,19 @@ func (o *Post) IsValid() *AppError {
 		o.Type == POST_REMOVE_FROM_CHANNEL || o.Type == POST_ADD_TO_CHANNEL ||
 		o.Type == POST_SLACK_ATTACHMENT || o.Type == POST_HEADER_CHANGE || o.Type == POST_PURPOSE_CHANGE ||
 		o.Type == POST_DISPLAYNAME_CHANGE || o.Type == POST_CHANNEL_DELETED) {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.type.app_error", nil, "id="+o.Type)
+		return NewAppError("Post.IsValid", "model.post.is_valid.type.app_error", nil, "id="+o.Type, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(ArrayToJson(o.Filenames)) > POST_FILENAMES_MAX_RUNES {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.filenames.app_error", nil, "id="+o.Id)
+		return NewAppError("Post.IsValid", "model.post.is_valid.filenames.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(ArrayToJson(o.FileIds)) > POST_FILEIDS_MAX_RUNES {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.file_ids.app_error", nil, "id="+o.Id)
+		return NewAppError("Post.IsValid", "model.post.is_valid.file_ids.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(StringInterfaceToJson(o.Props)) > POST_PROPS_MAX_RUNES {
-		return NewLocAppError("Post.IsValid", "model.post.is_valid.props.app_error", nil, "id="+o.Id)
+		return NewAppError("Post.IsValid", "model.post.is_valid.props.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/preference.go
+++ b/model/preference.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"regexp"
 	"strings"
 	"unicode/utf8"
@@ -67,25 +68,25 @@ func PreferenceFromJson(data io.Reader) *Preference {
 
 func (o *Preference) IsValid() *AppError {
 	if len(o.UserId) != 26 {
-		return NewLocAppError("Preference.IsValid", "model.preference.is_valid.id.app_error", nil, "user_id="+o.UserId)
+		return NewAppError("Preference.IsValid", "model.preference.is_valid.id.app_error", nil, "user_id="+o.UserId, http.StatusBadRequest)
 	}
 
 	if len(o.Category) == 0 || len(o.Category) > 32 {
-		return NewLocAppError("Preference.IsValid", "model.preference.is_valid.category.app_error", nil, "category="+o.Category)
+		return NewAppError("Preference.IsValid", "model.preference.is_valid.category.app_error", nil, "category="+o.Category, http.StatusBadRequest)
 	}
 
 	if len(o.Name) > 32 {
-		return NewLocAppError("Preference.IsValid", "model.preference.is_valid.name.app_error", nil, "name="+o.Name)
+		return NewAppError("Preference.IsValid", "model.preference.is_valid.name.app_error", nil, "name="+o.Name, http.StatusBadRequest)
 	}
 
 	if utf8.RuneCountInString(o.Value) > 2000 {
-		return NewLocAppError("Preference.IsValid", "model.preference.is_valid.value.app_error", nil, "value="+o.Value)
+		return NewAppError("Preference.IsValid", "model.preference.is_valid.value.app_error", nil, "value="+o.Value, http.StatusBadRequest)
 	}
 
 	if o.Category == PREFERENCE_CATEGORY_THEME {
 		var unused map[string]string
 		if err := json.NewDecoder(strings.NewReader(o.Value)).Decode(&unused); err != nil {
-			return NewLocAppError("Preference.IsValid", "model.preference.is_valid.theme.app_error", nil, "value="+o.Value)
+			return NewAppError("Preference.IsValid", "model.preference.is_valid.theme.app_error", nil, "value="+o.Value, http.StatusBadRequest)
 		}
 	}
 

--- a/model/reaction.go
+++ b/model/reaction.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"regexp"
 )
 
@@ -54,21 +55,21 @@ func ReactionsFromJson(data io.Reader) []*Reaction {
 
 func (o *Reaction) IsValid() *AppError {
 	if len(o.UserId) != 26 {
-		return NewLocAppError("Reaction.IsValid", "model.reaction.is_valid.user_id.app_error", nil, "user_id="+o.UserId)
+		return NewAppError("Reaction.IsValid", "model.reaction.is_valid.user_id.app_error", nil, "user_id="+o.UserId, http.StatusBadRequest)
 	}
 
 	if len(o.PostId) != 26 {
-		return NewLocAppError("Reaction.IsValid", "model.reaction.is_valid.post_id.app_error", nil, "post_id="+o.PostId)
+		return NewAppError("Reaction.IsValid", "model.reaction.is_valid.post_id.app_error", nil, "post_id="+o.PostId, http.StatusBadRequest)
 	}
 
 	validName := regexp.MustCompile(`^[a-zA-Z0-9\-\+_]+$`)
 
 	if len(o.EmojiName) == 0 || len(o.EmojiName) > 64 || !validName.MatchString(o.EmojiName) {
-		return NewLocAppError("Reaction.IsValid", "model.reaction.is_valid.emoji_name.app_error", nil, "emoji_name="+o.EmojiName)
+		return NewAppError("Reaction.IsValid", "model.reaction.is_valid.emoji_name.app_error", nil, "emoji_name="+o.EmojiName, http.StatusBadRequest)
 	}
 
 	if o.CreateAt == 0 {
-		return NewLocAppError("Reaction.IsValid", "model.reaction.is_valid.create_at.app_error", nil, "")
+		return NewAppError("Reaction.IsValid", "model.reaction.is_valid.create_at.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"strings"
 )
 
@@ -103,11 +104,11 @@ func TeamsUnreadFromJson(data io.Reader) []*TeamUnread {
 func (o *TeamMember) IsValid() *AppError {
 
 	if len(o.TeamId) != 26 {
-		return NewLocAppError("TeamMember.IsValid", "model.team_member.is_valid.team_id.app_error", nil, "")
+		return NewAppError("TeamMember.IsValid", "model.team_member.is_valid.team_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(o.UserId) != 26 {
-		return NewLocAppError("TeamMember.IsValid", "model.team_member.is_valid.user_id.app_error", nil, "")
+		return NewAppError("TeamMember.IsValid", "model.team_member.is_valid.user_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/utils.go
+++ b/model/utils.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
+	"net/http"
 	"net/mail"
 	"net/url"
 	"regexp"
@@ -91,7 +92,7 @@ func AppErrorFromJson(data io.Reader) *AppError {
 	if err == nil {
 		return &er
 	} else {
-		return NewLocAppError("AppErrorFromJson", "model.utils.decode_json.app_error", nil, "body: "+str)
+		return NewAppError("AppErrorFromJson", "model.utils.decode_json.app_error", nil, "body: "+str, http.StatusInternalServerError)
 	}
 }
 

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -27,7 +28,7 @@ func TestRandomString(t *testing.T) {
 }
 
 func TestAppError(t *testing.T) {
-	err := NewLocAppError("TestAppError", "message", nil, "")
+	err := NewAppError("TestAppError", "message", nil, "", http.StatusInternalServerError)
 	json := err.ToJson()
 	rerr := AppErrorFromJson(strings.NewReader(json))
 	if err.Message != rerr.Message {

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/gorilla/websocket"
 )
@@ -30,7 +31,7 @@ type WebSocketClient struct {
 func NewWebSocketClient(url, authToken string) (*WebSocketClient, *AppError) {
 	conn, _, err := websocket.DefaultDialer.Dial(url+API_URL_SUFFIX_V3+"/users/websocket", nil)
 	if err != nil {
-		return nil, NewLocAppError("NewWebSocketClient", "model.websocket_client.connect_fail.app_error", nil, err.Error())
+		return nil, NewAppError("NewWebSocketClient", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	client := &WebSocketClient{
@@ -55,7 +56,7 @@ func NewWebSocketClient(url, authToken string) (*WebSocketClient, *AppError) {
 func NewWebSocketClient4(url, authToken string) (*WebSocketClient, *AppError) {
 	conn, _, err := websocket.DefaultDialer.Dial(url+API_URL_SUFFIX+"/websocket", nil)
 	if err != nil {
-		return nil, NewLocAppError("NewWebSocketClient4", "model.websocket_client.connect_fail.app_error", nil, err.Error())
+		return nil, NewAppError("NewWebSocketClient4", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	client := &WebSocketClient{
@@ -79,7 +80,7 @@ func (wsc *WebSocketClient) Connect() *AppError {
 	var err error
 	wsc.Conn, _, err = websocket.DefaultDialer.Dial(wsc.ConnectUrl, nil)
 	if err != nil {
-		return NewLocAppError("Connect", "model.websocket_client.connect_fail.app_error", nil, err.Error())
+		return NewAppError("Connect", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	wsc.EventChannel = make(chan *WebSocketEvent, 100)
@@ -107,7 +108,7 @@ func (wsc *WebSocketClient) Listen() {
 			var err error
 			if _, rawMsg, err = wsc.Conn.ReadMessage(); err != nil {
 				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
-					wsc.ListenError = NewLocAppError("NewWebSocketClient", "model.websocket_client.connect_fail.app_error", nil, err.Error())
+					wsc.ListenError = NewAppError("NewWebSocketClient", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
 				}
 
 				return


### PR DESCRIPTION
#### Summary
This adds status codes to the remaining errors in the model package that don't have them. Nearly all the changes are adding `BadRequest` to `IsValid` errors, for consistency with all the other errors in this package where this is the case. There are a few `0` ones added where appropriate in the various client drivers, and a few others as appropriate in some other places.

Apologies once again for the long, boring PR. Github helpfully highlights the characters within the line that have changed, which makes it much less painful to review than some other diff tools!