### PR TITLE
PLT-6071/PLT-8004 Fixed not being able to autocomplete 'Town Square'

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1268,7 +1268,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
 	} else {
 		isPostgreSQL := s.DriverName() == model.DATABASE_DRIVER_POSTGRES
-		searchQuery = generateSearchQuery(searchQuery, term, "Name, DisplayName", parameters, isPostgreSQL)
+		searchQuery = generateSearchQuery(searchQuery, []string{term}, []string{"Name", "DisplayName"}, parameters, isPostgreSQL)
 	}
 
 	var channels model.ChannelList

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -1861,6 +1861,13 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o8.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&o8, -1))
 
+	o9 := model.Channel{}
+	o9.TeamId = o1.TeamId
+	o9.DisplayName = "Town Square"
+	o9.Name = "town-square"
+	o9.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o9, -1))
+
 	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
@@ -1924,6 +1931,19 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 		channels := result.Data.(*model.ChannelList)
 		if len(*channels) != 0 {
 			t.Fatal("should be empty")
+		}
+	}
+
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "town square"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
+
+		if (*channels)[0].Name != o9.Name {
+			t.Fatal("wrong channel returned")
 		}
 	}
 }


### PR DESCRIPTION
The search code was changed to split up all search terms so searching for "town square" searched for a channel with a name starting with "town" and with "square", so that obviously didn't work. Those changes to the search code also fixed an issue where "~town square town" autocompleted to "~town-square" because it's now using a like statement instead of the previous full text search that ignored the extra word

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-6071
https://mattermost.atlassian.net/browse/PLT-8004

#### Checklist
- Added or updated unit tests (required for all new features)