### PR TITLE
Fix german i18n

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -857,7 +857,7 @@
   },
   {
     "id": "api.command_shortcuts.name",
-    "translation": "tastaturkürzel"
+    "translation": "Tastaturkürzel"
   },
   {
     "id": "api.command_shortcuts.unsupported.app_error",
@@ -873,7 +873,7 @@
   },
   {
     "id": "api.command_shrug.name",
-    "translation": "zucken"
+    "translation": "Achselzucken"
   },
   {
     "id": "api.compliance.init.debug",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -857,7 +857,7 @@
   },
   {
     "id": "api.command_shortcuts.name",
-    "translation": "Tastaturkürzel"
+    "translation": "tastaturkürzel"
   },
   {
     "id": "api.command_shortcuts.unsupported.app_error",
@@ -873,7 +873,7 @@
   },
   {
     "id": "api.command_shrug.name",
-    "translation": "Achselzucken"
+    "translation": "achselzucken"
   },
   {
     "id": "api.compliance.init.debug",


### PR DESCRIPTION
#### Summary
Fix a wrong translations for the `shrug` command and add a capitalization issue.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/de.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/de.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
