### PR TITLE
Add two missing diagnostics entries

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -204,7 +204,7 @@ func trackConfig() {
 		"session_length_mobile_in_days":                    *utils.Cfg.ServiceSettings.SessionLengthMobileInDays,
 		"session_length_sso_in_days":                       *utils.Cfg.ServiceSettings.SessionLengthSSOInDays,
 		"session_cache_in_minutes":                         *utils.Cfg.ServiceSettings.SessionCacheInMinutes,
-		"session_idle_timeout":                             *utils.Cfg.ServiceSettings.SessionIdleTimeout,
+		"session_idle_timeout_in_minutes":                  *utils.Cfg.ServiceSettings.SessionIdleTimeoutInMinutes,
 		"isdefault_site_url":                               isDefault(*utils.Cfg.ServiceSettings.SiteURL, model.SERVICE_SETTINGS_DEFAULT_SITE_URL),
 		"isdefault_tls_cert_file":                          isDefault(*utils.Cfg.ServiceSettings.TLSCertFile, model.SERVICE_SETTINGS_DEFAULT_TLS_CERT_FILE),
 		"isdefault_tls_key_file":                           isDefault(*utils.Cfg.ServiceSettings.TLSKeyFile, model.SERVICE_SETTINGS_DEFAULT_TLS_KEY_FILE),

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -204,6 +204,7 @@ func trackConfig() {
 		"session_length_mobile_in_days":                    *utils.Cfg.ServiceSettings.SessionLengthMobileInDays,
 		"session_length_sso_in_days":                       *utils.Cfg.ServiceSettings.SessionLengthSSOInDays,
 		"session_cache_in_minutes":                         *utils.Cfg.ServiceSettings.SessionCacheInMinutes,
+		"session_idle_timeout":                             *utils.Cfg.ServiceSettings.SessionIdleTimeout,
 		"isdefault_site_url":                               isDefault(*utils.Cfg.ServiceSettings.SiteURL, model.SERVICE_SETTINGS_DEFAULT_SITE_URL),
 		"isdefault_tls_cert_file":                          isDefault(*utils.Cfg.ServiceSettings.TLSCertFile, model.SERVICE_SETTINGS_DEFAULT_TLS_CERT_FILE),
 		"isdefault_tls_key_file":                           isDefault(*utils.Cfg.ServiceSettings.TLSKeyFile, model.SERVICE_SETTINGS_DEFAULT_TLS_KEY_FILE),
@@ -442,6 +443,7 @@ func trackConfig() {
 		"sniff":                    *utils.Cfg.ElasticsearchSettings.Sniff,
 		"post_index_replicas":      *utils.Cfg.ElasticsearchSettings.PostIndexReplicas,
 		"post_index_shards":        *utils.Cfg.ElasticsearchSettings.PostIndexShards,
+		"isdefault_index_prefix":   isDefault(*utils.Cfg.ElasticsearchSettings.IndexPrefix, model.ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_PLUGIN, map[string]interface{}{

--- a/config/default.json
+++ b/config/default.json
@@ -36,7 +36,7 @@
         "SessionLengthMobileInDays": 30,
         "SessionLengthSSOInDays": 30,
         "SessionCacheInMinutes": 10,
-        "SessionIdleTimeout": 0,
+        "SessionIdleTimeoutInMinutes": 0,
         "WebsocketSecurePort": 443,
         "WebsocketPort": 80,
         "WebserverMode": "gzip",


### PR DESCRIPTION
One for session timeout (https://github.com/mattermost/mattermost-server/pull/7524), second for elasticsearch index prefix

And rename `SessionIdleTimeout` --> `SessionIdleTimeoutInMinutes` in config.json.