### PR TITLE
Allow default team to be configured

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -81,7 +81,8 @@
         "MaxNotificationsPerChannel": 1000,
         "EnableConfirmNotificationsToChannel": true,
         "TeammateNameDisplay": "username",
-        "ExperimentalTownSquareIsReadOnly": false
+        "ExperimentalTownSquareIsReadOnly": false,
+        "DefaultTeamName": ""
     },
     "ClientRequirements": {
         "AndroidLatestVersion": "",

--- a/model/config.go
+++ b/model/config.go
@@ -917,6 +917,7 @@ type TeamSettings struct {
 	EnableConfirmNotificationsToChannel *bool
 	TeammateNameDisplay                 *string
 	ExperimentalTownSquareIsReadOnly    *bool
+	DefaultTeamName                     *string
 }
 
 func (s *TeamSettings) SetDefaults() {

--- a/utils/config.go
+++ b/utils/config.go
@@ -463,6 +463,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictPrivateChannelManageMembers"] = *c.TeamSettings.RestrictPrivateChannelManageMembers
 	props["EnableXToLeaveChannelsFromLHS"] = strconv.FormatBool(*c.TeamSettings.EnableXToLeaveChannelsFromLHS)
 	props["TeammateNameDisplay"] = *c.TeamSettings.TeammateNameDisplay
+	props["DefaultTeamName"] = *c.TeamSettings.DefaultTeamName
 
 	props["AndroidLatestVersion"] = c.ClientRequirements.AndroidLatestVersion
 	props["AndroidMinVersion"] = c.ClientRequirements.AndroidMinVersion


### PR DESCRIPTION
#### Summary
Adds a config value  "DefaultTeamName" that allows to config the name of a default team:
```
"TeamSettings": {
  "DefaultTeamName": ""
```

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

CC @dmeza 