### PR TITLE
PLT-7608: plugin CRUD operations for users, posts, channels, and teams

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -413,18 +413,24 @@ func (a *App) UpdateChannelMemberNotifyProps(data map[string]string, channelId s
 }
 
 func (a *App) DeleteChannel(channel *model.Channel, userId string) *model.AppError {
-	uc := a.Srv.Store.User().Get(userId)
 	ihc := a.Srv.Store.Webhook().GetIncomingByChannel(channel.Id)
 	ohc := a.Srv.Store.Webhook().GetOutgoingByChannel(channel.Id, -1, -1)
 
-	if uresult := <-uc; uresult.Err != nil {
-		return uresult.Err
-	} else if ihcresult := <-ihc; ihcresult.Err != nil {
+	var user *model.User
+	if userId != "" {
+		uc := a.Srv.Store.User().Get(userId)
+		uresult := <-uc
+		if uresult.Err != nil {
+			return uresult.Err
+		}
+		user = uresult.Data.(*model.User)
+	}
+
+	if ihcresult := <-ihc; ihcresult.Err != nil {
 		return ihcresult.Err
 	} else if ohcresult := <-ohc; ohcresult.Err != nil {
 		return ohcresult.Err
 	} else {
-		user := uresult.Data.(*model.User)
 		incomingHooks := ihcresult.Data.([]*model.IncomingWebhook)
 		outgoingHooks := ohcresult.Data.([]*model.OutgoingWebhook)
 
@@ -438,20 +444,22 @@ func (a *App) DeleteChannel(channel *model.Channel, userId string) *model.AppErr
 			return err
 		}
 
-		T := utils.GetUserTranslations(user.Locale)
+		if user != nil {
+			T := utils.GetUserTranslations(user.Locale)
 
-		post := &model.Post{
-			ChannelId: channel.Id,
-			Message:   fmt.Sprintf(T("api.channel.delete_channel.archived"), user.Username),
-			Type:      model.POST_CHANNEL_DELETED,
-			UserId:    userId,
-			Props: model.StringInterface{
-				"username": user.Username,
-			},
-		}
+			post := &model.Post{
+				ChannelId: channel.Id,
+				Message:   fmt.Sprintf(T("api.channel.delete_channel.archived"), user.Username),
+				Type:      model.POST_CHANNEL_DELETED,
+				UserId:    userId,
+				Props: model.StringInterface{
+					"username": user.Username,
+				},
+			}
 
-		if _, err := a.CreatePost(post, channel, false); err != nil {
-			l4g.Error(utils.T("api.channel.delete_channel.failed_post.error"), err)
+			if _, err := a.CreatePost(post, channel, false); err != nil {
+				l4g.Error(utils.T("api.channel.delete_channel.failed_post.error"), err)
+			}
 		}
 
 		now := model.GetMillis()

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -41,20 +41,102 @@ func (api *PluginAPI) LoadPluginConfiguration(dest interface{}) error {
 	}
 }
 
+func (api *PluginAPI) CreateTeam(team *model.Team) (*model.Team, *model.AppError) {
+	return api.app.CreateTeam(team)
+}
+
+func (api *PluginAPI) DeleteTeam(teamId string) *model.AppError {
+	return api.app.SoftDeleteTeam(teamId)
+}
+
+func (api *PluginAPI) GetTeam(teamId string) (*model.Team, *model.AppError) {
+	return api.app.GetTeam(teamId)
+}
+
 func (api *PluginAPI) GetTeamByName(name string) (*model.Team, *model.AppError) {
 	return api.app.GetTeamByName(name)
+}
+
+func (api *PluginAPI) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
+	return api.app.UpdateTeam(team)
+}
+
+func (api *PluginAPI) CreateUser(user *model.User) (*model.User, *model.AppError) {
+	return api.app.CreateUser(user)
+}
+
+func (api *PluginAPI) DeleteUser(userId string) *model.AppError {
+	user, err := api.app.GetUser(userId)
+	if err != nil {
+		return err
+	}
+	_, err = api.app.UpdateActive(user, false)
+	return err
+}
+
+func (api *PluginAPI) GetUser(userId string) (*model.User, *model.AppError) {
+	return api.app.GetUser(userId)
+}
+
+func (api *PluginAPI) GetUserByEmail(email string) (*model.User, *model.AppError) {
+	return api.app.GetUserByEmail(email)
 }
 
 func (api *PluginAPI) GetUserByUsername(name string) (*model.User, *model.AppError) {
 	return api.app.GetUserByUsername(name)
 }
 
+func (api *PluginAPI) UpdateUser(user *model.User) (*model.User, *model.AppError) {
+	return api.app.UpdateUser(user, true)
+}
+
+func (api *PluginAPI) CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	return api.app.CreateChannel(channel, false)
+}
+
+func (api *PluginAPI) DeleteChannel(channelId string) *model.AppError {
+	channel, err := api.app.GetChannel(channelId)
+	if err != nil {
+		return err
+	}
+	return api.app.DeleteChannel(channel, "")
+}
+
+func (api *PluginAPI) GetChannel(channelId string) (*model.Channel, *model.AppError) {
+	return api.app.GetChannel(channelId)
+}
+
 func (api *PluginAPI) GetChannelByName(name, teamId string) (*model.Channel, *model.AppError) {
 	return api.app.GetChannelByName(name, teamId)
 }
 
