### PR TITLE
Miscellaneous app cleanup

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -61,12 +61,6 @@ type API struct {
 	BaseRoutes *Routes
 }
 
-func NewRouter() *mux.Router {
-	ret := mux.NewRouter()
-	ret.NotFoundHandler = http.HandlerFunc(Handle404)
-	return ret
-}
-
 func Init(a *app.App, root *mux.Router) *API {
 	api := &API{
 		App:        a,

--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -34,31 +34,26 @@ type TestHelper struct {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
+	utils.TranslationsPreInit()
+	utils.LoadConfig("config.json")
+	utils.InitTranslations(utils.Cfg.LocalizationSettings)
+
 	th := &TestHelper{
 		App: app.New(),
 	}
 
-	if th.App.Srv == nil {
-		utils.TranslationsPreInit()
-		utils.LoadConfig("config.json")
-		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
-		*utils.Cfg.RateLimitSettings.Enable = false
-		utils.Cfg.EmailSettings.SendEmailNotifications = true
-		utils.DisableDebugLogForTest()
-		th.App.NewServer()
-		th.App.InitStores()
-		th.App.Srv.Router = NewRouter()
-		th.App.Srv.WebSocketRouter = th.App.NewWebSocketRouter()
-		th.App.StartServer()
-		api4.Init(th.App, th.App.Srv.Router, false)
-		Init(th.App, th.App.Srv.Router)
-		wsapi.Init(th.App, th.App.Srv.WebSocketRouter)
-		utils.EnableDebugLogForTest()
-		th.App.Srv.Store.MarkSystemRanUnitTests()
+	*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+	*utils.Cfg.RateLimitSettings.Enable = false
+	utils.Cfg.EmailSettings.SendEmailNotifications = true
+	utils.DisableDebugLogForTest()
+	th.App.StartServer()
+	api4.Init(th.App, th.App.Srv.Router, false)
+	Init(th.App, th.App.Srv.Router)
+	wsapi.Init(th.App, th.App.Srv.WebSocketRouter)
+	utils.EnableDebugLogForTest()
+	th.App.Srv.Store.MarkSystemRanUnitTests()
 
-		*utils.Cfg.TeamSettings.EnableOpenServer = true
-	}
+	*utils.Cfg.TeamSettings.EnableOpenServer = true
 
 	utils.SetIsLicensed(enterprise)
 	if enterprise {

--- a/api4/api.go
+++ b/api4/api.go
@@ -109,12 +109,6 @@ type API struct {
 	BaseRoutes *Routes
 }
 
-func NewRouter() *mux.Router {
-	ret := mux.NewRouter()
-	ret.NotFoundHandler = http.HandlerFunc(Handle404)
-	return ret
-}
-
 func Init(a *app.App, root *mux.Router, full bool) *API {
 	api := &API{
 		App:        a,

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -46,37 +46,30 @@ type TestHelper struct {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
+	utils.TranslationsPreInit()
+	utils.LoadConfig("config.json")
+	utils.InitTranslations(utils.Cfg.LocalizationSettings)
+
 	th := &TestHelper{
 		App: app.New(),
 	}
 
-	if th.App.Srv == nil {
-		utils.TranslationsPreInit()
-		utils.LoadConfig("config.json")
-		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
-		*utils.Cfg.RateLimitSettings.Enable = false
-		utils.Cfg.EmailSettings.SendEmailNotifications = true
-		utils.DisableDebugLogForTest()
-		th.App.NewServer()
-		th.App.InitStores()
-		th.App.Srv.Router = NewRouter()
-		th.App.Srv.WebSocketRouter = th.App.NewWebSocketRouter()
-		th.App.StartServer()
-		Init(th.App, th.App.Srv.Router, true)
-		wsapi.Init(th.App, th.App.Srv.WebSocketRouter)
-		utils.EnableDebugLogForTest()
-		th.App.Srv.Store.MarkSystemRanUnitTests()
+	*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+	*utils.Cfg.RateLimitSettings.Enable = false
+	utils.Cfg.EmailSettings.SendEmailNotifications = true
+	utils.DisableDebugLogForTest()
+	th.App.StartServer()
+	Init(th.App, th.App.Srv.Router, true)
+	wsapi.Init(th.App, th.App.Srv.WebSocketRouter)
+	utils.EnableDebugLogForTest()
+	th.App.Srv.Store.MarkSystemRanUnitTests()
 
-		*utils.Cfg.TeamSettings.EnableOpenServer = true
-	}
+	*utils.Cfg.TeamSettings.EnableOpenServer = true
 
 	utils.SetIsLicensed(enterprise)
 	if enterprise {
 		utils.License().Features.SetDefaults()
 	}
-
-	th.App.Jobs.Store = th.App.Srv.Store
 
 	th.Client = th.CreateClient()
 	th.SystemAdminClient = th.CreateClient()

--- a/app/admin.go
+++ b/app/admin.go
@@ -15,7 +15,6 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/store/sqlstore"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -187,12 +186,13 @@ func (a *App) RecycleDatabaseConnection() {
 	oldStore := a.Srv.Store
 
 	l4g.Warn(utils.T("api.admin.recycle_db_start.warn"))
-	a.Srv.Store = store.NewLayeredStore(sqlstore.NewSqlSupplier(utils.Cfg.SqlSettings, a.Metrics), a.Metrics, a.Cluster)
-
+	a.Srv.Store = a.newStore()
 	a.Jobs.Store = a.Srv.Store
 
-	time.Sleep(20 * time.Second)
-	oldStore.Close()
+	if a.Srv.Store != oldStore {
+		time.Sleep(20 * time.Second)
+		oldStore.Close()
+	}
 
 	l4g.Warn(utils.T("api.admin.recycle_db_end.warn"))
 }

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -22,26 +22,23 @@ type TestHelper struct {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
+	utils.TranslationsPreInit()
+	utils.LoadConfig("config.json")
+	utils.InitTranslations(utils.Cfg.LocalizationSettings)
+
 	th := &TestHelper{
 		App: New(),
 	}
 
-	if th.App.Srv == nil {
-		utils.TranslationsPreInit()
-		utils.LoadConfig("config.json")
-		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
-		*utils.Cfg.RateLimitSettings.Enable = false
-		utils.DisableDebugLogForTest()
-		th.App.NewServer()
-		th.App.InitStores()
-		th.App.StartServer()
-		utils.InitHTML()
-		utils.EnableDebugLogForTest()
-		th.App.Srv.Store.MarkSystemRanUnitTests()
+	*utils.Cfg.TeamSettings.MaxUsersPerTeam = 50
+	*utils.Cfg.RateLimitSettings.Enable = false
+	utils.DisableDebugLogForTest()
+	th.App.StartServer()
+	utils.InitHTML()
+	utils.EnableDebugLogForTest()
+	th.App.Srv.Store.MarkSystemRanUnitTests()
 
-		*utils.Cfg.TeamSettings.EnableOpenServer = true
-	}
+	*utils.Cfg.TeamSettings.EnableOpenServer = true
 
 	utils.SetIsLicensed(enterprise)
 	if enterprise {

--- a/app/options.go
+++ b/app/options.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/mattermost-server/store"
+)
+
+type Option func(a *App)
+
+// By default, the app will use the store specified by the configuration. This allows you to
+// construct an app with a different store.
+//
+// The storeOrFactory parameter must be either a store.Store or func() store.Store.
+func StoreOverride(storeOrFactory interface{}) Option {
+	return func(a *App) {
+		switch s := storeOrFactory.(type) {
+		case store.Store:
+			a.newStore = func() store.Store {
+				return s
+			}
+		case func() store.Store:
+			a.newStore = s
+		default:
+			panic("invalid StoreOverride")
+		}
+	}
+}

--- a/app/post.go
+++ b/app/post.go
@@ -679,7 +679,7 @@ func GetOpenGraphMetadata(url string) *opengraph.OpenGraph {
 		l4g.Error("GetOpenGraphMetadata request failed for url=%v with err=%v", url, err.Error())
 		return og
 	}
-	defer CloseBody(res)
+	defer res.Body.Close()
 
 	if err := og.ProcessHTML(res.Body); err != nil {
 		l4g.Error("GetOpenGraphMetadata processing failed for url=%v with err=%v", url, err.Error())

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -109,7 +109,7 @@ func (a *App) TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.
 				if resp, err := utils.HttpClient(false).Do(req); err != nil {
 					l4g.Error(utils.T("api.post.handle_webhook_events_and_forget.event_post.error"), err.Error())
 				} else {
-					defer CloseBody(resp)
+					defer resp.Body.Close()
 					webhookResp := model.OutgoingWebhookResponseFromJson(resp.Body)
 
 					if webhookResp != nil && webhookResp.Text != nil {

--- a/app/webrtc.go
+++ b/app/webrtc.go
@@ -62,7 +62,7 @@ func GetWebrtcToken(sessionId string) (string, *model.AppError) {
 	if rp, err := utils.HttpClient(true).Do(rq); err != nil {
 		return "", model.NewAppError("WebRTC.Token", "model.client.connecting.app_error", nil, err.Error(), http.StatusInternalServerError)
 	} else if rp.StatusCode >= 300 {
-		defer CloseBody(rp)
+		defer rp.Body.Close()
 		return "", model.AppErrorFromJson(rp.Body)
 	} else {
 		janusResponse := model.GatewayResponseFromJson(rp.Body)

--- a/app/websocket_router.go
+++ b/app/websocket_router.go
@@ -21,13 +21,6 @@ type WebSocketRouter struct {
 	handlers map[string]webSocketHandler
 }
 
-func (a *App) NewWebSocketRouter() *WebSocketRouter {
-	return &WebSocketRouter{
-		app:      a,
-		handlers: make(map[string]webSocketHandler),
-	}
-}
-
 func (wr *WebSocketRouter) Handle(action string, handler webSocketHandler) {
 	wr.handlers[action] = handler
 }

--- a/cmd/platform/init.go
+++ b/cmd/platform/init.go
@@ -30,8 +30,6 @@ func initDBCommandContext(configFileLocation string) (*app.App, error) {
 	utils.ConfigureCmdLineLog()
 
 	a := app.New()
-	a.NewServer()
-	a.InitStores()
 	if model.BuildEnterpriseReady == "true" {
 		a.LoadLicense()
 	}

--- a/cmd/platform/jobserver.go
+++ b/cmd/platform/jobserver.go
@@ -8,9 +8,6 @@ import (
 	"syscall"
 
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/store"
-	"github.com/mattermost/mattermost-server/store/sqlstore"
-	"github.com/mattermost/mattermost-server/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -36,9 +33,7 @@ func jobserverCmdF(cmd *cobra.Command, args []string) {
 		panic(err.Error())
 	}
 	defer l4g.Close()
-
-	a.Jobs.Store = store.NewLayeredStore(sqlstore.NewSqlSupplier(utils.Cfg.SqlSettings, a.Metrics), a.Metrics, a.Cluster)
-	defer a.Jobs.Store.Close()
+	defer a.Shutdown()
 
 	a.Jobs.LoadLicense()
 

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -143,7 +143,6 @@ func runServer(configFileLocation string) {
 		}
 	}
 
-	a.Jobs.Store = a.Srv.Store
 	if *utils.Cfg.JobSettings.RunJobs {
 		a.Jobs.StartWorkers()
 	}

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -67,11 +67,6 @@ func runServer(configFileLocation string) {
 	a := app.New()
 	defer a.Shutdown()
 
-	a.NewServer()
-	a.InitStores()
-	a.Srv.Router = api.NewRouter()
-	a.Srv.WebSocketRouter = a.NewWebSocketRouter()
-
 	if model.BuildEnterpriseReady == "true" {
 		a.LoadLicense()
 	}
@@ -92,6 +87,7 @@ func runServer(configFileLocation string) {
 		l4g.Error("Unable to find webapp directory, could not initialize plugins")
 	}
 
+	a.StartServer()
 	api4.Init(a, a.Srv.Router, false)
 	api3 := api.Init(a, a.Srv.Router)
 	wsapi.Init(a, a.Srv.WebSocketRouter)
@@ -114,8 +110,6 @@ func runServer(configFileLocation string) {
 	}
 
 	resetStatuses(a)
-
-	a.StartServer()
 
 	// If we allow testing then listen for manual testing URL hits
 	if utils.Cfg.ServiceSettings.EnableTesting {

--- a/cmd/platform/test.go
+++ b/cmd/platform/test.go
@@ -52,13 +52,11 @@ func webClientTestsCmdF(cmd *cobra.Command, args []string) error {
 	defer a.Shutdown()
 
 	utils.InitTranslations(utils.Cfg.LocalizationSettings)
-	a.Srv.Router = api.NewRouter()
-	a.Srv.WebSocketRouter = a.NewWebSocketRouter()
+	a.StartServer()
 	api4.Init(a, a.Srv.Router, false)
 	api.Init(a, a.Srv.Router)
 	wsapi.Init(a, a.Srv.WebSocketRouter)
 	setupClientTests()
-	a.StartServer()
 	runWebClientTests()
 
 	return nil
@@ -72,13 +70,11 @@ func serverForWebClientTestsCmdF(cmd *cobra.Command, args []string) error {
 	defer a.Shutdown()
 
 	utils.InitTranslations(utils.Cfg.LocalizationSettings)
-	a.Srv.Router = api.NewRouter()
-	a.Srv.WebSocketRouter = a.NewWebSocketRouter()
+	a.StartServer()
 	api4.Init(a, a.Srv.Router, false)
 	api.Init(a, a.Srv.Router)
 	wsapi.Init(a, a.Srv.WebSocketRouter)
 	setupClientTests()
-	a.StartServer()
 
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -85,8 +85,12 @@ func tearDownStores() {
 		for _, st := range storeTypes {
 			st := st
 			go func() {
-				st.Store.Close()
-				st.Container.Stop()
+				if st.Store != nil {
+					st.Store.Close()
+				}
+				if st.Container != nil {
+					st.Container.Stop()
+				}
 				wg.Done()
 			}()
 		}

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -312,8 +312,8 @@ func UpgradeDatabaseToVersion43(sqlStore SqlStore) {
 }
 
 func UpgradeDatabaseToVersion44(sqlStore SqlStore) {
-	if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
-		// TODO: Uncomment following when version 4.4.0 is released
-		//saveSchemaVersion(sqlStore, VERSION_4_4_0)
-	}
+	// TODO: Uncomment following when version 4.4.0 is released
+	//if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
+	//	saveSchemaVersion(sqlStore, VERSION_4_4_0)
+	//}
 }

--- a/store/storetest/docker.go
+++ b/store/storetest/docker.go
@@ -116,7 +116,8 @@ func runContainer(args []string) (*RunningContainer, error) {
 }
 
 func waitForPort(port string) error {
-	for i := 0; i < 120; i++ {
+	deadline := time.Now().Add(time.Minute * 10)
+	for time.Now().Before(deadline) {
 		conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, time.Minute)
 		if err != nil {
 			return err

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -18,25 +18,22 @@ var ApiClient *model.Client
 var URL string
 
 func Setup() *app.App {
+	utils.TranslationsPreInit()
+	utils.LoadConfig("config.json")
+	utils.InitTranslations(utils.Cfg.LocalizationSettings)
+
 	a := app.New()
-	if a.Srv == nil {
-		utils.TranslationsPreInit()
-		utils.LoadConfig("config.json")
-		utils.InitTranslations(utils.Cfg.LocalizationSettings)
-		a.NewServer()
-		a.InitStores()
-		a.Srv.Router = api.NewRouter()
-		a.StartServer()
-		api4.Init(a, a.Srv.Router, false)
-		api3 := api.Init(a, a.Srv.Router)
-		Init(api3)
-		URL = "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress
-		ApiClient = model.NewClient(URL)
+	a.StartServer()
+	api4.Init(a, a.Srv.Router, false)
+	api3 := api.Init(a, a.Srv.Router)
+	Init(api3)
+	URL = "http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress
+	ApiClient = model.NewClient(URL)
 
-		a.Srv.Store.MarkSystemRanUnitTests()
+	a.Srv.Store.MarkSystemRanUnitTests()
 
-		*utils.Cfg.TeamSettings.EnableOpenServer = true
-	}
+	*utils.Cfg.TeamSettings.EnableOpenServer = true
+
 	return a
 }
 


### PR DESCRIPTION
#### Summary
Cleans up a few things:

* `App.New` now returns a functional app. You don't have to call `NewServer`, `InitStore`, `NewRouter`, or `NewWebSocketRouter` anymore. Those functions have all been deleted.
* You don't have to assign `App.Jobs.Store` anymore.
* The `CloseBody` function has been deleted. You don't have to consume the body of a response before closing it. This also fixes some inefficient / leaky code near one of those calls.
* `App.New` now accepts options. There's only one so far: `StoreOverride`. This is almost the entire reason I'm putting in this PR. I'm going to need that very soon to inject a faster store into the app for our tests.

#### Ticket Link
N/A

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)