### PR TITLE
Finally do away with NewLocAppError function.

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -309,8 +309,7 @@ func (a *App) DoUploadFile(now time.Time, teamId string, channelId string, userI
 	if info.IsImage() {
 		// Check dimensions before loading the whole thing into memory later on
 		if info.Width*info.Height > MaxImageSize {
-			err := model.NewLocAppError("uploadFile", "api.file.upload_file.large_image.app_error", map[string]interface{}{"Filename": filename}, "")
-			err.StatusCode = http.StatusBadRequest
+			err := model.NewAppError("uploadFile", "api.file.upload_file.large_image.app_error", map[string]interface{}{"Filename": filename}, "", http.StatusBadRequest)
 			return nil, err
 		}
 

--- a/app/post.go
+++ b/app/post.go
@@ -114,7 +114,7 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 		!post.IsSystemMessage() &&
 		channel.Name == model.DEFAULT_CHANNEL &&
 		!CheckIfRolesGrantPermission(user.GetRoles(), model.PERMISSION_MANAGE_SYSTEM.Id) {
-		return nil, model.NewLocAppError("createPost", "api.post.create_post.town_square_read_only", nil, "")
+		return nil, model.NewAppError("createPost", "api.post.create_post.town_square_read_only", nil, "", http.StatusForbidden)
 	}
 
 	// Verify the parent/child relationships are correct

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -522,7 +522,7 @@ func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookReq
 
 	if utils.IsLicensed() && *utils.Cfg.TeamSettings.ExperimentalTownSquareIsReadOnly &&
 		channel.Name == model.DEFAULT_CHANNEL {
-		return model.NewLocAppError("HandleIncomingWebhook", "api.post.create_post.town_square_read_only", nil, "")
+		return model.NewAppError("HandleIncomingWebhook", "api.post.create_post.town_square_read_only", nil, "", http.StatusForbidden)
 	}
 
 	if channel.Type != model.CHANNEL_OPEN && !a.HasPermissionToChannel(hook.UserId, channel.Id, model.PERMISSION_READ_CHANNEL) {

--- a/model/utils.go
+++ b/model/utils.go
@@ -108,18 +108,6 @@ func NewAppError(where string, id string, params map[string]interface{}, details
 	return ap
 }
 
-func NewLocAppError(where string, id string, params map[string]interface{}, details string) *AppError {
-	ap := &AppError{}
-	ap.Id = id
-	ap.params = params
-	ap.Message = id
-	ap.Where = where
-	ap.DetailedError = details
-	ap.StatusCode = 500
-	ap.IsOAuth = false
-	return ap
-}
-
 var encoding = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769")
 
 // NewId is a globally unique identifier.  It is a [A-Z0-9] string 26

--- a/utils/file.go
+++ b/utils/file.go
@@ -58,12 +58,12 @@ func TestFileConnection() *model.AppError {
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
-			return model.NewLocAppError("TestFileConnection", "Bad connection to S3 or minio.", nil, err.Error())
+			return model.NewAppError("TestFileConnection", "Bad connection to S3 or minio.", nil, err.Error(), http.StatusInternalServerError)
 		}
 
 		exists, err := s3Clnt.BucketExists(bucket)
 		if err != nil {
-			return model.NewLocAppError("TestFileConnection", "Error checking if bucket exists.", nil, err.Error())
+			return model.NewAppError("TestFileConnection", "Error checking if bucket exists.", nil, err.Error(), http.StatusInternalServerError)
 		}
 
 		if !exists {
@@ -83,7 +83,7 @@ func TestFileConnection() *model.AppError {
 		os.Remove(Cfg.FileSettings.Directory + TEST_FILE_PATH)
 		l4g.Info("Able to write files to local storage.")
 	} else {
-		return model.NewLocAppError("TestFileConnection", "No file driver selected.", nil, "")
+		return model.NewAppError("TestFileConnection", "No file driver selected.", nil, "", http.StatusInternalServerError)
 	}
 
 	return nil
@@ -99,22 +99,22 @@ func ReadFile(path string) ([]byte, *model.AppError) {
 		region := Cfg.FileSettings.AmazonS3Region
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
-			return nil, model.NewLocAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error())
+			return nil, model.NewAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 		bucket := Cfg.FileSettings.AmazonS3Bucket
 		minioObject, err := s3Clnt.GetObject(bucket, path)
 		defer minioObject.Close()
 		if err != nil {
-			return nil, model.NewLocAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error())
+			return nil, model.NewAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 		if f, err := ioutil.ReadAll(minioObject); err != nil {
-			return nil, model.NewLocAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error())
+			return nil, model.NewAppError("ReadFile", "api.file.read_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		} else {
 			return f, nil
 		}
 	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if f, err := ioutil.ReadFile(Cfg.FileSettings.Directory + path); err != nil {
-			return nil, model.NewLocAppError("ReadFile", "api.file.read_file.reading_local.app_error", nil, err.Error())
+			return nil, model.NewAppError("ReadFile", "api.file.read_file.reading_local.app_error", nil, err.Error(), http.StatusInternalServerError)
 		} else {
 			return f, nil
 		}
@@ -137,31 +137,31 @@ func MoveFile(oldPath, newPath string) *model.AppError {
 		}
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
-			return model.NewLocAppError("moveFile", "api.file.write_file.s3.app_error", nil, err.Error())
+			return model.NewAppError("moveFile", "api.file.write_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 		bucket := Cfg.FileSettings.AmazonS3Bucket
 
 		source := s3.NewSourceInfo(bucket, oldPath, nil)
 		destination, err := s3.NewDestinationInfo(bucket, newPath, nil, CopyMetadata(encrypt))
 		if err != nil {
-			return model.NewLocAppError("moveFile", "api.file.write_file.s3.app_error", nil, err.Error())
+			return model.NewAppError("moveFile", "api.file.write_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 		if err = s3Clnt.CopyObject(destination, source); err != nil {
-			return model.NewLocAppError("moveFile", "api.file.move_file.delete_from_s3.app_error", nil, err.Error())
+			return model.NewAppError("moveFile", "api.file.move_file.delete_from_s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 		if err = s3Clnt.RemoveObject(bucket, oldPath); err != nil {
-			return model.NewLocAppError("moveFile", "api.file.move_file.delete_from_s3.app_error", nil, err.Error())
+			return model.NewAppError("moveFile", "api.file.move_file.delete_from_s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.MkdirAll(filepath.Dir(Cfg.FileSettings.Directory+newPath), 0774); err != nil {
-			return model.NewLocAppError("moveFile", "api.file.move_file.rename.app_error", nil, err.Error())
+			return model.NewAppError("moveFile", "api.file.move_file.rename.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 
 		if err := os.Rename(Cfg.FileSettings.Directory+oldPath, Cfg.FileSettings.Directory+newPath); err != nil {
-			return model.NewLocAppError("moveFile", "api.file.move_file.rename.app_error", nil, err.Error())
+			return model.NewAppError("moveFile", "api.file.move_file.rename.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else {
-		return model.NewLocAppError("moveFile", "api.file.move_file.configured.app_error", nil, "")
+		return model.NewAppError("moveFile", "api.file.move_file.configured.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	return nil
@@ -182,7 +182,7 @@ func WriteFile(f []byte, path string) *model.AppError {
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
-			return model.NewLocAppError("WriteFile", "api.file.write_file.s3.app_error", nil, err.Error())
+			return model.NewAppError("WriteFile", "api.file.write_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 
 		bucket := Cfg.FileSettings.AmazonS3Bucket
@@ -194,14 +194,14 @@ func WriteFile(f []byte, path string) *model.AppError {
 
 		_, err = s3Clnt.PutObjectWithMetadata(bucket, path, bytes.NewReader(f), metaData, nil)
 		if err != nil {
-			return model.NewLocAppError("WriteFile", "api.file.write_file.s3.app_error", nil, err.Error())
+			return model.NewAppError("WriteFile", "api.file.write_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := writeFileLocally(f, Cfg.FileSettings.Directory+path); err != nil {
 			return err
 		}
 	} else {
-		return model.NewLocAppError("WriteFile", "api.file.write_file.configured.app_error", nil, "")
+		return model.NewAppError("WriteFile", "api.file.write_file.configured.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	return nil
@@ -210,11 +210,11 @@ func WriteFile(f []byte, path string) *model.AppError {
 func writeFileLocally(f []byte, path string) *model.AppError {
 	if err := os.MkdirAll(filepath.Dir(path), 0774); err != nil {
 		directory, _ := filepath.Abs(filepath.Dir(path))
-		return model.NewLocAppError("WriteFile", "api.file.write_file_locally.create_dir.app_error", nil, "directory="+directory+", err="+err.Error())
+		return model.NewAppError("WriteFile", "api.file.write_file_locally.create_dir.app_error", nil, "directory="+directory+", err="+err.Error(), http.StatusInternalServerError)
 	}
 
 	if err := ioutil.WriteFile(path, f, 0644); err != nil {
-		return model.NewLocAppError("WriteFile", "api.file.write_file_locally.writing.app_error", nil, err.Error())
+		return model.NewAppError("WriteFile", "api.file.write_file_locally.writing.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil
@@ -231,19 +231,19 @@ func RemoveFile(path string) *model.AppError {
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
-			return model.NewLocAppError("RemoveFile", "utils.file.remove_file.s3.app_error", nil, err.Error())
+			return model.NewAppError("RemoveFile", "utils.file.remove_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 
 		bucket := Cfg.FileSettings.AmazonS3Bucket
 		if err := s3Clnt.RemoveObject(bucket, path); err != nil {
-			return model.NewLocAppError("RemoveFile", "utils.file.remove_file.s3.app_error", nil, err.Error())
+			return model.NewAppError("RemoveFile", "utils.file.remove_file.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.Remove(Cfg.FileSettings.Directory + path); err != nil {
-			return model.NewLocAppError("RemoveFile", "utils.file.remove_file.local.app_error", nil, err.Error())
+			return model.NewAppError("RemoveFile", "utils.file.remove_file.local.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else {
-		return model.NewLocAppError("RemoveFile", "utils.file.remove_file.configured.app_error", nil, "")
+		return model.NewAppError("RemoveFile", "utils.file.remove_file.configured.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	return nil
@@ -280,7 +280,7 @@ func RemoveDirectory(path string) *model.AppError {
 
 		s3Clnt, err := s3New(endpoint, accessKey, secretKey, secure, signV2, region)
 		if err != nil {
-			return model.NewLocAppError("RemoveDirectory", "utils.file.remove_directory.s3.app_error", nil, err.Error())
+			return model.NewAppError("RemoveDirectory", "utils.file.remove_directory.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 
 		doneCh := make(chan struct{})
@@ -289,17 +289,17 @@ func RemoveDirectory(path string) *model.AppError {
 		for err := range s3Clnt.RemoveObjects(bucket, getPathsFromObjectInfos(s3Clnt.ListObjects(bucket, path, true, doneCh))) {
 			if err.Err != nil {
 				doneCh <- struct{}{}
-				return model.NewLocAppError("RemoveDirectory", "utils.file.remove_directory.s3.app_error", nil, err.Err.Error())
+				return model.NewAppError("RemoveDirectory", "utils.file.remove_directory.s3.app_error", nil, err.Err.Error(), http.StatusInternalServerError)
 			}
 		}
 
 		close(doneCh)
 	} else if *Cfg.FileSettings.DriverName == model.IMAGE_DRIVER_LOCAL {
 		if err := os.RemoveAll(Cfg.FileSettings.Directory + path); err != nil {
-			return model.NewLocAppError("RemoveDirectory", "utils.file.remove_directory.local.app_error", nil, err.Error())
+			return model.NewAppError("RemoveDirectory", "utils.file.remove_directory.local.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else {
-		return model.NewLocAppError("RemoveDirectory", "utils.file.remove_directory.configured.app_error", nil, "")
+		return model.NewAppError("RemoveDirectory", "utils.file.remove_directory.configured.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	return nil


### PR DESCRIPTION
This cleans up the few NewLocAppError calls that crept in since the main
bulk of them were removed, and finally removes the NewLocAppError
function altogether.