### PR TITLE
Remove einterface.GetX calls

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -14,7 +14,6 @@ import (
 	l4g "github.com/alecthomas/log4go"
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/app"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
@@ -169,7 +168,7 @@ func attachDeviceId(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.ClearSessionCacheForUser(c.Session.UserId)
+	c.App.ClearSessionCacheForUser(c.Session.UserId)
 	c.Session.SetExpireInDays(*utils.Cfg.ServiceSettings.SessionLengthMobileInDays)
 
 	maxAge := *utils.Cfg.ServiceSettings.SessionLengthMobileInDays * 60 * 60 * 24
@@ -1075,7 +1074,7 @@ func updateMfa(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 		c.LogAudit("success - activated")
 	} else {
-		if err := app.DeactivateMfa(c.Session.UserId); err != nil {
+		if err := c.App.DeactivateMfa(c.Session.UserId); err != nil {
 			c.Err = err
 			return
 		}
@@ -1126,7 +1125,7 @@ func checkMfa(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func loginWithSaml(c *Context, w http.ResponseWriter, r *http.Request) {
-	samlInterface := einterfaces.GetSamlInterface()
+	samlInterface := c.App.Saml
 
 	if samlInterface == nil {
 		c.Err = model.NewAppError("loginWithSaml", "api.user.saml.not_available.app_error", nil, "", http.StatusFound)
@@ -1169,7 +1168,7 @@ func loginWithSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
-	samlInterface := einterfaces.GetSamlInterface()
+	samlInterface := c.App.Saml
 
 	if samlInterface == nil {
 		c.Err = model.NewAppError("completeSaml", "api.user.saml.not_available.app_error", nil, "", http.StatusFound)
@@ -1203,7 +1202,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	} else {
-		if err := app.CheckUserAdditionalAuthenticationCriteria(user, ""); err != nil {
+		if err := c.App.CheckUserAdditionalAuthenticationCriteria(user, ""); err != nil {
 			c.Err = err
 			c.Err.StatusCode = http.StatusFound
 			return

--- a/api4/brand.go
+++ b/api4/brand.go
@@ -22,7 +22,7 @@ func InitBrand() {
 func getBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	// No permission check required
 
-	if img, err := app.GetBrandImage(); err != nil {
+	if img, err := c.App.GetBrandImage(); err != nil {
 		w.WriteHeader(http.StatusNotFound)
 		w.Write(nil)
 	} else {
@@ -60,7 +60,7 @@ func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.SaveBrandImage(imageArray[0]); err != nil {
+	if err := c.App.SaveBrandImage(imageArray[0]); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/cluster.go
+++ b/api4/cluster.go
@@ -24,6 +24,6 @@ func getClusterStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	infos := app.GetClusterStatus()
+	infos := c.App.GetClusterStatus()
 	w.Write([]byte(model.ClusterInfosToJson(infos)))
 }

--- a/api4/context.go
+++ b/api4/context.go
@@ -14,7 +14,6 @@ import (
 	goi18n "github.com/nicksnyder/go-i18n/i18n"
 
 	"github.com/mattermost/mattermost-server/app"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -184,17 +183,17 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(c.Err.StatusCode)
 		w.Write([]byte(c.Err.ToJson()))
 
-		if einterfaces.GetMetricsInterface() != nil {
-			einterfaces.GetMetricsInterface().IncrementHttpError()
+		if c.App.Metrics != nil {
+			c.App.Metrics.IncrementHttpError()
 		}
 	}
 
-	if einterfaces.GetMetricsInterface() != nil {
-		einterfaces.GetMetricsInterface().IncrementHttpRequest()
+	if c.App.Metrics != nil {
+		c.App.Metrics.IncrementHttpRequest()
 
 		if r.URL.Path != model.API_URL_SUFFIX+"/websocket" {
 			elapsed := float64(time.Since(now)) / float64(time.Second)
-			einterfaces.GetMetricsInterface().ObserveHttpRequestDuration(elapsed)
+			c.App.Metrics.ObserveHttpRequestDuration(elapsed)
 		}
 	}
 }

--- a/api4/elasticsearch.go
+++ b/api4/elasticsearch.go
@@ -30,7 +30,7 @@ func testElasticsearch(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.TestElasticsearch(cfg); err != nil {
+	if err := c.App.TestElasticsearch(cfg); err != nil {
 		c.Err = err
 		return
 	}
@@ -44,7 +44,7 @@ func purgeElasticsearchIndexes(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	if err := app.PurgeElasticsearchIndexes(); err != nil {
+	if err := c.App.PurgeElasticsearchIndexes(); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/ldap.go
+++ b/api4/ldap.go
@@ -25,7 +25,7 @@ func syncLdap(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.SyncLdap()
+	c.App.SyncLdap()
 
 	ReturnStatusOK(w)
 }
@@ -36,7 +36,7 @@ func testLdap(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := app.TestLdap(); err != nil {
+	if err := c.App.TestLdap(); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/saml.go
+++ b/api4/saml.go
@@ -30,7 +30,7 @@ func InitSaml() {
 }
 
 func getSamlMetadata(c *Context, w http.ResponseWriter, r *http.Request) {
-	metadata, err := app.GetSamlMetadata()
+	metadata, err := c.App.GetSamlMetadata()
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/system.go
+++ b/api4/system.go
@@ -94,7 +94,7 @@ func getConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cfg := app.GetConfig()
+	cfg := c.App.GetConfig()
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Write([]byte(cfg.ToJson()))
@@ -106,7 +106,7 @@ func configReload(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.ReloadConfig()
+	c.App.ReloadConfig()
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	ReturnStatusOK(w)
@@ -124,7 +124,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := app.SaveConfig(cfg, true)
+	err := c.App.SaveConfig(cfg, true)
 	if err != nil {
 		c.Err = err
 		return
@@ -132,7 +132,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("updateConfig")
 
-	cfg = app.GetConfig()
+	cfg = c.App.GetConfig()
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	w.Write([]byte(cfg.ToJson()))
@@ -188,7 +188,7 @@ func getLogs(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lines, err := app.GetLogs(c.Params.Page, c.Params.PerPage)
+	lines, err := c.App.GetLogs(c.Params.Page, c.Params.PerPage)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -108,7 +107,7 @@ func TestUpdateConfig(t *testing.T) {
 	defer TearDown()
 	Client := th.Client
 
-	cfg := app.GetConfig()
+	cfg := th.App.GetConfig()
 
 	_, resp := Client.UpdateConfig(cfg)
 	CheckForbiddenStatus(t, resp)

--- a/api4/user.go
+++ b/api4/user.go
@@ -947,7 +947,7 @@ func attachDeviceId(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.ClearSessionCacheForUser(c.Session.UserId)
+	c.App.ClearSessionCacheForUser(c.Session.UserId)
 	c.Session.SetExpireInDays(*utils.Cfg.ServiceSettings.SessionLengthMobileInDays)
 
 	maxAge := *utils.Cfg.ServiceSettings.SessionLengthMobileInDays * 60 * 60 * 24

--- a/app/admin.go
+++ b/app/admin.go
@@ -14,35 +14,34 @@ import (
 	"net/http"
 
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/jobs"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
-func GetLogs(page, perPage int) ([]string, *model.AppError) {
+func (a *App) GetLogs(page, perPage int) ([]string, *model.AppError) {
 
 	perPage = 10000
 
 	var lines []string
-	if einterfaces.GetClusterInterface() != nil && *utils.Cfg.ClusterSettings.Enable {
+	if a.Cluster != nil && *utils.Cfg.ClusterSettings.Enable {
 		lines = append(lines, "-----------------------------------------------------------------------------------------------------------")
 		lines = append(lines, "-----------------------------------------------------------------------------------------------------------")
-		lines = append(lines, einterfaces.GetClusterInterface().GetMyClusterInfo().Hostname)
+		lines = append(lines, a.Cluster.GetMyClusterInfo().Hostname)
 		lines = append(lines, "-----------------------------------------------------------------------------------------------------------")
 		lines = append(lines, "-----------------------------------------------------------------------------------------------------------")
 	}
 
-	melines, err := GetLogsSkipSend(page, perPage)
+	melines, err := a.GetLogsSkipSend(page, perPage)
 	if err != nil {
 		return nil, err
 	}
 
 	lines = append(lines, melines...)
 
-	if einterfaces.GetClusterInterface() != nil && *utils.Cfg.ClusterSettings.Enable {
-		clines, err := einterfaces.GetClusterInterface().GetLogs(page, perPage)
+	if a.Cluster != nil && *utils.Cfg.ClusterSettings.Enable {
+		clines, err := a.Cluster.GetLogs(page, perPage)
 		if err != nil {
 			return nil, err
 		}
@@ -53,7 +52,7 @@ func GetLogs(page, perPage int) ([]string, *model.AppError) {
 	return lines, nil
 }
 
-func GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
+func (a *App) GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 	var lines []string
 
 	if utils.Cfg.LogSettings.EnableFile {
@@ -86,11 +85,11 @@ func GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 	return lines, nil
 }
 
-func GetClusterStatus() []*model.ClusterInfo {
+func (a *App) GetClusterStatus() []*model.ClusterInfo {
 	infos := make([]*model.ClusterInfo, 0)
 
-	if einterfaces.GetClusterInterface() != nil {
-		infos = einterfaces.GetClusterInterface().GetClusterInfos()
+	if a.Cluster != nil {
+		infos = a.Cluster.GetClusterInfos()
 	}
 
 	return infos
@@ -100,7 +99,7 @@ func (a *App) InvalidateAllCaches() *model.AppError {
 	debug.FreeOSMemory()
 	a.InvalidateAllCachesSkipSend()
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 
 		msg := &model.ClusterMessage{
 			Event:            model.CLUSTER_EVENT_INVALIDATE_ALL_CACHES,
@@ -108,7 +107,7 @@ func (a *App) InvalidateAllCaches() *model.AppError {
 			WaitForAllToSend: true,
 		}
 
-		einterfaces.GetClusterInterface().SendClusterMessage(msg)
+		a.Cluster.SendClusterMessage(msg)
 	}
 
 	return nil
@@ -125,7 +124,7 @@ func (a *App) InvalidateAllCachesSkipSend() {
 	a.LoadLicense()
 }
 
-func GetConfig() *model.Config {
+func (a *App) GetConfig() *model.Config {
 	json := utils.Cfg.ToJson()
 	cfg := model.ConfigFromJson(strings.NewReader(json))
 	cfg.Sanitize()
@@ -133,7 +132,7 @@ func GetConfig() *model.Config {
 	return cfg
 }
 
-func ReloadConfig() {
+func (a *App) ReloadConfig() {
 	debug.FreeOSMemory()
 	utils.LoadConfig(utils.CfgFileName)
 
@@ -141,7 +140,7 @@ func ReloadConfig() {
 	InitEmailBatching()
 }
 
-func SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool) *model.AppError {
+func (a *App) SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool) *model.AppError {
 	oldCfg := utils.Cfg
 	cfg.SetDefaults()
 	utils.Desanitize(cfg)
@@ -163,16 +162,16 @@ func SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool) *model.A
 	utils.LoadConfig(utils.CfgFileName)
 	utils.EnableConfigWatch()
 
-	if einterfaces.GetMetricsInterface() != nil {
+	if a.Metrics != nil {
 		if *utils.Cfg.MetricsSettings.Enable {
-			einterfaces.GetMetricsInterface().StartServer()
+			a.Metrics.StartServer()
 		} else {
-			einterfaces.GetMetricsInterface().StopServer()
+			a.Metrics.StopServer()
 		}
 	}
 
-	if einterfaces.GetClusterInterface() != nil {
-		err := einterfaces.GetClusterInterface().ConfigChanged(cfg, oldCfg, sendConfigChangeClusterMessage)
+	if a.Cluster != nil {
+		err := a.Cluster.ConfigChanged(cfg, oldCfg, sendConfigChangeClusterMessage)
 		if err != nil {
 			return err
 		}

--- a/app/analytics.go
+++ b/app/analytics.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
@@ -98,8 +97,8 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 		}
 
 		// If in HA mode then aggregrate all the stats
-		if einterfaces.GetClusterInterface() != nil && *utils.Cfg.ClusterSettings.Enable {
-			stats, err := einterfaces.GetClusterInterface().GetClusterStats()
+		if a.Cluster != nil && *utils.Cfg.ClusterSettings.Enable {
+			stats, err := a.Cluster.GetClusterStats()
 			if err != nil {
 				return nil, err
 			}

--- a/app/app.go
+++ b/app/app.go
@@ -6,19 +6,45 @@ package app
 import (
 	"io/ioutil"
 	"net/http"
+	"sync"
 
+	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/plugin/pluginenv"
 )
 
 type App struct {
-	Srv                    *Server
+	Srv *Server
+
 	PluginEnv              *pluginenv.Environment
 	PluginConfigListenerId string
+
+	AccountMigration einterfaces.AccountMigrationInterface
+	Brand            einterfaces.BrandInterface
+	Cluster          einterfaces.ClusterInterface
+	Compliance       einterfaces.ComplianceInterface
+	Elasticsearch    einterfaces.ElasticsearchInterface
+	Ldap             einterfaces.LdapInterface
+	Metrics          einterfaces.MetricsInterface
+	Mfa              einterfaces.MfaInterface
+	Saml             einterfaces.SamlInterface
 }
 
 var globalApp App
 
+var initEnterprise sync.Once
+
 func Global() *App {
+	initEnterprise.Do(func() {
+		globalApp.AccountMigration = einterfaces.GetAccountMigrationInterface()
+		globalApp.Brand = einterfaces.GetBrandInterface()
+		globalApp.Cluster = einterfaces.GetClusterInterface()
+		globalApp.Compliance = einterfaces.GetComplianceInterface()
+		globalApp.Elasticsearch = einterfaces.GetElasticsearchInterface()
+		globalApp.Ldap = einterfaces.GetLdapInterface()
+		globalApp.Metrics = einterfaces.GetMetricsInterface()
+		globalApp.Mfa = einterfaces.GetMfaInterface()
+		globalApp.Saml = einterfaces.GetSamlInterface()
+	})
 	return &globalApp
 }
 

--- a/app/brand.go
+++ b/app/brand.go
@@ -7,39 +7,36 @@ import (
 	"mime/multipart"
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
-func SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
+func (a *App) SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		return model.NewAppError("SaveBrandImage", "api.admin.upload_brand_image.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	brandInterface := einterfaces.GetBrandInterface()
-	if brandInterface == nil {
+	if a.Brand == nil {
 		return model.NewAppError("SaveBrandImage", "api.admin.upload_brand_image.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if err := brandInterface.SaveBrandImage(imageData); err != nil {
+	if err := a.Brand.SaveBrandImage(imageData); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func GetBrandImage() ([]byte, *model.AppError) {
+func (a *App) GetBrandImage() ([]byte, *model.AppError) {
 	if len(*utils.Cfg.FileSettings.DriverName) == 0 {
 		return nil, model.NewAppError("GetBrandImage", "api.admin.get_brand_image.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	brandInterface := einterfaces.GetBrandInterface()
-	if brandInterface == nil {
+	if a.Brand == nil {
 		return nil, model.NewAppError("GetBrandImage", "api.admin.get_brand_image.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
 
-	if img, err := brandInterface.GetBrandImage(); err != nil {
+	if img, err := a.Brand.GetBrandImage(); err != nil {
 		return nil, err
 	} else {
 		return img, nil

--- a/app/channel.go
+++ b/app/channel.go
@@ -1087,7 +1087,7 @@ func (a *App) SetActiveChannel(userId string, channelId string) *model.AppError 
 		status.LastActivityAt = model.GetMillis()
 	}
 
-	AddStatusCache(status)
+	a.AddStatusCache(status)
 
 	if status.Status != oldStatus {
 		BroadcastStatus(status)

--- a/app/cluster_discovery.go
+++ b/app/cluster_discovery.go
@@ -9,6 +9,7 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/utils"
 )
 
 const (
@@ -74,4 +75,12 @@ func (me *ClusterDiscoveryService) Start() {
 
 func (me *ClusterDiscoveryService) Stop() {
 	me.stop <- true
+}
+
+func (a *App) IsLeader() bool {
+	if utils.IsLicensed() && *utils.Cfg.ClusterSettings.Enable && a.Cluster != nil {
+		return a.Cluster.IsLeader()
+	} else {
+		return true
+	}
 }

--- a/app/cluster_handlers.go
+++ b/app/cluster_handlers.go
@@ -6,33 +6,31 @@ package app
 import (
 	"strings"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 )
 
 func (a *App) RegisterAllClusterMessageHandlers() {
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_PUBLISH, ClusterPublishHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_UPDATE_STATUS, ClusterUpdateStatusHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_ALL_CACHES, a.ClusterInvalidateAllCachesHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_WEBHOOK, a.ClusterInvalidateCacheForWebhookHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_POSTS, a.ClusterInvalidateCacheForChannelPostsHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS_NOTIFY_PROPS, a.ClusterInvalidateCacheForChannelMembersNotifyPropHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS, a.ClusterInvalidateCacheForChannelMembersHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_BY_NAME, a.ClusterInvalidateCacheForChannelByNameHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL, a.ClusterInvalidateCacheForChannelHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_USER, a.ClusterInvalidateCacheForUserHandler)
-	einterfaces.GetClusterInterface().RegisterClusterMessageHandler(model.CLUSTER_EVENT_CLEAR_SESSION_CACHE_FOR_USER, ClusterClearSessionCacheForUserHandler)
-
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_PUBLISH, a.ClusterPublishHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_UPDATE_STATUS, a.ClusterUpdateStatusHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_ALL_CACHES, a.ClusterInvalidateAllCachesHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_WEBHOOK, a.ClusterInvalidateCacheForWebhookHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_POSTS, a.ClusterInvalidateCacheForChannelPostsHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS_NOTIFY_PROPS, a.ClusterInvalidateCacheForChannelMembersNotifyPropHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS, a.ClusterInvalidateCacheForChannelMembersHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_BY_NAME, a.ClusterInvalidateCacheForChannelByNameHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL, a.ClusterInvalidateCacheForChannelHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_USER, a.ClusterInvalidateCacheForUserHandler)
+	a.Cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_CLEAR_SESSION_CACHE_FOR_USER, ClusterClearSessionCacheForUserHandler)
 }
 
-func ClusterPublishHandler(msg *model.ClusterMessage) {
+func (a *App) ClusterPublishHandler(msg *model.ClusterMessage) {
 	event := model.WebSocketEventFromJson(strings.NewReader(msg.Data))
 	PublishSkipClusterSend(event)
 }
 
-func ClusterUpdateStatusHandler(msg *model.ClusterMessage) {
+func (a *App) ClusterUpdateStatusHandler(msg *model.ClusterMessage) {
 	status := model.StatusFromJson(strings.NewReader(msg.Data))
-	AddStatusCacheSkipClusterSend(status)
+	a.AddStatusCacheSkipClusterSend(status)
 }
 
 func (a *App) ClusterInvalidateAllCachesHandler(msg *model.ClusterMessage) {

--- a/app/compliance.go
+++ b/app/compliance.go
@@ -8,7 +8,6 @@ import (
 
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -26,7 +25,7 @@ func (a *App) GetComplianceReports(page, perPage int) (model.Compliances, *model
 }
 
 func (a *App) SaveComplianceReport(job *model.Compliance) (*model.Compliance, *model.AppError) {
-	if !*utils.Cfg.ComplianceSettings.Enable || !utils.IsLicensed() || !*utils.License().Features.Compliance || einterfaces.GetComplianceInterface() == nil {
+	if !*utils.Cfg.ComplianceSettings.Enable || !utils.IsLicensed() || !*utils.License().Features.Compliance || a.Compliance == nil {
 		return nil, model.NewAppError("saveComplianceReport", "ent.compliance.licence_disable.app_error", nil, "", http.StatusNotImplemented)
 	}
 
@@ -36,14 +35,14 @@ func (a *App) SaveComplianceReport(job *model.Compliance) (*model.Compliance, *m
 		return nil, result.Err
 	} else {
 		job = result.Data.(*model.Compliance)
-		go einterfaces.GetComplianceInterface().RunComplianceJob(job)
+		go a.Compliance.RunComplianceJob(job)
 	}
 
 	return job, nil
 }
 
 func (a *App) GetComplianceReport(reportId string) (*model.Compliance, *model.AppError) {
-	if !*utils.Cfg.ComplianceSettings.Enable || !utils.IsLicensed() || !*utils.License().Features.Compliance || einterfaces.GetComplianceInterface() == nil {
+	if !*utils.Cfg.ComplianceSettings.Enable || !utils.IsLicensed() || !*utils.License().Features.Compliance || a.Compliance == nil {
 		return nil, model.NewAppError("downloadComplianceReport", "ent.compliance.licence_disable.app_error", nil, "", http.StatusNotImplemented)
 	}
 

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -51,7 +51,7 @@ const (
 var client *analytics.Client
 
 func (a *App) SendDailyDiagnostics() {
-	if *utils.Cfg.LogSettings.EnableDiagnostics && utils.IsLeader() {
+	if *utils.Cfg.LogSettings.EnableDiagnostics && a.IsLeader() {
 		initDiagnostics("")
 		a.trackActivity()
 		trackConfig()

--- a/app/elasticsearch.go
+++ b/app/elasticsearch.go
@@ -6,12 +6,11 @@ package app
 import (
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
-func TestElasticsearch(cfg *model.Config) *model.AppError {
+func (a *App) TestElasticsearch(cfg *model.Config) *model.AppError {
 	if *cfg.ElasticsearchSettings.Password == model.FAKE_SETTING {
 		if *cfg.ElasticsearchSettings.ConnectionUrl == *utils.Cfg.ElasticsearchSettings.ConnectionUrl && *cfg.ElasticsearchSettings.Username == *utils.Cfg.ElasticsearchSettings.Username {
 			*cfg.ElasticsearchSettings.Password = *utils.Cfg.ElasticsearchSettings.Password
@@ -20,7 +19,7 @@ func TestElasticsearch(cfg *model.Config) *model.AppError {
 		}
 	}
 
-	if esI := einterfaces.GetElasticsearchInterface(); esI != nil {
+	if esI := a.Elasticsearch; esI != nil {
 		if err := esI.TestConfig(cfg); err != nil {
 			return err
 		}
@@ -32,8 +31,8 @@ func TestElasticsearch(cfg *model.Config) *model.AppError {
 	return nil
 }
 
-func PurgeElasticsearchIndexes() *model.AppError {
-	if esI := einterfaces.GetElasticsearchInterface(); esI != nil {
+func (a *App) PurgeElasticsearchIndexes() *model.AppError {
+	if esI := a.Elasticsearch; esI != nil {
 		if err := esI.PurgeIndexes(); err != nil {
 			return err
 		}

--- a/app/ldap.go
+++ b/app/ldap.go
@@ -7,15 +7,14 @@ import (
 	"net/http"
 
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
-func SyncLdap() {
+func (a *App) SyncLdap() {
 	go func() {
 		if utils.IsLicensed() && *utils.License().Features.LDAP && *utils.Cfg.LdapSettings.Enable {
-			if ldapI := einterfaces.GetLdapInterface(); ldapI != nil {
+			if ldapI := a.Ldap; ldapI != nil {
 				ldapI.SyncNow()
 			} else {
 				l4g.Error("%v", model.NewAppError("SyncLdap", "ent.ldap.disabled.app_error", nil, "", http.StatusNotImplemented).Error())
@@ -24,8 +23,8 @@ func SyncLdap() {
 	}()
 }
 
-func TestLdap() *model.AppError {
-	if ldapI := einterfaces.GetLdapInterface(); ldapI != nil && utils.IsLicensed() && *utils.License().Features.LDAP && *utils.Cfg.LdapSettings.Enable {
+func (a *App) TestLdap() *model.AppError {
+	if ldapI := a.Ldap; ldapI != nil && utils.IsLicensed() && *utils.License().Features.LDAP && *utils.Cfg.LdapSettings.Enable {
 		if err := ldapI.RunTest(); err != nil {
 			err.StatusCode = 500
 			return err
@@ -52,7 +51,7 @@ func (a *App) SwitchEmailToLdap(email, password, code, ldapId, ldapPassword stri
 		return "", err
 	}
 
-	ldapInterface := einterfaces.GetLdapInterface()
+	ldapInterface := a.Ldap
 	if ldapInterface == nil {
 		return "", model.NewAppError("SwitchEmailToLdap", "api.user.email_to_ldap.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -80,7 +79,7 @@ func (a *App) SwitchLdapToEmail(ldapPassword, code, email, newPassword string) (
 		return "", model.NewAppError("SwitchLdapToEmail", "api.user.ldap_to_email.not_ldap_account.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	ldapInterface := einterfaces.GetLdapInterface()
+	ldapInterface := a.Ldap
 	if ldapInterface == nil || user.AuthData == nil {
 		return "", model.NewAppError("SwitchLdapToEmail", "api.user.ldap_to_email.not_available.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -89,7 +88,7 @@ func (a *App) SwitchLdapToEmail(ldapPassword, code, email, newPassword string) (
 		return "", err
 	}
 
-	if err := CheckUserMfa(user, code); err != nil {
+	if err := a.CheckUserMfa(user, code); err != nil {
 		return "", err
 	}
 

--- a/app/license.go
+++ b/app/license.go
@@ -86,7 +86,7 @@ func (a *App) SaveLicense(licenseBytes []byte) (*model.License, *model.AppError)
 		return nil, model.NewAppError("addLicense", model.INVALID_LICENSE_ERROR, nil, "", http.StatusBadRequest)
 	}
 
-	ReloadConfig()
+	a.ReloadConfig()
 	a.InvalidateAllCaches()
 
 	return license, nil
@@ -104,7 +104,7 @@ func (a *App) RemoveLicense() *model.AppError {
 		return result.Err
 	}
 
-	ReloadConfig()
+	a.ReloadConfig()
 
 	a.InvalidateAllCaches()
 

--- a/app/login.go
+++ b/app/login.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 	"github.com/mssola/user_agent"
@@ -27,15 +26,15 @@ func (a *App) AuthenticateUserForLogin(id, loginId, password, mfaToken, deviceId
 	if len(id) != 0 {
 		if user, err = a.GetUser(id); err != nil {
 			err.StatusCode = http.StatusBadRequest
-			if einterfaces.GetMetricsInterface() != nil {
-				einterfaces.GetMetricsInterface().IncrementLoginFail()
+			if a.Metrics != nil {
+				a.Metrics.IncrementLoginFail()
 			}
 			return nil, err
 		}
 	} else {
 		if user, err = a.GetUserForLogin(loginId, ldapOnly); err != nil {
-			if einterfaces.GetMetricsInterface() != nil {
-				einterfaces.GetMetricsInterface().IncrementLoginFail()
+			if a.Metrics != nil {
+				a.Metrics.IncrementLoginFail()
 			}
 			return nil, err
 		}
@@ -43,14 +42,14 @@ func (a *App) AuthenticateUserForLogin(id, loginId, password, mfaToken, deviceId
 
 	// and then authenticate them
 	if user, err = a.authenticateUser(user, password, mfaToken); err != nil {
-		if einterfaces.GetMetricsInterface() != nil {
-			einterfaces.GetMetricsInterface().IncrementLoginFail()
+		if a.Metrics != nil {
+			a.Metrics.IncrementLoginFail()
 		}
 		return nil, err
 	}
 
-	if einterfaces.GetMetricsInterface() != nil {
-		einterfaces.GetMetricsInterface().IncrementLogin()
+	if a.Metrics != nil {
+		a.Metrics.IncrementLogin()
 	}
 
 	return user, nil

--- a/app/notification.go
+++ b/app/notification.go
@@ -18,7 +18,6 @@ import (
 	"unicode"
 
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
@@ -369,8 +368,8 @@ func (a *App) sendNotificationEmail(post *model.Post, user *model.User, channel 
 		}
 	}()
 
-	if einterfaces.GetMetricsInterface() != nil {
-		einterfaces.GetMetricsInterface().IncrementPostSentEmail()
+	if a.Metrics != nil {
+		a.Metrics.IncrementPostSentEmail()
 	}
 
 	return nil
@@ -641,8 +640,8 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 
 		go a.sendToPushProxy(tmpMessage, session)
 
-		if einterfaces.GetMetricsInterface() != nil {
-			einterfaces.GetMetricsInterface().IncrementPostSentPush()
+		if a.Metrics != nil {
+			a.Metrics.IncrementPostSentPush()
 		}
 	}
 
@@ -701,7 +700,7 @@ func (a *App) sendToPushProxy(msg model.PushNotification, session *model.Session
 		if pushResponse[model.PUSH_STATUS] == model.PUSH_STATUS_REMOVE {
 			l4g.Info("Device was reported as removed for UserId=%v SessionId=%v removing push for this session", session.UserId, session.Id)
 			a.AttachDeviceId(session.Id, "", session.ExpiresAt)
-			ClearSessionCacheForUser(session.UserId)
+			a.ClearSessionCacheForUser(session.UserId)
 		}
 
 		if pushResponse[model.PUSH_STATUS] == model.PUSH_STATUS_FAIL {

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -409,7 +409,7 @@ func (a *App) RevokeAccessToken(token string) *model.AppError {
 	}
 
 	if session != nil {
-		ClearSessionCacheForUser(session.UserId)
+		a.ClearSessionCacheForUser(session.UserId)
 	}
 
 	return nil

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -16,7 +16,6 @@ import (
 	l4g "github.com/alecthomas/log4go"
 
 	"github.com/gorilla/mux"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 
@@ -96,8 +95,7 @@ func (api *BuiltInPluginAPI) CreatePost(post *model.Post) (*model.Post, *model.A
 }
 
 func (api *BuiltInPluginAPI) GetLdapUserAttributes(userId string, attributes []string) (map[string]string, *model.AppError) {
-	ldapInterface := einterfaces.GetLdapInterface()
-	if ldapInterface == nil {
+	if api.app.Ldap == nil {
 		return nil, model.NewAppError("GetLdapUserAttributes", "ent.ldap.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
@@ -106,7 +104,7 @@ func (api *BuiltInPluginAPI) GetLdapUserAttributes(userId string, attributes []s
 		return nil, err
 	}
 
-	return ldapInterface.GetUserAttributes(*user.AuthData, attributes)
+	return api.app.Ldap.GetUserAttributes(*user.AuthData, attributes)
 }
 
 func (api *BuiltInPluginAPI) GetSessionFromRequest(r *http.Request) (*model.Session, *model.AppError) {

--- a/app/saml.go
+++ b/app/saml.go
@@ -11,19 +11,17 @@ import (
 
 	"path/filepath"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
-func GetSamlMetadata() (string, *model.AppError) {
-	samlInterface := einterfaces.GetSamlInterface()
-	if samlInterface == nil {
+func (a *App) GetSamlMetadata() (string, *model.AppError) {
+	if a.Saml == nil {
 		err := model.NewAppError("GetSamlMetadata", "api.admin.saml.not_available.app_error", nil, "", http.StatusNotImplemented)
 		return "", err
 	}
 
-	if result, err := samlInterface.GetMetadata(); err != nil {
+	if result, err := a.Saml.GetMetadata(); err != nil {
 		return "", model.NewAppError("GetSamlMetadata", "api.admin.saml.metadata.app_error", nil, "err="+err.Message, err.StatusCode)
 	} else {
 		return result, nil

--- a/app/session_test.go
+++ b/app/session_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestCache(t *testing.T) {
+	th := Setup().InitBasic()
+
 	session := &model.Session{
 		Id:     model.NewId(),
 		Token:  model.NewId(),
@@ -23,7 +25,7 @@ func TestCache(t *testing.T) {
 		t.Fatal("should have items")
 	}
 
-	ClearSessionCacheForUser(session.UserId)
+	th.App.ClearSessionCacheForUser(session.UserId)
 
 	rkeys := sessionCache.Keys()
 	if len(rkeys) != len(keys)-1 {

--- a/app/team.go
+++ b/app/team.go
@@ -161,7 +161,7 @@ func (a *App) UpdateTeamMemberRoles(teamId string, userId string, newRoles strin
 		return nil, result.Err
 	}
 
-	ClearSessionCacheForUser(userId)
+	a.ClearSessionCacheForUser(userId)
 
 	sendUpdatedMemberRoleEvent(userId, member)
 
@@ -324,7 +324,7 @@ func (a *App) JoinUserToTeam(team *model.Team, user *model.User, userRequestorId
 		l4g.Error(utils.T("api.user.create_user.joining.error"), user.Id, team.Id, err)
 	}
 
-	ClearSessionCacheForUser(user.Id)
+	a.ClearSessionCacheForUser(user.Id)
 	a.InvalidateCacheForUser(user.Id)
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_ADDED_TO_TEAM, "", "", user.Id, nil)
@@ -621,7 +621,7 @@ func (a *App) LeaveTeam(team *model.Team, user *model.User) *model.AppError {
 		return result.Err
 	}
 
-	ClearSessionCacheForUser(user.Id)
+	a.ClearSessionCacheForUser(user.Id)
 	a.InvalidateCacheForUser(user.Id)
 
 	return nil

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 
@@ -191,8 +190,8 @@ func (c *WebConn) WritePump() {
 					return
 				}
 
-				if einterfaces.GetMetricsInterface() != nil {
-					go einterfaces.GetMetricsInterface().IncrementWebSocketBroadcast(msg.EventType())
+				if c.App.Metrics != nil {
+					go c.App.Metrics.IncrementWebSocketBroadcast(msg.EventType())
 				}
 
 			}

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -15,7 +15,6 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -145,13 +144,17 @@ func HubUnregister(webConn *WebConn) {
 }
 
 func Publish(message *model.WebSocketEvent) {
-	if metrics := einterfaces.GetMetricsInterface(); metrics != nil {
+	Global().Publish(message)
+}
+
+func (a *App) Publish(message *model.WebSocketEvent) {
+	if metrics := a.Metrics; metrics != nil {
 		metrics.IncrementWebsocketEvent(message.Event)
 	}
 
 	PublishSkipClusterSend(message)
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 		cm := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_PUBLISH,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
@@ -166,7 +169,7 @@ func Publish(message *model.WebSocketEvent) {
 			cm.SendType = model.CLUSTER_SEND_RELIABLE
 		}
 
-		einterfaces.GetClusterInterface().SendClusterMessage(cm)
+		a.Cluster.SendClusterMessage(cm)
 	}
 }
 
@@ -180,14 +183,14 @@ func (a *App) InvalidateCacheForChannel(channel *model.Channel) {
 	a.InvalidateCacheForChannelSkipClusterSend(channel.Id)
 	a.InvalidateCacheForChannelByNameSkipClusterSend(channel.TeamId, channel.Name)
 
-	if cluster := einterfaces.GetClusterInterface(); cluster != nil {
+	if a.Cluster != nil {
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
 			Data:     channel.Id,
 		}
 
-		einterfaces.GetClusterInterface().SendClusterMessage(msg)
+		a.Cluster.SendClusterMessage(msg)
 
 		nameMsg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_BY_NAME,
@@ -202,7 +205,7 @@ func (a *App) InvalidateCacheForChannel(channel *model.Channel) {
 			nameMsg.Props["id"] = channel.TeamId
 		}
 
-		einterfaces.GetClusterInterface().SendClusterMessage(nameMsg)
+		a.Cluster.SendClusterMessage(nameMsg)
 	}
 }
 
@@ -213,13 +216,13 @@ func (a *App) InvalidateCacheForChannelSkipClusterSend(channelId string) {
 func (a *App) InvalidateCacheForChannelMembers(channelId string) {
 	a.InvalidateCacheForChannelMembersSkipClusterSend(channelId)
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
 			Data:     channelId,
 		}
-		einterfaces.GetClusterInterface().SendClusterMessage(msg)
+		a.Cluster.SendClusterMessage(msg)
 	}
 }
 
@@ -231,13 +234,13 @@ func (a *App) InvalidateCacheForChannelMembersSkipClusterSend(channelId string) 
 func (a *App) InvalidateCacheForChannelMembersNotifyProps(channelId string) {
 	a.InvalidateCacheForChannelMembersNotifyPropsSkipClusterSend(channelId)
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_MEMBERS_NOTIFY_PROPS,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
 			Data:     channelId,
 		}
-		einterfaces.GetClusterInterface().SendClusterMessage(msg)
+		a.Cluster.SendClusterMessage(msg)
 	}
 }
 
@@ -256,13 +259,13 @@ func (a *App) InvalidateCacheForChannelByNameSkipClusterSend(teamId, name string
 func (a *App) InvalidateCacheForChannelPosts(channelId string) {
 	a.InvalidateCacheForChannelPostsSkipClusterSend(channelId)
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNEL_POSTS,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
 			Data:     channelId,
 		}
-		einterfaces.GetClusterInterface().SendClusterMessage(msg)
+		a.Cluster.SendClusterMessage(msg)
 	}
 }
 
@@ -273,13 +276,13 @@ func (a *App) InvalidateCacheForChannelPostsSkipClusterSend(channelId string) {
 func (a *App) InvalidateCacheForUser(userId string) {
 	a.InvalidateCacheForUserSkipClusterSend(userId)
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_USER,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
 			Data:     userId,
 		}
-		einterfaces.GetClusterInterface().SendClusterMessage(msg)
+		a.Cluster.SendClusterMessage(msg)
 	}
 }
 
@@ -296,13 +299,13 @@ func (a *App) InvalidateCacheForUserSkipClusterSend(userId string) {
 func (a *App) InvalidateCacheForWebhook(webhookId string) {
 	a.InvalidateCacheForWebhookSkipClusterSend(webhookId)
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_WEBHOOK,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
 			Data:     webhookId,
 		}
-		einterfaces.GetClusterInterface().SendClusterMessage(msg)
+		a.Cluster.SendClusterMessage(msg)
 	}
 }
 

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -11,7 +11,6 @@ import (
 	"unicode/utf8"
 
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
@@ -126,7 +125,7 @@ func (a *App) CreateWebhookPost(userId string, channel *model.Channel, text, ove
 	post := &model.Post{UserId: userId, ChannelId: channel.Id, Message: text, Type: postType}
 	post.AddProp("from_webhook", "true")
 
-	if metrics := einterfaces.GetMetricsInterface(); metrics != nil {
+	if metrics := a.Metrics; metrics != nil {
 		metrics.IncrementWebhookPost()
 	}
 

--- a/cmd/platform/ldap.go
+++ b/cmd/platform/ldap.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/spf13/cobra"
 )
 
@@ -27,11 +26,12 @@ func init() {
 }
 
 func ldapSyncCmdF(cmd *cobra.Command, args []string) error {
-	if _, err := initDBCommandContextCobra(cmd); err != nil {
+	a, err := initDBCommandContextCobra(cmd)
+	if err != nil {
 		return err
 	}
 
-	if ldapI := einterfaces.GetLdapInterface(); ldapI != nil {
+	if ldapI := a.Ldap; ldapI != nil {
 		if err := ldapI.Syncronize(); err != nil {
 			CommandPrintErrorln("ERROR: AD/LDAP Synchronization Failed")
 		} else {

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/mattermost/mattermost-server/api"
 	"github.com/mattermost/mattermost-server/api4"
 	"github.com/mattermost/mattermost-server/app"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/jobs"
 	"github.com/mattermost/mattermost-server/manualtesting"
 	"github.com/mattermost/mattermost-server/model"
@@ -96,7 +95,7 @@ func runServer(configFileLocation string) {
 		utils.Cfg.TeamSettings.MaxNotificationsPerChannel = &MaxNotificationsPerChannelDefault
 	}
 
-	app.ReloadConfig()
+	a.ReloadConfig()
 
 	// Enable developer settings if this is a "dev" build
 	if model.BuildNumber == "dev" {
@@ -120,21 +119,21 @@ func runServer(configFileLocation string) {
 	go runTokenCleanupJob(a)
 	go runCommandWebhookCleanupJob(a)
 
-	if complianceI := einterfaces.GetComplianceInterface(); complianceI != nil {
+	if complianceI := a.Compliance; complianceI != nil {
 		complianceI.StartComplianceDailyJob()
 	}
 
-	if einterfaces.GetClusterInterface() != nil {
+	if a.Cluster != nil {
 		a.RegisterAllClusterMessageHandlers()
-		einterfaces.GetClusterInterface().StartInterNodeCommunication()
+		a.Cluster.StartInterNodeCommunication()
 	}
 
-	if einterfaces.GetMetricsInterface() != nil {
-		einterfaces.GetMetricsInterface().StartServer()
+	if a.Metrics != nil {
+		a.Metrics.StartServer()
 	}
 
-	if einterfaces.GetElasticsearchInterface() != nil {
-		if err := einterfaces.GetElasticsearchInterface().Start(); err != nil {
+	if a.Elasticsearch != nil {
+		if err := a.Elasticsearch.Start(); err != nil {
 			l4g.Error(err.Error())
 		}
 	}
@@ -153,12 +152,12 @@ func runServer(configFileLocation string) {
 	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	<-c
 
-	if einterfaces.GetClusterInterface() != nil {
-		einterfaces.GetClusterInterface().StopInterNodeCommunication()
+	if a.Cluster != nil {
+		a.Cluster.StopInterNodeCommunication()
 	}
 
-	if einterfaces.GetMetricsInterface() != nil {
-		einterfaces.GetMetricsInterface().StopServer()
+	if a.Metrics != nil {
+		a.Metrics.StopServer()
 	}
 
 	jobs.Srv.StopSchedulers()

--- a/cmd/platform/user.go
+++ b/cmd/platform/user.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/mattermost/mattermost-server/app"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 	"github.com/spf13/cobra"
@@ -320,7 +319,7 @@ func resetUserPasswordCmdF(cmd *cobra.Command, args []string) error {
 }
 
 func resetUserMfaCmdF(cmd *cobra.Command, args []string) error {
-	_, err := initDBCommandContextCobra(cmd)
+	a, err := initDBCommandContextCobra(cmd)
 	if err != nil {
 		return err
 	}
@@ -336,7 +335,7 @@ func resetUserMfaCmdF(cmd *cobra.Command, args []string) error {
 			return errors.New("Unable to find user '" + args[i] + "'")
 		}
 
-		if err := app.DeactivateMfa(user.Id); err != nil {
+		if err := a.DeactivateMfa(user.Id); err != nil {
 			return err
 		}
 	}
@@ -420,7 +419,7 @@ func deleteAllUsersCommandF(cmd *cobra.Command, args []string) error {
 }
 
 func migrateAuthCmdF(cmd *cobra.Command, args []string) error {
-	_, err := initDBCommandContextCobra(cmd)
+	a, err := initDBCommandContextCobra(cmd)
 	if err != nil {
 		return err
 	}
@@ -452,7 +451,7 @@ func migrateAuthCmdF(cmd *cobra.Command, args []string) error {
 
 	forceFlag, _ := cmd.Flags().GetBool("force")
 
-	if migrate := einterfaces.GetAccountMigrationInterface(); migrate != nil {
+	if migrate := a.AccountMigration; migrate != nil {
 		if err := migrate.MigrateToLdap(fromAuth, matchField, forceFlag); err != nil {
 			return errors.New("Error while migrating users: " + err.Error())
 		}

--- a/utils/config.go
+++ b/utils/config.go
@@ -689,11 +689,3 @@ func Desanitize(cfg *model.Config) {
 		cfg.SqlSettings.DataSourceSearchReplicas[i] = Cfg.SqlSettings.DataSourceSearchReplicas[i]
 	}
 }
-
-func IsLeader() bool {
-	if IsLicensed() && *Cfg.ClusterSettings.Enable && einterfaces.GetClusterInterface() != nil {
-		return einterfaces.GetClusterInterface().IsLeader()
-	} else {
-		return true
-	}
-}


### PR DESCRIPTION
#### Summary
Removes a bunch of calls to `einterfaces.GetX` functions. Mostly find/replace changes. To eliminate `Global()` calls in the enterprise repo, these can no longer be singletons. Instead, in a following commit, the enterprise repo will register factory functions, which will be invoked by a future `app.New` function.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes: https://github.com/mattermost/enterprise/pull/197