### PR TITLE
PLT-7789: Fix raciness on Aurora with importing team members.

### DIFF
--- a/app/import.go
+++ b/app/import.go
@@ -773,18 +773,14 @@ func (a *App) ImportUserTeams(username string, data *[]UserTeamImportData) *mode
 			roles = *tdata.Roles
 		}
 
-		if _, err := a.joinUserToTeam(team, user); err != nil {
+		var member *model.TeamMember
+		if member, _, err = a.joinUserToTeam(team, user); err != nil {
 			return err
 		}
 
-		var member *model.TeamMember
-		if member, err = a.GetTeamMember(team.Id, user.Id); err != nil {
-			return err
-		} else {
-			if member.Roles != roles {
-				if _, err := a.UpdateTeamMemberRoles(team.Id, user.Id, roles); err != nil {
-					return err
-				}
+		if member.Roles != roles {
+			if _, err := a.UpdateTeamMemberRoles(team.Id, user.Id, roles); err != nil {
+				return err
 			}
 		}
 

--- a/app/team.go
+++ b/app/team.go
@@ -273,7 +273,7 @@ func (a *App) AddUserToTeamByInviteId(inviteId string, userId string) (*model.Te
 	return team, nil
 }
 
-func (a *App) joinUserToTeam(team *model.Team, user *model.User) (bool, *model.AppError) {
+func (a *App) joinUserToTeam(team *model.Team, user *model.User) (*model.TeamMember, bool, *model.AppError) {
 	tm := &model.TeamMember{
 		TeamId: team.Id,
 		UserId: user.Id,
@@ -285,29 +285,31 @@ func (a *App) joinUserToTeam(team *model.Team, user *model.User) (bool, *model.A
 	}
 
 	if etmr := <-a.Srv.Store.Team().GetMember(team.Id, user.Id); etmr.Err == nil {
-		// Membership alredy exists.  Check if deleted and and update, otherwise do nothing
+		// Membership already exists.  Check if deleted and and update, otherwise do nothing
 		rtm := etmr.Data.(*model.TeamMember)
 
 		// Do nothing if already added
 		if rtm.DeleteAt == 0 {
-			return true, nil
+			return rtm, true, nil
 		}
 
 		if tmr := <-a.Srv.Store.Team().UpdateMember(tm); tmr.Err != nil {
-			return false, tmr.Err
+			return nil, false, tmr.Err
+		} else {
+			return tmr.Data.(*model.TeamMember), true, nil
 		}
 	} else {
 		// Membership appears to be missing.  Lets try to add.
 		if tmr := <-a.Srv.Store.Team().SaveMember(tm); tmr.Err != nil {
-			return false, tmr.Err
+			return nil, false, tmr.Err
+		} else {
+			return tmr.Data.(*model.TeamMember), true, nil
 		}
 	}
-
-	return false, nil
 }
 
 func (a *App) JoinUserToTeam(team *model.Team, user *model.User, userRequestorId string) *model.AppError {
-	if alreadyAdded, err := a.joinUserToTeam(team, user); err != nil {
+	if _, alreadyAdded, err := a.joinUserToTeam(team, user); err != nil {
 		return err
 	} else if alreadyAdded {
 		return nil

--- a/app/team.go
+++ b/app/team.go
@@ -273,6 +273,10 @@ func (a *App) AddUserToTeamByInviteId(inviteId string, userId string) (*model.Te
 	return team, nil
 }
 
+// Returns three values:
+// 1. a pointer to the team member, if successful
+// 2. a boolean: true if the user has a non-deleted team member for that team already, otherwise false.
+// 3. a pointer to an AppError if something went wrong.
 func (a *App) joinUserToTeam(team *model.Team, user *model.User) (*model.TeamMember, bool, *model.AppError) {
 	tm := &model.TeamMember{
 		TeamId: team.Id,
@@ -296,14 +300,14 @@ func (a *App) joinUserToTeam(team *model.Team, user *model.User) (*model.TeamMem
 		if tmr := <-a.Srv.Store.Team().UpdateMember(tm); tmr.Err != nil {
 			return nil, false, tmr.Err
 		} else {
-			return tmr.Data.(*model.TeamMember), true, nil
+			return tmr.Data.(*model.TeamMember), false, nil
 		}
 	} else {
 		// Membership appears to be missing.  Lets try to add.
 		if tmr := <-a.Srv.Store.Team().SaveMember(tm); tmr.Err != nil {
 			return nil, false, tmr.Err
 		} else {
-			return tmr.Data.(*model.TeamMember), true, nil
+			return tmr.Data.(*model.TeamMember), false, nil
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
This fixes bulk import failing on importing team members due to raciness between select on read replicas and insert on the master. This is most noticeable when using bulk import on an Aurora cluster.

Not sure if there's a better way of doing it than having a function which returns 3 parameters, which feels a bit unusual.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7789