### PR TITLE
Remove more global refs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -9,7 +9,6 @@ import (
 	l4g "github.com/alecthomas/log4go"
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/app"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 
@@ -124,7 +123,7 @@ func InitApi(root *mux.Router) {
 }
 
 func HandleEtag(etag string, routeName string, w http.ResponseWriter, r *http.Request) bool {
-	metrics := einterfaces.GetMetricsInterface()
+	metrics := app.Global().Metrics
 	if et := r.Header.Get(model.HEADER_ETAG_CLIENT); len(etag) > 0 {
 		if et == etag {
 			w.Header().Set(model.HEADER_ETAG_SERVER, etag)

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -1187,30 +1187,30 @@ func TestGetFlaggedPosts(t *testing.T) {
 }
 
 func TestGetMessageForNotification(t *testing.T) {
-	Setup().InitBasic()
+	th := Setup().InitBasic()
 
-	testPng := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
+	testPng := store.Must(th.App.Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test1.png",
 		Name:      "test1.png",
 		MimeType:  "image/png",
 	})).(*model.FileInfo)
 
-	testJpg1 := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
+	testJpg1 := store.Must(th.App.Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test2.jpg",
 		Name:      "test2.jpg",
 		MimeType:  "image/jpeg",
 	})).(*model.FileInfo)
 
-	testFile := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
+	testFile := store.Must(th.App.Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test1.go",
 		Name:      "test1.go",
 		MimeType:  "text/plain",
 	})).(*model.FileInfo)
 
