### PR TITLE
Add codecov yaml file

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch: off
 ignore:
   - store/storetest

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,2 @@
 ignore:
-  - store/storetest/mocks
+  - store/storetest

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - store/storetest/mocks

--- a/app/command_channel_header_test.go
+++ b/app/command_channel_header_test.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHeaderProviderDoCommand(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	hp := HeaderProvider{}
+	args := &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: th.BasicChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.ROLE_TEAM_USER.Id}}},
+	}
+
+	for msg, expected := range map[string]string{
+		"":      "api.command_channel_header.message.app_error",
+		"hello": "",
+	} {
+		actual := hp.DoCommand(th.App, args, msg).Text
+		assert.Equal(t, expected, actual)
+	}
+}


### PR DESCRIPTION
#### Summary
Adds a codecov yaml file, which can be used to exclude directories from coverage reports and altar Codecov behavior in several ways.

Also adds a test for demo purposes.

#### Ticket Link
N/A

#### Checklist
N/A