### PR TITLE
Add CloseUnusedDirectMessages to default config.json

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -51,7 +51,8 @@
         "EnableUserTypingMessages": true,
         "EnableChannelViewedMessages": true,
         "EnableUserStatuses": true,
-        "ClusterLogTimeoutMilliseconds": 2000
+        "ClusterLogTimeoutMilliseconds": 2000,
+        "CloseUnusedDirectMessages": false
     },
     "TeamSettings": {
         "SiteName": "Mattermost",


### PR DESCRIPTION
This got missed for 4.4, so people will have to add it manually for now.