### PR TITLE
Refactor HTML template code

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 
 	_ "github.com/nicksnyder/go-i18n/i18n"
 )
@@ -112,8 +111,6 @@ func Init(a *app.App, root *mux.Router) *API {
 
 	// 404 on any api route before web.go has a chance to serve it
 	root.Handle("/api/{anything:.*}", http.HandlerFunc(Handle404))
-
-	utils.InitHTML()
 
 	a.InitEmailBatching()
 

--- a/api/user.go
+++ b/api/user.go
@@ -1040,7 +1040,7 @@ func updateMfa(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := app.SendMfaChangeEmail(user.Email, activate, user.Locale, utils.GetSiteURL()); err != nil {
+		if err := c.App.SendMfaChangeEmail(user.Email, activate, user.Locale, utils.GetSiteURL()); err != nil {
 			l4g.Error(err.Error())
 		}
 	})

--- a/api4/api.go
+++ b/api4/api.go
@@ -222,8 +222,6 @@ func Init(a *app.App, root *mux.Router, full bool) *API {
 
 	// REMOVE CONDITION WHEN APIv3 REMOVED
 	if full {
-		utils.InitHTML()
-
 		a.InitEmailBatching()
 	}
 

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -66,7 +66,6 @@ func setupTestHelper(enterprise bool) *TestHelper {
 	}
 	th.App.StartServer()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = prevListenAddress })
-	utils.InitHTML()
 	utils.EnableDebugLogForTest()
 	th.App.Srv.Store.MarkSystemRanUnitTests()
 

--- a/app/email.go
+++ b/app/email.go
@@ -10,6 +10,8 @@ import (
 	"net/http"
 
 	l4g "github.com/alecthomas/log4go"
+	"github.com/nicksnyder/go-i18n/i18n"
+
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -21,7 +23,7 @@ func (a *App) SendChangeUsernameEmail(oldUsername, newUsername, email, locale, s
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
 			"TeamDisplayName": a.Config().TeamSettings.SiteName})
 
-	bodyPage := utils.NewHTMLTemplate("email_change_body", locale)
+	bodyPage := a.NewEmailTemplate("email_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.username_change_body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.username_change_body.info",
@@ -43,7 +45,7 @@ func (a *App) SendEmailChangeVerifyEmail(newUserEmail, locale, siteURL, token st
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
 			"TeamDisplayName": a.Config().TeamSettings.SiteName})
 
-	bodyPage := utils.NewHTMLTemplate("email_change_verify_body", locale)
+	bodyPage := a.NewEmailTemplate("email_change_verify_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.email_change_verify_body.title")
 	bodyPage.Props["Info"] = T("api.templates.email_change_verify_body.info",
@@ -65,7 +67,7 @@ func (a *App) SendEmailChangeEmail(oldEmail, newEmail, locale, siteURL string) *
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
 			"TeamDisplayName": a.Config().TeamSettings.SiteName})
 
