### PR TITLE
[PLT-7764] Fix in:channel search when channel name/displayname includes `-`

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -85,6 +85,11 @@ func (s SqlChannelStore) CreateIndexesIfNotExists() {
 	s.CreateIndexIfNotExists("idx_channels_create_at", "Channels", "CreateAt")
 	s.CreateIndexIfNotExists("idx_channels_delete_at", "Channels", "DeleteAt")
 
+	if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+		s.CreateIndexIfNotExists("idx_channels_name_lower", "Channels", "lower(Name)")
+		s.CreateIndexIfNotExists("idx_channels_displayname_lower", "Channels", "lower(DisplayName)")
+	}
+
 	s.CreateIndexIfNotExists("idx_channelmembers_channel_id", "ChannelMembers", "ChannelId")
 	s.CreateIndexIfNotExists("idx_channelmembers_user_id", "ChannelMembers", "UserId")
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1256,7 +1256,12 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 		term = strings.Replace(term, c, "*"+c, -1)
 	}
 
-	searchQuery = generateSearchQuery(searchQuery, term, "Name, DisplayName", parameters)
+	if term == "" {
+		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
+	} else {
+		isPostgreSQL := s.DriverName() == model.DATABASE_DRIVER_POSTGRES
+		searchQuery = generateSearchQuery(searchQuery, term, "Name, DisplayName", parameters, isPostgreSQL)
+	}
 
 	var channels model.ChannelList
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1246,42 +1246,19 @@ func (s SqlChannelStore) SearchMore(userId string, teamId string, term string) s
 func (s SqlChannelStore) performSearch(searchQuery string, term string, parameters map[string]interface{}) store.StoreResult {
 	result := store.StoreResult{}
 
-	// these chars have special meaning and can be treated as spaces
+	// These chars must be removed from the like query.
 	for _, c := range ignoreUserSearchChar {
-		term = strings.Replace(term, c, " ", -1)
+		term = strings.Replace(term, c, "", -1)
 	}
 
-	if term == "" {
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
-	} else if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
-		splitTerm := strings.Fields(term)
-		for i, t := range strings.Fields(term) {
-			if i == len(splitTerm)-1 {
-				splitTerm[i] = t + ":*"
-			} else {
-				splitTerm[i] = t + ":* &"
-			}
-		}
-
-		term = strings.Join(splitTerm, " ")
-
-		searchClause := fmt.Sprintf("AND (%s) @@  to_tsquery('simple', :Term)", "Name || ' ' || DisplayName")
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
-	} else if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
-		splitTerm := strings.Fields(term)
-		for i, t := range strings.Fields(term) {
-			splitTerm[i] = "+" + t + "*"
-		}
-
-		term = strings.Join(splitTerm, " ")
-
-		searchClause := fmt.Sprintf("AND MATCH(%s) AGAINST (:Term IN BOOLEAN MODE)", "Name, DisplayName")
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
+	// These chars must be escaped in the like query.
+	for _, c := range escapeUserSearchChar {
+		term = strings.Replace(term, c, "*"+c, -1)
 	}
+
+	searchQuery = generateSearchQuery(searchQuery, term, "Name, DisplayName", parameters)
 
 	var channels model.ChannelList
-
-	parameters["Term"] = term
 
 	if _, err := s.GetReplica().Select(&channels, searchQuery, parameters); err != nil {
 		result.Err = model.NewAppError("SqlChannelStore.Search", "store.sql_channel.search.app_error", nil, "term="+term+", "+", "+err.Error(), http.StatusInternalServerError)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -1673,6 +1673,27 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o5.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&o5))
 
+	o6 := model.Channel{}
+	o6.TeamId = o1.TeamId
+	o6.DisplayName = "Off-Topic"
+	o6.Name = "off-topic"
+	o6.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o6))
+
+	o7 := model.Channel{}
+	o7.TeamId = o1.TeamId
+	o7.DisplayName = "Off-Set"
+	o7.Name = "off-set"
+	o7.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o7))
+
+	o8 := model.Channel{}
+	o8.TeamId = o1.TeamId
+	o8.DisplayName = "Off-Limit"
+	o8.Name = "off-limit"
+	o8.Type = model.CHANNEL_PRIVATE
+	store.Must(ss.Channel().Save(&o8))
+
 	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
@@ -1708,6 +1729,45 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 		}
 	}
 
+	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 2 {
+			t.Fatal("should return 2 channels, not including private channel")
+		}
+
+		if (*channels)[0].Name != o7.Name {
+			t.Fatal("wrong channel returned")
+		}
+
+		if (*channels)[1].Name != o6.Name {
+			t.Fatal("wrong channel returned")
+		}
+	}
+
+	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-topic"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
+
+		if (*channels)[0].Name != o6.Name {
+			t.Fatal("wrong channel returned")
+		}
+	}
+
+	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-topics"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 0 {
+			t.Logf("%v\n", *channels)
+			t.Fatal("should be empty")
+		}
+	}
 }
 
 func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
@@ -1764,6 +1824,27 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o5.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&o5))
 
+	o6 := model.Channel{}
+	o6.TeamId = o1.TeamId
+	o6.DisplayName = "Off-Topic"
+	o6.Name = "off-topic"
+	o6.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o6))
+
+	o7 := model.Channel{}
+	o7.TeamId = o1.TeamId
+	o7.DisplayName = "Off-Set"
+	o7.Name = "off-set"
+	o7.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o7))
+
+	o8 := model.Channel{}
+	o8.TeamId = o1.TeamId
+	o8.DisplayName = "Off-Limit"
+	o8.Name = "off-limit"
+	o8.Type = model.CHANNEL_PRIVATE
+	store.Must(ss.Channel().Save(&o8))
+
 	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
@@ -1783,6 +1864,45 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	}
 
 	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "blargh"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 0 {
+			t.Fatal("should be empty")
+		}
+	}
+
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 2 {
+			t.Fatal("should return 2 channels, not including private channel")
+		}
+
+		if (*channels)[0].Name != o7.Name {
+			t.Fatal("wrong channel returned")
+		}
+
+		if (*channels)[1].Name != o6.Name {
+			t.Fatal("wrong channel returned")
+		}
+	}
+
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-topic"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
+
+		if (*channels)[0].Name != o6.Name {
+			t.Fatal("wrong channel returned")
+		}
+	}
+
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-topics"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		channels := result.Data.(*model.ChannelList)


### PR DESCRIPTION
#### Summary
`in:{channel}` search uses IN BOOLEAN MODE full text search where `-` is considered as NOT operator. Thus, search query like below will cause `syntax error, unexpected $end, expecting FTS_TERM or FTS_NUMB or '*'`.

```
SELECT * FROM Channels 
WHERE TeamId = 'qocdorjddi858f4przgz5hujxw' AND Type = 'O' AND DeleteAt = 0 
AND MATCH(Name, DisplayName) AGAINST ('+off-*' IN BOOLEAN MODE) 
ORDER BY DisplayName LIMIT 100;
```

This is fixed by following the same search query used in  `from:{user}`. Search query will now become like:
```
SELECT * FROM Channels 
WHERE TeamId = 'qocdorjddi858f4przgz5hujxw' AND Type = 'O' AND DeleteAt = 0 
AND (Name LIKE 'off-t%' escape '*' OR DisplayName LIKE 'off-t%' escape '*' ) 
ORDER BY DisplayName LIMIT 100;
```

#### Ticket Link
Jira ticket: [PLT-7764](https://mattermost.atlassian.net/browse/PLT-7764)

#### Checklist
- [x] Touches critical sections of the codebase (store channel search)
