### PR TITLE
PLT-8149: Fix config path overrides (release-4.4)

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -48,7 +48,8 @@ type App struct {
 	Mfa              einterfaces.MfaInterface
 	Saml             einterfaces.SamlInterface
 
-	newStore func() store.Store
+	configFile string
+	newStore   func() store.Store
 
 	sessionCache *utils.Cache
 }
@@ -63,26 +64,28 @@ func New(options ...Option) *App {
 		panic("Only one App should exist at a time. Did you forget to call Shutdown()?")
 	}
 
-	if utils.T == nil {
-		utils.TranslationsPreInit()
-	}
-	utils.LoadGlobalConfig("config.json")
-	utils.InitTranslations(utils.Cfg.LocalizationSettings)
-
-	l4g.Info(utils.T("api.server.new_server.init.info"))
-
 	app := &App{
 		goroutineExitSignal: make(chan struct{}, 1),
 		Srv: &Server{
 			Router: mux.NewRouter(),
 		},
 		sessionCache: utils.NewLru(model.SESSION_CACHE_SIZE),
+		configFile:   "config.json",
 	}
-	app.initEnterprise()
 
 	for _, option := range options {
 		option(app)
 	}
+
+	if utils.T == nil {
+		utils.TranslationsPreInit()
+	}
+	utils.LoadGlobalConfig(app.configFile)
+	utils.InitTranslations(utils.Cfg.LocalizationSettings)
+
+	l4g.Info(utils.T("api.server.new_server.init.info"))
+
+	app.initEnterprise()
 
 	if app.newStore == nil {
 		app.newStore = func() store.Store {

--- a/app/options.go
+++ b/app/options.go
@@ -29,3 +29,9 @@ func StoreOverride(override interface{}) Option {
 		}
 	}
 }
+
+func ConfigFile(file string) Option {
+	return func(a *App) {
+		a.configFile = file
+	}
+}

--- a/cmd/platform/cli_test.go
+++ b/cmd/platform/cli_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/api"
@@ -257,6 +258,19 @@ func TestCliMakeUserActiveAndInactive(t *testing.T) {
 
 	// activate the inactive user
 	checkCommand(t, "user", "activate", th.BasicUser.Email)
+}
+
+func TestCliConfigValidate(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "config.json")
+	config := &model.Config{}
+	config.SetDefaults()
+	require.NoError(t, ioutil.WriteFile(path, []byte(config.ToJson()), 0600))
+
+	assert.Contains(t, checkCommand(t, "--config", path, "config", "validate"), "The document is valid")
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/platform/init.go
+++ b/cmd/platform/init.go
@@ -32,7 +32,7 @@ func initDBCommandContext(configFileLocation string) (*app.App, error) {
 
 	utils.ConfigureCmdLineLog()
 
-	a := app.New()
+	a := app.New(app.ConfigFile(configFileLocation))
 	if model.BuildEnterpriseReady == "true" {
 		a.LoadLicense()
 	}

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -64,7 +64,7 @@ func runServer(configFileLocation string) {
 		l4g.Error("Problem with file storage settings: " + err.Error())
 	}
 
-	a := app.New()
+	a := app.New(app.ConfigFile(configFileLocation))
 	defer a.Shutdown()
 
 	if model.BuildEnterpriseReady == "true" {

--- a/utils/config.go
+++ b/utils/config.go
@@ -70,11 +70,20 @@ func RemoveConfigListener(id string) {
 	delete(cfgListeners, id)
 }
 
+// FindConfigFile attempts to find an existing configuration file. fileName can be an absolute or
+// relative path or name such as "/opt/mattermost/config.json" or simply "config.json". An empty
+// string is returned if no configuration is found.
 func FindConfigFile(fileName string) (path string) {
-	for _, dir := range []string{"./config", "../config", "../../config", "."} {
-		path, _ := filepath.Abs(filepath.Join(dir, fileName))
-		if _, err := os.Stat(path); err == nil {
-			return path
+	if filepath.IsAbs(fileName) {
+		if _, err := os.Stat(fileName); err == nil {
+			return fileName
+		}
+	} else {
+		for _, dir := range []string{"./config", "../config", "../../config", "."} {
+			path, _ := filepath.Abs(filepath.Join(dir, fileName))
+			if _, err := os.Stat(path); err == nil {
+				return path
+			}
 		}
 	}
 	return ""
@@ -310,8 +319,8 @@ func ReadConfigFile(path string, allowEnvironmentOverrides bool) (*model.Config,
 }
 
 // EnsureConfigFile will attempt to locate a config file with the given name. If it does not exist,
-// it will attempt to locate a default config file, and copy it. In either case, the config file
-// path is returned.
+// it will attempt to locate a default config file, and copy it to a file named fileName in the same
+// directory. In either case, the config file path is returned.
 func EnsureConfigFile(fileName string) (string, error) {
 	if configFile := FindConfigFile(fileName); configFile != "" {
 		return configFile, nil

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -4,7 +4,9 @@
 package utils
 
 import (
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,23 @@ func TestConfig(t *testing.T) {
 	TranslationsPreInit()
 	LoadGlobalConfig("config.json")
 	InitTranslations(Cfg.LocalizationSettings)
+}
+
+func TestFindConfigFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, ioutil.WriteFile(path, []byte("{}"), 0600))
+
+	assert.Equal(t, path, FindConfigFile(path))
+
+	prevDir, err := os.Getwd()
+	require.NoError(t, err)
+	defer os.Chdir(prevDir)
+	os.Chdir(dir)
+	assert.Equal(t, path, FindConfigFile(path))
 }
 
 func TestConfigFromEnviroVars(t *testing.T) {


### PR DESCRIPTION
https://github.com/mattermost/mattermost-server/pull/7850 with slight changes to the tests for 4.4

#### Summary
* `FindConfigFile` now works if the given path is an absolute path. This fixes the `config validate` CLI command with absolute paths.
* `app.New` now accepts a `ConfigFile` option and that option is set by the app construction in cmd/platform. This fixes the config CLI argument being ignored.
* Added a few tests and clarified behavior of relevant utils functions.
* Fixes #7838

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8149

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)