### PR TITLE
Fix preference test races

### DIFF
--- a/api4/preference_test.go
+++ b/api4/preference_test.go
@@ -252,6 +252,10 @@ func TestUpdatePreferencesWebsocket(t *testing.T) {
 	}
 
 	WebSocketClient.Listen()
+	time.Sleep(300 * time.Millisecond)
+	if resp := <-WebSocketClient.ResponseChannel; resp.Status != model.STATUS_OK {
+		t.Fatal("should have responded OK to authentication challenge")
+	}
 
 	userId := th.BasicUser.Id
 	preferences := &model.Preferences{
@@ -371,6 +375,10 @@ func TestDeletePreferencesWebsocket(t *testing.T) {
 	}
 
 	WebSocketClient.Listen()
+	time.Sleep(300 * time.Millisecond)
+	if resp := <-WebSocketClient.ResponseChannel; resp.Status != model.STATUS_OK {
+		t.Fatal("should have responded OK to authentication challenge")
+	}
 
 	_, resp = th.Client.DeletePreferences(userId, preferences)
 	CheckNoError(t, resp)


### PR DESCRIPTION
The websocket tests sometimes fail because websocket events can be dispatched before the websocket fully connects:

Client: Calls Connect()
Server: Begins processing the authentication message
Client: Calls Listen() and triggers a websocket event
Server: Sends the websocket event to the appropriate websockets, which does not include the not-yet-authenticated client
Server: Finishes processing the authentication message and registers the connection with the hub
Client: Waits for event that never comes

Once the okay comes, we're guaranteed to receive any newly triggered events.