### PR TITLE
Fix plugin config parsing

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -338,6 +338,12 @@ func LoadConfig(fileName string) *model.Config {
 
 	var config model.Config
 	unmarshalErr := viper.Unmarshal(&config)
+	if unmarshalErr == nil {
+		// https://github.com/spf13/viper/issues/324
+		// https://github.com/spf13/viper/issues/348
+		config.PluginSettings = model.PluginSettings{}
+		unmarshalErr = viper.UnmarshalKey("pluginsettings", &config.PluginSettings)
+	}
 	if unmarshalErr != nil {
 		errMsg := T("utils.config.load_config.decoding.panic", map[string]interface{}{"Filename": fileName, "Error": unmarshalErr.Error()})
 		fmt.Fprintln(os.Stderr, errMsg)


### PR DESCRIPTION
#### Summary
Ran into some trouble trying to put together a plugin. Maps with user-controlled keys in Viper configurations don't really work. In particular, periods in map keys make weird things happen. So reverse-dns plugin ids like "com.mattermost.plugins.jira" weren't working.

See https://github.com/spf13/viper/issues/324 and https://github.com/spf13/viper/issues/348.

~~I think it's probably best if we just avoid maps in configurations.~~

~~@jasonblais Are we okay with a breaking change for the JIRA plugin? Users would have to reconfigure it.~~

~~I'll need to put in a webapp PR as well, so no one merge this until I do that.~~

Edit: Figured out a less impactful workaround. Let's just go with that for now.

#### Ticket Link
N/A

#### Checklist
N/A