### PR TITLE
Refactor password validation and config defaults

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -310,7 +310,7 @@ func adminResetPassword(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	newPassword := props["new_password"]
-	if err := utils.IsPasswordValid(newPassword); err != nil {
+	if err := c.App.IsPasswordValid(newPassword); err != nil {
 		c.Err = err
 		return
 	}

--- a/api/user.go
+++ b/api/user.go
@@ -873,7 +873,7 @@ func oauthToEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 	props := model.MapFromJson(r.Body)
 
 	password := props["password"]
-	if err := utils.IsPasswordValid(password); err != nil {
+	if err := c.App.IsPasswordValid(password); err != nil {
 		c.Err = err
 		return
 	}
@@ -955,7 +955,7 @@ func ldapToEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	emailPassword := props["email_password"]
-	if err := utils.IsPasswordValid(emailPassword); err != nil {
+	if err := c.App.IsPasswordValid(emailPassword); err != nil {
 		c.Err = err
 		return
 	}

--- a/app/authentication.go
+++ b/app/authentication.go
@@ -11,6 +11,13 @@ import (
 	"github.com/mattermost/mattermost-server/utils"
 )
 
+func (a *App) IsPasswordValid(password string) *model.AppError {
+	if utils.IsLicensed() && *utils.License().Features.PasswordRequirements {
+		return utils.IsPasswordValidWithSettings(password, &a.Config().PasswordSettings)
+	}
+	return utils.IsPasswordValid(password)
+}
+
 func (a *App) CheckPasswordAndAllCriteria(user *model.User, password string, mfaToken string) *model.AppError {
 	if err := a.CheckUserAdditionalAuthenticationCriteria(user, mfaToken); err != nil {
 		return err

--- a/app/user.go
+++ b/app/user.go
@@ -213,7 +213,7 @@ func (a *App) CreateUser(user *model.User) (*model.User, *model.AppError) {
 func (a *App) createUser(user *model.User) (*model.User, *model.AppError) {
 	user.MakeNonNil()
 
-	if err := utils.IsPasswordValid(user.Password); user.AuthService == "" && err != nil {
+	if err := a.IsPasswordValid(user.Password); user.AuthService == "" && err != nil {
 		return nil, err
 	}
 
@@ -1086,7 +1086,7 @@ func (a *App) UpdatePasswordByUserIdSendEmail(userId, newPassword, method string
 }
 
 func (a *App) UpdatePassword(user *model.User, newPassword string) *model.AppError {
-	if err := utils.IsPasswordValid(newPassword); err != nil {
+	if err := a.IsPasswordValid(newPassword); err != nil {
 		return err
 	}
 

--- a/model/config.go
+++ b/model/config.go
@@ -207,6 +207,194 @@ type ServiceSettings struct {
 	CloseUnusedDirectMessages                *bool
 }
 
+func (s *ServiceSettings) SetDefaults() {
+	if s.SiteURL == nil {
+		s.SiteURL = NewString(SERVICE_SETTINGS_DEFAULT_SITE_URL)
+	}
+
+	if s.LicenseFileLocation == nil {
+		s.LicenseFileLocation = NewString("")
+	}
+
+	if s.ListenAddress == nil {
+		s.ListenAddress = NewString(SERVICE_SETTINGS_DEFAULT_LISTEN_AND_ADDRESS)
+	}
+
+	if s.EnableAPIv3 == nil {
+		s.EnableAPIv3 = NewBool(true)
+	}
+
+	if s.EnableLinkPreviews == nil {
+		s.EnableLinkPreviews = NewBool(false)
+	}
+
+	if s.EnableDeveloper == nil {
+		s.EnableDeveloper = NewBool(false)
+	}
+
+	if s.EnableSecurityFixAlert == nil {
+		s.EnableSecurityFixAlert = NewBool(true)
+	}
+
+	if s.EnableInsecureOutgoingConnections == nil {
+		s.EnableInsecureOutgoingConnections = NewBool(false)
+	}
+
+	if s.AllowedUntrustedInternalConnections == nil {
+		s.AllowedUntrustedInternalConnections = new(string)
+	}
+
+	if s.EnableMultifactorAuthentication == nil {
+		s.EnableMultifactorAuthentication = NewBool(false)
+	}
+
+	if s.EnforceMultifactorAuthentication == nil {
+		s.EnforceMultifactorAuthentication = NewBool(false)
+	}
+
+	if s.EnableUserAccessTokens == nil {
+		s.EnableUserAccessTokens = NewBool(false)
+	}
+
+	if s.GoroutineHealthThreshold == nil {
+		s.GoroutineHealthThreshold = NewInt(-1)
+	}
+
+	if s.ConnectionSecurity == nil {
+		s.ConnectionSecurity = NewString("")
+	}
+
+	if s.TLSKeyFile == nil {
+		s.TLSKeyFile = NewString(SERVICE_SETTINGS_DEFAULT_TLS_KEY_FILE)
+	}
+
+	if s.TLSCertFile == nil {
+		s.TLSCertFile = NewString(SERVICE_SETTINGS_DEFAULT_TLS_CERT_FILE)
+	}
+
+	if s.UseLetsEncrypt == nil {
+		s.UseLetsEncrypt = NewBool(false)
+	}
+
+	if s.LetsEncryptCertificateCacheFile == nil {
+		s.LetsEncryptCertificateCacheFile = NewString("./config/letsencrypt.cache")
+	}
+
+	if s.ReadTimeout == nil {
+		s.ReadTimeout = NewInt(SERVICE_SETTINGS_DEFAULT_READ_TIMEOUT)
+	}
+
+	if s.WriteTimeout == nil {
+		s.WriteTimeout = NewInt(SERVICE_SETTINGS_DEFAULT_WRITE_TIMEOUT)
+	}
+
+	if s.MaximumLoginAttempts == nil {
+		s.MaximumLoginAttempts = NewInt(SERVICE_SETTINGS_DEFAULT_MAX_LOGIN_ATTEMPTS)
+	}
+
+	if s.Forward80To443 == nil {
+		s.Forward80To443 = NewBool(false)
+	}
+
+	if s.TimeBetweenUserTypingUpdatesMilliseconds == nil {
+		s.TimeBetweenUserTypingUpdatesMilliseconds = NewInt64(5000)
+	}
+
+	if s.EnablePostSearch == nil {
+		s.EnablePostSearch = NewBool(true)
+	}
+
+	if s.EnableUserTypingMessages == nil {
+		s.EnableUserTypingMessages = NewBool(true)
+	}
+
+	if s.EnableChannelViewedMessages == nil {
+		s.EnableChannelViewedMessages = NewBool(true)
+	}
+
+	if s.EnableUserStatuses == nil {
+		s.EnableUserStatuses = NewBool(true)
+	}
+
+	if s.ClusterLogTimeoutMilliseconds == nil {
+		s.ClusterLogTimeoutMilliseconds = NewInt(2000)
+	}
+
+	if s.CloseUnusedDirectMessages == nil {
+		s.CloseUnusedDirectMessages = NewBool(false)
+	}
+
+	if s.SessionLengthWebInDays == nil {
+		s.SessionLengthWebInDays = NewInt(30)
+	}
+
+	if s.SessionLengthMobileInDays == nil {
+		s.SessionLengthMobileInDays = NewInt(30)
+	}
+
+	if s.SessionLengthSSOInDays == nil {
+		s.SessionLengthSSOInDays = NewInt(30)
+	}
+
+	if s.SessionCacheInMinutes == nil {
+		s.SessionCacheInMinutes = NewInt(10)
+	}
+
+	if s.SessionIdleTimeoutInMinutes == nil {
+		s.SessionIdleTimeoutInMinutes = NewInt(0)
+	}
+
+	if s.EnableCommands == nil {
+		s.EnableCommands = NewBool(false)
+	}
+
+	if s.EnableOnlyAdminIntegrations == nil {
+		s.EnableOnlyAdminIntegrations = NewBool(true)
+	}
+
+	if s.WebsocketPort == nil {
+		s.WebsocketPort = NewInt(80)
+	}
+
+	if s.WebsocketSecurePort == nil {
+		s.WebsocketSecurePort = NewInt(443)
+	}
+
+	if s.AllowCorsFrom == nil {
+		s.AllowCorsFrom = NewString(SERVICE_SETTINGS_DEFAULT_ALLOW_CORS_FROM)
+	}
+
+	if s.WebserverMode == nil {
+		s.WebserverMode = NewString("gzip")
+	} else if *s.WebserverMode == "regular" {
+		*s.WebserverMode = "gzip"
+	}
+
+	if s.EnableCustomEmoji == nil {
+		s.EnableCustomEmoji = NewBool(false)
+	}
+
+	if s.EnableEmojiPicker == nil {
+		s.EnableEmojiPicker = NewBool(true)
+	}
+
+	if s.RestrictCustomEmojiCreation == nil {
+		s.RestrictCustomEmojiCreation = NewString(RESTRICT_EMOJI_CREATION_ALL)
+	}
+
+	if s.RestrictPostDelete == nil {
+		s.RestrictPostDelete = NewString(PERMISSIONS_DELETE_POST_ALL)
+	}
+
+	if s.AllowEditPost == nil {
+		s.AllowEditPost = NewString(ALLOW_EDIT_POST_ALWAYS)
+	}
+
+	if s.PostEditTimeLimit == nil {
+		s.PostEditTimeLimit = NewInt(300)
+	}
+}
+
 type ClusterSettings struct {
 	Enable                *bool
 	ClusterName           *string
@@ -218,14 +406,68 @@ type ClusterSettings struct {
 	StreamingPort         *int
 }
 
+func (s *ClusterSettings) SetDefaults() {
+	if s.Enable == nil {
+		s.Enable = NewBool(false)
+	}
+
+	if s.ClusterName == nil {
+		s.ClusterName = NewString("")
+	}
+
+	if s.OverrideHostname == nil {
+		s.OverrideHostname = NewString("")
+	}
+
+	if s.UseIpAddress == nil {
+		s.UseIpAddress = NewBool(true)
+	}
+
+	if s.UseExperimentalGossip == nil {
+		s.UseExperimentalGossip = NewBool(false)
+	}
+
+	if s.ReadOnlyConfig == nil {
+		s.ReadOnlyConfig = NewBool(true)
+	}
+
+	if s.GossipPort == nil {
+		s.GossipPort = NewInt(8074)
+	}
+
+	if s.StreamingPort == nil {
+		s.StreamingPort = NewInt(8075)
+	}
+}
+
 type MetricsSettings struct {
 	Enable           *bool
 	BlockProfileRate *int
 	ListenAddress    *string
 }
 
+func (s *MetricsSettings) SetDefaults() {
+	if s.ListenAddress == nil {
+		s.ListenAddress = NewString(":8067")
+	}
+
+	if s.Enable == nil {
+		s.Enable = NewBool(false)
+	}
+
+	if s.BlockProfileRate == nil {
+		s.BlockProfileRate = NewInt(0)
+	}
+}
+
 type AnalyticsSettings struct {
 	MaxUsersForStatistics *int
+}
+
+func (s *AnalyticsSettings) SetDefaults() {
+	if s.MaxUsersForStatistics == nil {
+		s.MaxUsersForStatistics = NewInt(ANALYTICS_SETTINGS_DEFAULT_MAX_USERS_FOR_STATISTICS)
+	}
 }
 
 type SSOSettings struct {
@@ -250,6 +492,32 @@ type SqlSettings struct {
 	QueryTimeout             *int
 }
 
+func (s *SqlSettings) SetDefaults() {
+	if s.DriverName == nil {
+		s.DriverName = NewString(DATABASE_DRIVER_MYSQL)
+	}
+
+	if s.DataSource == nil {
+		s.DataSource = NewString(SQL_SETTINGS_DEFAULT_DATA_SOURCE)
+	}
+
+	if len(s.AtRestEncryptKey) == 0 {
+		s.AtRestEncryptKey = NewRandomString(32)
+	}
+
+	if s.MaxIdleConns == nil {
+		s.MaxIdleConns = NewInt(20)
+	}
+
+	if s.MaxOpenConns == nil {
+		s.MaxOpenConns = NewInt(300)
+	}
+
+	if s.QueryTimeout == nil {
+		s.QueryTimeout = NewInt(30)
+	}
+}
+
 type LogSettings struct {
 	EnableConsole          bool
 	ConsoleLevel           string
@@ -261,12 +529,40 @@ type LogSettings struct {
 	EnableDiagnostics      *bool
 }
 
+func (s *LogSettings) SetDefaults() {
+	if s.EnableDiagnostics == nil {
+		s.EnableDiagnostics = NewBool(true)
+	}
+}
+
 type PasswordSettings struct {
 	MinimumLength *int
 	Lowercase     *bool
 	Number        *bool
 	Uppercase     *bool
 	Symbol        *bool
+}
+
+func (s *PasswordSettings) SetDefaults() {
+	if s.MinimumLength == nil {
+		s.MinimumLength = NewInt(PASSWORD_MINIMUM_LENGTH)
+	}
+
+	if s.Lowercase == nil {
+		s.Lowercase = NewBool(false)
+	}
+
+	if s.Number == nil {
+		s.Number = NewBool(false)
+	}
+
+	if s.Uppercase == nil {
+		s.Uppercase = NewBool(false)
+	}
+
+	if s.Symbol == nil {
+		s.Symbol = NewBool(false)
+	}
 }
 
 type FileSettings struct {
@@ -288,6 +584,63 @@ type FileSettings struct {
 	AmazonS3SignV2          *bool
 	AmazonS3SSE             *bool
 	AmazonS3Trace           *bool
+}
+
+func (s *FileSettings) SetDefaults() {
+	if s.DriverName == nil {
+		s.DriverName = NewString(IMAGE_DRIVER_LOCAL)
+	}
+
+	if s.AmazonS3Endpoint == "" {
+		// Defaults to "s3.amazonaws.com"
+		s.AmazonS3Endpoint = "s3.amazonaws.com"
+	}
+
+	if s.AmazonS3SSL == nil {
+		s.AmazonS3SSL = NewBool(true) // Secure by default.
+	}
+
+	if s.AmazonS3SignV2 == nil {
+		s.AmazonS3SignV2 = new(bool)
+		// Signature v2 is not enabled by default.
+	}
+
+	if s.AmazonS3SSE == nil {
+		s.AmazonS3SSE = NewBool(false) // Not Encrypted by default.
+	}
+
+	if s.AmazonS3Trace == nil {
+		s.AmazonS3Trace = NewBool(false)
+	}
+
+	if s.EnableFileAttachments == nil {
+		s.EnableFileAttachments = NewBool(true)
+	}
+
+	if s.EnableMobileUpload == nil {
+		s.EnableMobileUpload = NewBool(true)
+	}
+
+	if s.EnableMobileDownload == nil {
+		s.EnableMobileDownload = NewBool(true)
+	}
+
+	if s.MaxFileSize == nil {
+		s.MaxFileSize = NewInt64(52428800) // 50 MB
+	}
+
+	if s.PublicLinkSalt == nil || len(*s.PublicLinkSalt) == 0 {
+		s.PublicLinkSalt = NewString(NewRandomString(32))
+	}
+
+	if s.InitialFont == "" {
+		// Defaults to "luximbi.ttf"
+		s.InitialFont = "luximbi.ttf"
+	}
+
+	if s.Directory == "" {
+		s.Directory = "./data/"
+	}
 }
 
 type EmailSettings struct {
@@ -316,6 +669,69 @@ type EmailSettings struct {
 	EmailNotificationContentsType     *string
 }
 
+func (s *EmailSettings) SetDefaults() {
+	if len(s.InviteSalt) == 0 {
+		s.InviteSalt = NewRandomString(32)
+	}
+
+	if s.EnableSignInWithEmail == nil {
+		s.EnableSignInWithEmail = NewBool(s.EnableSignUpWithEmail)
+	}
+
+	if s.EnableSignInWithUsername == nil {
+		s.EnableSignInWithUsername = NewBool(false)
+	}
+
+	if s.SendPushNotifications == nil {
+		s.SendPushNotifications = NewBool(false)
+	}
+
+	if s.PushNotificationServer == nil {
+		s.PushNotificationServer = NewString("")
+	}
+
+	if s.PushNotificationContents == nil {
+		s.PushNotificationContents = NewString(GENERIC_NOTIFICATION)
+	}
+
+	if s.FeedbackOrganization == nil {
+		s.FeedbackOrganization = NewString(EMAIL_SETTINGS_DEFAULT_FEEDBACK_ORGANIZATION)
+	}
+
+	if s.EnableEmailBatching == nil {
+		s.EnableEmailBatching = NewBool(false)
+	}
+
+	if s.EmailBatchingBufferSize == nil {
+		s.EmailBatchingBufferSize = NewInt(EMAIL_BATCHING_BUFFER_SIZE)
+	}
+
+	if s.EmailBatchingInterval == nil {
+		s.EmailBatchingInterval = NewInt(EMAIL_BATCHING_INTERVAL)
+	}
+
+	if s.EnableSMTPAuth == nil {
+		s.EnableSMTPAuth = new(bool)
+		if s.ConnectionSecurity == CONN_SECURITY_NONE {
+			*s.EnableSMTPAuth = false
+		} else {
+			*s.EnableSMTPAuth = true
+		}
+	}
+
+	if s.ConnectionSecurity == CONN_SECURITY_PLAIN {
+		s.ConnectionSecurity = CONN_SECURITY_NONE
+	}
+
+	if s.SkipServerCertificateVerification == nil {
+		s.SkipServerCertificateVerification = NewBool(false)
+	}
+
+	if s.EmailNotificationContentsType == nil {
+		s.EmailNotificationContentsType = NewString(EMAIL_NOTIFICATION_CONTENTS_FULL)
+	}
+}
+
 type RateLimitSettings struct {
 	Enable           *bool
 	PerSec           *int
@@ -323,6 +739,24 @@ type RateLimitSettings struct {
 	MemoryStoreSize  *int
 	VaryByRemoteAddr bool
 	VaryByHeader     string
+}
+
+func (s *RateLimitSettings) SetDefaults() {
+	if s.Enable == nil {
+		s.Enable = NewBool(false)
+	}
+
+	if s.PerSec == nil {
+		s.PerSec = NewInt(10)
+	}
+
+	if s.MaxBurst == nil {
+		s.MaxBurst = NewInt(100)
+	}
+
+	if s.MemoryStoreSize == nil {
+		s.MemoryStoreSize = NewInt(10000)
+	}
 }
 
 type PrivacySettings struct {
@@ -339,6 +773,52 @@ type SupportSettings struct {
 	SupportEmail       *string
 }
 
+func (s *SupportSettings) SetDefaults() {
+	if !IsSafeLink(s.TermsOfServiceLink) {
+		*s.TermsOfServiceLink = SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK
+	}
+
+	if s.TermsOfServiceLink == nil {
+		s.TermsOfServiceLink = NewString(SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK)
+	}
+
+	if !IsSafeLink(s.PrivacyPolicyLink) {
+		*s.PrivacyPolicyLink = ""
+	}
+
+	if s.PrivacyPolicyLink == nil {
+		s.PrivacyPolicyLink = NewString(SUPPORT_SETTINGS_DEFAULT_PRIVACY_POLICY_LINK)
+	}
+
+	if !IsSafeLink(s.AboutLink) {
+		*s.AboutLink = ""
+	}
+
+	if s.AboutLink == nil {
+		s.AboutLink = NewString(SUPPORT_SETTINGS_DEFAULT_ABOUT_LINK)
+	}
+
+	if !IsSafeLink(s.HelpLink) {
+		*s.HelpLink = ""
+	}
+
+	if s.HelpLink == nil {
+		s.HelpLink = NewString(SUPPORT_SETTINGS_DEFAULT_HELP_LINK)
+	}
+
+	if !IsSafeLink(s.ReportAProblemLink) {
+		*s.ReportAProblemLink = ""
+	}
+
+	if s.ReportAProblemLink == nil {
+		s.ReportAProblemLink = NewString(SUPPORT_SETTINGS_DEFAULT_REPORT_A_PROBLEM_LINK)
+	}
+
+	if s.SupportEmail == nil {
+		s.SupportEmail = NewString(SUPPORT_SETTINGS_DEFAULT_SUPPORT_EMAIL)
+	}
+}
+
 type AnnouncementSettings struct {
 	EnableBanner         *bool
 	BannerText           *string
@@ -347,11 +827,51 @@ type AnnouncementSettings struct {
 	AllowBannerDismissal *bool
 }
 
+func (s *AnnouncementSettings) SetDefaults() {
+	if s.EnableBanner == nil {
+		s.EnableBanner = NewBool(false)
+	}
+
+	if s.BannerText == nil {
+		s.BannerText = NewString("")
+	}
+
+	if s.BannerColor == nil {
+		s.BannerColor = NewString(ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_COLOR)
+	}
+
+	if s.BannerTextColor == nil {
+		s.BannerTextColor = NewString(ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_TEXT_COLOR)
+	}
+
+	if s.AllowBannerDismissal == nil {
+		s.AllowBannerDismissal = NewBool(true)
+	}
+}
+
 type ThemeSettings struct {
 	EnableThemeSelection *bool
 	DefaultTheme         *string
 	AllowCustomThemes    *bool
 	AllowedThemes        []string
+}
+
+func (s *ThemeSettings) SetDefaults() {
+	if s.EnableThemeSelection == nil {
+		s.EnableThemeSelection = NewBool(true)
+	}
+
+	if s.DefaultTheme == nil {
+		s.DefaultTheme = NewString(TEAM_SETTINGS_DEFAULT_TEAM_TEXT)
+	}
+
+	if s.AllowCustomThemes == nil {
+		s.AllowCustomThemes = NewBool(true)
+	}
+
+	if s.AllowedThemes == nil {
+		s.AllowedThemes = []string{}
+	}
 }
 
 type TeamSettings struct {
@@ -380,6 +900,101 @@ type TeamSettings struct {
 	EnableConfirmNotificationsToChannel *bool
 	TeammateNameDisplay                 *string
 	ExperimentalTownSquareIsReadOnly    *bool
+}
+
+func (s *TeamSettings) SetDefaults() {
+	if s.MaxUsersPerTeam == nil {
+		s.MaxUsersPerTeam = NewInt(TEAM_SETTINGS_DEFAULT_MAX_USERS_PER_TEAM)
+	}
+
+	if s.EnableCustomBrand == nil {
+		s.EnableCustomBrand = NewBool(false)
+	}
+
+	if s.CustomBrandText == nil {
+		s.CustomBrandText = NewString(TEAM_SETTINGS_DEFAULT_CUSTOM_BRAND_TEXT)
+	}
+
+	if s.CustomDescriptionText == nil {
+		s.CustomDescriptionText = NewString(TEAM_SETTINGS_DEFAULT_CUSTOM_DESCRIPTION_TEXT)
+	}
+
+	if s.EnableOpenServer == nil {
+		s.EnableOpenServer = NewBool(false)
+	}
+
+	if s.RestrictDirectMessage == nil {
+		s.RestrictDirectMessage = NewString(DIRECT_MESSAGE_ANY)
+	}
+
+	if s.RestrictTeamInvite == nil {
+		s.RestrictTeamInvite = NewString(PERMISSIONS_ALL)
+	}
+
+	if s.RestrictPublicChannelManagement == nil {
+		s.RestrictPublicChannelManagement = NewString(PERMISSIONS_ALL)
+	}
+
+	if s.RestrictPrivateChannelManagement == nil {
+		s.RestrictPrivateChannelManagement = NewString(PERMISSIONS_ALL)
+	}
+
+	if s.RestrictPublicChannelCreation == nil {
+		s.RestrictPublicChannelCreation = new(string)
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		if *s.RestrictPublicChannelManagement == PERMISSIONS_CHANNEL_ADMIN {
+			*s.RestrictPublicChannelCreation = PERMISSIONS_TEAM_ADMIN
+		} else {
+			*s.RestrictPublicChannelCreation = *s.RestrictPublicChannelManagement
+		}
+	}
+
+	if s.RestrictPrivateChannelCreation == nil {
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		if *s.RestrictPrivateChannelManagement == PERMISSIONS_CHANNEL_ADMIN {
+			s.RestrictPrivateChannelCreation = NewString(PERMISSIONS_TEAM_ADMIN)
+		} else {
+			s.RestrictPrivateChannelCreation = NewString(*s.RestrictPrivateChannelManagement)
+		}
+	}
+
+	if s.RestrictPublicChannelDeletion == nil {
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		s.RestrictPublicChannelDeletion = NewString(*s.RestrictPublicChannelManagement)
+	}
+
+	if s.RestrictPrivateChannelDeletion == nil {
+		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
+		s.RestrictPrivateChannelDeletion = NewString(*s.RestrictPrivateChannelManagement)
+	}
+
+	if s.RestrictPrivateChannelManageMembers == nil {
+		s.RestrictPrivateChannelManageMembers = NewString(PERMISSIONS_ALL)
+	}
+
+	if s.EnableXToLeaveChannelsFromLHS == nil {
+		s.EnableXToLeaveChannelsFromLHS = NewBool(false)
+	}
+
+	if s.UserStatusAwayTimeout == nil {
+		s.UserStatusAwayTimeout = NewInt64(TEAM_SETTINGS_DEFAULT_USER_STATUS_AWAY_TIMEOUT)
+	}
+
+	if s.MaxChannelsPerTeam == nil {
+		s.MaxChannelsPerTeam = NewInt64(2000)
+	}
+
+	if s.MaxNotificationsPerChannel == nil {
+		s.MaxNotificationsPerChannel = NewInt64(1000)
+	}
+
+	if s.EnableConfirmNotificationsToChannel == nil {
+		s.EnableConfirmNotificationsToChannel = NewBool(true)
+	}
+
+	if s.ExperimentalTownSquareIsReadOnly == nil {
+		s.ExperimentalTownSquareIsReadOnly = NewBool(false)
+	}
 }
 
 type ClientRequirements struct {
@@ -426,16 +1041,131 @@ type LdapSettings struct {
 	LoginFieldName *string
 }
 
+func (s *LdapSettings) SetDefaults() {
+	if s.Enable == nil {
+		s.Enable = NewBool(false)
+	}
+
+	// When unset should default to LDAP Enabled
+	if s.EnableSync == nil {
+		s.EnableSync = NewBool(*s.Enable)
+	}
+
+	if s.LdapServer == nil {
+		s.LdapServer = NewString("")
+	}
+
+	if s.LdapPort == nil {
+		s.LdapPort = NewInt(389)
+	}
+
+	if s.ConnectionSecurity == nil {
+		s.ConnectionSecurity = NewString("")
+	}
+
+	if s.BaseDN == nil {
+		s.BaseDN = NewString("")
+	}
+
+	if s.BindUsername == nil {
+		s.BindUsername = NewString("")
+	}
+
+	if s.BindPassword == nil {
+		s.BindPassword = NewString("")
+	}
+
+	if s.UserFilter == nil {
+		s.UserFilter = NewString("")
+	}
+
+	if s.FirstNameAttribute == nil {
+		s.FirstNameAttribute = NewString(LDAP_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE)
+	}
+
+	if s.LastNameAttribute == nil {
+		s.LastNameAttribute = NewString(LDAP_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE)
+	}
+
+	if s.EmailAttribute == nil {
+		s.EmailAttribute = NewString(LDAP_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE)
+	}
+
+	if s.UsernameAttribute == nil {
+		s.UsernameAttribute = NewString(LDAP_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE)
+	}
+
+	if s.NicknameAttribute == nil {
+		s.NicknameAttribute = NewString(LDAP_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE)
+	}
+
+	if s.IdAttribute == nil {
+		s.IdAttribute = NewString(LDAP_SETTINGS_DEFAULT_ID_ATTRIBUTE)
+	}
+
+	if s.PositionAttribute == nil {
+		s.PositionAttribute = NewString(LDAP_SETTINGS_DEFAULT_POSITION_ATTRIBUTE)
+	}
+
+	if s.SyncIntervalMinutes == nil {
+		s.SyncIntervalMinutes = NewInt(60)
+	}
+
+	if s.SkipCertificateVerification == nil {
+		s.SkipCertificateVerification = NewBool(false)
+	}
+
+	if s.QueryTimeout == nil {
+		s.QueryTimeout = NewInt(60)
+	}
+
+	if s.MaxPageSize == nil {
+		s.MaxPageSize = NewInt(0)
+	}
+
+	if s.LoginFieldName == nil {
+		s.LoginFieldName = NewString(LDAP_SETTINGS_DEFAULT_LOGIN_FIELD_NAME)
+	}
+}
+
 type ComplianceSettings struct {
 	Enable      *bool
 	Directory   *string
 	EnableDaily *bool
 }
 
+func (s *ComplianceSettings) SetDefaults() {
+	if s.Enable == nil {
+		s.Enable = NewBool(false)
+	}
+
+	if s.Directory == nil {
+		s.Directory = NewString("./data/")
+	}
+
+	if s.EnableDaily == nil {
+		s.EnableDaily = NewBool(false)
+	}
+}
+
 type LocalizationSettings struct {
 	DefaultServerLocale *string
 	DefaultClientLocale *string
 	AvailableLocales    *string
+}
+
+func (s *LocalizationSettings) SetDefaults() {
+	if s.DefaultServerLocale == nil {
+		s.DefaultServerLocale = NewString(DEFAULT_LOCALE)
+	}
+
+	if s.DefaultClientLocale == nil {
+		s.DefaultClientLocale = NewString(DEFAULT_LOCALE)
+	}
+
+	if s.AvailableLocales == nil {
+		s.AvailableLocales = NewString("")
+	}
 }
 
 type SamlSettings struct {
@@ -466,10 +1196,98 @@ type SamlSettings struct {
 	LoginButtonText *string
 }
 
+func (s *SamlSettings) SetDefaults() {
+	if s.Enable == nil {
+		s.Enable = NewBool(false)
+	}
+
+	if s.EnableSyncWithLdap == nil {
+		s.EnableSyncWithLdap = NewBool(false)
+	}
+
+	if s.Verify == nil {
+		s.Verify = NewBool(true)
+	}
+
+	if s.Encrypt == nil {
+		s.Encrypt = NewBool(true)
+	}
+
+	if s.IdpUrl == nil {
+		s.IdpUrl = NewString("")
+	}
+
+	if s.IdpDescriptorUrl == nil {
+		s.IdpDescriptorUrl = NewString("")
+	}
+
+	if s.IdpCertificateFile == nil {
+		s.IdpCertificateFile = NewString("")
+	}
+
+	if s.PublicCertificateFile == nil {
+		s.PublicCertificateFile = NewString("")
+	}
+
+	if s.PrivateKeyFile == nil {
+		s.PrivateKeyFile = NewString("")
+	}
+
+	if s.AssertionConsumerServiceURL == nil {
+		s.AssertionConsumerServiceURL = NewString("")
+	}
+
+	if s.LoginButtonText == nil || *s.LoginButtonText == "" {
+		s.LoginButtonText = NewString(USER_AUTH_SERVICE_SAML_TEXT)
+	}
+
+	if s.FirstNameAttribute == nil {
+		s.FirstNameAttribute = NewString(SAML_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE)
+	}
+
+	if s.LastNameAttribute == nil {
+		s.LastNameAttribute = NewString(SAML_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE)
+	}
+
+	if s.EmailAttribute == nil {
+		s.EmailAttribute = NewString(SAML_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE)
+	}
+
+	if s.UsernameAttribute == nil {
+		s.UsernameAttribute = NewString(SAML_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE)
+	}
+
+	if s.NicknameAttribute == nil {
+		s.NicknameAttribute = NewString(SAML_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE)
+	}
+
+	if s.PositionAttribute == nil {
+		s.PositionAttribute = NewString(SAML_SETTINGS_DEFAULT_POSITION_ATTRIBUTE)
+	}
+
+	if s.LocaleAttribute == nil {
+		s.LocaleAttribute = NewString(SAML_SETTINGS_DEFAULT_LOCALE_ATTRIBUTE)
+	}
+}
+
 type NativeAppSettings struct {
 	AppDownloadLink        *string
 	AndroidAppDownloadLink *string
 	IosAppDownloadLink     *string
+}
+
+func (s *NativeAppSettings) SetDefaults() {
+	if s.AppDownloadLink == nil {
+		s.AppDownloadLink = NewString(NATIVEAPP_SETTINGS_DEFAULT_APP_DOWNLOAD_LINK)
+	}
+
+	if s.AndroidAppDownloadLink == nil {
+		s.AndroidAppDownloadLink = NewString(NATIVEAPP_SETTINGS_DEFAULT_ANDROID_APP_DOWNLOAD_LINK)
+	}
+
+	if s.IosAppDownloadLink == nil {
+		s.IosAppDownloadLink = NewString(NATIVEAPP_SETTINGS_DEFAULT_IOS_APP_DOWNLOAD_LINK)
+	}
 }
 
 type WebrtcSettings struct {
@@ -481,6 +1299,40 @@ type WebrtcSettings struct {
 	TurnURI             *string
 	TurnUsername        *string
 	TurnSharedKey       *string
+}
+
+func (s *WebrtcSettings) SetDefaults() {
+	if s.Enable == nil {
+		s.Enable = NewBool(false)
+	}
+
+	if s.GatewayWebsocketUrl == nil {
+		s.GatewayWebsocketUrl = NewString("")
+	}
+
+	if s.GatewayAdminUrl == nil {
+		s.GatewayAdminUrl = NewString("")
+	}
+
+	if s.GatewayAdminSecret == nil {
+		s.GatewayAdminSecret = NewString("")
+	}
+
+	if s.StunURI == nil {
+		s.StunURI = NewString(WEBRTC_SETTINGS_DEFAULT_STUN_URI)
+	}
+
+	if s.TurnURI == nil {
+		s.TurnURI = NewString(WEBRTC_SETTINGS_DEFAULT_TURN_URI)
+	}
+
+	if s.TurnUsername == nil {
+		s.TurnUsername = NewString("")
+	}
+
+	if s.TurnSharedKey == nil {
+		s.TurnSharedKey = NewString("")
+	}
 }
 
 type ElasticsearchSettings struct {
@@ -500,6 +1352,64 @@ type ElasticsearchSettings struct {
 	RequestTimeoutSeconds         *int
 }
 
+func (s *ElasticsearchSettings) SetDefaults() {
+	if s.ConnectionUrl == nil {
+		s.ConnectionUrl = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL)
+	}
+
+	if s.Username == nil {
+		s.Username = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME)
+	}
+
+	if s.Password == nil {
+		s.Password = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD)
+	}
+
+	if s.EnableIndexing == nil {
+		s.EnableIndexing = NewBool(false)
+	}
+
+	if s.EnableSearching == nil {
+		s.EnableSearching = NewBool(false)
+	}
+
+	if s.Sniff == nil {
+		s.Sniff = NewBool(true)
+	}
+
+	if s.PostIndexReplicas == nil {
+		s.PostIndexReplicas = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_REPLICAS)
+	}
+
+	if s.PostIndexShards == nil {
+		s.PostIndexShards = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_SHARDS)
+	}
+
+	if s.AggregatePostsAfterDays == nil {
+		s.AggregatePostsAfterDays = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_AGGREGATE_POSTS_AFTER_DAYS)
+	}
+
+	if s.PostsAggregatorJobStartTime == nil {
+		s.PostsAggregatorJobStartTime = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_POSTS_AGGREGATOR_JOB_START_TIME)
+	}
+
+	if s.IndexPrefix == nil {
+		s.IndexPrefix = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX)
+	}
+
+	if s.LiveIndexingBatchSize == nil {
+		s.LiveIndexingBatchSize = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_LIVE_INDEXING_BATCH_SIZE)
+	}
+
+	if s.BulkIndexingTimeWindowSeconds == nil {
+		s.BulkIndexingTimeWindowSeconds = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_BULK_INDEXING_TIME_WINDOW_SECONDS)
+	}
+
+	if s.RequestTimeoutSeconds == nil {
+		s.RequestTimeoutSeconds = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_REQUEST_TIMEOUT_SECONDS)
+	}
+}
+
 type DataRetentionSettings struct {
 	EnableMessageDeletion *bool
 	EnableFileDeletion    *bool
@@ -508,9 +1418,41 @@ type DataRetentionSettings struct {
 	DeletionJobStartTime  *string
 }
 
+func (s *DataRetentionSettings) SetDefaults() {
+	if s.EnableMessageDeletion == nil {
+		s.EnableMessageDeletion = NewBool(false)
+	}
+
+	if s.EnableFileDeletion == nil {
+		s.EnableFileDeletion = NewBool(false)
+	}
+
+	if s.MessageRetentionDays == nil {
+		s.MessageRetentionDays = NewInt(DATA_RETENTION_SETTINGS_DEFAULT_MESSAGE_RETENTION_DAYS)
+	}
+
+	if s.FileRetentionDays == nil {
+		s.FileRetentionDays = NewInt(DATA_RETENTION_SETTINGS_DEFAULT_FILE_RETENTION_DAYS)
+	}
+
+	if s.DeletionJobStartTime == nil {
+		s.DeletionJobStartTime = NewString(DATA_RETENTION_SETTINGS_DEFAULT_DELETION_JOB_START_TIME)
+	}
+}
+
 type JobSettings struct {
 	RunJobs      *bool
 	RunScheduler *bool
+}
+
+func (s *JobSettings) SetDefaults() {
+	if s.RunJobs == nil {
+		s.RunJobs = NewBool(true)
+	}
+
+	if s.RunScheduler == nil {
+		s.RunScheduler = NewBool(true)
+	}
 }
 
 type PluginState struct {
@@ -523,6 +1465,32 @@ type PluginSettings struct {
 	Directory     *string
 	Plugins       map[string]interface{}
 	PluginStates  map[string]*PluginState
+}
+
+func (s *PluginSettings) SetDefaults() {
+	if s.Enable == nil {
+		s.Enable = NewBool(true)
+	}
+
+	if s.EnableUploads == nil {
+		s.EnableUploads = NewBool(false)
+	}
+
+	if s.Directory == nil {
+		s.Directory = NewString(PLUGIN_SETTINGS_DEFAULT_DIRECTORY)
+	}
+
+	if *s.Directory == "" {
+		*s.Directory = PLUGIN_SETTINGS_DEFAULT_DIRECTORY
+	}
+
+	if s.Plugins == nil {
+		s.Plugins = make(map[string]interface{})
+	}
+
+	if s.PluginStates == nil {
+		s.PluginStates = make(map[string]*PluginState)
+	}
 }
 
 type ConfigFunc func() *Config
@@ -601,690 +1569,30 @@ func ConfigFromJson(data io.Reader) *Config {
 }
 
 func (o *Config) SetDefaults() {
-
-	if o.SqlSettings.DriverName == nil {
-		o.SqlSettings.DriverName = NewString(DATABASE_DRIVER_MYSQL)
-	}
-
-	if o.SqlSettings.DataSource == nil {
-		o.SqlSettings.DataSource = NewString(SQL_SETTINGS_DEFAULT_DATA_SOURCE)
-	}
-
-	if len(o.SqlSettings.AtRestEncryptKey) == 0 {
-		o.SqlSettings.AtRestEncryptKey = NewRandomString(32)
-	}
-
-	if o.SqlSettings.MaxIdleConns == nil {
-		o.SqlSettings.MaxIdleConns = NewInt(20)
-	}
-
-	if o.SqlSettings.MaxOpenConns == nil {
-		o.SqlSettings.MaxOpenConns = NewInt(300)
-	}
-
-	if o.SqlSettings.QueryTimeout == nil {
-		o.SqlSettings.QueryTimeout = NewInt(30)
-	}
-
-	if o.FileSettings.DriverName == nil {
-		o.FileSettings.DriverName = NewString(IMAGE_DRIVER_LOCAL)
-	}
-
-	if o.FileSettings.AmazonS3Endpoint == "" {
-		// Defaults to "s3.amazonaws.com"
-		o.FileSettings.AmazonS3Endpoint = "s3.amazonaws.com"
-	}
-
-	if o.FileSettings.AmazonS3SSL == nil {
-		o.FileSettings.AmazonS3SSL = NewBool(true) // Secure by default.
-	}
-
-	if o.FileSettings.AmazonS3SignV2 == nil {
-		o.FileSettings.AmazonS3SignV2 = new(bool)
-		// Signature v2 is not enabled by default.
-	}
-
-	if o.FileSettings.AmazonS3SSE == nil {
-		o.FileSettings.AmazonS3SSE = NewBool(false) // Not Encrypted by default.
-	}
-
-	if o.FileSettings.AmazonS3Trace == nil {
-		o.FileSettings.AmazonS3Trace = NewBool(false)
-	}
-
-	if o.FileSettings.EnableFileAttachments == nil {
-		o.FileSettings.EnableFileAttachments = NewBool(true)
-	}
-
-	if o.FileSettings.EnableMobileUpload == nil {
-		o.FileSettings.EnableMobileUpload = NewBool(true)
-	}
-
-	if o.FileSettings.EnableMobileDownload == nil {
-		o.FileSettings.EnableMobileDownload = NewBool(true)
-	}
-
-	if o.FileSettings.MaxFileSize == nil {
-		o.FileSettings.MaxFileSize = NewInt64(52428800) // 50 MB
-	}
-
-	if o.FileSettings.PublicLinkSalt == nil || len(*o.FileSettings.PublicLinkSalt) == 0 {
-		o.FileSettings.PublicLinkSalt = NewString(NewRandomString(32))
-	}
-
-	if o.FileSettings.InitialFont == "" {
-		// Defaults to "luximbi.ttf"
-		o.FileSettings.InitialFont = "luximbi.ttf"
-	}
-
-	if o.FileSettings.Directory == "" {
-		o.FileSettings.Directory = "./data/"
-	}
-
-	if len(o.EmailSettings.InviteSalt) == 0 {
-		o.EmailSettings.InviteSalt = NewRandomString(32)
-	}
-
-	if o.ServiceSettings.SiteURL == nil {
-		o.ServiceSettings.SiteURL = NewString(SERVICE_SETTINGS_DEFAULT_SITE_URL)
-	}
-
-	if o.ServiceSettings.LicenseFileLocation == nil {
-		o.ServiceSettings.LicenseFileLocation = NewString("")
-	}
-
-	if o.ServiceSettings.ListenAddress == nil {
-		o.ServiceSettings.ListenAddress = NewString(SERVICE_SETTINGS_DEFAULT_LISTEN_AND_ADDRESS)
-	}
-
-	if o.ServiceSettings.EnableAPIv3 == nil {
-		o.ServiceSettings.EnableAPIv3 = NewBool(true)
-	}
-
-	if o.ServiceSettings.EnableLinkPreviews == nil {
-		o.ServiceSettings.EnableLinkPreviews = NewBool(false)
-	}
-
-	if o.ServiceSettings.EnableDeveloper == nil {
-		o.ServiceSettings.EnableDeveloper = NewBool(false)
-	}
-
-	if o.ServiceSettings.EnableSecurityFixAlert == nil {
-		o.ServiceSettings.EnableSecurityFixAlert = NewBool(true)
-	}
-
-	if o.ServiceSettings.EnableInsecureOutgoingConnections == nil {
-		o.ServiceSettings.EnableInsecureOutgoingConnections = NewBool(false)
-	}
-
-	if o.ServiceSettings.AllowedUntrustedInternalConnections == nil {
-		o.ServiceSettings.AllowedUntrustedInternalConnections = new(string)
-	}
-
-	if o.ServiceSettings.EnableMultifactorAuthentication == nil {
-		o.ServiceSettings.EnableMultifactorAuthentication = NewBool(false)
-	}
-
-	if o.ServiceSettings.EnforceMultifactorAuthentication == nil {
-		o.ServiceSettings.EnforceMultifactorAuthentication = NewBool(false)
-	}
-
-	if o.ServiceSettings.EnableUserAccessTokens == nil {
-		o.ServiceSettings.EnableUserAccessTokens = NewBool(false)
-	}
-
-	if o.PasswordSettings.MinimumLength == nil {
-		o.PasswordSettings.MinimumLength = NewInt(PASSWORD_MINIMUM_LENGTH)
-	}
-
-	if o.PasswordSettings.Lowercase == nil {
-		o.PasswordSettings.Lowercase = NewBool(false)
-	}
-
-	if o.PasswordSettings.Number == nil {
-		o.PasswordSettings.Number = NewBool(false)
-	}
-
-	if o.PasswordSettings.Uppercase == nil {
-		o.PasswordSettings.Uppercase = NewBool(false)
-	}
-
-	if o.PasswordSettings.Symbol == nil {
-		o.PasswordSettings.Symbol = NewBool(false)
-	}
-
-	if o.TeamSettings.MaxUsersPerTeam == nil {
-		o.TeamSettings.MaxUsersPerTeam = NewInt(TEAM_SETTINGS_DEFAULT_MAX_USERS_PER_TEAM)
-	}
-
-	if o.TeamSettings.EnableCustomBrand == nil {
-		o.TeamSettings.EnableCustomBrand = NewBool(false)
-	}
-
-	if o.TeamSettings.CustomBrandText == nil {
-		o.TeamSettings.CustomBrandText = NewString(TEAM_SETTINGS_DEFAULT_CUSTOM_BRAND_TEXT)
-	}
-
-	if o.TeamSettings.CustomDescriptionText == nil {
-		o.TeamSettings.CustomDescriptionText = NewString(TEAM_SETTINGS_DEFAULT_CUSTOM_DESCRIPTION_TEXT)
-	}
-
-	if o.TeamSettings.EnableOpenServer == nil {
-		o.TeamSettings.EnableOpenServer = NewBool(false)
-	}
-
-	if o.TeamSettings.RestrictDirectMessage == nil {
-		o.TeamSettings.RestrictDirectMessage = NewString(DIRECT_MESSAGE_ANY)
-	}
-
-	if o.TeamSettings.RestrictTeamInvite == nil {
-		o.TeamSettings.RestrictTeamInvite = NewString(PERMISSIONS_ALL)
-	}
-
-	if o.TeamSettings.RestrictPublicChannelManagement == nil {
-		o.TeamSettings.RestrictPublicChannelManagement = NewString(PERMISSIONS_ALL)
-	}
-
-	if o.TeamSettings.RestrictPrivateChannelManagement == nil {
-		o.TeamSettings.RestrictPrivateChannelManagement = NewString(PERMISSIONS_ALL)
-	}
-
-	if o.TeamSettings.RestrictPublicChannelCreation == nil {
-		o.TeamSettings.RestrictPublicChannelCreation = new(string)
-		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
-		if *o.TeamSettings.RestrictPublicChannelManagement == PERMISSIONS_CHANNEL_ADMIN {
-			*o.TeamSettings.RestrictPublicChannelCreation = PERMISSIONS_TEAM_ADMIN
-		} else {
-			*o.TeamSettings.RestrictPublicChannelCreation = *o.TeamSettings.RestrictPublicChannelManagement
-		}
-	}
-
-	if o.TeamSettings.RestrictPrivateChannelCreation == nil {
-		o.TeamSettings.RestrictPrivateChannelCreation = new(string)
-		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
-		if *o.TeamSettings.RestrictPrivateChannelManagement == PERMISSIONS_CHANNEL_ADMIN {
-			*o.TeamSettings.RestrictPrivateChannelCreation = PERMISSIONS_TEAM_ADMIN
-		} else {
-			*o.TeamSettings.RestrictPrivateChannelCreation = *o.TeamSettings.RestrictPrivateChannelManagement
-		}
-	}
-
-	if o.TeamSettings.RestrictPublicChannelDeletion == nil {
-		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
-		o.TeamSettings.RestrictPublicChannelDeletion = NewString(*o.TeamSettings.RestrictPublicChannelManagement)
-	}
-
-	if o.TeamSettings.RestrictPrivateChannelDeletion == nil {
-		// If this setting does not exist, assume migration from <3.6, so use management setting as default.
-		o.TeamSettings.RestrictPrivateChannelDeletion = NewString(*o.TeamSettings.RestrictPrivateChannelManagement)
-	}
-
-	if o.TeamSettings.RestrictPrivateChannelManageMembers == nil {
-		o.TeamSettings.RestrictPrivateChannelManageMembers = NewString(PERMISSIONS_ALL)
-	}
-
-	if o.TeamSettings.EnableXToLeaveChannelsFromLHS == nil {
-		o.TeamSettings.EnableXToLeaveChannelsFromLHS = NewBool(false)
-	}
-
-	if o.TeamSettings.UserStatusAwayTimeout == nil {
-		o.TeamSettings.UserStatusAwayTimeout = NewInt64(TEAM_SETTINGS_DEFAULT_USER_STATUS_AWAY_TIMEOUT)
-	}
-
-	if o.TeamSettings.MaxChannelsPerTeam == nil {
-		o.TeamSettings.MaxChannelsPerTeam = NewInt64(2000)
-	}
-
-	if o.TeamSettings.MaxNotificationsPerChannel == nil {
-		o.TeamSettings.MaxNotificationsPerChannel = NewInt64(1000)
-	}
-
-	if o.TeamSettings.EnableConfirmNotificationsToChannel == nil {
-		o.TeamSettings.EnableConfirmNotificationsToChannel = NewBool(true)
-	}
-
-	if o.TeamSettings.ExperimentalTownSquareIsReadOnly == nil {
-		o.TeamSettings.ExperimentalTownSquareIsReadOnly = NewBool(false)
-	}
-
-	if o.EmailSettings.EnableSignInWithEmail == nil {
-		o.EmailSettings.EnableSignInWithEmail = new(bool)
-		*o.EmailSettings.EnableSignInWithEmail = o.EmailSettings.EnableSignUpWithEmail
-	}
-
-	if o.EmailSettings.EnableSignInWithUsername == nil {
-		o.EmailSettings.EnableSignInWithUsername = NewBool(false)
-	}
-
-	if o.EmailSettings.SendPushNotifications == nil {
-		o.EmailSettings.SendPushNotifications = NewBool(false)
-	}
-
-	if o.EmailSettings.PushNotificationServer == nil {
-		o.EmailSettings.PushNotificationServer = NewString("")
-	}
-
-	if o.EmailSettings.PushNotificationContents == nil {
-		o.EmailSettings.PushNotificationContents = NewString(GENERIC_NOTIFICATION)
-	}
-
-	if o.EmailSettings.FeedbackOrganization == nil {
-		o.EmailSettings.FeedbackOrganization = NewString(EMAIL_SETTINGS_DEFAULT_FEEDBACK_ORGANIZATION)
-	}
-
-	if o.EmailSettings.EnableEmailBatching == nil {
-		o.EmailSettings.EnableEmailBatching = NewBool(false)
-	}
-
-	if o.EmailSettings.EmailBatchingBufferSize == nil {
-		o.EmailSettings.EmailBatchingBufferSize = NewInt(EMAIL_BATCHING_BUFFER_SIZE)
-	}
-
-	if o.EmailSettings.EmailBatchingInterval == nil {
-		o.EmailSettings.EmailBatchingInterval = NewInt(EMAIL_BATCHING_INTERVAL)
-	}
-
-	if o.EmailSettings.EnableSMTPAuth == nil {
-		o.EmailSettings.EnableSMTPAuth = new(bool)
-		if o.EmailSettings.ConnectionSecurity == CONN_SECURITY_NONE {
-			*o.EmailSettings.EnableSMTPAuth = false
-		} else {
-			*o.EmailSettings.EnableSMTPAuth = true
-		}
-	}
-
-	if o.EmailSettings.ConnectionSecurity == CONN_SECURITY_PLAIN {
-		o.EmailSettings.ConnectionSecurity = CONN_SECURITY_NONE
-	}
-
-	if o.EmailSettings.SkipServerCertificateVerification == nil {
-		o.EmailSettings.SkipServerCertificateVerification = NewBool(false)
-	}
-
-	if o.EmailSettings.EmailNotificationContentsType == nil {
-		o.EmailSettings.EmailNotificationContentsType = NewString(EMAIL_NOTIFICATION_CONTENTS_FULL)
-	}
-
-	if !IsSafeLink(o.SupportSettings.TermsOfServiceLink) {
-		*o.SupportSettings.TermsOfServiceLink = SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK
-	}
-
-	if o.SupportSettings.TermsOfServiceLink == nil {
-		o.SupportSettings.TermsOfServiceLink = NewString(SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK)
-	}
-
-	if !IsSafeLink(o.SupportSettings.PrivacyPolicyLink) {
-		*o.SupportSettings.PrivacyPolicyLink = ""
-	}
-
-	if o.SupportSettings.PrivacyPolicyLink == nil {
-		o.SupportSettings.PrivacyPolicyLink = NewString(SUPPORT_SETTINGS_DEFAULT_PRIVACY_POLICY_LINK)
-	}
-
-	if !IsSafeLink(o.SupportSettings.AboutLink) {
-		*o.SupportSettings.AboutLink = ""
-	}
-
-	if o.SupportSettings.AboutLink == nil {
-		o.SupportSettings.AboutLink = NewString(SUPPORT_SETTINGS_DEFAULT_ABOUT_LINK)
-	}
-
-	if !IsSafeLink(o.SupportSettings.HelpLink) {
-		*o.SupportSettings.HelpLink = ""
-	}
-
-	if o.SupportSettings.HelpLink == nil {
-		o.SupportSettings.HelpLink = NewString(SUPPORT_SETTINGS_DEFAULT_HELP_LINK)
-	}
-
-	if !IsSafeLink(o.SupportSettings.ReportAProblemLink) {
-		*o.SupportSettings.ReportAProblemLink = ""
-	}
-
-	if o.SupportSettings.ReportAProblemLink == nil {
-		o.SupportSettings.ReportAProblemLink = NewString(SUPPORT_SETTINGS_DEFAULT_REPORT_A_PROBLEM_LINK)
-	}
-
-	if o.SupportSettings.SupportEmail == nil {
-		o.SupportSettings.SupportEmail = NewString(SUPPORT_SETTINGS_DEFAULT_SUPPORT_EMAIL)
-	}
-
-	if o.AnnouncementSettings.EnableBanner == nil {
-		o.AnnouncementSettings.EnableBanner = NewBool(false)
-	}
-
-	if o.AnnouncementSettings.BannerText == nil {
-		o.AnnouncementSettings.BannerText = NewString("")
-	}
-
-	if o.AnnouncementSettings.BannerColor == nil {
-		o.AnnouncementSettings.BannerColor = NewString(ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_COLOR)
-	}
-
-	if o.AnnouncementSettings.BannerTextColor == nil {
-		o.AnnouncementSettings.BannerTextColor = NewString(ANNOUNCEMENT_SETTINGS_DEFAULT_BANNER_TEXT_COLOR)
-	}
-
-	if o.AnnouncementSettings.AllowBannerDismissal == nil {
-		o.AnnouncementSettings.AllowBannerDismissal = NewBool(true)
-	}
-
-	if o.ThemeSettings.EnableThemeSelection == nil {
-		o.ThemeSettings.EnableThemeSelection = NewBool(true)
-	}
-
-	if o.ThemeSettings.DefaultTheme == nil {
-		o.ThemeSettings.DefaultTheme = NewString(TEAM_SETTINGS_DEFAULT_TEAM_TEXT)
-	}
-
-	if o.ThemeSettings.AllowCustomThemes == nil {
-		o.ThemeSettings.AllowCustomThemes = NewBool(true)
-	}
-
-	if o.ThemeSettings.AllowedThemes == nil {
-		o.ThemeSettings.AllowedThemes = []string{}
-	}
-
-	if o.LdapSettings.Enable == nil {
-		o.LdapSettings.Enable = NewBool(false)
-	}
-
-	// When unset should default to LDAP Enabled
-	if o.LdapSettings.EnableSync == nil {
-		o.LdapSettings.EnableSync = new(bool)
-		*o.LdapSettings.EnableSync = *o.LdapSettings.Enable
-	}
-
-	if o.LdapSettings.LdapServer == nil {
-		o.LdapSettings.LdapServer = NewString("")
-	}
-
-	if o.LdapSettings.LdapPort == nil {
-		o.LdapSettings.LdapPort = NewInt(389)
-	}
-
-	if o.LdapSettings.ConnectionSecurity == nil {
-		o.LdapSettings.ConnectionSecurity = NewString("")
-	}
-
-	if o.LdapSettings.BaseDN == nil {
-		o.LdapSettings.BaseDN = NewString("")
-	}
-
-	if o.LdapSettings.BindUsername == nil {
-		o.LdapSettings.BindUsername = NewString("")
-	}
-
-	if o.LdapSettings.BindPassword == nil {
-		o.LdapSettings.BindPassword = NewString("")
-	}
-
-	if o.LdapSettings.UserFilter == nil {
-		o.LdapSettings.UserFilter = NewString("")
-	}
-
-	if o.LdapSettings.FirstNameAttribute == nil {
-		o.LdapSettings.FirstNameAttribute = NewString(LDAP_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE)
-	}
-
-	if o.LdapSettings.LastNameAttribute == nil {
-		o.LdapSettings.LastNameAttribute = NewString(LDAP_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE)
-	}
-
-	if o.LdapSettings.EmailAttribute == nil {
-		o.LdapSettings.EmailAttribute = NewString(LDAP_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE)
-	}
-
-	if o.LdapSettings.UsernameAttribute == nil {
-		o.LdapSettings.UsernameAttribute = NewString(LDAP_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE)
-	}
-
-	if o.LdapSettings.NicknameAttribute == nil {
-		o.LdapSettings.NicknameAttribute = NewString(LDAP_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE)
-	}
-
-	if o.LdapSettings.IdAttribute == nil {
-		o.LdapSettings.IdAttribute = NewString(LDAP_SETTINGS_DEFAULT_ID_ATTRIBUTE)
-	}
-
-	if o.LdapSettings.PositionAttribute == nil {
-		o.LdapSettings.PositionAttribute = NewString(LDAP_SETTINGS_DEFAULT_POSITION_ATTRIBUTE)
-	}
-
-	if o.LdapSettings.SyncIntervalMinutes == nil {
-		o.LdapSettings.SyncIntervalMinutes = NewInt(60)
-	}
-
-	if o.LdapSettings.SkipCertificateVerification == nil {
-		o.LdapSettings.SkipCertificateVerification = NewBool(false)
-	}
-
-	if o.LdapSettings.QueryTimeout == nil {
-		o.LdapSettings.QueryTimeout = NewInt(60)
-	}
-
-	if o.LdapSettings.MaxPageSize == nil {
-		o.LdapSettings.MaxPageSize = NewInt(0)
-	}
-
-	if o.LdapSettings.LoginFieldName == nil {
-		o.LdapSettings.LoginFieldName = NewString(LDAP_SETTINGS_DEFAULT_LOGIN_FIELD_NAME)
-	}
-
-	if o.ServiceSettings.SessionLengthWebInDays == nil {
-		o.ServiceSettings.SessionLengthWebInDays = NewInt(30)
-	}
-
-	if o.ServiceSettings.SessionLengthMobileInDays == nil {
-		o.ServiceSettings.SessionLengthMobileInDays = NewInt(30)
-	}
-
-	if o.ServiceSettings.SessionLengthSSOInDays == nil {
-		o.ServiceSettings.SessionLengthSSOInDays = NewInt(30)
-	}
-
-	if o.ServiceSettings.SessionCacheInMinutes == nil {
-		o.ServiceSettings.SessionCacheInMinutes = NewInt(10)
-	}
-
-	if o.ServiceSettings.SessionIdleTimeoutInMinutes == nil {
-		o.ServiceSettings.SessionIdleTimeoutInMinutes = NewInt(0)
-	}
-
-	if o.ServiceSettings.EnableCommands == nil {
-		o.ServiceSettings.EnableCommands = NewBool(false)
-	}
-
-	if o.ServiceSettings.EnableOnlyAdminIntegrations == nil {
-		o.ServiceSettings.EnableOnlyAdminIntegrations = NewBool(true)
-	}
-
-	if o.ServiceSettings.WebsocketPort == nil {
-		o.ServiceSettings.WebsocketPort = NewInt(80)
-	}
-
-	if o.ServiceSettings.WebsocketSecurePort == nil {
-		o.ServiceSettings.WebsocketSecurePort = NewInt(443)
-	}
-
-	if o.ServiceSettings.AllowCorsFrom == nil {
-		o.ServiceSettings.AllowCorsFrom = NewString(SERVICE_SETTINGS_DEFAULT_ALLOW_CORS_FROM)
-	}
-
-	if o.ServiceSettings.WebserverMode == nil {
-		o.ServiceSettings.WebserverMode = NewString("gzip")
-	} else if *o.ServiceSettings.WebserverMode == "regular" {
-		*o.ServiceSettings.WebserverMode = "gzip"
-	}
-
-	if o.ServiceSettings.EnableCustomEmoji == nil {
-		o.ServiceSettings.EnableCustomEmoji = NewBool(false)
-	}
-
-	if o.ServiceSettings.EnableEmojiPicker == nil {
-		o.ServiceSettings.EnableEmojiPicker = NewBool(true)
-	}
-
-	if o.ServiceSettings.RestrictCustomEmojiCreation == nil {
-		o.ServiceSettings.RestrictCustomEmojiCreation = NewString(RESTRICT_EMOJI_CREATION_ALL)
-	}
-
-	if o.ServiceSettings.RestrictPostDelete == nil {
-		o.ServiceSettings.RestrictPostDelete = NewString(PERMISSIONS_DELETE_POST_ALL)
-	}
-
-	if o.ServiceSettings.AllowEditPost == nil {
-		o.ServiceSettings.AllowEditPost = NewString(ALLOW_EDIT_POST_ALWAYS)
-	}
-
-	if o.ServiceSettings.PostEditTimeLimit == nil {
-		o.ServiceSettings.PostEditTimeLimit = NewInt(300)
-	}
-
-	if o.ClusterSettings.Enable == nil {
-		o.ClusterSettings.Enable = NewBool(false)
-	}
-
-	if o.ClusterSettings.ClusterName == nil {
-		o.ClusterSettings.ClusterName = NewString("")
-	}
-
-	if o.ClusterSettings.OverrideHostname == nil {
-		o.ClusterSettings.OverrideHostname = NewString("")
-	}
-
-	if o.ClusterSettings.UseIpAddress == nil {
-		o.ClusterSettings.UseIpAddress = NewBool(true)
-	}
-
-	if o.ClusterSettings.UseExperimentalGossip == nil {
-		o.ClusterSettings.UseExperimentalGossip = NewBool(false)
-	}
-
-	if o.ClusterSettings.ReadOnlyConfig == nil {
-		o.ClusterSettings.ReadOnlyConfig = NewBool(true)
-	}
-
-	if o.ClusterSettings.GossipPort == nil {
-		o.ClusterSettings.GossipPort = NewInt(8074)
-	}
-
-	if o.ClusterSettings.StreamingPort == nil {
-		o.ClusterSettings.StreamingPort = NewInt(8075)
-	}
-
-	if o.MetricsSettings.ListenAddress == nil {
-		o.MetricsSettings.ListenAddress = NewString(":8067")
-	}
-
-	if o.MetricsSettings.Enable == nil {
-		o.MetricsSettings.Enable = NewBool(false)
-	}
-
-	if o.AnalyticsSettings.MaxUsersForStatistics == nil {
-		o.AnalyticsSettings.MaxUsersForStatistics = NewInt(ANALYTICS_SETTINGS_DEFAULT_MAX_USERS_FOR_STATISTICS)
-	}
-
-	if o.ComplianceSettings.Enable == nil {
-		o.ComplianceSettings.Enable = NewBool(false)
-	}
-
-	if o.ComplianceSettings.Directory == nil {
-		o.ComplianceSettings.Directory = NewString("./data/")
-	}
-
-	if o.ComplianceSettings.EnableDaily == nil {
-		o.ComplianceSettings.EnableDaily = NewBool(false)
-	}
-
-	if o.LocalizationSettings.DefaultServerLocale == nil {
-		o.LocalizationSettings.DefaultServerLocale = NewString(DEFAULT_LOCALE)
-	}
-
-	if o.LocalizationSettings.DefaultClientLocale == nil {
-		o.LocalizationSettings.DefaultClientLocale = NewString(DEFAULT_LOCALE)
-	}
-
-	if o.LocalizationSettings.AvailableLocales == nil {
-		o.LocalizationSettings.AvailableLocales = NewString("")
-	}
-
-	if o.LogSettings.EnableDiagnostics == nil {
-		o.LogSettings.EnableDiagnostics = NewBool(true)
-	}
-
-	if o.SamlSettings.Enable == nil {
-		o.SamlSettings.Enable = NewBool(false)
-	}
-
-	if o.SamlSettings.EnableSyncWithLdap == nil {
-		o.SamlSettings.EnableSyncWithLdap = new(bool)
-		*o.SamlSettings.EnableSyncWithLdap = false
-	}
-
-	if o.SamlSettings.Verify == nil {
-		o.SamlSettings.Verify = NewBool(true)
-	}
-
-	if o.SamlSettings.Encrypt == nil {
-		o.SamlSettings.Encrypt = NewBool(true)
-	}
-
-	if o.SamlSettings.IdpUrl == nil {
-		o.SamlSettings.IdpUrl = NewString("")
-	}
-
-	if o.SamlSettings.IdpDescriptorUrl == nil {
-		o.SamlSettings.IdpDescriptorUrl = NewString("")
-	}
-
-	if o.SamlSettings.IdpCertificateFile == nil {
-		o.SamlSettings.IdpCertificateFile = NewString("")
-	}
-
-	if o.SamlSettings.PublicCertificateFile == nil {
-		o.SamlSettings.PublicCertificateFile = NewString("")
-	}
-
-	if o.SamlSettings.PrivateKeyFile == nil {
-		o.SamlSettings.PrivateKeyFile = NewString("")
-	}
-
-	if o.SamlSettings.AssertionConsumerServiceURL == nil {
-		o.SamlSettings.AssertionConsumerServiceURL = NewString("")
-	}
-
-	if o.SamlSettings.LoginButtonText == nil || *o.SamlSettings.LoginButtonText == "" {
-		o.SamlSettings.LoginButtonText = NewString(USER_AUTH_SERVICE_SAML_TEXT)
-	}
-
-	if o.SamlSettings.FirstNameAttribute == nil {
-		o.SamlSettings.FirstNameAttribute = NewString(SAML_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE)
-	}
-
-	if o.SamlSettings.LastNameAttribute == nil {
-		o.SamlSettings.LastNameAttribute = NewString(SAML_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE)
-	}
-
-	if o.SamlSettings.EmailAttribute == nil {
-		o.SamlSettings.EmailAttribute = NewString(SAML_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE)
-	}
-
-	if o.SamlSettings.UsernameAttribute == nil {
-		o.SamlSettings.UsernameAttribute = NewString(SAML_SETTINGS_DEFAULT_USERNAME_ATTRIBUTE)
-	}
-
-	if o.SamlSettings.NicknameAttribute == nil {
-		o.SamlSettings.NicknameAttribute = NewString(SAML_SETTINGS_DEFAULT_NICKNAME_ATTRIBUTE)
-	}
-
-	if o.SamlSettings.PositionAttribute == nil {
-		o.SamlSettings.PositionAttribute = NewString(SAML_SETTINGS_DEFAULT_POSITION_ATTRIBUTE)
-	}
-
-	if o.SamlSettings.LocaleAttribute == nil {
-		o.SamlSettings.LocaleAttribute = NewString(SAML_SETTINGS_DEFAULT_LOCALE_ATTRIBUTE)
-	}
+	o.SqlSettings.SetDefaults()
+	o.FileSettings.SetDefaults()
+	o.EmailSettings.SetDefaults()
+	o.ServiceSettings.SetDefaults()
+	o.PasswordSettings.SetDefaults()
+	o.TeamSettings.SetDefaults()
+	o.MetricsSettings.SetDefaults()
+	o.SupportSettings.SetDefaults()
+	o.AnnouncementSettings.SetDefaults()
+	o.ThemeSettings.SetDefaults()
+	o.LdapSettings.SetDefaults()
+	o.ClusterSettings.SetDefaults()
+	o.SamlSettings.SetDefaults()
+	o.PluginSettings.SetDefaults()
+	o.AnalyticsSettings.SetDefaults()
+	o.ComplianceSettings.SetDefaults()
+	o.LocalizationSettings.SetDefaults()
+	o.ElasticsearchSettings.SetDefaults()
+	o.NativeAppSettings.SetDefaults()
+	o.DataRetentionSettings.SetDefaults()
+	o.RateLimitSettings.SetDefaults()
+	o.LogSettings.SetDefaults()
+	o.JobSettings.SetDefaults()
+	o.WebrtcSettings.SetDefaults()
 
 	if o.TeamSettings.TeammateNameDisplay == nil {
 		o.TeamSettings.TeammateNameDisplay = NewString(SHOW_USERNAME)
@@ -1293,217 +1601,6 @@ func (o *Config) SetDefaults() {
 			*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
 		}
 	}
-
-	if o.NativeAppSettings.AppDownloadLink == nil {
-		o.NativeAppSettings.AppDownloadLink = NewString(NATIVEAPP_SETTINGS_DEFAULT_APP_DOWNLOAD_LINK)
-	}
-
-	if o.NativeAppSettings.AndroidAppDownloadLink == nil {
-		o.NativeAppSettings.AndroidAppDownloadLink = NewString(NATIVEAPP_SETTINGS_DEFAULT_ANDROID_APP_DOWNLOAD_LINK)
-	}
-
-	if o.NativeAppSettings.IosAppDownloadLink == nil {
-		o.NativeAppSettings.IosAppDownloadLink = NewString(NATIVEAPP_SETTINGS_DEFAULT_IOS_APP_DOWNLOAD_LINK)
-	}
-
-	if o.RateLimitSettings.Enable == nil {
-		o.RateLimitSettings.Enable = NewBool(false)
-	}
-
-	if o.RateLimitSettings.PerSec == nil {
-		o.RateLimitSettings.PerSec = NewInt(10)
-	}
-
-	if o.RateLimitSettings.MaxBurst == nil {
-		o.RateLimitSettings.MaxBurst = NewInt(100)
-	}
-
-	if o.RateLimitSettings.MemoryStoreSize == nil {
-		o.RateLimitSettings.MemoryStoreSize = NewInt(10000)
-	}
-
-	if o.ServiceSettings.GoroutineHealthThreshold == nil {
-		o.ServiceSettings.GoroutineHealthThreshold = NewInt(-1)
-	}
-
-	if o.ServiceSettings.ConnectionSecurity == nil {
-		o.ServiceSettings.ConnectionSecurity = NewString("")
-	}
-
-	if o.ServiceSettings.TLSKeyFile == nil {
-		o.ServiceSettings.TLSKeyFile = NewString(SERVICE_SETTINGS_DEFAULT_TLS_KEY_FILE)
-	}
-
-	if o.ServiceSettings.TLSCertFile == nil {
-		o.ServiceSettings.TLSCertFile = NewString(SERVICE_SETTINGS_DEFAULT_TLS_CERT_FILE)
-	}
-
-	if o.ServiceSettings.UseLetsEncrypt == nil {
-		o.ServiceSettings.UseLetsEncrypt = NewBool(false)
-	}
-
-	if o.ServiceSettings.LetsEncryptCertificateCacheFile == nil {
-		o.ServiceSettings.LetsEncryptCertificateCacheFile = NewString("./config/letsencrypt.cache")
-	}
-
-	if o.ServiceSettings.ReadTimeout == nil {
-		o.ServiceSettings.ReadTimeout = NewInt(SERVICE_SETTINGS_DEFAULT_READ_TIMEOUT)
-	}
-
-	if o.ServiceSettings.WriteTimeout == nil {
-		o.ServiceSettings.WriteTimeout = NewInt(SERVICE_SETTINGS_DEFAULT_WRITE_TIMEOUT)
-	}
-
-	if o.ServiceSettings.MaximumLoginAttempts == nil {
-		o.ServiceSettings.MaximumLoginAttempts = NewInt(SERVICE_SETTINGS_DEFAULT_MAX_LOGIN_ATTEMPTS)
-	}
-
-	if o.ServiceSettings.Forward80To443 == nil {
-		o.ServiceSettings.Forward80To443 = NewBool(false)
-	}
-
-	if o.MetricsSettings.BlockProfileRate == nil {
-		o.MetricsSettings.BlockProfileRate = NewInt(0)
-	}
-
-	if o.ServiceSettings.TimeBetweenUserTypingUpdatesMilliseconds == nil {
-		o.ServiceSettings.TimeBetweenUserTypingUpdatesMilliseconds = NewInt64(5000)
-	}
-
-	if o.ServiceSettings.EnablePostSearch == nil {
-		o.ServiceSettings.EnablePostSearch = NewBool(true)
-	}
-
-	if o.ServiceSettings.EnableUserTypingMessages == nil {
-		o.ServiceSettings.EnableUserTypingMessages = NewBool(true)
-	}
-
-	if o.ServiceSettings.EnableChannelViewedMessages == nil {
-		o.ServiceSettings.EnableChannelViewedMessages = NewBool(true)
-	}
-
-	if o.ServiceSettings.EnableUserStatuses == nil {
-		o.ServiceSettings.EnableUserStatuses = NewBool(true)
-	}
-
-	if o.ServiceSettings.ClusterLogTimeoutMilliseconds == nil {
-		o.ServiceSettings.ClusterLogTimeoutMilliseconds = NewInt(2000)
-	}
-
-	if o.ServiceSettings.CloseUnusedDirectMessages == nil {
-		o.ServiceSettings.CloseUnusedDirectMessages = NewBool(false)
-	}
-
-	if o.ElasticsearchSettings.ConnectionUrl == nil {
-		o.ElasticsearchSettings.ConnectionUrl = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_CONNECTION_URL)
-	}
-
-	if o.ElasticsearchSettings.Username == nil {
-		o.ElasticsearchSettings.Username = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_USERNAME)
-	}
-
-	if o.ElasticsearchSettings.Password == nil {
-		o.ElasticsearchSettings.Password = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_PASSWORD)
-	}
-
-	if o.ElasticsearchSettings.EnableIndexing == nil {
-		o.ElasticsearchSettings.EnableIndexing = NewBool(false)
-	}
-
-	if o.ElasticsearchSettings.EnableSearching == nil {
-		o.ElasticsearchSettings.EnableSearching = NewBool(false)
-	}
-
-	if o.ElasticsearchSettings.Sniff == nil {
-		o.ElasticsearchSettings.Sniff = NewBool(true)
-	}
-
-	if o.ElasticsearchSettings.PostIndexReplicas == nil {
-		o.ElasticsearchSettings.PostIndexReplicas = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_REPLICAS)
-	}
-
-	if o.ElasticsearchSettings.PostIndexShards == nil {
-		o.ElasticsearchSettings.PostIndexShards = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_POST_INDEX_SHARDS)
-	}
-
-	if o.ElasticsearchSettings.AggregatePostsAfterDays == nil {
-		o.ElasticsearchSettings.AggregatePostsAfterDays = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_AGGREGATE_POSTS_AFTER_DAYS)
-	}
-
-	if o.ElasticsearchSettings.PostsAggregatorJobStartTime == nil {
-		o.ElasticsearchSettings.PostsAggregatorJobStartTime = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_POSTS_AGGREGATOR_JOB_START_TIME)
-	}
-
-	if o.ElasticsearchSettings.IndexPrefix == nil {
-		o.ElasticsearchSettings.IndexPrefix = NewString(ELASTICSEARCH_SETTINGS_DEFAULT_INDEX_PREFIX)
-	}
-
-	if o.ElasticsearchSettings.LiveIndexingBatchSize == nil {
-		o.ElasticsearchSettings.LiveIndexingBatchSize = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_LIVE_INDEXING_BATCH_SIZE)
-	}
-
-	if o.ElasticsearchSettings.BulkIndexingTimeWindowSeconds == nil {
-		o.ElasticsearchSettings.BulkIndexingTimeWindowSeconds = new(int)
-		*o.ElasticsearchSettings.BulkIndexingTimeWindowSeconds = ELASTICSEARCH_SETTINGS_DEFAULT_BULK_INDEXING_TIME_WINDOW_SECONDS
-	}
-
-	if o.ElasticsearchSettings.RequestTimeoutSeconds == nil {
-		o.ElasticsearchSettings.RequestTimeoutSeconds = NewInt(ELASTICSEARCH_SETTINGS_DEFAULT_REQUEST_TIMEOUT_SECONDS)
-	}
-
-	if o.DataRetentionSettings.EnableMessageDeletion == nil {
-		o.DataRetentionSettings.EnableMessageDeletion = NewBool(false)
-	}
-
-	if o.DataRetentionSettings.EnableFileDeletion == nil {
-		o.DataRetentionSettings.EnableFileDeletion = NewBool(false)
-	}
-
-	if o.DataRetentionSettings.MessageRetentionDays == nil {
-		o.DataRetentionSettings.MessageRetentionDays = NewInt(DATA_RETENTION_SETTINGS_DEFAULT_MESSAGE_RETENTION_DAYS)
-	}
-
-	if o.DataRetentionSettings.FileRetentionDays == nil {
-		o.DataRetentionSettings.FileRetentionDays = NewInt(DATA_RETENTION_SETTINGS_DEFAULT_FILE_RETENTION_DAYS)
-	}
-
-	if o.DataRetentionSettings.DeletionJobStartTime == nil {
-		o.DataRetentionSettings.DeletionJobStartTime = NewString(DATA_RETENTION_SETTINGS_DEFAULT_DELETION_JOB_START_TIME)
-	}
-
-	if o.JobSettings.RunJobs == nil {
-		o.JobSettings.RunJobs = NewBool(true)
-	}
-
-	if o.JobSettings.RunScheduler == nil {
-		o.JobSettings.RunScheduler = NewBool(true)
-	}
-
-	if o.PluginSettings.Enable == nil {
-		o.PluginSettings.Enable = NewBool(true)
-	}
-
-	if o.PluginSettings.EnableUploads == nil {
-		o.PluginSettings.EnableUploads = NewBool(false)
-	}
-
-	if o.PluginSettings.Directory == nil {
-		o.PluginSettings.Directory = NewString(PLUGIN_SETTINGS_DEFAULT_DIRECTORY)
-	}
-
-	if *o.PluginSettings.Directory == "" {
-		*o.PluginSettings.Directory = PLUGIN_SETTINGS_DEFAULT_DIRECTORY
-	}
-
-	if o.PluginSettings.Plugins == nil {
-		o.PluginSettings.Plugins = make(map[string]interface{})
-	}
-
-	if o.PluginSettings.PluginStates == nil {
-		o.PluginSettings.PluginStates = make(map[string]*PluginState)
-	}
-
-	o.defaultWebrtcSettings()
 }
 
 func (o *Config) IsValid() *AppError {
@@ -1924,38 +2021,4 @@ func (o *Config) Sanitize() {
 	}
 
 	*o.ElasticsearchSettings.Password = FAKE_SETTING
-}
-
-func (o *Config) defaultWebrtcSettings() {
-	if o.WebrtcSettings.Enable == nil {
-		o.WebrtcSettings.Enable = NewBool(false)
-	}
-
-	if o.WebrtcSettings.GatewayWebsocketUrl == nil {
-		o.WebrtcSettings.GatewayWebsocketUrl = NewString("")
-	}
-
-	if o.WebrtcSettings.GatewayAdminUrl == nil {
-		o.WebrtcSettings.GatewayAdminUrl = NewString("")
-	}
-
-	if o.WebrtcSettings.GatewayAdminSecret == nil {
-		o.WebrtcSettings.GatewayAdminSecret = NewString("")
-	}
-
-	if o.WebrtcSettings.StunURI == nil {
-		o.WebrtcSettings.StunURI = NewString(WEBRTC_SETTINGS_DEFAULT_STUN_URI)
-	}
-
-	if o.WebrtcSettings.TurnURI == nil {
-		o.WebrtcSettings.TurnURI = NewString(WEBRTC_SETTINGS_DEFAULT_TURN_URI)
-	}
-
-	if o.WebrtcSettings.TurnUsername == nil {
-		o.WebrtcSettings.TurnUsername = NewString("")
-	}
-
-	if o.WebrtcSettings.TurnSharedKey == nil {
-		o.WebrtcSettings.TurnSharedKey = NewString("")
-	}
 }

--- a/model/config.go
+++ b/model/config.go
@@ -1569,6 +1569,17 @@ func ConfigFromJson(data io.Reader) *Config {
 }
 
 func (o *Config) SetDefaults() {
+	o.LdapSettings.SetDefaults()
+	o.SamlSettings.SetDefaults()
+
+	if o.TeamSettings.TeammateNameDisplay == nil {
+		o.TeamSettings.TeammateNameDisplay = NewString(SHOW_USERNAME)
+
+		if *o.SamlSettings.Enable || *o.LdapSettings.Enable {
+			*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
+		}
+	}
+
 	o.SqlSettings.SetDefaults()
 	o.FileSettings.SetDefaults()
 	o.EmailSettings.SetDefaults()
@@ -1579,9 +1590,7 @@ func (o *Config) SetDefaults() {
 	o.SupportSettings.SetDefaults()
 	o.AnnouncementSettings.SetDefaults()
 	o.ThemeSettings.SetDefaults()
-	o.LdapSettings.SetDefaults()
 	o.ClusterSettings.SetDefaults()
-	o.SamlSettings.SetDefaults()
 	o.PluginSettings.SetDefaults()
 	o.AnalyticsSettings.SetDefaults()
 	o.ComplianceSettings.SetDefaults()
@@ -1593,14 +1602,6 @@ func (o *Config) SetDefaults() {
 	o.LogSettings.SetDefaults()
 	o.JobSettings.SetDefaults()
 	o.WebrtcSettings.SetDefaults()
-
-	if o.TeamSettings.TeammateNameDisplay == nil {
-		o.TeamSettings.TeammateNameDisplay = NewString(SHOW_USERNAME)
-
-		if *o.SamlSettings.Enable || *o.LdapSettings.Enable {
-			*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
-		}
-	}
 }
 
 func (o *Config) IsValid() *AppError {

--- a/utils/password.go
+++ b/utils/password.go
@@ -11,55 +11,55 @@ import (
 )
 
 func IsPasswordValid(password string) *model.AppError {
+	if len(password) > model.PASSWORD_MAXIMUM_LENGTH || len(password) < model.PASSWORD_MINIMUM_LENGTH {
+		return model.NewAppError("User.IsValid", "model.user.is_valid.pwd.app_error", map[string]interface{}{"Min": model.PASSWORD_MINIMUM_LENGTH}, "", http.StatusBadRequest)
+	}
+
+	return nil
+}
+
+func IsPasswordValidWithSettings(password string, settings *model.PasswordSettings) *model.AppError {
 	id := "model.user.is_valid.pwd"
 	isError := false
-	min := model.PASSWORD_MINIMUM_LENGTH
 
-	if IsLicensed() && *License().Features.PasswordRequirements {
-		if len(password) < *Cfg.PasswordSettings.MinimumLength || len(password) > model.PASSWORD_MAXIMUM_LENGTH {
+	if len(password) < *settings.MinimumLength || len(password) > model.PASSWORD_MAXIMUM_LENGTH {
+		isError = true
+	}
+
+	if *settings.Lowercase {
+		if !strings.ContainsAny(password, model.LOWERCASE_LETTERS) {
 			isError = true
 		}
 
-		if *Cfg.PasswordSettings.Lowercase {
-			if !strings.ContainsAny(password, model.LOWERCASE_LETTERS) {
-				isError = true
-			}
+		id = id + "_lowercase"
+	}
 
-			id = id + "_lowercase"
+	if *settings.Uppercase {
+		if !strings.ContainsAny(password, model.UPPERCASE_LETTERS) {
+			isError = true
 		}
 
-		if *Cfg.PasswordSettings.Uppercase {
-			if !strings.ContainsAny(password, model.UPPERCASE_LETTERS) {
-				isError = true
-			}
+		id = id + "_uppercase"
+	}
 
-			id = id + "_uppercase"
+	if *settings.Number {
+		if !strings.ContainsAny(password, model.NUMBERS) {
+			isError = true
 		}
 
-		if *Cfg.PasswordSettings.Number {
-			if !strings.ContainsAny(password, model.NUMBERS) {
-				isError = true
-			}
+		id = id + "_number"
+	}
 
-			id = id + "_number"
+	if *settings.Symbol {
+		if !strings.ContainsAny(password, model.SYMBOLS) {
+			isError = true
 		}
 
-		if *Cfg.PasswordSettings.Symbol {
-			if !strings.ContainsAny(password, model.SYMBOLS) {
-				isError = true
-			}
-
-			id = id + "_symbol"
-		}
-
-		min = *Cfg.PasswordSettings.MinimumLength
-	} else if len(password) > model.PASSWORD_MAXIMUM_LENGTH || len(password) < model.PASSWORD_MINIMUM_LENGTH {
-		isError = true
-		min = model.PASSWORD_MINIMUM_LENGTH
+		id = id + "_symbol"
 	}
 
 	if isError {
-		return model.NewAppError("User.IsValid", id+".app_error", map[string]interface{}{"Min": min}, "", http.StatusBadRequest)
+		return model.NewAppError("User.IsValid", id+".app_error", map[string]interface{}{"Min": *settings.MinimumLength}, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/utils/password_test.go
+++ b/utils/password_test.go
@@ -1,0 +1,127 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func TestIsPasswordValid(t *testing.T) {
+	for name, tc := range map[string]struct {
+		Password      string
+		ExpectedError string
+	}{
+		"Short": {
+			Password: strings.Repeat("x", model.PASSWORD_MINIMUM_LENGTH),
+		},
+		"Long": {
+			Password: strings.Repeat("x", model.PASSWORD_MAXIMUM_LENGTH),
+		},
+		"TooShort": {
+			Password:      strings.Repeat("x", model.PASSWORD_MINIMUM_LENGTH-1),
+			ExpectedError: "model.user.is_valid.pwd.app_error",
+		},
+		"TooLong": {
+			Password:      strings.Repeat("x", model.PASSWORD_MAXIMUM_LENGTH+1),
+			ExpectedError: "model.user.is_valid.pwd.app_error",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := IsPasswordValid(tc.Password); tc.ExpectedError == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tc.ExpectedError, err.Id)
+			}
+		})
+	}
+}
+
+func TestIsPasswordValidWithSettings(t *testing.T) {
+	for name, tc := range map[string]struct {
+		Password      string
+		Settings      *model.PasswordSettings
+		ExpectedError string
+	}{
+		"Short": {
+			Password: strings.Repeat("x", 3),
+			Settings: &model.PasswordSettings{
+				MinimumLength: model.NewInt(3),
+			},
+		},
+		"Long": {
+			Password: strings.Repeat("x", model.PASSWORD_MAXIMUM_LENGTH),
+			Settings: &model.PasswordSettings{},
+		},
+		"TooShort": {
+			Password: strings.Repeat("x", 2),
+			Settings: &model.PasswordSettings{
+				MinimumLength: model.NewInt(3),
+			},
+			ExpectedError: "model.user.is_valid.pwd.app_error",
+		},
+		"TooLong": {
+			Password:      strings.Repeat("x", model.PASSWORD_MAXIMUM_LENGTH+1),
+			Settings:      &model.PasswordSettings{},
+			ExpectedError: "model.user.is_valid.pwd.app_error",
+		},
+		"MissingLower": {
+			Password: "ASD123!@#",
+			Settings: &model.PasswordSettings{
+				Lowercase: model.NewBool(true),
+			},
+			ExpectedError: "model.user.is_valid.pwd_lowercase.app_error",
+		},
+		"MissingUpper": {
+			Password: "asd123!@#",
+			Settings: &model.PasswordSettings{
+				Uppercase: model.NewBool(true),
+			},
+			ExpectedError: "model.user.is_valid.pwd_uppercase.app_error",
+		},
+		"MissingNumber": {
+			Password: "asdASD!@#",
+			Settings: &model.PasswordSettings{
+				Number: model.NewBool(true),
+			},
+			ExpectedError: "model.user.is_valid.pwd_number.app_error",
+		},
+		"MissingSymbol": {
+			Password: "asdASD123",
+			Settings: &model.PasswordSettings{
+				Symbol: model.NewBool(true),
+			},
+			ExpectedError: "model.user.is_valid.pwd_symbol.app_error",
+		},
+		"MissingMultiple": {
+			Password: "asd",
+			Settings: &model.PasswordSettings{
+				Lowercase: model.NewBool(true),
+				Uppercase: model.NewBool(true),
+				Number:    model.NewBool(true),
+				Symbol:    model.NewBool(true),
+			},
+			ExpectedError: "model.user.is_valid.pwd_lowercase_uppercase_number_symbol.app_error",
+		},
+		"Everything": {
+			Password: "asdASD!@#123",
+			Settings: &model.PasswordSettings{
+				Lowercase: model.NewBool(true),
+				Uppercase: model.NewBool(true),
+				Number:    model.NewBool(true),
+				Symbol:    model.NewBool(true),
+			},
+		},
+	} {
+		tc.Settings.SetDefaults()
+		t.Run(name, func(t *testing.T) {
+			if err := IsPasswordValidWithSettings(tc.Password, tc.Settings); tc.ExpectedError == "" {
+				assert.Nil(t, err)
+			} else {
+				assert.Equal(t, tc.ExpectedError, err.Id)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
This separates the *massive* `SetDefaults` method in models/config.go into several `SetDefaults` methods, one for each settings struct. In addition to enforcing better organization, this makes testing easier when functions don't require the full configuration. This is demonstrated with a refactor of `utils.IsValidPassword`, which is now purely functional (doesn't use any global state) and has clean unit tests with 100% coverage.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)