### PR TITLE
PLT-7667: Clean up elasticsearch indexes when running data retention jobs.

### DIFF
--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -3,7 +3,11 @@
 
 package einterfaces
 
-import "github.com/mattermost/mattermost-server/model"
+import (
+	"time"
+
+	"github.com/mattermost/mattermost-server/model"
+)
 
 type ElasticsearchInterface interface {
 	Start() *model.AppError
@@ -12,6 +16,7 @@ type ElasticsearchInterface interface {
 	DeletePost(post *model.Post) *model.AppError
 	TestConfig(cfg *model.Config) *model.AppError
 	PurgeIndexes() *model.AppError
+	DataRetentionDeleteIndexes(cutoff time.Time) *model.AppError
 }
 
 var theElasticsearchInterface ElasticsearchInterface

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3720,6 +3720,14 @@
     "translation": "Failed to setup Elasticsearch index mapping"
   },
   {
+    "id": "ent.elasticsearch.data_retention_delete_indexes.get_indexes.error",
+    "translation": "Failed to get Elasticsearch indexes"
+  },
+  {
+    "id": "ent.elasticsearch.data_retention_delete_indexes.delete_index.error",
+    "translation": "Failed to delete Elasticsearch index"
+  },
+  {
     "id": "ent.elasticsearch.delete_post.error",
     "translation": "Failed to delete the post"
   },


### PR DESCRIPTION
#### Summary
Clean up elasticsearch indexes when running data retention jobs.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7667

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/199
- [x] Includes text changes and localization file updates