-	bodyPage := utils.NewHTMLTemplate("email_change_body", locale)
+	bodyPage := a.NewEmailTemplate("email_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.email_change_body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.email_change_body.info",
@@ -88,7 +90,7 @@ func (a *App) SendVerifyEmail(userEmail, locale, siteURL, token string) *model.A
 	subject := T("api.templates.verify_subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
-	bodyPage := utils.NewHTMLTemplate("verify_body", locale)
+	bodyPage := a.NewEmailTemplate("verify_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.verify_body.title", map[string]interface{}{"ServerURL": url.Host})
 	bodyPage.Props["Info"] = T("api.templates.verify_body.info")
@@ -108,7 +110,7 @@ func (a *App) SendSignInChangeEmail(email, method, locale, siteURL string) *mode
 	subject := T("api.templates.signin_change_email.subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
-	bodyPage := utils.NewHTMLTemplate("signin_change_body", locale)
+	bodyPage := a.NewEmailTemplate("signin_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.signin_change_email.body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.signin_change_email.body.info",
@@ -130,7 +132,7 @@ func (a *App) SendWelcomeEmail(userId string, email string, verified bool, local
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
 			"ServerURL": rawUrl.Host})
 
-	bodyPage := utils.NewHTMLTemplate("welcome_body", locale)
+	bodyPage := a.NewEmailTemplate("welcome_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.welcome_body.title", map[string]interface{}{"ServerURL": rawUrl.Host})
 	bodyPage.Props["Info"] = T("api.templates.welcome_body.info")
@@ -167,7 +169,7 @@ func (a *App) SendPasswordChangeEmail(email, method, locale, siteURL string) *mo
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"],
 			"TeamDisplayName": a.Config().TeamSettings.SiteName})
 
-	bodyPage := utils.NewHTMLTemplate("password_change_body", locale)
+	bodyPage := a.NewEmailTemplate("password_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.password_change_body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.password_change_body.info",
@@ -180,13 +182,13 @@ func (a *App) SendPasswordChangeEmail(email, method, locale, siteURL string) *mo
 	return nil
 }
 
-func SendUserAccessTokenAddedEmail(email, locale string) *model.AppError {
+func (a *App) SendUserAccessTokenAddedEmail(email, locale string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
 	subject := T("api.templates.user_access_token_subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
-	bodyPage := utils.NewHTMLTemplate("password_change_body", locale)
+	bodyPage := a.NewEmailTemplate("password_change_body", locale)
 	bodyPage.Props["Title"] = T("api.templates.user_access_token_body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.user_access_token_body.info",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"], "SiteURL": utils.GetSiteURL()})
@@ -198,7 +200,7 @@ func SendUserAccessTokenAddedEmail(email, locale string) *model.AppError {
 	return nil
 }
 
-func SendPasswordResetEmail(email string, token *model.Token, locale, siteURL string) (bool, *model.AppError) {
+func (a *App) SendPasswordResetEmail(email string, token *model.Token, locale, siteURL string) (bool, *model.AppError) {
 
 	T := utils.GetUserTranslations(locale)
 
@@ -207,7 +209,7 @@ func SendPasswordResetEmail(email string, token *model.Token, locale, siteURL st
 	subject := T("api.templates.reset_subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
-	bodyPage := utils.NewHTMLTemplate("reset_body", locale)
+	bodyPage := a.NewEmailTemplate("reset_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.reset_body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.reset_body.info", nil)
@@ -221,13 +223,13 @@ func SendPasswordResetEmail(email string, token *model.Token, locale, siteURL st
 	return true, nil
 }
 
-func SendMfaChangeEmail(email string, activated bool, locale, siteURL string) *model.AppError {
+func (a *App) SendMfaChangeEmail(email string, activated bool, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
 	subject := T("api.templates.mfa_change_subject",
 		map[string]interface{}{"SiteName": utils.ClientCfg["SiteName"]})
 
-	bodyPage := utils.NewHTMLTemplate("mfa_change_body", locale)
+	bodyPage := a.NewEmailTemplate("mfa_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 
 	bodyText := ""
@@ -258,7 +260,7 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, invites []st
 					"TeamDisplayName": team.DisplayName,
 					"SiteName":        utils.ClientCfg["SiteName"]})
 
-			bodyPage := utils.NewHTMLTemplate("invite_body", model.DEFAULT_LOCALE)
+			bodyPage := a.NewEmailTemplate("invite_body", model.DEFAULT_LOCALE)
 			bodyPage.Props["SiteURL"] = siteURL
 			bodyPage.Props["Title"] = utils.T("api.templates.invite_body.title")
 			bodyPage.Html["Info"] = utils.TranslateAsHtml(utils.T, "api.templates.invite_body.info",
@@ -287,4 +289,28 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, invites []st
 			}
 		}
 	}
+}
+
+func (a *App) NewEmailTemplate(name, locale string) *utils.HTMLTemplate {
+	t := utils.NewHTMLTemplate(a.HTMLTemplates(), name)
+
+	var localT i18n.TranslateFunc
+	if locale != "" {
+		localT = utils.GetUserTranslations(locale)
+	} else {
+		localT = utils.T
+	}
+
+	t.Props["Footer"] = localT("api.templates.email_footer")
+
+	if *a.Config().EmailSettings.FeedbackOrganization != "" {
+		t.Props["Organization"] = localT("api.templates.email_organization") + *a.Config().EmailSettings.FeedbackOrganization
+	} else {
+		t.Props["Organization"] = ""
+	}
+
+	t.Html["EmailInfo"] = utils.TranslateAsHtml(localT, "api.templates.email_info",
+		map[string]interface{}{"SupportEmail": *a.Config().SupportSettings.SupportEmail, "SiteName": a.Config().TeamSettings.SiteName})
+
+	return t
 }

--- a/app/email_batching.go
+++ b/app/email_batching.go
@@ -236,7 +236,7 @@ func (a *App) sendBatchedEmailNotification(userId string, notifications []*batch
 		"Day":      tm.Day(),
 	})
 
-	body := utils.NewHTMLTemplate("post_batched_body", user.Locale)
+	body := a.NewEmailTemplate("post_batched_body", user.Locale)
 	body.Props["SiteURL"] = *a.Config().ServiceSettings.SiteURL
 	body.Props["Posts"] = template.HTML(contents)
 	body.Props["BodyText"] = translateFunc("api.email_batching.send_batched_email_notification.body_text", len(notifications))
@@ -250,9 +250,9 @@ func (a *App) renderBatchedPost(notification *batchedNotification, channel *mode
 	// don't include message contents if email notification contents type is set to generic
 	var template *utils.HTMLTemplate
 	if emailNotificationContentsType == model.EMAIL_NOTIFICATION_CONTENTS_FULL {
-		template = utils.NewHTMLTemplate("post_batched_post_full", userLocale)
+		template = a.NewEmailTemplate("post_batched_post_full", userLocale)
 	} else {
-		template = utils.NewHTMLTemplate("post_batched_post_generic", userLocale)
+		template = a.NewEmailTemplate("post_batched_post_generic", userLocale)
 	}
 
 	template.Props["Button"] = translateFunc("api.email_batching.render_batched_post.go_to_post")

--- a/app/notification.go
+++ b/app/notification.go
@@ -413,10 +413,10 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 	// only include message contents in notification email if email notification contents type is set to full
 	var bodyPage *utils.HTMLTemplate
 	if emailNotificationContentsType == model.EMAIL_NOTIFICATION_CONTENTS_FULL {
-		bodyPage = utils.NewHTMLTemplate("post_body_full", recipient.Locale)
+		bodyPage = a.NewEmailTemplate("post_body_full", recipient.Locale)
 		bodyPage.Props["PostMessage"] = a.GetMessageForNotification(post, translateFunc)
 	} else {
-		bodyPage = utils.NewHTMLTemplate("post_body_generic", recipient.Locale)
+		bodyPage = a.NewEmailTemplate("post_body_generic", recipient.Locale)
 	}
 
 	bodyPage.Props["SiteURL"] = utils.GetSiteURL()

--- a/app/session.go
+++ b/app/session.go
@@ -247,7 +247,7 @@ func (a *App) CreateUserAccessToken(token *model.UserAccessToken) (*model.UserAc
 		l4g.Error(result.Err.Error())
 	} else {
 		user := result.Data.(*model.User)
-		if err := SendUserAccessTokenAddedEmail(user.Email, user.Locale); err != nil {
+		if err := a.SendUserAccessTokenAddedEmail(user.Email, user.Locale); err != nil {
 			l4g.Error(err.Error())
 		}
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -1067,7 +1067,7 @@ func (a *App) UpdateMfa(activate bool, userId, token string) *model.AppError {
 			return
 		}
 
-		if err := SendMfaChangeEmail(user.Email, activate, user.Locale, utils.GetSiteURL()); err != nil {
+		if err := a.SendMfaChangeEmail(user.Email, activate, user.Locale, utils.GetSiteURL()); err != nil {
 			l4g.Error(err.Error())
 		}
 	})
@@ -1162,7 +1162,7 @@ func (a *App) SendPasswordReset(email string, siteURL string) (bool, *model.AppE
 		return false, err
 	}
 
-	if _, err := SendPasswordResetEmail(user.Email, token, user.Locale, siteURL); err != nil {
+	if _, err := a.SendPasswordResetEmail(user.Email, token, user.Locale, siteURL); err != nil {
 		return false, model.NewAppError("SendPasswordReset", "api.user.send_password_reset.send.app_error", nil, "err="+err.Message, http.StatusInternalServerError)
 	}
 

--- a/cmd/platform/user.go
+++ b/cmd/platform/user.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -259,8 +258,6 @@ func userInviteCmdF(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	utils.InitHTML()
 
 	if len(args) < 2 {
 		return errors.New("Expected at least two arguments. See help text for details.")

--- a/web/web.go
+++ b/web/web.go
@@ -81,13 +81,12 @@ func CheckBrowserCompatability(c *api.Context, r *http.Request) bool {
 	}
 
 	return true
-
 }
 
 func root(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	if !CheckBrowserCompatability(c, r) {
 		w.Header().Set("Cache-Control", "no-store")
-		page := utils.NewHTMLTemplate("unsupported_browser", c.Locale)
+		page := utils.NewHTMLTemplate(c.App.HTMLTemplates(), "unsupported_browser")
 		page.Props["Title"] = c.T("web.error.unsupported_browser.title")
 		page.Props["Message"] = c.T("web.error.unsupported_browser.message")
 		page.RenderToWriter(w)


### PR DESCRIPTION
#### Summary
The goal of this was to eliminate global state in the template code, improve testability, increase coverage, and eliminate races.

* `(*utils.HTMLTemplate).addDefaultProps` (a global config offender) is now part of a new method `(*app.App).NewEmailTemplate`. Calls to `utils.NewHTMLTemplate` that required the props set by that function have been replaced.
* `utils.InitHTML` and `utils.InitHTMLWithDir` have been removed. The template directory watching functionality is now encapsulated by a new `HTMLTemplateWatcher` struct instead of being global. `app.App` now owns an instance of this type.
* The code in `utils/html.go` has brand new tests with much better coverage than before.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)