### PR TITLE
[PLT-7362] Add post' root ID to APIv4 addChannelMember to render added user (as system post) at RHS

### DIFF
--- a/api/channel.go
+++ b/api/channel.go
@@ -649,7 +649,7 @@ func addMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.App.Go(func() {
-		c.App.PostAddToChannelMessage(oUser, nUser, channel)
+		c.App.PostAddToChannelMessage(oUser, nUser, channel, "")
 	})
 
 	c.App.UpdateChannelLastViewedAt([]string{id}, oUser.Id)

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -803,8 +803,11 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var err *model.AppError
 	if ok && len(postRootId) == 26 {
-		if _, err = c.App.GetSinglePost(postRootId); err != nil {
+		if rootPost, err := c.App.GetSinglePost(postRootId); err != nil {
 			c.Err = err
+			return
+		} else if rootPost.ChannelId != member.ChannelId {
+			c.SetInvalidParam("post_root_id")
 			return
 		}
 	}

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -783,21 +783,33 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	member := model.ChannelMemberFromJson(r.Body)
-	if member == nil {
-		c.SetInvalidParam("channel_member")
-		return
-	}
-
-	if len(member.UserId) != 26 {
+	props := model.StringInterfaceFromJson(r.Body)
+	userId, ok := props["user_id"].(string)
+	if !ok || len(userId) != 26 {
 		c.SetInvalidParam("user_id")
 		return
 	}
 
-	member.ChannelId = c.Params.ChannelId
+	member := &model.ChannelMember{
+		ChannelId: c.Params.ChannelId,
+		UserId:    userId,
+	}
+
+	postRootId, ok := props["post_root_id"].(string)
+	if ok && len(postRootId) != 0 && len(postRootId) != 26 {
+		c.SetInvalidParam("post_root_id")
+		return
+	}
+
+	var err *model.AppError
+	if ok && len(postRootId) == 26 {
+		if _, err = c.App.GetSinglePost(postRootId); err != nil {
+			c.Err = err
+			return
+		}
+	}
 
 	var channel *model.Channel
-	var err *model.AppError
 	if channel, err = c.App.GetChannel(member.ChannelId); err != nil {
 		c.Err = err
 		return
@@ -828,7 +840,7 @@ func addChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if cm, err := c.App.AddChannelMember(member.UserId, channel, c.Session.UserId); err != nil {
+	if cm, err := c.App.AddChannelMember(member.UserId, channel, c.Session.UserId, postRootId); err != nil {
 		c.Err = err
 		return
 	} else {

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1717,7 +1717,7 @@ func TestAddChannelMember(t *testing.T) {
 	_, resp := th.SystemAdminClient.AddTeamMember(team.Id, user3.Id)
 	CheckNoError(t, resp)
 
-	cm, resp := Client.AddChannelMember(publicChannel.Id, user2.Id, "")
+	cm, resp := Client.AddChannelMember(publicChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 	CheckCreatedStatus(t, resp)
 
@@ -1729,7 +1729,7 @@ func TestAddChannelMember(t *testing.T) {
 		t.Fatal("should have returned exact user added to public channel")
 	}
 
-	cm, resp = Client.AddChannelMember(privateChannel.Id, user2.Id, "")
+	cm, resp = Client.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
 	if cm.ChannelId != privateChannel.Id {
@@ -1747,35 +1747,35 @@ func TestAddChannelMember(t *testing.T) {
 	}
 
 	Client.RemoveUserFromChannel(publicChannel.Id, user.Id)
-	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, rpost.Id)
+	_, resp = Client.AddChannelMemberWithRootId(publicChannel.Id, user.Id, rpost.Id)
 	CheckNoError(t, resp)
 	CheckCreatedStatus(t, resp)
 
 	Client.RemoveUserFromChannel(publicChannel.Id, user.Id)
-	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, "junk")
+	_, resp = Client.AddChannelMemberWithRootId(publicChannel.Id, user.Id, "junk")
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, GenerateTestId())
+	_, resp = Client.AddChannelMemberWithRootId(publicChannel.Id, user.Id, GenerateTestId())
 	CheckNotFoundStatus(t, resp)
 
 	Client.RemoveUserFromChannel(publicChannel.Id, user.Id)
-	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, "")
+	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id)
 	CheckNoError(t, resp)
 
-	cm, resp = Client.AddChannelMember(publicChannel.Id, "junk", "")
+	cm, resp = Client.AddChannelMember(publicChannel.Id, "junk")
 	CheckBadRequestStatus(t, resp)
 
 	if cm != nil {
 		t.Fatal("should return nothing")
 	}
 
-	_, resp = Client.AddChannelMember(publicChannel.Id, GenerateTestId(), "")
+	_, resp = Client.AddChannelMember(publicChannel.Id, GenerateTestId())
 	CheckNotFoundStatus(t, resp)
 
-	_, resp = Client.AddChannelMember("junk", user2.Id, "")
+	_, resp = Client.AddChannelMember("junk", user2.Id)
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(GenerateTestId(), user2.Id, "")
+	_, resp = Client.AddChannelMember(GenerateTestId(), user2.Id)
 	CheckNotFoundStatus(t, resp)
 
 	otherUser := th.CreateUser()
@@ -1783,39 +1783,39 @@ func TestAddChannelMember(t *testing.T) {
 	Client.Logout()
 	Client.Login(user2.Id, user2.Password)
 
-	_, resp = Client.AddChannelMember(publicChannel.Id, otherUser.Id, "")
+	_, resp = Client.AddChannelMember(publicChannel.Id, otherUser.Id)
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(privateChannel.Id, otherUser.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, otherUser.Id)
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id, "")
+	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id)
 	CheckUnauthorizedStatus(t, resp)
 
 	Client.Logout()
 	Client.Login(user.Id, user.Password)
 
 	// should fail adding user who is not a member of the team
-	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id, "")
+	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id)
 	CheckUnauthorizedStatus(t, resp)
 
 	Client.DeleteChannel(otherChannel.Id)
 
 	// should fail adding user to a deleted channel
