### PR TITLE
Reduce cfg boilerplate

### DIFF
--- a/api/command_loadtest_test.go
+++ b/api/command_loadtest_test.go
@@ -18,12 +18,6 @@ func TestLoadTestHelpCommands(t *testing.T) {
 	Client := th.BasicClient
 	channel := th.BasicChannel
 
-	// enable testing to use /test but don't save it since we don't want to overwrite config.json
-	enableTesting := th.App.Config().ServiceSettings.EnableTesting
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = enableTesting })
-	}()
-
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = true })
 
 	rs := Client.Must(Client.Command(channel.Id, "/test help")).Data.(*model.CommandResponse)
@@ -40,12 +34,6 @@ func TestLoadTestSetupCommands(t *testing.T) {
 
 	Client := th.BasicClient
 	channel := th.BasicChannel
-
-	// enable testing to use /test but don't save it since we don't want to overwrite config.json
-	enableTesting := th.App.Config().ServiceSettings.EnableTesting
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = enableTesting })
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = true })
 
@@ -64,12 +52,6 @@ func TestLoadTestUsersCommands(t *testing.T) {
 	Client := th.BasicClient
 	channel := th.BasicChannel
 
-	// enable testing to use /test but don't save it since we don't want to overwrite config.json
-	enableTesting := th.App.Config().ServiceSettings.EnableTesting
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = enableTesting })
-	}()
-
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = true })
 
 	rs := Client.Must(Client.Command(channel.Id, "/test users fuzz 1 2")).Data.(*model.CommandResponse)
@@ -86,12 +68,6 @@ func TestLoadTestChannelsCommands(t *testing.T) {
 
 	Client := th.BasicClient
 	channel := th.BasicChannel
-
-	// enable testing to use /test but don't save it since we don't want to overwrite config.json
-	enableTesting := th.App.Config().ServiceSettings.EnableTesting
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = enableTesting })
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = true })
 
@@ -110,12 +86,6 @@ func TestLoadTestPostsCommands(t *testing.T) {
 	Client := th.BasicClient
 	channel := th.BasicChannel
 
-	// enable testing to use /test but don't save it since we don't want to overwrite config.json
-	enableTesting := th.App.Config().ServiceSettings.EnableTesting
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = enableTesting })
-	}()
-
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableTesting = true })
 
 	rs := Client.Must(Client.Command(channel.Id, "/test posts fuzz 2 3 2")).Data.(*model.CommandResponse)
@@ -124,86 +94,4 @@ func TestLoadTestPostsCommands(t *testing.T) {
 	}
 
 	time.Sleep(2 * time.Second)
-}
-
-func TestLoadTestUrlCommands(t *testing.T) {
-	//th := Setup().InitBasic()
-	//Client := th.BasicClient
-	//channel := th.BasicChannel
-
-	// enable testing to use /loadtest but don't save it since we don't want to overwrite config.json
-	//enableTesting := utils.Cfg.ServiceSettings.EnableTesting
-	//defer func() {
-	//	utils.Cfg.ServiceSettings.EnableTesting = enableTesting
-	//}()
-
-	//utils.Cfg.ServiceSettings.EnableTesting = true
-
-	//command := "/loadtest url "
-	//if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Command must contain a url" {
-	//	t.Fatal("/loadtest url with no url should've failed")
-	//}
-	//
-	//command = "/loadtest url http://missingfiletonwhere/path/asdf/qwerty"
-	//if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Unable to get file" {
-	//	t.Log(r.Text)
-	//	t.Fatal("/loadtest url with invalid url should've failed")
-	//}
-	//
-	//command = "/loadtest url https://raw.githubusercontent.com/mattermost/mattermost-server/master/README.md"
-	//if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Loaded data" {
-	//	t.Fatal("/loadtest url for README.md should've executed")
-	//}
-
-	// Removing these tests since they break compatibilty with previous release branches because the url pulls from github master
-
-	// command = "/loadtest url test-emoticons1.md"
-	// if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Loading data..." {
-	// 	t.Fatal("/loadtest url for test-emoticons.md should've executed")
-	// }
-
-	// command = "/loadtest url test-emoticons1"
-	// if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Loading data..." {
-	// 	t.Fatal("/loadtest url for test-emoticons should've executed")
-	// }
-
-	// posts := Client.Must(Client.GetPosts(channel.Id, 0, 5, "")).Data.(*model.PostList)
-	// // note that this may make more than 3 posts if files are too long to fit in an individual post
-	// if len(posts.Order) < 3 {
-	// 	t.Fatal("/loadtest url made too few posts, perhaps there needs to be a delay before GetPosts in the test?")
-	// }
-
-	//time.Sleep(2 * time.Second)
-}
-
-func TestLoadTestJsonCommands(t *testing.T) {
-	//th := Setup().InitBasic()
-	//Client := th.BasicClient
-	//channel := th.BasicChannel
-
-	// enable testing to use /loadtest but don't save it since we don't want to overwrite config.json
-	//enableTesting := utils.Cfg.ServiceSettings.EnableTesting
-	//defer func() {
-	//	utils.Cfg.ServiceSettings.EnableTesting = enableTesting
-	//}()
-
-	//utils.Cfg.ServiceSettings.EnableTesting = true
-
-	//command := "/loadtest json "
-	//if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Command must contain a url" {
-	//	t.Fatal("/loadtest url with no url should've failed")
-	//}
-	//
-	//command = "/loadtest json http://missingfiletonwhere/path/asdf/qwerty"
-	//if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Unable to get file" {
-	//	t.Log(r.Text)
-	//	t.Fatal("/loadtest url with invalid url should've failed")
-	//}
-	//
-	//command = "/loadtest json test-slack-attachments"
-	//if r := Client.Must(Client.Command(channel.Id, command, false)).Data.(*model.CommandResponse); r.Text != "Loaded data" {
-	//	t.Fatal("/loadtest json should've executed")
-	//}
-
-	//time.Sleep(2 * time.Second)
 }

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -241,16 +241,8 @@ func testCreatePostWithOutgoingHook(
 	user := th.SystemAdminUser
 	channel := th.CreateChannel(Client, team)
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	allowedInternalConnections := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
-		})
-	}()
-	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ServiceSettings.EnableOutgoingWebhooks = true
 		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
 	})
 
@@ -405,13 +397,6 @@ func TestUpdatePost(t *testing.T) {
 
 	Client := th.BasicClient
 	channel1 := th.BasicChannel
-
-	allowEditPost := *th.App.Config().ServiceSettings.AllowEditPost
-	postEditTimeLimit := *th.App.Config().ServiceSettings.PostEditTimeLimit
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = allowEditPost })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.PostEditTimeLimit = postEditTimeLimit })
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = model.ALLOW_EDIT_POST_ALWAYS })
 
@@ -981,11 +966,6 @@ func TestDeletePosts(t *testing.T) {
 	channel1 := th.BasicChannel
 	team1 := th.BasicTeam
 
-	restrictPostDelete := *th.App.Config().ServiceSettings.RestrictPostDelete
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.RestrictPostDelete = restrictPostDelete })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.RestrictPostDelete = model.PERMISSIONS_DELETE_POST_ALL })
 	utils.SetDefaultRolesBasedOnConfig()
 
@@ -1482,16 +1462,8 @@ func TestGetOpenGraphMetadata(t *testing.T) {
 
 	Client := th.BasicClient
 
-	enableLinkPreviews := *th.App.Config().ServiceSettings.EnableLinkPreviews
-	allowedInternalConnections := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableLinkPreviews = enableLinkPreviews })
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
-		})
-	}()
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableLinkPreviews = true })
 	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.EnableLinkPreviews = true
 		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
 	})
 

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -89,18 +89,11 @@ func TestLogin(t *testing.T) {
 
 	Client := th.BasicClient
 
-	enableSignInWithEmail := *th.App.Config().EmailSettings.EnableSignInWithEmail
-	enableSignInWithUsername := *th.App.Config().EmailSettings.EnableSignInWithUsername
-	enableLdap := *th.App.Config().LdapSettings.Enable
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.EmailSettings.EnableSignInWithEmail = enableSignInWithEmail })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.EmailSettings.EnableSignInWithUsername = enableSignInWithUsername })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.LdapSettings.Enable = enableLdap })
-	}()
-
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.EmailSettings.EnableSignInWithEmail = false })
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.EmailSettings.EnableSignInWithUsername = false })
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.LdapSettings.Enable = false })
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.EmailSettings.EnableSignInWithEmail = false
+		*cfg.EmailSettings.EnableSignInWithUsername = false
+		*cfg.LdapSettings.Enable = false
+	})
 
 	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
@@ -272,12 +265,6 @@ func TestPasswordGuessLockout(t *testing.T) {
 	user := th.BasicUser
 	Client.Must(Client.Logout())
 
-	enableSignInWithEmail := *th.App.Config().EmailSettings.EnableSignInWithEmail
-	passwordAttempts := *th.App.Config().ServiceSettings.MaximumLoginAttempts
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.EmailSettings.EnableSignInWithEmail = enableSignInWithEmail })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.EmailSettings.EnableSignInWithEmail = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = 2 })
 
