### PR TITLE
PLT-8060: fix builtin plugin http router

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -93,6 +93,7 @@ func New(options ...Option) *App {
 	app.Srv.Store = app.newStore()
 	app.initJobs()
 
+	app.initBuiltInPlugins()
 	app.Srv.Router.HandleFunc("/plugins/{plugin_id:[A-Za-z0-9\\_\\-\\.]+}", app.ServePluginRequest)
 	app.Srv.Router.HandleFunc("/plugins/{plugin_id:[A-Za-z0-9\\_\\-\\.]+}/{anything:.*}", app.ServePluginRequest)
 

--- a/app/plugins.go
+++ b/app/plugins.go
@@ -249,7 +249,7 @@ func (api *BuiltInPluginAPI) I18n(id string, r *http.Request) string {
 	return f(id)
 }
 
-func (a *App) InitBuiltInPlugins() {
+func (a *App) initBuiltInPlugins() {
 	plugins := map[string]builtinplugin.Plugin{
 		"jira":       &jira.Plugin{},
 		"ldapextras": &ldapextras.Plugin{},

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -71,8 +71,6 @@ func runServer(configFileLocation string) {
 		a.LoadLicense()
 	}
 
-	a.InitBuiltInPlugins()
-
 	if webappDir, ok := utils.FindDir(model.CLIENT_DIR); ok {
 		a.InitPlugins(*a.Config().PluginSettings.Directory, webappDir+"/plugins")
 		utils.AddConfigListener(func(prevCfg, cfg *model.Config) {


### PR DESCRIPTION
#### Summary
The built-in plugin routes need to be registered before the others.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8060

#### Checklist
N/A