### PR TITLE
PLT-7709 Add UI settings to plugin manifest

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -499,6 +499,7 @@ func (a *App) trackPlugins() {
 		totalInactiveCount := -1 // -1 to indicate disabled or error
 		webappInactiveCount := 0
 		backendInactiveCount := 0
+		settingsCount := 0
 
 		plugins, _ := a.GetPluginManifests()
 
@@ -513,6 +514,10 @@ func (a *App) trackPlugins() {
 				if plugin.Backend != nil {
 					backendActiveCount += 1
 				}
+
+				if plugin.SettingsSchema != nil {
+					settingsCount += 1
+				}
 			}
 
 			totalInactiveCount = len(plugins.Inactive)
@@ -525,6 +530,10 @@ func (a *App) trackPlugins() {
 				if plugin.Backend != nil {
 					backendInactiveCount += 1
 				}
+
+				if plugin.SettingsSchema != nil {
+					settingsCount += 1
+				}
 			}
 		}
 
@@ -535,6 +544,7 @@ func (a *App) trackPlugins() {
 			"inactive_plugins":         totalInactiveCount,
 			"inactive_webapp_plugins":  webappInactiveCount,
 			"inactive_backend_plugins": backendInactiveCount,
+			"plugins_with_settings":    settingsCount,
 		})
 	}
 }

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License.txt for license information.
 
 package model