@@ -410,12 +397,6 @@ func TestGetUser(t *testing.T) {
 		t.Fatal("shouldn't exist")
 	}
 
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
@@ -517,11 +498,6 @@ func TestGetProfiles(t *testing.T) {
 
 	th.BasicClient.Must(th.BasicClient.CreateDirectChannel(th.BasicUser2.Id))
 
-	prevShowEmail := th.App.Config().PrivacySettings.ShowEmailAddress
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = prevShowEmail })
-	}()
-
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = true })
 
 	if result, err := th.BasicClient.GetProfiles(0, 100, ""); err != nil {
@@ -571,11 +547,6 @@ func TestGetProfiles(t *testing.T) {
 func TestGetProfilesByIds(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
-
-	prevShowEmail := th.App.Config().PrivacySettings.ShowEmailAddress
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = prevShowEmail })
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = true })
 
@@ -960,10 +931,6 @@ func TestUserUpdatePassword(t *testing.T) {
 	}
 
 	// Test lockout
-	passwordAttempts := *th.App.Config().ServiceSettings.MaximumLoginAttempts
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = 2 })
 
 	// Fail twice
@@ -1887,11 +1854,9 @@ func TestUpdateMfa(t *testing.T) {
 
 	isLicensed := utils.IsLicensed()
 	license := utils.License()
-	enableMfa := *th.App.Config().ServiceSettings.EnableMultifactorAuthentication
 	defer func() {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = enableMfa })
 	}()
 	utils.SetIsLicensed(false)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
@@ -2059,11 +2024,6 @@ func TestGetProfilesInChannel(t *testing.T) {
 
 	Client := th.BasicClient
 
-	prevShowEmail := th.App.Config().PrivacySettings.ShowEmailAddress
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = prevShowEmail })
-	}()
-
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = true })
 
 	if result, err := Client.GetProfilesInChannel(th.BasicChannel.Id, 0, 100, ""); err != nil {
@@ -2132,11 +2092,6 @@ func TestGetProfilesNotInChannel(t *testing.T) {
 	defer th.TearDown()
 
 	Client := th.BasicClient
-
-	prevShowEmail := th.App.Config().PrivacySettings.ShowEmailAddress
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = prevShowEmail })
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = true })
 
@@ -2359,12 +2314,6 @@ func TestSearchUsers(t *testing.T) {
 		}
 	}
 
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
@@ -2653,10 +2602,6 @@ func TestAutocompleteUsers(t *testing.T) {
 		}
 	}
 
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
 	privacyUser := &model.User{Email: strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com", Nickname: "Corey Hulen", Password: "passwd1", FirstName: model.NewId(), LastName: "Jimmers"}
@@ -2712,13 +2657,6 @@ func TestGetByUsername(t *testing.T) {
 		}
 	}
 
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
-
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
@@ -2748,13 +2686,6 @@ func TestGetByEmail(t *testing.T) {
 	if _, respMetdata := Client.GetByEmail(th.BasicUser.Email, ""); respMetdata.Error != nil {
 		t.Fatal("Failed to get user by email")
 	}
-
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -25,13 +25,6 @@ func TestCreateIncomingHook(t *testing.T) {
 	user2 := th.CreateUser(Client)
 	th.LinkUserToTeam(user2, team)
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -138,14 +131,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 	user3 := th.CreateUser(Client)
 	th.LinkUserToTeam(user3, team2)
 	th.UpdateUserToTeamAdmin(user3, team2)
-
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
@@ -338,13 +323,6 @@ func TestListIncomingHooks(t *testing.T) {
 	user2 := th.CreateUser(Client)
 	th.LinkUserToTeam(user2, team)
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -397,13 +375,6 @@ func TestDeleteIncomingHook(t *testing.T) {
 	user2 := th.CreateUser(Client)
 	th.LinkUserToTeam(user2, team)
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -475,13 +446,6 @@ func TestCreateOutgoingHook(t *testing.T) {
 	user3 := th.CreateUser(Client)
 	th.LinkUserToTeam(user3, team2)
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -586,13 +550,6 @@ func TestListOutgoingHooks(t *testing.T) {
 	user2 := th.CreateUser(Client)
 	th.LinkUserToTeam(user2, team)
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -650,14 +607,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	th.LinkUserToTeam(user2, team)
 	user3 := th.CreateUser(Client)
 	th.LinkUserToTeam(user3, team2)
-
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
@@ -829,13 +778,6 @@ func TestDeleteOutgoingHook(t *testing.T) {
 	user2 := th.CreateUser(Client)
 	th.LinkUserToTeam(user2, team)
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -905,13 +847,6 @@ func TestRegenOutgoingHookToken(t *testing.T) {
 	user3 := th.CreateUser(Client)
 	th.LinkUserToTeam(user3, team2)
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -32,7 +32,8 @@ import (
 )
 
 type TestHelper struct {
-	App *app.App
+	App            *app.App
+	originalConfig *model.Config
 
 	Client              *model.Client4
 	BasicUser           *model.User
@@ -86,6 +87,7 @@ func setupTestHelper(enterprise bool) *TestHelper {
 	th := &TestHelper{
 		App: app.New(options...),
 	}
+	th.originalConfig = *th.App.Config().Clone()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.MaxUsersPerTeam = 50 })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.RateLimitSettings.Enable = false })
@@ -176,6 +178,11 @@ func (me *TestHelper) TearDown() {
 	}()
 
 	wg.Wait()
+
+	me.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg = *me.originalConfig
+	})
+	utils.SetDefaultRolesBasedOnConfig()
 
 	me.App.Shutdown()
 

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -87,7 +87,7 @@ func setupTestHelper(enterprise bool) *TestHelper {
 	th := &TestHelper{
 		App: app.New(options...),
 	}
-	th.originalConfig = *th.App.Config().Clone()
+	th.originalConfig = th.App.Config().Clone()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.MaxUsersPerTeam = 50 })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.RateLimitSettings.Enable = false })

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -286,6 +286,8 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		_, resp := Client.CreateUserWithInviteId(&user, inviteId)
 		CheckNotImplementedStatus(t, resp)
 		CheckErrorMessage(t, resp, "api.user.create_user.signup_email_disabled.app_error")
+
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = true })
 	})
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -63,12 +63,6 @@ func TestCreateUser(t *testing.T) {
 	CheckErrorMessage(t, resp, "model.user.is_valid.email.app_error")
 	CheckBadRequestStatus(t, resp)
 
-	openServer := *th.App.Config().TeamSettings.EnableOpenServer
-	canCreateAccount := th.App.Config().TeamSettings.EnableUserCreation
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = openServer })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = canCreateAccount })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = false })
 
@@ -185,10 +179,6 @@ func TestCreateUserWithHash(t *testing.T) {
 		data := model.MapToJson(props)
 		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
 
-		canCreateAccount := th.App.Config().TeamSettings.EnableUserCreation
-		defer func() {
-			th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = canCreateAccount })
-		}()
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = false })
 
 		_, resp := Client.CreateUserWithHash(&user, hash, data)
@@ -208,10 +198,6 @@ func TestCreateUserWithHash(t *testing.T) {
 		data := model.MapToJson(props)
 		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
 
-		openServer := *th.App.Config().TeamSettings.EnableOpenServer
-		defer func() {
-			th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = openServer })
-		}()
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = false })
 
 		ruser, resp := Client.CreateUserWithHash(&user, hash, data)
@@ -291,10 +277,6 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	t.Run("EnableUserCreationDisable", func(t *testing.T) {
 		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
 
-		canCreateAccount := th.App.Config().TeamSettings.EnableUserCreation
-		defer func() {
-			th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = canCreateAccount })
-		}()
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = false })
 
 		inviteId := th.BasicTeam.InviteId
@@ -307,10 +289,6 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {
 		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
 
-		openServer := *th.App.Config().TeamSettings.EnableOpenServer
-		defer func() {
-			th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = openServer })
-		}()
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = false })
 
 		inviteId := th.BasicTeam.InviteId
@@ -374,12 +352,6 @@ func TestGetUser(t *testing.T) {
 	CheckNotFoundStatus(t, resp)
 
 	// Check against privacy config settings
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
@@ -435,12 +407,6 @@ func TestGetUserByUsername(t *testing.T) {
 	CheckNotFoundStatus(t, resp)
 
 	// Check against privacy config settings
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
@@ -499,12 +465,6 @@ func TestGetUserByEmail(t *testing.T) {
 	CheckNotFoundStatus(t, resp)
 
 	// Check against privacy config settings
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
@@ -666,12 +626,6 @@ func TestSearchUsers(t *testing.T) {
 
 	search.Term = th.BasicUser.Username
 
-	emailPrivacy := th.App.Config().PrivacySettings.ShowEmailAddress
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = emailPrivacy })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
@@ -824,10 +778,6 @@ func TestAutocompleteUsers(t *testing.T) {
 	CheckNoError(t, resp)
 
 	// Check against privacy config settings
-	namePrivacy := th.App.Config().PrivacySettings.ShowFullName
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = namePrivacy })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
 	th.LoginBasic()
@@ -1733,10 +1683,6 @@ func TestUpdateUserPassword(t *testing.T) {
 	th.LoginBasic()
 
 	// Test lockout
-	passwordAttempts := *th.App.Config().ServiceSettings.MaximumLoginAttempts
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = passwordAttempts })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.MaximumLoginAttempts = 2 })
 
 	// Fail twice
