### PR TITLE
PLT-8103 Include current user in WebSocket update event when setting profile image

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -826,9 +826,7 @@ func (a *App) SetProfileImage(userId string, imageData *multipart.FileHeader) *m
 		options := a.Config().GetSanitizeOptions()
 		user.SanitizeProfile(options)
 
-		omitUsers := make(map[string]bool, 1)
-		omitUsers[userId] = true
-		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", omitUsers)
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
 		message.Add("user", user)
 
 		a.Publish(message)


### PR DESCRIPTION
#### Summary
To alert other clients of the logged-in user that the user's profile image changed.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8103