### PR TITLE
PLT-7264: add missing license headers, test to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,7 +271,10 @@ gofmt:
 	done
 	@echo "gofmt success"; \
 
-check-style: govet gofmt
+check-licenses:
+	./scripts/license-check.sh $(TE_PACKAGES) $(EE_PACKAGES)
+
+check-style: govet gofmt check-licenses
 
 test-te-race:
 	@echo Testing TE race conditions

--- a/cmd/platform/init.go
+++ b/cmd/platform/init.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package main
 
 import (

--- a/model/bundle_info.go
+++ b/model/bundle_info.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package model
 
 type BundleInfo struct {

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package model
 
 import (

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package plugin
 
 import (

--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package plugin
 
 import (

--- a/plugin/pluginenv/environment.go
+++ b/plugin/pluginenv/environment.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 // Package pluginenv provides high level functionality for discovering and launching plugins.
 package pluginenv
 

--- a/plugin/pluginenv/options.go
+++ b/plugin/pluginenv/options.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package pluginenv
 
 import (

--- a/plugin/pluginenv/search_path.go
+++ b/plugin/pluginenv/search_path.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package pluginenv
 
 import (

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package plugintest
 
 import (

--- a/plugin/plugintest/hooks.go
+++ b/plugin/plugintest/hooks.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package plugintest
 
 import (

--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/hooks.go
+++ b/plugin/rpcplugin/hooks.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/http.go
+++ b/plugin/rpcplugin/http.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/io.go
+++ b/plugin/rpcplugin/io.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/ipc.go
+++ b/plugin/rpcplugin/ipc.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/main.go
+++ b/plugin/rpcplugin/main.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/muxer.go
+++ b/plugin/rpcplugin/muxer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/process.go
+++ b/plugin/rpcplugin/process.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/rpcplugin/process_unix.go
+++ b/plugin/rpcplugin/process_unix.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 // +build !windows
 
 package rpcplugin

--- a/plugin/rpcplugin/supervisor.go
+++ b/plugin/rpcplugin/supervisor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package rpcplugin
 
 import (

--- a/plugin/supervisor.go
+++ b/plugin/supervisor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package plugin
 
 // Supervisor provides the interface for an object that controls the execution of a plugin.

--- a/scripts/license-check.sh
+++ b/scripts/license-check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+IFS=$'\n'
+count=0
+for fileType in GoFiles; do
+    for file in `go list -f $'{{range .GoFiles}}{{$.Dir}}/{{.}}\n{{end}}' "$@"`; do
+        case $file in
+            */utils/lru.go)
+            # Third-party, doesn't require a header.
+            ;;
+        *)
+            if ! grep 'Mattermost, Inc. All Rights Reserved.' $file -q; then
+                >&2 echo "FAIL: $file is missing a license header."
+                ((count++))
+            fi
+        esac
+    done
+done
+if [ $count -eq 0 ]; then
+    exit 0
+fi
+
+if [ $count -gt 1 ]; then
+    >&2 echo "$count files are missing license headers."
+else
+    >&2 echo "$count file is missing a license header."
+fi
+exit 1

--- a/store/constants.go
+++ b/store/constants.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package store
 
 const (

--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -1,3 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package sqlstore

--- a/utils/i18n.go
+++ b/utils/i18n.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package utils
 
 import (

--- a/utils/inbucket.go
+++ b/utils/inbucket.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package utils
 
 import (

--- a/utils/logger/log4go_json_writer.go
+++ b/utils/logger/log4go_json_writer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 // glue functions that allow logger.go to leverage log4Go to write JSON-formatted log records to a file
 
 package logger

--- a/utils/logger/logger.go
+++ b/utils/logger/logger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 // this is a new logger interface for mattermost
 
 package logger

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package utils
 
 import (


### PR DESCRIPTION
#### Summary
I knew this would find a ton of violations when I eventually got around to it. Admittedly, a lot of them were made by me, but a lot of them weren't.

Output looks like this:

```
FAIL: /Users/chris/go/src/github.com/mattermost/mattermost-server/enterprise/oauth/google/google.go is missing a license header.
1 file is missing a license header.
make: *** [check-licenses] Error 1
```

Enterprise fixes: https://github.com/mattermost/enterprise/pull/222

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7264?filter=14400

#### Checklist
N/A