### PR TITLE
[PLT-7701] Fix emoji names that trigger mention

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -801,9 +801,6 @@ func GetExplicitMentions(message string, keywords map[string][]string) (map[stri
 		}
 	}
 
-	const emojiPattern = `:([a-zA-Z0-9_-]+):`
-	r, _ := regexp.Compile(emojiPattern)
-
 	message = removeCodeFromMessage(message)
 
 	for _, word := range strings.FieldsFunc(message, func(c rune) bool {
@@ -813,16 +810,8 @@ func GetExplicitMentions(message string, keywords map[string][]string) (map[stri
 		isMention := false
 
 		// skip word with format ':word:' with an assumption that it is an emoji format only
-		if matchEmojiFormat := r.MatchString(word); matchEmojiFormat {
+		if word[0] == ':' && word[len(word)-1] == ':' {
 			continue
-		}
-
-		matchedWord := strings.FieldsFunc(word, func(c rune) bool {
-			return c == ':'
-		})
-
-		if len(matchedWord) > 0 && matchedWord[0] != "" {
-			word = matchedWord[0]
 		}
 
 		if word == "@here" {
@@ -853,10 +842,10 @@ func GetExplicitMentions(message string, keywords map[string][]string) (map[stri
 			continue
 		}
 
-		if strings.ContainsAny(word, ".-") {
+		if strings.ContainsAny(word, ".-:") {
 			// This word contains a character that may be the end of a sentence, so split further
 			splitWords := strings.FieldsFunc(word, func(c rune) bool {
-				return c == '.' || c == '-'
+				return c == '.' || c == '-' || c == ':'
 			})
 
 			for _, splitWord := range splitWords {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -254,7 +254,7 @@ func TestGetExplicitMentionsAtHere(t *testing.T) {
 		"\\@here\\": true,
 		"|@here|":   true,
 		";@here;":   true,
-		":@here:":   true,
+		":@here:":   false, // This case shouldn't trigger a mention since it follows the format of reactions e.g. :word:
 		"'@here'":   true,
 		"\"@here\"": true,
 		",@here,":   true,

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -200,6 +200,30 @@ func TestGetExplicitMentions(t *testing.T) {
 	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 1 || !mentions[id1] || mentions[id2] || mentions[id3] {
 		t.Fatal("should've only mentioned aaa")
 	}
+
+	message = ":smile:"
+	keywords = map[string][]string{"smile": {id1}, "smiley": {id2}, "smiley_cat": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) == 1 || mentions[id1] {
+		t.Fatal("should not mentioned smile")
+	}
+
+	message = "smile"
+	keywords = map[string][]string{"smile": {id1}, "smiley": {id2}, "smiley_cat": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 1 || !mentions[id1] || mentions[id2] || mentions[id3] {
+		t.Fatal("should've only mentioned smile")
+	}
+
+	message = ":smile"
+	keywords = map[string][]string{"smile": {id1}, "smiley": {id2}, "smiley_cat": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 1 || !mentions[id1] || mentions[id2] || mentions[id3] {
+		t.Fatal("should've only mentioned smile")
+	}
+
+	message = "smile:"
+	keywords = map[string][]string{"smile": {id1}, "smiley": {id2}, "smiley_cat": {id3}}
+	if mentions, _, _, _, _ := GetExplicitMentions(message, keywords); len(mentions) != 1 || !mentions[id1] || mentions[id2] || mentions[id3] {
+		t.Fatal("should've only mentioned smile")
+	}
 }
 
 func TestGetExplicitMentionsAtHere(t *testing.T) {


### PR DESCRIPTION
#### Summary
Fix emoji names that trigger mention, by skipping word of with pattern of `:word:` with the assumption that it's an emoji pattern only.

#### Ticket Link
Jira ticket: [PLT-7701](https://mattermost.atlassian.net/browse/PLT-7701)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
