### PR TITLE
Add config option to hide locale setting

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -253,7 +253,8 @@
     "LocalizationSettings": {
         "DefaultServerLocale": "en",
         "DefaultClientLocale": "en",
-        "AvailableLocales": ""
+        "AvailableLocales": "",
+        "EnableLocaleSetting": false
     },
     "SamlSettings": {
         "Enable": false,

--- a/model/config.go
+++ b/model/config.go
@@ -1153,6 +1153,7 @@ type LocalizationSettings struct {
 	DefaultServerLocale *string
 	DefaultClientLocale *string
 	AvailableLocales    *string
+	EnableLocaleSetting *bool
 }
 
 func (s *LocalizationSettings) SetDefaults() {

--- a/utils/config.go
+++ b/utils/config.go
@@ -521,6 +521,8 @@ func getClientConfig(c *model.Config) map[string]string {
 
 	props["DefaultClientLocale"] = *c.LocalizationSettings.DefaultClientLocale
 	props["AvailableLocales"] = *c.LocalizationSettings.AvailableLocales
+	props["EnableLocaleSetting"] = strconv.FormatBool(*c.LocalizationSettings.EnableLocaleSetting)
+
 	props["SQLDriverName"] = *c.SqlSettings.DriverName
 
 	props["EnableCustomEmoji"] = strconv.FormatBool(*c.ServiceSettings.EnableCustomEmoji)


### PR DESCRIPTION
#### Summary
Adds the config property `EnableLocaleSetting` to the `LocalizationSettings` config to hide the locale setting for a user. Default is `false`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
