### PR TITLE
PLT-7759: Make GetNewestJobByStatusAndType not fail when no jobs match.

### DIFF
--- a/store/sqlstore/job_store.go
+++ b/store/sqlstore/job_store.go
@@ -344,8 +344,8 @@ func (jss SqlJobStore) GetNewestJobByStatusAndType(status string, jobType string
 				Type = :Type
 			ORDER BY
 				CreateAt DESC
-			LIMIT 1`, map[string]interface{}{"Status": status, "Type": jobType}); err != nil {
-			result.Err = model.NewAppError("SqlJobStore.GetAllByStatus", "store.sql_job.get_newest_job_by_status_and_type.app_error", nil, "Status="+status+", "+err.Error(), http.StatusInternalServerError)
+			LIMIT 1`, map[string]interface{}{"Status": status, "Type": jobType}); err != nil && err != sql.ErrNoRows {
+			result.Err = model.NewAppError("SqlJobStore.GetNewestJobByStatusAndType", "store.sql_job.get_newest_job_by_status_and_type.app_error", nil, "Status="+status+", "+err.Error(), http.StatusInternalServerError)
 		} else {
 			result.Data = job
 		}

--- a/store/sqlstore/job_store_test.go
+++ b/store/sqlstore/job_store_test.go
@@ -275,6 +275,10 @@ func TestJobStoreGetNewestJobByStatusAndType(t *testing.T) {
 	result := <-ss.Job().GetNewestJobByStatusAndType(status1, jobType1)
 	assert.Nil(t, result.Err)
 	assert.EqualValues(t, jobs[0].Id, result.Data.(*model.Job).Id)
+
+	result = <-ss.Job().GetNewestJobByStatusAndType(model.NewId(), model.NewId())
+	assert.Nil(t, result.Err)
+	assert.Nil(t, result.Data.(*model.Job))
 }
 
 func TestJobStoreGetCountByStatusAndType(t *testing.T) {


### PR DESCRIPTION
#### Summary
Make GetNewestJobByStatusAndType not fail when no jobs match. It should not error, but should return a nil job.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7759

#### Checklist
- [x] Added or updated unit tests (required for all new features)
