### PR TITLE
Revert "workaround for go smtp bug (#7620)"

### DIFF
--- a/utils/mail.go
+++ b/utils/mail.go
@@ -7,12 +7,13 @@ import (
 	"crypto/tls"
 	"mime"
 	"net"
-	"net/http"
 	"net/mail"
 	"net/smtp"
 	"time"
 
 	"gopkg.in/gomail.v2"
+
+	"net/http"
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/html2text"
@@ -47,20 +48,6 @@ func connectToSMTPServer(config *model.Config) (net.Conn, *model.AppError) {
 	return conn, nil
 }
 
-// TODO: Remove once this bug is fixed: https://github.com/golang/go/issues/22166
-type plainAuthOverTLSConn struct {
-	smtp.Auth
-}
-
-func PlainAuthOverTLSConn(identity, username, password, host string) smtp.Auth {
-	return &plainAuthOverTLSConn{smtp.PlainAuth(identity, username, password, host)}
-}
-
-func (a *plainAuthOverTLSConn) Start(server *smtp.ServerInfo) (string, []byte, error) {
-	server.TLS = true
-	return a.Auth.Start(server)
-}
-
 func newSMTPClient(conn net.Conn, config *model.Config) (*smtp.Client, *model.AppError) {
 	c, err := smtp.NewClient(conn, config.EmailSettings.SMTPServer+":"+config.EmailSettings.SMTPPort)
 	if err != nil {
@@ -86,12 +73,7 @@ func newSMTPClient(conn net.Conn, config *model.Config) (*smtp.Client, *model.Ap
 	}
 
 	if *config.EmailSettings.EnableSMTPAuth {
-		var auth smtp.Auth
-		if _, ok := conn.(*tls.Conn); ok {
-			auth = PlainAuthOverTLSConn("", config.EmailSettings.SMTPUsername, config.EmailSettings.SMTPPassword, config.EmailSettings.SMTPServer+":"+config.EmailSettings.SMTPPort)
-		} else {
-			auth = smtp.PlainAuth("", config.EmailSettings.SMTPUsername, config.EmailSettings.SMTPPassword, config.EmailSettings.SMTPServer+":"+config.EmailSettings.SMTPPort)
-		}
+		auth := smtp.PlainAuth("", config.EmailSettings.SMTPUsername, config.EmailSettings.SMTPPassword, config.EmailSettings.SMTPServer+":"+config.EmailSettings.SMTPPort)
 
 		if err = c.Auth(auth); err != nil {
 			return nil, model.NewAppError("SendMail", "utils.mail.new_client.auth.app_error", nil, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
#### Summary
This reverts commit 8966452d1183e94fecc373b9d08c65a0573cbbc6.

The bug introduced by Go 1.9.1 was fixed in Go 1.9.2. See https://github.com/golang/go/issues/22166

#### Ticket Link
N/A

#### Checklist
N/A