### PR TITLE
PLT-7750: Improve the error messages for invalid data retention config.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4369,15 +4369,15 @@
   },
   {
     "id": "model.config.is_valid.data_retention.deletion_job_start_time.app_error",
-    "translation": "DataRetention DeletionJobStartTime setting must be set to a time in the format \"hh:mm\""
+    "translation": "Data retention job start time must be a 24-hour time stamp in the form HH:MM."
   },
   {
     "id": "model.config.is_valid.data_retention.file_retention_days_too_low.app_error",
-    "translation": "DataRetention FileRetentionDays setting must be at least 1"
+    "translation": "File retention must be one day or longer."
   },
   {
     "id": "model.config.is_valid.data_retention.message_retention_days_too_low.app_error",
-    "translation": "DataRetention MessageRetentionDays setting must be at least 1"
+    "translation": "Message retention must be one day or longer."
   },
   {
     "id": "model.config.is_valid.elastic_search.aggregate_posts_after_days.app_error",


### PR DESCRIPTION
Tidies up error messages for data retention invalid inputs.

This doesn't fix the error when you enter an enormous number of days - that needs to happen client side actually as it's generating an invalid config json which the parser chokes on, so I can't validate it specifically server side.