### PR TITLE
Add token to header for commands

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -217,7 +217,7 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 
 				req, _ := http.NewRequest(method, cmd.URL, strings.NewReader(p.Encode()))
 				req.Header.Set("Accept", "application/json")
-				req.Header.Set("Token", cmd.Token)
+				req.Header.Set("Authorization", "Token "+cmd.Token)
 				if cmd.Method == model.COMMAND_METHOD_POST {
 					req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				}

--- a/app/command.go
+++ b/app/command.go
@@ -217,6 +217,7 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 
 				req, _ := http.NewRequest(method, cmd.URL, strings.NewReader(p.Encode()))
 				req.Header.Set("Accept", "application/json")
+				req.Header.Set("Token", cmd.Token)
 				if cmd.Method == model.COMMAND_METHOD_POST {
 					req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				}


### PR DESCRIPTION
#### Summary
There are many backend proxy layers that can easily block header. We've added this to pass those requirements.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
 
cc @dmeza 