### PR TITLE
Basic manifest docs

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -66,7 +66,24 @@ type PluginSettingsSchema struct {
 	Settings map[string]*PluginSetting `json:"settings" yaml:"settings"`
 }
 
-// All plugins must have a manifest with an id and name defined.
+// The plugin manifest defines the metadata required to load and present your plugin. The manifest
+// file should be named plugin.json or plugin.yaml and placed in the top of your
+// plugin bundle.
+//
+// Example plugin.yaml:
+//
+//     id: com.mycompany.myplugin
+//     name: My Plugin
+//     description: This is my plugin. It does stuff.
+//     backend:
+//         executable: myplugin
+//     settings_schema:
+//         settings:
+//             enable_extra_thing:
+//                 type: bool
+//                 display_name: Enable Extra Thing
+//                 help_text: When true, an extra thing will be enabled!
+//                 default: false
 type Manifest struct {
 	// The id is a globally unique identifier that represents your plugin. Reverse-DNS notation
 	// using a name you control is a good option. For example, "com.mycompany.myplugin".

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -22,40 +22,79 @@ const (
 )
 
 type PluginOption struct {
+	// The display name for the option.
 	DisplayName string `json:"display_name" yaml:"display_name"`
-	Value       string `json:"value" yaml:"value"`
+	// The string value for the option.
+	Value string `json:"value" yaml:"value"`
 }
 
 type PluginSetting struct {
-	DisplayName        string          `json:"display_name" yaml:"display_name"`
-	Type               string          `json:"type" yaml:"type"`
-	HelpText           string          `json:"help_text" yaml:"help_text"`
-	RegenerateHelpText string          `json:"regenerate_help_text,omitempty" yaml:"regenerate_help_text,omitempty"`
-	Default            interface{}     `json:"default" yaml:"default"`
-	Options            []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
+	// The display name for the setting.
+	DisplayName string `json:"display_name" yaml:"display_name"`
+	// The type of the setting.
+	//
+	// "bool" will result in a boolean true or false setting.
+	//
+	// "dropdown" will result in a string setting that allows the user to select from a list of
+	// pre-defined options.
+	//
+	// "generated" will result in a string setting that is set to a random, cryptographically secure
+	// string.
+	//
+	// "radio" will result in a string setting that allows the user to select from a short selection
+	// of pre-defined options.
+	//
+	// "text" will result in a string setting that can be typed in manually.
+	Type string `json:"type" yaml:"type"`
+	// The help text to display to the user.
+	HelpText string `json:"help_text" yaml:"help_text"`
+	// The help text to display alongside the "Regenerate" button for settings of the "generated" type.
+	RegenerateHelpText string `json:"regenerate_help_text,omitempty" yaml:"regenerate_help_text,omitempty"`
+	// The default value of the setting.
+	Default interface{} `json:"default" yaml:"default"`
+	// For "radio" or "dropdown" settings, this is the list of pre-defined options that the user can choose
+	// from.
+	Options []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 type PluginSettingsSchema struct {
-	Header   string                    `json:"header" yaml:"header"`
-	Footer   string                    `json:"footer" yaml:"footer"`
+	// Optional text to display above the settings.
+	Header string `json:"header" yaml:"header"`
+	// Optional text to display below the settings.
+	Footer string `json:"footer" yaml:"footer"`
+	// A mapping of setting keys to schema definitions.
 	Settings map[string]*PluginSetting `json:"settings" yaml:"settings"`
 }
 
+// All plugins must have a manifest with an id and name defined.
 type Manifest struct {
-	Id             string                `json:"id" yaml:"id"`
-	Name           string                `json:"name,omitempty" yaml:"name,omitempty"`
-	Description    string                `json:"description,omitempty" yaml:"description,omitempty"`
-	Version        string                `json:"version" yaml:"version"`
-	Backend        *ManifestBackend      `json:"backend,omitempty" yaml:"backend,omitempty"`
-	Webapp         *ManifestWebapp       `json:"webapp,omitempty" yaml:"webapp,omitempty"`
+	// The id is a globally unique identifier that represents your plugin. Reverse-DNS notation
+	// using a name you control is a good option. For example, "com.mycompany.myplugin".
+	Id string `json:"id" yaml:"id"`
+	// The name to be displayed for the plugin.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	// A description of what your plugin is and does.
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	// A version number for your plugin. Semantic versioning is recommended: http://semver.org
+	Version string `json:"version" yaml:"version"`
+	// If your plugin extends the server, you'll need define backend.
+	Backend *ManifestBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
+	// If your plugin extends the web app, you'll need to define webapp.
+	Webapp *ManifestWebapp `json:"webapp,omitempty" yaml:"webapp,omitempty"`
+	// To allow administrators to configure your plugin via the Mattermost system console, you can
+	// provide your settings schema.
 	SettingsSchema *PluginSettingsSchema `json:"settings_schema,omitempty" yaml:"settings_schema,omitempty"`
 }
 
 type ManifestBackend struct {
+	// The path to your executable binary. This should be relative to the root of your bundle and the
+	// location of the manifest file.
 	Executable string `json:"executable" yaml:"executable"`
 }
 
 type ManifestWebapp struct {
+	// The path to your webapp bundle. This should be relative to the root of your bundle and the
+	// location of the manifest file.
 	BundlePath string `json:"bundle_path" yaml:"bundle_path"`
 }
 

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -24,6 +24,7 @@ const (
 type PluginOption struct {
 	// The display name for the option.
 	DisplayName string `json:"display_name" yaml:"display_name"`
+
 	// The string value for the option.
 	Value string `json:"value" yaml:"value"`
 }
@@ -31,6 +32,7 @@ type PluginOption struct {
 type PluginSetting struct {
 	// The display name for the setting.
 	DisplayName string `json:"display_name" yaml:"display_name"`
+
 	// The type of the setting.
 	//
 	// "bool" will result in a boolean true or false setting.
@@ -46,12 +48,16 @@ type PluginSetting struct {
 	//
 	// "text" will result in a string setting that can be typed in manually.
 	Type string `json:"type" yaml:"type"`
+
 	// The help text to display to the user.
 	HelpText string `json:"help_text" yaml:"help_text"`
+
 	// The help text to display alongside the "Regenerate" button for settings of the "generated" type.
 	RegenerateHelpText string `json:"regenerate_help_text,omitempty" yaml:"regenerate_help_text,omitempty"`
+
 	// The default value of the setting.
 	Default interface{} `json:"default" yaml:"default"`
+
 	// For "radio" or "dropdown" settings, this is the list of pre-defined options that the user can choose
 	// from.
 	Options []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
@@ -60,8 +66,10 @@ type PluginSetting struct {
 type PluginSettingsSchema struct {
 	// Optional text to display above the settings.
 	Header string `json:"header" yaml:"header"`
+
 	// Optional text to display below the settings.
 	Footer string `json:"footer" yaml:"footer"`
+
 	// A mapping of setting keys to schema definitions.
 	Settings map[string]*PluginSetting `json:"settings" yaml:"settings"`
 }
@@ -88,16 +96,22 @@ type Manifest struct {
 	// The id is a globally unique identifier that represents your plugin. Reverse-DNS notation
 	// using a name you control is a good option. For example, "com.mycompany.myplugin".
 	Id string `json:"id" yaml:"id"`
+
 	// The name to be displayed for the plugin.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
 	// A description of what your plugin is and does.
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+
 	// A version number for your plugin. Semantic versioning is recommended: http://semver.org
 	Version string `json:"version" yaml:"version"`
+
 	// If your plugin extends the server, you'll need define backend.
 	Backend *ManifestBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
+
 	// If your plugin extends the web app, you'll need to define webapp.
 	Webapp *ManifestWebapp `json:"webapp,omitempty" yaml:"webapp,omitempty"`
+
 	// To allow administrators to configure your plugin via the Mattermost system console, you can
 	// provide your settings schema.
 	SettingsSchema *PluginSettingsSchema `json:"settings_schema,omitempty" yaml:"settings_schema,omitempty"`


### PR DESCRIPTION
#### Summary
Just adding basic some documentation to be parsed out by the dev site.

See https://github.com/mattermost/mattermost-developer-documentation/pull/34

It'll be used to populate this page: http://mattermost-developer-documentation.s3-website-us-east-1.amazonaws.com/branches/manifest-reference/extend/manifest-reference/

<img width="766" alt="screen shot 2017-11-09 at 12 17 54 am" src="https://user-images.githubusercontent.com/1731074/32591159-9d660678-c4e3-11e7-8b7e-924841c6d099.png">

#### Ticket Link
N/A

#### Checklist
N/A