### PR TITLE
Update diagnostics.go with missing config settings

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -364,6 +364,7 @@ func (a *App) trackConfig() {
 
 	SendDiagnostic(TRACK_CONFIG_LDAP, map[string]interface{}{
 		"enable":                         *cfg.LdapSettings.Enable,
+		"enable_sync":                    *cfg.LdapSettings.EnableSync,
 		"connection_security":            *cfg.LdapSettings.ConnectionSecurity,
 		"skip_certificate_verification":  *cfg.LdapSettings.SkipCertificateVerification,
 		"sync_interval_minutes":          *cfg.LdapSettings.SyncIntervalMinutes,
@@ -392,6 +393,7 @@ func (a *App) trackConfig() {
 
 	SendDiagnostic(TRACK_CONFIG_SAML, map[string]interface{}{
 		"enable":                         *cfg.SamlSettings.Enable,
+		"enable_sync_with_ldap":          *cfg.SamlSettings.EnableSyncWithLdap,
 		"verify":                         *cfg.SamlSettings.Verify,
 		"encrypt":                        *cfg.SamlSettings.Encrypt,
 		"isdefault_first_name_attribute": isDefault(*cfg.SamlSettings.FirstNameAttribute, model.SAML_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE),
@@ -440,15 +442,18 @@ func (a *App) trackConfig() {
 	})
 
 	SendDiagnostic(TRACK_CONFIG_ELASTICSEARCH, map[string]interface{}{
-		"isdefault_connection_url": isDefault(*cfg.ElasticsearchSettings.ConnectionUrl, model.ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL),
-		"isdefault_username":       isDefault(*cfg.ElasticsearchSettings.Username, model.ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME),
-		"isdefault_password":       isDefault(*cfg.ElasticsearchSettings.Password, model.ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD),
-		"enable_indexing":          *cfg.ElasticsearchSettings.EnableIndexing,
-		"enable_searching":         *cfg.ElasticsearchSettings.EnableSearching,
-		"sniff":                    *cfg.ElasticsearchSettings.Sniff,
-		"post_index_replicas":      *cfg.ElasticsearchSettings.PostIndexReplicas,
-		"post_index_shards":        *cfg.ElasticsearchSettings.PostIndexShards,
-		"isdefault_index_prefix":   isDefault(*cfg.ElasticsearchSettings.IndexPrefix, model.ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX),
+		"isdefault_connection_url":          isDefault(*cfg.ElasticsearchSettings.ConnectionUrl, model.ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL),
+		"isdefault_username":                isDefault(*cfg.ElasticsearchSettings.Username, model.ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME),
+		"isdefault_password":                isDefault(*cfg.ElasticsearchSettings.Password, model.ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD),
+		"enable_indexing":                   *cfg.ElasticsearchSettings.EnableIndexing,
+		"enable_searching":                  *cfg.ElasticsearchSettings.EnableSearching,
+		"sniff":                             *cfg.ElasticsearchSettings.Sniff,
+		"post_index_replicas":               *cfg.ElasticsearchSettings.PostIndexReplicas,
+		"post_index_shards":                 *cfg.ElasticsearchSettings.PostIndexShards,
+		"isdefault_index_prefix":            isDefault(*cfg.ElasticsearchSettings.IndexPrefix, model.ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX),
+		"live_indexing_batch_size":          *cfg.ElasticsearchSettings.LiveIndexingBatchSize,
+		"bulk_indexing_time_window_seconds": *cfg.ElasticsearchSettings.BulkIndexingTimeWindowSeconds,
+		"request_timeout_seconds":           *cfg.ElasticsearchSettings.RequestTimeoutSeconds,
 	})
 
 	SendDiagnostic(TRACK_CONFIG_PLUGIN, map[string]interface{}{


### PR DESCRIPTION
ElasticsearchSettings: LiveIndexingBatchSize, BulkIndexingTimeWindowSeconds
LdapSettings: EnableSync
SamlSettings: EnableSyncWithLdap