### PR TITLE
PLT-7218: CLI to move slash commands between teams.

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -336,6 +336,16 @@ func (a *App) UpdateCommand(oldCmd, updatedCmd *model.Command) (*model.Command, 
 	}
 }
 
+func (a *App) MoveCommand(team *model.Team, command *model.Command) *model.AppError {
+	command.TeamId = team.Id
+
+	if result := <-a.Srv.Store.Command().Update(command); result.Err != nil {
+		return result.Err
+	}
+
+	return nil
+}
+
 func (a *App) RegenCommandToken(cmd *model.Command) (*model.Command, *model.AppError) {
 	if !*utils.Cfg.ServiceSettings.EnableCommands {
 		return nil, model.NewAppError("RegenCommandToken", "api.command.disabled.app_error", nil, "", http.StatusNotImplemented)

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func TestMoveCommand(t *testing.T) {
+	th := Setup().InitBasic()
+
+	sourceTeam := th.CreateTeam()
+	targetTeam := th.CreateTeam()
+
+	command := &model.Command{}
+	command.CreatorId = model.NewId()
+	command.Method = model.COMMAND_METHOD_POST
+	command.TeamId = sourceTeam.Id
+	command.URL = "http://nowhere.com/"
+	command.Trigger = "trigger1"
+
+	command, err := th.App.CreateCommand(command)
+	assert.Nil(t, err)
+
+	defer func() {
+		th.App.PermanentDeleteTeam(sourceTeam)
+		th.App.PermanentDeleteTeam(targetTeam)
+	}()
+
+	// Move a command and check the team is updated.
+	assert.Nil(t, th.App.MoveCommand(targetTeam, command))
+	retrievedCommand, err := th.App.GetCommand(command.Id)
+	assert.Nil(t, err)
+	assert.EqualValues(t, targetTeam.Id, retrievedCommand.TeamId)
+
+	// Move it to the team it's already in. Nothing should change.
+	assert.Nil(t, th.App.MoveCommand(targetTeam, command))
+	retrievedCommand, err = th.App.GetCommand(command.Id)
+	assert.Nil(t, err)
+	assert.EqualValues(t, targetTeam.Id, retrievedCommand.TeamId)
+}

--- a/cmd/platform/command.go
+++ b/cmd/platform/command.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+package main
+
+import (
+	"errors"
+	"github.com/mattermost/mattermost-server/app"
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/spf13/cobra"
+)
+
+var commandCmd = &cobra.Command{
+	Use:   "command",
+	Short: "Management of slash commands",
+}
+
+var commandMoveCmd = &cobra.Command{
+	Use:     "move",
+	Short:   "Move a slash command to a different team",
+	Long:    `Move a slash command to a different team. Commands can be specified by [team]:[command-trigger-word]. ie. myteam:trigger or by command ID.`,
+	Example: `  command move newteam oldteam:command`,
+	RunE:    moveCommandCmdF,
+}
+
+func init() {
+	commandCmd.AddCommand(
+		commandMoveCmd,
+	)
+}
+
+func moveCommandCmdF(cmd *cobra.Command, args []string) error {
+	a, err := initDBCommandContextCobra(cmd)
+	if err != nil {
+		return err
+	}
+
+	if len(args) < 2 {
+		return errors.New("Enter the destination team and at least one comamnd to move.")
+	}
+
+	team := getTeamFromTeamArg(a, args[0])
+	if team == nil {
+		return errors.New("Unable to find destination team '" + args[0] + "'")
+	}
+
+	commands := getCommandsFromCommandArgs(a, args[1:])
+	CommandPrintErrorln(commands)
+	for i, command := range commands {
+		if command == nil {
+			CommandPrintErrorln("Unable to find command '" + args[i+1] + "'")
+			continue
+		}
+		if err := moveCommand(a, team, command); err != nil {
+			CommandPrintErrorln("Unable to move command '" + command.Trigger + "' error: " + err.Error())
+		} else {
+			CommandPrettyPrintln("Moved command '" + command.Trigger + "'")
+		}
+	}
+
+	return nil
+}
+
+func moveCommand(a *app.App, team *model.Team, command *model.Command) *model.AppError {
+	if err := a.MoveCommand(team, command); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/platform/commandargs.go
+++ b/cmd/platform/commandargs.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost-server/app"
+	"github.com/mattermost/mattermost-server/model"
+)
+
+const COMMAND_ARGS_SEPARATOR = ":"
+
+func getCommandsFromCommandArgs(a *app.App, commandArgs []string) []*model.Command {
+	commands := make([]*model.Command, 0, len(commandArgs))
+
+	for _, commandArg := range commandArgs {
+		command := getCommandFromCommandArg(a, commandArg)
+		commands = append(commands, command)
+	}
+
+	return commands
+}
+
+func parseCommandArg(commandArg string) (string, string) {
+	result := strings.SplitN(commandArg, COMMAND_ARGS_SEPARATOR, 2)
+
+	if len(result) == 1 {
+		return "", commandArg
+	}
+
+	return result[0], result[1]
+}
+
+func getCommandFromCommandArg(a *app.App, commandArg string) *model.Command {
+	teamArg, commandPart := parseCommandArg(commandArg)
+	if teamArg == "" && commandPart == "" {
+		return nil
+	}
+
+	var command *model.Command
+	if teamArg != "" {
+		team := getTeamFromTeamArg(a, teamArg)
+		if team == nil {
+			return nil
+		}
+
+		if result := <-a.Srv.Store.Command().GetByTrigger(team.Id, commandPart); result.Err == nil {
+			command = result.Data.(*model.Command)
+		} else {
+			fmt.Println(result.Err.Error())
+		}
+	}
+
+	if command == nil {
+		if result := <-a.Srv.Store.Command().Get(commandPart); result.Err == nil {
+			command = result.Data.(*model.Command)
+		}
+	}
+
+	return command
+}

--- a/cmd/platform/mattermost.go
+++ b/cmd/platform/mattermost.go
@@ -40,7 +40,7 @@ func init() {
 
 	resetCmd.Flags().Bool("confirm", false, "Confirm you really want to delete everything and a DB backup has been performed.")
 
-	rootCmd.AddCommand(serverCmd, versionCmd, userCmd, teamCmd, licenseCmd, importCmd, resetCmd, channelCmd, rolesCmd, testCmd, ldapCmd, configCmd, jobserverCmd)
+	rootCmd.AddCommand(serverCmd, versionCmd, userCmd, teamCmd, licenseCmd, importCmd, resetCmd, channelCmd, rolesCmd, testCmd, ldapCmd, configCmd, jobserverCmd, commandCmd)
 }
 
 var rootCmd = &cobra.Command{

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5580,6 +5580,10 @@
     "translation": "We couldn't update the command"
   },
   {
+    "id": "store.sql_command.get_by_trigger.app_error",
+    "translation": "We couldn't get the command"
+  },
+  {
     "id": "store.sql_command_webhooks.get.app_error",
     "translation": "We couldn't get the webhook"
   },

--- a/store/store.go
+++ b/store/store.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	l4g "github.com/alecthomas/log4go"
+
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -322,6 +323,7 @@ type CommandStore interface {
 	Save(webhook *model.Command) StoreChannel
 	Get(id string) StoreChannel
 	GetByTeam(teamId string) StoreChannel
+	GetByTrigger(teamId string, trigger string) StoreChannel
 	Delete(commandId string, time int64) StoreChannel
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	PermanentDeleteByUser(userId string) StoreChannel


### PR DESCRIPTION
#### Summary
Adds a CLI command to move slash commands between teams.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7218

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
