### PR TITLE
Use webapp build from cache when possible

### DIFF
--- a/build/Jenkinsfile
+++ b/build/Jenkinsfile
@@ -136,7 +136,7 @@ podTemplate(label: 'jenkins-slave',
             sh 'cd /go/src/github.com/mattermost/mattermost-server && make build BUILD_NUMBER=$BUILD_NUMBER'
         }
         container('mattermost-node') {
-            sh 'cd mattermost-webapp && make build BUILD_NUMBER=$BUILD_NUMBER'
+            sh 'cd mattermost-webapp && curl -f -o ./dist.tar.gz https://releases.mattermost.com/mattermost-webapp/commit/`git rev-parse HEAD`/mattermost-webapp.tar.gz && mkdir ./dist && tar -xvf ./dist.tar.gz -C ./dist --strip-components=1 || make build'
         }
         container('golang') {
             sh 'cd /go/src/github.com/mattermost/mattermost-server && make package BUILD_NUMBER=$BUILD_NUMBER'


### PR DESCRIPTION
#### Summary
Attempts to download a webapp build from S3 before invoking `make build`.

#### Ticket Link
N/A

#### Checklist
N/A