### PR TITLE
PLT-7932: prevent deactivation of sso users

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -729,7 +729,7 @@ func updateActive(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ruser, err := c.App.UpdateActiveNoLdap(userId, active); err != nil {
+	if ruser, err := c.App.UpdateNonSSOUserActive(userId, active); err != nil {
 		c.Err = err
 	} else {
 		c.LogAuditWithUserId(ruser.Id, fmt.Sprintf("active=%v", active))

--- a/api4/user.go
+++ b/api4/user.go
@@ -683,7 +683,7 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ruser, err := c.App.UpdateActiveNoLdap(c.Params.UserId, active); err != nil {
+	if ruser, err := c.App.UpdateNonSSOUserActive(c.Params.UserId, active); err != nil {
 		c.Err = err
 	} else {
 		c.LogAuditWithUserId(ruser.Id, fmt.Sprintf("active=%v", active))

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -521,7 +521,7 @@ func TestSearchUsers(t *testing.T) {
 		t.Fatal("should have found user")
 	}
 
-	_, err := th.App.UpdateActiveNoLdap(th.BasicUser2.Id, false)
+	_, err := th.App.UpdateNonSSOUserActive(th.BasicUser2.Id, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +638,7 @@ func TestSearchUsers(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowEmailAddress = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.PrivacySettings.ShowFullName = false })
 
-	_, err = th.App.UpdateActiveNoLdap(th.BasicUser2.Id, true)
+	_, err = th.App.UpdateNonSSOUserActive(th.BasicUser2.Id, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -867,15 +867,15 @@ func (a *App) UpdatePasswordAsUser(userId, currentPassword, newPassword string) 
 	return a.UpdatePasswordSendEmail(user, newPassword, T("api.user.update_password.menu"))
 }
 
-func (a *App) UpdateActiveNoLdap(userId string, active bool) (*model.User, *model.AppError) {
+func (a *App) UpdateNonSSOUserActive(userId string, active bool) (*model.User, *model.AppError) {
 	var user *model.User
 	var err *model.AppError
 	if user, err = a.GetUser(userId); err != nil {
 		return nil, err
 	}
 
-	if user.IsLDAPUser() {
-		err := model.NewAppError("UpdateActive", "api.user.update_active.no_deactivate_ldap.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
+	if user.IsSSOUser() {
+		err := model.NewAppError("UpdateActive", "api.user.update_active.no_deactivate_sso.app_error", nil, "userId="+user.Id, http.StatusBadRequest)
 		err.StatusCode = http.StatusBadRequest
 		return nil, err
 	}

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/model/gitlab"
@@ -96,6 +98,24 @@ func TestCreateOAuthUser(t *testing.T) {
 	if err == nil {
 		t.Fatal("should have failed - user creation disabled")
 	}
+}
+
+func TestDeactivateSSOUser(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	glUser := oauthgitlab.GitLabUser{Id: int64(r.Intn(1000)) + 1, Username: "o" + model.NewId(), Email: model.NewId() + "@simulator.amazonses.com", Name: "Joram Wilander"}
+
+	json := glUser.ToJson()
+	user, err := th.App.CreateOAuthUser(model.USER_AUTH_SERVICE_GITLAB, strings.NewReader(json), th.BasicTeam.Id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer th.App.PermanentDeleteUser(user)
+
+	_, err = th.App.UpdateNonSSOUserActive(user.Id, false)
+	assert.Equal(t, "api.user.update_active.no_deactivate_sso.app_error", err.Id)
 }
 
 func TestCreateProfileImage(t *testing.T) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2800,8 +2800,8 @@
     "translation": "Failed to send welcome email successfully"
   },
   {
-    "id": "api.user.update_active.no_deactivate_ldap.app_error",
-    "translation": "You can not modify the activation status of AD/LDAP accounts. Please modify through the AD/LDAP server."
+    "id": "api.user.update_active.no_deactivate_sso.app_error",
+    "translation": "You can not modify the activation status of SSO accounts. Please modify through the SSO server."
   },
   {
     "id": "api.user.update_active.permissions.app_error",


### PR DESCRIPTION
#### Summary
Just replaces our LDAP check and error message with a check and error message for all SSO users.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7932

#### Checklist
- [x] Added or updated unit tests (required for all new features)