### PR TITLE
7740: Set auto-submitted and precedence headers for emails

### DIFF
--- a/utils/mail.go
+++ b/utils/mail.go
@@ -148,8 +148,8 @@ func SendMailUsingConfig(to, subject, htmlBody string, config *model.Config) *mo
 		"To":                        {to},
 		"Subject":                   {encodeRFC2047Word(subject)},
 		"Content-Transfer-Encoding": {"8bit"},
-		"Auto-Submitted": {"auto-generated"},
-		"Precedence": {"bulk"},
+		"Auto-Submitted":            {"auto-generated"},
+		"Precedence":                {"bulk"},
 	})
 	m.SetDateHeader("Date", time.Now())
 

--- a/utils/mail.go
+++ b/utils/mail.go
@@ -148,6 +148,8 @@ func SendMailUsingConfig(to, subject, htmlBody string, config *model.Config) *mo
 		"To":                        {to},
 		"Subject":                   {encodeRFC2047Word(subject)},
 		"Content-Transfer-Encoding": {"8bit"},
+		"Auto-Submitted": {"auto-generated"},
+		"Precedence": {"bulk"},
 	})
 	m.SetDateHeader("Date", time.Now())
 


### PR DESCRIPTION
This prevents auto-responses from out-of-office agents.

#### Summary
Sets the `Auto-Submitted` and `Precedence` headers so that e.g. out-of-office agents to not respond to mattermost mails.

#### Ticket Link
#7740
