### PR TITLE
[PLT-7787] remove an extra ephemeral message posted for slash commands

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -47,7 +47,7 @@ func (a *App) CreateCommandPost(post *model.Post, teamId string, response *model
 
 	if response.ResponseType == model.COMMAND_RESPONSE_TYPE_IN_CHANNEL {
 		return a.CreatePostMissingChannel(post, true)
-	} else if response.ResponseType == "" || response.ResponseType == model.COMMAND_RESPONSE_TYPE_EPHEMERAL {
+	} else if (response.ResponseType == "" || response.ResponseType == model.COMMAND_RESPONSE_TYPE_EPHEMERAL) && (response.Text != "" || response.Attachments != nil) {
 		post.ParentId = ""
 		a.SendEphemeralPost(post.UserId, post)
 	}


### PR DESCRIPTION
#### Summary

When some commands return an empty message it should not post in the channel, this PR check if the message is empty and if it blocks the post.

#### Ticket Link

JIRA: https://mattermost.atlassian.net/browse/PLT-7787