### PR TITLE
PLT-7822: Fix search order for SQL search backend.

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -645,6 +645,8 @@ func (a *App) SearchPostsInTeam(terms string, userId string, teamId string, isOr
 			}
 		}
 
+		posts.SortByCreateAt()
+
 		return posts, nil
 	}
 }

--- a/model/post_list.go
+++ b/model/post_list.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"sort"
 )
 
 type PostList struct {
@@ -80,6 +81,12 @@ func (o *PostList) Extend(other *PostList) {
 			o.AddOrder(postId)
 		}
 	}
+}
+
+func (o *PostList) SortByCreateAt() {
+	sort.Slice(o.Order, func(i, j int) bool {
+		return o.Posts[o.Order[i]].CreateAt > o.Posts[o.Order[j]].CreateAt
+	})
 }
 
 func (o *PostList) Etag() string {

--- a/model/post_list_test.go
+++ b/model/post_list_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPostListJson(t *testing.T) {
@@ -67,4 +69,24 @@ func TestPostListExtend(t *testing.T) {
 	} else if len(l2.Posts) != 3 || len(l2.Order) != 3 {
 		t.Fatal("extending l2 again changed l2")
 	}
+}
+
+func TestPostListSortByCreateAt(t *testing.T) {
+	pl := PostList{}
+	p1 := &Post{Id: NewId(), Message: NewId(), CreateAt: 2}
+	pl.AddPost(p1)
+	p2 := &Post{Id: NewId(), Message: NewId(), CreateAt: 1}
+	pl.AddPost(p2)
+	p3 := &Post{Id: NewId(), Message: NewId(), CreateAt: 3}
+	pl.AddPost(p3)
+
+	pl.AddOrder(p1.Id)
+	pl.AddOrder(p2.Id)
+	pl.AddOrder(p3.Id)
+
+	pl.SortByCreateAt()
+
+	assert.EqualValues(t, pl.Order[0], p3.Id)
+	assert.EqualValues(t, pl.Order[1], p1.Id)
+	assert.EqualValues(t, pl.Order[2], p2.Id)
 }


### PR DESCRIPTION
#### Summary
Fixes the order of search results using OR (notifications) so that they are in the right order, even if the terms include hashtags (which results in two separate queries being issued).

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7822 - there will be a separate fix coming for this ticket when using the Elasticsearch backend, as the bug is actually different in that case.

#### Checklist
- [x] Added or updated unit tests (required for all new features)