### PR TITLE
PLT-7637 Differentiate between installed and activated states for plugins

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -65,18 +65,76 @@ func TestPlugin(t *testing.T) {
 	_, resp = th.Client.UploadPlugin(file)
 	CheckForbiddenStatus(t, resp)
 
-	// Successful get
-	manifests, resp := th.SystemAdminClient.GetPlugins()
+	// Successful gets
+	pluginsResp, resp := th.SystemAdminClient.GetPlugins()
 	CheckNoError(t, resp)
 
 	found := false
-	for _, m := range manifests {
+	for _, m := range pluginsResp.Inactive {
 		if m.Id == manifest.Id {
 			found = true
 		}
 	}
 
 	assert.True(t, found)
+
+	found = false
+	for _, m := range pluginsResp.Active {
+		if m.Id == manifest.Id {
+			found = true
+		}
+	}
+
+	assert.False(t, found)
+
+	states := th.App.Config().PluginSettings.PluginStates
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.PluginSettings.PluginStates = states })
+	}()
+
+	// Successful activate
+	ok, resp := th.SystemAdminClient.ActivatePlugin(manifest.Id)
+	CheckNoError(t, resp)
+	assert.True(t, ok)
+
+	pluginsResp, resp = th.SystemAdminClient.GetPlugins()
+	CheckNoError(t, resp)
+
+	found = false
+	for _, m := range pluginsResp.Active {
+		if m.Id == manifest.Id {
+			found = true
+		}
+	}
+
+	assert.True(t, found)
+
+	// Activate error case
+	ok, resp = th.SystemAdminClient.ActivatePlugin("junk")
+	CheckBadRequestStatus(t, resp)
+	assert.False(t, ok)
+
+	// Successful deactivate
+	ok, resp = th.SystemAdminClient.DeactivatePlugin(manifest.Id)
+	CheckNoError(t, resp)
+	assert.True(t, ok)
+
+	pluginsResp, resp = th.SystemAdminClient.GetPlugins()
+	CheckNoError(t, resp)
+
+	found = false
+	for _, m := range pluginsResp.Inactive {
+		if m.Id == manifest.Id {
+			found = true
+		}
+	}
+
+	assert.True(t, found)
+
+	// Deactivate error case
+	ok, resp = th.SystemAdminClient.DeactivatePlugin("junk")
+	CheckBadRequestStatus(t, resp)
+	assert.False(t, ok)
 
 	// Get error cases
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = false })
@@ -88,7 +146,10 @@ func TestPlugin(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	// Successful webapp get
-	manifests, resp = th.Client.GetWebappPlugins()
+	_, resp = th.SystemAdminClient.ActivatePlugin(manifest.Id)
+	CheckNoError(t, resp)
+
+	manifests, resp := th.Client.GetWebappPlugins()
 	CheckNoError(t, resp)
 
 	found = false
@@ -101,15 +162,13 @@ func TestPlugin(t *testing.T) {
 	assert.True(t, found)
 
 	// Successful remove
-	ok, resp := th.SystemAdminClient.RemovePlugin(manifest.Id)
+	ok, resp = th.SystemAdminClient.RemovePlugin(manifest.Id)
 	CheckNoError(t, resp)
-
 	assert.True(t, ok)
 
 	// Remove error cases
 	ok, resp = th.SystemAdminClient.RemovePlugin(manifest.Id)
 	CheckBadRequestStatus(t, resp)
-
 	assert.False(t, ok)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = false })

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -75,14 +75,6 @@ func runServer(configFileLocation string) {
 
 	if webappDir, ok := utils.FindDir(model.CLIENT_DIR); ok {
 		a.InitPlugins("plugins", webappDir+"/plugins")
-
-		utils.AddConfigListener(func(prevCfg *model.Config, cfg *model.Config) {
-			if !*prevCfg.PluginSettings.Enable && *cfg.PluginSettings.Enable {
-				a.InitPlugins("plugins", webappDir+"/plugins")
-			} else if *prevCfg.PluginSettings.Enable && !*cfg.PluginSettings.Enable {
-				a.ShutDownPlugins()
-			}
-		})
 	} else {
 		l4g.Error("Unable to find webapp directory, could not initialize plugins")
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3472,6 +3472,18 @@
     "translation": "Unable to activate extracted plugin. Plugin may already exist and be activated."
   },
   {
+    "id": "app.plugin.get_plugins.app_error",
+    "translation": "Unable to get plugins"
+  },
+  {
+    "id": "app.plugin.not_installed.app_error",
+    "translation": "Plugin is not installed"
+  },
+  {
+    "id": "app.plugin.config.app_error",
+    "translation": "Error saving plugin state in config"
+  },
+  {
     "id": "app.plugin.deactivate.app_error",
     "translation": "Unable to deactivate plugin"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -3150,12 +3150,12 @@ func (c *Client4) UploadPlugin(file io.Reader) (*Manifest, *Response) {
 
 // GetPlugins will return a list of plugin manifests for currently active plugins.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
-func (c *Client4) GetPlugins() ([]*Manifest, *Response) {
+func (c *Client4) GetPlugins() (*PluginsResponse, *Response) {
 	if r, err := c.DoApiGet(c.GetPluginsRoute(), ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)
-		return ManifestListFromJson(r.Body), BuildResponse(r)
+		return PluginsResponseFromJson(r.Body), BuildResponse(r)
 	}
 }
 
@@ -3178,5 +3178,27 @@ func (c *Client4) GetWebappPlugins() ([]*Manifest, *Response) {
 	} else {
 		defer closeBody(r)
 		return ManifestListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// ActivatePlugin will activate an plugin installed.
+// WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
+func (c *Client4) ActivatePlugin(id string) (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetPluginRoute(id)+"/activate", ""); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
+	}
+}
+
+// DeactivatePlugin will deactivate an active plugin.
+// WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
+func (c *Client4) DeactivatePlugin(id string) (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetPluginRoute(id)+"/deactivate", ""); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
 	}
 }

