### PR TITLE
Run file tests on Minio and local drivers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,16 @@ start-docker:
 		docker start mattermost-inbucket > /dev/null; \
 	fi
 
+	@if [ $(shell docker ps -a | grep -ci mattermost-minio) -eq 0 ]; then \
+		echo starting mattermost-minio; \
+		docker run --name mattermost-minio -p 9001:9000 -e "MINIO_ACCESS_KEY=minioaccesskey" \
+		-e "MINIO_SECRET_KEY=miniosecretkey" -d minio/minio:latest server /data > /dev/null; \
+		docker exec -it mattermost-minio /bin/sh -c "mkdir /data/mattermost-test" > /dev/null; \
+	elif [ $(shell docker ps | grep -ci mattermost-minio) -eq 0 ]; then \
+		echo restarting mattermost-minio; \
+		docker start mattermost-minio > /dev/null; \
+	fi
+
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Ldap test user test.one
 	@if [ $(shell docker ps -a | grep -ci mattermost-openldap) -eq 0 ]; then \
@@ -183,6 +193,11 @@ stop-docker:
 		docker stop mattermost-inbucket > /dev/null; \
 	fi
 
+		@if [ $(shell docker ps -a | grep -ci mattermost-minio) -eq 1 ]; then \
+    		echo stopping mattermost-minio; \
+    		docker stop mattermost-minio > /dev/null; \
+    	fi
+
 	@if [ $(shell docker ps -a | grep -ci mattermost-elasticsearch) -eq 1 ]; then \
 		echo stopping mattermost-elasticsearch; \
 		docker stop mattermost-elasticsearch > /dev/null; \
@@ -213,6 +228,12 @@ clean-docker:
 		echo removing mattermost-inbucket; \
 		docker stop mattermost-inbucket > /dev/null; \
 		docker rm -v mattermost-inbucket > /dev/null; \
+	fi
+
+	@if [ $(shell docker ps -a | grep -ci mattermost-minio) -eq 1 ]; then \
+		echo removing mattermost-minio; \
+		docker stop mattermost-minio > /dev/null; \
+		docker rm -v mattermost-minio > /dev/null; \
 	fi
 
 	@if [ $(shell docker ps -a | grep -ci mattermost-elasticsearch) -eq 1 ]; then \

