### PR TITLE
Add Config to disable Auth Transfers.

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2099,7 +2099,7 @@ func TestSwitchAccount(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	th.App.UpdateConfig(func(cfg *model.Config) { cfg.GitLabSettings.Enable = true; *cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.GitLabSettings.Enable = true })
 
 	Client.Logout()
 
@@ -2117,6 +2117,17 @@ func TestSwitchAccount(t *testing.T) {
 		t.Fatal("bad link")
 	}
 
+	isLicensed := utils.IsLicensed()
+	license := utils.License()
+	enableAuthenticationTransfer := *th.App.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer
+	defer func() {
+		utils.SetIsLicensed(isLicensed)
+		utils.SetLicense(license)
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer = enableAuthenticationTransfer })
+	}()
+	utils.SetIsLicensed(true)
+	utils.SetLicense(&model.License{Features: &model.Features{}})
+	utils.License().Features.SetDefaults()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer = false })
 
 	sr = &model.SwitchRequest{

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -194,6 +194,7 @@ func (a *App) trackConfig() {
 		"enable_user_access_tokens":                        *cfg.ServiceSettings.EnableUserAccessTokens,
 		"enable_custom_emoji":                              *cfg.ServiceSettings.EnableCustomEmoji,
 		"enable_emoji_picker":                              *cfg.ServiceSettings.EnableEmojiPicker,
+		"experimental_enable_authentication_transfer":      *cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer,
 		"restrict_custom_emoji_creation":                   *cfg.ServiceSettings.RestrictCustomEmojiCreation,
 		"enable_testing":                                   cfg.ServiceSettings.EnableTesting,
 		"enable_developer":                                 *cfg.ServiceSettings.EnableDeveloper,

--- a/app/ldap.go
+++ b/app/ldap.go
@@ -39,6 +39,10 @@ func (a *App) TestLdap() *model.AppError {
 }
 
 func (a *App) SwitchEmailToLdap(email, password, code, ldapId, ldapPassword string) (string, *model.AppError) {
+	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+		return "", model.NewAppError("emailToLdap", "api.user.email_to_ldap.not_available.app_error", nil, "", http.StatusForbidden)
+	}
+
 	user, err := a.GetUserByEmail(email)
 	if err != nil {
 		return "", err
@@ -71,6 +75,10 @@ func (a *App) SwitchEmailToLdap(email, password, code, ldapId, ldapPassword stri
 }
 
 func (a *App) SwitchLdapToEmail(ldapPassword, code, email, newPassword string) (string, *model.AppError) {
+	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+		return "", model.NewAppError("ldapToEmail", "api.user.ldap_to_email.not_available.app_error", nil, "", http.StatusForbidden)
+	}
+
 	user, err := a.GetUserByEmail(email)
 	if err != nil {
 		return "", err

--- a/app/ldap.go
+++ b/app/ldap.go
@@ -39,7 +39,7 @@ func (a *App) TestLdap() *model.AppError {
 }
 
 func (a *App) SwitchEmailToLdap(email, password, code, ldapId, ldapPassword string) (string, *model.AppError) {
-	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+	if utils.IsLicensed() && !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
 		return "", model.NewAppError("emailToLdap", "api.user.email_to_ldap.not_available.app_error", nil, "", http.StatusForbidden)
 	}
 
@@ -75,7 +75,7 @@ func (a *App) SwitchEmailToLdap(email, password, code, ldapId, ldapPassword stri
 }
 
 func (a *App) SwitchLdapToEmail(ldapPassword, code, email, newPassword string) (string, *model.AppError) {
-	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+	if utils.IsLicensed() && !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
 		return "", model.NewAppError("ldapToEmail", "api.user.ldap_to_email.not_available.app_error", nil, "", http.StatusForbidden)
 	}
 

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -717,7 +717,7 @@ func (a *App) AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service
 }
 
 func (a *App) SwitchEmailToOAuth(w http.ResponseWriter, r *http.Request, email, password, code, service string) (string, *model.AppError) {
-	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+	if utils.IsLicensed() && !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
 		return "", model.NewAppError("emailToOAuth", "api.user.email_to_oauth.not_available.app_error", nil, "", http.StatusForbidden)
 	}
 
@@ -747,7 +747,7 @@ func (a *App) SwitchEmailToOAuth(w http.ResponseWriter, r *http.Request, email, 
 }
 
 func (a *App) SwitchOAuthToEmail(email, password, requesterId string) (string, *model.AppError) {
-	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+	if utils.IsLicensed() && !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
 		return "", model.NewAppError("oauthToEmail", "api.user.oauth_to_email.not_available.app_error", nil, "", http.StatusForbidden)
 	}
 

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -717,6 +717,10 @@ func (a *App) AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service
 }
 
 func (a *App) SwitchEmailToOAuth(w http.ResponseWriter, r *http.Request, email, password, code, service string) (string, *model.AppError) {
+	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+		return "", model.NewAppError("emailToOAuth", "api.user.email_to_oauth.not_available.app_error", nil, "", http.StatusForbidden)
+	}
+
 	var user *model.User
 	var err *model.AppError
 	if user, err = a.GetUserByEmail(email); err != nil {
@@ -743,6 +747,10 @@ func (a *App) SwitchEmailToOAuth(w http.ResponseWriter, r *http.Request, email, 
 }
 
 func (a *App) SwitchOAuthToEmail(email, password, requesterId string) (string, *model.AppError) {
+	if !*a.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer {
+		return "", model.NewAppError("oauthToEmail", "api.user.oauth_to_email.not_available.app_error", nil, "", http.StatusForbidden)
+	}
+
 	var user *model.User
 	var err *model.AppError
 	if user, err = a.GetUserByEmail(email); err != nil {

--- a/config/default.json
+++ b/config/default.json
@@ -46,6 +46,7 @@
         "RestrictPostDelete": "all",
         "AllowEditPost": "always",
         "PostEditTimeLimit": 300,
+        "ExperimentalEnableAuthenticationTransfer": true,
         "TimeBetweenUserTypingUpdatesMilliseconds": 5000,
         "EnablePostSearch": true,
         "EnableUserTypingMessages": true,

--- a/model/config.go
+++ b/model/config.go
@@ -203,6 +203,7 @@ type ServiceSettings struct {
 	EnableUserTypingMessages                 *bool
 	EnableChannelViewedMessages              *bool
 	EnableUserStatuses                       *bool
+	ExperimentalEnableAuthenticationTransfer *bool
 	ClusterLogTimeoutMilliseconds            *int
 	CloseUnusedDirectMessages                *bool
 	EnablePreviewFeatures                    *bool
@@ -389,6 +390,10 @@ func (s *ServiceSettings) SetDefaults() {
 
 	if s.AllowEditPost == nil {
 		s.AllowEditPost = NewString(ALLOW_EDIT_POST_ALWAYS)
+	}
+
+	if s.ExperimentalEnableAuthenticationTransfer == nil {
+		s.ExperimentalEnableAuthenticationTransfer = NewBool(true)
 	}
 
 	if s.PostEditTimeLimit == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -526,7 +526,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["EnableEmojiPicker"] = strconv.FormatBool(*c.ServiceSettings.EnableEmojiPicker)
 	props["RestrictCustomEmojiCreation"] = *c.ServiceSettings.RestrictCustomEmojiCreation
 	props["MaxFileSize"] = strconv.FormatInt(*c.FileSettings.MaxFileSize, 10)
-
+	props["ExperimentalEnableAuthenticationTransfer"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableAuthenticationTransfer)
 	props["AppDownloadLink"] = *c.NativeAppSettings.AppDownloadLink
 	props["AndroidAppDownloadLink"] = *c.NativeAppSettings.AndroidAppDownloadLink
 	props["IosAppDownloadLink"] = *c.NativeAppSettings.IosAppDownloadLink

--- a/utils/config.go
+++ b/utils/config.go
@@ -526,7 +526,6 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["EnableEmojiPicker"] = strconv.FormatBool(*c.ServiceSettings.EnableEmojiPicker)
 	props["RestrictCustomEmojiCreation"] = *c.ServiceSettings.RestrictCustomEmojiCreation
 	props["MaxFileSize"] = strconv.FormatInt(*c.FileSettings.MaxFileSize, 10)
-	props["ExperimentalEnableAuthenticationTransfer"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableAuthenticationTransfer)
 	props["AppDownloadLink"] = *c.NativeAppSettings.AppDownloadLink
 	props["AndroidAppDownloadLink"] = *c.NativeAppSettings.AndroidAppDownloadLink
 	props["IosAppDownloadLink"] = *c.NativeAppSettings.IosAppDownloadLink
@@ -547,6 +546,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	if IsLicensed() {
 		License := License()
 		props["ExperimentalTownSquareIsReadOnly"] = strconv.FormatBool(*c.TeamSettings.ExperimentalTownSquareIsReadOnly)
+		props["ExperimentalEnableAuthenticationTransfer"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableAuthenticationTransfer)
 
 		if *License.Features.CustomBrand {
 			props["EnableCustomBrand"] = strconv.FormatBool(*c.TeamSettings.EnableCustomBrand)


### PR DESCRIPTION
#### Summary
Again, this might not be the right approach given the growth of the platform. But this api allowed critical exploit of user auth to change their auth type. It was blocked completely.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
