### PR TITLE
PLT-7785: Slash commands can be issued to a channel in a team without it

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -212,16 +212,9 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// DMs don't have teams, so get the team id from the channel if not specified
-	if commandArgs.TeamId == "" {
-		commandArgs.TeamId = channel.TeamId
-	}
-
-	// ensure that the specified channel is a part of the specified team
-	if commandArgs.TeamId != channel.TeamId {
-		c.SetPermissionError(model.PERMISSION_USE_SLASH_COMMANDS)
-		return
-	}
+	// team id is implicitly taken from channel so that slash commands
+	// created on some other team can't be run against this one
+	commandArgs.TeamId = channel.TeamId
 
 	commandArgs.UserId = c.Session.UserId
 	commandArgs.T = c.T

--- a/api4/command.go
+++ b/api4/command.go
@@ -212,9 +212,13 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// DMs don't have teams, so get the team id from the channel if not specified
 	if commandArgs.TeamId == "" {
 		commandArgs.TeamId = channel.TeamId
-	} else if c.Session.GetTeamByTeamId(commandArgs.TeamId) == nil {
+	}
+
+	// ensure that the specified channel is a part of the specified team
+	if commandArgs.TeamId != channel.TeamId {
 		c.SetPermissionError(model.PERMISSION_USE_SLASH_COMMANDS)
 		return
 	}

--- a/api4/command_help_test.go
+++ b/api4/command_help_test.go
@@ -23,13 +23,13 @@ func TestHelpCommand(t *testing.T) {
 	}()
 
 	*utils.Cfg.SupportSettings.HelpLink = ""
-	rs1, _ := Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/help ")
+	rs1, _ := Client.ExecuteCommand(channel.Id, "/help ")
 	if rs1.GotoLocation != model.SUPPORT_SETTINGS_DEFAULT_HELP_LINK {
 		t.Fatal("failed to default help link")
 	}
 
 	*utils.Cfg.SupportSettings.HelpLink = "https://docs.mattermost.com/guides/user.html"
-	rs2, _ := Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/help ")
+	rs2, _ := Client.ExecuteCommand(channel.Id, "/help ")
 	if rs2.GotoLocation != "https://docs.mattermost.com/guides/user.html" {
 		t.Fatal("failed to help link")
 	}

--- a/api4/command_help_test.go
+++ b/api4/command_help_test.go
@@ -23,13 +23,13 @@ func TestHelpCommand(t *testing.T) {
 	}()
 
 	*utils.Cfg.SupportSettings.HelpLink = ""
-	rs1, _ := Client.ExecuteCommand(channel.Id, "/help ")
+	rs1, _ := Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/help ")
 	if rs1.GotoLocation != model.SUPPORT_SETTINGS_DEFAULT_HELP_LINK {
 		t.Fatal("failed to default help link")
 	}
 
 	*utils.Cfg.SupportSettings.HelpLink = "https://docs.mattermost.com/guides/user.html"
-	rs2, _ := Client.ExecuteCommand(channel.Id, "/help ")
+	rs2, _ := Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/help ")
 	if rs2.GotoLocation != "https://docs.mattermost.com/guides/user.html" {
 		t.Fatal("failed to help link")
 	}

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -408,7 +408,7 @@ func TestExecuteCommand(t *testing.T) {
 		t.Fatal("failed to create post command")
 	}
 
