### PR TITLE
make `config validate` exit with non-zero code on failure

### DIFF
--- a/cmd/platform/config.go
+++ b/cmd/platform/config.go
@@ -20,7 +20,8 @@ var configCmd = &cobra.Command{
 var validateConfigCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate config file",
-	Run:   configValidateCmdF,
+	Long:  "If the config file is valid, this command will output a success message and have a zero exit code. If it is invalid, this command will output an error and have a non-zero exit code.",
+	RunE:  configValidateCmdF,
 }
 
 func init() {
@@ -29,39 +30,35 @@ func init() {
 	)
 }
 
-func configValidateCmdF(cmd *cobra.Command, args []string) {
+func configValidateCmdF(cmd *cobra.Command, args []string) error {
 	utils.TranslationsPreInit()
 	filePath, err := cmd.Flags().GetString("config")
 	if err != nil {
-		CommandPrintErrorln(err)
-		return
+		return err
 	}
 
 	filePath = utils.FindConfigFile(filePath)
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		CommandPrintErrorln(err)
-		return
+		return err
 	}
 
 	decoder := json.NewDecoder(file)
 	config := model.Config{}
 	err = decoder.Decode(&config)
 	if err != nil {
-		CommandPrintErrorln(err)
-		return
+		return err
 	}
 
 	if _, err := file.Stat(); err != nil {
-		CommandPrintErrorln(err)
-		return
+		return err
 	}
 
 	if err := config.IsValid(); err != nil {
-		CommandPrintErrorln(errors.New(utils.T(err.Id)))
-		return
+		return errors.New(utils.T(err.Id))
 	}
 
 	CommandPrettyPrintln("The document is valid")
+	return nil
 }

--- a/cmd/platform/config_test.go
+++ b/cmd/platform/config_test.go
@@ -25,5 +25,6 @@ func TestConfigValidate(t *testing.T) {
 	config.SetDefaults()
 	require.NoError(t, ioutil.WriteFile(path, []byte(config.ToJson()), 0600))
 
-	assert.Contains(t, checkCommand(t, "--config", path, "config", "validate"), "The document is valid")
+	assert.Error(t, runCommand(t, "--config", "foo.json", "config", "validate"))
+	assert.NoError(t, runCommand(t, "--config", path, "config", "validate"))
 }

--- a/cmd/platform/mattermost_test.go
+++ b/cmd/platform/mattermost_test.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -25,17 +24,9 @@ func TestConfigFlag(t *testing.T) {
 	configPath := filepath.Join(dir, "foo.json")
 	require.NoError(t, ioutil.WriteFile(configPath, []byte(config.ToJson()), 0600))
 
-	os.Mkdir(filepath.Join(dir, "i18n"), 0700)
 	i18n, ok := utils.FindDir("i18n")
 	require.True(t, ok)
-	en, err := os.Open(filepath.Join(i18n, "en.json"))
-	require.NoError(t, err)
-	defer en.Close()
-	dest, err := os.OpenFile(filepath.Join(dir, "i18n", "en.json"), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	require.NoError(t, err)
-	defer dest.Close()
-	_, err = io.Copy(dest, en)
-	require.NoError(t, err)
+	require.NoError(t, utils.CopyDir(i18n, filepath.Join(dir, "i18n")))
 
 	prevDir, err := os.Getwd()
 	require.NoError(t, err)


### PR DESCRIPTION
#### Summary
Makes it usable by non-humans as well.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)