### PR TITLE
Refactor max channels per team enforcement (and fix off-by-one)

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -142,7 +142,7 @@ func (a *App) CreateChannelWithUser(channel *model.Channel, userId string) (*mod
 }
 
 func (a *App) CreateChannel(channel *model.Channel, addMember bool) (*model.Channel, *model.AppError) {
-	if result := <-a.Srv.Store.Channel().Save(channel); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().Save(channel, *a.Config().TeamSettings.MaxChannelsPerTeam); result.Err != nil {
 		return nil, result.Err
 	} else {
 		sc := result.Data.(*model.Channel)
@@ -282,7 +282,7 @@ func (a *App) createGroupChannel(userIds []string, creatorId string) (*model.Cha
 		Type:        model.CHANNEL_GROUP,
 	}
 
-	if result := <-a.Srv.Store.Channel().Save(group); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().Save(group, *a.Config().TeamSettings.MaxChannelsPerTeam); result.Err != nil {
 		if result.Err.Id == store.CHANNEL_EXISTS_ERROR {
 			return result.Data.(*model.Channel), result.Err
 		} else {

--- a/app/import.go
+++ b/app/import.go
@@ -1476,7 +1476,7 @@ func (a *App) OldImportUser(team *model.Team, user *model.User) *model.User {
 }
 
 func (a *App) OldImportChannel(channel *model.Channel) *model.Channel {
-	if result := <-a.Srv.Store.Channel().Save(channel); result.Err != nil {
+	if result := <-a.Srv.Store.Channel().Save(channel, *a.Config().TeamSettings.MaxChannelsPerTeam); result.Err != nil {
 		return nil
 	} else {
 		sc := result.Data.(*model.Channel)

--- a/store/store.go
+++ b/store/store.go
@@ -104,7 +104,7 @@ type TeamStore interface {
 }
 
 type ChannelStore interface {
-	Save(channel *model.Channel) StoreChannel
+	Save(channel *model.Channel, maxChannelsPerTeam int64) StoreChannel
 	CreateDirectChannel(userId string, otherUserId string) StoreChannel
 	SaveDirectChannel(channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) StoreChannel
 	Update(channel *model.Channel) StoreChannel

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -46,6 +46,7 @@ func TestChannelStore(t *testing.T, ss store.Store) {
 	t.Run("GetMembersByIds", func(t *testing.T) { testChannelStoreGetMembersByIds(t, ss) })
 	t.Run("AnalyticsDeletedTypeCount", func(t *testing.T) { testChannelStoreAnalyticsDeletedTypeCount(t, ss) })
 	t.Run("GetPinnedPosts", func(t *testing.T) { testChannelStoreGetPinnedPosts(t, ss) })
+	t.Run("MaxChannelsPerTeam", func(t *testing.T) { testChannelStoreMaxChannelsPerTeam(t, ss) })
 }
 
 func testChannelStoreSave(t *testing.T, ss store.Store) {
@@ -57,23 +58,23 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
 
-	if err := (<-ss.Channel().Save(&o1)).Err; err != nil {
+	if err := (<-ss.Channel().Save(&o1, -1)).Err; err != nil {
 		t.Fatal("couldn't save item", err)
 	}
 
-	if err := (<-ss.Channel().Save(&o1)).Err; err == nil {
+	if err := (<-ss.Channel().Save(&o1, -1)).Err; err == nil {
 		t.Fatal("shouldn't be able to update from save")
 	}
 
 	o1.Id = ""
-	if err := (<-ss.Channel().Save(&o1)).Err; err == nil {
+	if err := (<-ss.Channel().Save(&o1, -1)).Err; err == nil {
 		t.Fatal("should be unique name")
 	}
 
 	o1.Id = ""
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_DIRECT
-	if err := (<-ss.Channel().Save(&o1)).Err; err == nil {
+	if err := (<-ss.Channel().Save(&o1, -1)).Err; err == nil {
 		t.Fatal("Should not be able to save direct channel")
 	}
 }
@@ -179,14 +180,14 @@ func testChannelStoreUpdate(t *testing.T, ss store.Store) {
 	o1.DisplayName = "Name"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Name"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -223,13 +224,13 @@ func testGetChannelUnread(t *testing.T, ss store.Store) {
 
 	// Setup Channel 1
 	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Downtown", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
-	store.Must(ss.Channel().Save(c1))
+	store.Must(ss.Channel().Save(c1, -1))
 	cm1 := &model.ChannelMember{ChannelId: c1.Id, UserId: m1.UserId, NotifyProps: notifyPropsModel, MsgCount: 90}
 	store.Must(ss.Channel().SaveMember(cm1))
 
 	// Setup Channel 2
 	c2 := &model.Channel{TeamId: m2.TeamId, Name: model.NewId(), DisplayName: "Cultural", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
-	store.Must(ss.Channel().Save(c2))
+	store.Must(ss.Channel().Save(c2, -1))
 	cm2 := &model.ChannelMember{ChannelId: c2.Id, UserId: m2.UserId, NotifyProps: notifyPropsModel, MsgCount: 90, MentionCount: 5}
 	store.Must(ss.Channel().SaveMember(cm2))
 
@@ -288,7 +289,7 @@ func testChannelStoreGet(t *testing.T, ss store.Store) {
 	o1.DisplayName = "Name"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	if r1 := <-ss.Channel().Get(o1.Id, false); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -373,7 +374,7 @@ func testChannelStoreGetForPost(t *testing.T, ss store.Store) {
 		DisplayName: "Name",
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
-	})).(*model.Channel)
+	}, -1)).(*model.Channel)
 
 	p1 := store.Must(ss.Post().Save(&model.Post{
 		UserId:    model.NewId(),
@@ -394,7 +395,7 @@ func testChannelStoreRestore(t *testing.T, ss store.Store) {
 	o1.DisplayName = "Channel1"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	if r := <-ss.Channel().Delete(o1.Id, model.GetMillis()); r.Err != nil {
 		t.Fatal(r.Err)
@@ -420,28 +421,28 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	o1.DisplayName = "Channel1"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	o3 := model.Channel{}
 	o3.TeamId = o1.TeamId
 	o3.DisplayName = "Channel3"
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o3))
+	store.Must(ss.Channel().Save(&o3, -1))
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
 	o4.DisplayName = "Channel4"
 	o4.Name = "zz" + model.NewId() + "b"
 	o4.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o4))
+	store.Must(ss.Channel().Save(&o4, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -500,7 +501,7 @@ func testChannelStoreGetByName(t *testing.T, ss store.Store) {
 	o1.DisplayName = "Name"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	r1 := <-ss.Channel().GetByName(o1.TeamId, o1.Name, true)
 	if r1.Err != nil {
@@ -541,7 +542,7 @@ func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
 	o1.DeleteAt = model.GetMillis()
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	if r1 := <-ss.Channel().GetDeletedByName(o1.TeamId, o1.Name); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -563,7 +564,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
 	o1.DeleteAt = model.GetMillis()
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	cresult := <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -584,7 +585,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	cresult = <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -602,7 +603,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_OPEN
 	o3.DeleteAt = model.GetMillis()
-	store.Must(ss.Channel().Save(&o3))
+	store.Must(ss.Channel().Save(&o3, -1))
 
 	cresult = <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -642,7 +643,7 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	c1.DisplayName = "NameName"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = *store.Must(ss.Channel().Save(&c1)).(*model.Channel)
+	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
 
 	c1t1 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
 	t1 := c1t1.ExtraUpdateAt
@@ -737,7 +738,7 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	c1.DisplayName = "NameName"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = *store.Must(ss.Channel().Save(&c1)).(*model.Channel)
+	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
 
 	c1t1 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
 	t1 := c1t1.ExtraUpdateAt
@@ -801,14 +802,14 @@ func testChannelStoreGetChannels(t *testing.T, ss store.Store) {
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -878,14 +879,14 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o1.DisplayName = "Channel1"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -910,21 +911,21 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o3.DisplayName = "ChannelA"
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o3))
+	store.Must(ss.Channel().Save(&o3, -1))
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
 	o4.DisplayName = "ChannelB"
 	o4.Name = "zz" + model.NewId() + "b"
 	o4.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o4))
+	store.Must(ss.Channel().Save(&o4, -1))
 
 	o5 := model.Channel{}
 	o5.TeamId = o1.TeamId
 	o5.DisplayName = "ChannelC"
 	o5.Name = "zz" + model.NewId() + "b"
 	o5.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o5))
+	store.Must(ss.Channel().Save(&o5, -1))
 
 	cresult := <-ss.Channel().GetMoreChannels(o1.TeamId, m1.UserId, 0, 100)
 	if cresult.Err != nil {
@@ -945,7 +946,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o6.DisplayName = "ChannelA"
 	o6.Name = "zz" + model.NewId() + "b"
 	o6.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o6))
+	store.Must(ss.Channel().Save(&o6, -1))
 
 	cresult = <-ss.Channel().GetMoreChannels(o1.TeamId, m1.UserId, 0, 100)
 	list = cresult.Data.(*model.ChannelList)
@@ -993,21 +994,21 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o1.DisplayName = "OpenChannel1Team1"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "OpenChannel1Team2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	o3 := model.Channel{}
 	o3.TeamId = o1.TeamId
 	o3.DisplayName = "PrivateChannel1Team1"
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o3))
+	store.Must(ss.Channel().Save(&o3, -1))
 
 	cresult := <-ss.Channel().GetPublicChannelsForTeam(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -1028,7 +1029,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o4.DisplayName = "OpenChannel2Team1"
 	o4.Name = "zz" + model.NewId() + "b"
 	o4.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o4))
+	store.Must(ss.Channel().Save(&o4, -1))
 
 	cresult = <-ss.Channel().GetPublicChannelsForTeam(o1.TeamId, 0, 100)
 	list = cresult.Data.(*model.ChannelList)
@@ -1078,21 +1079,21 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc1.DisplayName = "OpenChannel1Team1"
 	oc1.Name = "zz" + model.NewId() + "b"
 	oc1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&oc1))
+	store.Must(ss.Channel().Save(&oc1, -1))
 
 	oc2 := model.Channel{}
 	oc2.TeamId = model.NewId()
 	oc2.DisplayName = "OpenChannel2TeamOther"
 	oc2.Name = "zz" + model.NewId() + "b"
 	oc2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&oc2))
+	store.Must(ss.Channel().Save(&oc2, -1))
 
 	pc3 := model.Channel{}
 	pc3.TeamId = teamId1
 	pc3.DisplayName = "PrivateChannel3Team1"
 	pc3.Name = "zz" + model.NewId() + "b"
 	pc3.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&pc3))