-	commandResponse, resp := Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/postcommand")
+	commandResponse, resp := Client.ExecuteCommand(channel.Id, "/postcommand")
 	CheckNoError(t, resp)
 
 	if commandResponse == nil {
@@ -452,7 +452,7 @@ func TestExecuteCommand(t *testing.T) {
 		t.Fatal("failed to create get command")
 	}
 
-	commandResponse, resp = Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/getcommand")
+	commandResponse, resp = Client.ExecuteCommand(channel.Id, "/getcommand")
 	CheckNoError(t, resp)
 
 	if commandResponse == nil {
@@ -464,30 +464,30 @@ func TestExecuteCommand(t *testing.T) {
 		t.Fatal("Test command failed to send")
 	}
 
-	_, resp = Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "")
+	_, resp = Client.ExecuteCommand(channel.Id, "")
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/")
+	_, resp = Client.ExecuteCommand(channel.Id, "/")
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "getcommand")
+	_, resp = Client.ExecuteCommand(channel.Id, "getcommand")
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/junk")
+	_, resp = Client.ExecuteCommand(channel.Id, "/junk")
 	CheckNotFoundStatus(t, resp)
 
 	otherUser := th.CreateUser()
 	Client.Login(otherUser.Email, otherUser.Password)
 
-	_, resp = Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/getcommand")
+	_, resp = Client.ExecuteCommand(channel.Id, "/getcommand")
 	CheckForbiddenStatus(t, resp)
 
 	Client.Logout()
 
-	_, resp = Client.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/getcommand")
+	_, resp = Client.ExecuteCommand(channel.Id, "/getcommand")
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = th.SystemAdminClient.ExecuteCommand(th.BasicTeam.Id, channel.Id, "/getcommand")
+	_, resp = th.SystemAdminClient.ExecuteCommand(channel.Id, "/getcommand")
 	CheckNoError(t, resp)
 }
 
@@ -506,7 +506,7 @@ func TestExecuteCommandAgainstChannelOnAnotherTeam(t *testing.T) {
 	*utils.Cfg.ServiceSettings.EnableCommands = true
 	*utils.Cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost"
 
-	// create a slash command on some other team where we have permissionto do so
+	// create a slash command on some other team where we have permission to do so
 	team2 := th.CreateTeam()
 	postCmd := &model.Command{
 		CreatorId: th.BasicUser.Id,
@@ -520,7 +520,8 @@ func TestExecuteCommandAgainstChannelOnAnotherTeam(t *testing.T) {
 		t.Fatal("failed to create post command")
 	}
 
-	// use that slash command on a channel that belongs to the team we're attacking
-	_, resp := Client.ExecuteCommand(team2.Id, channel.Id, "/postcommand")
-	CheckForbiddenStatus(t, resp)
+	// the execute command endpoint will always search for the command by trigger and team id, inferring team id from the
+	// channel id, so there is no way to use that slash command on a channel that belongs to some other team
+	_, resp := Client.ExecuteCommand(channel.Id, "/postcommand")
+	CheckNotFoundStatus(t, resp)
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -2807,8 +2807,12 @@ func (c *Client4) ListCommands(teamId string, customOnly bool) ([]*Command, *Res
 }
 
 // ExecuteCommand executes a given command.
-func (c *Client4) ExecuteCommand(channelId, command string) (*CommandResponse, *Response) {
-	commandArgs := &CommandArgs{ChannelId: channelId, Command: command}
+func (c *Client4) ExecuteCommand(teamId, channelId, command string) (*CommandResponse, *Response) {
+	commandArgs := &CommandArgs{
+		TeamId:    teamId,
+		ChannelId: channelId,
+		Command:   command,
+	}
 	if r, err := c.DoApiPost(c.GetCommandsRoute()+"/execute", commandArgs.ToJson()); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {

--- a/model/client4.go
+++ b/model/client4.go
@@ -2807,9 +2807,8 @@ func (c *Client4) ListCommands(teamId string, customOnly bool) ([]*Command, *Res
 }
 
 // ExecuteCommand executes a given command.
-func (c *Client4) ExecuteCommand(teamId, channelId, command string) (*CommandResponse, *Response) {
+func (c *Client4) ExecuteCommand(channelId, command string) (*CommandResponse, *Response) {
 	commandArgs := &CommandArgs{
-		TeamId:    teamId,
 		ChannelId: channelId,
 		Command:   command,
 	}


### PR DESCRIPTION
#### Summary
Ensured that specified channel is a part of specified team prior to executing the slash command.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7785

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)