### PR TITLE
Fix email race condition

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -196,7 +196,7 @@ func (me *TestHelper) CreateUser(client *model.Client) *model.User {
 	id := model.NewId()
 
 	user := &model.User{
-		Email:    "success+" + id + "@simulator.amazonses.com",
+		Email:    GenerateTestEmail(),
 		Username: "un_" + id,
 		Nickname: "nn_" + id,
 		Password: "Password1",
@@ -360,7 +360,10 @@ func (me *TestHelper) LoginSystemAdmin() {
 }
 
 func GenerateTestEmail() string {
-	return strings.ToLower("success+" + model.NewId() + "@simulator.amazonses.com")
+	if utils.Cfg.EmailSettings.SMTPServer != "dockerhost" {
+		return strings.ToLower("success+" + model.NewId() + "@simulator.amazonses.com")
+	}
+	return strings.ToLower(model.NewId() + "@dockerhost")
 }
 
 func GenerateTestTeamName() string {

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -446,7 +446,10 @@ func (me *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 }
 
 func GenerateTestEmail() string {
-	return strings.ToLower("success+" + model.NewId() + "@simulator.amazonses.com")
+	if utils.Cfg.EmailSettings.SMTPServer != "dockerhost" {
+		return strings.ToLower("success+" + model.NewId() + "@simulator.amazonses.com")
+	}
+	return strings.ToLower(model.NewId() + "@dockerhost")
 }
 
 func GenerateTestUsername() string {


### PR DESCRIPTION
#### Summary
Previously, all test users would share the same mailbox ("success@simulator.amazonses.com"). This gives each user a distinct mailbox when using the default docker SMTP server, so calls to functions like `utils.DeleteMailBox` don't delete the emails for users in parallel tests.

#### Ticket Link
N/A

#### Checklist
N/A