### PR TITLE
[PLT-7794] Add user access token enable/disable endpoints

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2302,6 +2302,8 @@ func TestCreateUserAccessToken(t *testing.T) {
 		t.Fatal("id should not be empty")
 	} else if rtoken.Description != testDescription {
 		t.Fatal("description did not match")
+	} else if !rtoken.IsActive {
+		t.Fatal("token should be active")
 	}
 
 	oldSessionToken := Client.AuthToken
@@ -2456,6 +2458,54 @@ func TestRevokeUserAccessToken(t *testing.T) {
 	CheckNoError(t, resp)
 
 	ok, resp = Client.RevokeUserAccessToken(token.Id)
+	CheckForbiddenStatus(t, resp)
+
+	if ok {
+		t.Fatal("should have failed")
+	}
+}
+
+func TestDisableUserAccessToken(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+	AdminClient := th.SystemAdminClient
+
+	testDescription := "test token"
+
+	enableUserAccessTokens := *utils.Cfg.ServiceSettings.EnableUserAccessTokens
+	defer func() {
+		*utils.Cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens
+	}()
+	*utils.Cfg.ServiceSettings.EnableUserAccessTokens = true
+
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id)
+	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
+	CheckNoError(t, resp)
+
+	oldSessionToken := Client.AuthToken
+	Client.AuthToken = token.Token
+	_, resp = Client.GetMe("")
+	CheckNoError(t, resp)
+	Client.AuthToken = oldSessionToken
+
+	ok, resp := Client.DisableUserAccessToken(token.Id)
+	CheckNoError(t, resp)
+
+	if !ok {
+		t.Fatal("should have passed")
+	}
+
+	oldSessionToken = Client.AuthToken
+	Client.AuthToken = token.Token
+	_, resp = Client.GetMe("")
+	CheckUnauthorizedStatus(t, resp)
+	Client.AuthToken = oldSessionToken
+
+	token, resp = AdminClient.CreateUserAccessToken(th.BasicUser2.Id, testDescription)
+	CheckNoError(t, resp)
+
+	ok, resp = Client.DisableUserAccessToken(token.Id)
 	CheckForbiddenStatus(t, resp)
 
 	if ok {

--- a/model/client4.go
+++ b/model/client4.go
@@ -1065,6 +1065,32 @@ func (c *Client4) RevokeUserAccessToken(tokenId string) (bool, *Response) {
 	}
 }
 
