### PR TITLE
PLT-7111: Fix for groupmsgProvider.GetCommand method signature.

### DIFF
--- a/app/command_groupmsg.go
+++ b/app/command_groupmsg.go
@@ -27,7 +27,7 @@ func (me *groupmsgProvider) GetTrigger() string {
 	return CMD_GROUPMSG
 }
 
-func (me *groupmsgProvider) GetCommand(T goi18n.TranslateFunc) *model.Command {
+func (me *groupmsgProvider) GetCommand(a *App, T goi18n.TranslateFunc) *model.Command {
 	return &model.Command{
 		Trigger:          CMD_GROUPMSG,
 		AutoComplete:     true,


### PR DESCRIPTION
#### Summary
Was getting a compilation error but I have no clue about the wider context here so I'm relying on the original reviewers to figure out if this change makes sense.

#### Ticket Link
https://github.com/mattermost/mattermost-server/pull/7419

#### Checklist