### PR TITLE
Don't force AmazonS3Region by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -129,7 +129,7 @@
         "AmazonS3AccessKeyId": "",
         "AmazonS3SecretAccessKey": "",
         "AmazonS3Bucket": "",
-        "AmazonS3Region": "us-east-1",
+        "AmazonS3Region": "",
         "AmazonS3Endpoint": "s3.amazonaws.com",
         "AmazonS3SSL": true,
         "AmazonS3SignV2": false,


### PR DESCRIPTION
In [this issue](https://mattermost.atlassian.net/browse/PLT-7475), it says that the UI text should be `Help Text: (Optional) AWS region you selected when creating your S3 bucket. If no region is set, Mattermost attempts to get the appropriate region from AWS, or sets it to "us-east-1" if none found.` 

The [Mattermost documentation](https://docs.mattermost.com/administration/config-settings.html#amazon-s3-region) says the default for this value is `""`, but it's set here. For this reason the behavior described above (getting the appropriate region from AWS, then falling back to `us-east-1` only if that fails) **does not happen**; Mattermost tries region `us-east-1` even if `AmazonS3Endpoint` points to a different region.

#### Summary
Stop forcing AmazonS3Region of `us-east-1` by default

#### Ticket Link
Closes https://github.com/mattermost/mattermost-server/issues/7829
