### PR TITLE
PLT-7694: Allow setting a prefix for Elasticsearch indexes.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -314,7 +314,8 @@
         "PostIndexReplicas": 1,
         "PostIndexShards": 1,
         "AggregatePostsAfterDays": 365,
-        "PostsAggregatorJobStartTime": "03:00"
+        "PostsAggregatorJobStartTime": "03:00",
+        "IndexPrefix": ""
     },
     "DataRetentionSettings": {
         "EnableMessageDeletion": false,

--- a/model/config.go
+++ b/model/config.go
@@ -138,6 +138,7 @@ const (
 	ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_SHARDS               = 1
 	ELASTICSEARCH_SETTINGS_DEFAULT_AGGREGATE_POSTS_AFTER_DAYS      = 365
 	ELASTICSEARCH_SETTINGS_DEFAULT_POSTS_AGGREGATOR_JOB_START_TIME = "03:00"
+	ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX                    = ""
 
 	DATA_RETENTION_SETTINGS_DEFAULT_MESSAGE_RETENTION_DAYS  = 365
 	DATA_RETENTION_SETTINGS_DEFAULT_FILE_RETENTION_DAYS     = 365
@@ -482,6 +483,7 @@ type ElasticsearchSettings struct {
 	PostIndexShards             *int
 	AggregatePostsAfterDays     *int
 	PostsAggregatorJobStartTime *string
+	IndexPrefix                 *string
 }
 
 type DataRetentionSettings struct {
@@ -1567,6 +1569,11 @@ func (o *Config) SetDefaults() {
 	if o.ElasticsearchSettings.PostsAggregatorJobStartTime == nil {
 		o.ElasticsearchSettings.PostsAggregatorJobStartTime = new(string)
 		*o.ElasticsearchSettings.PostsAggregatorJobStartTime = ELASTICSEARCH_SETTINGS_DEFAULT_POSTS_AGGREGATOR_JOB_START_TIME
+	}
+
+	if o.ElasticsearchSettings.IndexPrefix == nil {
+		o.ElasticsearchSettings.IndexPrefix = new(string)
+		*o.ElasticsearchSettings.IndexPrefix = ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX
 	}
 
 	if o.DataRetentionSettings.EnableMessageDeletion == nil {


### PR DESCRIPTION
#### Summary
Allow setting a prefix for Elasticsearch indexes.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7694

#### Checklist
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/200