### PR TITLE
PLT-8011: Make Elasticsearch startup fully async.

### DIFF
--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -130,11 +130,11 @@ func runServer(configFileLocation string) {
 	}
 
 	if a.Elasticsearch != nil {
-		go func() {
+		a.Go(func() {
 			if err := a.Elasticsearch.Start(); err != nil {
 				l4g.Error(err.Error())
 			}
-		}()
+		})
 	}
 
 	if *utils.Cfg.JobSettings.RunJobs {

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -130,9 +130,11 @@ func runServer(configFileLocation string) {
 	}
 
 	if a.Elasticsearch != nil {
-		if err := a.Elasticsearch.Start(); err != nil {
-			l4g.Error(err.Error())
-		}
+		go func() {
+			if err := a.Elasticsearch.Start(); err != nil {
+				l4g.Error(err.Error())
+			}
+		}()
 	}
 
 	if *utils.Cfg.JobSettings.RunJobs {


### PR DESCRIPTION
#### Summary
This makes the Elasticsearch startup happen asynchronously, so that if there is a delay connecting to Elasticsearch it doesn't block the rest of the app startup sequence.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8011

#### Checklist
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/227