+func (api *PluginAPI) GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.AppError) {
+	return api.app.GetDirectChannel(userId1, userId2)
+}
+
+func (api *PluginAPI) GetGroupChannel(userIds []string) (*model.Channel, *model.AppError) {
+	return api.app.CreateGroupChannel(userIds, "")
+}
+
+func (api *PluginAPI) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	return api.app.UpdateChannel(channel)
+}
+
 func (api *PluginAPI) CreatePost(post *model.Post) (*model.Post, *model.AppError) {
 	return api.app.CreatePostMissingChannel(post, true)
+}
+
+func (api *PluginAPI) DeletePost(postId string) *model.AppError {
+	_, err := api.app.DeletePost(postId)
+	return err
+}
+
+func (api *PluginAPI) GetPost(postId string) (*model.Post, *model.AppError) {
+	return api.app.GetSinglePost(postId)
+}
+
+func (api *PluginAPI) UpdatePost(post *model.Post) (*model.Post, *model.AppError) {
+	return api.app.UpdatePost(post, false)
 }
 
 type BuiltInPluginAPI struct {

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -9,15 +9,69 @@ type API interface {
 	// struct that the configuration JSON can be unmarshalled to.
 	LoadPluginConfiguration(dest interface{}) error
 
-	// GetTeamByName gets a team by its name.
-	GetTeamByName(name string) (*model.Team, *model.AppError)
+	// CreateUser creates a user.
+	CreateUser(user *model.User) (*model.User, *model.AppError)
+
+	// DeleteUser deletes a user.
+	DeleteUser(userId string) *model.AppError
+
+	// GetUser gets a user.
+	GetUser(userId string) (*model.User, *model.AppError)
+
+	// GetUserByEmail gets a user by their email address.
+	GetUserByEmail(email string) (*model.User, *model.AppError)
 
 	// GetUserByUsername gets a user by their username.
 	GetUserByUsername(name string) (*model.User, *model.AppError)
 
+	// UpdateUser updates a user.
+	UpdateUser(user *model.User) (*model.User, *model.AppError)
+
+	// CreateTeam creates a team.
+	CreateTeam(team *model.Team) (*model.Team, *model.AppError)
+
+	// DeleteTeam deletes a team.
+	DeleteTeam(teamId string) *model.AppError
+
+	// GetTeam gets a team.
+	GetTeam(teamId string) (*model.Team, *model.AppError)
+
+	// GetTeamByName gets a team by its name.
+	GetTeamByName(name string) (*model.Team, *model.AppError)
+
+	// UpdateTeam updates a team.
+	UpdateTeam(team *model.Team) (*model.Team, *model.AppError)
+
+	// CreateChannel creates a channel.
+	CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError)
+
+	// DeleteChannel deletes a channel.
+	DeleteChannel(channelId string) *model.AppError
+
+	// GetChannel gets a channel.
+	GetChannel(channelId string) (*model.Channel, *model.AppError)
+
 	// GetChannelByName gets a channel by its name.
 	GetChannelByName(name, teamId string) (*model.Channel, *model.AppError)
 
+	// GetDirectChannel gets a direct message channel.
+	GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.AppError)
+
+	// GetGroupChannel gets a group message channel.
+	GetGroupChannel(userIds []string) (*model.Channel, *model.AppError)
+
+	// UpdateChannel updates a channel.
+	UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError)
+
 	// CreatePost creates a post.
 	CreatePost(post *model.Post) (*model.Post, *model.AppError)