-	_, resp = Client.AddChannelMember(otherChannel.Id, user2.Id, "")
+	_, resp = Client.AddChannelMember(otherChannel.Id, user2.Id)
 	CheckUnauthorizedStatus(t, resp)
 
 	Client.Logout()
-	_, resp = Client.AddChannelMember(publicChannel.Id, user2.Id, "")
+	_, resp = Client.AddChannelMember(publicChannel.Id, user2.Id)
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(privateChannel.Id, user2.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = th.SystemAdminClient.AddChannelMember(publicChannel.Id, user2.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(publicChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
 	// Test policy does not apply to TE.
@@ -1832,12 +1832,12 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1858,12 +1858,12 @@ func TestAddChannelMember(t *testing.T) {
 	// Check that a regular channel user can add other users.
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1878,12 +1878,12 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckForbiddenStatus(t, resp)
 	Client.Logout()
 
@@ -1895,7 +1895,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1910,12 +1910,12 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckForbiddenStatus(t, resp)
 	Client.Logout()
 
@@ -1927,7 +1927,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1942,16 +1942,16 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id)
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckForbiddenStatus(t, resp)
 	Client.Logout()
 
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user3.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user3.Id)
 	CheckNoError(t, resp)
 }
 
@@ -2027,9 +2027,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2051,9 +2051,9 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	// Check that a regular channel user can remove other users.
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2069,9 +2069,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2096,9 +2096,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2123,9 +2123,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1717,7 +1717,7 @@ func TestAddChannelMember(t *testing.T) {
 	_, resp := th.SystemAdminClient.AddTeamMember(team.Id, user3.Id)
 	CheckNoError(t, resp)
 
-	cm, resp := Client.AddChannelMember(publicChannel.Id, user2.Id)
+	cm, resp := Client.AddChannelMember(publicChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 	CheckCreatedStatus(t, resp)
 
@@ -1729,7 +1729,7 @@ func TestAddChannelMember(t *testing.T) {
 		t.Fatal("should have returned exact user added to public channel")
 	}
 
-	cm, resp = Client.AddChannelMember(privateChannel.Id, user2.Id)
+	cm, resp = Client.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
 	if cm.ChannelId != privateChannel.Id {
@@ -1740,24 +1740,42 @@ func TestAddChannelMember(t *testing.T) {
 		t.Fatal("should have returned exact user added to private channel")
 	}
 
+	post := &model.Post{ChannelId: publicChannel.Id, Message: "a" + GenerateTestId() + "a"}
+	rpost, err := Client.CreatePost(post)
+	if err == nil {
+		t.Fatal("should have created a post")
+	}
+
 	Client.RemoveUserFromChannel(publicChannel.Id, user.Id)
-	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id)
+	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, rpost.Id)
+	CheckNoError(t, resp)
+	CheckCreatedStatus(t, resp)
+
+	Client.RemoveUserFromChannel(publicChannel.Id, user.Id)
+	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, "junk")
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, GenerateTestId())
+	CheckNotFoundStatus(t, resp)
+
+	Client.RemoveUserFromChannel(publicChannel.Id, user.Id)
+	_, resp = Client.AddChannelMember(publicChannel.Id, user.Id, "")
 	CheckNoError(t, resp)
 
