### PR TITLE
Added plural for api.email_batching.check_pending_emails.finished_run…

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1025,7 +1025,9 @@
   },
   {
     "id": "api.email_batching.check_pending_emails.finished_running",
-    "translation": "Email batching job ran. %v user(s) still have notifications pending."
+      "one": "Email batching job ran. %v user still has notifications pending.",
+      "other": "Email batching job ran. %v users still have notifications pending."
+    }
   },
   {
     "id": "api.email_batching.render_batched_post.channel.app_error",


### PR DESCRIPTION
#### Summary
Added plural version for "Email batching job ran. %v user(s) still have notifications pending."

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
