### PR TITLE
PLT-7863: prevent users from changing email addresses to restricted domains

### DIFF
--- a/app/user_test.go
+++ b/app/user_test.go
@@ -137,6 +137,25 @@ func TestCreateProfileImage(t *testing.T) {
 	}
 }
 
+func TestUpdateUserToRestrictedDomain(t *testing.T) {
+	th := Setup()
+	defer th.TearDown()
+
+	user := th.CreateUser()
+	defer th.App.PermanentDeleteUser(user)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.TeamSettings.RestrictCreationToDomains = "foo.com"
+	})
+
+	_, err := th.App.UpdateUser(user, false)
+	assert.True(t, err == nil)
+
+	user.Email = "asdf@ghjk.l"
+	_, err = th.App.UpdateUser(user, false)
+	assert.False(t, err == nil)
+}
+
 func TestUpdateOAuthUserAttrs(t *testing.T) {
 	th := Setup()
 	defer th.TearDown()


### PR DESCRIPTION
#### Summary
When `RestrictCreationToDomains` is used, this prevents users from changing their email address to anything outside of those domains.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7863

#### Checklist
- [x] Added or updated unit tests (required for all new features)