### PR TITLE
fix push notification when user status is in DND

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -988,14 +988,17 @@ func DoesNotifyPropsAllowPushNotification(user *model.User, channelNotifyProps m
 }
 
 func DoesStatusAllowPushNotification(userNotifyProps model.StringMap, status *model.Status, channelId string) bool {
+	// If User status is DND return false right away
+	if status.Status == model.STATUS_DND {
+		return false
+	}
+
 	if pushStatus, ok := userNotifyProps["push_status"]; (pushStatus == model.STATUS_ONLINE || !ok) && (status.ActiveChannel != channelId || model.GetMillis()-status.LastActivityAt > model.STATUS_CHANNEL_TIMEOUT) {
 		return true
 	} else if pushStatus == model.STATUS_AWAY && (status.Status == model.STATUS_AWAY || status.Status == model.STATUS_OFFLINE) {
 		return true
 	} else if pushStatus == model.STATUS_OFFLINE && status.Status == model.STATUS_OFFLINE {
 		return true
-	} else if status.Status == model.STATUS_DND {
-		return false
 	}
 
 	return false

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -796,6 +796,7 @@ func TestDoesStatusAllowPushNotification(t *testing.T) {
 	offline := &model.Status{UserId: userId, Status: model.STATUS_OFFLINE, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
 	away := &model.Status{UserId: userId, Status: model.STATUS_AWAY, Manual: false, LastActivityAt: 0, ActiveChannel: ""}
 	online := &model.Status{UserId: userId, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}
+	dnd := &model.Status{UserId: userId, Status: model.STATUS_DND, Manual: true, LastActivityAt: model.GetMillis(), ActiveChannel: ""}
 
 	userNotifyProps["push_status"] = model.STATUS_ONLINE
 	// WHEN props is ONLINE and user is offline
@@ -822,6 +823,15 @@ func TestDoesStatusAllowPushNotification(t *testing.T) {
 	}
 
 	if DoesStatusAllowPushNotification(userNotifyProps, online, "") {
+		t.Fatal("Should have been false")
+	}
+
+	// WHEN props is ONLINE and user is dnd
+	if DoesStatusAllowPushNotification(userNotifyProps, dnd, channelId) {
+		t.Fatal("Should have been false")
+	}
+
+	if DoesStatusAllowPushNotification(userNotifyProps, dnd, "") {
 		t.Fatal("Should have been false")
 	}
 
@@ -853,8 +863,17 @@ func TestDoesStatusAllowPushNotification(t *testing.T) {
 		t.Fatal("Should have been false")
 	}
 
+	// WHEN props is AWAY and user is dnd
+	if DoesStatusAllowPushNotification(userNotifyProps, dnd, channelId) {
+		t.Fatal("Should have been false")
+	}
+
+	if DoesStatusAllowPushNotification(userNotifyProps, dnd, "") {
+		t.Fatal("Should have been false")
+	}
+
 	userNotifyProps["push_status"] = model.STATUS_OFFLINE
-	// WHEN props is AWAY and user is offline
+	// WHEN props is OFFLINE and user is offline
 	if !DoesStatusAllowPushNotification(userNotifyProps, offline, channelId) {
 		t.Fatal("Should have been true")
 	}
@@ -863,7 +882,7 @@ func TestDoesStatusAllowPushNotification(t *testing.T) {
 		t.Fatal("Should have been true")
 	}
 
-	// WHEN props is AWAY and user is away
+	// WHEN props is OFFLINE and user is away
 	if DoesStatusAllowPushNotification(userNotifyProps, away, channelId) {
 		t.Fatal("Should have been false")
 	}
@@ -872,7 +891,7 @@ func TestDoesStatusAllowPushNotification(t *testing.T) {
 		t.Fatal("Should have been false")
 	}
 
-	// WHEN props is AWAY and user is online
+	// WHEN props is OFFLINE and user is online
 	if DoesStatusAllowPushNotification(userNotifyProps, online, channelId) {
 		t.Fatal("Should have been false")
 	}
@@ -880,6 +899,16 @@ func TestDoesStatusAllowPushNotification(t *testing.T) {
 	if DoesStatusAllowPushNotification(userNotifyProps, online, "") {
 		t.Fatal("Should have been false")
 	}
+
+	// WHEN props is OFFLINE and user is dnd
+	if DoesStatusAllowPushNotification(userNotifyProps, dnd, channelId) {
+		t.Fatal("Should have been false")
+	}
+
+	if DoesStatusAllowPushNotification(userNotifyProps, dnd, "") {
+		t.Fatal("Should have been false")
+	}
+
 }
 
 func TestGetDirectMessageNotificationEmailSubject(t *testing.T) {


### PR DESCRIPTION
#### Summary
I realize I forgot to add some tests for the push part when the user is in DND mode.
Doing the tests I discovery my logic was totally wrong.

This PR fixes the wrong logic and when MM is checking if need to send a push to the user if the users status is set to DND it will block that.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)

