### PR TITLE
PLT-7511: Fix error message escaping

### DIFF
--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -422,7 +422,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		if action == model.OAUTH_ACTION_MOBILE {
 			w.Write([]byte(err.ToJson()))
 		} else {
-			http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+err.Message, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+url.QueryEscape(err.Message), http.StatusTemporaryRedirect)
 		}
 		return
 	}
@@ -434,7 +434,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		if action == model.OAUTH_ACTION_MOBILE {
 			w.Write([]byte(err.ToJson()))
 		} else {
-			http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+err.Message, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+url.QueryEscape(err.Message), http.StatusTemporaryRedirect)
 		}
 		return
 	}


### PR DESCRIPTION
#### Summary
> In the error message that displays when trying to switch to a GitLab login already in use, if there is a plus sign in the email address, the error message prints a space instead, so the email link is incomplete.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7511

#### Checklist
N/A