-	cm, resp = Client.AddChannelMember(publicChannel.Id, "junk")
+	cm, resp = Client.AddChannelMember(publicChannel.Id, "junk", "")
 	CheckBadRequestStatus(t, resp)
 
 	if cm != nil {
 		t.Fatal("should return nothing")
 	}
 
-	_, resp = Client.AddChannelMember(publicChannel.Id, GenerateTestId())
+	_, resp = Client.AddChannelMember(publicChannel.Id, GenerateTestId(), "")
 	CheckNotFoundStatus(t, resp)
 
-	_, resp = Client.AddChannelMember("junk", user2.Id)
+	_, resp = Client.AddChannelMember("junk", user2.Id, "")
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(GenerateTestId(), user2.Id)
+	_, resp = Client.AddChannelMember(GenerateTestId(), user2.Id, "")
 	CheckNotFoundStatus(t, resp)
 
 	otherUser := th.CreateUser()
@@ -1765,39 +1783,39 @@ func TestAddChannelMember(t *testing.T) {
 	Client.Logout()
 	Client.Login(user2.Id, user2.Password)
 
-	_, resp = Client.AddChannelMember(publicChannel.Id, otherUser.Id)
+	_, resp = Client.AddChannelMember(publicChannel.Id, otherUser.Id, "")
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(privateChannel.Id, otherUser.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, otherUser.Id, "")
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id)
+	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id, "")
 	CheckUnauthorizedStatus(t, resp)
 
 	Client.Logout()
 	Client.Login(user.Id, user.Password)
 
 	// should fail adding user who is not a member of the team
-	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id)
+	_, resp = Client.AddChannelMember(otherChannel.Id, otherUser.Id, "")
 	CheckUnauthorizedStatus(t, resp)
 
 	Client.DeleteChannel(otherChannel.Id)
 
 	// should fail adding user to a deleted channel
-	_, resp = Client.AddChannelMember(otherChannel.Id, user2.Id)
+	_, resp = Client.AddChannelMember(otherChannel.Id, user2.Id, "")
 	CheckUnauthorizedStatus(t, resp)
 
 	Client.Logout()