--- a/model/config.go
+++ b/model/config.go
@@ -504,9 +504,14 @@ type JobSettings struct {
 	RunScheduler *bool
 }
 
+type PluginState struct {
+	Enable bool
+}
+
 type PluginSettings struct {
-	Enable  *bool
-	Plugins map[string]interface{}
+	Enable       *bool
+	Plugins      map[string]interface{}
+	PluginStates map[string]*PluginState
 }
 
 type Config struct {
@@ -1641,6 +1646,10 @@ func (o *Config) SetDefaults() {
 
 	if o.PluginSettings.Plugins == nil {
 		o.PluginSettings.Plugins = make(map[string]interface{})
+	}
+
+	if o.PluginSettings.PluginStates == nil {
+		o.PluginSettings.PluginStates = make(map[string]*PluginState)
 	}
 
 	o.defaultWebrtcSettings()

--- a/model/plugins_response.go
+++ b/model/plugins_response.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type PluginsResponse struct {
+	Active   []*Manifest `json:"active"`
+	Inactive []*Manifest `json:"inactive"`
+}
+
+func (m *PluginsResponse) ToJson() string {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func PluginsResponseFromJson(data io.Reader) *PluginsResponse {
+	decoder := json.NewDecoder(data)
+	var m PluginsResponse
+	err := decoder.Decode(&m)
+	if err == nil {
+		return &m
+	} else {
+		return nil
+	}
+}

--- a/model/plugins_response_test.go
+++ b/model/plugins_response_test.go
@@ -1,0 +1,31 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPluginsResponseJson(t *testing.T) {
+	manifest := &Manifest{
+		Id: "theid",
+		Backend: &ManifestBackend{
+			Executable: "theexecutable",
+		},
+		Webapp: &ManifestWebapp{
+			BundlePath: "thebundlepath",
+		},
+	}
+
+	response := &PluginsResponse{
+		Active:   []*Manifest{manifest},
+		Inactive: []*Manifest{},
+	}
+
+	json := response.ToJson()
+	newResponse := PluginsResponseFromJson(strings.NewReader(json))
+	assert.Equal(t, newResponse, response)
+	assert.Equal(t, newResponse.ToJson(), json)
+	assert.Equal(t, PluginsResponseFromJson(strings.NewReader("junk")), (*PluginsResponse)(nil))
+}

--- a/plugin/pluginenv/environment.go
+++ b/plugin/pluginenv/environment.go
@@ -89,6 +89,20 @@ func (env *Environment) ActivePluginIds() (ids []string) {
 	return
 }
 
+// Returns true if the plugin is active, false otherwise.
+func (env *Environment) IsPluginActive(pluginId string) bool {
+	env.mutex.RLock()
+	defer env.mutex.RUnlock()
+
+	for id := range env.activePlugins {
+		if id == pluginId {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Activates the plugin with the given id.
 func (env *Environment) ActivatePlugin(id string) error {
 	env.mutex.Lock()

--- a/plugin/pluginenv/environment_test.go
+++ b/plugin/pluginenv/environment_test.go
@@ -152,10 +152,12 @@ func TestEnvironment(t *testing.T) {
 	activePlugins = env.ActivePlugins()
 	assert.Len(t, activePlugins, 1)
 	assert.Error(t, env.ActivatePlugin("foo"))
+	assert.True(t, env.IsPluginActive("foo"))
 
 	hooks.On("OnDeactivate").Return(nil)
 	assert.NoError(t, env.DeactivatePlugin("foo"))
 	assert.Error(t, env.DeactivatePlugin("foo"))
+	assert.False(t, env.IsPluginActive("foo"))
 
 	assert.NoError(t, env.ActivatePlugin("foo"))
 	assert.Equal(t, env.ActivePluginIds(), []string{"foo"})


### PR DESCRIPTION
#### Summary
Description of states:
* **Installed** - Plugin is uploaded into the /plugins directory but not running
* **Activated** - Plugin was previously installed and is now running
* **Uninstalled** - Plugin does not exist on the server

To install and activate:
1. Upload a plugin through the API or manually places the plugin in the /plugins directory
2. Hit the API for activating the plugin or set `PluginStates: {"mypluginid": {"Enable": true}}` under `PluginSettings` and reload the config

To deactivate:
1. Hit the API for deactivating the plugin or set `PluginStates: {"mypluginid": {"Enable": false}}` under `PluginSettings` and reload the config

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7637

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
