### PR TITLE
[PLT-7362] Add RootId to out-of-channel-mentions ephemeral post for that to rend…

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -775,6 +775,7 @@ func (a *App) sendOutOfChannelMentions(sender *model.User, post *model.Post, cha
 		post.UserId,
 		&model.Post{
 			Id:        ephemeralPostId,
+			RootId:    post.RootId,
 			ChannelId: post.ChannelId,
 			Message:   message,
 			CreateAt:  post.CreateAt + 1,


### PR DESCRIPTION
#### Summary
- Follow up PR to https://github.com/mattermost/mattermost-server/pull/7619
- Add `RootId` to out-of-channel-mentions ephemeral post for that to render at RHS. Issue found while testing client side changes here: https://github.com/mattermost/mattermost-webapp/pull/149#pullrequestreview-71651916


#### Ticket Link
Jira ticket: [PLT-7362](https://mattermost.atlassian.net/browse/PLT-7362)
