### PR TITLE
PLT-8149: Fix config path overrides (master)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -48,7 +48,8 @@ type App struct {
 	Mfa              einterfaces.MfaInterface
 	Saml             einterfaces.SamlInterface
 
-	newStore func() store.Store
+	configFile string
+	newStore   func() store.Store
 
 	sessionCache *utils.Cache
 }
@@ -63,26 +64,28 @@ func New(options ...Option) *App {
 		panic("Only one App should exist at a time. Did you forget to call Shutdown()?")
 	}
 
-	if utils.T == nil {
-		utils.TranslationsPreInit()
-	}
-	utils.LoadGlobalConfig("config.json")
-	utils.InitTranslations(utils.Cfg.LocalizationSettings)
-
-	l4g.Info(utils.T("api.server.new_server.init.info"))
-
 	app := &App{
 		goroutineExitSignal: make(chan struct{}, 1),
 		Srv: &Server{
 			Router: mux.NewRouter(),
 		},
 		sessionCache: utils.NewLru(model.SESSION_CACHE_SIZE),
+		configFile:   "config.json",
 	}
-	app.initEnterprise()
 
 	for _, option := range options {
 		option(app)
 	}
+
+	if utils.T == nil {
+		utils.TranslationsPreInit()
+	}
+	utils.LoadGlobalConfig(app.configFile)
+	utils.InitTranslations(utils.Cfg.LocalizationSettings)
+
+	l4g.Info(utils.T("api.server.new_server.init.info"))
+
+	app.initEnterprise()
 
 	if app.newStore == nil {
 		app.newStore = func() store.Store {

--- a/app/options.go
+++ b/app/options.go
@@ -29,3 +29,9 @@ func StoreOverride(override interface{}) Option {
 		}
 	}
 }
+
+func ConfigFile(file string) Option {
+	return func(a *App) {
+		a.configFile = file
+	}
+}

--- a/cmd/platform/config_test.go
+++ b/cmd/platform/config_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func TestConfigValidate(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "config.json")
+	config := &model.Config{}
+	config.SetDefaults()
+	require.NoError(t, ioutil.WriteFile(path, []byte(config.ToJson()), 0600))
+
+	assert.Contains(t, checkCommand(t, "--config", path, "config", "validate"), "The document is valid")
+}

--- a/cmd/platform/init.go
+++ b/cmd/platform/init.go
@@ -32,7 +32,7 @@ func initDBCommandContext(configFileLocation string) (*app.App, error) {
 
 	utils.ConfigureCmdLineLog()
 
-	a := app.New()
+	a := app.New(app.ConfigFile(configFileLocation))
 	if model.BuildEnterpriseReady == "true" {
 		a.LoadLicense()
 	}

--- a/cmd/platform/platform_test.go
+++ b/cmd/platform/platform_test.go
@@ -35,7 +35,7 @@ func checkCommand(t *testing.T, args ...string) string {
 	require.NoError(t, err)
 	output, err := exec.Command(path, execArgs(t, args)...).CombinedOutput()
 	require.NoError(t, err, string(output))
-	return string(output)
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(string(output)), "PASS"))
 }
 
 func runCommand(t *testing.T, args ...string) error {

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -64,7 +64,7 @@ func runServer(configFileLocation string) {
 		l4g.Error("Problem with file storage settings: " + err.Error())
 	}
 
-	a := app.New()
+	a := app.New(app.ConfigFile(configFileLocation))
 	defer a.Shutdown()
 
 	if model.BuildEnterpriseReady == "true" {

--- a/utils/config.go
+++ b/utils/config.go
@@ -70,11 +70,20 @@ func RemoveConfigListener(id string) {
 	delete(cfgListeners, id)
 }
 
+// FindConfigFile attempts to find an existing configuration file. fileName can be an absolute or
+// relative path or name such as "/opt/mattermost/config.json" or simply "config.json". An empty
+// string is returned if no configuration is found.
 func FindConfigFile(fileName string) (path string) {
-	for _, dir := range []string{"./config", "../config", "../../config", "."} {
-		path, _ := filepath.Abs(filepath.Join(dir, fileName))
-		if _, err := os.Stat(path); err == nil {
-			return path
+	if filepath.IsAbs(fileName) {
+		if _, err := os.Stat(fileName); err == nil {
+			return fileName
+		}
+	} else {
+		for _, dir := range []string{"./config", "../config", "../../config", "."} {
+			path, _ := filepath.Abs(filepath.Join(dir, fileName))
+			if _, err := os.Stat(path); err == nil {
+				return path
+			}
 		}
 	}
 	return ""
@@ -310,8 +319,8 @@ func ReadConfigFile(path string, allowEnvironmentOverrides bool) (*model.Config,
 }
 
 // EnsureConfigFile will attempt to locate a config file with the given name. If it does not exist,
-// it will attempt to locate a default config file, and copy it. In either case, the config file
-// path is returned.
+// it will attempt to locate a default config file, and copy it to a file named fileName in the same
+// directory. In either case, the config file path is returned.
 func EnsureConfigFile(fileName string) (string, error) {
 	if configFile := FindConfigFile(fileName); configFile != "" {
 		return configFile, nil

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -4,7 +4,9 @@
 package utils
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,23 @@ func TestConfig(t *testing.T) {
 	TranslationsPreInit()
 	LoadGlobalConfig("config.json")
 	InitTranslations(Cfg.LocalizationSettings)
+}
+
+func TestFindConfigFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, ioutil.WriteFile(path, []byte("{}"), 0600))
+
+	assert.Equal(t, path, FindConfigFile(path))
+
+	prevDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(prevDir)
+	os.Chdir(dir)
+	assert.Equal(t, path, FindConfigFile(path))
 }
 
 func TestConfigFromEnviroVars(t *testing.T) {


### PR DESCRIPTION
#### Summary
* `FindConfigFile` now works if the given path is an absolute path. This fixes the `config validate` CLI command with absolute paths.
* `app.New` now accepts a `ConfigFile` option and that option is set by the app construction in cmd/platform. This fixes the config CLI argument being ignored.
* Added a few tests and clarified behavior of relevant utils functions.
* Fixes #7838

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8149

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
