### PR TITLE
Fixes running webapp from custom location using ENV variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,9 +370,7 @@ run-cli: start-docker
 run-client:
 	@echo Running mattermost client for development
 
-	@if [ ! -e client ]; then \
-		ln -s $(BUILD_WEBAPP_DIR)/dist client; \
-	fi
+	ln -nfs $(BUILD_WEBAPP_DIR)/dist client
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) run
 
 run-client-fullmap:


### PR DESCRIPTION
#### Summary
Recreates the `client` symlink so that changing mattermost-webapp repo locations with the `BUILD_WEBAPP_DIR` environment variable works smoothly.

#### Ticket Link
n/a

#### Checklist
n/a