### PR TITLE
Fix teams create example

### DIFF
--- a/cmd/platform/team.go
+++ b/cmd/platform/team.go
@@ -21,7 +21,7 @@ var teamCreateCmd = &cobra.Command{
 	Short: "Create a team",
 	Long:  `Create a team.`,
 	Example: `  team create --name mynewteam --display_name "My New Team"
-  teams create --name private --display_name "My New Private Team" --private`,
+  team create --name private --display_name "My New Private Team" --private`,
 	RunE: createTeamCmdF,
 }
 


### PR DESCRIPTION
Fix the "team create" command wrongly shows a `teams create` example, where an extra "s" is appended to the command name.