### PR TITLE
config watcher fix

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -221,7 +221,7 @@ func InitializeConfigWatch() {
 						if event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create {
 							l4g.Info(fmt.Sprintf("Config file watcher detected a change reloading %v", CfgFileName))
 
-							if configReadErr := viper.ReadInConfig(); configReadErr == nil {
+							if _, configReadErr := ReadConfigFile(CfgFileName, true); configReadErr == nil {
 								LoadGlobalConfig(CfgFileName)
 							} else {
 								l4g.Error(fmt.Sprintf("Failed to read while watching config file at %v with err=%v", CfgFileName, configReadErr.Error()))


### PR DESCRIPTION
#### Summary
The viper singleton shouldn't be used anymore.

#### Ticket Link
N/A

#### Checklist
N/A