@@ -2175,10 +2121,6 @@ func TestSwitchAccount(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableGitLab := th.App.Config().GitLabSettings.Enable
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.GitLabSettings.Enable = enableGitLab })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.GitLabSettings.Enable = true })
 
 	Client.Logout()
@@ -2269,10 +2211,6 @@ func TestCreateUserAccessToken(t *testing.T) {
 
 	testDescription := "test token"
 
-	enableUserAccessTokens := *th.App.Config().ServiceSettings.EnableUserAccessTokens
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
 	_, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
@@ -2354,10 +2292,6 @@ func TestGetUserAccessToken(t *testing.T) {
 
 	testDescription := "test token"
 
-	enableUserAccessTokens := *th.App.Config().ServiceSettings.EnableUserAccessTokens
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
 	_, resp := Client.GetUserAccessToken("123")
@@ -2425,10 +2359,6 @@ func TestRevokeUserAccessToken(t *testing.T) {
 
 	testDescription := "test token"
 
-	enableUserAccessTokens := *th.App.Config().ServiceSettings.EnableUserAccessTokens
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
 	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id)
@@ -2447,7 +2377,7 @@ func TestRevokeUserAccessToken(t *testing.T) {
 	if !ok {
 		t.Fatal("should have passed")
 	}
-	
+
 	oldSessionToken = Client.AuthToken
 	Client.AuthToken = token.Token
 	_, resp = Client.GetMe("")
@@ -2566,10 +2496,6 @@ func TestUserAccessTokenInactiveUser(t *testing.T) {
 
 	testDescription := "test token"
 
-	enableUserAccessTokens := *th.App.Config().ServiceSettings.EnableUserAccessTokens
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
 	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id)
@@ -2593,10 +2519,6 @@ func TestUserAccessTokenDisableConfig(t *testing.T) {
 
 	testDescription := "test token"
 
-	enableUserAccessTokens := *th.App.Config().ServiceSettings.EnableUserAccessTokens
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
 	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -184,6 +184,8 @@ func TestCreateUserWithHash(t *testing.T) {
 		_, resp := Client.CreateUserWithHash(&user, hash, data)
 		CheckNotImplementedStatus(t, resp)
 		CheckErrorMessage(t, resp, "api.user.create_user.signup_email_disabled.app_error")
+
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = true })
 	})
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {

--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -19,13 +19,6 @@ func TestCreateIncomingWebhook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -76,13 +69,6 @@ func TestGetIncomingWebhooks(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -158,13 +144,6 @@ func TestGetIncomingWebhook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.SystemAdminClient
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -206,13 +185,6 @@ func TestDeleteIncomingWebhook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.SystemAdminClient
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -266,13 +238,6 @@ func TestCreateOutgoingWebhook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -319,13 +284,6 @@ func TestGetOutgoingWebhooks(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -424,13 +382,6 @@ func TestGetOutgoingWebhook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -463,13 +414,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -632,13 +576,6 @@ func TestRegenOutgoingHookToken(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -673,13 +610,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()
@@ -840,13 +770,6 @@ func TestDeleteOutgoingHook(t *testing.T) {
 	defer th.TearDown()
 	Client := th.SystemAdminClient
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	utils.SetDefaultRolesBasedOnConfig()

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -4,21 +4,16 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestPermanentDeleteChannel(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
-	incomingWasEnabled := utils.Cfg.ServiceSettings.EnableIncomingWebhooks
-	outgoingWasEnabled := utils.Cfg.ServiceSettings.EnableOutgoingWebhooks
-	utils.Cfg.ServiceSettings.EnableIncomingWebhooks = true
-	utils.Cfg.ServiceSettings.EnableOutgoingWebhooks = true
-	defer func() {
-		utils.Cfg.ServiceSettings.EnableIncomingWebhooks = incomingWasEnabled
-		utils.Cfg.ServiceSettings.EnableOutgoingWebhooks = outgoingWasEnabled
-	}()
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.ServiceSettings.EnableIncomingWebhooks = true
+		cfg.ServiceSettings.EnableOutgoingWebhooks = true
+	})
 
 	channel, err := th.App.CreateChannel(&model.Channel{DisplayName: "deletion-test", Name: "deletion-test", Type: model.CHANNEL_OPEN, TeamId: th.BasicTeam.Id}, false)
 	if err != nil {

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -55,7 +55,7 @@ func (a *App) SendDailyDiagnostics() {
 	if *a.Config().LogSettings.EnableDiagnostics && a.IsLeader() {
 		initDiagnostics("")
 		a.trackActivity()
-		trackConfig()
+		a.trackConfig()
 		trackLicense()
 		a.trackServer()
 	}
@@ -92,8 +92,8 @@ func isDefault(setting interface{}, defaultValue interface{}) bool {
 	return false
 }
 
-func pluginSetting(plugin, key string, defaultValue interface{}) interface{} {
-	settings, ok := utils.Cfg.PluginSettings.Plugins[plugin]
+func pluginSetting(cfg *model.Config, plugin, key string, defaultValue interface{}) interface{} {
+	settings, ok := cfg.PluginSettings.Plugins[plugin]
 	if !ok {
 		return defaultValue
 	}
@@ -175,287 +175,288 @@ func (a *App) trackActivity() {
 	})
 }
 
-func trackConfig() {
+func (a *App) trackConfig() {
+	cfg := a.Config()
 	SendDiagnostic(TRACK_CONFIG_SERVICE, map[string]interface{}{
-		"web_server_mode":                                  *utils.Cfg.ServiceSettings.WebserverMode,
-		"enable_security_fix_alert":                        *utils.Cfg.ServiceSettings.EnableSecurityFixAlert,
-		"enable_insecure_outgoing_connections":             *utils.Cfg.ServiceSettings.EnableInsecureOutgoingConnections,
-		"enable_incoming_webhooks":                         utils.Cfg.ServiceSettings.EnableIncomingWebhooks,
-		"enable_outgoing_webhooks":                         utils.Cfg.ServiceSettings.EnableOutgoingWebhooks,
-		"enable_commands":                                  *utils.Cfg.ServiceSettings.EnableCommands,
-		"enable_only_admin_integrations":                   *utils.Cfg.ServiceSettings.EnableOnlyAdminIntegrations,
-		"enable_post_username_override":                    utils.Cfg.ServiceSettings.EnablePostUsernameOverride,
-		"enable_post_icon_override":                        utils.Cfg.ServiceSettings.EnablePostIconOverride,
-		"enable_apiv3":                                     *utils.Cfg.ServiceSettings.EnableAPIv3,
-		"enable_user_access_tokens":                        *utils.Cfg.ServiceSettings.EnableUserAccessTokens,
-		"enable_custom_emoji":                              *utils.Cfg.ServiceSettings.EnableCustomEmoji,
-		"enable_emoji_picker":                              *utils.Cfg.ServiceSettings.EnableEmojiPicker,
-		"restrict_custom_emoji_creation":                   *utils.Cfg.ServiceSettings.RestrictCustomEmojiCreation,
-		"enable_testing":                                   utils.Cfg.ServiceSettings.EnableTesting,
-		"enable_developer":                                 *utils.Cfg.ServiceSettings.EnableDeveloper,
-		"enable_multifactor_authentication":                *utils.Cfg.ServiceSettings.EnableMultifactorAuthentication,
-		"enforce_multifactor_authentication":               *utils.Cfg.ServiceSettings.EnforceMultifactorAuthentication,
-		"enable_oauth_service_provider":                    utils.Cfg.ServiceSettings.EnableOAuthServiceProvider,
-		"connection_security":                              *utils.Cfg.ServiceSettings.ConnectionSecurity,
-		"uses_letsencrypt":                                 *utils.Cfg.ServiceSettings.UseLetsEncrypt,
-		"forward_80_to_443":                                *utils.Cfg.ServiceSettings.Forward80To443,
-		"maximum_login_attempts":                           *utils.Cfg.ServiceSettings.MaximumLoginAttempts,
-		"session_length_web_in_days":                       *utils.Cfg.ServiceSettings.SessionLengthWebInDays,
-		"session_length_mobile_in_days":                    *utils.Cfg.ServiceSettings.SessionLengthMobileInDays,
-		"session_length_sso_in_days":                       *utils.Cfg.ServiceSettings.SessionLengthSSOInDays,
-		"session_cache_in_minutes":                         *utils.Cfg.ServiceSettings.SessionCacheInMinutes,
-		"session_idle_timeout_in_minutes":                  *utils.Cfg.ServiceSettings.SessionIdleTimeoutInMinutes,
-		"isdefault_site_url":                               isDefault(*utils.Cfg.ServiceSettings.SiteURL, model.SERVICE_SETTINGS_DEFAULT_SITE_URL),
-		"isdefault_tls_cert_file":                          isDefault(*utils.Cfg.ServiceSettings.TLSCertFile, model.SERVICE_SETTINGS_DEFAULT_TLS_CERT_FILE),
-		"isdefault_tls_key_file":                           isDefault(*utils.Cfg.ServiceSettings.TLSKeyFile, model.SERVICE_SETTINGS_DEFAULT_TLS_KEY_FILE),
-		"isdefault_read_timeout":                           isDefault(*utils.Cfg.ServiceSettings.ReadTimeout, model.SERVICE_SETTINGS_DEFAULT_READ_TIMEOUT),
-		"isdefault_write_timeout":                          isDefault(*utils.Cfg.ServiceSettings.WriteTimeout, model.SERVICE_SETTINGS_DEFAULT_WRITE_TIMEOUT),
-		"isdefault_google_developer_key":                   isDefault(utils.Cfg.ServiceSettings.GoogleDeveloperKey, ""),
-		"isdefault_allow_cors_from":                        isDefault(*utils.Cfg.ServiceSettings.AllowCorsFrom, model.SERVICE_SETTINGS_DEFAULT_ALLOW_CORS_FROM),
-		"isdefault_allowed_untrusted_internal_connections": isDefault(*utils.Cfg.ServiceSettings.AllowedUntrustedInternalConnections, ""),
-		"restrict_post_delete":                             *utils.Cfg.ServiceSettings.RestrictPostDelete,
-		"allow_edit_post":                                  *utils.Cfg.ServiceSettings.AllowEditPost,
-		"post_edit_time_limit":                             *utils.Cfg.ServiceSettings.PostEditTimeLimit,
-		"enable_user_typing_messages":                      *utils.Cfg.ServiceSettings.EnableUserTypingMessages,
-		"enable_channel_viewed_messages":                   *utils.Cfg.ServiceSettings.EnableChannelViewedMessages,
-		"time_between_user_typing_updates_milliseconds":    *utils.Cfg.ServiceSettings.TimeBetweenUserTypingUpdatesMilliseconds,
-		"cluster_log_timeout_milliseconds":                 *utils.Cfg.ServiceSettings.ClusterLogTimeoutMilliseconds,
-		"enable_post_search":                               *utils.Cfg.ServiceSettings.EnablePostSearch,
-		"enable_user_statuses":                             *utils.Cfg.ServiceSettings.EnableUserStatuses,
+		"web_server_mode":                                  *cfg.ServiceSettings.WebserverMode,
+		"enable_security_fix_alert":                        *cfg.ServiceSettings.EnableSecurityFixAlert,
+		"enable_insecure_outgoing_connections":             *cfg.ServiceSettings.EnableInsecureOutgoingConnections,
+		"enable_incoming_webhooks":                         cfg.ServiceSettings.EnableIncomingWebhooks,
+		"enable_outgoing_webhooks":                         cfg.ServiceSettings.EnableOutgoingWebhooks,
+		"enable_commands":                                  *cfg.ServiceSettings.EnableCommands,
+		"enable_only_admin_integrations":                   *cfg.ServiceSettings.EnableOnlyAdminIntegrations,
+		"enable_post_username_override":                    cfg.ServiceSettings.EnablePostUsernameOverride,
+		"enable_post_icon_override":                        cfg.ServiceSettings.EnablePostIconOverride,
+		"enable_apiv3":                                     *cfg.ServiceSettings.EnableAPIv3,
+		"enable_user_access_tokens":                        *cfg.ServiceSettings.EnableUserAccessTokens,
+		"enable_custom_emoji":                              *cfg.ServiceSettings.EnableCustomEmoji,
+		"enable_emoji_picker":                              *cfg.ServiceSettings.EnableEmojiPicker,
+		"restrict_custom_emoji_creation":                   *cfg.ServiceSettings.RestrictCustomEmojiCreation,
+		"enable_testing":                                   cfg.ServiceSettings.EnableTesting,
+		"enable_developer":                                 *cfg.ServiceSettings.EnableDeveloper,
+		"enable_multifactor_authentication":                *cfg.ServiceSettings.EnableMultifactorAuthentication,
+		"enforce_multifactor_authentication":               *cfg.ServiceSettings.EnforceMultifactorAuthentication,
+		"enable_oauth_service_provider":                    cfg.ServiceSettings.EnableOAuthServiceProvider,
+		"connection_security":                              *cfg.ServiceSettings.ConnectionSecurity,
+		"uses_letsencrypt":                                 *cfg.ServiceSettings.UseLetsEncrypt,
+		"forward_80_to_443":                                *cfg.ServiceSettings.Forward80To443,
+		"maximum_login_attempts":                           *cfg.ServiceSettings.MaximumLoginAttempts,
+		"session_length_web_in_days":                       *cfg.ServiceSettings.SessionLengthWebInDays,
+		"session_length_mobile_in_days":                    *cfg.ServiceSettings.SessionLengthMobileInDays,
+		"session_length_sso_in_days":                       *cfg.ServiceSettings.SessionLengthSSOInDays,
+		"session_cache_in_minutes":                         *cfg.ServiceSettings.SessionCacheInMinutes,
+		"session_idle_timeout_in_minutes":                  *cfg.ServiceSettings.SessionIdleTimeoutInMinutes,
+		"isdefault_site_url":                               isDefault(*cfg.ServiceSettings.SiteURL, model.SERVICE_SETTINGS_DEFAULT_SITE_URL),
+		"isdefault_tls_cert_file":                          isDefault(*cfg.ServiceSettings.TLSCertFile, model.SERVICE_SETTINGS_DEFAULT_TLS_CERT_FILE),
+		"isdefault_tls_key_file":                           isDefault(*cfg.ServiceSettings.TLSKeyFile, model.SERVICE_SETTINGS_DEFAULT_TLS_KEY_FILE),
+		"isdefault_read_timeout":                           isDefault(*cfg.ServiceSettings.ReadTimeout, model.SERVICE_SETTINGS_DEFAULT_READ_TIMEOUT),
+		"isdefault_write_timeout":                          isDefault(*cfg.ServiceSettings.WriteTimeout, model.SERVICE_SETTINGS_DEFAULT_WRITE_TIMEOUT),
+		"isdefault_google_developer_key":                   isDefault(cfg.ServiceSettings.GoogleDeveloperKey, ""),
+		"isdefault_allow_cors_from":                        isDefault(*cfg.ServiceSettings.AllowCorsFrom, model.SERVICE_SETTINGS_DEFAULT_ALLOW_CORS_FROM),
+		"isdefault_allowed_untrusted_internal_connections": isDefault(*cfg.ServiceSettings.AllowedUntrustedInternalConnections, ""),
+		"restrict_post_delete":                             *cfg.ServiceSettings.RestrictPostDelete,
+		"allow_edit_post":                                  *cfg.ServiceSettings.AllowEditPost,
+		"post_edit_time_limit":                             *cfg.ServiceSettings.PostEditTimeLimit,
+		"enable_user_typing_messages":                      *cfg.ServiceSettings.EnableUserTypingMessages,
+		"enable_channel_viewed_messages":                   *cfg.ServiceSettings.EnableChannelViewedMessages,
+		"time_between_user_typing_updates_milliseconds":    *cfg.ServiceSettings.TimeBetweenUserTypingUpdatesMilliseconds,
+		"cluster_log_timeout_milliseconds":                 *cfg.ServiceSettings.ClusterLogTimeoutMilliseconds,
+		"enable_post_search":                               *cfg.ServiceSettings.EnablePostSearch,
+		"enable_user_statuses":                             *cfg.ServiceSettings.EnableUserStatuses,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{
-		"enable_user_creation":                    utils.Cfg.TeamSettings.EnableUserCreation,
-		"enable_team_creation":                    utils.Cfg.TeamSettings.EnableTeamCreation,
-		"restrict_team_invite":                    *utils.Cfg.TeamSettings.RestrictTeamInvite,
-		"restrict_public_channel_creation":        *utils.Cfg.TeamSettings.RestrictPublicChannelCreation,
-		"restrict_private_channel_creation":       *utils.Cfg.TeamSettings.RestrictPrivateChannelCreation,
-		"restrict_public_channel_management":      *utils.Cfg.TeamSettings.RestrictPublicChannelManagement,
-		"restrict_private_channel_management":     *utils.Cfg.TeamSettings.RestrictPrivateChannelManagement,
-		"restrict_public_channel_deletion":        *utils.Cfg.TeamSettings.RestrictPublicChannelDeletion,
-		"restrict_private_channel_deletion":       *utils.Cfg.TeamSettings.RestrictPrivateChannelDeletion,
-		"enable_open_server":                      *utils.Cfg.TeamSettings.EnableOpenServer,
-		"enable_custom_brand":                     *utils.Cfg.TeamSettings.EnableCustomBrand,
-		"restrict_direct_message":                 *utils.Cfg.TeamSettings.RestrictDirectMessage,
-		"max_notifications_per_channel":           *utils.Cfg.TeamSettings.MaxNotificationsPerChannel,
-		"enable_confirm_notifications_to_channel": *utils.Cfg.TeamSettings.EnableConfirmNotificationsToChannel,
-		"max_users_per_team":                      *utils.Cfg.TeamSettings.MaxUsersPerTeam,
-		"max_channels_per_team":                   *utils.Cfg.TeamSettings.MaxChannelsPerTeam,
-		"teammate_name_display":                   *utils.Cfg.TeamSettings.TeammateNameDisplay,
-		"isdefault_site_name":                     isDefault(utils.Cfg.TeamSettings.SiteName, "Mattermost"),
-		"isdefault_custom_brand_text":             isDefault(*utils.Cfg.TeamSettings.CustomBrandText, model.TEAM_SETTINGS_DEFAULT_CUSTOM_BRAND_TEXT),
-		"isdefault_custom_description_text":       isDefault(*utils.Cfg.TeamSettings.CustomDescriptionText, model.TEAM_SETTINGS_DEFAULT_CUSTOM_DESCRIPTION_TEXT),
-		"isdefault_user_status_away_timeout":      isDefault(*utils.Cfg.TeamSettings.UserStatusAwayTimeout, model.TEAM_SETTINGS_DEFAULT_USER_STATUS_AWAY_TIMEOUT),
-		"restrict_private_channel_manage_members": *utils.Cfg.TeamSettings.RestrictPrivateChannelManageMembers,
-		"enable_X_to_leave_channels_from_LHS":     *utils.Cfg.TeamSettings.EnableXToLeaveChannelsFromLHS,
-		"experimental_town_square_is_read_only":   *utils.Cfg.TeamSettings.ExperimentalTownSquareIsReadOnly,
+		"enable_user_creation":                    cfg.TeamSettings.EnableUserCreation,
+		"enable_team_creation":                    cfg.TeamSettings.EnableTeamCreation,
+		"restrict_team_invite":                    *cfg.TeamSettings.RestrictTeamInvite,
+		"restrict_public_channel_creation":        *cfg.TeamSettings.RestrictPublicChannelCreation,
+		"restrict_private_channel_creation":       *cfg.TeamSettings.RestrictPrivateChannelCreation,
+		"restrict_public_channel_management":      *cfg.TeamSettings.RestrictPublicChannelManagement,
+		"restrict_private_channel_management":     *cfg.TeamSettings.RestrictPrivateChannelManagement,
+		"restrict_public_channel_deletion":        *cfg.TeamSettings.RestrictPublicChannelDeletion,
+		"restrict_private_channel_deletion":       *cfg.TeamSettings.RestrictPrivateChannelDeletion,
+		"enable_open_server":                      *cfg.TeamSettings.EnableOpenServer,
+		"enable_custom_brand":                     *cfg.TeamSettings.EnableCustomBrand,
+		"restrict_direct_message":                 *cfg.TeamSettings.RestrictDirectMessage,
+		"max_notifications_per_channel":           *cfg.TeamSettings.MaxNotificationsPerChannel,
+		"enable_confirm_notifications_to_channel": *cfg.TeamSettings.EnableConfirmNotificationsToChannel,
+		"max_users_per_team":                      *cfg.TeamSettings.MaxUsersPerTeam,
+		"max_channels_per_team":                   *cfg.TeamSettings.MaxChannelsPerTeam,
+		"teammate_name_display":                   *cfg.TeamSettings.TeammateNameDisplay,
+		"isdefault_site_name":                     isDefault(cfg.TeamSettings.SiteName, "Mattermost"),
+		"isdefault_custom_brand_text":             isDefault(*cfg.TeamSettings.CustomBrandText, model.TEAM_SETTINGS_DEFAULT_CUSTOM_BRAND_TEXT),
+		"isdefault_custom_description_text":       isDefault(*cfg.TeamSettings.CustomDescriptionText, model.TEAM_SETTINGS_DEFAULT_CUSTOM_DESCRIPTION_TEXT),
+		"isdefault_user_status_away_timeout":      isDefault(*cfg.TeamSettings.UserStatusAwayTimeout, model.TEAM_SETTINGS_DEFAULT_USER_STATUS_AWAY_TIMEOUT),
+		"restrict_private_channel_manage_members": *cfg.TeamSettings.RestrictPrivateChannelManageMembers,
+		"enable_X_to_leave_channels_from_LHS":     *cfg.TeamSettings.EnableXToLeaveChannelsFromLHS,
+		"experimental_town_square_is_read_only":   *cfg.TeamSettings.ExperimentalTownSquareIsReadOnly,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_CLIENT_REQ, map[string]interface{}{
-		"android_latest_version": utils.Cfg.ClientRequirements.AndroidLatestVersion,
-		"android_min_version":    utils.Cfg.ClientRequirements.AndroidMinVersion,
-		"desktop_latest_version": utils.Cfg.ClientRequirements.DesktopLatestVersion,
-		"desktop_min_version":    utils.Cfg.ClientRequirements.DesktopMinVersion,
-		"ios_latest_version":     utils.Cfg.ClientRequirements.IosLatestVersion,
-		"ios_min_version":        utils.Cfg.ClientRequirements.IosMinVersion,
+		"android_latest_version": cfg.ClientRequirements.AndroidLatestVersion,
+		"android_min_version":    cfg.ClientRequirements.AndroidMinVersion,
+		"desktop_latest_version": cfg.ClientRequirements.DesktopLatestVersion,
+		"desktop_min_version":    cfg.ClientRequirements.DesktopMinVersion,
+		"ios_latest_version":     cfg.ClientRequirements.IosLatestVersion,
+		"ios_min_version":        cfg.ClientRequirements.IosMinVersion,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_SQL, map[string]interface{}{
-		"driver_name":                 *utils.Cfg.SqlSettings.DriverName,
-		"trace":                       utils.Cfg.SqlSettings.Trace,
-		"max_idle_conns":              *utils.Cfg.SqlSettings.MaxIdleConns,
-		"max_open_conns":              *utils.Cfg.SqlSettings.MaxOpenConns,
-		"data_source_replicas":        len(utils.Cfg.SqlSettings.DataSourceReplicas),
-		"data_source_search_replicas": len(utils.Cfg.SqlSettings.DataSourceSearchReplicas),
-		"query_timeout":               *utils.Cfg.SqlSettings.QueryTimeout,
+		"driver_name":                 *cfg.SqlSettings.DriverName,
+		"trace":                       cfg.SqlSettings.Trace,
+		"max_idle_conns":              *cfg.SqlSettings.MaxIdleConns,
+		"max_open_conns":              *cfg.SqlSettings.MaxOpenConns,
+		"data_source_replicas":        len(cfg.SqlSettings.DataSourceReplicas),
+		"data_source_search_replicas": len(cfg.SqlSettings.DataSourceSearchReplicas),
+		"query_timeout":               *cfg.SqlSettings.QueryTimeout,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_LOG, map[string]interface{}{
-		"enable_console":           utils.Cfg.LogSettings.EnableConsole,
-		"console_level":            utils.Cfg.LogSettings.ConsoleLevel,
-		"enable_file":              utils.Cfg.LogSettings.EnableFile,
-		"file_level":               utils.Cfg.LogSettings.FileLevel,
-		"enable_webhook_debugging": utils.Cfg.LogSettings.EnableWebhookDebugging,
-		"isdefault_file_format":    isDefault(utils.Cfg.LogSettings.FileFormat, ""),
-		"isdefault_file_location":  isDefault(utils.Cfg.LogSettings.FileLocation, ""),
+		"enable_console":           cfg.LogSettings.EnableConsole,
+		"console_level":            cfg.LogSettings.ConsoleLevel,
+		"enable_file":              cfg.LogSettings.EnableFile,
+		"file_level":               cfg.LogSettings.FileLevel,
+		"enable_webhook_debugging": cfg.LogSettings.EnableWebhookDebugging,
+		"isdefault_file_format":    isDefault(cfg.LogSettings.FileFormat, ""),
+		"isdefault_file_location":  isDefault(cfg.LogSettings.FileLocation, ""),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_PASSWORD, map[string]interface{}{
-		"minimum_length": *utils.Cfg.PasswordSettings.MinimumLength,
-		"lowercase":      *utils.Cfg.PasswordSettings.Lowercase,
-		"number":         *utils.Cfg.PasswordSettings.Number,
-		"uppercase":      *utils.Cfg.PasswordSettings.Uppercase,
-		"symbol":         *utils.Cfg.PasswordSettings.Symbol,
+		"minimum_length": *cfg.PasswordSettings.MinimumLength,
+		"lowercase":      *cfg.PasswordSettings.Lowercase,
+		"number":         *cfg.PasswordSettings.Number,
+		"uppercase":      *cfg.PasswordSettings.Uppercase,
+		"symbol":         *cfg.PasswordSettings.Symbol,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_FILE, map[string]interface{}{
-		"enable_public_links":     utils.Cfg.FileSettings.EnablePublicLink,
-		"driver_name":             *utils.Cfg.FileSettings.DriverName,
-		"amazon_s3_ssl":           *utils.Cfg.FileSettings.AmazonS3SSL,
-		"amazon_s3_sse":           *utils.Cfg.FileSettings.AmazonS3SSE,
-		"amazon_s3_signv2":        *utils.Cfg.FileSettings.AmazonS3SignV2,
-		"amazon_s3_trace":         *utils.Cfg.FileSettings.AmazonS3Trace,
-		"max_file_size":           *utils.Cfg.FileSettings.MaxFileSize,
-		"enable_file_attachments": *utils.Cfg.FileSettings.EnableFileAttachments,
-		"enable_mobile_upload":    *utils.Cfg.FileSettings.EnableMobileUpload,
-		"enable_mobile_download":  *utils.Cfg.FileSettings.EnableMobileDownload,
+		"enable_public_links":     cfg.FileSettings.EnablePublicLink,
+		"driver_name":             *cfg.FileSettings.DriverName,
+		"amazon_s3_ssl":           *cfg.FileSettings.AmazonS3SSL,
+		"amazon_s3_sse":           *cfg.FileSettings.AmazonS3SSE,
+		"amazon_s3_signv2":        *cfg.FileSettings.AmazonS3SignV2,
+		"amazon_s3_trace":         *cfg.FileSettings.AmazonS3Trace,
+		"max_file_size":           *cfg.FileSettings.MaxFileSize,
+		"enable_file_attachments": *cfg.FileSettings.EnableFileAttachments,
+		"enable_mobile_upload":    *cfg.FileSettings.EnableMobileUpload,
+		"enable_mobile_download":  *cfg.FileSettings.EnableMobileDownload,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_EMAIL, map[string]interface{}{
-		"enable_sign_up_with_email":            utils.Cfg.EmailSettings.EnableSignUpWithEmail,
-		"enable_sign_in_with_email":            *utils.Cfg.EmailSettings.EnableSignInWithEmail,
-		"enable_sign_in_with_username":         *utils.Cfg.EmailSettings.EnableSignInWithUsername,
-		"require_email_verification":           utils.Cfg.EmailSettings.RequireEmailVerification,
-		"send_email_notifications":             utils.Cfg.EmailSettings.SendEmailNotifications,
-		"email_notification_contents_type":     *utils.Cfg.EmailSettings.EmailNotificationContentsType,
-		"enable_smtp_auth":                     *utils.Cfg.EmailSettings.EnableSMTPAuth,
-		"connection_security":                  utils.Cfg.EmailSettings.ConnectionSecurity,
-		"send_push_notifications":              *utils.Cfg.EmailSettings.SendPushNotifications,
-		"push_notification_contents":           *utils.Cfg.EmailSettings.PushNotificationContents,
-		"enable_email_batching":                *utils.Cfg.EmailSettings.EnableEmailBatching,
-		"email_batching_buffer_size":           *utils.Cfg.EmailSettings.EmailBatchingBufferSize,
-		"email_batching_interval":              *utils.Cfg.EmailSettings.EmailBatchingInterval,
-		"isdefault_feedback_name":              isDefault(utils.Cfg.EmailSettings.FeedbackName, ""),
-		"isdefault_feedback_email":             isDefault(utils.Cfg.EmailSettings.FeedbackEmail, ""),
-		"isdefault_feedback_organization":      isDefault(*utils.Cfg.EmailSettings.FeedbackOrganization, model.EMAIL_SETTINGS_DEFAULT_FEEDBACK_ORGANIZATION),
-		"skip_server_certificate_verification": *utils.Cfg.EmailSettings.SkipServerCertificateVerification,
+		"enable_sign_up_with_email":            cfg.EmailSettings.EnableSignUpWithEmail,
+		"enable_sign_in_with_email":            *cfg.EmailSettings.EnableSignInWithEmail,
+		"enable_sign_in_with_username":         *cfg.EmailSettings.EnableSignInWithUsername,
+		"require_email_verification":           cfg.EmailSettings.RequireEmailVerification,
+		"send_email_notifications":             cfg.EmailSettings.SendEmailNotifications,
+		"email_notification_contents_type":     *cfg.EmailSettings.EmailNotificationContentsType,
+		"enable_smtp_auth":                     *cfg.EmailSettings.EnableSMTPAuth,
+		"connection_security":                  cfg.EmailSettings.ConnectionSecurity,
+		"send_push_notifications":              *cfg.EmailSettings.SendPushNotifications,
+		"push_notification_contents":           *cfg.EmailSettings.PushNotificationContents,
+		"enable_email_batching":                *cfg.EmailSettings.EnableEmailBatching,
+		"email_batching_buffer_size":           *cfg.EmailSettings.EmailBatchingBufferSize,
+		"email_batching_interval":              *cfg.EmailSettings.EmailBatchingInterval,
+		"isdefault_feedback_name":              isDefault(cfg.EmailSettings.FeedbackName, ""),
+		"isdefault_feedback_email":             isDefault(cfg.EmailSettings.FeedbackEmail, ""),
+		"isdefault_feedback_organization":      isDefault(*cfg.EmailSettings.FeedbackOrganization, model.EMAIL_SETTINGS_DEFAULT_FEEDBACK_ORGANIZATION),
+		"skip_server_certificate_verification": *cfg.EmailSettings.SkipServerCertificateVerification,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_RATE, map[string]interface{}{
-		"enable_rate_limiter":      *utils.Cfg.RateLimitSettings.Enable,
-		"vary_by_remote_address":   utils.Cfg.RateLimitSettings.VaryByRemoteAddr,
-		"per_sec":                  *utils.Cfg.RateLimitSettings.PerSec,
-		"max_burst":                *utils.Cfg.RateLimitSettings.MaxBurst,
-		"memory_store_size":        *utils.Cfg.RateLimitSettings.MemoryStoreSize,
-		"isdefault_vary_by_header": isDefault(utils.Cfg.RateLimitSettings.VaryByHeader, ""),
+		"enable_rate_limiter":      *cfg.RateLimitSettings.Enable,
+		"vary_by_remote_address":   cfg.RateLimitSettings.VaryByRemoteAddr,
+		"per_sec":                  *cfg.RateLimitSettings.PerSec,
+		"max_burst":                *cfg.RateLimitSettings.MaxBurst,
+		"memory_store_size":        *cfg.RateLimitSettings.MemoryStoreSize,
+		"isdefault_vary_by_header": isDefault(cfg.RateLimitSettings.VaryByHeader, ""),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_PRIVACY, map[string]interface{}{
-		"show_email_address": utils.Cfg.PrivacySettings.ShowEmailAddress,
-		"show_full_name":     utils.Cfg.PrivacySettings.ShowFullName,
+		"show_email_address": cfg.PrivacySettings.ShowEmailAddress,
+		"show_full_name":     cfg.PrivacySettings.ShowFullName,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_THEME, map[string]interface{}{
-		"enable_theme_selection":  *utils.Cfg.ThemeSettings.EnableThemeSelection,
-		"isdefault_default_theme": isDefault(*utils.Cfg.ThemeSettings.DefaultTheme, model.TEAM_SETTINGS_DEFAULT_TEAM_TEXT),
-		"allow_custom_themes":     *utils.Cfg.ThemeSettings.AllowCustomThemes,
-		"allowed_themes":          len(utils.Cfg.ThemeSettings.AllowedThemes),
+		"enable_theme_selection":  *cfg.ThemeSettings.EnableThemeSelection,
+		"isdefault_default_theme": isDefault(*cfg.ThemeSettings.DefaultTheme, model.TEAM_SETTINGS_DEFAULT_TEAM_TEXT),
+		"allow_custom_themes":     *cfg.ThemeSettings.AllowCustomThemes,
+		"allowed_themes":          len(cfg.ThemeSettings.AllowedThemes),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_OAUTH, map[string]interface{}{
-		"enable_gitlab":    utils.Cfg.GitLabSettings.Enable,
-		"enable_google":    utils.Cfg.GoogleSettings.Enable,
-		"enable_office365": utils.Cfg.Office365Settings.Enable,
+		"enable_gitlab":    cfg.GitLabSettings.Enable,
+		"enable_google":    cfg.GoogleSettings.Enable,
+		"enable_office365": cfg.Office365Settings.Enable,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_SUPPORT, map[string]interface{}{
-		"isdefault_terms_of_service_link": isDefault(*utils.Cfg.SupportSettings.TermsOfServiceLink, model.SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK),
-		"isdefault_privacy_policy_link":   isDefault(*utils.Cfg.SupportSettings.PrivacyPolicyLink, model.SUPPORT_SETTINGS_DEFAULT_PRIVACY_POLICY_LINK),
-		"isdefault_about_link":            isDefault(*utils.Cfg.SupportSettings.AboutLink, model.SUPPORT_SETTINGS_DEFAULT_ABOUT_LINK),
-		"isdefault_help_link":             isDefault(*utils.Cfg.SupportSettings.HelpLink, model.SUPPORT_SETTINGS_DEFAULT_HELP_LINK),
-		"isdefault_report_a_problem_link": isDefault(*utils.Cfg.SupportSettings.ReportAProblemLink, model.SUPPORT_SETTINGS_DEFAULT_REPORT_A_PROBLEM_LINK),
-		"isdefault_support_email":         isDefault(*utils.Cfg.SupportSettings.SupportEmail, model.SUPPORT_SETTINGS_DEFAULT_SUPPORT_EMAIL),
+		"isdefault_terms_of_service_link": isDefault(*cfg.SupportSettings.TermsOfServiceLink, model.SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK),
+		"isdefault_privacy_policy_link":   isDefault(*cfg.SupportSettings.PrivacyPolicyLink, model.SUPPORT_SETTINGS_DEFAULT_PRIVACY_POLICY_LINK),
+		"isdefault_about_link":            isDefault(*cfg.SupportSettings.AboutLink, model.SUPPORT_SETTINGS_DEFAULT_ABOUT_LINK),
+		"isdefault_help_link":             isDefault(*cfg.SupportSettings.HelpLink, model.SUPPORT_SETTINGS_DEFAULT_HELP_LINK),
+		"isdefault_report_a_problem_link": isDefault(*cfg.SupportSettings.ReportAProblemLink, model.SUPPORT_SETTINGS_DEFAULT_REPORT_A_PROBLEM_LINK),
+		"isdefault_support_email":         isDefault(*cfg.SupportSettings.SupportEmail, model.SUPPORT_SETTINGS_DEFAULT_SUPPORT_EMAIL),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_LDAP, map[string]interface{}{
-		"enable":                         *utils.Cfg.LdapSettings.Enable,
-		"connection_security":            *utils.Cfg.LdapSettings.ConnectionSecurity,
-		"skip_certificate_verification":  *utils.Cfg.LdapSettings.SkipCertificateVerification,
-		"sync_interval_minutes":          *utils.Cfg.LdapSettings.SyncIntervalMinutes,
-		"query_timeout":                  *utils.Cfg.LdapSettings.QueryTimeout,
-		"max_page_size":                  *utils.Cfg.LdapSettings.MaxPageSize,
-		"isdefault_first_name_attribute": isDefault(*utils.Cfg.LdapSettings.FirstNameAttribute, model.LDAP_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE),
-		"isdefault_last_name_attribute":  isDefault(*utils.Cfg.LdapSettings.LastNameAttribute, model.LDAP_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE),
-		"isdefault_email_attribute":      isDefault(*utils.Cfg.LdapSettings.EmailAttribute, model.LDAP_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE),
-		"isdefault_username_attribute":   isDefault(*utils.Cfg.LdapSettings.UsernameAttribute, model.LDAP_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE),
-		"isdefault_nickname_attribute":   isDefault(*utils.Cfg.LdapSettings.NicknameAttribute, model.LDAP_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE),
-		"isdefault_id_attribute":         isDefault(*utils.Cfg.LdapSettings.IdAttribute, model.LDAP_SETTINGS_DEFAULT_ID_ATTRIBUTE),
-		"isdefault_position_attribute":   isDefault(*utils.Cfg.LdapSettings.PositionAttribute, model.LDAP_SETTINGS_DEFAULT_POSITION_ATTRIBUTE),
-		"isdefault_login_field_name":     isDefault(*utils.Cfg.LdapSettings.LoginFieldName, model.LDAP_SETTINGS_DEFAULT_LOGIN_FIELD_NAME),
+		"enable":                         *cfg.LdapSettings.Enable,
+		"connection_security":            *cfg.LdapSettings.ConnectionSecurity,
+		"skip_certificate_verification":  *cfg.LdapSettings.SkipCertificateVerification,
+		"sync_interval_minutes":          *cfg.LdapSettings.SyncIntervalMinutes,
+		"query_timeout":                  *cfg.LdapSettings.QueryTimeout,
+		"max_page_size":                  *cfg.LdapSettings.MaxPageSize,
+		"isdefault_first_name_attribute": isDefault(*cfg.LdapSettings.FirstNameAttribute, model.LDAP_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE),
+		"isdefault_last_name_attribute":  isDefault(*cfg.LdapSettings.LastNameAttribute, model.LDAP_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE),
+		"isdefault_email_attribute":      isDefault(*cfg.LdapSettings.EmailAttribute, model.LDAP_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE),
+		"isdefault_username_attribute":   isDefault(*cfg.LdapSettings.UsernameAttribute, model.LDAP_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE),
+		"isdefault_nickname_attribute":   isDefault(*cfg.LdapSettings.NicknameAttribute, model.LDAP_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE),
+		"isdefault_id_attribute":         isDefault(*cfg.LdapSettings.IdAttribute, model.LDAP_SETTINGS_DEFAULT_ID_ATTRIBUTE),
+		"isdefault_position_attribute":   isDefault(*cfg.LdapSettings.PositionAttribute, model.LDAP_SETTINGS_DEFAULT_POSITION_ATTRIBUTE),
+		"isdefault_login_field_name":     isDefault(*cfg.LdapSettings.LoginFieldName, model.LDAP_SETTINGS_DEFAULT_LOGIN_FIELD_NAME),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_COMPLIANCE, map[string]interface{}{
-		"enable":       *utils.Cfg.ComplianceSettings.Enable,
-		"enable_daily": *utils.Cfg.ComplianceSettings.EnableDaily,
+		"enable":       *cfg.ComplianceSettings.Enable,
+		"enable_daily": *cfg.ComplianceSettings.EnableDaily,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_LOCALIZATION, map[string]interface{}{
-		"default_server_locale": *utils.Cfg.LocalizationSettings.DefaultServerLocale,
-		"default_client_locale": *utils.Cfg.LocalizationSettings.DefaultClientLocale,
-		"available_locales":     *utils.Cfg.LocalizationSettings.AvailableLocales,
+		"default_server_locale": *cfg.LocalizationSettings.DefaultServerLocale,
+		"default_client_locale": *cfg.LocalizationSettings.DefaultClientLocale,
+		"available_locales":     *cfg.LocalizationSettings.AvailableLocales,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_SAML, map[string]interface{}{
-		"enable":                         *utils.Cfg.SamlSettings.Enable,
-		"verify":                         *utils.Cfg.SamlSettings.Verify,
-		"encrypt":                        *utils.Cfg.SamlSettings.Encrypt,
-		"isdefault_first_name_attribute": isDefault(*utils.Cfg.SamlSettings.FirstNameAttribute, model.SAML_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE),
-		"isdefault_last_name_attribute":  isDefault(*utils.Cfg.SamlSettings.LastNameAttribute, model.SAML_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE),
-		"isdefault_email_attribute":      isDefault(*utils.Cfg.SamlSettings.EmailAttribute, model.SAML_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE),
-		"isdefault_username_attribute":   isDefault(*utils.Cfg.SamlSettings.UsernameAttribute, model.SAML_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE),
-		"isdefault_nickname_attribute":   isDefault(*utils.Cfg.SamlSettings.NicknameAttribute, model.SAML_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE),
-		"isdefault_locale_attribute":     isDefault(*utils.Cfg.SamlSettings.LocaleAttribute, model.SAML_SETTINGS_DEFAULT_LOCALE_ATTRIBUTE),
-		"isdefault_position_attribute":   isDefault(*utils.Cfg.SamlSettings.PositionAttribute, model.SAML_SETTINGS_DEFAULT_POSITION_ATTRIBUTE),
-		"isdefault_login_button_text":    isDefault(*utils.Cfg.SamlSettings.LoginButtonText, model.USER_AUTH_SERVICE_SAML_TEXT),
+		"enable":                         *cfg.SamlSettings.Enable,
+		"verify":                         *cfg.SamlSettings.Verify,
+		"encrypt":                        *cfg.SamlSettings.Encrypt,
+		"isdefault_first_name_attribute": isDefault(*cfg.SamlSettings.FirstNameAttribute, model.SAML_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE),
+		"isdefault_last_name_attribute":  isDefault(*cfg.SamlSettings.LastNameAttribute, model.SAML_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE),
+		"isdefault_email_attribute":      isDefault(*cfg.SamlSettings.EmailAttribute, model.SAML_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE),
+		"isdefault_username_attribute":   isDefault(*cfg.SamlSettings.UsernameAttribute, model.SAML_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE),
+		"isdefault_nickname_attribute":   isDefault(*cfg.SamlSettings.NicknameAttribute, model.SAML_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE),
+		"isdefault_locale_attribute":     isDefault(*cfg.SamlSettings.LocaleAttribute, model.SAML_SETTINGS_DEFAULT_LOCALE_ATTRIBUTE),
+		"isdefault_position_attribute":   isDefault(*cfg.SamlSettings.PositionAttribute, model.SAML_SETTINGS_DEFAULT_POSITION_ATTRIBUTE),
+		"isdefault_login_button_text":    isDefault(*cfg.SamlSettings.LoginButtonText, model.USER_AUTH_SERVICE_SAML_TEXT),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_CLUSTER, map[string]interface{}{
-		"enable":                  *utils.Cfg.ClusterSettings.Enable,
-		"use_ip_address":          *utils.Cfg.ClusterSettings.UseIpAddress,
-		"use_experimental_gossip": *utils.Cfg.ClusterSettings.UseExperimentalGossip,
-		"read_only_config":        *utils.Cfg.ClusterSettings.ReadOnlyConfig,
+		"enable":                  *cfg.ClusterSettings.Enable,
+		"use_ip_address":          *cfg.ClusterSettings.UseIpAddress,
+		"use_experimental_gossip": *cfg.ClusterSettings.UseExperimentalGossip,
+		"read_only_config":        *cfg.ClusterSettings.ReadOnlyConfig,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_METRICS, map[string]interface{}{
-		"enable":             *utils.Cfg.MetricsSettings.Enable,
-		"block_profile_rate": *utils.Cfg.MetricsSettings.BlockProfileRate,
+		"enable":             *cfg.MetricsSettings.Enable,
+		"block_profile_rate": *cfg.MetricsSettings.BlockProfileRate,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_NATIVEAPP, map[string]interface{}{
-		"isdefault_app_download_link":         isDefault(*utils.Cfg.NativeAppSettings.AppDownloadLink, model.NATIVEAPP_SETTINGS_DEFAULT_APP_DOWNLOAD_LINK),
-		"isdefault_android_app_download_link": isDefault(*utils.Cfg.NativeAppSettings.AndroidAppDownloadLink, model.NATIVEAPP_SETTINGS_DEFAULT_ANDROID_APP_DOWNLOAD_LINK),
-		"isdefault_iosapp_download_link":      isDefault(*utils.Cfg.NativeAppSettings.IosAppDownloadLink, model.NATIVEAPP_SETTINGS_DEFAULT_IOS_APP_DOWNLOAD_LINK),
+		"isdefault_app_download_link":         isDefault(*cfg.NativeAppSettings.AppDownloadLink, model.NATIVEAPP_SETTINGS_DEFAULT_APP_DOWNLOAD_LINK),
+		"isdefault_android_app_download_link": isDefault(*cfg.NativeAppSettings.AndroidAppDownloadLink, model.NATIVEAPP_SETTINGS_DEFAULT_ANDROID_APP_DOWNLOAD_LINK),
+		"isdefault_iosapp_download_link":      isDefault(*cfg.NativeAppSettings.IosAppDownloadLink, model.NATIVEAPP_SETTINGS_DEFAULT_IOS_APP_DOWNLOAD_LINK),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_WEBRTC, map[string]interface{}{
-		"enable":             *utils.Cfg.WebrtcSettings.Enable,
-		"isdefault_stun_uri": isDefault(*utils.Cfg.WebrtcSettings.StunURI, model.WEBRTC_SETTINGS_DEFAULT_STUN_URI),
-		"isdefault_turn_uri": isDefault(*utils.Cfg.WebrtcSettings.TurnURI, model.WEBRTC_SETTINGS_DEFAULT_TURN_URI),
+		"enable":             *cfg.WebrtcSettings.Enable,
+		"isdefault_stun_uri": isDefault(*cfg.WebrtcSettings.StunURI, model.WEBRTC_SETTINGS_DEFAULT_STUN_URI),
+		"isdefault_turn_uri": isDefault(*cfg.WebrtcSettings.TurnURI, model.WEBRTC_SETTINGS_DEFAULT_TURN_URI),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_ANALYTICS, map[string]interface{}{
-		"isdefault_max_users_for_statistics": isDefault(*utils.Cfg.AnalyticsSettings.MaxUsersForStatistics, model.ANALYTICS_SETTINGS_DEFAULT_MAX_USERS_FOR_STATISTICS),
+		"isdefault_max_users_for_statistics": isDefault(*cfg.AnalyticsSettings.MaxUsersForStatistics, model.ANALYTICS_SETTINGS_DEFAULT_MAX_USERS_FOR_STATISTICS),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_ANNOUNCEMENT, map[string]interface{}{
-		"enable_banner":               *utils.Cfg.AnnouncementSettings.EnableBanner,
-		"isdefault_banner_color":      isDefault(*utils.Cfg.AnnouncementSettings.BannerColor, model.ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_COLOR),
-		"isdefault_banner_text_color": isDefault(*utils.Cfg.AnnouncementSettings.BannerTextColor, model.ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_TEXT_COLOR),
-		"allow_banner_dismissal":      *utils.Cfg.AnnouncementSettings.AllowBannerDismissal,
+		"enable_banner":               *cfg.AnnouncementSettings.EnableBanner,
+		"isdefault_banner_color":      isDefault(*cfg.AnnouncementSettings.BannerColor, model.ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_COLOR),
+		"isdefault_banner_text_color": isDefault(*cfg.AnnouncementSettings.BannerTextColor, model.ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_TEXT_COLOR),
+		"allow_banner_dismissal":      *cfg.AnnouncementSettings.AllowBannerDismissal,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_ELASTICSEARCH, map[string]interface{}{
-		"isdefault_connection_url": isDefault(*utils.Cfg.ElasticsearchSettings.ConnectionUrl, model.ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL),
-		"isdefault_username":       isDefault(*utils.Cfg.ElasticsearchSettings.Username, model.ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME),
-		"isdefault_password":       isDefault(*utils.Cfg.ElasticsearchSettings.Password, model.ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD),
-		"enable_indexing":          *utils.Cfg.ElasticsearchSettings.EnableIndexing,
-		"enable_searching":         *utils.Cfg.ElasticsearchSettings.EnableSearching,
-		"sniff":                    *utils.Cfg.ElasticsearchSettings.Sniff,
-		"post_index_replicas":      *utils.Cfg.ElasticsearchSettings.PostIndexReplicas,
-		"post_index_shards":        *utils.Cfg.ElasticsearchSettings.PostIndexShards,
-		"isdefault_index_prefix":   isDefault(*utils.Cfg.ElasticsearchSettings.IndexPrefix, model.ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX),
+		"isdefault_connection_url": isDefault(*cfg.ElasticsearchSettings.ConnectionUrl, model.ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL),
+		"isdefault_username":       isDefault(*cfg.ElasticsearchSettings.Username, model.ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME),
+		"isdefault_password":       isDefault(*cfg.ElasticsearchSettings.Password, model.ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD),
+		"enable_indexing":          *cfg.ElasticsearchSettings.EnableIndexing,
+		"enable_searching":         *cfg.ElasticsearchSettings.EnableSearching,
+		"sniff":                    *cfg.ElasticsearchSettings.Sniff,
+		"post_index_replicas":      *cfg.ElasticsearchSettings.PostIndexReplicas,
+		"post_index_shards":        *cfg.ElasticsearchSettings.PostIndexShards,
+		"isdefault_index_prefix":   isDefault(*cfg.ElasticsearchSettings.IndexPrefix, model.ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_PLUGIN, map[string]interface{}{
-		"enable_jira": pluginSetting("jira", "enabled", false),
+		"enable_jira": pluginSetting(cfg, "jira", "enabled", false),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_DATA_RETENTION, map[string]interface{}{
-		"enable_message_deletion": *utils.Cfg.DataRetentionSettings.EnableMessageDeletion,
-		"enable_file_deletion":    *utils.Cfg.DataRetentionSettings.EnableFileDeletion,
-		"message_retention_days":  *utils.Cfg.DataRetentionSettings.MessageRetentionDays,
-		"file_retention_days":     *utils.Cfg.DataRetentionSettings.FileRetentionDays,
-		"deletion_job_start_time": *utils.Cfg.DataRetentionSettings.DeletionJobStartTime,
+		"enable_message_deletion": *cfg.DataRetentionSettings.EnableMessageDeletion,
+		"enable_file_deletion":    *cfg.DataRetentionSettings.EnableFileDeletion,
+		"message_retention_days":  *cfg.DataRetentionSettings.MessageRetentionDays,
+		"file_retention_days":     *cfg.DataRetentionSettings.FileRetentionDays,
+		"deletion_job_start_time": *cfg.DataRetentionSettings.DeletionJobStartTime,
 	})
 }
 

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -92,8 +92,8 @@ func isDefault(setting interface{}, defaultValue interface{}) bool {
 	return false
 }
 
-func pluginSetting(cfg *model.Config, plugin, key string, defaultValue interface{}) interface{} {
-	settings, ok := cfg.PluginSettings.Plugins[plugin]
+func pluginSetting(pluginSettings *model.PluginSettings, plugin, key string, defaultValue interface{}) interface{} {
+	settings, ok := pluginSettings.Plugins[plugin]
 	if !ok {
 		return defaultValue
 	}
@@ -448,7 +448,7 @@ func (a *App) trackConfig() {
 	})
 
 	SendDiagnostic(TRACK_CONFIG_PLUGIN, map[string]interface{}{
-		"enable_jira": pluginSetting(cfg, "jira", "enabled", false),
+		"enable_jira": pluginSetting(&cfg.PluginSettings, "jira", "enabled", false),
 	})
 
 	SendDiagnostic(TRACK_CONFIG_DATA_RETENTION, map[string]interface{}{

--- a/app/diagnostics_test.go
+++ b/app/diagnostics_test.go
@@ -12,6 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
@@ -29,21 +32,15 @@ func newTestServer() (chan string, *httptest.Server) {
 }
 
 func TestPluginSetting(t *testing.T) {
-	before := utils.Cfg.PluginSettings.Plugins
-	utils.Cfg.PluginSettings.Plugins = map[string]interface{}{
-		"test": map[string]string{
-			"foo": "bar",
+	settings := &model.PluginSettings{
+		Plugins: map[string]interface{}{
+			"test": map[string]string{
+				"foo": "bar",
+			},
 		},
 	}
-	defer func() {
-		utils.Cfg.PluginSettings.Plugins = before
-	}()
-	if pluginSetting("test", "foo", "asd") != "bar" {
-		t.Fatal()
-	}
-	if pluginSetting("test", "qwe", "asd") != "asd" {
-		t.Fatal()
-	}
+	assert.Equal(t, "bar", pluginSetting(settings, "test", "foo", "asd"))
+	assert.Equal(t, "asd", pluginSetting(settings, "test", "qwe", "asd"))
 }
 
 func TestDiagnostics(t *testing.T) {

--- a/model/config.go
+++ b/model/config.go
@@ -541,6 +541,14 @@ type Config struct {
 	PluginSettings        PluginSettings
 }
 
+func (o *Config) Clone() *Config {
+	var ret Config
+	if err := json.Unmarshal([]byte(o.ToJson()), &ret); err != nil {
+		panic(err)
+	}
+	return &ret
+}
+
 func (o *Config) ToJson() string {
 	b, err := json.Marshal(o)
 	if err != nil {


### PR DESCRIPTION
#### Summary
I'm aiming to make it impossible for tests to contaminate global state. That means I'm eliminating all of this sort of thing:

```go
prevX = utils.Cfg.X
defer func() {
    utils.Cfg.X = prevX
}()
utils.Cfg.X = testXValue
```

There is a lot of code that can just be deleted. This doesn't cover all of it. Just some that I covered by hand. I'll have some follow up reviews to get the rest.

#### Ticket Link
N/A

#### Checklist
N/A