### PR TITLE
Remove duplicate post edit WS event and cache invalidation

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -357,9 +357,6 @@ func (a *App) PatchPost(postId string, patch *model.PostPatch) (*model.Post, *mo
 		return nil, err
 	}
 
-	a.sendUpdatedPostEvent(updatedPost)
-	a.InvalidateCacheForChannelPosts(updatedPost.ChannelId)
-
 	return updatedPost, nil
 }
 


### PR DESCRIPTION
#### Summary
`PatchPost` calls `UpdatePost` which already does a `sendUpdatedPostEvent()` and `InvalidateCacheForChannelPosts()`. This was causing two post edit events to be sent and the cache to be invalidated twice.

#### Ticket Link
None.