### PR TITLE
PLT-5458: If someone posts a channel link to channel_A that you don't belong to, it doesn't render properly

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -757,6 +757,18 @@ func (a *App) GetChannelByName(channelName, teamId string) (*model.Channel, *mod
 	}
 }
 
+func (a *App) GetChannelsByNames(channelNames []string, teamId string) ([]*model.Channel, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().GetByNames(teamId, channelNames, true); result.Err != nil && result.Err.Id == "store.sql_channel.get_by_name.missing.app_error" {
+		result.Err.StatusCode = http.StatusNotFound
+		return nil, result.Err
+	} else if result.Err != nil {
+		result.Err.StatusCode = http.StatusBadRequest
+		return nil, result.Err
+	} else {
+		return result.Data.([]*model.Channel), nil
+	}
+}
+
 func (a *App) GetChannelByNameForTeamName(channelName, teamName string) (*model.Channel, *model.AppError) {
 	var team *model.Team
 

--- a/model/post.go
+++ b/model/post.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 )
@@ -292,6 +293,20 @@ func PostPatchFromJson(data io.Reader) *PostPatch {
 	}
 
 	return &post
+}
+
+var channelMentionRegexp = regexp.MustCompile(`(^|\s)(~([a-zA-Z0-9.\-_]*))`)
+
+func (o *Post) ChannelMentions() (names []string) {
+	alreadyMentioned := make(map[string]bool)
+	for _, match := range channelMentionRegexp.FindAllStringSubmatch(o.Message, -1) {
+		name := match[3]
+		if !alreadyMentioned[name] {
+			names = append(names, name)
+			alreadyMentioned[name] = true
+		}
+	}
+	return
 }
 
 func (r *PostActionIntegrationRequest) ToJson() string {

--- a/model/post.go
+++ b/model/post.go
@@ -298,12 +298,14 @@ func PostPatchFromJson(data io.Reader) *PostPatch {
 var channelMentionRegexp = regexp.MustCompile(`(^|\s)(~([a-zA-Z0-9.\-_]*))`)
 
 func (o *Post) ChannelMentions() (names []string) {
-	alreadyMentioned := make(map[string]bool)
-	for _, match := range channelMentionRegexp.FindAllStringSubmatch(o.Message, -1) {
-		name := match[3]
-		if !alreadyMentioned[name] {
-			names = append(names, name)
-			alreadyMentioned[name] = true
+	if strings.Contains(o.Message, "~") {
+		alreadyMentioned := make(map[string]bool)
+		for _, match := range channelMentionRegexp.FindAllStringSubmatch(o.Message, -1) {
+			name := match[3]
+			if !alreadyMentioned[name] {
+				names = append(names, name)
+				alreadyMentioned[name] = true
+			}
 		}
 	}
 	return

--- a/model/post.go
+++ b/model/post.go
@@ -295,13 +295,13 @@ func PostPatchFromJson(data io.Reader) *PostPatch {
 	return &post
 }
 
-var channelMentionRegexp = regexp.MustCompile(`(^|\s)(~([a-zA-Z0-9.\-_]*))`)
+var channelMentionRegexp = regexp.MustCompile(`\B~[a-zA-Z0-9\-_]+`)
 
 func (o *Post) ChannelMentions() (names []string) {
 	if strings.Contains(o.Message, "~") {
 		alreadyMentioned := make(map[string]bool)
-		for _, match := range channelMentionRegexp.FindAllStringSubmatch(o.Message, -1) {
-			name := match[3]
+		for _, match := range channelMentionRegexp.FindAllString(o.Message, -1) {
+			name := match[1:]
 			if !alreadyMentioned[name] {
 				names = append(names, name)
 				alreadyMentioned[name] = true

--- a/model/post_test.go
+++ b/model/post_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPostJson(t *testing.T) {
@@ -122,6 +124,11 @@ func TestPostIsSystemMessage(t *testing.T) {
 	if !post2.IsSystemMessage() {
 		t.Fatalf("TestPostIsSystemMessage failed, expected post2.IsSystemMessage() to be true")
 	}
+}
+
+func TestPostChannelMentions(t *testing.T) {
+	post := Post{Message: "~a ~b ~b ~c/~d."}
+	assert.Equal(t, []string{"a", "b", "c", "d"}, post.ChannelMentions())
 }
 
 func TestPostSanitizeProps(t *testing.T) {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -586,6 +586,65 @@ func (s SqlChannelStore) GetByName(teamId string, name string, allowFromCache bo
 	return s.getByName(teamId, name, false, allowFromCache)
 }
 
+func (s SqlChannelStore) GetByNames(teamId string, names []string, allowFromCache bool) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var channels []*model.Channel
+
+		if allowFromCache {
+			var misses []string
+			visited := make(map[string]struct{})
+			for _, name := range names {
+				if _, ok := visited[name]; ok {
+					continue
+				}
+				visited[name] = struct{}{}
+				if cacheItem, ok := channelByNameCache.Get(teamId + name); ok {
+					if s.metrics != nil {
+						s.metrics.IncrementMemCacheHitCounter("Channel By Name")
+					}
+					channels = append(channels, cacheItem.(*model.Channel))
+				} else {
+					if s.metrics != nil {
+						s.metrics.IncrementMemCacheMissCounter("Channel By Name")
+					}
+					misses = append(misses, name)
+				}
+			}
+			names = misses
+		}
+
+		if len(names) > 0 {
+			props := map[string]interface{}{}
+			var namePlaceholders []string
+			for _, name := range names {
+				key := fmt.Sprintf("Name%v", len(namePlaceholders))
+				props[key] = name
+				namePlaceholders = append(namePlaceholders, ":"+key)
+			}
+
+			var query string
+			if teamId == "" {
+				query = `SELECT * FROM Channels WHERE Name IN (` + strings.Join(namePlaceholders, ", ") + `) AND DeleteAt = 0`
+			} else {
+				props["TeamId"] = teamId
+				query = `SELECT * FROM Channels WHERE Name IN (` + strings.Join(namePlaceholders, ", ") + `) AND TeamId = :TeamId AND DeleteAt = 0`
+			}
+
+			var dbChannels []*model.Channel
+			if _, err := s.GetReplica().Select(&dbChannels, query, props); err != nil && err != sql.ErrNoRows {
+				result.Err = model.NewAppError("SqlChannelStore.GetByName", "store.sql_channel.get_by_name.existing.app_error", nil, "teamId="+teamId+", "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+			for _, channel := range dbChannels {
+				channelByNameCache.AddWithExpiresInSecs(teamId+channel.Name, channel, CHANNEL_CACHE_SEC)
+				channels = append(channels, channel)
+			}
+		}
+
+		result.Data = channels
+	})
+}
+
 func (s SqlChannelStore) GetByNameIncludeDeleted(teamId string, name string, allowFromCache bool) store.StoreChannel {
 	return s.getByName(teamId, name, true, allowFromCache)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -119,6 +119,7 @@ type ChannelStore interface {
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	PermanentDelete(channelId string) StoreChannel
 	GetByName(team_id string, name string, allowFromCache bool) StoreChannel
+	GetByNames(team_id string, names []string, allowFromCache bool) StoreChannel
 	GetByNameIncludeDeleted(team_id string, name string, allowFromCache bool) StoreChannel
 	GetDeletedByName(team_id string, name string) StoreChannel
 	GetDeleted(team_id string, offset int, limit int) StoreChannel

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -189,6 +189,22 @@ func (_m *ChannelStore) GetByNameIncludeDeleted(team_id string, name string, all
 	return r0
 }
 
+// GetByNames provides a mock function with given fields: team_id, names, allowFromCache
+func (_m *ChannelStore) GetByNames(team_id string, names []string, allowFromCache bool) store.StoreChannel {
+	ret := _m.Called(team_id, names, allowFromCache)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, []string, bool) store.StoreChannel); ok {
+		r0 = rf(team_id, names, allowFromCache)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetChannelCounts provides a mock function with given fields: teamId, userId
 func (_m *ChannelStore) GetChannelCounts(teamId string, userId string) store.StoreChannel {
 	ret := _m.Called(teamId, userId)

--- a/store/storetest/mocks/SqlStore.go
+++ b/store/storetest/mocks/SqlStore.go
@@ -157,6 +157,20 @@ func (_m *SqlStore) CreateCompositeIndexIfNotExists(indexName string, tableName 
 	return r0
 }
 
+// CreateCompositeIndexIfNotExists provides a mock function with given fields: indexName, tableName, columnNames
+func (_m *SqlStore) CreateCompositeIndexIfNotExists(indexName string, tableName string, columnNames []string) bool {
+	ret := _m.Called(indexName, tableName, columnNames)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, []string) bool); ok {
+		r0 = rf(indexName, tableName, columnNames)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // CreateFullTextIndexIfNotExists provides a mock function with given fields: indexName, tableName, columnName
 func (_m *SqlStore) CreateFullTextIndexIfNotExists(indexName string, tableName string, columnName string) bool {
 	ret := _m.Called(indexName, tableName, columnName)

--- a/store/storetest/mocks/SqlStore.go
+++ b/store/storetest/mocks/SqlStore.go
@@ -157,20 +157,6 @@ func (_m *SqlStore) CreateCompositeIndexIfNotExists(indexName string, tableName 
 	return r0
 }
 
-// CreateCompositeIndexIfNotExists provides a mock function with given fields: indexName, tableName, columnNames
-func (_m *SqlStore) CreateCompositeIndexIfNotExists(indexName string, tableName string, columnNames []string) bool {
-	ret := _m.Called(indexName, tableName, columnNames)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(string, string, []string) bool); ok {
-		r0 = rf(indexName, tableName, columnNames)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 // CreateFullTextIndexIfNotExists provides a mock function with given fields: indexName, tableName, columnName
 func (_m *SqlStore) CreateFullTextIndexIfNotExists(indexName string, tableName string, columnName string) bool {
 	ret := _m.Called(indexName, tableName, columnName)


### PR DESCRIPTION
#### Summary
This adds hints to posts that the client can use to identify and build channel links when the user isn't in those channels and the client has no knowledge of them.

It's a resubmission of the server portion of https://github.com/mattermost/mattermost-server/pull/7324 with some optimizations. We held off on merging it last time so we could load test it.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-5458

#### Checklist
- [x] Added or updated unit tests (required for all new features)