### PR TITLE
Add placeholder field and user_autocomplete type to plugin manifest

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -14,11 +14,12 @@ import (
 )
 
 const (
-	PLUGIN_CONFIG_TYPE_TEXT      = "text"
-	PLUGIN_CONFIG_TYPE_BOOL      = "bool"
-	PLUGIN_CONFIG_TYPE_RADIO     = "radio"
-	PLUGIN_CONFIG_TYPE_DROPDOWN  = "dropdown"
-	PLUGIN_CONFIG_TYPE_GENERATED = "generated"
+	PLUGIN_CONFIG_TYPE_TEXT              = "text"
+	PLUGIN_CONFIG_TYPE_BOOL              = "bool"
+	PLUGIN_CONFIG_TYPE_RADIO             = "radio"
+	PLUGIN_CONFIG_TYPE_DROPDOWN          = "dropdown"
+	PLUGIN_CONFIG_TYPE_GENERATED         = "generated"
+	PLUGIN_CONFIG_TYPE_USER_AUTOCOMPLETE = "user_autocomplete"
 )
 
 type PluginOption struct {
@@ -47,6 +48,8 @@ type PluginSetting struct {
 	// of pre-defined options.
 	//
 	// "text" will result in a string setting that can be typed in manually.
+	//
+	// "user_autocomplete" will result in a text setting that will autocomplete to a username.
 	Type string `json:"type" yaml:"type"`
 
 	// The help text to display to the user.
@@ -54,6 +57,9 @@ type PluginSetting struct {
 
 	// The help text to display alongside the "Regenerate" button for settings of the "generated" type.
 	RegenerateHelpText string `json:"regenerate_help_text,omitempty" yaml:"regenerate_help_text,omitempty"`
+
+	// The placeholder to display for "text", "generated" and "user_autocomplete" types when blank.
+	Placeholder string `json:"placeholder" yaml:"placeholder"`
 
 	// The default value of the setting.
 	Default interface{} `json:"default" yaml:"default"`

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -14,12 +14,12 @@ import (
 )
 
 const (
-	PLUGIN_CONFIG_TYPE_TEXT              = "text"
-	PLUGIN_CONFIG_TYPE_BOOL              = "bool"
-	PLUGIN_CONFIG_TYPE_RADIO             = "radio"
-	PLUGIN_CONFIG_TYPE_DROPDOWN          = "dropdown"
-	PLUGIN_CONFIG_TYPE_GENERATED         = "generated"
-	PLUGIN_CONFIG_TYPE_USER_AUTOCOMPLETE = "user_autocomplete"
+	PLUGIN_CONFIG_TYPE_TEXT      = "text"
+	PLUGIN_CONFIG_TYPE_BOOL      = "bool"
+	PLUGIN_CONFIG_TYPE_RADIO     = "radio"
+	PLUGIN_CONFIG_TYPE_DROPDOWN  = "dropdown"
+	PLUGIN_CONFIG_TYPE_GENERATED = "generated"
+	PLUGIN_CONFIG_TYPE_USERNAME  = "username"
 )
 
 type PluginOption struct {
@@ -49,7 +49,7 @@ type PluginSetting struct {
 	//
 	// "text" will result in a string setting that can be typed in manually.
 	//
-	// "user_autocomplete" will result in a text setting that will autocomplete to a username.
+	// "username" will result in a text setting that will autocomplete to a username.
 	Type string `json:"type" yaml:"type"`
 
 	// The help text to display to the user.
@@ -58,7 +58,7 @@ type PluginSetting struct {
 	// The help text to display alongside the "Regenerate" button for settings of the "generated" type.
 	RegenerateHelpText string `json:"regenerate_help_text,omitempty" yaml:"regenerate_help_text,omitempty"`
 
-	// The placeholder to display for "text", "generated" and "user_autocomplete" types when blank.
+	// The placeholder to display for "text", "generated" and "username" types when blank.
 	Placeholder string `json:"placeholder" yaml:"placeholder"`
 
 	// The default value of the setting.

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -76,6 +76,7 @@ func TestManifestUnmarshal(t *testing.T) {
 					Type:               PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:           "thehelptext",
 					RegenerateHelpText: "theregeneratehelptext",
+					Placeholder:        "theplaceholder",
 					Options: []*PluginOption{
 						&PluginOption{
 							DisplayName: "theoptiondisplayname",
@@ -104,6 +105,7 @@ settings_schema:
             type: dropdown
             help_text: thehelptext
             regenerate_help_text: theregeneratehelptext
+            placeholder: theplaceholder
             options:
                 - display_name: theoptiondisplayname
                   value: thevalue
@@ -129,6 +131,7 @@ settings_schema:
                 "type": "dropdown",
                 "help_text": "thehelptext",
                 "regenerate_help_text": "theregeneratehelptext",
+                "placeholder": "theplaceholder",
                 "options": [
                     {
                         "display_name": "theoptiondisplayname",
@@ -178,6 +181,7 @@ func TestManifestJson(t *testing.T) {
 					Type:               PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:           "thehelptext",
 					RegenerateHelpText: "theregeneratehelptext",
+					Placeholder:        "theplaceholder",
 					Options: []*PluginOption{
 						&PluginOption{
 							DisplayName: "theoptiondisplayname",
@@ -241,6 +245,7 @@ func TestManifestClientManifest(t *testing.T) {
 					Type:               PLUGIN_CONFIG_TYPE_DROPDOWN,
 					HelpText:           "thehelptext",
 					RegenerateHelpText: "theregeneratehelptext",
+					Placeholder:        "theplaceholder",
 					Options: []*PluginOption{
 						&PluginOption{
 							DisplayName: "theoptiondisplayname",


### PR DESCRIPTION
#### Summary
Needed a placeholder field and decided to add a user_autocomplete type to plugin manifest.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/PLT-7709