--- a/utils/file_test.go
+++ b/utils/file_test.go
@@ -6,117 +6,138 @@ package utils
 import (
 	"testing"
 
+	"github.com/stretchr/testify/suite"
+
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func TestReadWriteFile(t *testing.T) {
+type FileTestSuite struct {
+	suite.Suite
+
+	testDriver string
+
+	// Config to be reset after tests.
+	driverName              string
+	amazonS3AccessKeyId     string
+	amazonS3SecretAccessKey string
+	amazonS3Bucket          string
+	amazonS3Endpoint        string
+	amazonS3SSL             bool
+}
+
+func TestFileLocalTestSuite(t *testing.T) {
+	testsuite := FileTestSuite{
+		testDriver: model.IMAGE_DRIVER_LOCAL,
+	}
+	suite.Run(t, &testsuite)
+}
+
+func TestFileMinioTestSuite(t *testing.T) {
+	testsuite := FileTestSuite{
+		testDriver: model.IMAGE_DRIVER_S3,
+	}
+	suite.Run(t, &testsuite)
+}
+
+func (s *FileTestSuite) SetupTest() {
 	TranslationsPreInit()
 	LoadConfig("config.json")
 	InitTranslations(Cfg.LocalizationSettings)
 
-	b := []byte("test")
-	path := "tests/" + model.NewId()
+	// Save state to restore after the test has run.
+	s.driverName = *Cfg.FileSettings.DriverName
+	s.amazonS3AccessKeyId = Cfg.FileSettings.AmazonS3AccessKeyId
+	s.amazonS3SecretAccessKey = Cfg.FileSettings.AmazonS3SecretAccessKey
+	s.amazonS3Bucket = Cfg.FileSettings.AmazonS3Bucket
+	s.amazonS3Endpoint = Cfg.FileSettings.AmazonS3Endpoint
+	s.amazonS3SSL = *Cfg.FileSettings.AmazonS3SSL
 
-	if err := WriteFile(b, path); err != nil {
-		t.Fatal(err)
-	}
-	defer RemoveFile(path)
-
-	if read, err := ReadFile(path); err != nil {
-		t.Fatal(err)
-	} else if readString := string(read); readString != "test" {
-		t.Fatal("should've read back contents of file")
+	// Set up the state for the tests.
+	if s.testDriver == model.IMAGE_DRIVER_LOCAL {
+		*Cfg.FileSettings.DriverName = model.IMAGE_DRIVER_LOCAL
+	} else if s.testDriver == model.IMAGE_DRIVER_S3 {
+		*Cfg.FileSettings.DriverName = model.IMAGE_DRIVER_S3
+		Cfg.FileSettings.AmazonS3AccessKeyId = "minioaccesskey"
+		Cfg.FileSettings.AmazonS3SecretAccessKey = "miniosecretkey"
+		Cfg.FileSettings.AmazonS3Bucket = "mattermost-test"
+		Cfg.FileSettings.AmazonS3Endpoint = "dockerhost:9001"
+		*Cfg.FileSettings.AmazonS3SSL = false
+	} else {
+		s.T().Fatal("Invalid image driver set for test suite.")
 	}
 }
 
-func TestMoveFile(t *testing.T) {
-	TranslationsPreInit()
-	LoadConfig("config.json")
-	InitTranslations(Cfg.LocalizationSettings)
+func (s *FileTestSuite) TearDownTest() {
+	// Restore the test state.
+	*Cfg.FileSettings.DriverName = s.driverName
+	Cfg.FileSettings.AmazonS3AccessKeyId = s.amazonS3AccessKeyId
+	Cfg.FileSettings.AmazonS3SecretAccessKey = s.amazonS3SecretAccessKey
+	Cfg.FileSettings.AmazonS3Bucket = s.amazonS3Bucket
+	Cfg.FileSettings.AmazonS3Endpoint = s.amazonS3Endpoint
+	*Cfg.FileSettings.AmazonS3SSL = s.amazonS3SSL
+}
 
+func (s *FileTestSuite) TestReadWriteFile() {
+	b := []byte("test")
+	path := "tests/" + model.NewId()
+
+	s.Nil(WriteFile(b, path))
+	defer RemoveFile(path)
+
+	read, err := ReadFile(path)
+	s.Nil(err)
+
+	readString := string(read)
+	s.EqualValues(readString, "test")
+}
+
+func (s *FileTestSuite) TestMoveFile() {
 	b := []byte("test")
 	path1 := "tests/" + model.NewId()
 	path2 := "tests/" + model.NewId()
 
-	if err := WriteFile(b, path1); err != nil {
-		t.Fatal(err)
-	}
+	s.Nil(WriteFile(b, path1))
 	defer RemoveFile(path1)
 
-	if err := MoveFile(path1, path2); err != nil {
-		t.Fatal(err)
-	}
+	s.Nil(MoveFile(path1, path2))
 	defer RemoveFile(path2)
 
-	if _, err := ReadFile(path1); err == nil {
-		t.Fatal("file should no longer exist at old path")
-	}
+	_, err := ReadFile(path1)
+	s.Error(err)
 
-	if _, err := ReadFile(path2); err != nil {
-		t.Fatal("file should exist at new path", err)
-	}
+	_, err = ReadFile(path2)
+	s.Nil(err)
 }
 
-func TestRemoveFile(t *testing.T) {
-	TranslationsPreInit()
-	LoadConfig("config.json")
-	InitTranslations(Cfg.LocalizationSettings)
-
+func (s *FileTestSuite) TestRemoveFile() {
 	b := []byte("test")
 	path := "tests/" + model.NewId()
 
-	if err := WriteFile(b, path); err != nil {
-		t.Fatal(err)
-	}
+	s.Nil(WriteFile(b, path))
+	s.Nil(RemoveFile(path))
 
-	if err := RemoveFile(path); err != nil {
-		t.Fatal(err)
-	}
+	_, err := ReadFile(path)
+	s.Error(err)
 
-	if _, err := ReadFile(path); err == nil {
-		t.Fatal("should've removed file")
-	}
-
-	if err := WriteFile(b, "tests2/foo"); err != nil {
-		t.Fatal(err)
-	}
-	if err := WriteFile(b, "tests2/bar"); err != nil {
-		t.Fatal(err)
-	}
-	if err := WriteFile(b, "tests2/asdf"); err != nil {
-		t.Fatal(err)
-	}
-	if err := RemoveDirectory("tests2"); err != nil {
-		t.Fatal(err)
-	}
+	s.Nil(WriteFile(b, "tests2/foo"))
+	s.Nil(WriteFile(b, "tests2/bar"))
+	s.Nil(WriteFile(b, "tests2/asdf"))
+	s.Nil(RemoveDirectory("tests2"))
 }
 
-func TestRemoveDirectory(t *testing.T) {
-	TranslationsPreInit()
-	LoadConfig("config.json")
-	InitTranslations(Cfg.LocalizationSettings)
-
+func (s *FileTestSuite) TestRemoveDirectory() {
 	b := []byte("test")
 
-	if err := WriteFile(b, "tests2/foo"); err != nil {
-		t.Fatal(err)
-	}
-	if err := WriteFile(b, "tests2/bar"); err != nil {
-		t.Fatal(err)
-	}
-	if err := WriteFile(b, "tests2/aaa"); err != nil {
-		t.Fatal(err)
-	}
+	s.Nil(WriteFile(b, "tests2/foo"))
+	s.Nil(WriteFile(b, "tests2/bar"))
+	s.Nil(WriteFile(b, "tests2/aaa"))
 
-	if err := RemoveDirectory("tests2"); err != nil {
-		t.Fatal(err)
-	}
+	s.Nil(RemoveDirectory("tests2"))
 
-	if _, err := ReadFile("tests2/foo"); err == nil {
-		t.Fatal("should've removed file")
-	} else if _, err := ReadFile("tests2/bar"); err == nil {
-		t.Fatal("should've removed file")
-	} else if _, err := ReadFile("tests2/asdf"); err == nil {
-		t.Fatal("should've removed file")
-	}
+	_, err := ReadFile("tests2/foo")
+	s.Error(err)
+	_, err = ReadFile("tests2/bar")
+	s.Error(err)
+	_, err = ReadFile("tests2/asdf")
+	s.Error(err)
 }


### PR DESCRIPTION
#### Summary
This ports the file tests to testify, and runs the suite twice - once using the `local` driver and once using the `s3` driver with minio.

This adds a minio docker image to the Makefile.