+
+	// DeletePost deletes a post.
+	DeletePost(postId string) *model.AppError
+
+	// GetPost gets a post.
+	GetPost(postId string) (*model.Post, *model.AppError)
+
+	// Update post updates a post.
+	UpdatePost(post *model.Post) (*model.Post, *model.AppError)
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -17,14 +17,43 @@ func (m *API) LoadPluginConfiguration(dest interface{}) error {
 	return m.Called(dest).Error(0)
 }
 
-func (m *API) GetTeamByName(name string) (*model.Team, *model.AppError) {
-	ret := m.Called(name)
-	if f, ok := ret.Get(0).(func(string) (*model.Team, *model.AppError)); ok {
-		return f(name)
+func (m *API) CreateUser(user *model.User) (*model.User, *model.AppError) {
+	ret := m.Called(user)
+	if f, ok := ret.Get(0).(func(*model.User) (*model.User, *model.AppError)); ok {
+		return f(user)
 	}
-	team, _ := ret.Get(0).(*model.Team)
+	userOut, _ := ret.Get(0).(*model.User)
 	err, _ := ret.Get(1).(*model.AppError)
-	return team, err
+	return userOut, err
+}
+
+func (m *API) DeleteUser(userId string) *model.AppError {
+	ret := m.Called(userId)
+	if f, ok := ret.Get(0).(func(string) *model.AppError); ok {
+		return f(userId)
+	}
+	err, _ := ret.Get(0).(*model.AppError)
+	return err
+}
+
+func (m *API) GetUser(userId string) (*model.User, *model.AppError) {
+	ret := m.Called(userId)
+	if f, ok := ret.Get(0).(func(string) (*model.User, *model.AppError)); ok {
+		return f(userId)
+	}
+	user, _ := ret.Get(0).(*model.User)
+	err, _ := ret.Get(1).(*model.AppError)
+	return user, err
+}
+
+func (m *API) GetUserByEmail(email string) (*model.User, *model.AppError) {
+	ret := m.Called(email)
+	if f, ok := ret.Get(0).(func(string) (*model.User, *model.AppError)); ok {
+		return f(email)
+	}
+	user, _ := ret.Get(0).(*model.User)
+	err, _ := ret.Get(1).(*model.AppError)
+	return user, err
 }
 
 func (m *API) GetUserByUsername(name string) (*model.User, *model.AppError) {
@@ -37,6 +66,94 @@ func (m *API) GetUserByUsername(name string) (*model.User, *model.AppError) {
 	return user, err
 }
 
+func (m *API) UpdateUser(user *model.User) (*model.User, *model.AppError) {
+	ret := m.Called(user)
+	if f, ok := ret.Get(0).(func(*model.User) (*model.User, *model.AppError)); ok {
+		return f(user)
+	}
+	userOut, _ := ret.Get(0).(*model.User)
+	err, _ := ret.Get(1).(*model.AppError)
+	return userOut, err
+}
+
+func (m *API) CreateTeam(team *model.Team) (*model.Team, *model.AppError) {
+	ret := m.Called(team)
+	if f, ok := ret.Get(0).(func(*model.Team) (*model.Team, *model.AppError)); ok {
+		return f(team)
+	}
+	teamOut, _ := ret.Get(0).(*model.Team)
+	err, _ := ret.Get(1).(*model.AppError)
+	return teamOut, err
+}
+
+func (m *API) DeleteTeam(teamId string) *model.AppError {
+	ret := m.Called(teamId)
+	if f, ok := ret.Get(0).(func(string) *model.AppError); ok {
+		return f(teamId)
+	}
+	err, _ := ret.Get(0).(*model.AppError)
+	return err
+}
+
+func (m *API) GetTeam(teamId string) (*model.Team, *model.AppError) {
+	ret := m.Called(teamId)
+	if f, ok := ret.Get(0).(func(string) (*model.Team, *model.AppError)); ok {
+		return f(teamId)
+	}
+	team, _ := ret.Get(0).(*model.Team)
+	err, _ := ret.Get(1).(*model.AppError)
+	return team, err
+}
+
+func (m *API) GetTeamByName(name string) (*model.Team, *model.AppError) {
+	ret := m.Called(name)
+	if f, ok := ret.Get(0).(func(string) (*model.Team, *model.AppError)); ok {
+		return f(name)
+	}
+	team, _ := ret.Get(0).(*model.Team)
+	err, _ := ret.Get(1).(*model.AppError)
+	return team, err
+}
+
+func (m *API) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
+	ret := m.Called(team)
+	if f, ok := ret.Get(0).(func(*model.Team) (*model.Team, *model.AppError)); ok {
+		return f(team)
+	}
+	teamOut, _ := ret.Get(0).(*model.Team)
+	err, _ := ret.Get(1).(*model.AppError)
+	return teamOut, err
+}
+
+func (m *API) CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	ret := m.Called(channel)
+	if f, ok := ret.Get(0).(func(*model.Channel) (*model.Channel, *model.AppError)); ok {
+		return f(channel)
+	}
+	channelOut, _ := ret.Get(0).(*model.Channel)
+	err, _ := ret.Get(1).(*model.AppError)
+	return channelOut, err
+}
+
+func (m *API) DeleteChannel(channelId string) *model.AppError {
+	ret := m.Called(channelId)
+	if f, ok := ret.Get(0).(func(string) *model.AppError); ok {
+		return f(channelId)
+	}
+	err, _ := ret.Get(0).(*model.AppError)
+	return err
+}
+
+func (m *API) GetChannel(channelId string) (*model.Channel, *model.AppError) {
+	ret := m.Called(channelId)
+	if f, ok := ret.Get(0).(func(string) (*model.Channel, *model.AppError)); ok {
+		return f(channelId)
+	}
+	channel, _ := ret.Get(0).(*model.Channel)
+	err, _ := ret.Get(1).(*model.AppError)
+	return channel, err
+}
+
 func (m *API) GetChannelByName(name, teamId string) (*model.Channel, *model.AppError) {
 	ret := m.Called(name, teamId)
 	if f, ok := ret.Get(0).(func(_, _ string) (*model.Channel, *model.AppError)); ok {
@@ -47,7 +164,66 @@ func (m *API) GetChannelByName(name, teamId string) (*model.Channel, *model.AppE
 	return channel, err
 }
 
+func (m *API) GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.AppError) {
+	ret := m.Called(userId1, userId2)
+	if f, ok := ret.Get(0).(func(_, _ string) (*model.Channel, *model.AppError)); ok {
+		return f(userId1, userId2)
+	}
+	channel, _ := ret.Get(0).(*model.Channel)
+	err, _ := ret.Get(1).(*model.AppError)
+	return channel, err
+}
+
+func (m *API) GetGroupChannel(userIds []string) (*model.Channel, *model.AppError) {
+	ret := m.Called(userIds)
+	if f, ok := ret.Get(0).(func([]string) (*model.Channel, *model.AppError)); ok {
+		return f(userIds)
+	}
+	channel, _ := ret.Get(0).(*model.Channel)
+	err, _ := ret.Get(1).(*model.AppError)
+	return channel, err
+}
+
+func (m *API) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	ret := m.Called(channel)
+	if f, ok := ret.Get(0).(func(*model.Channel) (*model.Channel, *model.AppError)); ok {
+		return f(channel)
+	}
+	channelOut, _ := ret.Get(0).(*model.Channel)
+	err, _ := ret.Get(1).(*model.AppError)
+	return channelOut, err
+}
+
 func (m *API) CreatePost(post *model.Post) (*model.Post, *model.AppError) {
+	ret := m.Called(post)
+	if f, ok := ret.Get(0).(func(*model.Post) (*model.Post, *model.AppError)); ok {
+		return f(post)
+	}
+	postOut, _ := ret.Get(0).(*model.Post)
+	err, _ := ret.Get(1).(*model.AppError)
+	return postOut, err
+}
+
+func (m *API) DeletePost(postId string) *model.AppError {
+	ret := m.Called(postId)
+	if f, ok := ret.Get(0).(func(string) *model.AppError); ok {
+		return f(postId)
+	}
+	err, _ := ret.Get(0).(*model.AppError)
+	return err
+}
+
+func (m *API) GetPost(postId string) (*model.Post, *model.AppError) {
+	ret := m.Called(postId)
+	if f, ok := ret.Get(0).(func(string) (*model.Post, *model.AppError)); ok {
+		return f(postId)
+	}
+	post, _ := ret.Get(0).(*model.Post)
+	err, _ := ret.Get(1).(*model.AppError)
+	return post, err
+}
+
+func (m *API) UpdatePost(post *model.Post) (*model.Post, *model.AppError) {
 	ret := m.Called(post)
 	if f, ok := ret.Get(0).(func(*model.Post) (*model.Post, *model.AppError)); ok {
 		return f(post)

--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -28,13 +28,51 @@ func (api *LocalAPI) LoadPluginConfiguration(args struct{}, reply *[]byte) error
 	return nil
 }
 
+type APIErrorReply struct {
+	Error *model.AppError
+}
+
 type APITeamReply struct {
 	Team  *model.Team
 	Error *model.AppError
 }
 
+func (api *LocalAPI) CreateTeam(args *model.Team, reply *APITeamReply) error {
+	team, err := api.api.CreateTeam(args)
+	*reply = APITeamReply{
+		Team:  team,
+		Error: err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) DeleteTeam(args string, reply *APIErrorReply) error {
+	*reply = APIErrorReply{
+		Error: api.api.DeleteTeam(args),
+	}
+	return nil
+}
+
+func (api *LocalAPI) GetTeam(args string, reply *APITeamReply) error {
+	team, err := api.api.GetTeam(args)
+	*reply = APITeamReply{
+		Team:  team,
+		Error: err,
+	}
+	return nil
+}
+
 func (api *LocalAPI) GetTeamByName(args string, reply *APITeamReply) error {
 	team, err := api.api.GetTeamByName(args)
+	*reply = APITeamReply{
+		Team:  team,
+		Error: err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) UpdateTeam(args *model.Team, reply *APITeamReply) error {
+	team, err := api.api.UpdateTeam(args)
 	*reply = APITeamReply{
 		Team:  team,
 		Error: err,
@@ -47,8 +85,51 @@ type APIUserReply struct {
 	Error *model.AppError
 }
 
+func (api *LocalAPI) CreateUser(args *model.User, reply *APIUserReply) error {
+	user, err := api.api.CreateUser(args)
+	*reply = APIUserReply{
+		User:  user,
+		Error: err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) DeleteUser(args string, reply *APIErrorReply) error {
+	*reply = APIErrorReply{
+		Error: api.api.DeleteUser(args),
+	}
+	return nil
+}
+
+func (api *LocalAPI) GetUser(args string, reply *APIUserReply) error {
+	user, err := api.api.GetUser(args)
+	*reply = APIUserReply{
+		User:  user,
+		Error: err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) GetUserByEmail(args string, reply *APIUserReply) error {
+	user, err := api.api.GetUserByEmail(args)
+	*reply = APIUserReply{
+		User:  user,
+		Error: err,
+	}
+	return nil
+}
+
 func (api *LocalAPI) GetUserByUsername(args string, reply *APIUserReply) error {
 	user, err := api.api.GetUserByUsername(args)
+	*reply = APIUserReply{
+		User:  user,
+		Error: err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) UpdateUser(args *model.User, reply *APIUserReply) error {
+	user, err := api.api.UpdateUser(args)
 	*reply = APIUserReply{
 		User:  user,
 		Error: err,
@@ -61,13 +142,74 @@ type APIGetChannelByNameArgs struct {
 	TeamId string
 }
 
+type APIGetDirectChannelArgs struct {
+	UserId1 string
+	UserId2 string
+}
+
+type APIGetGroupChannelArgs struct {
+	UserIds []string
+}
+
 type APIChannelReply struct {
 	Channel *model.Channel
 	Error   *model.AppError
 }
 
+func (api *LocalAPI) CreateChannel(args *model.Channel, reply *APIChannelReply) error {
+	channel, err := api.api.CreateChannel(args)
+	*reply = APIChannelReply{
+		Channel: channel,
+		Error:   err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) DeleteChannel(args string, reply *APIErrorReply) error {
+	*reply = APIErrorReply{
+		Error: api.api.DeleteChannel(args),
+	}
+	return nil
+}
+
+func (api *LocalAPI) GetChannel(args string, reply *APIChannelReply) error {
+	channel, err := api.api.GetChannel(args)
+	*reply = APIChannelReply{
+		Channel: channel,
+		Error:   err,
+	}
+	return nil
+}
+
 func (api *LocalAPI) GetChannelByName(args *APIGetChannelByNameArgs, reply *APIChannelReply) error {
 	channel, err := api.api.GetChannelByName(args.Name, args.TeamId)
+	*reply = APIChannelReply{
+		Channel: channel,
+		Error:   err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) GetDirectChannel(args *APIGetDirectChannelArgs, reply *APIChannelReply) error {
+	channel, err := api.api.GetDirectChannel(args.UserId1, args.UserId2)
+	*reply = APIChannelReply{
+		Channel: channel,
+		Error:   err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) GetGroupChannel(args *APIGetGroupChannelArgs, reply *APIChannelReply) error {
+	channel, err := api.api.GetGroupChannel(args.UserIds)
+	*reply = APIChannelReply{
+		Channel: channel,
+		Error:   err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) UpdateChannel(args *model.Channel, reply *APIChannelReply) error {
+	channel, err := api.api.UpdateChannel(args)
 	*reply = APIChannelReply{
 		Channel: channel,
 		Error:   err,
@@ -82,6 +224,31 @@ type APIPostReply struct {
 
 func (api *LocalAPI) CreatePost(args *model.Post, reply *APIPostReply) error {
 	post, err := api.api.CreatePost(args)
+	*reply = APIPostReply{
+		Post:  post,
+		Error: err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) DeletePost(args string, reply *APIErrorReply) error {
+	*reply = APIErrorReply{
+		Error: api.api.DeletePost(args),
+	}
+	return nil
+}
+
+func (api *LocalAPI) GetPost(args string, reply *APIPostReply) error {
+	post, err := api.api.GetPost(args)
+	*reply = APIPostReply{
+		Post:  post,
+		Error: err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) UpdatePost(args *model.Post, reply *APIPostReply) error {
+	post, err := api.api.UpdatePost(args)
 	*reply = APIPostReply{
 		Post:  post,
 		Error: err,
@@ -113,12 +280,36 @@ func (api *RemoteAPI) LoadPluginConfiguration(dest interface{}) error {
 	return json.Unmarshal(config, dest)
 }
 
-func (api *RemoteAPI) GetTeamByName(name string) (*model.Team, *model.AppError) {
-	var reply APITeamReply
-	if err := api.client.Call("LocalAPI.GetTeamByName", name, &reply); err != nil {
-		return nil, model.NewAppError("RemoteAPI.GetTeamByName", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+func (api *RemoteAPI) CreateUser(user *model.User) (*model.User, *model.AppError) {
+	var reply APIUserReply
+	if err := api.client.Call("LocalAPI.CreateUser", user, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.CreateUser", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
 	}
-	return reply.Team, reply.Error
+	return reply.User, reply.Error
+}
+
+func (api *RemoteAPI) DeleteUser(userId string) *model.AppError {
+	var reply APIErrorReply
+	if err := api.client.Call("LocalAPI.DeleteUser", userId, &reply); err != nil {
+		return model.NewAppError("RemoteAPI.DeleteUser", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Error
+}
+
+func (api *RemoteAPI) GetUser(userId string) (*model.User, *model.AppError) {
+	var reply APIUserReply
+	if err := api.client.Call("LocalAPI.GetUser", userId, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetUser", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.User, reply.Error
+}
+
+func (api *RemoteAPI) GetUserByEmail(email string) (*model.User, *model.AppError) {
+	var reply APIUserReply
+	if err := api.client.Call("LocalAPI.GetUserByEmail", email, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetUserByEmail", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.User, reply.Error
 }
 
 func (api *RemoteAPI) GetUserByUsername(name string) (*model.User, *model.AppError) {
@@ -127,6 +318,78 @@ func (api *RemoteAPI) GetUserByUsername(name string) (*model.User, *model.AppErr
 		return nil, model.NewAppError("RemoteAPI.GetUserByUsername", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
 	}
 	return reply.User, reply.Error
+}
+
+func (api *RemoteAPI) UpdateUser(user *model.User) (*model.User, *model.AppError) {
+	var reply APIUserReply
+	if err := api.client.Call("LocalAPI.UpdateUser", user, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.UpdateUser", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.User, reply.Error
+}
+
+func (api *RemoteAPI) CreateTeam(team *model.Team) (*model.Team, *model.AppError) {
+	var reply APITeamReply
+	if err := api.client.Call("LocalAPI.CreateTeam", team, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.CreateTeam", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Team, reply.Error
+}
+
+func (api *RemoteAPI) DeleteTeam(teamId string) *model.AppError {
+	var reply APIErrorReply
+	if err := api.client.Call("LocalAPI.DeleteTeam", teamId, &reply); err != nil {
+		return model.NewAppError("RemoteAPI.DeleteTeam", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Error
+}
+
+func (api *RemoteAPI) GetTeam(teamId string) (*model.Team, *model.AppError) {
+	var reply APITeamReply
+	if err := api.client.Call("LocalAPI.GetTeam", teamId, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetTeam", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Team, reply.Error
+}
+
+func (api *RemoteAPI) GetTeamByName(name string) (*model.Team, *model.AppError) {
+	var reply APITeamReply
+	if err := api.client.Call("LocalAPI.GetTeamByName", name, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetTeamByName", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Team, reply.Error
+}
+
+func (api *RemoteAPI) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
+	var reply APITeamReply
+	if err := api.client.Call("LocalAPI.UpdateTeam", team, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.UpdateTeam", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Team, reply.Error
+}
+
+func (api *RemoteAPI) CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	var reply APIChannelReply
+	if err := api.client.Call("LocalAPI.CreateChannel", channel, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.CreateChannel", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Channel, reply.Error
+}
+
+func (api *RemoteAPI) DeleteChannel(channelId string) *model.AppError {
+	var reply APIErrorReply
+	if err := api.client.Call("LocalAPI.DeleteChannel", channelId, &reply); err != nil {
+		return model.NewAppError("RemoteAPI.DeleteChannel", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Error
+}
+
+func (api *RemoteAPI) GetChannel(channelId string) (*model.Channel, *model.AppError) {
+	var reply APIChannelReply
+	if err := api.client.Call("LocalAPI.GetChannel", channelId, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetChannel", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Channel, reply.Error
 }
 
 func (api *RemoteAPI) GetChannelByName(name, teamId string) (*model.Channel, *model.AppError) {
@@ -140,10 +403,63 @@ func (api *RemoteAPI) GetChannelByName(name, teamId string) (*model.Channel, *mo
 	return reply.Channel, reply.Error
 }
 
+func (api *RemoteAPI) GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.AppError) {
+	var reply APIChannelReply
+	if err := api.client.Call("LocalAPI.GetDirectChannel", &APIGetDirectChannelArgs{
+		UserId1: userId1,
+		UserId2: userId2,
+	}, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetDirectChannel", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Channel, reply.Error
+}
+
+func (api *RemoteAPI) GetGroupChannel(userIds []string) (*model.Channel, *model.AppError) {
+	var reply APIChannelReply
+	if err := api.client.Call("LocalAPI.GetGroupChannel", &APIGetGroupChannelArgs{
+		UserIds: userIds,
+	}, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetGroupChannel", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Channel, reply.Error
+}
+
+func (api *RemoteAPI) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
+	var reply APIChannelReply
+	if err := api.client.Call("LocalAPI.UpdateChannel", channel, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.UpdateChannel", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Channel, reply.Error
+}
+
 func (api *RemoteAPI) CreatePost(post *model.Post) (*model.Post, *model.AppError) {
 	var reply APIPostReply
 	if err := api.client.Call("LocalAPI.CreatePost", post, &reply); err != nil {
 		return nil, model.NewAppError("RemoteAPI.CreatePost", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Post, reply.Error
+}
+
+func (api *RemoteAPI) DeletePost(postId string) *model.AppError {
+	var reply APIErrorReply
+	if err := api.client.Call("LocalAPI.DeletePost", postId, &reply); err != nil {
+		return model.NewAppError("RemoteAPI.DeletePost", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Error
+}
+
+func (api *RemoteAPI) GetPost(postId string) (*model.Post, *model.AppError) {
+	var reply APIPostReply
+	if err := api.client.Call("LocalAPI.GetPost", postId, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.GetPost", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Post, reply.Error
+}
+
+func (api *RemoteAPI) UpdatePost(post *model.Post) (*model.Post, *model.AppError) {
+	var reply APIPostReply
+	if err := api.client.Call("LocalAPI.UpdatePost", post, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.UpdatePost", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
 	}
 	return reply.Post, reply.Error
 }


### PR DESCRIPTION
#### Summary
Added the following APIs:

```go
CreateUser(user *model.User) (*model.User, *model.AppError)
DeleteUser(userId string) *model.AppError
GetUser(userId string) (*model.User, *model.AppError)
GetUserByEmail(email string) (*model.User, *model.AppError)
UpdateUser(user *model.User) (*model.User, *model.AppError)
CreateTeam(team *model.Team) (*model.Team, *model.AppError)
DeleteTeam(teamId string) *model.AppError
GetTeam(teamId string) (*model.Team, *model.AppError)
UpdateTeam(team *model.Team) (*model.Team, *model.AppError)
CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError)
DeleteChannel(channelId string) *model.AppError
GetChannel(channelId string) (*model.Channel, *model.AppError)
GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.AppError)
GetGroupChannel(userIds []string) (*model.Channel, *model.AppError)
UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError)
DeletePost(postId string) *model.AppError
GetPost(postId string) (*model.Post, *model.AppError)
UpdatePost(post *model.Post) (*model.Post, *model.AppError)
```

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7608

#### Checklist
- [x] Added or updated unit tests (required for all new features)