### PR TITLE
Make test execution not take quadratic compilation time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,14 +309,14 @@ do-cover-file:
 test-te: do-cover-file
 	@echo Testing TE
 	@echo "Packages to test: "$(TE_PACKAGES)
-	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGS) -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(TE_PACKAGES)
+	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGS) -p 1 -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(TE_PACKAGES)
 
 test-ee: do-cover-file
 	@echo Testing EE
 
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo "Packages to test: "$(EE_PACKAGES)
-	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGSEE) -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(EE_PACKAGES)
+	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGSEE) -p 1 -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(EE_PACKAGES)
 	rm -f config/*.crt
 	rm -f config/*.key
 endif

--- a/Makefile
+++ b/Makefile
@@ -309,14 +309,18 @@ do-cover-file:
 test-te: do-cover-file
 	@echo Testing TE
 	@echo "Packages to test: "$(TE_PACKAGES)
+	find . -name 'cprofile.out' -exec sh -c 'rm "{}"' \;
 	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGS) -p 1 -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(TE_PACKAGES)
+	find . -name 'cprofile.out' -exec sh -c 'tail -n +2 {} >> cover.out ; rm "{}"' \;
 
 test-ee: do-cover-file
 	@echo Testing EE
 
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo "Packages to test: "$(EE_PACKAGES)
+	find . -name 'cprofile.out' -exec sh -c 'rm "{}"' \;
 	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGSEE) -p 1 -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(EE_PACKAGES)
+	find . -name 'cprofile.out' -exec sh -c 'tail -n +2 {} >> cover.out ; rm "{}"' \;
 	rm -f config/*.crt
 	rm -f config/*.key
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: build package run stop run-client run-server stop-client stop-server restart restart-server restart-client start-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist setup-mac prepare-enteprise run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows internal-test-web-client vet run-server-for-web-client-tests
 
+ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 # Build Flags
 BUILD_NUMBER ?= $(BUILD_NUMBER:)
 BUILD_DATE = $(shell date -u)
@@ -62,7 +64,7 @@ DIST_PATH=$(DIST_ROOT)/mattermost
 TESTS=.
 
 TESTFLAGS ?= -short
-TESTFLAGSEE ?= -test.short
+TESTFLAGSEE ?= -short
 
 # Packages lists
 TE_PACKAGES=$(shell go list ./... | grep -v vendor)
@@ -306,39 +308,15 @@ do-cover-file:
 
 test-te: do-cover-file
 	@echo Testing TE
-
-
 	@echo "Packages to test: "$(TE_PACKAGES)
-
-	@for package in $(TE_PACKAGES); do \
-		echo "Testing "$$package; \
-		$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGS) -test.v -test.timeout=2000s -covermode=count -coverprofile=cprofile.out -coverpkg=$(ALL_PACKAGES_COMMA) $$package || exit 1; \
-		if [ -f cprofile.out ]; then \
-			tail -n +2 cprofile.out >> cover.out; \
-			rm cprofile.out; \
-		fi; \
-	done
+	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGS) -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(TE_PACKAGES)
 
 test-ee: do-cover-file
 	@echo Testing EE
 
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo "Packages to test: "$(EE_PACKAGES)
-
-	for package in $(EE_PACKAGES); do \
-		echo "Testing "$$package; \
-		$(GO) test $(GOFLAGS) -run=$(TESTS) -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -c $$package || exit 1; \
-		if [ -f $$(basename $$package).test ]; then \
-			echo "Testing "$$package; \
-			./$$(basename $$package).test -test.v $(TESTFLAGSEE) -test.timeout=2000s -test.coverprofile=cprofile.out || exit 1; \
-			if [ -f cprofile.out ]; then \
-				tail -n +2 cprofile.out >> cover.out; \
-				rm cprofile.out; \
-			fi; \
-			rm -r $$(basename $$package).test; \
-		fi; \
-	done
-
+	$(GO) test $(GOFLAGS) -run=$(TESTS) $(TESTFLAGSEE) -v -timeout=2000s -covermode=count -coverpkg=$(ALL_PACKAGES_COMMA) -exec $(ROOT)/scripts/test-xprog.sh $(EE_PACKAGES)
 	rm -f config/*.crt
 	rm -f config/*.key
 endif

--- a/scripts/test-xprog.sh
+++ b/scripts/test-xprog.sh
@@ -2,11 +2,8 @@
 set -e
 [[ $1 =~ (github.com.*)/_test ]] && \
     echo Testing ${BASH_REMATCH[1]}
+coverprofile=`pwd`/cprofile.out
 if [[ $1 == *"/enterprise/"* ]]; then
     cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
 fi
-"$@" -test.coverprofile=cprofile.out
-if [ -f cprofile.out ]; then
-    tail -n +2 cprofile.out >> cover.out;
-    rm cprofile.out;
-fi;
+"$@" -test.coverprofile "$coverprofile"

--- a/scripts/test-xprog.sh
+++ b/scripts/test-xprog.sh
@@ -2,7 +2,7 @@
 set -e
 [[ $1 =~ (github.com.*)/_test ]] && \
     echo Testing ${BASH_REMATCH[1]}
-if [[ $1 == *"github.com/mattermost/enterprise"* ]]; then
+if [[ $1 == *"/enterprise/"* ]]; then
     cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
 fi
 "$@" -test.coverprofile=cprofile.out

--- a/scripts/test-xprog.sh
+++ b/scripts/test-xprog.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+[[ $1 =~ (github.com.*)/_test ]] && \
+    echo Testing ${BASH_REMATCH[1]}
+"$@" -test.coverprofile=cprofile.out
+if [ -f cprofile.out ]; then
+    tail -n +2 cprofile.out >> cover.out;
+    rm cprofile.out;
+fi;

--- a/scripts/test-xprog.sh
+++ b/scripts/test-xprog.sh
@@ -2,6 +2,9 @@
 set -e
 [[ $1 =~ (github.com.*)/_test ]] && \
     echo Testing ${BASH_REMATCH[1]}
+if [[ $1 == *"github.com/mattermost/enterprise"* ]]; then
+    cd "$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+fi
 "$@" -test.coverprofile=cprofile.out
 if [ -f cprofile.out ]; then
     tail -n +2 cprofile.out >> cover.out;


### PR DESCRIPTION
#### Summary
For every package, we run a command like this to test it:

```
go test -run=asdqwqwe -short -v -timeout=2000s -covermode=count -coverprofile=cprofile.out
    -coverpkg=github.com/mattermost/mattermost-server,
              github.com/mattermost/mattermost-server/api,
              github.com/mattermost/mattermost-server/api4,
              github.com/mattermost/mattermost-server/app,
              github.com/mattermost/mattermost-server/app/plugin,
              github.com/mattermost/mattermost-server/app/plugin/jira,
              [and about 30 other packages...]
    github.com/mattermost/mattermost-server/api
```

Under the hood, `go test` compiles every source file in every one of those packages with additional instrumentation added:

```
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_183 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_184 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_185 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_186 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_187 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_188 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_189 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_190 -o <...>
/usr/local/go/pkg/tool/darwin_amd64/cover -mode count -var GoCover_191 -o <...>
[and about 400 more times...]
```

Then when it's done, `go test` links them, executes the resulting binary, and cleans up everything. So the compilation during a `make test-te` is `O(packageCount*codebaseSize)` complexity and takes about 6 minutes on my MacBook (not including the actual execution of anything). This isn't C++. We can do better.

If we pass multiple packages to `go test`, it will run tests for all of the packages without compiling things more than once. But the `-coverprofile` flag isn't allowed for multiple packages. So we use the `-exec` flag to wrap the invocation of the test binary, adding the `-test.coverprofile` flag and doing the concatenation that we had previously done in the Makefile loop.

This reduces job time by about 8 minutes on Jenkins.

#### Ticket Link
N/A

#### Checklist
N/A