### PR TITLE
Replace Channel Name for Team in Email Notifications

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -352,7 +352,7 @@ func (a *App) sendNotificationEmail(post *model.Post, user *model.User, channel 
 	if channel.Type == model.CHANNEL_DIRECT {
 		subjectText = getDirectMessageNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, senderName)
 	} else if *a.Config().EmailSettings.UseChannelInEmailNotifications {
-		subjectText = getNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, channel.DisplayName)
+		subjectText = getNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, team.DisplayName+" ("+channel.DisplayName+")")
 	} else {
 		subjectText = getNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, team.DisplayName)
 	}

--- a/app/notification.go
+++ b/app/notification.go
@@ -351,6 +351,8 @@ func (a *App) sendNotificationEmail(post *model.Post, user *model.User, channel 
 	var subjectText string
 	if channel.Type == model.CHANNEL_DIRECT {
 		subjectText = getDirectMessageNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, senderName)
+	} else if *a.Config().EmailSettings.UseChannelInEmailNotifications {
+		subjectText = getNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, channel.DisplayName)
 	} else {
 		subjectText = getNotificationEmailSubject(post, translateFunc, a.Config().TeamSettings.SiteName, team.DisplayName)
 	}

--- a/config/default.json
+++ b/config/default.json
@@ -142,6 +142,7 @@
         "EnableSignInWithEmail": true,
         "EnableSignInWithUsername": true,
         "SendEmailNotifications": true,
+        "UseChannelInEmailNotifications": false,
         "RequireEmailVerification": false,
         "FeedbackName": "",
         "FeedbackEmail": "test@example.com",

--- a/model/config.go
+++ b/model/config.go
@@ -653,6 +653,7 @@ type EmailSettings struct {
 	EnableSignInWithEmail             *bool
 	EnableSignInWithUsername          *bool
 	SendEmailNotifications            bool
+	UseChannelInEmailNotifications    *bool
 	RequireEmailVerification          bool
 	FeedbackName                      string
 	FeedbackEmail                     string
@@ -685,6 +686,10 @@ func (s *EmailSettings) SetDefaults() {
 
 	if s.EnableSignInWithUsername == nil {
 		s.EnableSignInWithUsername = NewBool(false)
+	}
+
+	if s.UseChannelInEmailNotifications == nil {
+		s.UseChannelInEmailNotifications = NewBool(false)
 	}
 
 	if s.SendPushNotifications == nil {


### PR DESCRIPTION
#### Summary
Add config option to place channel name instead of team name. For servers with users primarily on single team, the email notifications have no context in the subject without the channel name.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

@dmeza 