+// DisableUserAccessToken will disable a user access token by id. Must have the
+// 'revoke_user_access_token' permission and if disabling for another user, must have the
+// 'edit_other_users' permission.
+func (c *Client4) DisableUserAccessToken(tokenId string) (bool, *Response) {
+	requestBody := map[string]string{"token_id": tokenId}
+	if r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/disable", MapToJson(requestBody)); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// EnableUserAccessToken will enable a user access token by id. Must have the
+// 'create_user_access_token' permission and if enabling for another user, must have the
+// 'edit_other_users' permission.
+func (c *Client4) EnableUserAccessToken(tokenId string) (bool, *Response) {
+	requestBody := map[string]string{"token_id": tokenId}
+	if r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/enable", MapToJson(requestBody)); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
 // Team Section
 
 // CreateTeam creates a team in the system based on the provided team struct.

--- a/model/user_access_token.go
+++ b/model/user_access_token.go
@@ -14,6 +14,7 @@ type UserAccessToken struct {
 	Token       string `json:"token,omitempty"`
 	UserId      string `json:"user_id"`
 	Description string `json:"description"`
+	IsActive    bool   `json:"is_active"`
 }
 
 func (t *UserAccessToken) IsValid() *AppError {
@@ -38,6 +39,7 @@ func (t *UserAccessToken) IsValid() *AppError {
 
 func (t *UserAccessToken) PreSave() {
 	t.Id = NewId()
+	t.IsActive = true
 }
 
 func (t *UserAccessToken) ToJson() string {

--- a/model/version.go
+++ b/model/version.go
@@ -13,6 +13,7 @@ import (
 // It should be maitained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"4.4.0",
 	"4.3.0",
 	"4.2.0",
 	"4.1.0",

--- a/model/version.go
+++ b/model/version.go
@@ -13,7 +13,6 @@ import (
 // It should be maitained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
-	"4.4.0",
 	"4.3.0",
 	"4.2.0",
 	"4.1.0",

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -315,9 +315,9 @@ func UpgradeDatabaseToVersion44(sqlStore SqlStore) {
 	// TODO: Uncomment following condition when version 4.4.0 is released
 	// if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
 
-		// Add the IsActive column to UserAccessToken.
-		sqlStore.CreateColumnIfNotExists("UserAccessTokens", "IsActive", "boolean", "boolean", "1")
+	// Add the IsActive column to UserAccessToken.
+	sqlStore.CreateColumnIfNotExists("UserAccessTokens", "IsActive", "boolean", "boolean", "1")
 
-		// saveSchemaVersion(sqlStore, VERSION_4_4_0)
+	// saveSchemaVersion(sqlStore, VERSION_4_4_0)
 	// }
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -314,7 +314,7 @@ func UpgradeDatabaseToVersion43(sqlStore SqlStore) {
 func UpgradeDatabaseToVersion44(sqlStore SqlStore) {
 	if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
 		// Add the IsActive column to UserAccessToken.
-		sqlStore.CreateColumnIfNotExists("UserAccessTokens", "IsActive", "boolean", "boolean", "0")
+		sqlStore.CreateColumnIfNotExists("UserAccessTokens", "IsActive", "boolean", "boolean", "1")
 
 		saveSchemaVersion(sqlStore, VERSION_4_4_0)
 	}

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -312,8 +312,10 @@ func UpgradeDatabaseToVersion43(sqlStore SqlStore) {
 }
 
 func UpgradeDatabaseToVersion44(sqlStore SqlStore) {
-	// TODO: Uncomment following when version 4.4.0 is released
-	//if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
-	//	saveSchemaVersion(sqlStore, VERSION_4_4_0)
-	//}
+	if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
+		// Add the IsActive column to UserAccessToken.
+		sqlStore.CreateColumnIfNotExists("UserAccessTokens", "IsActive", "boolean", "boolean", "0")
+
+		saveSchemaVersion(sqlStore, VERSION_4_4_0)
+	}
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -312,10 +312,12 @@ func UpgradeDatabaseToVersion43(sqlStore SqlStore) {
 }
 
 func UpgradeDatabaseToVersion44(sqlStore SqlStore) {
-	if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
+	// TODO: Uncomment following condition when version 4.4.0 is released
+	// if shouldPerformUpgrade(sqlStore, VERSION_4_3_0, VERSION_4_4_0) {
+
 		// Add the IsActive column to UserAccessToken.
 		sqlStore.CreateColumnIfNotExists("UserAccessTokens", "IsActive", "boolean", "boolean", "1")
 
-		saveSchemaVersion(sqlStore, VERSION_4_4_0)
-	}
+		// saveSchemaVersion(sqlStore, VERSION_4_4_0)
+	// }
 }

--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -25,7 +25,6 @@ func NewSqlUserAccessTokenStore(sqlStore SqlStore) store.UserAccessTokenStore {
 		table.ColMap("Token").SetMaxSize(26).SetUnique(true)
 		table.ColMap("UserId").SetMaxSize(26)
 		table.ColMap("Description").SetMaxSize(512)
-		table.ColMap("IsActive").SetMaxSize(1)
 	}
 
 	return s

--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -238,9 +238,9 @@ func (s SqlUserAccessTokenStore) deleteSessionsAndDisableToken(transaction *gorp
 	result := store.StoreResult{}
 
 	query := ""
-	if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+	if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
 		query = "DELETE FROM Sessions s USING UserAccessTokens o WHERE o.Token = s.Token AND o.Id = :Id"
-	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+	} else if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
 		query = "DELETE s.* FROM Sessions s INNER JOIN UserAccessTokens o ON o.Token = s.Token WHERE o.Id = :Id"
 	}
 

--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -199,3 +199,65 @@ func (s SqlUserAccessTokenStore) GetByUser(userId string, offset, limit int) sto
 		result.Data = tokens
 	})
 }
+
+func (s SqlUserAccessTokenStore) UpdateTokenEnable(tokenId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if _, err := s.GetMaster().Exec("UPDATE UserAccessTokens SET IsActive = TRUE WHERE Id = :Id", map[string]interface{}{"Id": tokenId}); err != nil {
+			result.Err = model.NewAppError("SqlUserAccessTokenStore.UpdateTokenEnable", "store.sql_user_access_token.update_token_enable.app_error", nil, "id="+tokenId+", "+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = tokenId
+		}
+	})
+}
+
+func (s SqlUserAccessTokenStore) UpdateTokenDisable(tokenId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		transaction, err := s.GetMaster().Begin()
+		if err != nil {
+			result.Err = model.NewAppError("SqlUserAccessTokenStore.UpdateTokenDisable", "store.sql_user_access_token.update_token_disble.app_error", nil, err.Error(), http.StatusInternalServerError)
+		} else {
+			if extrasResult := s.deleteSessionsAndDisableToken(transaction, tokenId); extrasResult.Err != nil {
+				*result = extrasResult
+			}
+
+			if result.Err == nil {
+				if err := transaction.Commit(); err != nil {
+					// don't need to rollback here since the transaction is already closed
+					result.Err = model.NewAppError("SqlUserAccessTokenStore.UpdateTokenDisable", "store.sql_user_access_token.update_token_disable.app_error", nil, err.Error(), http.StatusInternalServerError)
+				}
+			} else {
+				if err := transaction.Rollback(); err != nil {
+					result.Err = model.NewAppError("SqlUserAccessTokenStore.UpdateTokenDisable", "store.sql_user_access_token.update_token_disable.app_error", nil, err.Error(), http.StatusInternalServerError)
+				}
+			}
+		}
+	})
+}
+
+func (s SqlUserAccessTokenStore) deleteSessionsAndDisableToken(transaction *gorp.Transaction, tokenId string) store.StoreResult {
+	result := store.StoreResult{}
+
+	query := ""
+	if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_POSTGRES {
+		query = "DELETE FROM Sessions s USING UserAccessTokens o WHERE o.Token = s.Token AND o.Id = :Id"
+	} else if *utils.Cfg.SqlSettings.DriverName == model.DATABASE_DRIVER_MYSQL {
+		query = "DELETE s.* FROM Sessions s INNER JOIN UserAccessTokens o ON o.Token = s.Token WHERE o.Id = :Id"
+	}
+
+	if _, err := transaction.Exec(query, map[string]interface{}{"Id": tokenId}); err != nil {
+		result.Err = model.NewAppError("SqlUserAccessTokenStore.deleteSessionsAndDisableToken", "store.sql_user_access_token.update_token_disable.app_error", nil, "id="+tokenId+", err="+err.Error(), http.StatusInternalServerError)
+		return result
+	}
+
+	return s.updateTokenDisable(transaction, tokenId)
+}
+
+func (s SqlUserAccessTokenStore) updateTokenDisable(transaction *gorp.Transaction, tokenId string) store.StoreResult {
+	result := store.StoreResult{}
+
+	if _, err := transaction.Exec("UPDATE UserAccessTokens SET IsActive = FALSE WHERE Id = :Id", map[string]interface{}{"Id": tokenId}); err != nil {
+		result.Err = model.NewAppError("SqlUserAccessTokenStore.updateTokenDisable", "store.sql_user_access_token.update_token_disable.app_error", nil, "", http.StatusInternalServerError)
+	}
+
+	return result
+}

--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -25,6 +25,7 @@ func NewSqlUserAccessTokenStore(sqlStore SqlStore) store.UserAccessTokenStore {
 		table.ColMap("Token").SetMaxSize(26).SetUnique(true)
 		table.ColMap("UserId").SetMaxSize(26)
 		table.ColMap("Description").SetMaxSize(512)
+		table.ColMap("IsActive").SetMaxSize(1)
 	}
 
 	return s

--- a/store/store.go
+++ b/store/store.go
@@ -436,4 +436,6 @@ type UserAccessTokenStore interface {
 	Get(tokenId string) StoreChannel
 	GetByToken(tokenString string) StoreChannel
 	GetByUser(userId string, page, perPage int) StoreChannel
+	UpdateTokenEnable(tokenId string) StoreChannel
+	UpdateTokenDisable(tokenId string) StoreChannel
 }


### PR DESCRIPTION
#### Summary
Adds functionality to enable/disable user access tokens. A disabled user access token is not revoked but cannot be used to authenticate a session.

Adds a column in the UserAccessTokens table for token active/inactive status. Adds two new endpoints to the APIv4, allowing for temporarily enabling and disabling user access tokens.

Disabling a user access token also deletes any sessions associated with the token.

A companion client-side PR is forthcoming.

#### Ticket Link
Github #7583 
Jira PLT-7794
See also https://github.com/mattermost/mattermost-api-reference/pull/295

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