+	store.Must(ss.Channel().Save(&pc3, -1))
 
 	cids := []string{oc1.Id}
 	cresult := <-ss.Channel().GetPublicChannelsByIdsForTeam(teamId1, cids)
@@ -1121,7 +1122,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc4.DisplayName = "OpenChannel4Team1"
 	oc4.Name = "zz" + model.NewId() + "b"
 	oc4.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&oc4))
+	store.Must(ss.Channel().Save(&oc4, -1))
 
 	cids = append(cids, oc4.Id)
 	cresult = <-ss.Channel().GetPublicChannelsByIdsForTeam(teamId1, cids)
@@ -1155,14 +1156,14 @@ func testChannelStoreGetChannelCounts(t *testing.T, ss store.Store) {
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -1207,14 +1208,14 @@ func testChannelStoreGetMembersForUser(t *testing.T, ss store.Store) {
 	o1.DisplayName = "Channel1"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -1245,7 +1246,7 @@ func testChannelStoreUpdateLastViewedAt(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 	o1.TotalMsgCount = 25
 	o1.LastPostAt = 12345
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -1260,7 +1261,7 @@ func testChannelStoreUpdateLastViewedAt(t *testing.T, ss store.Store) {
 	o2.Type = model.CHANNEL_OPEN
 	o2.TotalMsgCount = 26
 	o2.LastPostAt = 123456
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	m2 := model.ChannelMember{}
 	m2.ChannelId = o2.Id
@@ -1302,7 +1303,7 @@ func testChannelStoreIncrementMentionCount(t *testing.T, ss store.Store) {
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
 	o1.TotalMsgCount = 25
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -1340,7 +1341,7 @@ func testUpdateChannelMember(t *testing.T, ss store.Store) {
 		Name:        model.NewId(),
 		Type:        model.CHANNEL_OPEN,
 	}
-	store.Must(ss.Channel().Save(c1))
+	store.Must(ss.Channel().Save(c1, -1))
 
 	m1 := &model.ChannelMember{
 		ChannelId:   c1.Id,
@@ -1369,7 +1370,7 @@ func testGetMember(t *testing.T, ss store.Store) {
 		Name:        model.NewId(),
 		Type:        model.CHANNEL_OPEN,
 	}
-	store.Must(ss.Channel().Save(c1))
+	store.Must(ss.Channel().Save(c1, -1))
 
 	c2 := &model.Channel{
 		TeamId:      c1.TeamId,
@@ -1377,7 +1378,7 @@ func testGetMember(t *testing.T, ss store.Store) {
 		Name:        model.NewId(),
 		Type:        model.CHANNEL_OPEN,
 	}
-	store.Must(ss.Channel().Save(c2))
+	store.Must(ss.Channel().Save(c2, -1))
 
 	m1 := &model.ChannelMember{
 		ChannelId:   c1.Id,
@@ -1444,7 +1445,7 @@ func testChannelStoreGetMemberForPost(t *testing.T, ss store.Store) {
 		DisplayName: "Name",
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
-	})).(*model.Channel)
+	}, -1)).(*model.Channel)
 
 	m1 := store.Must(ss.Channel().SaveMember(&model.ChannelMember{
 		ChannelId:   o1.Id,
@@ -1478,7 +1479,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
-	store.Must(ss.Channel().Save(&c1))
+	store.Must(ss.Channel().Save(&c1, -1))
 
 	c2 := model.Channel{
 		TeamId:      teamId,
@@ -1486,7 +1487,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
-	store.Must(ss.Channel().Save(&c2))
+	store.Must(ss.Channel().Save(&c2, -1))
 
 	u1 := &model.User{
 		Email:    model.NewId(),
@@ -1580,7 +1581,7 @@ func testUpdateExtrasByUser(t *testing.T, ss store.Store) {
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
-	store.Must(ss.Channel().Save(&c1))
+	store.Must(ss.Channel().Save(&c1, -1))
 
 	c2 := model.Channel{
 		TeamId:      teamId,
@@ -1588,7 +1589,7 @@ func testUpdateExtrasByUser(t *testing.T, ss store.Store) {
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
-	store.Must(ss.Channel().Save(&c2))
+	store.Must(ss.Channel().Save(&c2, -1))
 
 	u1 := &model.User{
 		Email:    model.NewId(),
@@ -1625,14 +1626,14 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o1.DisplayName = "ChannelA"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -1657,42 +1658,42 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o3.DisplayName = "ChannelA"
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o3))
+	store.Must(ss.Channel().Save(&o3, -1))
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
 	o4.DisplayName = "ChannelB"
 	o4.Name = "zz" + model.NewId() + "b"
 	o4.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o4))
+	store.Must(ss.Channel().Save(&o4, -1))
 
 	o5 := model.Channel{}
 	o5.TeamId = o1.TeamId
 	o5.DisplayName = "ChannelC"
 	o5.Name = "zz" + model.NewId() + "b"
 	o5.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o5))
+	store.Must(ss.Channel().Save(&o5, -1))
 
 	o6 := model.Channel{}
 	o6.TeamId = o1.TeamId
 	o6.DisplayName = "Off-Topic"
 	o6.Name = "off-topic"
 	o6.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o6))
+	store.Must(ss.Channel().Save(&o6, -1))
 
 	o7 := model.Channel{}
 	o7.TeamId = o1.TeamId
 	o7.DisplayName = "Off-Set"
 	o7.Name = "off-set"
 	o7.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o7))
+	store.Must(ss.Channel().Save(&o7, -1))
 
 	o8 := model.Channel{}
 	o8.TeamId = o1.TeamId
 	o8.DisplayName = "Off-Limit"
 	o8.Name = "off-limit"
 	o8.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o8))
