### PR TITLE
PLT-7740 Update encoding of filename in file headers

### DIFF
--- a/api4/file.go
+++ b/api4/file.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
@@ -338,9 +337,9 @@ func writeFileResponse(filename string, contentType string, bytes []byte, forceD
 	}
 
 	if toDownload {
-		w.Header().Set("Content-Disposition", "attachment;filename=\""+filename+"\"; filename*=UTF-8''"+url.QueryEscape(filename))
+		w.Header().Set("Content-Disposition", "attachment;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
 	} else {
-		w.Header().Set("Content-Disposition", "inline;filename=\""+filename+"\"; filename*=UTF-8''"+url.QueryEscape(filename))
+		w.Header().Set("Content-Disposition", "inline;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
 	}
 
 	// prevent file links from being embedded in iframes

--- a/api4/file.go
+++ b/api4/file.go
@@ -5,6 +5,7 @@ package api4
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -335,6 +336,8 @@ func writeFileResponse(filename string, contentType string, bytes []byte, forceD
 
 		toDownload = !isMediaType
 	}
+
+	filename = url.PathEscape(filename)
 
 	if toDownload {
 		w.Header().Set("Content-Disposition", "attachment;filename=\""+filename+"\"; filename*=UTF-8''"+filename)


### PR DESCRIPTION
#### Summary
Replace query escaping with path escaping from filenames in Content-Disposition header. I don't think this is a security concern because:

* CRLF injection is prevented by Golang itself https://github.com/golang/go/commit/2c420ece67e25c7692e28f641d374deb0bec9b7d
* The recipient is responsible for dealing with malicious filenames https://tools.ietf.org/html/rfc6266#section-4.3
* We remove path separators on upload https://github.com/mattermost/mattermost-server/blob/master/app/file.go#L295

Let me know if there are other security implications to consider.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7740

#### Checklist
- [x] Touches critical sections of the codebase (filenames)
