### PR TITLE
Only update session activity on specific endpoints

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -716,6 +716,8 @@ func viewChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	c.App.UpdateLastActivityAtIfNeeded(c.Session)
+
 	// Returning {"status": "OK", ...} for backwards compatability
 	resp := &model.ChannelViewResponse{
 		Status:            "OK",

--- a/api4/context.go
+++ b/api4/context.go
@@ -157,7 +157,6 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewAppError("ServeHTTP", "api.context.token_provided.app_error", nil, "token="+token, http.StatusUnauthorized)
 		} else {
 			c.Session = *session
-			c.App.UpdateLastActivityAtIfNeeded(*session)
 		}
 	}
 

--- a/api4/post.go
+++ b/api4/post.go
@@ -69,6 +69,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.App.SetStatusOnline(c.Session.UserId, c.Session.Id, false)
+	c.App.UpdateLastActivityAtIfNeeded(c.Session)
 
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte(rp.ToJson()))

--- a/api4/user.go
+++ b/api4/user.go
@@ -121,6 +121,7 @@ func getUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		} else {
 			app.SanitizeProfile(user, c.IsSystemAdmin())
 		}
+		c.App.UpdateLastActivityAtIfNeeded(c.Session)
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 		w.Write([]byte(user.ToJson()))
 		return
@@ -369,6 +370,7 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		if len(etag) > 0 {
 			w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 		}
+		c.App.UpdateLastActivityAtIfNeeded(c.Session)
 		w.Write([]byte(model.UserListToJson(profiles)))
 	}
 }


### PR DESCRIPTION
#### Summary
This is an update to the PR that added the idle session timeout features. Some endpoints get hit even if there is no activity from the user, making it look like the session activity is from the user. I moved the session activity update from all requests to a few active routes that generally require user action.