-	testJpg2 := store.Must(app.Global().Srv.Store.FileInfo().Save(&model.FileInfo{
+	testJpg2 := store.Must(th.App.Srv.Store.FileInfo().Save(&model.FileInfo{
 		CreatorId: model.NewId(),
 		Path:      "test3.jpg",
 		Name:      "test3.jpg",
@@ -1224,39 +1224,39 @@ func TestGetMessageForNotification(t *testing.T) {
 		Message: "test",
 	}
 
-	if app.Global().GetMessageForNotification(post, translateFunc) != "test" {
+	if th.App.GetMessageForNotification(post, translateFunc) != "test" {
 		t.Fatal("should've returned message text")
 	}
 
 	post.FileIds = model.StringArray{testPng.Id}
-	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testPng.Id, post.Id))
-	if app.Global().GetMessageForNotification(post, translateFunc) != "test" {
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(testPng.Id, post.Id))
+	if th.App.GetMessageForNotification(post, translateFunc) != "test" {
 		t.Fatal("should've returned message text, even with attachments")
 	}
 
 	post.Message = ""
-	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "1 image sent: test1.png" {
+	if message := th.App.GetMessageForNotification(post, translateFunc); message != "1 image sent: test1.png" {
 		t.Fatal("should've returned number of images:", message)
 	}
 
 	post.FileIds = model.StringArray{testPng.Id, testJpg1.Id}
-	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testJpg1.Id, post.Id))
-	app.Global().Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
-	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "2 images sent: test1.png, test2.jpg" && message != "2 images sent: test2.jpg, test1.png" {
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(testJpg1.Id, post.Id))
+	th.App.Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
+	if message := th.App.GetMessageForNotification(post, translateFunc); message != "2 images sent: test1.png, test2.jpg" && message != "2 images sent: test2.jpg, test1.png" {
 		t.Fatal("should've returned number of images:", message)
 	}
 
 	post.Id = model.NewId()
 	post.FileIds = model.StringArray{testFile.Id}
-	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testFile.Id, post.Id))
-	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "1 file sent: test1.go" {
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(testFile.Id, post.Id))
+	if message := th.App.GetMessageForNotification(post, translateFunc); message != "1 file sent: test1.go" {
 		t.Fatal("should've returned number of files:", message)
 	}
 
-	store.Must(app.Global().Srv.Store.FileInfo().AttachToPost(testJpg2.Id, post.Id))
-	app.Global().Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(testJpg2.Id, post.Id))
+	th.App.Srv.Store.FileInfo().InvalidateFileInfosForPostCache(post.Id)
 	post.FileIds = model.StringArray{testFile.Id, testJpg2.Id}
-	if message := app.Global().GetMessageForNotification(post, translateFunc); message != "2 files sent: test1.go, test3.jpg" && message != "2 files sent: test3.jpg, test1.go" {
+	if message := th.App.GetMessageForNotification(post, translateFunc); message != "2 files sent: test1.go, test3.jpg" && message != "2 files sent: test3.jpg, test1.go" {
 		t.Fatal("should've returned number of mixed files:", message)
 	}
 }

--- a/api4/api.go
+++ b/api4/api.go
@@ -9,7 +9,6 @@ import (
 	l4g "github.com/alecthomas/log4go"
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/app"
-	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 
@@ -225,7 +224,7 @@ func InitApi(root *mux.Router, full bool) {
 }
 
 func HandleEtag(etag string, routeName string, w http.ResponseWriter, r *http.Request) bool {
-	metrics := einterfaces.GetMetricsInterface()
+	metrics := app.Global().Metrics
 	if et := r.Header.Get(model.HEADER_ETAG_CLIENT); len(etag) > 0 {
 		if et == etag {
 			w.Header().Set(model.HEADER_ETAG_SERVER, etag)

--- a/app/admin.go
+++ b/app/admin.go
@@ -149,7 +149,7 @@ func (a *App) SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool)
 		return err
 	}
 
-	if err := utils.ValidateLdapFilter(cfg); err != nil {
+	if err := utils.ValidateLdapFilter(cfg, a.Ldap); err != nil {
 		return err
 	}
 
@@ -187,7 +187,7 @@ func (a *App) RecycleDatabaseConnection() {
 	oldStore := a.Srv.Store
 
 	l4g.Warn(utils.T("api.admin.recycle_db_start.warn"))
-	a.Srv.Store = store.NewLayeredStore()
+	a.Srv.Store = store.NewLayeredStore(a.Metrics, a.Cluster)
 
 	jobs.Srv.Store = a.Srv.Store
 

--- a/app/app.go
+++ b/app/app.go
@@ -9,7 +9,9 @@ import (
 	"sync"
 
 	"github.com/mattermost/mattermost-server/einterfaces"
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/pluginenv"
+	"github.com/mattermost/mattermost-server/utils"
 )
 
 type App struct {
@@ -35,17 +37,91 @@ var initEnterprise sync.Once
 
 func Global() *App {
 	initEnterprise.Do(func() {
-		globalApp.AccountMigration = einterfaces.GetAccountMigrationInterface()
-		globalApp.Brand = einterfaces.GetBrandInterface()
-		globalApp.Cluster = einterfaces.GetClusterInterface()
-		globalApp.Compliance = einterfaces.GetComplianceInterface()
-		globalApp.Elasticsearch = einterfaces.GetElasticsearchInterface()
-		globalApp.Ldap = einterfaces.GetLdapInterface()
-		globalApp.Metrics = einterfaces.GetMetricsInterface()
-		globalApp.Mfa = einterfaces.GetMfaInterface()
-		globalApp.Saml = einterfaces.GetSamlInterface()
+		globalApp.initEnterprise()
 	})
 	return &globalApp
+}
+
+var accountMigrationInterface func(*App) einterfaces.AccountMigrationInterface
+
+func RegisterAccountMigrationInterface(f func(*App) einterfaces.AccountMigrationInterface) {
+	accountMigrationInterface = f
+}
+
+var clusterInterface func(*App) einterfaces.ClusterInterface
+
+func RegisterClusterInterface(f func(*App) einterfaces.ClusterInterface) {
+	clusterInterface = f
+}
+
+var complianceInterface func(*App) einterfaces.ComplianceInterface
+
+func RegisterComplianceInterface(f func(*App) einterfaces.ComplianceInterface) {
+	complianceInterface = f
+}
+
+var ldapInterface func(*App) einterfaces.LdapInterface
+
+func RegisterLdapInterface(f func(*App) einterfaces.LdapInterface) {
+	ldapInterface = f
+}
+
+var metricsInterface func(*App) einterfaces.MetricsInterface
+
+func RegisterMetricsInterface(f func(*App) einterfaces.MetricsInterface) {
+	metricsInterface = f
+}
+
+var mfaInterface func(*App) einterfaces.MfaInterface
+
+func RegisterMfaInterface(f func(*App) einterfaces.MfaInterface) {
+	mfaInterface = f
+}
+
+var samlInterface func(*App) einterfaces.SamlInterface
+
+func RegisterSamlInterface(f func(*App) einterfaces.SamlInterface) {
+	samlInterface = f
+}
+
+func (a *App) initEnterprise() {
+	if accountMigrationInterface != nil {
+		a.AccountMigration = accountMigrationInterface(a)
+	}
+	a.Brand = einterfaces.GetBrandInterface()
+	if clusterInterface != nil {
+		a.Cluster = clusterInterface(a)
+	}
+	if complianceInterface != nil {
+		a.Compliance = complianceInterface(a)
+	}
+	a.Elasticsearch = einterfaces.GetElasticsearchInterface()
+	if ldapInterface != nil {
+		a.Ldap = ldapInterface(a)
+		utils.AddConfigListener(func(_, cfg *model.Config) {
+			if err := utils.ValidateLdapFilter(cfg, a.Ldap); err != nil {
+				panic(utils.T(err.Id))
+			}
+
+			a.Ldap.StartLdapSyncJob()
+		})
+	}
+	if metricsInterface != nil {
+		a.Metrics = metricsInterface(a)
+	}
+	if mfaInterface != nil {
+		a.Mfa = mfaInterface(a)
+	}
+	if samlInterface != nil {
+		a.Saml = samlInterface(a)
+		utils.AddConfigListener(func(_, cfg *model.Config) {
+			a.Saml.ConfigureSP()
+		})
+	}
+}
+
+func (a *App) Config() *model.Config {
+	return utils.Cfg
 }
 
 func CloseBody(r *http.Response) {

--- a/app/cluster_discovery.go
+++ b/app/cluster_discovery.go
@@ -18,12 +18,14 @@ const (
 
 type ClusterDiscoveryService struct {
 	model.ClusterDiscovery
+	app  *App
 	stop chan bool
 }
 
-func NewClusterDiscoveryService() *ClusterDiscoveryService {
+func (a *App) NewClusterDiscoveryService() *ClusterDiscoveryService {
 	ds := &ClusterDiscoveryService{
 		ClusterDiscovery: model.ClusterDiscovery{},
+		app:              a,
 		stop:             make(chan bool),
 	}
 
@@ -32,19 +34,19 @@ func NewClusterDiscoveryService() *ClusterDiscoveryService {
 
 func (me *ClusterDiscoveryService) Start() {
 
-	<-Global().Srv.Store.ClusterDiscovery().Cleanup()
+	<-me.app.Srv.Store.ClusterDiscovery().Cleanup()
 
-	if cresult := <-Global().Srv.Store.ClusterDiscovery().Exists(&me.ClusterDiscovery); cresult.Err != nil {
+	if cresult := <-me.app.Srv.Store.ClusterDiscovery().Exists(&me.ClusterDiscovery); cresult.Err != nil {
 		l4g.Error(fmt.Sprintf("ClusterDiscoveryService failed to check if row exists for %v with err=%v", me.ClusterDiscovery.ToJson(), cresult.Err))
 	} else {
 		if cresult.Data.(bool) {
-			if u := <-Global().Srv.Store.ClusterDiscovery().Delete(&me.ClusterDiscovery); u.Err != nil {
+			if u := <-me.app.Srv.Store.ClusterDiscovery().Delete(&me.ClusterDiscovery); u.Err != nil {
 				l4g.Error(fmt.Sprintf("ClusterDiscoveryService failed to start clean for %v with err=%v", me.ClusterDiscovery.ToJson(), u.Err))
 			}
 		}
 	}
 
-	if result := <-Global().Srv.Store.ClusterDiscovery().Save(&me.ClusterDiscovery); result.Err != nil {
+	if result := <-me.app.Srv.Store.ClusterDiscovery().Save(&me.ClusterDiscovery); result.Err != nil {
 		l4g.Error(fmt.Sprintf("ClusterDiscoveryService failed to save for %v with err=%v", me.ClusterDiscovery.ToJson(), result.Err))
 		return
 	}
@@ -54,7 +56,7 @@ func (me *ClusterDiscoveryService) Start() {
 		ticker := time.NewTicker(DISCOVERY_SERVICE_WRITE_PING)
 		defer func() {
 			ticker.Stop()
-			if u := <-Global().Srv.Store.ClusterDiscovery().Delete(&me.ClusterDiscovery); u.Err != nil {
+			if u := <-me.app.Srv.Store.ClusterDiscovery().Delete(&me.ClusterDiscovery); u.Err != nil {
 				l4g.Error(fmt.Sprintf("ClusterDiscoveryService failed to cleanup for %v with err=%v", me.ClusterDiscovery.ToJson(), u.Err))
 			}
 			l4g.Debug(fmt.Sprintf("ClusterDiscoveryService ping writer stopped for %v", me.ClusterDiscovery.ToJson()))
@@ -63,7 +65,7 @@ func (me *ClusterDiscoveryService) Start() {
 		for {
 			select {
 			case <-ticker.C:
-				if u := <-Global().Srv.Store.ClusterDiscovery().SetLastPingAt(&me.ClusterDiscovery); u.Err != nil {
+				if u := <-me.app.Srv.Store.ClusterDiscovery().SetLastPingAt(&me.ClusterDiscovery); u.Err != nil {
 					l4g.Error(fmt.Sprintf("ClusterDiscoveryService failed to write ping for %v with err=%v", me.ClusterDiscovery.ToJson(), u.Err))
 				}
 			case <-me.stop:

--- a/app/cluster_discovery_test.go
+++ b/app/cluster_discovery_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestClusterDiscoveryService(t *testing.T) {
-	Setup()
+	th := Setup()
 
-	ds := NewClusterDiscoveryService()
+	ds := th.App.NewClusterDiscoveryService()
 	ds.Type = model.CDS_TYPE_APP
 	ds.ClusterName = "ClusterA"
 	ds.AutoFillHostname()

--- a/app/server.go
+++ b/app/server.go
@@ -84,7 +84,7 @@ func (a *App) NewServer() {
 }
 
 func (a *App) InitStores() {
-	a.Srv.Store = store.NewLayeredStore()
+	a.Srv.Store = store.NewLayeredStore(a.Metrics, a.Cluster)
 }
 
 type VaryBy struct{}

--- a/cmd/platform/channel.go
+++ b/cmd/platform/channel.go
@@ -151,7 +151,7 @@ func createChannelCmdF(cmd *cobra.Command, args []string) error {
 		channelType = model.CHANNEL_PRIVATE
 	}
 
-	team := getTeamFromTeamArg(teamArg)
+	team := getTeamFromTeamArg(a, teamArg)
 	if team == nil {
 		return errors.New("Unable to find team: " + teamArg)
 	}
@@ -183,12 +183,12 @@ func removeChannelUsersCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Not enough arguments.")
 	}
 
-	channel := getChannelFromChannelArg(args[0])
+	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
 	}
 
-	users := getUsersFromUserArgs(args[1:])
+	users := getUsersFromUserArgs(a, args[1:])
 	for i, user := range users {
 		removeUserFromChannel(a, channel, user, args[i+1])
 	}
@@ -216,12 +216,12 @@ func addChannelUsersCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Not enough arguments.")
 	}
 
-	channel := getChannelFromChannelArg(args[0])
+	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
 	}
 
-	users := getUsersFromUserArgs(args[1:])
+	users := getUsersFromUserArgs(a, args[1:])
 	for i, user := range users {
 		addUserToChannel(a, channel, user, args[i+1])
 	}
@@ -249,7 +249,7 @@ func archiveChannelsCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Enter at least one channel to archive.")
 	}
 
-	channels := getChannelsFromChannelArgs(args)
+	channels := getChannelsFromChannelArgs(a, args)
 	for i, channel := range channels {
 		if channel == nil {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
@@ -283,7 +283,7 @@ func deleteChannelsCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	channels := getChannelsFromChannelArgs(args)
+	channels := getChannelsFromChannelArgs(a, args)
 	for i, channel := range channels {
 		if channel == nil {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
@@ -313,12 +313,12 @@ func moveChannelsCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Enter the destination team and at least one channel to move.")
 	}
 
-	team := getTeamFromTeamArg(args[0])
+	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
 		return errors.New("Unable to find destination team '" + args[0] + "'")
 	}
 
-	channels := getChannelsFromChannelArgs(args[1:])
+	channels := getChannelsFromChannelArgs(a, args[1:])
 	for i, channel := range channels {
 		if channel == nil {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
@@ -380,7 +380,7 @@ func listChannelsCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Enter at least one team.")
 	}
 
-	teams := getTeamsFromTeamArgs(args)
+	teams := getTeamsFromTeamArgs(a, args)
 	for i, team := range teams {
 		if team == nil {
 			CommandPrintErrorln("Unable to find team '" + args[i] + "'")
@@ -414,7 +414,7 @@ func restoreChannelsCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Enter at least one channel.")
 	}
 
-	channels := getChannelsFromChannelArgs(args)
+	channels := getChannelsFromChannelArgs(a, args)
 	for i, channel := range channels {
 		if channel == nil {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
@@ -445,7 +445,7 @@ func modifyChannelCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("You must specify only one of --public or --private")
 	}
 
-	channel := getChannelFromChannelArg(args[0])
+	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
 		return errors.New("Unable to find channel '" + args[0] + "'")
 	}

--- a/cmd/platform/channelargs.go
+++ b/cmd/platform/channelargs.go
@@ -12,10 +12,10 @@ import (
 
 const CHANNEL_ARG_SEPARATOR = ":"
 
-func getChannelsFromChannelArgs(channelArgs []string) []*model.Channel {
+func getChannelsFromChannelArgs(a *app.App, channelArgs []string) []*model.Channel {
 	channels := make([]*model.Channel, 0, len(channelArgs))
 	for _, channelArg := range channelArgs {
-		channel := getChannelFromChannelArg(channelArg)
+		channel := getChannelFromChannelArg(a, channelArg)
 		channels = append(channels, channel)
 	}
 	return channels
@@ -29,7 +29,7 @@ func parseChannelArg(channelArg string) (string, string) {
 	return result[0], result[1]
 }
 
-func getChannelFromChannelArg(channelArg string) *model.Channel {
+func getChannelFromChannelArg(a *app.App, channelArg string) *model.Channel {
 	teamArg, channelPart := parseChannelArg(channelArg)
 	if teamArg == "" && channelPart == "" {
 		return nil
@@ -37,12 +37,12 @@ func getChannelFromChannelArg(channelArg string) *model.Channel {
 
 	var channel *model.Channel
 	if teamArg != "" {
-		team := getTeamFromTeamArg(teamArg)
+		team := getTeamFromTeamArg(a, teamArg)
 		if team == nil {
 			return nil
 		}
 
-		if result := <-app.Global().Srv.Store.Channel().GetByNameIncludeDeleted(team.Id, channelPart, true); result.Err == nil {
+		if result := <-a.Srv.Store.Channel().GetByNameIncludeDeleted(team.Id, channelPart, true); result.Err == nil {
 			channel = result.Data.(*model.Channel)
 		} else {
 			fmt.Println(result.Err.Error())
@@ -50,7 +50,7 @@ func getChannelFromChannelArg(channelArg string) *model.Channel {
 	}
 
 	if channel == nil {
-		if result := <-app.Global().Srv.Store.Channel().Get(channelPart, true); result.Err == nil {
+		if result := <-a.Srv.Store.Channel().Get(channelPart, true); result.Err == nil {
 			channel = result.Data.(*model.Channel)
 		}
 	}

--- a/cmd/platform/import.go
+++ b/cmd/platform/import.go
@@ -53,7 +53,7 @@ func slackImportCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Incorrect number of arguments.")
 	}
 
-	team := getTeamFromTeamArg(args[0])
+	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
 	}

--- a/cmd/platform/jobserver.go
+++ b/cmd/platform/jobserver.go
@@ -10,7 +10,6 @@ import (
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-server/jobs"
 	"github.com/mattermost/mattermost-server/store"
-	"github.com/mattermost/mattermost-server/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -31,10 +30,13 @@ func jobserverCmdF(cmd *cobra.Command, args []string) {
 	noSchedule, _ := cmd.Flags().GetBool("noschedule")
 
 	// Initialize
-	utils.InitAndLoadConfig("config.json")
+	a, err := initDBCommandContext("config.json")
+	if err != nil {
+		panic(err.Error())
+	}
 	defer l4g.Close()
 
-	jobs.Srv.Store = store.NewLayeredStore()
+	jobs.Srv.Store = store.NewLayeredStore(a.Metrics, a.Cluster)
 	defer jobs.Srv.Store.Close()
 
 	jobs.Srv.LoadLicense()

--- a/cmd/platform/roles.go
+++ b/cmd/platform/roles.go
@@ -46,7 +46,7 @@ func makeSystemAdminCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Enter at least one user.")
 	}
 
-	users := getUsersFromUserArgs(args)
+	users := getUsersFromUserArgs(a, args)
 	for i, user := range users {
 		if user == nil {
 			return errors.New("Unable to find user '" + args[i] + "'")
@@ -70,7 +70,7 @@ func makeMemberCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Enter at least one user.")
 	}
 
-	users := getUsersFromUserArgs(args)
+	users := getUsersFromUserArgs(a, args)
 	for i, user := range users {
 		if user == nil {
 			return errors.New("Unable to find user '" + args[i] + "'")

--- a/cmd/platform/team.go
+++ b/cmd/platform/team.go
@@ -112,12 +112,12 @@ func removeUsersCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Not enough arguments.")
 	}
 
-	team := getTeamFromTeamArg(args[0])
+	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
 	}
 
-	users := getUsersFromUserArgs(args[1:])
+	users := getUsersFromUserArgs(a, args[1:])
 	for i, user := range users {
 		removeUserFromTeam(a, team, user, args[i+1])
 	}
@@ -145,12 +145,12 @@ func addUsersCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Not enough arguments.")
 	}
 
-	team := getTeamFromTeamArg(args[0])
+	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
 		return errors.New("Unable to find team '" + args[0] + "'")
 	}
 
-	users := getUsersFromUserArgs(args[1:])
+	users := getUsersFromUserArgs(a, args[1:])
 	for i, user := range users {
 		addUserToTeam(a, team, user, args[i+1])
 	}
@@ -194,7 +194,7 @@ func deleteTeamsCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	teams := getTeamsFromTeamArgs(args)
+	teams := getTeamsFromTeamArgs(a, args)
 	for i, team := range teams {
 		if team == nil {
 			CommandPrintErrorln("Unable to find team '" + args[i] + "'")

--- a/cmd/platform/teamargs.go
+++ b/cmd/platform/teamargs.go
@@ -7,23 +7,23 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func getTeamsFromTeamArgs(teamArgs []string) []*model.Team {
+func getTeamsFromTeamArgs(a *app.App, teamArgs []string) []*model.Team {
 	teams := make([]*model.Team, 0, len(teamArgs))
 	for _, teamArg := range teamArgs {
-		team := getTeamFromTeamArg(teamArg)
+		team := getTeamFromTeamArg(a, teamArg)
 		teams = append(teams, team)
 	}
 	return teams
 }
 
-func getTeamFromTeamArg(teamArg string) *model.Team {
+func getTeamFromTeamArg(a *app.App, teamArg string) *model.Team {
 	var team *model.Team
-	if result := <-app.Global().Srv.Store.Team().GetByName(teamArg); result.Err == nil {
+	if result := <-a.Srv.Store.Team().GetByName(teamArg); result.Err == nil {
 		team = result.Data.(*model.Team)
 	}
 
 	if team == nil {
-		if result := <-app.Global().Srv.Store.Team().Get(teamArg); result.Err == nil {
+		if result := <-a.Srv.Store.Team().Get(teamArg); result.Err == nil {
 			team = result.Data.(*model.Team)
 		}
 	}

--- a/cmd/platform/user.go
+++ b/cmd/platform/user.go
@@ -171,7 +171,7 @@ func userActivateCmdF(cmd *cobra.Command, args []string) error {
 }
 
 func changeUsersActiveStatus(a *app.App, userArgs []string, active bool) {
-	users := getUsersFromUserArgs(userArgs)
+	users := getUsersFromUserArgs(a, userArgs)
 	for i, user := range users {
 		err := changeUserActiveStatus(a, user, userArgs[i], active)
 
@@ -255,7 +255,7 @@ func userCreateCmdF(cmd *cobra.Command, args []string) error {
 }
 
 func userInviteCmdF(cmd *cobra.Command, args []string) error {
-	_, err := initDBCommandContextCobra(cmd)
+	a, err := initDBCommandContextCobra(cmd)
 	if err != nil {
 		return err
 	}
@@ -271,7 +271,7 @@ func userInviteCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Invalid email")
 	}
 
-	teams := getTeamsFromTeamArgs(args[1:])
+	teams := getTeamsFromTeamArgs(a, args[1:])
 	for i, team := range teams {
 		err := inviteUser(email, team, args[i+1])
 
@@ -305,7 +305,7 @@ func resetUserPasswordCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Expected two arguments. See help text for details.")
 	}
 
-	user := getUserFromUserArg(args[0])
+	user := getUserFromUserArg(a, args[0])
 	if user == nil {
 		return errors.New("Unable to find user '" + args[0] + "'")
 	}
@@ -328,7 +328,7 @@ func resetUserMfaCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
-	users := getUsersFromUserArgs(args)
+	users := getUsersFromUserArgs(a, args)
 
 	for i, user := range users {
 		if user == nil {
@@ -369,7 +369,7 @@ func deleteUserCmdF(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	users := getUsersFromUserArgs(args)
+	users := getUsersFromUserArgs(a, args)
 
 	for i, user := range users {
 		if user == nil {
@@ -472,7 +472,7 @@ func verifyUserCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
-	users := getUsersFromUserArgs(args)
+	users := getUsersFromUserArgs(a, args)
 
 	for i, user := range users {
 		if user == nil {
@@ -488,7 +488,7 @@ func verifyUserCmdF(cmd *cobra.Command, args []string) error {
 }
 
 func searchUserCmdF(cmd *cobra.Command, args []string) error {
-	_, err := initDBCommandContextCobra(cmd)
+	a, err := initDBCommandContextCobra(cmd)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func searchUserCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
-	users := getUsersFromUserArgs(args)
+	users := getUsersFromUserArgs(a, args)
 
 	for i, user := range users {
 		if i > 0 {

--- a/cmd/platform/userargs.go
+++ b/cmd/platform/userargs.go
@@ -7,29 +7,29 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func getUsersFromUserArgs(userArgs []string) []*model.User {
+func getUsersFromUserArgs(a *app.App, userArgs []string) []*model.User {
 	users := make([]*model.User, 0, len(userArgs))
 	for _, userArg := range userArgs {
-		user := getUserFromUserArg(userArg)
+		user := getUserFromUserArg(a, userArg)
 		users = append(users, user)
 	}
 	return users
 }
 
-func getUserFromUserArg(userArg string) *model.User {
+func getUserFromUserArg(a *app.App, userArg string) *model.User {
 	var user *model.User
-	if result := <-app.Global().Srv.Store.User().GetByEmail(userArg); result.Err == nil {
+	if result := <-a.Srv.Store.User().GetByEmail(userArg); result.Err == nil {
 		user = result.Data.(*model.User)
 	}
 
 	if user == nil {
-		if result := <-app.Global().Srv.Store.User().GetByUsername(userArg); result.Err == nil {
+		if result := <-a.Srv.Store.User().GetByUsername(userArg); result.Err == nil {
 			user = result.Data.(*model.User)
 		}
 	}
 
 	if user == nil {
-		if result := <-app.Global().Srv.Store.User().Get(userArg); result.Err == nil {
+		if result := <-a.Srv.Store.User().Get(userArg); result.Err == nil {
 			user = result.Data.(*model.User)
 		}
 	}

--- a/einterfaces/account_migration.go
+++ b/einterfaces/account_migration.go
@@ -8,13 +8,3 @@ import "github.com/mattermost/mattermost-server/model"
 type AccountMigrationInterface interface {
 	MigrateToLdap(fromAuthService string, forignUserFieldNameToMatch string, force bool) *model.AppError
 }
-
-var theAccountMigrationInterface AccountMigrationInterface
-
-func RegisterAccountMigrationInterface(newInterface AccountMigrationInterface) {
-	theAccountMigrationInterface = newInterface
-}
-
-func GetAccountMigrationInterface() AccountMigrationInterface {
-	return theAccountMigrationInterface
-}

--- a/einterfaces/cluster.go
+++ b/einterfaces/cluster.go
@@ -23,13 +23,3 @@ type ClusterInterface interface {
 	GetLogs(page, perPage int) ([]string, *model.AppError)
 	ConfigChanged(previousConfig *model.Config, newConfig *model.Config, sendToOtherServer bool) *model.AppError
 }
-
-var theClusterInterface ClusterInterface
-
-func RegisterClusterInterface(newInterface ClusterInterface) {
-	theClusterInterface = newInterface
-}
-
-func GetClusterInterface() ClusterInterface {
-	return theClusterInterface
-}

--- a/einterfaces/compliance.go
+++ b/einterfaces/compliance.go
@@ -11,13 +11,3 @@ type ComplianceInterface interface {
 	StartComplianceDailyJob()
 	RunComplianceJob(job *model.Compliance) *model.AppError
 }
-
-var theComplianceInterface ComplianceInterface
-
-func RegisterComplianceInterface(newInterface ComplianceInterface) {
-	theComplianceInterface = newInterface
-}
-
-func GetComplianceInterface() ComplianceInterface {
-	return theComplianceInterface
-}

--- a/einterfaces/ldap.go
+++ b/einterfaces/ldap.go
@@ -20,13 +20,3 @@ type LdapInterface interface {
 	RunTest() *model.AppError
 	GetAllLdapUsers() ([]*model.User, *model.AppError)
 }
-
-var theLdapInterface LdapInterface
-
-func RegisterLdapInterface(newInterface LdapInterface) {
-	theLdapInterface = newInterface
-}
-
-func GetLdapInterface() LdapInterface {
-	return theLdapInterface
-}

--- a/einterfaces/metrics.go
+++ b/einterfaces/metrics.go
@@ -38,13 +38,3 @@ type MetricsInterface interface {
 	AddMemCacheHitCounter(cacheName string, amount float64)
 	AddMemCacheMissCounter(cacheName string, amount float64)
 }
-
-var theMetricsInterface MetricsInterface
-
-func RegisterMetricsInterface(newInterface MetricsInterface) {
-	theMetricsInterface = newInterface
-}
-
-func GetMetricsInterface() MetricsInterface {
-	return theMetricsInterface
-}

--- a/einterfaces/mfa.go
+++ b/einterfaces/mfa.go
@@ -13,13 +13,3 @@ type MfaInterface interface {
 	Deactivate(userId string) *model.AppError
 	ValidateToken(secret, token string) (bool, *model.AppError)
 }
-
-var theMfaInterface MfaInterface
-
-func RegisterMfaInterface(newInterface MfaInterface) {
-	theMfaInterface = newInterface
-}
-
-func GetMfaInterface() MfaInterface {
-	return theMfaInterface
-}

--- a/einterfaces/saml.go
+++ b/einterfaces/saml.go
@@ -13,13 +13,3 @@ type SamlInterface interface {
 	DoLogin(encodedXML string, relayState map[string]string) (*model.User, *model.AppError)
 	GetMetadata() (string, *model.AppError)
 }
-
-var theSamlInterface SamlInterface
-
-func RegisterSamlInterface(newInterface SamlInterface) {
-	theSamlInterface = newInterface
-}
-
-func GetSamlInterface() SamlInterface {
-	return theSamlInterface
-}

--- a/store/layered_store.go
+++ b/store/layered_store.go
@@ -24,11 +24,11 @@ type LayeredStore struct {
 	LayerChainHead  LayeredStoreSupplier
 }
 
-func NewLayeredStore() Store {
+func NewLayeredStore(metrics einterfaces.MetricsInterface, cluster einterfaces.ClusterInterface) Store {
 	store := &LayeredStore{
 		TmpContext:      context.TODO(),
-		DatabaseLayer:   NewSqlSupplier(einterfaces.GetMetricsInterface()),
-		LocalCacheLayer: NewLocalCacheSupplier(einterfaces.GetMetricsInterface(), einterfaces.GetClusterInterface()),
+		DatabaseLayer:   NewSqlSupplier(metrics),
+		LocalCacheLayer: NewLocalCacheSupplier(metrics, cluster),
 	}
 
 	store.ReactionStore = &LayeredReactionStore{store}

--- a/store/local_cache_supplier.go
+++ b/store/local_cache_supplier.go
@@ -32,15 +32,11 @@ func NewLocalCacheSupplier(metrics einterfaces.MetricsInterface, cluster einterf
 		cluster:       cluster,
 	}
 
-	registerClusterHandlers(supplier)
-
-	return supplier
-}
-
-func registerClusterHandlers(supplier *LocalCacheSupplier) {
-	if cluster := einterfaces.GetClusterInterface(); cluster != nil {
+	if cluster != nil {
 		cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_REACTIONS, supplier.handleClusterInvalidateReaction)
 	}
+
+	return supplier
 }
 
 func (s *LocalCacheSupplier) SetChainNext(next LayeredStoreSupplier) {

--- a/store/sql_store_test.go
+++ b/store/sql_store_test.go
@@ -12,7 +12,7 @@ func Setup() {
 		utils.TranslationsPreInit()
 		utils.LoadConfig("config.json")
 		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		store = NewLayeredStore()
+		store = NewLayeredStore(nil, nil)
 
 		store.MarkSystemRanUnitTests()
 	}

--- a/utils/config.go
+++ b/utils/config.go
@@ -373,10 +373,6 @@ func LoadConfig(fileName string) {
 		cfgMutex.Lock()
 	}
 
-	if err := ValidateLdapFilter(&config); err != nil {
-		panic(T(err.Id))
-	}
-
 	configureLog(&config.LogSettings)
 
 	if *config.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
@@ -391,16 +387,6 @@ func LoadConfig(fileName string) {
 	ClientCfg = getClientConfig(Cfg)
 	clientCfgJson, _ := json.Marshal(ClientCfg)
 	ClientCfgHash = fmt.Sprintf("%x", md5.Sum(clientCfgJson))
-
-	// Actions that need to run every time the config is loaded
-	if ldapI := einterfaces.GetLdapInterface(); ldapI != nil {
-		// This restarts the job if nessisary (works for config reloads)
-		ldapI.StartLdapSyncJob()
-	}
-
-	if samlI := einterfaces.GetSamlInterface(); samlI != nil {
-		samlI.ConfigureSP()
-	}
 
 	SetDefaultRolesBasedOnConfig()
 	SetSiteURL(*Cfg.ServiceSettings.SiteURL)
@@ -596,10 +582,9 @@ func getClientConfig(c *model.Config) map[string]string {
 	return props
 }
 
-func ValidateLdapFilter(cfg *model.Config) *model.AppError {
-	ldapInterface := einterfaces.GetLdapInterface()
-	if *cfg.LdapSettings.Enable && ldapInterface != nil && *cfg.LdapSettings.UserFilter != "" {
-		if err := ldapInterface.ValidateFilter(*cfg.LdapSettings.UserFilter); err != nil {
+func ValidateLdapFilter(cfg *model.Config, ldap einterfaces.LdapInterface) *model.AppError {
+	if *cfg.LdapSettings.Enable && ldap != nil && *cfg.LdapSettings.UserFilter != "" {
+		if err := ldap.ValidateFilter(*cfg.LdapSettings.UserFilter); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
#### Summary
This one's exciting: I'm finally actually removing some package level variables!

This allows me to remove the last of the `app.Global` references in our enterprise code. I've also started to replace some of the `utils.Cfg` references.

Very few `app.Global` references remaining. Then I'll probably do a find/replace or AST patch to replace all of the `utils.Cfg` references in one big sweep.

Enterprise PR: https://github.com/mattermost/enterprise/pull/198

#### Checklist
- [x] Has enterprise changes (please link)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
