### PR TITLE
Hide tutorial with config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -54,7 +54,8 @@
         "EnableUserStatuses": true,
         "ClusterLogTimeoutMilliseconds": 2000,
         "EnablePreviewFeatures": true,
-        "CloseUnusedDirectMessages": false
+        "CloseUnusedDirectMessages": false,
+        "EnableTutorial": true
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/model/config.go
+++ b/model/config.go
@@ -209,6 +209,7 @@ type ServiceSettings struct {
 	ClusterLogTimeoutMilliseconds            *int
 	CloseUnusedDirectMessages                *bool
 	EnablePreviewFeatures                    *bool
+	EnableTutorial                           *bool
 }
 
 func (s *ServiceSettings) SetDefaults() {
@@ -326,6 +327,10 @@ func (s *ServiceSettings) SetDefaults() {
 
 	if s.CloseUnusedDirectMessages == nil {
 		s.CloseUnusedDirectMessages = NewBool(false)
+	}
+
+	if s.EnableTutorial == nil {
+		s.EnableTutorial = NewBool(true)
 	}
 
 	if s.SessionLengthWebInDays == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -489,6 +489,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["PostEditTimeLimit"] = fmt.Sprintf("%v", *c.ServiceSettings.PostEditTimeLimit)
 	props["CloseUnusedDirectMessages"] = strconv.FormatBool(*c.ServiceSettings.CloseUnusedDirectMessages)
 	props["EnablePreviewFeatures"] = strconv.FormatBool(*c.ServiceSettings.EnablePreviewFeatures)
+	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
 
 	props["SendEmailNotifications"] = strconv.FormatBool(c.EmailSettings.SendEmailNotifications)
 	props["SendPushNotifications"] = strconv.FormatBool(*c.EmailSettings.SendPushNotifications)


### PR DESCRIPTION
#### Summary
Add config option to hide tutorial screens. The tutorial doesn’t necessarily apply, rather than choose parts to show and not others, we’ve added a config to be sent to frontend.

web pr: https://github.com/mattermost/mattermost-webapp/pull/325
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

cc @dmeza 