### PR TITLE
PLT-7684 Add support to outgoing webhooks and slash commands to set post type and props

### DIFF
--- a/api/post_test.go
+++ b/api/post_test.go
@@ -295,6 +295,16 @@ func testCreatePostWithOutgoingHook(
 			}
 		}
 
+		resp := &model.OutgoingWebhookResponse{}
+		resp.Text = new(string)
+		*resp.Text = "some test text"
+		resp.Username = "testusername"
+		resp.IconURL = "http://www.mattermost.org/wp-content/uploads/2016/04/icon.png"
+		resp.Props = map[string]interface{}{"someprop": "somevalue"}
+		resp.Type = "custom_test"
+
+		w.Write([]byte(resp.ToJson()))
+
 		success <- true
 	}))
 	defer ts.Close()

--- a/api4/command.go
+++ b/api4/command.go
@@ -305,6 +305,8 @@ func testCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	rc := &model.CommandResponse{
 		Text:         "test command response " + msg,
 		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
+		Type:         "custom_test",
+		Props:        map[string]interface{}{"someprop": "somevalue"},
 	}
 
 	w.Write([]byte(rc.ToJson()))

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -423,6 +423,14 @@ func TestExecuteCommand(t *testing.T) {
 	cmdPosted := false
 	for _, post := range posts.Posts {
 		if strings.Contains(post.Message, "test command response") {
+			if post.Type != "custom_test" {
+				t.Fatal("wrong type set in slash command post")
+			}
+
+			if post.Props["someprop"] != "somevalue" {
+				t.Fatal("wrong prop set in slash command post")
+			}
+
 			cmdPosted = true
 			break
 		}

--- a/app/command.go
+++ b/app/command.go
@@ -239,6 +239,8 @@ func (a *App) HandleCommandResponse(command *model.Command, args *model.CommandA
 	post.RootId = args.RootId
 	post.ParentId = args.ParentId
 	post.UserId = args.UserId
+	post.Type = response.Type
+	post.Props = response.Props
 
 	if !builtIn {
 		post.AddProp("from_webhook", "true")

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -105,10 +105,10 @@ func (a *App) TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.
 				l4g.Error(utils.T("api.post.handle_webhook_events_and_forget.event_post.error"), err.Error())
 			} else {
 				defer CloseBody(resp)
-				respProps := model.MapFromJson(resp.Body)
+				webhookResp := model.OutgoingWebhookResponseFromJson(resp.Body)
 
-				if text, ok := respProps["text"]; ok {
-					if _, err := a.CreateWebhookPost(hook.CreatorId, channel, text, respProps["username"], respProps["icon_url"], post.Props, post.Type); err != nil {
+				if webhookResp.Text != nil {
+					if _, err := a.CreateWebhookPost(hook.CreatorId, channel, *webhookResp.Text, webhookResp.Username, webhookResp.IconURL, webhookResp.Props, webhookResp.Type); err != nil {
 						l4g.Error(utils.T("api.post.handle_webhook_events_and_forget.create_post.error"), err)
 					}
 				}

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -107,7 +107,7 @@ func (a *App) TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.
 				defer CloseBody(resp)
 				webhookResp := model.OutgoingWebhookResponseFromJson(resp.Body)
 
-				if webhookResp.Text != nil {
+				if webhookResp != nil && webhookResp.Text != nil {
 					if _, err := a.CreateWebhookPost(hook.CreatorId, channel, *webhookResp.Text, webhookResp.Username, webhookResp.IconURL, webhookResp.Props, webhookResp.Type); err != nil {
 						l4g.Error(utils.T("api.post.handle_webhook_events_and_forget.create_post.error"), err)
 					}

--- a/model/command_response.go
+++ b/model/command_response.go
@@ -20,6 +20,8 @@ type CommandResponse struct {
 	Text         string             `json:"text"`
 	Username     string             `json:"username"`
 	IconURL      string             `json:"icon_url"`
+	Type         string             `json:"type"`
+	Props        StringInterface    `json:"props"`
 	GotoLocation string             `json:"goto_location"`
 	Attachments  []*SlackAttachment `json:"attachments"`
 }

--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -45,6 +45,14 @@ type OutgoingWebhookPayload struct {
 	FileIds     string `json:"file_ids"`
 }
 
+type OutgoingWebhookResponse struct {
+	Text     *string         `json:"text"`
+	Username string          `json:"username"`
+	IconURL  string          `json:"icon_url"`
+	Props    StringInterface `json:"props"`
+	Type     string          `json:"type"`
+}
+
 func (o *OutgoingWebhookPayload) ToJSON() string {
 	b, err := json.Marshal(o)
 	if err != nil {
@@ -107,6 +115,26 @@ func OutgoingWebhookListFromJson(data io.Reader) []*OutgoingWebhook {
 	err := decoder.Decode(&o)
 	if err == nil {
 		return o
+	} else {
+		return nil
+	}
+}
+
+func (o *OutgoingWebhookResponse) ToJson() string {
+	b, err := json.Marshal(o)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func OutgoingWebhookResponseFromJson(data io.Reader) *OutgoingWebhookResponse {
+	decoder := json.NewDecoder(data)
+	var o OutgoingWebhookResponse
+	err := decoder.Decode(&o)
+	if err == nil {
+		return &o
 	} else {
 		return nil
 	}

--- a/model/outgoing_webhook_test.go
+++ b/model/outgoing_webhook_test.go
@@ -176,3 +176,16 @@ func TestOutgoingWebhookTriggerWordStartsWith(t *testing.T) {
 		t.Fatal("Should return false")
 	}
 }
+
+func TestOutgoingWebhookResponseJson(t *testing.T) {
+	o := OutgoingWebhookResponse{}
+	o.Text = new(string)
+	*o.Text = "some text"
+
+	json := o.ToJson()
+	ro := OutgoingWebhookResponseFromJson(strings.NewReader(json))
+
+	if *o.Text != *ro.Text {
+		t.Fatal("Text does not match")
+	}
+}


### PR DESCRIPTION
#### Summary
Add support to outgoing webhooks and slash commands to set post type and props. Incoming webhooks already had support for it.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7684

#### Checklist
- [x] Added or updated unit tests (required for all new features)