### PR TITLE
PLT-7193: Regression - Custom slash commands don't work in direct or group message channels

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -296,13 +296,17 @@ func (me *TestHelper) CreatePrivateChannel() *model.Channel {
 }
 
 func (me *TestHelper) CreateChannelWithClient(client *model.Client4, channelType string) *model.Channel {
+	return me.CreateChannelWithClientAndTeam(client, channelType, me.BasicTeam.Id)
+}
+
+func (me *TestHelper) CreateChannelWithClientAndTeam(client *model.Client4, channelType string, teamId string) *model.Channel {
 	id := model.NewId()
 
 	channel := &model.Channel{
 		DisplayName: "dn_" + id,
 		Name:        GenerateTestChannelName(),
 		Type:        channelType,
-		TeamId:      me.BasicTeam.Id,
+		TeamId:      teamId,
 	}
 
 	utils.DisableDebugLogForTest()

--- a/api4/command.go
+++ b/api4/command.go
@@ -210,11 +210,11 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.Err = err
 		return
+	} else if channel.Type != model.CHANNEL_DIRECT && channel.Type != model.CHANNEL_GROUP {
+		// if this isn't a DM or GM, the team id is implicitly taken from the channel so that slash commands created on
+		// some other team can't be run against this one
+		commandArgs.TeamId = channel.TeamId
 	}
-
-	// team id is implicitly taken from channel so that slash commands
-	// created on some other team can't be run against this one
-	commandArgs.TeamId = channel.TeamId
 
 	commandArgs.UserId = c.Session.UserId
 	commandArgs.T = c.T

--- a/model/client4.go
+++ b/model/client4.go
@@ -2816,10 +2816,26 @@ func (c *Client4) ListCommands(teamId string, customOnly bool) ([]*Command, *Res
 	}
 }
 
-// ExecuteCommand executes a given command.
+// ExecuteCommand executes a given slash command.
 func (c *Client4) ExecuteCommand(channelId, command string) (*CommandResponse, *Response) {
 	commandArgs := &CommandArgs{
 		ChannelId: channelId,
+		Command:   command,
+	}
+	if r, err := c.DoApiPost(c.GetCommandsRoute()+"/execute", commandArgs.ToJson()); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CommandResponseFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// ExecuteCommand executes a given slash command against the specified team
+// Use this when executing slash commands in a DM/GM, since the team id cannot be inferred in that case
+func (c *Client4) ExecuteCommandWithTeam(channelId, teamId, command string) (*CommandResponse, *Response) {
+	commandArgs := &CommandArgs{
+		ChannelId: channelId,
+		TeamId:    teamId,
 		Command:   command,
 	}
 	if r, err := c.DoApiPost(c.GetCommandsRoute()+"/execute", commandArgs.ToJson()); err != nil {


### PR DESCRIPTION
#### Summary
No longer overriding specified team id for DMs/GMs, as these types of channels don't belong to a team, and doing so breaks slash commands for them

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7193