### PR TITLE
Fix webconn shutdown race

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -46,3 +46,11 @@ func TestMain(m *testing.M) {
 
 	status = m.Run()
 }
+
+func TestAppRace(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		a := New()
+		a.StartServer()
+		a.Shutdown()
+	}
+}

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -112,12 +112,12 @@ func (c *WebConn) Pump() {
 	}()
 	c.readPump()
 	<-ch
+	c.App.HubUnregister(c)
 	c.pumpFinished <- struct{}{}
 }
 
 func (c *WebConn) readPump() {
 	defer func() {
-		c.App.HubUnregister(c)
 		c.WebSocket.Close()
 	}()
 	c.WebSocket.SetReadLimit(model.SOCKET_MAX_MESSAGE_SIZE_KB)

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -59,7 +59,7 @@ func (a *App) NewWebConn(ws *websocket.Conn, session model.Session, t goi18n.Tra
 		UserId:       session.UserId,
 		T:            t,
 		Locale:       locale,
-		endWritePump: make(chan struct{}, 1),
+		endWritePump: make(chan struct{}, 2),
 		pumpFinished: make(chan struct{}, 1),
 	}
 
@@ -111,6 +111,7 @@ func (c *WebConn) Pump() {
 		ch <- struct{}{}
 	}()
 	c.readPump()
+	c.endWritePump <- struct{}{}
 	<-ch
 	c.App.HubUnregister(c)
 	c.pumpFinished <- struct{}{}


### PR DESCRIPTION
#### Summary
The race:

1. client closes connection
2. readPump returns, unregistering the connection from the hub
3. server shuts down. because the connection is no longer registered, we can't wait on it
4. writePump is still executing, panics because log channel has been closed

Fix: Wait for writePump before unregistering. Now the hub properly waits on the connection before returning from Stop().

#### Ticket Link
N/A

#### Checklist
N/A