### PR TITLE
Fix /msg switching teams

### DIFF
--- a/app/command_msg.go
+++ b/app/command_msg.go
@@ -37,12 +37,10 @@ func (me *msgProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
 }
 
 func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
-
 	splitMessage := strings.SplitN(message, " ", 2)
 
 	parsedMessage := ""
 	targetUsername := ""
-	teamId := ""
 
 	if len(splitMessage) > 1 {
 		parsedMessage = strings.SplitN(message, " ", 2)[1]
@@ -81,7 +79,6 @@ func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string
 	} else {
 		channel := channel.Data.(*model.Channel)
 		targetChannelId = channel.Id
-		teamId = channel.TeamId
 	}
 
 	if len(parsedMessage) > 0 {
@@ -94,11 +91,16 @@ func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string
 		}
 	}
 
+	teamId := args.TeamId
 	if teamId == "" {
 		if len(args.Session.TeamMembers) == 0 {
 			return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 		}
 		teamId = args.Session.TeamMembers[0].TeamId
+	}
+
+	if args.Session.GetTeamByTeamId(teamId) == nil {
+		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
 	team, err := a.GetTeam(teamId)

--- a/app/command_msg.go
+++ b/app/command_msg.go
@@ -99,10 +99,6 @@ func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string
 		teamId = args.Session.TeamMembers[0].TeamId
 	}
 
-	if args.Session.GetTeamByTeamId(teamId) == nil {
-		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	}
-
 	team, err := a.GetTeam(teamId)
 	if err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}

--- a/app/command_msg_test.go
+++ b/app/command_msg_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/nicksnyder/go-i18n/i18n"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func TestMsgProvider(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	team := th.CreateTeam()
+	th.LinkUserToTeam(th.BasicUser, team)
+	cmd := &msgProvider{}
+	resp := cmd.DoCommand(th.App, &model.CommandArgs{
+		T:       i18n.IdentityTfunc(),
+		SiteURL: "http://test.url",
+		TeamId:  team.Id,
+		UserId:  th.BasicUser.Id,
+		Session: model.Session{
+			TeamMembers: []*model.TeamMember{
+				{
+					TeamId: team.Id,
+				},
+			},
+		},
+	}, "@"+th.BasicUser2.Username+" hello")
+	channelName := model.GetDMNameFromIds(th.BasicUser.Id, th.BasicUser2.Id)
+	assert.Equal(t, "", resp.Text)
+	assert.Equal(t, "http://test.url/"+team.Name+"/channels/"+channelName, resp.GotoLocation)
+}

--- a/app/command_msg_test.go
+++ b/app/command_msg_test.go
@@ -24,13 +24,6 @@ func TestMsgProvider(t *testing.T) {
 		SiteURL: "http://test.url",
 		TeamId:  team.Id,
 		UserId:  th.BasicUser.Id,
-		Session: model.Session{
-			TeamMembers: []*model.TeamMember{
-				{
-					TeamId: team.Id,
-				},
-			},
-		},
 	}, "@"+th.BasicUser2.Username+" hello")
 	channelName := model.GetDMNameFromIds(th.BasicUser.Id, th.BasicUser2.Id)
 	assert.Equal(t, "", resp.Text)


### PR DESCRIPTION
#### Summary
Before: When you use that command, you'll sometimes be switched to another team. This seems to be the same team each time, and it'll happen unless you're already viewing that team.
After: When you use that command, you stay on your current team.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8001

#### Checklist
- [x] Added or updated unit tests (required for all new features)