### PR TITLE
PLT-7619: Cleanup flags in data retention.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5888,6 +5888,10 @@
     "translation": "We encountered an error permanently deleting the batch of posts"
   },
   {
+    "id": "store.sql_preference.cleanup_flags_batch.app_error",
+    "translation": "We encountered an error cleaning up the batch of flags"
+  },
+  {
     "id": "store.sql_preference.delete.app_error",
     "translation": "We encountered an error while deleting preferences"
   },

--- a/store/store.go
+++ b/store/store.go
@@ -346,6 +346,7 @@ type PreferenceStore interface {
 	DeleteCategoryAndName(category string, name string) StoreChannel
 	PermanentDeleteByUser(userId string) StoreChannel
 	IsFeatureEnabled(feature, userId string) StoreChannel
+	CleanupFlagsBatch(limit int64) StoreChannel
 }
 
 type LicenseStore interface {


### PR DESCRIPTION
#### Summary
Adds a function to the posts store to clean up dangling flagged posts which point to posts that no longer exist.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7619

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/201
- [x] Includes text changes and localization file updates