@@ -13,13 +13,35 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	PLUGIN_CONFIG_TYPE_TEXT      = "text"
+	PLUGIN_CONFIG_TYPE_BOOL      = "bool"
+	PLUGIN_CONFIG_TYPE_RADIO     = "radio"
+	PLUGIN_CONFIG_TYPE_DROPDOWN  = "dropdown"
+	PLUGIN_CONFIG_TYPE_GENERATED = "generated"
+)
+
+type PluginUISetting struct {
+	DisplayName string      `json:"display_name" yaml:"display_name"`
+	Type        string      `json:"type" yaml:"type"`
+	HelpText    string      `json:"help_text" yaml:"help_text"`
+	Default     interface{} `json:"default" yaml:"default"`
+}
+
+type PluginUISettings struct {
+	HeaderText string                      `json:"header_text" yaml:"header_text"`
+	FooterText string                      `json:"footer_text" yaml:"footer_text"`
+	Settings   map[string]*PluginUISetting `json:"settings" yaml:"settings"`
+}
+
 type Manifest struct {
-	Id          string           `json:"id" yaml:"id"`
-	Name        string           `json:"name,omitempty" yaml:"name,omitempty"`
-	Description string           `json:"description,omitempty" yaml:"description,omitempty"`
-	Version     string           `json:"version" yaml:"version"`
-	Backend     *ManifestBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
-	Webapp      *ManifestWebapp  `json:"webapp,omitempty" yaml:"webapp,omitempty"`
+	Id          string            `json:"id" yaml:"id"`
+	Name        string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Version     string            `json:"version" yaml:"version"`
+	Backend     *ManifestBackend  `json:"backend,omitempty" yaml:"backend,omitempty"`
+	Webapp      *ManifestWebapp   `json:"webapp,omitempty" yaml:"webapp,omitempty"`
+	UISettings  *PluginUISettings `json:"ui_settings,omitempty" yaml:"ui_settings,omitempty"`
 }
 
 type ManifestBackend struct {

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -21,11 +21,17 @@ const (
 	PLUGIN_CONFIG_TYPE_GENERATED = "generated"
 )
 
+type PluginOption struct {
+	DisplayName string `json:"display_name" yaml:"display_name"`
+	Value       string `json:"value" yaml:"value"`
+}
+
 type PluginUISetting struct {
-	DisplayName string      `json:"display_name" yaml:"display_name"`
-	Type        string      `json:"type" yaml:"type"`
-	HelpText    string      `json:"help_text" yaml:"help_text"`
-	Default     interface{} `json:"default" yaml:"default"`
+	DisplayName string          `json:"display_name" yaml:"display_name"`
+	Type        string          `json:"type" yaml:"type"`
+	HelpText    string          `json:"help_text" yaml:"help_text"`
+	Default     interface{}     `json:"default" yaml:"default"`
+	Options     []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 type PluginUISettings struct {

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -26,7 +26,7 @@ type PluginOption struct {
 	Value       string `json:"value" yaml:"value"`
 }
 
-type PluginUISetting struct {
+type PluginSetting struct {
 	DisplayName string          `json:"display_name" yaml:"display_name"`
 	Type        string          `json:"type" yaml:"type"`
 	HelpText    string          `json:"help_text" yaml:"help_text"`
@@ -34,20 +34,20 @@ type PluginUISetting struct {
 	Options     []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
-type PluginUISettings struct {
-	HeaderText string                      `json:"header_text" yaml:"header_text"`
-	FooterText string                      `json:"footer_text" yaml:"footer_text"`
-	Settings   map[string]*PluginUISetting `json:"settings" yaml:"settings"`
+type PluginSettingsSchema struct {
+	Header   string                    `json:"header" yaml:"header"`
+	Footer   string                    `json:"footer" yaml:"footer"`
+	Settings map[string]*PluginSetting `json:"settings" yaml:"settings"`
 }
 
 type Manifest struct {
-	Id          string            `json:"id" yaml:"id"`
-	Name        string            `json:"name,omitempty" yaml:"name,omitempty"`
-	Description string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Version     string            `json:"version" yaml:"version"`
-	Backend     *ManifestBackend  `json:"backend,omitempty" yaml:"backend,omitempty"`
-	Webapp      *ManifestWebapp   `json:"webapp,omitempty" yaml:"webapp,omitempty"`
-	UISettings  *PluginUISettings `json:"ui_settings,omitempty" yaml:"ui_settings,omitempty"`
+	Id             string                `json:"id" yaml:"id"`
+	Name           string                `json:"name,omitempty" yaml:"name,omitempty"`
+	Description    string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Version        string                `json:"version" yaml:"version"`
+	Backend        *ManifestBackend      `json:"backend,omitempty" yaml:"backend,omitempty"`
+	Webapp         *ManifestWebapp       `json:"webapp,omitempty" yaml:"webapp,omitempty"`
+	SettingsSchema *PluginSettingsSchema `json:"settings_schema,omitempty" yaml:"settings_schema,omitempty"`
 }
 
 type ManifestBackend struct {

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -27,11 +27,12 @@ type PluginOption struct {
 }
 
 type PluginSetting struct {
-	DisplayName string          `json:"display_name" yaml:"display_name"`
-	Type        string          `json:"type" yaml:"type"`
-	HelpText    string          `json:"help_text" yaml:"help_text"`
-	Default     interface{}     `json:"default" yaml:"default"`
-	Options     []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
+	DisplayName        string          `json:"display_name" yaml:"display_name"`
+	Type               string          `json:"type" yaml:"type"`
+	HelpText           string          `json:"help_text" yaml:"help_text"`
+	RegenerateHelpText string          `json:"regenerate_help_text,omitempty" yaml:"regenerate_help_text,omitempty"`
+	Default            interface{}     `json:"default" yaml:"default"`
+	Options            []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 type PluginSettingsSchema struct {

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -73,9 +73,14 @@ func TestManifestUnmarshal(t *testing.T) {
 			Settings: map[string]*PluginUISetting{
 				"thesetting": &PluginUISetting{
 					DisplayName: "thedisplayname",
-					Type:        PLUGIN_CONFIG_TYPE_TEXT,
+					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:    "thehelptext",
-					Default:     "thedefault",
+					Options: []*PluginOption{&PluginOption{
+						DisplayName: "theoptiondisplayname",
+						Value:       "thevalue",
+					},
+					},
+					Default: "thedefault",
 				},
 			},
 		},
@@ -94,8 +99,11 @@ ui_settings:
     settings:
         thesetting:
             display_name: thedisplayname
-            type: text
+            type: dropdown
             help_text: thehelptext
+            options:
+                - display_name: theoptiondisplayname
+                  value: thevalue
             default: thedefault
 `), &yamlResult))
 	assert.Equal(t, expected, yamlResult)
@@ -115,8 +123,14 @@ ui_settings:
         "settings": {
             "thesetting": {
                 "display_name": "thedisplayname",
-                "type": "text",
+                "type": "dropdown",
                 "help_text": "thehelptext",
+                "options": [
+                    {
+                        "display_name": "theoptiondisplayname",
+                        "value": "thevalue"
+                    }
+                ],
                 "default": "thedefault"
             }
         }
@@ -157,9 +171,14 @@ func TestManifestJson(t *testing.T) {
 			Settings: map[string]*PluginUISetting{
 				"thesetting": &PluginUISetting{
 					DisplayName: "thedisplayname",
-					Type:        PLUGIN_CONFIG_TYPE_TEXT,
+					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:    "thehelptext",
-					Default:     "thedefault",
+					Options: []*PluginOption{&PluginOption{
+						DisplayName: "theoptiondisplayname",
+						Value:       "thevalue",
+					},
+					},
+					Default: "thedefault",
 				},
 			},
 		},
@@ -213,9 +232,14 @@ func TestManifestClientManifest(t *testing.T) {
 			Settings: map[string]*PluginUISetting{
 				"thesetting": &PluginUISetting{
 					DisplayName: "thedisplayname",
-					Type:        PLUGIN_CONFIG_TYPE_TEXT,
+					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:    "thehelptext",
-					Default:     "thedefault",
+					Options: []*PluginOption{&PluginOption{
+						DisplayName: "theoptiondisplayname",
+						Value:       "thevalue",
+					},
+					},
+					Default: "thedefault",
 				},
 			},
 		},

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -67,11 +67,11 @@ func TestManifestUnmarshal(t *testing.T) {
 		Webapp: &ManifestWebapp{
 			BundlePath: "thebundlepath",
 		},
-		UISettings: &PluginUISettings{
-			HeaderText: "theheadertext",
-			FooterText: "thefootertext",
-			Settings: map[string]*PluginUISetting{
-				"thesetting": &PluginUISetting{
+		SettingsSchema: &PluginSettingsSchema{
+			Header: "theheadertext",
+			Footer: "thefootertext",
+			Settings: map[string]*PluginSetting{
+				"thesetting": &PluginSetting{
 					DisplayName: "thedisplayname",
 					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:    "thehelptext",
@@ -93,9 +93,9 @@ backend:
     executable: theexecutable
 webapp:
     bundle_path: thebundlepath
-ui_settings:
-    header_text: theheadertext
-    footer_text: thefootertext
+settings_schema:
+    header: theheadertext
+    footer: thefootertext
     settings:
         thesetting:
             display_name: thedisplayname
@@ -117,9 +117,9 @@ ui_settings:
 	"webapp": {
 		"bundle_path": "thebundlepath"
 	},
-    "ui_settings": {
-        "header_text": "theheadertext",
-        "footer_text": "thefootertext",
+    "settings_schema": {
+        "header": "theheadertext",
+        "footer": "thefootertext",
         "settings": {
             "thesetting": {
                 "display_name": "thedisplayname",
@@ -165,18 +165,19 @@ func TestManifestJson(t *testing.T) {
 		Webapp: &ManifestWebapp{
 			BundlePath: "thebundlepath",
 		},
-		UISettings: &PluginUISettings{
-			HeaderText: "theheadertext",
-			FooterText: "thefootertext",
-			Settings: map[string]*PluginUISetting{
-				"thesetting": &PluginUISetting{
+		SettingsSchema: &PluginSettingsSchema{
+			Header: "theheadertext",
+			Footer: "thefootertext",
+			Settings: map[string]*PluginSetting{
+				"thesetting": &PluginSetting{
 					DisplayName: "thedisplayname",
 					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:    "thehelptext",
-					Options: []*PluginOption{&PluginOption{
-						DisplayName: "theoptiondisplayname",
-						Value:       "thevalue",
-					},
+					Options: []*PluginOption{
+						&PluginOption{
+							DisplayName: "theoptiondisplayname",
+							Value:       "thevalue",
+						},
 					},
 					Default: "thedefault",
 				},
@@ -226,11 +227,11 @@ func TestManifestClientManifest(t *testing.T) {
 		Webapp: &ManifestWebapp{
 			BundlePath: "thebundlepath",
 		},
-		UISettings: &PluginUISettings{
-			HeaderText: "theheadertext",
-			FooterText: "thefootertext",
-			Settings: map[string]*PluginUISetting{
-				"thesetting": &PluginUISetting{
+		SettingsSchema: &PluginSettingsSchema{
+			Header: "theheadertext",
+			Footer: "thefootertext",
+			Settings: map[string]*PluginSetting{
+				"thesetting": &PluginSetting{
 					DisplayName: "thedisplayname",
 					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:    "thehelptext",
@@ -250,7 +251,7 @@ func TestManifestClientManifest(t *testing.T) {
 	assert.NotEmpty(t, sanitized.Id)
 	assert.NotEmpty(t, sanitized.Version)
 	assert.NotEmpty(t, sanitized.Webapp)
-	assert.NotEmpty(t, sanitized.UISettings)
+	assert.NotEmpty(t, sanitized.SettingsSchema)
 	assert.Empty(t, sanitized.Name)
 	assert.Empty(t, sanitized.Description)
 	assert.Empty(t, sanitized.Backend)
@@ -261,5 +262,5 @@ func TestManifestClientManifest(t *testing.T) {
 	assert.NotEmpty(t, manifest.Name)
 	assert.NotEmpty(t, manifest.Description)
 	assert.NotEmpty(t, manifest.Backend)
-	assert.NotEmpty(t, manifest.UISettings)
+	assert.NotEmpty(t, manifest.SettingsSchema)
 }

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -207,6 +207,18 @@ func TestManifestClientManifest(t *testing.T) {
 		Webapp: &ManifestWebapp{
 			BundlePath: "thebundlepath",
 		},
+		UISettings: &PluginUISettings{
+			HeaderText: "theheadertext",
+			FooterText: "thefootertext",
+			Settings: map[string]*PluginUISetting{
+				"thesetting": &PluginUISetting{
+					DisplayName: "thedisplayname",
+					Type:        PLUGIN_CONFIG_TYPE_TEXT,
+					HelpText:    "thehelptext",
+					Default:     "thedefault",
+				},
+			},
+		},
 	}
 
 	sanitized := manifest.ClientManifest()
@@ -214,6 +226,7 @@ func TestManifestClientManifest(t *testing.T) {
 	assert.NotEmpty(t, sanitized.Id)
 	assert.NotEmpty(t, sanitized.Version)
 	assert.NotEmpty(t, sanitized.Webapp)
+	assert.NotEmpty(t, sanitized.UISettings)
 	assert.Empty(t, sanitized.Name)
 	assert.Empty(t, sanitized.Description)
 	assert.Empty(t, sanitized.Backend)
@@ -224,4 +237,5 @@ func TestManifestClientManifest(t *testing.T) {
 	assert.NotEmpty(t, manifest.Name)
 	assert.NotEmpty(t, manifest.Description)
 	assert.NotEmpty(t, manifest.Backend)
+	assert.NotEmpty(t, manifest.UISettings)
 }

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package model
 
 import (
@@ -64,6 +67,18 @@ func TestManifestUnmarshal(t *testing.T) {
 		Webapp: &ManifestWebapp{
 			BundlePath: "thebundlepath",
 		},
+		UISettings: &PluginUISettings{
+			HeaderText: "theheadertext",
+			FooterText: "thefootertext",
+			Settings: map[string]*PluginUISetting{
+				"thesetting": &PluginUISetting{
+					DisplayName: "thedisplayname",
+					Type:        PLUGIN_CONFIG_TYPE_TEXT,
+					HelpText:    "thehelptext",
+					Default:     "thedefault",
+				},
+			},
+		},
 	}
 
 	var yamlResult Manifest
@@ -73,6 +88,15 @@ backend:
     executable: theexecutable
 webapp:
     bundle_path: thebundlepath
+ui_settings:
+    header_text: theheadertext
+    footer_text: thefootertext
+    settings:
+        thesetting:
+            display_name: thedisplayname
+            type: text
+            help_text: thehelptext
+            default: thedefault
 `), &yamlResult))
 	assert.Equal(t, expected, yamlResult)
 
@@ -84,7 +108,19 @@ webapp:
 	},
 	"webapp": {
 		"bundle_path": "thebundlepath"
-	}
+	},
+    "ui_settings": {
+        "header_text": "theheadertext",
+        "footer_text": "thefootertext",
+        "settings": {
+            "thesetting": {
+                "display_name": "thedisplayname",
+                "type": "text",
+                "help_text": "thehelptext",
+                "default": "thedefault"
+            }
+        }
+    }
 	}`), &jsonResult))
 	assert.Equal(t, expected, jsonResult)
 }
@@ -114,6 +150,18 @@ func TestManifestJson(t *testing.T) {
 		},
 		Webapp: &ManifestWebapp{
 			BundlePath: "thebundlepath",
+		},
+		UISettings: &PluginUISettings{
+			HeaderText: "theheadertext",
+			FooterText: "thefootertext",
+			Settings: map[string]*PluginUISetting{
+				"thesetting": &PluginUISetting{
+					DisplayName: "thedisplayname",
+					Type:        PLUGIN_CONFIG_TYPE_TEXT,
+					HelpText:    "thehelptext",
+					Default:     "thedefault",
+				},
+			},
 		},
 	}
 

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -72,13 +72,15 @@ func TestManifestUnmarshal(t *testing.T) {
 			Footer: "thefootertext",
 			Settings: map[string]*PluginSetting{
 				"thesetting": &PluginSetting{
-					DisplayName: "thedisplayname",
-					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
-					HelpText:    "thehelptext",
-					Options: []*PluginOption{&PluginOption{
-						DisplayName: "theoptiondisplayname",
-						Value:       "thevalue",
-					},
+					DisplayName:        "thedisplayname",
+					Type:               PLUGIN_CONFIG_TYPE_DROPDOWN,
+					HelpText:           "thehelptext",
+					RegenerateHelpText: "theregeneratehelptext",
+					Options: []*PluginOption{
+						&PluginOption{
+							DisplayName: "theoptiondisplayname",
+							Value:       "thevalue",
+						},
 					},
 					Default: "thedefault",
 				},
@@ -101,6 +103,7 @@ settings_schema:
             display_name: thedisplayname
             type: dropdown
             help_text: thehelptext
+            regenerate_help_text: theregeneratehelptext
             options:
                 - display_name: theoptiondisplayname
                   value: thevalue
@@ -125,6 +128,7 @@ settings_schema:
                 "display_name": "thedisplayname",
                 "type": "dropdown",
                 "help_text": "thehelptext",
+                "regenerate_help_text": "theregeneratehelptext",
                 "options": [
                     {
                         "display_name": "theoptiondisplayname",
@@ -170,9 +174,10 @@ func TestManifestJson(t *testing.T) {
 			Footer: "thefootertext",
 			Settings: map[string]*PluginSetting{
 				"thesetting": &PluginSetting{
-					DisplayName: "thedisplayname",
-					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
-					HelpText:    "thehelptext",
+					DisplayName:        "thedisplayname",
+					Type:               PLUGIN_CONFIG_TYPE_DROPDOWN,
+					HelpText:           "thehelptext",
+					RegenerateHelpText: "theregeneratehelptext",
 					Options: []*PluginOption{
 						&PluginOption{
 							DisplayName: "theoptiondisplayname",
@@ -232,13 +237,15 @@ func TestManifestClientManifest(t *testing.T) {
 			Footer: "thefootertext",
 			Settings: map[string]*PluginSetting{
 				"thesetting": &PluginSetting{
-					DisplayName: "thedisplayname",
-					Type:        PLUGIN_CONFIG_TYPE_DROPDOWN,
-					HelpText:    "thehelptext",
-					Options: []*PluginOption{&PluginOption{
-						DisplayName: "theoptiondisplayname",
-						Value:       "thevalue",
-					},
+					DisplayName:        "thedisplayname",
+					Type:               PLUGIN_CONFIG_TYPE_DROPDOWN,
+					HelpText:           "thehelptext",
+					RegenerateHelpText: "theregeneratehelptext",
+					Options: []*PluginOption{
+						&PluginOption{
+							DisplayName: "theoptiondisplayname",
+							Value:       "thevalue",
+						},
 					},
 					Default: "thedefault",
 				},


### PR DESCRIPTION
#### Summary
Add UI settings to the plugin manifest for defining configuration settings to display in the system console.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/PLT-7709