+	store.Must(ss.Channel().Save(&o8, -1))
 
 	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
@@ -1776,14 +1777,14 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o1.DisplayName = "ChannelA"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = o1.Id
@@ -1808,42 +1809,42 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o3.DisplayName = "ChannelA"
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o3))
+	store.Must(ss.Channel().Save(&o3, -1))
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
 	o4.DisplayName = "ChannelB"
 	o4.Name = "zz" + model.NewId() + "b"
 	o4.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o4))
+	store.Must(ss.Channel().Save(&o4, -1))
 
 	o5 := model.Channel{}
 	o5.TeamId = o1.TeamId
 	o5.DisplayName = "ChannelC"
 	o5.Name = "zz" + model.NewId() + "b"
 	o5.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o5))
+	store.Must(ss.Channel().Save(&o5, -1))
 
 	o6 := model.Channel{}
 	o6.TeamId = o1.TeamId
 	o6.DisplayName = "Off-Topic"
 	o6.Name = "off-topic"
 	o6.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o6))
+	store.Must(ss.Channel().Save(&o6, -1))
 
 	o7 := model.Channel{}
 	o7.TeamId = o1.TeamId
 	o7.DisplayName = "Off-Set"
 	o7.Name = "off-set"
 	o7.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o7))
+	store.Must(ss.Channel().Save(&o7, -1))
 
 	o8 := model.Channel{}
 	o8.TeamId = o1.TeamId
 	o8.DisplayName = "Off-Limit"
 	o8.Name = "off-limit"
 	o8.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&o8))