-	_, resp = Client.AddChannelMember(publicChannel.Id, user2.Id)
+	_, resp = Client.AddChannelMember(publicChannel.Id, user2.Id, "")
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = Client.AddChannelMember(privateChannel.Id, user2.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckUnauthorizedStatus(t, resp)
 
-	_, resp = th.SystemAdminClient.AddChannelMember(publicChannel.Id, user2.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(publicChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
 	// Test policy does not apply to TE.
@@ -1814,12 +1832,12 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1840,12 +1858,12 @@ func TestAddChannelMember(t *testing.T) {
 	// Check that a regular channel user can add other users.
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1860,12 +1878,12 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckForbiddenStatus(t, resp)
 	Client.Logout()
 
@@ -1877,7 +1895,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1892,12 +1910,12 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckForbiddenStatus(t, resp)
 	Client.Logout()
 
@@ -1909,7 +1927,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
@@ -1924,16 +1942,16 @@ func TestAddChannelMember(t *testing.T) {
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id, "")
 	CheckNoError(t, resp)
 	Client.Logout()
 
 	Client.Login(user.Username, user.Password)
-	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckForbiddenStatus(t, resp)
 	Client.Logout()
 
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user3.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user3.Id, "")
 	CheckNoError(t, resp)
 }
 
@@ -2009,9 +2027,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2033,9 +2051,9 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	// Check that a regular channel user can remove other users.
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2051,9 +2069,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2078,9 +2096,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)
@@ -2105,9 +2123,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id, "")
 	CheckNoError(t, resp)
-	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id)
+	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user2.Id, "")
 	CheckNoError(t, resp)
 
 	_, resp = Client.RemoveUserFromChannel(privateChannel.Id, user2.Id)

--- a/model/client4.go
+++ b/model/client4.go
@@ -1653,9 +1653,20 @@ func (c *Client4) UpdateChannelNotifyProps(channelId, userId string, props map[s
 }
 
 // AddChannelMember adds user to channel and return a channel member.
-func (c *Client4) AddChannelMember(channelId, userId, postRootId string) (*ChannelMember, *Response) {
-	requestBody := map[string]interface{}{"user_id": userId, "post_root_id": postRootId}
-	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", StringInterfaceToJson(requestBody)); err != nil {
+func (c *Client4) AddChannelMember(channelId, userId string) (*ChannelMember, *Response) {
+	requestBody := map[string]string{"user_id": userId}
+	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", MapToJson(requestBody)); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return ChannelMemberFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// AddChannelMemberWithRootId adds user to channel and return a channel member. Post add to channel message has the postRootId.
+func (c *Client4) AddChannelMemberWithRootId(channelId, userId, postRootId string) (*ChannelMember, *Response) {
+	requestBody := map[string]string{"user_id": userId, "post_root_id": postRootId}
+	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", MapToJson(requestBody)); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)

--- a/model/client4.go
+++ b/model/client4.go
@@ -1653,9 +1653,9 @@ func (c *Client4) UpdateChannelNotifyProps(channelId, userId string, props map[s
 }
 
 // AddChannelMember adds user to channel and return a channel member.
-func (c *Client4) AddChannelMember(channelId, userId string) (*ChannelMember, *Response) {
-	requestBody := map[string]string{"user_id": userId}
-	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", MapToJson(requestBody)); err != nil {
+func (c *Client4) AddChannelMember(channelId, userId, postRootId string) (*ChannelMember, *Response) {
+	requestBody := map[string]interface{}{"user_id": userId, "post_root_id": postRootId}
+	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", StringInterfaceToJson(requestBody)); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)


### PR DESCRIPTION
#### Summary
- Follow up PR to #7619 and #7726 
- Add post' root ID to APIv4 `addChannelMember` to render added user (as system post) at RHS. Feature is requested while testing `webapp` https://github.com/mattermost/mattermost-webapp/pull/149#pullrequestreview-72349879

Note that corresponding APIv3 was not updated.

#### Ticket Link
Jira ticket: [PLT-7362](https://mattermost.atlassian.net/browse/PLT-7362)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (link to follow)
- [x] All new/modified APIs include changes to the drivers
- [x] Has UI changes (https://github.com/mattermost/mattermost-webapp/pull/149)
- [x] Has mattermost-redux changes (https://github.com/mattermost/mattermost-redux/pull/286)
