### PR TITLE
PLT-7714 Add User To Channel api route returns a 400 error when trying to add …

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -826,6 +826,11 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if channel.Type == model.CHANNEL_DIRECT || channel.Type == model.CHANNEL_GROUP {
+		c.Err = model.NewAppError("addUserToChannel", "api.channel.add_user_to_channel.type.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
 	if cm, err := c.App.AddChannelMember(member.UserId, channel, c.Session.UserId); err != nil {
 		c.Err = err
 		return


### PR DESCRIPTION
…users to a DM or GM channel
#### Summary
When creating a direct or group message channel using the API and attempting to add a user to the channel using the API, a 400 error is now returned stating that the user cannot be added to that type of channel instead of a 404 error

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7526

#### Checklist