### PR TITLE
Simplify things

### DIFF
--- a/api/emoji_test.go
+++ b/api/emoji_test.go
@@ -206,7 +206,7 @@ func TestCreateEmoji(t *testing.T) {
 		CreatorId: th.BasicUser.Id,
 		Name:      model.NewId(),
 	}
-	if _, err := Client.CreateEmoji(emoji, make([]byte, 100, 100), "image.gif"); err == nil {
+	if _, err := Client.CreateEmoji(emoji, make([]byte, 100), "image.gif"); err == nil {
 		t.Fatal("shouldn't be able to create an emoji with non-image data")
 	}
 

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -1321,7 +1321,7 @@ func TestGetFileInfosForPost(t *testing.T) {
 	Client := th.BasicClient
 	channel1 := th.BasicChannel
 
-	fileIds := make([]string, 3, 3)
+	fileIds := make([]string, 3)
 	if data, err := readTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
@@ -1531,7 +1531,7 @@ func TestPinPost(t *testing.T) {
 	if rupost1, err := Client.PinPost(post.ChannelId, post.Id); err != nil {
 		t.Fatal(err)
 	} else {
-		if rupost1.Data.(*model.Post).IsPinned != true {
+		if !rupost1.Data.(*model.Post).IsPinned {
 			t.Fatal("failed to pin post")
 		}
 	}
@@ -1540,7 +1540,7 @@ func TestPinPost(t *testing.T) {
 	if rupost2, err := Client.PinPost(pinnedPost.ChannelId, pinnedPost.Id); err != nil {
 		t.Fatal(err)
 	} else {
-		if rupost2.Data.(*model.Post).IsPinned != true {
+		if !rupost2.Data.(*model.Post).IsPinned {
 			t.Fatal("pinning a post should be idempotent")
 		}
 	}
@@ -1556,7 +1556,7 @@ func TestUnpinPost(t *testing.T) {
 	if rupost1, err := Client.UnpinPost(pinnedPost.ChannelId, pinnedPost.Id); err != nil {
 		t.Fatal(err)
 	} else {
-		if rupost1.Data.(*model.Post).IsPinned != false {
+		if rupost1.Data.(*model.Post).IsPinned {
 			t.Fatal("failed to unpin post")
 		}
 	}
@@ -1565,7 +1565,7 @@ func TestUnpinPost(t *testing.T) {
 	if rupost2, err := Client.UnpinPost(post.ChannelId, post.Id); err != nil {
 		t.Fatal(err)
 	} else {
-		if rupost2.Data.(*model.Post).IsPinned != false {
+		if rupost2.Data.(*model.Post).IsPinned {
 			t.Fatal("unpinning a post should be idempotent")
 		}
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -1167,7 +1167,6 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 					c.App.AddDirectChannels(teamId, user)
 				})
 			}
-			break
 		case model.OAUTH_ACTION_EMAIL_TO_SSO:
 			if err := c.App.RevokeAllSessions(user.Id); err != nil {
 				c.Err = err
@@ -1179,7 +1178,6 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 					l4g.Error(err.Error())
 				}
 			})
-			break
 		}
 		doLogin(c, w, r, user, "")
 		if c.Err != nil {

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -322,7 +322,6 @@ func getChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write([]byte(channel.ToJson()))
-	return
 }
 
 func getChannelUnread(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -601,7 +600,6 @@ func getChannelByNameForTeamName(c *Context, w http.ResponseWriter, r *http.Requ
 	}
 
 	w.Write([]byte(channel.ToJson()))
-	return
 }
 
 func getChannelMembers(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -127,7 +127,7 @@ func TestCreateEmoji(t *testing.T) {
 		Name:      model.NewId(),
 	}
 
-	_, resp = Client.CreateEmoji(emoji, make([]byte, 100, 100), "image.gif")
+	_, resp = Client.CreateEmoji(emoji, make([]byte, 100), "image.gif")
 	CheckBadRequestStatus(t, resp)
 	CheckErrorMessage(t, resp, "api.emoji.upload.image.app_error")
 
@@ -232,7 +232,7 @@ func TestDeleteEmoji(t *testing.T) {
 
 	ok, resp := Client.DeleteEmoji(newEmoji.Id)
 	CheckNoError(t, resp)
-	if ok != true {
+	if !ok {
 		t.Fatal("should return true")
 	} else {
 		_, err := Client.GetEmoji(newEmoji.Id)
@@ -247,7 +247,7 @@ func TestDeleteEmoji(t *testing.T) {
 
 	ok, resp = th.SystemAdminClient.DeleteEmoji(newEmoji.Id)
 	CheckNoError(t, resp)
-	if ok != true {
+	if !ok {
 		t.Fatal("should return true")
 	} else {
 		_, err := th.SystemAdminClient.GetEmoji(newEmoji.Id)

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -151,7 +151,7 @@ func TestGetFile(t *testing.T) {
 	data, resp := Client.GetFile(fileId)
 	CheckNoError(t, resp)
 
-	if data == nil || len(data) == 0 {
+	if len(data) == 0 {
 		t.Fatal("should not be empty")
 	}
 
@@ -268,7 +268,7 @@ func TestGetFileThumbnail(t *testing.T) {
 	data, resp := Client.GetFileThumbnail(fileId)
 	CheckNoError(t, resp)
 
-	if data == nil || len(data) == 0 {
+	if len(data) == 0 {
 		t.Fatal("should not be empty")
 	}
 
@@ -395,7 +395,7 @@ func TestGetFilePreview(t *testing.T) {
 	data, resp := Client.GetFilePreview(fileId)
 	CheckNoError(t, resp)
 
-	if data == nil || len(data) == 0 {
+	if len(data) == 0 {
 		t.Fatal("should not be empty")
 	}
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -572,7 +572,7 @@ func TestPatchPost(t *testing.T) {
 	rpost, resp := Client.PatchPost(post.Id, patch)
 	CheckNoError(t, resp)
 
-	if rpost.IsPinned != false {
+	if rpost.IsPinned {
 		t.Fatal("IsPinned did not update properly")
 	}
 	if rpost.Message != "#otherhashtag other message" {
@@ -593,7 +593,7 @@ func TestPatchPost(t *testing.T) {
 	if !reflect.DeepEqual(rpost.FileIds, *patch.FileIds) {
 		t.Fatal("FileIds did not update properly")
 	}
-	if rpost.HasReactions != false {
+	if rpost.HasReactions {
 		t.Fatal("HasReactions did not update properly")
 	}
 
@@ -642,7 +642,7 @@ func TestPinPost(t *testing.T) {
 		t.Fatal("should have passed")
 	}
 
-	if rpost, err := th.App.GetSinglePost(post.Id); err != nil && rpost.IsPinned != true {
+	if rpost, err := th.App.GetSinglePost(post.Id); err != nil && !rpost.IsPinned {
 		t.Fatal("failed to pin post")
 	}
 
@@ -677,7 +677,7 @@ func TestUnpinPost(t *testing.T) {
 		t.Fatal("should have passed")
 	}
 
-	if rpost, err := th.App.GetSinglePost(pinnedPost.Id); err != nil && rpost.IsPinned != false {
+	if rpost, err := th.App.GetSinglePost(pinnedPost.Id); err != nil && rpost.IsPinned {
 		t.Fatal("failed to pin post")
 	}
 
@@ -1157,7 +1157,7 @@ func TestDeletePost(t *testing.T) {
 	CheckUnauthorizedStatus(t, resp)
 
 	status, resp := th.SystemAdminClient.DeletePost(post.Id)
-	if status == false {
+	if !status {
 		t.Fatal("post should return status OK")
 	}
 	CheckNoError(t, resp)
@@ -1443,7 +1443,7 @@ func TestGetFileInfosForPost(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	fileIds := make([]string, 3, 3)
+	fileIds := make([]string, 3)
 	if data, err := readTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -87,13 +87,13 @@ func TestReloadConfig(t *testing.T) {
 
 	flag, resp := Client.ReloadConfig()
 	CheckForbiddenStatus(t, resp)
-	if flag == true {
+	if flag {
 		t.Fatal("should not Reload the config due no permission.")
 	}
 
 	flag, resp = th.SystemAdminClient.ReloadConfig()
 	CheckNoError(t, resp)
-	if flag == false {
+	if !flag {
 		t.Fatal("should Reload the config")
 	}
 
@@ -285,13 +285,13 @@ func TestInvalidateCaches(t *testing.T) {
 
 	flag, resp := Client.InvalidateCaches()
 	CheckForbiddenStatus(t, resp)
-	if flag == true {
+	if flag {
 		t.Fatal("should not clean the cache due no permission.")
 	}
 
 	flag, resp = th.SystemAdminClient.InvalidateCaches()
 	CheckNoError(t, resp)
-	if flag == false {
+	if !flag {
 		t.Fatal("should clean the cache")
 	}
 }

--- a/api4/team.go
+++ b/api4/team.go
@@ -604,7 +604,6 @@ func teamExists(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write([]byte(model.MapBoolToJson(resp)))
-	return
 }
 
 func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -282,7 +282,7 @@ func TestUpdateTeam(t *testing.T) {
 	uteam, resp = Client.UpdateTeam(team)
 	CheckNoError(t, resp)
 
-	if uteam.AllowOpenInvite != true {
+	if !uteam.AllowOpenInvite {
 		t.Fatal("Update failed")
 	}
 
@@ -419,7 +419,7 @@ func TestPatchTeam(t *testing.T) {
 	if rteam.InviteId != "inviteid1" {
 		t.Fatal("InviteId did not update properly")
 	}
-	if rteam.AllowOpenInvite != true {
+	if !rteam.AllowOpenInvite {
 		t.Fatal("AllowOpenInvite did not update properly")
 	}
 
@@ -1780,13 +1780,13 @@ func TestTeamExists(t *testing.T) {
 
 	exists, resp := Client.TeamExists(team.Name, "")
 	CheckNoError(t, resp)
-	if exists != true {
+	if !exists {
 		t.Fatal("team should exist")
 	}
 
 	exists, resp = Client.TeamExists("testingteam", "")
 	CheckNoError(t, resp)
-	if exists != false {
+	if exists {
 		t.Fatal("team should not exist")
 	}
 
@@ -1889,7 +1889,7 @@ func TestInviteUsersToTeam(t *testing.T) {
 
 	okMsg, resp := th.SystemAdminClient.InviteUsersToTeam(th.BasicTeam.Id, emailList)
 	CheckNoError(t, resp)
-	if okMsg != true {
+	if !okMsg {
 		t.Fatal("should return true")
 	}
 

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -821,7 +821,7 @@ func TestGetProfileImage(t *testing.T) {
 
 	data, resp := Client.GetProfileImage(user.Id, "")
 	CheckNoError(t, resp)
-	if data == nil || len(data) == 0 {
+	if len(data) == 0 {
 		t.Fatal("Should not be empty")
 	}
 
@@ -1860,7 +1860,7 @@ func TestRevokeSessions(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	status, resp := Client.RevokeSession(user.Id, session.Id)
-	if status == false {
+	if !status {
 		t.Fatal("user session revoke unsuccessful")
 	}
 	CheckNoError(t, resp)
@@ -1912,7 +1912,7 @@ func TestRevokeAllSessions(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	status, resp := Client.RevokeAllSessions(user.Id)
-	if status == false {
+	if !status {
 		t.Fatal("user all sessions revoke unsuccessful")
 	}
 	CheckNoError(t, resp)

--- a/app/auto_channels.go
+++ b/app/auto_channels.go
@@ -65,7 +65,7 @@ func (cfg *AutoChannelCreator) CreateTestChannels(num utils.Range) ([]*model.Cha
 	for i := 0; i < numChannels; i++ {
 		var err bool
 		channels[i], err = cfg.createRandomChannel()
-		if err != true {
+		if !err {
 			return channels, false
 		}
 	}

--- a/app/auto_environment.go
+++ b/app/auto_environment.go
@@ -22,7 +22,7 @@ func CreateTestEnvironmentWithTeams(a *App, client *model.Client, rangeTeams uti
 	teamCreator := NewAutoTeamCreator(client)
 	teamCreator.Fuzzy = fuzzy
 	teams, err := teamCreator.CreateTestTeams(rangeTeams)
-	if err != true {
+	if !err {
 		return TestEnvironment{}, false
 	}
 
@@ -32,13 +32,13 @@ func CreateTestEnvironmentWithTeams(a *App, client *model.Client, rangeTeams uti
 		userCreator := NewAutoUserCreator(a, client, team)
 		userCreator.Fuzzy = fuzzy
 		randomUser, err := userCreator.createRandomUser()
-		if err != true {
+		if !err {
 			return TestEnvironment{}, false
 		}
 		client.LoginById(randomUser.Id, USER_PASSWORD)
 		client.SetTeamId(team.Id)
 		teamEnvironment, err := CreateTestEnvironmentInTeam(a, client, team, rangeChannels, rangeUsers, rangePosts, fuzzy)
-		if err != true {
+		if !err {
 			return TestEnvironment{}, false
 		}
 		environment.Environments[i] = teamEnvironment
@@ -58,7 +58,7 @@ func CreateTestEnvironmentInTeam(a *App, client *model.Client, team *model.Team,
 	userCreator := NewAutoUserCreator(a, client, team)
 	userCreator.Fuzzy = fuzzy
 	users, err := userCreator.CreateTestUsers(rangeUsers)
-	if err != true {
+	if !err {
 		return TeamEnvironment{}, false
 	}
 	usernames := make([]string, len(users))
@@ -78,7 +78,7 @@ func CreateTestEnvironmentInTeam(a *App, client *model.Client, team *model.Team,
 		}
 	}
 
-	if err != true {
+	if !err {
 		return TeamEnvironment{}, false
 	}
 

--- a/app/auto_posts.go
+++ b/app/auto_posts.go
@@ -65,7 +65,7 @@ func (cfg *AutoPostCreator) CreateRandomPost() (*model.Post, bool) {
 	if cfg.HasImage {
 		var err1 bool
 		fileIds, err1 = cfg.UploadTestFile()
-		if err1 == false {
+		if !err1 {
 			return nil, false
 		}
 	}
@@ -95,7 +95,7 @@ func (cfg *AutoPostCreator) CreateTestPosts(rangePosts utils.Range) ([]*model.Po
 	for i := 0; i < numPosts; i++ {
 		var err bool
 		posts[i], err = cfg.CreateRandomPost()
-		if err != true {
+		if !err {
 			return posts, false
 		}
 	}

--- a/app/auto_teams.go
+++ b/app/auto_teams.go
@@ -72,7 +72,7 @@ func (cfg *AutoTeamCreator) CreateTestTeams(num utils.Range) ([]*model.Team, boo
 	for i := 0; i < numTeams; i++ {
 		var err bool
 		teams[i], err = cfg.createRandomTeam()
-		if err != true {
+		if !err {
 			return teams, false
 		}
 	}

--- a/app/auto_users.go
+++ b/app/auto_users.go
@@ -38,7 +38,7 @@ func NewAutoUserCreator(a *App, client *model.Client, team *model.Team) *AutoUse
 // Basic test team and user so you always know one
 func (a *App) CreateBasicUser(client *model.Client) *model.AppError {
 	result, _ := client.FindTeamByName(BTEST_TEAM_NAME)
-	if result.Data.(bool) == false {
+	if !result.Data.(bool) {
 		newteam := &model.Team{DisplayName: BTEST_TEAM_DISPLAY_NAME, Name: BTEST_TEAM_NAME, Email: BTEST_TEAM_EMAIL, Type: BTEST_TEAM_TYPE}
 		result, err := client.CreateTeam(newteam)
 		if err != nil {
@@ -102,7 +102,7 @@ func (cfg *AutoUserCreator) CreateTestUsers(num utils.Range) ([]*model.User, boo
 	for i := 0; i < numUsers; i++ {
 		var err bool
 		users[i], err = cfg.createRandomUser()
-		if err != true {
+		if !err {
 			return users, false
 		}
 	}

--- a/app/command_echo.go
+++ b/app/command_echo.go
@@ -53,7 +53,7 @@ func (me *EchoProvider) DoCommand(a *App, args *model.CommandArgs, message strin
 			delay = checkDelay
 		}
 		message = message[1:endMsg]
-	} else if strings.Index(message, " ") > -1 {
+	} else if strings.Contains(message, " ") {
 		delayIdx := strings.LastIndex(message, " ")
 		delayStr := strings.Trim(message[delayIdx:], " ")
 

--- a/app/command_loadtest.go
+++ b/app/command_loadtest.go
@@ -173,7 +173,7 @@ func (me *LoadTestProvider) SetupCommand(a *App, args *model.CommandArgs, messag
 			utils.Range{Begin: numUsers, End: numUsers},
 			utils.Range{Begin: numPosts, End: numPosts},
 			doFuzz)
-		if err != true {
+		if !err {
 			return &model.CommandResponse{Text: "Failed to create testing environment", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		} else {
 			l4g.Info("Testing environment created")
@@ -216,7 +216,7 @@ func (me *LoadTestProvider) UsersCommand(a *App, args *model.CommandArgs, messag
 	}
 
 	usersr, err := parseRange(cmd, "")
-	if err == false {
+	if !err {
 		usersr = utils.Range{Begin: 2, End: 5}
 	}
 
@@ -246,7 +246,7 @@ func (me *LoadTestProvider) ChannelsCommand(a *App, args *model.CommandArgs, mes
 	}
 
 	channelsr, err := parseRange(cmd, "")
-	if err == false {
+	if !err {
 		channelsr = utils.Range{Begin: 2, End: 5}
 	}
 
@@ -277,7 +277,7 @@ func (me *LoadTestProvider) PostsCommand(a *App, args *model.CommandArgs, messag
 	}
 
 	postsr, err := parseRange(cmd, "")
-	if err == false {
+	if !err {
 		postsr = utils.Range{Begin: 20, End: 30}
 	}
 

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -86,10 +86,7 @@ func SendDiagnostic(event string, properties map[string]interface{}) {
 }
 
 func isDefault(setting interface{}, defaultValue interface{}) bool {
-	if setting == defaultValue {
-		return true
-	}
-	return false
+	return setting == defaultValue
 }
 
 func pluginSetting(pluginSettings *model.PluginSettings, plugin, key string, defaultValue interface{}) interface{} {

--- a/app/email_batching_test.go
+++ b/app/email_batching_test.go
@@ -184,7 +184,7 @@ func TestCheckPendingNotifications(t *testing.T) {
 		if post.Message != "post1" {
 			t.Fatal("should've received post1 first")
 		}
-	case _ = <-timeout:
+	case <-timeout:
 		t.Fatal("timed out waiting for first post notification")
 	}
 
@@ -193,7 +193,7 @@ func TestCheckPendingNotifications(t *testing.T) {
 		if post.Message != "post2" {
 			t.Fatal("should've received post2 second")
 		}
-	case _ = <-timeout:
+	case <-timeout:
 		t.Fatal("timed out waiting for second post notification")
 	}
 }

--- a/app/import.go
+++ b/app/import.go
@@ -849,7 +849,7 @@ func (a *App) ImportUserChannels(user *model.User, team *model.Team, teamMember 
 			}
 		}
 
-		if cdata.Favorite != nil && *cdata.Favorite == true {
+		if cdata.Favorite != nil && *cdata.Favorite {
 			preferences = append(preferences, model.Preference{
 				UserId:   user.Id,
 				Category: model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL,

--- a/app/session.go
+++ b/app/session.go
@@ -267,7 +267,7 @@ func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Sessio
 	} else {
 		token = result.Data.(*model.UserAccessToken)
 
-		if token.IsActive == false {
+		if !token.IsActive {
 			return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "inactive_token", http.StatusUnauthorized)
 		}
 	}

--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -243,7 +243,7 @@ func (a *App) SlackAddPosts(teamId string, channel *model.Channel, posts []Slack
 				CreateAt:  SlackConvertTimeStamp(sPost.TimeStamp),
 			}
 			if sPost.Upload {
-				if fileInfo, ok := a.SlackUploadFile(sPost, uploads, teamId, newPost.ChannelId, newPost.UserId); ok == true {
+				if fileInfo, ok := a.SlackUploadFile(sPost, uploads, teamId, newPost.ChannelId, newPost.UserId); ok {
 					newPost.FileIds = append(newPost.FileIds, fileInfo.Id)
 					newPost.Message = sPost.File.Title
 				}
@@ -395,7 +395,7 @@ func (a *App) SlackAddPosts(teamId string, channel *model.Channel, posts []Slack
 
 func (a *App) SlackUploadFile(sPost SlackPost, uploads map[string]*zip.File, teamId string, channelId string, userId string) (*model.FileInfo, bool) {
 	if sPost.File != nil {
-		if file, ok := uploads[sPost.File.Id]; ok == true {
+		if file, ok := uploads[sPost.File.Id]; ok {
 			openFile, err := file.Open()
 			if err != nil {
 				l4g.Warn(utils.T("api.slackimport.slack_add_posts.upload_file_open_failed.warn", map[string]interface{}{"FileId": sPost.File.Id, "Error": err.Error()}))
@@ -655,7 +655,7 @@ func (a *App) SlackImport(fileData multipart.File, fileSize int64, teamID string
 			if len(spl) == 2 && strings.HasSuffix(spl[1], ".json") {
 				newposts, _ := SlackParsePosts(reader)
 				channel := spl[0]
-				if _, ok := posts[channel]; ok == false {
+				if _, ok := posts[channel]; !ok {
 					posts[channel] = newposts
 				} else {
 					posts[channel] = append(posts[channel], newposts...)

--- a/app/user.go
+++ b/app/user.go
@@ -864,11 +864,7 @@ func (a *App) UpdatePasswordAsUser(userId, currentPassword, newPassword string) 
 
 	T := utils.GetUserTranslations(user.Locale)
 
-	if err := a.UpdatePasswordSendEmail(user, newPassword, T("api.user.update_password.menu")); err != nil {
-		return err
-	}
-
-	return nil
+	return a.UpdatePasswordSendEmail(user, newPassword, T("api.user.update_password.menu"))
 }
 
 func (a *App) UpdateActiveNoLdap(userId string, active bool) (*model.User, *model.AppError) {
@@ -1353,11 +1349,7 @@ func (a *App) GetVerifyEmailToken(token string) (*model.Token, *model.AppError) 
 }
 
 func (a *App) VerifyUserEmail(userId string) *model.AppError {
-	if err := (<-a.Srv.Store.User().VerifyEmail(userId)).Err; err != nil {
-		return err
-	}
-
-	return nil
+	return (<-a.Srv.Store.User().VerifyEmail(userId)).Err
 }
 
 func (a *App) SearchUsers(props *model.UserSearch, searchOptions map[string]bool, asAdmin bool) ([]*model.User, *model.AppError) {

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -98,7 +98,7 @@ func (a *App) HubStart() {
 						splits := strings.Split(output, "goroutine ")
 
 						for _, part := range splits {
-							if strings.Index(part, fmt.Sprintf("%v", hub.goroutineId)) > -1 {
+							if strings.Contains(part, fmt.Sprintf("%v", hub.goroutineId)) {
 								l4g.Error("Trace for possible deadlock goroutine %v", part)
 							}
 						}

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -597,11 +597,8 @@ func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookReq
 	overrideUsername := req.Username
 	overrideIconUrl := req.IconURL
 
-	if _, err := a.CreateWebhookPost(hook.UserId, channel, text, overrideUsername, overrideIconUrl, req.Props, webhookType); err != nil {
-		return err
-	}
-
-	return nil
+	_, err := a.CreateWebhookPost(hook.UserId, channel, text, overrideUsername, overrideIconUrl, req.Props, webhookType)
+	return err
 }
 
 func (a *App) CreateCommandWebhook(commandId string, args *model.CommandArgs) (*model.CommandWebhook, *model.AppError) {

--- a/cmd/platform/command.go
+++ b/cmd/platform/command.go
@@ -61,9 +61,5 @@ func moveCommandCmdF(cmd *cobra.Command, args []string) error {
 }
 
 func moveCommand(a *app.App, team *model.Team, command *model.Command) *model.AppError {
-	if err := a.MoveCommand(team, command); err != nil {
-		return err
-	}
-
-	return nil
+	return a.MoveCommand(team, command)
 }

--- a/jobs/jobs_watcher.go
+++ b/jobs/jobs_watcher.go
@@ -40,7 +40,7 @@ func (watcher *Watcher) Start() {
 	// Delay for some random number of milliseconds before starting to ensure that multiple
 	// instances of the jobserver  don't poll at a time too close to each other.
 	rand.Seed(time.Now().UTC().UnixNano())
-	_ = <-time.After(time.Duration(rand.Intn(watcher.pollingInterval)) * time.Millisecond)
+	<-time.After(time.Duration(rand.Intn(watcher.pollingInterval)) * time.Millisecond)
 
 	defer func() {
 		l4g.Debug("Watcher Finished")

--- a/manualtesting/test_autolink.go
+++ b/manualtesting/test_autolink.go
@@ -25,7 +25,7 @@ https://medium.com/@slackhq/11-useful-tips-for-getting-the-most-of-slack-5dfb3d1
 func testAutoLink(env TestEnvironment) *model.AppError {
 	l4g.Info(utils.T("manaultesting.test_autolink.info"))
 	channelID, err := getChannelID(env.Context.App, model.DEFAULT_CHANNEL, env.CreatedTeamId, env.CreatedUserId)
-	if err != true {
+	if !err {
 		return model.NewAppError("/manualtest", "manaultesting.test_autolink.unable.app_error", nil, "", http.StatusInternalServerError)
 	}
 
@@ -33,9 +33,5 @@ func testAutoLink(env TestEnvironment) *model.AppError {
 		ChannelId: channelID,
 		Message:   LINK_POST_TEXT}
 	_, err2 := env.Client.CreatePost(post)
-	if err2 != nil {
-		return err2
-	}
-
-	return nil
+	return err2
 }

--- a/model/authorize.go
+++ b/model/authorize.go
@@ -155,10 +155,5 @@ func AuthorizeRequestFromJson(data io.Reader) *AuthorizeRequest {
 }
 
 func (ad *AuthData) IsExpired() bool {
-
-	if GetMillis() > ad.CreateAt+int64(ad.ExpiresIn*1000) {
-		return true
-	}
-
-	return false
+	return GetMillis() > ad.CreateAt+int64(ad.ExpiresIn*1000)
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -44,7 +44,7 @@ func BuildErrorResponse(r *http.Response, err *AppError) *Response {
 		header = r.Header
 	} else {
 		statusCode = 0
-		header = make(http.Header, 0)
+		header = make(http.Header)
 	}
 
 	return &Response{

--- a/model/config.go
+++ b/model/config.go
@@ -850,12 +850,7 @@ func (o *Config) SetDefaults() {
 
 	if o.EmailSettings.EnableSignInWithEmail == nil {
 		o.EmailSettings.EnableSignInWithEmail = new(bool)
-
-		if o.EmailSettings.EnableSignUpWithEmail == true {
-			*o.EmailSettings.EnableSignInWithEmail = true
-		} else {
-			*o.EmailSettings.EnableSignInWithEmail = false
-		}
+		*o.EmailSettings.EnableSignInWithEmail = o.EmailSettings.EnableSignUpWithEmail
 	}
 
 	if o.EmailSettings.EnableSignInWithUsername == nil {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -29,7 +29,7 @@ func TestConfigDefaultFileSettingsS3SSE(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()
 
-	if *c1.FileSettings.AmazonS3SSE != false {
+	if *c1.FileSettings.AmazonS3SSE {
 		t.Fatal("FileSettings.AmazonS3SSE should default to false")
 	}
 }

--- a/model/license.go
+++ b/model/license.go
@@ -155,19 +155,11 @@ func (f *Features) SetDefaults() {
 }
 
 func (l *License) IsExpired() bool {
-	now := GetMillis()
-	if l.ExpiresAt < now {
-		return true
-	}
-	return false
+	return l.ExpiresAt < GetMillis()
 }
 
 func (l *License) IsStarted() bool {
-	now := GetMillis()
-	if l.StartsAt < now {
-		return true
-	}
-	return false
+	return l.StartsAt < GetMillis()
 }
 
 func (l *License) ToJson() string {

--- a/model/scheduled_task_test.go
+++ b/model/scheduled_task_test.go
@@ -36,7 +36,7 @@ func TestCreateTask(t *testing.T) {
 		t.Fatal("Bad interval")
 	}
 
-	if task.Recurring != false {
+	if task.Recurring {
 		t.Fatal("should not reccur")
 	}
 }
@@ -75,7 +75,7 @@ func TestCreateRecurringTask(t *testing.T) {
 		t.Fatal("Bad interval")
 	}
 
-	if task.Recurring != true {
+	if !task.Recurring {
 		t.Fatal("should reccur")
 	}
 

--- a/model/search_params.go
+++ b/model/search_params.go
@@ -31,16 +31,6 @@ func (o *SearchParams) ToJson() string {
 
 var searchFlags = [...]string{"from", "channel", "in"}
 
-func splitWordsNoQuotes(text string) []string {
-	words := []string{}
-
-	for _, word := range strings.Fields(text) {
-		words = append(words, word)
-	}
-
-	return words
-}
-
 func splitWords(text string) []string {
 	words := []string{}
 
@@ -55,14 +45,14 @@ func splitWords(text string) []string {
 				foundQuote = false
 				location = i + 1
 			} else {
-				words = append(words, splitWordsNoQuotes(text[location:i])...)
+				words = append(words, strings.Fields(text[location:i])...)
 				foundQuote = true
 				location = i
 			}
 		}
 	}
 
-	words = append(words, splitWordsNoQuotes(text[location:])...)
+	words = append(words, strings.Fields(text[location:])...)
 
 	return words
 }

--- a/model/search_params_test.go
+++ b/model/search_params_test.go
@@ -177,19 +177,19 @@ func TestParseSearchParams(t *testing.T) {
 		t.Fatalf("Incorrect output from parse search params: %v", sp)
 	}
 
-	if sp := ParseSearchParams("words words"); len(sp) != 1 || sp[0].Terms != "words words" || sp[0].IsHashtag != false || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
+	if sp := ParseSearchParams("words words"); len(sp) != 1 || sp[0].Terms != "words words" || sp[0].IsHashtag || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
 		t.Fatalf("Incorrect output from parse search params: %v", sp)
 	}
 
-	if sp := ParseSearchParams("\"my stuff\""); len(sp) != 1 || sp[0].Terms != "\"my stuff\"" || sp[0].IsHashtag != false || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
+	if sp := ParseSearchParams("\"my stuff\""); len(sp) != 1 || sp[0].Terms != "\"my stuff\"" || sp[0].IsHashtag || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
 		t.Fatalf("Incorrect output from parse search params: %v", sp)
 	}
 
-	if sp := ParseSearchParams("#words #words"); len(sp) != 1 || sp[0].Terms != "#words #words" || sp[0].IsHashtag != true || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
+	if sp := ParseSearchParams("#words #words"); len(sp) != 1 || sp[0].Terms != "#words #words" || !sp[0].IsHashtag || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
 		t.Fatalf("Incorrect output from parse search params: %v", sp)
 	}
 
-	if sp := ParseSearchParams("#words words"); len(sp) != 2 || sp[1].Terms != "#words" || sp[1].IsHashtag != true || len(sp[1].InChannels) != 0 || len(sp[1].FromUsers) != 0 || sp[0].Terms != "words" || sp[0].IsHashtag != false || len(sp[0].InChannels) != 0 {
+	if sp := ParseSearchParams("#words words"); len(sp) != 2 || sp[1].Terms != "#words" || !sp[1].IsHashtag || len(sp[1].InChannels) != 0 || len(sp[1].FromUsers) != 0 || sp[0].Terms != "words" || sp[0].IsHashtag || len(sp[0].InChannels) != 0 {
 		t.Fatalf("Incorrect output from parse search params: %v", sp)
 	}
 
@@ -213,11 +213,11 @@ func TestParseSearchParams(t *testing.T) {
 		t.Fatalf("Incorrect output from parse search params: %v", sp[0])
 	}
 
-	if sp := ParseSearchParams("##hashtag +#plus+"); len(sp) != 1 || sp[0].Terms != "#hashtag #plus" || sp[0].IsHashtag != true || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
+	if sp := ParseSearchParams("##hashtag +#plus+"); len(sp) != 1 || sp[0].Terms != "#hashtag #plus" || !sp[0].IsHashtag || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
 		t.Fatalf("Incorrect output from parse search params: %v", sp[0])
 	}
 
-	if sp := ParseSearchParams("wildcar*"); len(sp) != 1 || sp[0].Terms != "wildcar*" || sp[0].IsHashtag != false || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
+	if sp := ParseSearchParams("wildcar*"); len(sp) != 1 || sp[0].Terms != "wildcar*" || sp[0].IsHashtag || len(sp[0].InChannels) != 0 || len(sp[0].FromUsers) != 0 {
 		t.Fatalf("Incorrect output from parse search params: %v", sp[0])
 	}
 }

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -61,8 +61,7 @@ func TestStatusListFromJson(t *testing.T) {
 	}
 
 	toDec := strings.NewReader(jsonStream)
-	var statusesFromJson []*Status
-	statusesFromJson = StatusListFromJson(toDec)
+	statusesFromJson := StatusListFromJson(toDec)
 
 	if statusesFromJson[0].UserId != dat[0]["user_id"] {
 		t.Fatal("UserId should be equal")

--- a/model/utils.go
+++ b/model/utils.go
@@ -273,11 +273,7 @@ func GetServerIpAddress() string {
 }
 
 func IsLower(s string) bool {
-	if strings.ToLower(s) == s {
-		return true
-	}
-
-	return false
+	return strings.ToLower(s) == s
 }
 
 func IsValidEmail(email string) bool {

--- a/store/redis_supplier.go
+++ b/store/redis_supplier.go
@@ -34,11 +34,7 @@ func GetBytes(key interface{}) ([]byte, error) {
 
 func DecodeBytes(input []byte, thing interface{}) error {
 	dec := gob.NewDecoder(bytes.NewReader(input))
-	err := dec.Decode(thing)
-	if err != nil {
-		return err
-	}
-	return nil
+	return dec.Decode(thing)
 }
 
 func NewRedisSupplier() *RedisSupplier {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -831,7 +831,7 @@ func (s SqlPostStore) Search(teamId string, userId string, params *model.SearchP
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
 		} else if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
 			// Parse text for wildcards
-			if wildcard, err := regexp.Compile("\\*($| )"); err == nil {
+			if wildcard, err := regexp.Compile(`\*($| )`); err == nil {
 				terms = wildcard.ReplaceAllLiteralString(terms, ":* ")
 			}
 

--- a/store/sqlstore/session_store.go
+++ b/store/sqlstore/session_store.go
@@ -84,7 +84,7 @@ func (me SqlSessionStore) Get(sessionIdOrToken string) store.StoreChannel {
 
 		if _, err := me.GetReplica().Select(&sessions, "SELECT * FROM Sessions WHERE Token = :Token OR Id = :Id LIMIT 1", map[string]interface{}{"Token": sessionIdOrToken, "Id": sessionIdOrToken}); err != nil {
 			result.Err = model.NewAppError("SqlSessionStore.Get", "store.sql_session.get.app_error", nil, "sessionIdOrToken="+sessionIdOrToken+", "+err.Error(), http.StatusInternalServerError)
-		} else if sessions == nil || len(sessions) == 0 {
+		} else if len(sessions) == 0 {
 			result.Err = model.NewAppError("SqlSessionStore.Get", "store.sql_session.get.app_error", nil, "sessionIdOrToken="+sessionIdOrToken, http.StatusNotFound)
 		} else {
 			result.Data = sessions[0]

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -285,27 +285,27 @@ func testIsFeatureEnabled(t *testing.T, ss store.Store) {
 
 	if result := <-ss.Preference().IsFeatureEnabled(feature1, userId); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); data != true {
+	} else if data := result.Data.(bool); !data {
 		t.Fatalf("got incorrect setting for feature1, %v=%v", true, data)
 	}
 
 	if result := <-ss.Preference().IsFeatureEnabled(feature2, userId); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); data != false {
+	} else if data := result.Data.(bool); data {
 		t.Fatalf("got incorrect setting for feature2, %v=%v", false, data)
 	}
 
 	// make sure we get false if something different than "true" or "false" has been saved to database
 	if result := <-ss.Preference().IsFeatureEnabled(feature3, userId); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); data != false {
+	} else if data := result.Data.(bool); data {
 		t.Fatalf("got incorrect setting for feature3, %v=%v", false, data)
 	}
 
 	// make sure false is returned if a non-existent feature is queried
 	if result := <-ss.Preference().IsFeatureEnabled("someOtherFeature", userId); result.Err != nil {
 		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); data != false {
+	} else if data := result.Data.(bool); data {
 		t.Fatalf("got incorrect setting for non-existent feature 'someOtherFeature', %v=%v", false, data)
 	}
 }

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -18,13 +18,11 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_TEAM_USER.Permissions,
 				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 			)
-			break
 		case model.PERMISSIONS_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
@@ -40,7 +38,6 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_TEAM_USER.Permissions,
 				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 			)
-			break
 		case model.PERMISSIONS_CHANNEL_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
@@ -50,13 +47,11 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_CHANNEL_ADMIN.Permissions,
 				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 			)
-			break
 		case model.PERMISSIONS_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
@@ -72,7 +67,6 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_TEAM_USER.Permissions,
 				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			)
-			break
 		case model.PERMISSIONS_CHANNEL_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
@@ -82,13 +76,11 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_CHANNEL_ADMIN.Permissions,
 				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			)
-			break
 		case model.PERMISSIONS_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
@@ -104,13 +96,11 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_TEAM_USER.Permissions,
 				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 			)
-			break
 		case model.PERMISSIONS_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
@@ -126,7 +116,6 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_TEAM_USER.Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 			)
-			break
 		case model.PERMISSIONS_CHANNEL_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
@@ -136,13 +125,11 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_CHANNEL_ADMIN.Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 			)
-			break
 		case model.PERMISSIONS_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
@@ -158,7 +145,6 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_TEAM_USER.Permissions,
 				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 			)
-			break
 		case model.PERMISSIONS_CHANNEL_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
@@ -168,13 +154,11 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_CHANNEL_ADMIN.Permissions,
 				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 			)
-			break
 		case model.PERMISSIONS_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_TEAM_USER.Permissions = append(
@@ -191,7 +175,6 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_CHANNEL_USER.Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 			)
-			break
 		case model.PERMISSIONS_CHANNEL_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
@@ -201,13 +184,11 @@ func SetDefaultRolesBasedOnConfig() {
 				model.ROLE_CHANNEL_ADMIN.Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 			)
-			break
 		case model.PERMISSIONS_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_CHANNEL_USER.Permissions = append(
@@ -268,14 +249,12 @@ func SetDefaultRolesBasedOnConfig() {
 				model.PERMISSION_DELETE_POST.Id,
 				model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 			)
-			break
 		case model.PERMISSIONS_DELETE_POST_TEAM_ADMIN:
 			model.ROLE_TEAM_ADMIN.Permissions = append(
 				model.ROLE_TEAM_ADMIN.Permissions,
 				model.PERMISSION_DELETE_POST.Id,
 				model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 			)
-			break
 		}
 	} else {
 		model.ROLE_CHANNEL_USER.Permissions = append(
@@ -295,5 +274,4 @@ func SetDefaultRolesBasedOnConfig() {
 			model.PERMISSION_CREATE_TEAM.Id,
 		)
 	}
-
 }

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -37,7 +37,7 @@ func TestConfigFromEnviroVars(t *testing.T) {
 		t.Fatal("Couldn't read config from enviroment var")
 	}
 
-	if *Cfg.ServiceSettings.EnableCommands != false {
+	if *Cfg.ServiceSettings.EnableCommands {
 		t.Fatal("Couldn't read config from enviroment var")
 	}
 

--- a/utils/emoji.go
+++ b/utils/emoji.go
@@ -27,8 +27,8 @@ func CreateTestAnimatedGif(t *testing.T, width int, height int, frames int) []by
 	var buffer bytes.Buffer
 
 	img := gif.GIF{
-		Image: make([]*image.Paletted, frames, frames),
-		Delay: make([]int, frames, frames),
+		Image: make([]*image.Paletted, frames),
+		Delay: make([]int, frames),
 	}
 	for i := 0; i < frames; i++ {
 		img.Image[i] = image.NewPaletted(image.Rect(0, 0, width, height), color.Palette{color.Black})

--- a/utils/extract.go
+++ b/utils/extract.go
@@ -23,7 +23,7 @@ func ExtractTarGz(gzipStream io.Reader, dst string) error {
 
 	tarReader := tar.NewReader(uncompressedStream)
 
-	for true {
+	for {
 		header, err := tarReader.Next()
 
 		if err == io.EOF {

--- a/utils/inbucket.go
+++ b/utils/inbucket.go
@@ -102,10 +102,8 @@ func GetMessageFromMailbox(email, id string) (results JSONMessageInbucket, err e
 	}
 	defer resp.Body.Close()
 
-	if err := json.NewDecoder(resp.Body).Decode(&record); err != nil {
-		return record, err
-	}
-	return record, nil
+	err = json.NewDecoder(resp.Body).Decode(&record)
+	return record, err
 }
 
 func DeleteMailBox(email string) (err error) {

--- a/utils/lru_test.go
+++ b/utils/lru_test.go
@@ -85,10 +85,10 @@ func TestLRUAdd(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	if l.Add(1, 1) == true || evictCounter != 0 {
+	if l.Add(1, 1) || evictCounter != 0 {
 		t.Errorf("should not have an eviction")
 	}
-	if l.Add(2, 2) == false || evictCounter != 1 {
+	if !l.Add(2, 2) || evictCounter != 1 {
 		t.Errorf("should have an eviction")
 	}
 }


### PR DESCRIPTION
#### Summary
Simplifies a lot of odd expressions and patterns:

`make([]foo, X, X)` -> `make([]foo, X)`
`make([]foo, 0)` -> `make([]foo)`
`X == true` -> `X`
`X != true` -> `!X`
`X == false` -> `!X`
`X != false` -> `X`
`if err != nil { return err }; return nil` -> `return err`
`return` at the end of a function without named return values -> removed
`break` at the end of a case clause -> removed
`X == nil || len(X) == 0` -> `len(X) == 0`
`strings.Index(X, Y) > -1` -> `strings.Contains(X, Y)`
`if X { return true}; return false` -> `return X`
`_ = <-X` -> `<-X`
`splitWordsNoQuotes(X)` -> `strings.Fields(X)`
`for true` -> `for`
`var X foo; X = Y` -> `X := Y`
`"\\"` -> `` `\` ``

#### Ticket Link
N/A

#### Checklist
N/A