### PR TITLE
Fix websocket client races

### DIFF
--- a/app/websocket_router.go
+++ b/app/websocket_router.go
@@ -63,10 +63,10 @@ func (wr *WebSocketRouter) ServeWebSocket(conn *WebConn, r *model.WebSocketReque
 			conn.SetSessionToken(session.Token)
 			conn.UserId = session.UserId
 
-			wr.app.HubRegister(conn)
-
 			resp := model.NewWebSocketResponse(model.STATUS_OK, r.Seq, nil)
 			conn.Send <- resp
+
+			wr.app.HubRegister(conn)
 		}
 
 		return


### PR DESCRIPTION
#### Summary
The websocket tests sometimes fail because websocket events can be dispatched before the websocket fully connects:

Before:

1. Client: Calls Connect()
2. Server: Begins processing the authentication message
3. Client: Calls Listen() and triggers a websocket event
4. Server: Sends the websocket event to the appropriate websockets, which does not include the not-yet-authenticated client
5. Server: Finishes processing the authentication message and registers the connection with the hub
6. Client: Waits for event that never comes

This introduces the guarantee that events triggered after Connect() returns will be received by the websocket. After:

1. Client: Calls Connect()
2. Server: Fully processes the authentication message and registers the connection with the hub
3. Client: Returns from Connect(), calls Listen(), and triggers a websocket event
4. Server: Sends the websocket event to the appropriate websockets, which does include the fully authenticated client
5. Client: Waits for event that is guaranteed to come

#### Ticket Link
N/A

#### Checklist
N/A