### PR TITLE
PLT-7976: Configurable timeout for Elasticsearch requests.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -318,7 +318,8 @@
         "PostsAggregatorJobStartTime": "03:00",
         "IndexPrefix": "",
         "LiveIndexingBatchSize": 1,
-        "BulkIndexingTimeWindowSeconds": 3600
+        "BulkIndexingTimeWindowSeconds": 3600,
+        "RequestTimeoutSeconds": 30
     },
     "DataRetentionSettings": {
         "EnableMessageDeletion": false,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3868,6 +3868,10 @@
     "translation": "Elasticsearch Bulk Indexing Time Window must be at least 1 second."
   },
   {
+    "id": "model.config.is_valid.elastic_search.request_timeout_seconds.app_error",
+    "translation": "Elasticsearch Request Timeout must be at least 1 second."
+  },
+  {
     "id": "ent.emoji.licence_disable.app_error",
     "translation": "Custom emoji restrictions disabled by current license. Please contact your system administrator about upgrading your enterprise license."
   },

--- a/model/config.go
+++ b/model/config.go
@@ -142,6 +142,7 @@ const (
 	ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX                      = ""
 	ELASTICSEARCH_SETTINGS_DEFAULT_LIVE_INDEXING_BATCH_SIZE          = 1
 	ELASTICSEARCH_SETTINGS_DEFAULT_BULK_INDEXING_TIME_WINDOW_SECONDS = 3600
+	ELASTICSEARCH_SETTINGS_DEFAULT_REQUEST_TIMEOUT_SECONDS           = 30
 
 	DATA_RETENTION_SETTINGS_DEFAULT_MESSAGE_RETENTION_DAYS  = 365
 	DATA_RETENTION_SETTINGS_DEFAULT_FILE_RETENTION_DAYS     = 365
@@ -491,6 +492,7 @@ type ElasticsearchSettings struct {
 	IndexPrefix                   *string
 	LiveIndexingBatchSize         *int
 	BulkIndexingTimeWindowSeconds *int
+	RequestTimeoutSeconds         *int
 }
 
 type DataRetentionSettings struct {
@@ -1431,6 +1433,10 @@ func (o *Config) SetDefaults() {
 		*o.ElasticsearchSettings.BulkIndexingTimeWindowSeconds = ELASTICSEARCH_SETTINGS_DEFAULT_BULK_INDEXING_TIME_WINDOW_SECONDS
 	}
 
+	if o.ElasticsearchSettings.RequestTimeoutSeconds == nil {
+		o.ElasticsearchSettings.RequestTimeoutSeconds = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_REQUEST_TIMEOUT_SECONDS)
+	}
+
 	if o.DataRetentionSettings.EnableMessageDeletion == nil {
 		o.DataRetentionSettings.EnableMessageDeletion = NewBool(false)
 	}
@@ -1822,6 +1828,10 @@ func (ess *ElasticsearchSettings) isValid() *AppError {
 
 	if *ess.BulkIndexingTimeWindowSeconds < 1 {
 		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.bulk_indexing_time_window_seconds.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if *ess.RequestTimeoutSeconds < 1 {
+		return NewAppError("Config.IsValid", "model.config.is_valid.elastic_search.request_timeout_seconds.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary
Configurable timeout for Elasticsearch requests.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7976

#### Checklist
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/224
- [x] Includes text changes and localization file updates