+	store.Must(ss.Channel().Save(&o8, -1))
 
 	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
@@ -1918,7 +1919,7 @@ func testChannelStoreGetMembersByIds(t *testing.T, ss store.Store) {
 	o1.DisplayName = "ChannelA"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	m1 := &model.ChannelMember{ChannelId: o1.Id, UserId: model.NewId(), NotifyProps: model.GetDefaultChannelNotifyProps()}
 	store.Must(ss.Channel().SaveMember(m1))
@@ -1961,21 +1962,21 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	o1.DisplayName = "ChannelA"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o1))
+	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
 	o2.Name = "zz" + model.NewId() + "b"
 	o2.Type = model.CHANNEL_OPEN
-	store.Must(ss.Channel().Save(&o2))
+	store.Must(ss.Channel().Save(&o2, -1))
 
 	p3 := model.Channel{}
 	p3.TeamId = model.NewId()
 	p3.DisplayName = "Channel3"
 	p3.Name = "zz" + model.NewId() + "b"
 	p3.Type = model.CHANNEL_PRIVATE
-	store.Must(ss.Channel().Save(&p3))
+	store.Must(ss.Channel().Save(&p3, -1))
 
 	u1 := &model.User{}
 	u1.Email = model.NewId()
@@ -2051,7 +2052,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 		DisplayName: "Name",
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
-	})).(*model.Channel)
+	}, -1)).(*model.Channel)
 
 	p1 := store.Must(ss.Post().Save(&model.Post{
 		UserId:    model.NewId(),
@@ -2071,7 +2072,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 		DisplayName: "Name",
 		Name:        "zz" + model.NewId() + "b",
 		Type:        model.CHANNEL_OPEN,
-	})).(*model.Channel)
+	}, -1)).(*model.Channel)
 
 	store.Must(ss.Post().Save(&model.Post{
 		UserId:    model.NewId(),
@@ -2084,4 +2085,20 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	} else if len(r2.Data.(*model.PostList).Posts) != 0 {
 		t.Fatal("wasn't supposed to return posts")
 	}
+}
+
+func testChannelStoreMaxChannelsPerTeam(t *testing.T, ss store.Store) {
+	channel := &model.Channel{
+		TeamId:      model.NewId(),
+		DisplayName: "Channel",
+		Name:        model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}
+	result := <-ss.Channel().Save(channel, 0)
+	assert.NotEqual(t, nil, result.Err)
+	assert.Equal(t, result.Err.Id, "store.sql_channel.save_channel.limit.app_error")
+
+	channel.Id = ""
+	result = <-ss.Channel().Save(channel, 1)
+	assert.Nil(t, result.Err)
 }

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -94,7 +94,7 @@ func testComplianceExport(t *testing.T, ss store.Store) {
 	c1.DisplayName = "Channel2"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = store.Must(ss.Channel().Save(c1)).(*model.Channel)
+	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
 	o1 := &model.Post{}
 	o1.ChannelId = c1.Id
@@ -256,7 +256,7 @@ func testComplianceExportDirectMessages(t *testing.T, ss store.Store) {
 	c1.DisplayName = "Channel2"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = store.Must(ss.Channel().Save(c1)).(*model.Channel)
+	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
 	cDM := store.Must(ss.Channel().CreateDirectChannel(u1.Id, u2.Id)).(*model.Channel)
 

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -794,7 +794,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	c1.DisplayName = "Channel1"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = (<-ss.Channel().Save(c1)).Data.(*model.Channel)
+	c1 = (<-ss.Channel().Save(c1, -1)).Data.(*model.Channel)
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = c1.Id
@@ -807,7 +807,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	c2.DisplayName = "Channel1"
 	c2.Name = "zz" + model.NewId() + "b"
 	c2.Type = model.CHANNEL_OPEN
-	c2 = (<-ss.Channel().Save(c2)).Data.(*model.Channel)
+	c2 = (<-ss.Channel().Save(c2, -1)).Data.(*model.Channel)
 
 	o1 := &model.Post{}
 	o1.ChannelId = c1.Id
@@ -926,7 +926,7 @@ func testUserCountsWithPostsByDay(t *testing.T, ss store.Store) {
 	c1.DisplayName = "Channel2"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = store.Must(ss.Channel().Save(c1)).(*model.Channel)
+	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
 	o1 := &model.Post{}
 	o1.ChannelId = c1.Id
@@ -984,7 +984,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	c1.DisplayName = "Channel2"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = store.Must(ss.Channel().Save(c1)).(*model.Channel)
+	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
 	o1 := &model.Post{}
 	o1.ChannelId = c1.Id
@@ -1045,7 +1045,7 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store) {
 	c1.DisplayName = "Channel1"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = store.Must(ss.Channel().Save(c1)).(*model.Channel)
+	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
 	o1 := &model.Post{}
 	o1.ChannelId = c1.Id
@@ -1585,14 +1585,14 @@ func testPostStoreGetPostsBatchForIndexing(t *testing.T, ss store.Store) {
 	c1.DisplayName = "Channel1"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = (<-ss.Channel().Save(c1)).Data.(*model.Channel)
+	c1 = (<-ss.Channel().Save(c1, -1)).Data.(*model.Channel)
 
 	c2 := &model.Channel{}
 	c2.TeamId = model.NewId()
 	c2.DisplayName = "Channel2"
 	c2.Name = "zz" + model.NewId() + "b"
 	c2.Type = model.CHANNEL_OPEN
-	c2 = (<-ss.Channel().Save(c2)).Data.(*model.Channel)
+	c2 = (<-ss.Channel().Save(c2, -1)).Data.(*model.Channel)
 
 	o1 := &model.Post{}
 	o1.ChannelId = c1.Id

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -923,9 +923,9 @@ func testGetChannelUnreadsForAllTeams(t *testing.T, ss store.Store) {
 	store.Must(ss.Team().SaveMember(m2))
 
 	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
-	store.Must(ss.Channel().Save(c1))
+	store.Must(ss.Channel().Save(c1, -1))
 	c2 := &model.Channel{TeamId: m2.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
-	store.Must(ss.Channel().Save(c2))
+	store.Must(ss.Channel().Save(c2, -1))
 
 	cm1 := &model.ChannelMember{ChannelId: c1.Id, UserId: m1.UserId, NotifyProps: model.GetDefaultChannelNotifyProps(), MsgCount: 90}
 	store.Must(ss.Channel().SaveMember(cm1))
@@ -986,9 +986,9 @@ func testGetChannelUnreadsForTeam(t *testing.T, ss store.Store) {
 	store.Must(ss.Team().SaveMember(m1))
 
 	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
-	store.Must(ss.Channel().Save(c1))
+	store.Must(ss.Channel().Save(c1, -1))
 	c2 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
-	store.Must(ss.Channel().Save(c2))
+	store.Must(ss.Channel().Save(c2, -1))
 
 	cm1 := &model.ChannelMember{ChannelId: c1.Id, UserId: m1.UserId, NotifyProps: model.GetDefaultChannelNotifyProps(), MsgCount: 90}
 	store.Must(ss.Channel().SaveMember(cm1))

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -410,8 +410,8 @@ func testUserStoreGetProfilesInChannel(t *testing.T, ss store.Store) {
 	c2.Name = "profiles-" + model.NewId()
 	c2.Type = model.CHANNEL_PRIVATE
 
-	store.Must(ss.Channel().Save(&c1))
-	store.Must(ss.Channel().Save(&c2))
+	store.Must(ss.Channel().Save(&c1, -1))
+	store.Must(ss.Channel().Save(&c2, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = c1.Id
@@ -527,8 +527,8 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, ss store.Store) {
 	c2.Name = "profiles-" + model.NewId()
 	c2.Type = model.CHANNEL_PRIVATE
 
-	store.Must(ss.Channel().Save(&c1))
-	store.Must(ss.Channel().Save(&c2))
+	store.Must(ss.Channel().Save(&c1, -1))
+	store.Must(ss.Channel().Save(&c2, -1))
 
 	m1 := model.ChannelMember{}
 	m1.ChannelId = c1.Id
@@ -615,8 +615,8 @@ func testUserStoreGetProfilesNotInChannel(t *testing.T, ss store.Store) {
 	c2.Name = "profiles-" + model.NewId()
 	c2.Type = model.CHANNEL_PRIVATE
 
-	store.Must(ss.Channel().Save(&c1))
-	store.Must(ss.Channel().Save(&c2))
+	store.Must(ss.Channel().Save(&c1, -1))
+	store.Must(ss.Channel().Save(&c2, -1))
 
 	if r1 := <-ss.User().GetProfilesNotInChannel(teamId, c1.Id, 0, 100); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -1164,7 +1164,7 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}))
 
-	if err := (<-ss.Channel().Save(&c1)).Err; err != nil {
+	if err := (<-ss.Channel().Save(&c1, -1)).Err; err != nil {
 		t.Fatal("couldn't save item", err)
 	}
 
@@ -1581,7 +1581,7 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 	c1.DisplayName = "NameName"
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
-	c1 = *store.Must(ss.Channel().Save(&c1)).(*model.Channel)
+	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
 
 	if r1 := <-ss.User().SearchNotInChannel(tid, c1.Id, "jimb", searchOptions); r1.Err != nil {
 		t.Fatal(r1.Err)


### PR DESCRIPTION
#### Summary
`MaxChannelsPerTeam` and `MaxUsersPerTeam` are the only config values the stores rely on. Imo they aren't enough to justify a dependency on `utils.Cfg` and it's better to just add arguments to `ChannelStore.Save` and `TeamStore.SaveMember`. This makes that change for the former (The latter is in [this PR](https://github.com/mattermost/mattermost-server/pull/7691).).

It also fixes an off-by-one error, which made the actual channel limit `MaxChannelsPerTeam+1` per team and adds a unit test for it.

#### Ticket Link
N/A

#### Checklist
N/A