### PR TITLE
Hide pre-release features section of advanced settings pane.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -51,7 +51,8 @@
         "EnableUserTypingMessages": true,
         "EnableChannelViewedMessages": true,
         "EnableUserStatuses": true,
-        "ClusterLogTimeoutMilliseconds": 2000
+        "ClusterLogTimeoutMilliseconds": 2000,
+        "EnablePreviewFeatures": true
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/model/config.go
+++ b/model/config.go
@@ -205,6 +205,7 @@ type ServiceSettings struct {
 	EnableUserStatuses                       *bool
 	ClusterLogTimeoutMilliseconds            *int
 	CloseUnusedDirectMessages                *bool
+	EnablePreviewFeatures                    *bool
 }
 
 func (s *ServiceSettings) SetDefaults() {

--- a/utils/config.go
+++ b/utils/config.go
@@ -489,6 +489,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["AllowEditPost"] = *c.ServiceSettings.AllowEditPost
 	props["PostEditTimeLimit"] = fmt.Sprintf("%v", *c.ServiceSettings.PostEditTimeLimit)
 	props["CloseUnusedDirectMessages"] = strconv.FormatBool(*c.ServiceSettings.CloseUnusedDirectMessages)
+	props["EnablePreviewFeatures"] = strconv.FormatBool(*c.ServiceSettings.EnablePreviewFeatures)
 
 	props["SendEmailNotifications"] = strconv.FormatBool(c.EmailSettings.SendEmailNotifications)
 	props["SendPushNotifications"] = strconv.FormatBool(*c.EmailSettings.SendPushNotifications)


### PR DESCRIPTION
#### Summary
Adds config property `EnablePreviewFeatures` to the config for enabling/disabling the display of the advanced preview features in the user settings. The default is `true`.

webapp: https://github.com/mattermost/mattermost-webapp/pull/333

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
