### PR TITLE
Only check LDAP attributes if auth data set

### DIFF
--- a/app/plugins.go
+++ b/app/plugins.go
@@ -186,6 +186,10 @@ func (api *BuiltInPluginAPI) GetLdapUserAttributes(userId string, attributes []s
 		return nil, err
 	}
 
+	if user.AuthData == nil {
+		return map[string]string{}, nil
+	}
+
 	return api.app.Ldap.GetUserAttributes(*user.AuthData, attributes)
 }
 


### PR DESCRIPTION
#### Summary
Minor fix for ldapextras built-in plugin.