### PR TITLE
[PLT-7396] Add the ability to revoke user sessions in System Console > Users #7493

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -53,6 +53,7 @@ func (api *API) InitUser() {
 
 	api.BaseRoutes.User.Handle("/sessions", api.ApiSessionRequired(getSessions)).Methods("GET")
 	api.BaseRoutes.User.Handle("/sessions/revoke", api.ApiSessionRequired(revokeSession)).Methods("POST")
+	api.BaseRoutes.User.Handle("/sessions/revoke/all", api.ApiSessionRequired(revokeAllSessionsForUser)).Methods("POST")
 	api.BaseRoutes.Users.Handle("/sessions/device", api.ApiSessionRequired(attachDeviceId)).Methods("PUT")
 	api.BaseRoutes.User.Handle("/audits", api.ApiSessionRequired(getUserAudits)).Methods("GET")
 
@@ -979,6 +980,25 @@ func revokeSession(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := c.App.RevokeSession(session); err != nil {
+		c.Err = err
+		return
+	}
+
+	ReturnStatusOK(w)
+}
+
+func revokeAllSessionsForUser(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireUserId()
+	if c.Err != nil {
+		return
+	}
+
+	if !app.SessionHasPermissionToUser(c.Session, c.Params.UserId) {
+		c.SetPermissionError(model.PERMISSION_EDIT_OTHER_USERS)
+		return
+	}
+
+	if err := c.App.RevokeAllSessions(c.Params.UserId); err != nil {
 		c.Err = err
 		return
 	}

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1971,6 +1971,54 @@ func TestRevokeSessions(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
+func TestRevokeAllSessions(t *testing.T) {
+	th := Setup().InitBasic()
+	defer TearDown()
+	Client := th.Client
+
+	user := th.BasicUser
+	Client.Login(user.Email, user.Password)
+
+	_, resp := Client.RevokeAllSessions(th.BasicUser2.Id)
+	CheckForbiddenStatus(t, resp)
+
+	th.InitSystemAdmin()
+
+	_, resp = Client.RevokeAllSessions("junk" + user.Id)
+	CheckBadRequestStatus(t, resp)
+
+	status, resp := Client.RevokeAllSessions(user.Id)
+	if status == false {
+		t.Fatal("user all sessions revoke unsuccessful")
+	}
+	CheckNoError(t, resp)
+
+	Client.Logout()
+	_, resp = Client.RevokeAllSessions(user.Id)
+	CheckUnauthorizedStatus(t, resp)
+
+	// log in twice to get multiple sessions
+	Client.Login(user.Email, user.Password)
+	ClientOnAnotherBrowser := Setup().InitBasic().InitSystemAdmin().Client
+	ClientOnAnotherBrowser.Login(user.Email, user.Password)
+
+	sessions, _ := Client.GetSessions(user.Id, "")
+	if len(sessions) != 2 {
+		t.Fatal("2 sessions should exist")
+	}
+
+	_, resp = Client.RevokeAllSessions(user.Id)
+	CheckNoError(t, resp)
+
+	sessions, _ = th.SystemAdminClient.GetSessions(user.Id, "")
+	if len(sessions) != 0 {
+		t.Fatal("no sessions should exist for user")
+	}
+
+	_, resp = Client.RevokeAllSessions(user.Id)
+	CheckUnauthorizedStatus(t, resp)
+}
+
 func TestAttachDeviceId(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1973,7 +1973,7 @@ func TestRevokeSessions(t *testing.T) {
 
 func TestRevokeAllSessions(t *testing.T) {
 	th := Setup().InitBasic()
-	defer TearDown()
+	defer th.TearDown()
 	Client := th.Client
 
 	user := th.BasicUser
@@ -1997,14 +1997,11 @@ func TestRevokeAllSessions(t *testing.T) {
 	_, resp = Client.RevokeAllSessions(user.Id)
 	CheckUnauthorizedStatus(t, resp)
 
-	// log in twice to get multiple sessions
 	Client.Login(user.Email, user.Password)
-	ClientOnAnotherBrowser := Setup().InitBasic().InitSystemAdmin().Client
-	ClientOnAnotherBrowser.Login(user.Email, user.Password)
 
 	sessions, _ := Client.GetSessions(user.Id, "")
-	if len(sessions) != 2 {
-		t.Fatal("2 sessions should exist")
+	if len(sessions) < 1 {
+		t.Fatal("session should exist")
 	}
 
 	_, resp = Client.RevokeAllSessions(user.Id)

--- a/model/client4.go
+++ b/model/client4.go
@@ -901,6 +901,16 @@ func (c *Client4) RevokeSession(userId, sessionId string) (bool, *Response) {
 	}
 }
 
+// RevokeAllSessions revokes all sessions for the provided user id string.
+func (c *Client4) RevokeAllSessions(userId string) (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetUserRoute(userId)+"/sessions/revoke/all", ""); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // AttachDeviceId attaches a mobile device ID to the current session.
 func (c *Client4) AttachDeviceId(deviceId string) (bool, *Response) {
 	requestBody := map[string]string{"device_id": deviceId}


### PR DESCRIPTION
#### NOTE! This PR is part of a group of PRs with identical title in the following 4 repos, all of which must be merged simultaneously:
mattermost-server
mattermost-redux
mattermost-webapp
mattermost-api-reference

#### Summary
Adds api endpoint for revoking all sessions for a user, as used by this new feature accessed from the system users dropdown.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7493

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
