### PR TITLE
Role refactor

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -115,7 +115,7 @@ func (me *TestHelper) InitBasic() *TestHelper {
 
 	me.BasicClient = me.CreateClient()
 	me.BasicUser = me.CreateUser(me.BasicClient)
-	me.App.UpdateUserRoles(me.BasicUser.Id, model.ROLE_SYSTEM_USER.Id, false)
+	me.App.UpdateUserRoles(me.BasicUser.Id, model.SYSTEM_USER_ROLE_ID, false)
 	me.LoginBasic()
 	me.BasicTeam = me.CreateTeam(me.BasicClient)
 	me.LinkUserToTeam(me.BasicUser, me.BasicTeam)
@@ -142,7 +142,7 @@ func (me *TestHelper) InitSystemAdmin() *TestHelper {
 	me.SystemAdminTeam = me.CreateTeam(me.SystemAdminClient)
 	me.LinkUserToTeam(me.SystemAdminUser, me.SystemAdminTeam)
 	me.SystemAdminClient.SetTeamId(me.SystemAdminTeam.Id)
-	me.App.UpdateUserRoles(me.SystemAdminUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_ADMIN.Id, false)
+	me.App.UpdateUserRoles(me.SystemAdminUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_ADMIN_ROLE_ID, false)
 	me.SystemAdminChannel = me.CreateChannel(me.SystemAdminClient, me.SystemAdminTeam)
 
 	return me
@@ -218,7 +218,7 @@ func (me *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 func (me *TestHelper) UpdateUserToTeamAdmin(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.ROLE_TEAM_USER.Id + " " + model.ROLE_TEAM_ADMIN.Id}
+	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.TEAM_USER_ROLE_ID + " " + model.TEAM_ADMIN_ROLE_ID}
 	if tmr := <-me.App.Srv.Store.Team().UpdateMember(tm); tmr.Err != nil {
 		utils.EnableDebugLogForTest()
 		l4g.Error(tmr.Err.Error())
@@ -232,7 +232,7 @@ func (me *TestHelper) UpdateUserToTeamAdmin(user *model.User, team *model.Team) 
 func (me *TestHelper) UpdateUserToNonTeamAdmin(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.ROLE_TEAM_USER.Id}
+	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.TEAM_USER_ROLE_ID}
 	if tmr := <-me.App.Srv.Store.Team().UpdateMember(tm); tmr.Err != nil {
 		utils.EnableDebugLogForTest()
 		l4g.Error(tmr.Err.Error())
@@ -365,7 +365,6 @@ func (me *TestHelper) TearDown() {
 	me.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg = *me.originalConfig
 	})
-	utils.SetDefaultRolesBasedOnConfig()
 
 	me.App.Shutdown()
 	if err := recover(); err != nil {

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -106,11 +106,11 @@ func TestCreateChannel(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -130,7 +130,7 @@ func TestCreateChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic2()
 	channel2.Name = "zz" + model.NewId() + "a"
@@ -160,7 +160,7 @@ func TestCreateChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel2.Name = "zz" + model.NewId() + "a"
 	channel3.Name = "zz" + model.NewId() + "a"
@@ -183,7 +183,7 @@ func TestCreateChannel(t *testing.T) {
 	// Check that if unlicensed the policy restriction is not enforced.
 	utils.SetIsLicensed(false)
 	utils.SetLicense(nil)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel4 := model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel5 := model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
@@ -196,7 +196,7 @@ func TestCreateChannel(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_ALL })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 }
 
 func TestCreateDirectChannel(t *testing.T) {
@@ -376,14 +376,14 @@ func TestUpdateChannel(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel2 := th.CreateChannel(Client, team)
 	channel3 := th.CreatePrivateChannel(Client, team)
@@ -411,7 +411,7 @@ func TestUpdateChannel(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.MakeUserChannelUser(th.BasicUser, channel2)
 	th.MakeUserChannelUser(th.BasicUser, channel3)
 	sqlstore.ClearChannelCaches()
@@ -454,7 +454,7 @@ func TestUpdateChannel(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
 		t.Fatal("should have errored not team admin")
@@ -484,7 +484,7 @@ func TestUpdateChannel(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
 		t.Fatal("should have errored not system admin")
@@ -505,7 +505,7 @@ func TestUpdateChannel(t *testing.T) {
 	// Check that if unlicensed the policy restriction is not enforced.
 	utils.SetIsLicensed(false)
 	utils.SetLicense(nil)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err != nil {
 		t.Fatal(err)
@@ -627,14 +627,14 @@ func TestUpdateChannelHeader(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 	channel2 := th.CreateChannel(Client, team)
@@ -663,7 +663,7 @@ func TestUpdateChannelHeader(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.MakeUserChannelUser(th.BasicUser, channel2)
 	th.MakeUserChannelUser(th.BasicUser, channel3)
 	sqlstore.ClearChannelCaches()
@@ -692,7 +692,7 @@ func TestUpdateChannelHeader(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelHeader(data2); err == nil {
 		t.Fatal("should have errored not team admin")
@@ -719,7 +719,7 @@ func TestUpdateChannelHeader(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelHeader(data2); err == nil {
 		t.Fatal("should have errored not system admin")
@@ -743,7 +743,7 @@ func TestUpdateChannelHeader(t *testing.T) {
 	// Check that if unlicensed the policy restriction is not enforced.
 	utils.SetIsLicensed(false)
 	utils.SetLicense(nil)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
 		t.Fatal(err)
@@ -823,14 +823,14 @@ func TestUpdateChannelPurpose(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 	channel2 := th.CreateChannel(Client, team)
@@ -859,7 +859,7 @@ func TestUpdateChannelPurpose(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.MakeUserChannelUser(th.BasicUser, channel2)
 	th.MakeUserChannelUser(th.BasicUser, channel3)
 	sqlstore.ClearChannelCaches()
@@ -888,7 +888,7 @@ func TestUpdateChannelPurpose(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelPurpose(data2); err == nil {
 		t.Fatal("should have errored not team admin")
@@ -915,7 +915,7 @@ func TestUpdateChannelPurpose(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelPurpose(data2); err == nil {
 		t.Fatal("should have errored not system admin")
@@ -939,7 +939,7 @@ func TestUpdateChannelPurpose(t *testing.T) {
 	// Check that if unlicensed the policy restriction is not enforced.
 	utils.SetIsLicensed(false)
 	utils.SetLicense(nil)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
 		t.Fatal(err)
 	}
@@ -1409,14 +1409,14 @@ func TestDeleteChannel(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
 	th.LinkUserToTeam(th.BasicUser, team)
@@ -1447,7 +1447,7 @@ func TestDeleteChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
 
@@ -1507,7 +1507,7 @@ func TestDeleteChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
 
@@ -1546,7 +1546,7 @@ func TestDeleteChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
 
@@ -1580,7 +1580,7 @@ func TestDeleteChannel(t *testing.T) {
 	// Check that if unlicensed the policy restriction is not enforced.
 	utils.SetIsLicensed(false)
 	utils.SetLicense(nil)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel2 = th.CreateChannel(Client, team)
 	channel3 = th.CreatePrivateChannel(Client, team)
@@ -1598,7 +1598,7 @@ func TestDeleteChannel(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_ALL })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 }
 
 func TestGetChannelStats(t *testing.T) {
@@ -1684,7 +1684,7 @@ func TestAddChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel3 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel3 = Client.Must(th.SystemAdminClient.CreateChannel(channel3)).Data.(*model.Channel)
@@ -1699,13 +1699,13 @@ func TestAddChannelMember(t *testing.T) {
 	defer func() {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Check that a regular channel user can add other users.
 	channel4 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
@@ -1722,7 +1722,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel5 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel5 = Client.Must(th.SystemAdminClient.CreateChannel(channel5)).Data.(*model.Channel)
@@ -1736,7 +1736,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.AddChannelMember(channel5.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1749,7 +1749,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel6 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel6 = Client.Must(th.SystemAdminClient.CreateChannel(channel6)).Data.(*model.Channel)
@@ -1763,7 +1763,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.AddChannelMember(channel6.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1776,7 +1776,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel7 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel7 = Client.Must(th.SystemAdminClient.CreateChannel(channel7)).Data.(*model.Channel)
@@ -1869,7 +1869,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel3 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel3 = Client.Must(th.SystemAdminClient.CreateChannel(channel3)).Data.(*model.Channel)
@@ -1885,13 +1885,13 @@ func TestRemoveChannelMember(t *testing.T) {
 	defer func() {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Check that a regular channel user can remove other users.
 	channel4 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
@@ -1909,7 +1909,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel5 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel5 = Client.Must(th.SystemAdminClient.CreateChannel(channel5)).Data.(*model.Channel)
@@ -1936,7 +1936,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel6 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel6 = Client.Must(th.SystemAdminClient.CreateChannel(channel6)).Data.(*model.Channel)
@@ -1951,7 +1951,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.RemoveChannelMember(channel6.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1964,7 +1964,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel7 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel7 = Client.Must(th.SystemAdminClient.CreateChannel(channel7)).Data.(*model.Channel)

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -89,12 +89,8 @@ func TestOAuthRegisterApp(t *testing.T) {
 	}
 
 	adminOnly := *th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
+	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 
@@ -217,7 +213,6 @@ func TestOAuthGetAppsByUser(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	if result, err := Client.GetOAuthAppsByUser(); err != nil {
 		t.Fatal(err)
@@ -445,7 +440,6 @@ func TestOAuthDeleteApp(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	oauthApp := &model.OAuthApp{Name: "TestApp5" + model.NewId(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 
@@ -504,11 +498,9 @@ func TestOAuthAccessToken(t *testing.T) {
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = enableOAuth })
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
-		utils.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	oauthApp := &model.OAuthApp{Name: "TestApp5" + model.NewId(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 	oauthApp = Client.Must(Client.RegisterApp(oauthApp)).Data.(*model.OAuthApp)
@@ -751,12 +743,8 @@ func TestOAuthComplete(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 
 	adminOnly := *th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
+	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	oauthApp := &model.OAuthApp{
 		Name:        "TestApp5" + model.NewId(),

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -167,10 +167,10 @@ func TestCreatePost(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = disableTownSquareReadOnly })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
@@ -966,7 +966,7 @@ func TestDeletePosts(t *testing.T) {
 	team1 := th.BasicTeam
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.RestrictPostDelete = model.PERMISSIONS_DELETE_POST_ALL })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	time.Sleep(10 * time.Millisecond)
 	post1 := &model.Post{ChannelId: channel1.Id, Message: "zz" + model.NewId() + "a"}
@@ -1044,7 +1044,7 @@ func TestDeletePosts(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.RestrictPostDelete = model.PERMISSIONS_DELETE_POST_TEAM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 
@@ -1069,7 +1069,7 @@ func TestDeletePosts(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.RestrictPostDelete = model.PERMISSIONS_DELETE_POST_SYSTEM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 
@@ -1090,7 +1090,7 @@ func TestDeletePosts(t *testing.T) {
 	// Check that if unlicensed the policy restriction is not enforced.
 	utils.SetIsLicensed(false)
 	utils.SetLicense(nil)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	time.Sleep(10 * time.Millisecond)
 	post7 := &model.Post{ChannelId: channel1.Id, Message: "zz" + model.NewId() + "a"}

--- a/api/team.go
+++ b/api/team.go
@@ -13,7 +13,6 @@ import (
 	l4g "github.com/alecthomas/log4go"
 	"github.com/gorilla/mux"
 
-	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -86,7 +85,7 @@ func GetAllTeamListings(c *Context, w http.ResponseWriter, r *http.Request) {
 		m[v.Id] = v
 	}
 
-	sanitizeTeamMap(c.Session, m)
+	sanitizeTeamMap(c, m)
 
 	w.Write([]byte(model.TeamMapToJson(m)))
 }
@@ -113,7 +112,7 @@ func getAll(c *Context, w http.ResponseWriter, r *http.Request) {
 		m[v.Id] = v
 	}
 
-	sanitizeTeamMap(c.Session, m)
+	sanitizeTeamMap(c, m)
 
 	w.Write([]byte(model.TeamMapToJson(m)))
 }
@@ -210,7 +209,7 @@ func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	app.SanitizeTeam(c.Session, team)
+	c.App.SanitizeTeam(c.Session, team)
 
 	w.Write([]byte(team.ToJson()))
 }
@@ -244,7 +243,7 @@ func getTeamByName(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		app.SanitizeTeam(c.Session, team)
+		c.App.SanitizeTeam(c.Session, team)
 
 		w.Write([]byte(team.ToJson()))
 		return
@@ -299,7 +298,7 @@ func updateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.SanitizeTeam(c.Session, updatedTeam)
+	c.App.SanitizeTeam(c.Session, updatedTeam)
 
 	w.Write([]byte(updatedTeam.ToJson()))
 }
@@ -350,7 +349,7 @@ func getMyTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.Header().Set(model.HEADER_ETAG_SERVER, team.Etag())
 
-		app.SanitizeTeam(c.Session, team)
+		c.App.SanitizeTeam(c.Session, team)
 
 		w.Write([]byte(team.ToJson()))
 		return
@@ -544,8 +543,8 @@ func getTeamMembersByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func sanitizeTeamMap(session model.Session, teams map[string]*model.Team) {
+func sanitizeTeamMap(c *Context, teams map[string]*model.Team) {
 	for _, team := range teams {
-		app.SanitizeTeam(session, team)
+		c.App.SanitizeTeam(c.Session, team)
 	}
 }

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -147,12 +147,12 @@ func TestAddUserToTeam(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 
 	// Set the config so that only team admins can add a user to a team.
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Test without the EE license to see that the permission restriction is ignored.
 	user3 := th.CreateUser(th.BasicClient)
@@ -164,7 +164,7 @@ func TestAddUserToTeam(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Check that a regular user can't add someone to the team.
 	user4 := th.CreateUser(th.BasicClient)
@@ -179,7 +179,7 @@ func TestAddUserToTeam(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	user5 := th.CreateUser(th.BasicClient)
 	if _, err := th.BasicClient.AddUserToTeam(th.BasicTeam.Id, user5.Id); err != nil {
@@ -188,7 +188,7 @@ func TestAddUserToTeam(t *testing.T) {
 
 	// Change permission level to System Admin
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Should not work as team admin.
 	user6 := th.CreateUser(th.BasicClient)
@@ -395,7 +395,7 @@ func TestGetAllTeamListings(t *testing.T) {
 		}
 	}
 
-	th.App.UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id, false)
+	th.App.UpdateUserRoles(user.Id, model.SYSTEM_ADMIN_ROLE_ID, false)
 
 	Client.Login(user.Email, "passwd1")
 	Client.SetTeamId(team.Id)
@@ -568,10 +568,10 @@ func TestInviteMembers(t *testing.T) {
 	restrictTeamInvite := *th.App.Config().TeamSettings.RestrictTeamInvite
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic2()
 	th.LinkUserToTeam(th.BasicUser2, team)
@@ -585,12 +585,12 @@ func TestInviteMembers(t *testing.T) {
 	defer func() {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.InviteMembers(invites); err == nil {
 		t.Fatal("should have errored not team admin and licensed")
@@ -606,7 +606,7 @@ func TestInviteMembers(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.InviteMembers(invites); err == nil {
 		t.Fatal("should have errored not system admin and licensed")

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -483,7 +483,7 @@ func TestGetUser(t *testing.T) {
 		t.Fatal("shouldn't have accss")
 	}
 
-	th.App.UpdateUserRoles(ruser.Data.(*model.User).Id, model.ROLE_SYSTEM_ADMIN.Id, false)
+	th.App.UpdateUserRoles(ruser.Data.(*model.User).Id, model.SYSTEM_ADMIN_ROLE_ID, false)
 
 	Client.Login(user.Email, "passwd1")
 
@@ -842,7 +842,7 @@ func TestUserUpdate(t *testing.T) {
 	Client.SetTeamId(team.Id)
 
 	user.Nickname = "Jim Jimmy"
-	user.Roles = model.ROLE_SYSTEM_ADMIN.Id
+	user.Roles = model.SYSTEM_ADMIN_ROLE_ID
 	user.LastPasswordUpdate = 123
 
 	if result, err := Client.UpdateUser(user); err != nil {
@@ -851,7 +851,7 @@ func TestUserUpdate(t *testing.T) {
 		if result.Data.(*model.User).Nickname != "Jim Jimmy" {
 			t.Fatal("Nickname did not update properly")
 		}
-		if result.Data.(*model.User).Roles != model.ROLE_SYSTEM_USER.Id {
+		if result.Data.(*model.User).Roles != model.SYSTEM_USER_ROLE_ID {
 			t.Fatal("Roles should not have updated")
 		}
 		if result.Data.(*model.User).LastPasswordUpdate == 123 {

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -27,7 +27,6 @@ func TestCreateIncomingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.IncomingWebhook{ChannelId: channel1.Id}
 
@@ -94,7 +93,7 @@ func TestCreateIncomingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.CreateIncomingWebhook(hook); err != nil {
 		t.Fatal(err)
@@ -134,7 +133,7 @@ func TestUpdateIncomingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := createIncomingWebhook(channel1.Id, Client, t)
 
@@ -218,7 +217,7 @@ func TestUpdateIncomingHook(t *testing.T) {
 
 	t.Run("OnlyAdminIntegrationsDisabled", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 
 		t.Run("UpdateHookOfSameUser", func(t *testing.T) {
 			sameUserHook := &model.IncomingWebhook{ChannelId: channel1.Id, UserId: user2.Id}
@@ -241,7 +240,7 @@ func TestUpdateIncomingHook(t *testing.T) {
 	})
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Logout()
 	th.UpdateUserToTeamAdmin(user2, team)
@@ -325,7 +324,7 @@ func TestListIncomingHooks(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook1 := &model.IncomingWebhook{ChannelId: channel1.Id}
 	hook1 = Client.Must(Client.CreateIncomingWebhook(hook1)).Data.(*model.IncomingWebhook)
@@ -352,7 +351,7 @@ func TestListIncomingHooks(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.ListIncomingWebhooks(); err != nil {
 		t.Fatal(err)
@@ -377,7 +376,7 @@ func TestDeleteIncomingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.IncomingWebhook{ChannelId: channel1.Id}
 	hook = Client.Must(Client.CreateIncomingWebhook(hook)).Data.(*model.IncomingWebhook)
@@ -411,7 +410,7 @@ func TestDeleteIncomingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.DeleteIncomingWebhook(hook.Id); err == nil {
 		t.Fatal("should have failed - not creator or team admin")
@@ -448,7 +447,7 @@ func TestCreateOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 
@@ -519,7 +518,7 @@ func TestCreateOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.CreateOutgoingWebhook(hook); err != nil {
 		t.Fatal(err)
@@ -552,7 +551,7 @@ func TestListOutgoingHooks(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook1 := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook1 = Client.Must(Client.CreateOutgoingWebhook(hook1)).Data.(*model.OutgoingWebhook)
@@ -579,7 +578,7 @@ func TestListOutgoingHooks(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.ListOutgoingWebhooks(); err != nil {
 		t.Fatal(err)
@@ -610,7 +609,7 @@ func TestUpdateOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := createOutgoingWebhook(channel1.Id, []string{"http://nowhere.com"}, []string{"cats"}, Client, t)
 	createOutgoingWebhook(channel1.Id, []string{"http://nowhere.com"}, []string{"dogs"}, Client, t)
@@ -684,7 +683,7 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	hook2 := createOutgoingWebhook(channel1.Id, []string{"http://nowhereelse.com"}, []string{"dogs"}, Client, t)
 
 	if _, err := Client.UpdateOutgoingWebhook(hook2); err != nil {
@@ -692,7 +691,7 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Logout()
 	th.LinkUserToTeam(user3, team)
@@ -780,7 +779,7 @@ func TestDeleteOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook = Client.Must(Client.CreateOutgoingWebhook(hook)).Data.(*model.OutgoingWebhook)
@@ -814,7 +813,7 @@ func TestDeleteOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.DeleteOutgoingWebhook(hook.Id); err == nil {
 		t.Fatal("should have failed - not creator or team admin")
@@ -849,7 +848,7 @@ func TestRegenOutgoingHookToken(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook = Client.Must(Client.CreateOutgoingWebhook(hook)).Data.(*model.OutgoingWebhook)
@@ -884,7 +883,7 @@ func TestRegenOutgoingHookToken(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook = &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook = Client.Must(Client.CreateOutgoingWebhook(hook)).Data.(*model.OutgoingWebhook)
@@ -970,10 +969,10 @@ func TestIncomingWebhooks(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = disableTownSquareReadOnly })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -178,7 +178,6 @@ func (me *TestHelper) TearDown() {
 	me.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg = *me.originalConfig
 	})
-	utils.SetDefaultRolesBasedOnConfig()
 
 	me.App.Shutdown()
 
@@ -194,7 +193,7 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.waitForConnectivity()
 
 	me.TeamAdminUser = me.CreateUser()
-	me.App.UpdateUserRoles(me.TeamAdminUser.Id, model.ROLE_SYSTEM_USER.Id, false)
+	me.App.UpdateUserRoles(me.TeamAdminUser.Id, model.SYSTEM_USER_ROLE_ID, false)
 	me.LoginTeamAdmin()
 	me.BasicTeam = me.CreateTeam()
 	me.BasicChannel = me.CreatePublicChannel()
@@ -211,7 +210,7 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.App.AddUserToChannel(me.BasicUser2, me.BasicChannel2)
 	me.App.AddUserToChannel(me.BasicUser, me.BasicPrivateChannel)
 	me.App.AddUserToChannel(me.BasicUser2, me.BasicPrivateChannel)
-	me.App.UpdateUserRoles(me.BasicUser.Id, model.ROLE_SYSTEM_USER.Id, false)
+	me.App.UpdateUserRoles(me.BasicUser.Id, model.SYSTEM_USER_ROLE_ID, false)
 	me.LoginBasic()
 
 	return me
@@ -221,7 +220,7 @@ func (me *TestHelper) InitSystemAdmin() *TestHelper {
 	me.waitForConnectivity()
 
 	me.SystemAdminUser = me.CreateUser()
-	me.App.UpdateUserRoles(me.SystemAdminUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_ADMIN.Id, false)
+	me.App.UpdateUserRoles(me.SystemAdminUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_ADMIN_ROLE_ID, false)
 	me.LoginSystemAdmin()
 
 	return me
@@ -760,7 +759,7 @@ func (me *TestHelper) MakeUserChannelAdmin(user *model.User, channel *model.Chan
 func (me *TestHelper) UpdateUserToTeamAdmin(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.ROLE_TEAM_USER.Id + " " + model.ROLE_TEAM_ADMIN.Id}
+	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.TEAM_USER_ROLE_ID + " " + model.TEAM_ADMIN_ROLE_ID}
 	if tmr := <-me.App.Srv.Store.Team().UpdateMember(tm); tmr.Err != nil {
 		utils.EnableDebugLogForTest()
 		l4g.Error(tmr.Err.Error())
@@ -774,7 +773,7 @@ func (me *TestHelper) UpdateUserToTeamAdmin(user *model.User, team *model.Team) 
 func (me *TestHelper) UpdateUserToNonTeamAdmin(user *model.User, team *model.Team) {
 	utils.DisableDebugLogForTest()
 
-	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.ROLE_TEAM_USER.Id}
+	tm := &model.TeamMember{TeamId: team.Id, UserId: user.Id, Roles: model.TEAM_USER_ROLE_ID}
 	if tmr := <-me.App.Srv.Store.Team().UpdateMember(tm); tmr.Err != nil {
 		utils.EnableDebugLogForTest()
 		l4g.Error(tmr.Err.Error())

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -90,14 +90,14 @@ func TestCreateChannel(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelCreation = restrictPrivateChannel })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel.Name = GenerateTestChannelName()
 	_, resp = Client.CreateChannel(channel)
@@ -113,7 +113,7 @@ func TestCreateChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.CreateChannel(channel)
 	CheckForbiddenStatus(t, resp)
@@ -145,7 +145,7 @@ func TestCreateChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 
@@ -174,7 +174,7 @@ func TestCreateChannel(t *testing.T) {
 	// Check that if unlicensed the policy restriction is not enforced.
 	utils.SetIsLicensed(false)
 	utils.SetLicense(nil)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel.Name = GenerateTestChannelName()
 	_, resp = Client.CreateChannel(channel)
@@ -895,14 +895,14 @@ func TestDeleteChannel(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client = th.Client
 	team = th.BasicTeam
@@ -929,7 +929,7 @@ func TestDeleteChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// channels created by SystemAdmin
 	publicChannel6 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
@@ -982,7 +982,7 @@ func TestDeleteChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.UpdateUserToNonTeamAdmin(user, team)
 	th.App.InvalidateAllCaches()
 	utils.SetIsLicensed(true)
@@ -1033,7 +1033,7 @@ func TestDeleteChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// channels created by SystemAdmin
 	publicChannel6 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
@@ -1828,7 +1828,7 @@ func TestAddChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
@@ -1847,13 +1847,13 @@ func TestAddChannelMember(t *testing.T) {
 	defer func() {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Check that a regular channel user can add other users.
 	Client.Login(user2.Username, user2.Password)
@@ -1874,7 +1874,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
@@ -1892,7 +1892,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user.Username, user.Password)
 	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
@@ -1906,7 +1906,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
@@ -1924,7 +1924,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user.Username, user.Password)
 	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
@@ -1938,7 +1938,7 @@ func TestAddChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Login(user2.Username, user2.Password)
 	privateChannel = th.CreatePrivateChannel()
@@ -2024,7 +2024,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	privateChannel := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
@@ -2041,13 +2041,13 @@ func TestRemoveChannelMember(t *testing.T) {
 	defer func() {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_ALL })
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Check that a regular channel user can remove other users.
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
@@ -2066,7 +2066,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
@@ -2093,7 +2093,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)
@@ -2120,7 +2120,7 @@ func TestRemoveChannelMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	privateChannel = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user1.Id)

--- a/api4/oauth_test.go
+++ b/api4/oauth_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestCreateOAuthApp(t *testing.T) {
@@ -26,7 +25,7 @@ func TestCreateOAuthApp(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{Name: GenerateTestAppName(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}, IsTrusted: true}
 
@@ -43,12 +42,12 @@ func TestCreateOAuthApp(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	_, resp = Client.CreateOAuthApp(oapp)
 	CheckForbiddenStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	rapp, resp = Client.CreateOAuthApp(oapp)
 	CheckNoError(t, resp)
 	CheckCreatedStatus(t, resp)
@@ -94,7 +93,7 @@ func TestUpdateOAuthApp(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{
 		Name:         "oapp",
@@ -166,7 +165,7 @@ func TestUpdateOAuthApp(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	_, resp = Client.UpdateOAuthApp(oapp)
 	CheckForbiddenStatus(t, resp)
 
@@ -201,7 +200,7 @@ func TestGetOAuthApps(t *testing.T) {
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{Name: GenerateTestAppName(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 
@@ -245,7 +244,7 @@ func TestGetOAuthApps(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.GetOAuthApps(0, 1000)
 	CheckForbiddenStatus(t, resp)
@@ -274,7 +273,7 @@ func TestGetOAuthApp(t *testing.T) {
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{Name: GenerateTestAppName(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 
@@ -314,7 +313,7 @@ func TestGetOAuthApp(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.GetOAuthApp(rapp2.Id)
 	CheckForbiddenStatus(t, resp)
@@ -349,7 +348,7 @@ func TestGetOAuthAppInfo(t *testing.T) {
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{Name: GenerateTestAppName(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 
@@ -389,7 +388,7 @@ func TestGetOAuthAppInfo(t *testing.T) {
 	CheckNoError(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.GetOAuthAppInfo(rapp2.Id)
 	CheckNoError(t, resp)
@@ -424,7 +423,7 @@ func TestDeleteOAuthApp(t *testing.T) {
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{Name: GenerateTestAppName(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 
@@ -459,7 +458,7 @@ func TestDeleteOAuthApp(t *testing.T) {
 	CheckNoError(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	_, resp = Client.DeleteOAuthApp(rapp.Id)
 	CheckForbiddenStatus(t, resp)
 
@@ -492,7 +491,7 @@ func TestRegenerateOAuthAppSecret(t *testing.T) {
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{Name: GenerateTestAppName(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 
@@ -531,7 +530,7 @@ func TestRegenerateOAuthAppSecret(t *testing.T) {
 	CheckNoError(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	_, resp = Client.RegenerateOAuthAppSecret(rapp.Id)
 	CheckForbiddenStatus(t, resp)
 
@@ -621,7 +620,7 @@ func TestAuthorizeOAuthApp(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = enableOAuth })
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	oapp := &model.OAuthApp{Name: GenerateTestAppName(), Homepage: "https://nowhere.com", Description: "test", CallbackUrls: []string{"https://nowhere.com"}}
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -136,14 +136,14 @@ func testCreatePostWithOutgoingHook(
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
 		})
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
 	})
@@ -323,7 +323,7 @@ func TestCreatePostPublic(t *testing.T) {
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "#hashtag a" + model.NewId() + "a"}
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_USER.Id}
+	user := model.User{Email: GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_USER_ROLE_ID}
 
 	ruser, resp := Client.CreateUser(&user)
 	CheckNoError(t, resp)
@@ -333,7 +333,7 @@ func TestCreatePostPublic(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckForbiddenStatus(t, resp)
 
-	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_POST_ALL_PUBLIC.Id, false)
+	th.App.UpdateUserRoles(ruser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_POST_ALL_PUBLIC_ROLE_ID, false)
 	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
@@ -345,9 +345,9 @@ func TestCreatePostPublic(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckForbiddenStatus(t, resp)
 
-	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id, false)
+	th.App.UpdateUserRoles(ruser.Id, model.SYSTEM_USER_ROLE_ID, false)
 	th.App.JoinUserToTeam(th.BasicTeam, ruser, "")
-	th.App.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.ROLE_TEAM_USER.Id+" "+model.ROLE_TEAM_POST_ALL_PUBLIC.Id)
+	th.App.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.TEAM_USER_ROLE_ID+" "+model.TEAM_POST_ALL_PUBLIC_ROLE_ID)
 	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
@@ -368,7 +368,7 @@ func TestCreatePostAll(t *testing.T) {
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "#hashtag a" + model.NewId() + "a"}
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_USER.Id}
+	user := model.User{Email: GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_USER_ROLE_ID}
 
 	directChannel, _ := th.App.CreateDirectChannel(th.BasicUser.Id, th.BasicUser2.Id)
 
@@ -380,7 +380,7 @@ func TestCreatePostAll(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckForbiddenStatus(t, resp)
 
-	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_POST_ALL.Id, false)
+	th.App.UpdateUserRoles(ruser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_POST_ALL_ROLE_ID, false)
 	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
@@ -396,9 +396,9 @@ func TestCreatePostAll(t *testing.T) {
 	_, resp = Client.CreatePost(post)
 	CheckNoError(t, resp)
 
-	th.App.UpdateUserRoles(ruser.Id, model.ROLE_SYSTEM_USER.Id, false)
+	th.App.UpdateUserRoles(ruser.Id, model.SYSTEM_USER_ROLE_ID, false)
 	th.App.JoinUserToTeam(th.BasicTeam, ruser, "")
-	th.App.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.ROLE_TEAM_USER.Id+" "+model.ROLE_TEAM_POST_ALL.Id)
+	th.App.UpdateTeamMemberRoles(th.BasicTeam.Id, ruser.Id, model.TEAM_USER_ROLE_ID+" "+model.TEAM_POST_ALL_ROLE_ID)
 	th.App.InvalidateAllCaches()
 
 	Client.Login(user.Email, user.Password)
@@ -496,14 +496,14 @@ func TestUpdatePost(t *testing.T) {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = allowEditPost })
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = model.ALLOW_EDIT_POST_ALWAYS })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	post := &model.Post{ChannelId: channel.Id, Message: "zz" + model.NewId() + "a"}
 	rpost, resp := Client.CreatePost(post)
@@ -581,14 +581,14 @@ func TestPatchPost(t *testing.T) {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = allowEditPost })
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = model.ALLOW_EDIT_POST_ALWAYS })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	post := &model.Post{
 		ChannelId:    channel.Id,

--- a/api4/team.go
+++ b/api4/team.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	l4g "github.com/alecthomas/log4go"
-	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -92,7 +91,7 @@ func getTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		app.SanitizeTeam(c.Session, team)
+		c.App.SanitizeTeam(c.Session, team)
 
 		w.Write([]byte(team.ToJson()))
 		return
@@ -114,7 +113,7 @@ func getTeamByName(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		app.SanitizeTeam(c.Session, team)
+		c.App.SanitizeTeam(c.Session, team)
 
 		w.Write([]byte(team.ToJson()))
 		return
@@ -148,7 +147,7 @@ func updateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.SanitizeTeam(c.Session, updatedTeam)
+	c.App.SanitizeTeam(c.Session, updatedTeam)
 
 	w.Write([]byte(updatedTeam.ToJson()))
 }
@@ -178,7 +177,7 @@ func patchTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.SanitizeTeam(c.Session, patchedTeam)
+	c.App.SanitizeTeam(c.Session, patchedTeam)
 
 	c.LogAudit("")
 	w.Write([]byte(patchedTeam.ToJson()))
@@ -225,7 +224,7 @@ func getTeamsForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	} else {
-		app.SanitizeTeams(c.Session, teams)
+		c.App.SanitizeTeams(c.Session, teams)
 
 		w.Write([]byte(model.TeamListToJson(teams)))
 	}
@@ -553,7 +552,7 @@ func getAllTeams(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.SanitizeTeams(c.Session, teams)
+	c.App.SanitizeTeams(c.Session, teams)
 
 	w.Write([]byte(model.TeamListToJson(teams)))
 }
@@ -584,7 +583,7 @@ func searchTeams(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.SanitizeTeams(c.Session, teams)
+	c.App.SanitizeTeams(c.Session, teams)
 
 	w.Write([]byte(model.TeamListToJson(teams)))
 }

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -71,10 +71,10 @@ func TestCreateTeam(t *testing.T) {
 	enableTeamCreation := th.App.Config().TeamSettings.EnableTeamCreation
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableTeamCreation = enableTeamCreation })
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableTeamCreation = false })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 	_, resp = Client.CreateTeam(team)
@@ -1297,12 +1297,12 @@ func TestAddTeamMember(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 
 	// Set the config so that only team admins can add a user to a team.
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Test without the EE license to see that the permission restriction is ignored.
@@ -1313,7 +1313,7 @@ func TestAddTeamMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Check that a regular user can't add someone to the team.
@@ -1327,7 +1327,7 @@ func TestAddTeamMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a team admin.
@@ -1336,7 +1336,7 @@ func TestAddTeamMember(t *testing.T) {
 
 	// Change permission level to System Admin
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Should not work as team admin.
 	_, resp = Client.AddTeamMember(team.Id, otherUser.Id)
@@ -1353,7 +1353,7 @@ func TestAddTeamMember(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a regular user.
@@ -1364,7 +1364,7 @@ func TestAddTeamMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
 	utils.SetIsLicensed(isLicensed)
 	utils.SetLicense(license)
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// by hash and data
@@ -1511,12 +1511,12 @@ func TestAddTeamMembers(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		utils.SetDefaultRolesBasedOnConfig()
+		th.App.SetDefaultRolesBasedOnConfig()
 	}()
 
 	// Set the config so that only team admins can add a user to a team.
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Test without the EE license to see that the permission restriction is ignored.
@@ -1527,7 +1527,7 @@ func TestAddTeamMembers(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Check that a regular user can't add someone to the team.
@@ -1541,7 +1541,7 @@ func TestAddTeamMembers(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a team admin.
@@ -1550,7 +1550,7 @@ func TestAddTeamMembers(t *testing.T) {
 
 	// Change permission level to System Admin
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Should not work as team admin.
 	_, resp = Client.AddTeamMembers(team.Id, userList)
@@ -1567,7 +1567,7 @@ func TestAddTeamMembers(t *testing.T) {
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})
 	utils.License().Features.SetDefaults()
-	utils.SetDefaultRolesBasedOnConfig()
+	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a regular user.

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -22,7 +22,7 @@ func TestCreateUser(t *testing.T) {
 	Client := th.Client
 	AdminClient := th.SystemAdminClient
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+	user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 	ruser, resp := Client.CreateUser(&user)
 	CheckNoError(t, resp)
@@ -34,7 +34,7 @@ func TestCreateUser(t *testing.T) {
 		t.Fatal("nickname didn't match")
 	}
 
-	if ruser.Roles != model.ROLE_SYSTEM_USER.Id {
+	if ruser.Roles != model.SYSTEM_USER_ROLE_ID {
 		t.Log(ruser.Roles)
 		t.Fatal("did not clear roles")
 	}
@@ -86,7 +86,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	Client := th.Client
 
 	t.Run("CreateWithHashHappyPath", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		props := make(map[string]string)
 		props["email"] = user.Email
 		props["id"] = th.BasicTeam.Id
@@ -104,7 +104,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		if ruser.Nickname != user.Nickname {
 			t.Fatal("nickname didn't match")
 		}
-		if ruser.Roles != model.ROLE_SYSTEM_USER.Id {
+		if ruser.Roles != model.SYSTEM_USER_ROLE_ID {
 			t.Log(ruser.Roles)
 			t.Fatal("did not clear roles")
 		}
@@ -112,7 +112,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("NoHashAndNoData", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		props := make(map[string]string)
 		props["email"] = user.Email
 		props["id"] = th.BasicTeam.Id
@@ -132,7 +132,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("HashExpired", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		timeNow := time.Now()
 		past49Hours := timeNow.Add(-49*time.Hour).UnixNano() / int64(time.Millisecond)
 
@@ -151,7 +151,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("WrongHash", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		props := make(map[string]string)
 		props["email"] = user.Email
 		props["id"] = th.BasicTeam.Id
@@ -167,7 +167,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("EnableUserCreationDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		props := make(map[string]string)
 		props["email"] = user.Email
@@ -188,7 +188,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		props := make(map[string]string)
 		props["email"] = user.Email
@@ -209,7 +209,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		if ruser.Nickname != user.Nickname {
 			t.Fatal("nickname didn't match")
 		}
-		if ruser.Roles != model.ROLE_SYSTEM_USER.Id {
+		if ruser.Roles != model.SYSTEM_USER_ROLE_ID {
 			t.Log(ruser.Roles)
 			t.Fatal("did not clear roles")
 		}
@@ -224,7 +224,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	AdminClient := th.SystemAdminClient
 
 	t.Run("CreateWithInviteIdHappyPath", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -236,7 +236,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		if ruser.Nickname != user.Nickname {
 			t.Fatal("nickname didn't match")
 		}
-		if ruser.Roles != model.ROLE_SYSTEM_USER.Id {
+		if ruser.Roles != model.SYSTEM_USER_ROLE_ID {
 			t.Log(ruser.Roles)
 			t.Fatal("did not clear roles")
 		}
@@ -244,7 +244,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("WrongInviteId", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		inviteId := model.NewId()
 
@@ -254,7 +254,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("NoInviteId", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		_, resp := Client.CreateUserWithInviteId(&user, "")
 		CheckBadRequestStatus(t, resp)
@@ -262,7 +262,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("ExpiredInviteId", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -276,7 +276,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("EnableUserCreationDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = false })
 
@@ -290,7 +290,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = false })
 
@@ -304,7 +304,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 		if ruser.Nickname != user.Nickname {
 			t.Fatal("nickname didn't match")
 		}
-		if ruser.Roles != model.ROLE_SYSTEM_USER.Id {
+		if ruser.Roles != model.SYSTEM_USER_ROLE_ID {
 			t.Log(ruser.Roles)
 			t.Fatal("did not clear roles")
 		}
@@ -923,7 +923,7 @@ func TestUpdateUser(t *testing.T) {
 	Client.Login(user.Email, user.Password)
 
 	user.Nickname = "Joram Wilander"
-	user.Roles = model.ROLE_SYSTEM_ADMIN.Id
+	user.Roles = model.SYSTEM_ADMIN_ROLE_ID
 	user.LastPasswordUpdate = 123
 
 	ruser, resp := Client.UpdateUser(user)
@@ -933,7 +933,7 @@ func TestUpdateUser(t *testing.T) {
 	if ruser.Nickname != "Joram Wilander" {
 		t.Fatal("Nickname did not update properly")
 	}
-	if ruser.Roles != model.ROLE_SYSTEM_USER.Id {
+	if ruser.Roles != model.SYSTEM_USER_ROLE_ID {
 		t.Fatal("Roles should not have updated")
 	}
 	if ruser.LastPasswordUpdate == 123 {
@@ -1101,22 +1101,22 @@ func TestUpdateUserRoles(t *testing.T) {
 	Client := th.Client
 	SystemAdminClient := th.SystemAdminClient
 
-	_, resp := Client.UpdateUserRoles(th.SystemAdminUser.Id, model.ROLE_SYSTEM_USER.Id)
+	_, resp := Client.UpdateUserRoles(th.SystemAdminUser.Id, model.SYSTEM_USER_ROLE_ID)
 	CheckForbiddenStatus(t, resp)
 
-	_, resp = SystemAdminClient.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id)
+	_, resp = SystemAdminClient.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID)
 	CheckNoError(t, resp)
 
-	_, resp = SystemAdminClient.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_ADMIN.Id)
+	_, resp = SystemAdminClient.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_ADMIN_ROLE_ID)
 	CheckNoError(t, resp)
 
 	_, resp = SystemAdminClient.UpdateUserRoles(th.BasicUser.Id, "junk")
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = SystemAdminClient.UpdateUserRoles("junk", model.ROLE_SYSTEM_USER.Id)
+	_, resp = SystemAdminClient.UpdateUserRoles("junk", model.SYSTEM_USER_ROLE_ID)
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = SystemAdminClient.UpdateUserRoles(model.NewId(), model.ROLE_SYSTEM_USER.Id)
+	_, resp = SystemAdminClient.UpdateUserRoles(model.NewId(), model.SYSTEM_USER_ROLE_ID)
 	CheckBadRequestStatus(t, resp)
 }
 
@@ -2000,7 +2000,7 @@ func TestVerifyUserEmail(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id}
+	user := model.User{Email: GenerateTestEmail(), Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 	ruser, resp := Client.CreateUser(&user)
 
@@ -2200,7 +2200,7 @@ func TestCreateUserAccessToken(t *testing.T) {
 	_, resp = Client.CreateUserAccessToken(th.BasicUser.Id, "")
 	CheckBadRequestStatus(t, resp)
 
-	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id, false)
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = false })
 	_, resp = Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
@@ -2278,7 +2278,7 @@ func TestGetUserAccessToken(t *testing.T) {
 	_, resp = Client.GetUserAccessToken(model.NewId())
 	CheckForbiddenStatus(t, resp)
 
-	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id, false)
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
 
@@ -2339,7 +2339,7 @@ func TestRevokeUserAccessToken(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id, false)
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
 
@@ -2385,7 +2385,7 @@ func TestDisableUserAccessToken(t *testing.T) {
 	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
 	*th.App.Config().ServiceSettings.EnableUserAccessTokens = true
 
-	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id, false)
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
 
@@ -2430,7 +2430,7 @@ func TestEnableUserAccessToken(t *testing.T) {
 	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
 	*th.App.Config().ServiceSettings.EnableUserAccessTokens = true
 
-	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id, false)
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
 
@@ -2472,7 +2472,7 @@ func TestUserAccessTokenInactiveUser(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id, false)
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
 
@@ -2495,7 +2495,7 @@ func TestUserAccessTokenDisableConfig(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
 
-	th.App.UpdateUserRoles(th.BasicUser.Id, model.ROLE_SYSTEM_USER.Id+" "+model.ROLE_SYSTEM_USER_ACCESS_TOKEN.Id, false)
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
 

--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestCreateIncomingWebhook(t *testing.T) {
@@ -21,7 +20,6 @@ func TestCreateIncomingWebhook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.IncomingWebhook{ChannelId: th.BasicChannel.Id}
 
@@ -54,7 +52,6 @@ func TestCreateIncomingWebhook(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.CreateIncomingWebhook(hook)
 	CheckNoError(t, resp)
@@ -71,7 +68,6 @@ func TestGetIncomingWebhooks(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.IncomingWebhook{ChannelId: th.BasicChannel.Id}
 	rhook, resp := th.SystemAdminClient.CreateIncomingWebhook(hook)
@@ -123,7 +119,6 @@ func TestGetIncomingWebhooks(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.GetIncomingWebhooksForTeam(th.BasicTeam.Id, 0, 1000, "")
 	CheckNoError(t, resp)
@@ -146,7 +141,6 @@ func TestGetIncomingWebhook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	var resp *model.Response
 	var rhook *model.IncomingWebhook
@@ -187,7 +181,6 @@ func TestDeleteIncomingWebhook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	var resp *model.Response
 	var rhook *model.IncomingWebhook
@@ -240,7 +233,6 @@ func TestCreateOutgoingWebhook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id, TeamId: th.BasicChannel.TeamId, CallbackURLs: []string{"http://nowhere.com"}}
 
@@ -269,7 +261,6 @@ func TestCreateOutgoingWebhook(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.CreateOutgoingWebhook(hook)
 	CheckNoError(t, resp)
@@ -286,7 +277,6 @@ func TestGetOutgoingWebhooks(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id, TeamId: th.BasicChannel.TeamId, CallbackURLs: []string{"http://nowhere.com"}}
 	rhook, resp := th.SystemAdminClient.CreateOutgoingWebhook(hook)
@@ -355,7 +345,6 @@ func TestGetOutgoingWebhooks(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	_, resp = Client.GetOutgoingWebhooksForTeam(th.BasicTeam.Id, 0, 1000, "")
 	CheckNoError(t, resp)
@@ -384,7 +373,6 @@ func TestGetOutgoingWebhook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id, TeamId: th.BasicChannel.TeamId, CallbackURLs: []string{"http://nowhere.com"}}
 
@@ -416,7 +404,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook1 := &model.IncomingWebhook{ChannelId: th.BasicChannel.Id}
 
@@ -503,7 +490,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 
 	t.Run("OnlyAdminIntegrationsDisabled", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-		utils.SetDefaultRolesBasedOnConfig()
 
 		t.Run("UpdateHookOfSameUser", func(t *testing.T) {
 			sameUserHook := &model.IncomingWebhook{ChannelId: th.BasicChannel.Id, UserId: th.BasicUser2.Id}
@@ -522,7 +508,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 	})
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	Client.Logout()
 	th.UpdateUserToTeamAdmin(th.BasicUser2, th.BasicTeam)
@@ -578,7 +563,6 @@ func TestRegenOutgoingHookToken(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id, TeamId: th.BasicChannel.TeamId, CallbackURLs: []string{"http://nowhere.com"}}
 	rhook, resp := th.SystemAdminClient.CreateOutgoingWebhook(hook)
@@ -612,7 +596,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	createdHook := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id, TeamId: th.BasicChannel.TeamId,
 		CallbackURLs: []string{"http://nowhere.com"}, TriggerWords: []string{"cats"}}
@@ -686,7 +669,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	})
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	utils.SetDefaultRolesBasedOnConfig()
 	hook2 := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id, TeamId: th.BasicChannel.TeamId,
 		CallbackURLs: []string{"http://nowhere.com"}, TriggerWords: []string{"rats2"}}
 
@@ -697,7 +679,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	Client.Logout()
 	th.UpdateUserToTeamAdmin(th.BasicUser2, th.BasicTeam)
@@ -772,7 +753,6 @@ func TestDeleteOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	var resp *model.Response
 	var rhook *model.OutgoingWebhook

--- a/app/app.go
+++ b/app/app.go
@@ -55,6 +55,8 @@ type App struct {
 
 	htmlTemplateWatcher *utils.HTMLTemplateWatcher
 	sessionCache        *utils.Cache
+	roles               map[string]*model.Role
+	configListenerId    string
 }
 
 var appCount = 0
@@ -85,6 +87,11 @@ func New(options ...Option) *App {
 	}
 	utils.LoadGlobalConfig(app.configFile)
 	utils.InitTranslations(utils.Cfg.LocalizationSettings)
+
+	app.configListenerId = utils.AddConfigListener(func(_, cfg *model.Config) {
+		app.SetDefaultRolesBasedOnConfig()
+	})
+	app.SetDefaultRolesBasedOnConfig()
 
 	l4g.Info(utils.T("api.server.new_server.init.info"))
 
@@ -137,6 +144,7 @@ func (a *App) Shutdown() {
 		a.htmlTemplateWatcher.Close()
 	}
 
+	utils.RemoveConfigListener(a.configListenerId)
 	l4g.Info(utils.T("api.server.stop_server.stopped.info"))
 }
 

--- a/app/authorization_test.go
+++ b/app/authorization_test.go
@@ -10,23 +10,26 @@ import (
 )
 
 func TestCheckIfRolesGrantPermission(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
 	cases := []struct {
 		roles        []string
 		permissionId string
 		shouldGrant  bool
 	}{
-		{[]string{model.ROLE_SYSTEM_ADMIN.Id}, model.ROLE_SYSTEM_ADMIN.Permissions[0], true},
-		{[]string{model.ROLE_SYSTEM_ADMIN.Id}, "non-existant-permission", false},
-		{[]string{model.ROLE_CHANNEL_USER.Id}, model.ROLE_CHANNEL_USER.Permissions[0], true},
-		{[]string{model.ROLE_CHANNEL_USER.Id}, model.PERMISSION_MANAGE_SYSTEM.Id, false},
-		{[]string{model.ROLE_SYSTEM_ADMIN.Id, model.ROLE_CHANNEL_USER.Id}, model.PERMISSION_MANAGE_SYSTEM.Id, true},
-		{[]string{model.ROLE_CHANNEL_USER.Id, model.ROLE_SYSTEM_ADMIN.Id}, model.PERMISSION_MANAGE_SYSTEM.Id, true},
-		{[]string{model.ROLE_TEAM_USER.Id, model.ROLE_TEAM_ADMIN.Id}, model.PERMISSION_MANAGE_SLASH_COMMANDS.Id, true},
-		{[]string{model.ROLE_TEAM_ADMIN.Id, model.ROLE_TEAM_USER.Id}, model.PERMISSION_MANAGE_SLASH_COMMANDS.Id, true},
+		{[]string{model.SYSTEM_ADMIN_ROLE_ID}, th.App.Role(model.SYSTEM_ADMIN_ROLE_ID).Permissions[0], true},
+		{[]string{model.SYSTEM_ADMIN_ROLE_ID}, "non-existant-permission", false},
+		{[]string{model.CHANNEL_USER_ROLE_ID}, th.App.Role(model.CHANNEL_USER_ROLE_ID).Permissions[0], true},
+		{[]string{model.CHANNEL_USER_ROLE_ID}, model.PERMISSION_MANAGE_SYSTEM.Id, false},
+		{[]string{model.SYSTEM_ADMIN_ROLE_ID, model.CHANNEL_USER_ROLE_ID}, model.PERMISSION_MANAGE_SYSTEM.Id, true},
+		{[]string{model.CHANNEL_USER_ROLE_ID, model.SYSTEM_ADMIN_ROLE_ID}, model.PERMISSION_MANAGE_SYSTEM.Id, true},
+		{[]string{model.TEAM_USER_ROLE_ID, model.TEAM_ADMIN_ROLE_ID}, model.PERMISSION_MANAGE_SLASH_COMMANDS.Id, true},
+		{[]string{model.TEAM_ADMIN_ROLE_ID, model.TEAM_USER_ROLE_ID}, model.PERMISSION_MANAGE_SLASH_COMMANDS.Id, true},
 	}
 
 	for testnum, testcase := range cases {
-		if CheckIfRolesGrantPermission(testcase.roles, testcase.permissionId) != testcase.shouldGrant {
+		if th.App.CheckIfRolesGrantPermission(testcase.roles, testcase.permissionId) != testcase.shouldGrant {
 			t.Fatal("Failed test case ", testnum)
 		}
 	}

--- a/app/channel.go
+++ b/app/channel.go
@@ -151,7 +151,7 @@ func (a *App) CreateChannel(channel *model.Channel, addMember bool) (*model.Chan
 			cm := &model.ChannelMember{
 				ChannelId:   sc.Id,
 				UserId:      channel.CreatorId,
-				Roles:       model.ROLE_CHANNEL_USER.Id + " " + model.ROLE_CHANNEL_ADMIN.Id,
+				Roles:       model.CHANNEL_USER_ROLE_ID + " " + model.CHANNEL_ADMIN_ROLE_ID,
 				NotifyProps: model.GetDefaultChannelNotifyProps(),
 			}
 
@@ -296,7 +296,7 @@ func (a *App) createGroupChannel(userIds []string, creatorId string) (*model.Cha
 				UserId:      user.Id,
 				ChannelId:   group.Id,
 				NotifyProps: model.GetDefaultChannelNotifyProps(),
-				Roles:       model.ROLE_CHANNEL_USER.Id,
+				Roles:       model.CHANNEL_USER_ROLE_ID,
 			}
 
 			if result := <-a.Srv.Store.Channel().SaveMember(cm); result.Err != nil {
@@ -514,7 +514,7 @@ func (a *App) addUserToChannel(user *model.User, channel *model.Channel, teamMem
 		ChannelId:   channel.Id,
 		UserId:      user.Id,
 		NotifyProps: model.GetDefaultChannelNotifyProps(),
-		Roles:       model.ROLE_CHANNEL_USER.Id,
+		Roles:       model.CHANNEL_USER_ROLE_ID,
 	}
 	if result := <-a.Srv.Store.Channel().SaveMember(newMember); result.Err != nil {
 		l4g.Error("Failed to add member user_id=%v channel_id=%v err=%v", user.Id, channel.Id, result.Err)

--- a/app/command_channel_header_test.go
+++ b/app/command_channel_header_test.go
@@ -15,7 +15,7 @@ func TestHeaderProviderDoCommand(t *testing.T) {
 	args := &model.CommandArgs{
 		T:         func(s string, args ...interface{}) string { return s },
 		ChannelId: th.BasicChannel.Id,
-		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.ROLE_TEAM_USER.Id}}},
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
 	}
 
 	for msg, expected := range map[string]string{

--- a/app/command_channel_rename_test.go
+++ b/app/command_channel_rename_test.go
@@ -15,7 +15,7 @@ func TestRenameProviderDoCommand(t *testing.T) {
 	args := &model.CommandArgs{
 		T:         func(s string, args ...interface{}) string { return s },
 		ChannelId: th.BasicChannel.Id,
-		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.ROLE_TEAM_USER.Id}}},
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
 	}
 
 	// Blank text is a success

--- a/app/import.go
+++ b/app/import.go
@@ -572,8 +572,8 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 		}
 	} else if len(user.Roles) == 0 {
 		// Set SYSTEM_USER roles on newly created users by default.
-		if user.Roles != model.ROLE_SYSTEM_USER.Id {
-			roles = model.ROLE_SYSTEM_USER.Id
+		if user.Roles != model.SYSTEM_USER_ROLE_ID {
+			roles = model.SYSTEM_USER_ROLE_ID
 			hasUserRolesChanged = true
 		}
 	}
@@ -769,7 +769,7 @@ func (a *App) ImportUserTeams(user *model.User, data *[]UserTeamImportData) *mod
 
 		var roles string
 		if tdata.Roles == nil {
-			roles = model.ROLE_TEAM_USER.Id
+			roles = model.TEAM_USER_ROLE_ID
 		} else {
 			roles = *tdata.Roles
 		}
@@ -809,7 +809,7 @@ func (a *App) ImportUserChannels(user *model.User, team *model.Team, teamMember 
 
 		var roles string
 		if cdata.Roles == nil {
-			roles = model.ROLE_CHANNEL_USER.Id
+			roles = model.CHANNEL_USER_ROLE_ID
 		} else {
 			roles = *cdata.Roles
 		}
@@ -1455,7 +1455,7 @@ func (a *App) OldImportPost(post *model.Post) {
 func (a *App) OldImportUser(team *model.Team, user *model.User) *model.User {
 	user.MakeNonNil()
 
-	user.Roles = model.ROLE_SYSTEM_USER.Id
+	user.Roles = model.SYSTEM_USER_ROLE_ID
 
 	if result := <-a.Srv.Store.User().Save(user); result.Err != nil {
 		l4g.Error(utils.T("api.import.import_user.saving.error"), result.Err)

--- a/app/oauth_test.go
+++ b/app/oauth_test.go
@@ -21,7 +21,7 @@ func TestOAuthRevokeAccessToken(t *testing.T) {
 	session.CreateAt = model.GetMillis()
 	session.UserId = model.NewId()
 	session.Token = model.NewId()
-	session.Roles = model.ROLE_SYSTEM_USER.Id
+	session.Roles = model.SYSTEM_USER_ROLE_ID
 	session.SetExpireInDays(1)
 
 	session, _ = th.App.CreateSession(session)
@@ -71,7 +71,7 @@ func TestOAuthDeleteApp(t *testing.T) {
 	session.CreateAt = model.GetMillis()
 	session.UserId = model.NewId()
 	session.Token = model.NewId()
-	session.Roles = model.ROLE_SYSTEM_USER.Id
+	session.Roles = model.SYSTEM_USER_ROLE_ID
 	session.IsOAuth = true
 	session.SetExpireInDays(1)
 

--- a/app/post.go
+++ b/app/post.go
@@ -122,7 +122,7 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 	if utils.IsLicensed() && *a.Config().TeamSettings.ExperimentalTownSquareIsReadOnly &&
 		!post.IsSystemMessage() &&
 		channel.Name == model.DEFAULT_CHANNEL &&
-		!CheckIfRolesGrantPermission(user.GetRoles(), model.PERMISSION_MANAGE_SYSTEM.Id) {
+		!a.CheckIfRolesGrantPermission(user.GetRoles(), model.PERMISSION_MANAGE_SYSTEM.Id) {
 		return nil, model.NewAppError("createPost", "api.post.create_post.town_square_read_only", nil, "", http.StatusForbidden)
 	}
 

--- a/app/role.go
+++ b/app/role.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/utils"
+)
+
+func (a *App) Role(id string) *model.Role {
+	return a.roles[id]
+}
+
+// Updates the roles based on the app config and the global license check. You may need to invoke
+// this when license changes are made.
+func (a *App) SetDefaultRolesBasedOnConfig() {
+	a.roles = utils.DefaultRolesBasedOnConfig(a.Config())
+}

--- a/app/team.go
+++ b/app/team.go
@@ -281,11 +281,11 @@ func (a *App) joinUserToTeam(team *model.Team, user *model.User) (*model.TeamMem
 	tm := &model.TeamMember{
 		TeamId: team.Id,
 		UserId: user.Id,
-		Roles:  model.ROLE_TEAM_USER.Id,
+		Roles:  model.TEAM_USER_ROLE_ID,
 	}
 
 	if team.Email == user.Email {
-		tm.Roles = model.ROLE_TEAM_USER.Id + " " + model.ROLE_TEAM_ADMIN.Id
+		tm.Roles = model.TEAM_USER_ROLE_ID + " " + model.TEAM_ADMIN_ROLE_ID
 	}
 
 	if etmr := <-a.Srv.Store.Team().GetMember(team.Id, user.Id); etmr.Err == nil {
@@ -323,10 +323,10 @@ func (a *App) JoinUserToTeam(team *model.Team, user *model.User, userRequestorId
 		return uua.Err
 	}
 
-	channelRole := model.ROLE_CHANNEL_USER.Id
+	channelRole := model.CHANNEL_USER_ROLE_ID
 
 	if team.Email == user.Email {
-		channelRole = model.ROLE_CHANNEL_USER.Id + " " + model.ROLE_CHANNEL_ADMIN.Id
+		channelRole = model.CHANNEL_USER_ROLE_ID + " " + model.CHANNEL_ADMIN_ROLE_ID
 	}
 
 	// Soft error if there is an issue joining the default channels
@@ -869,17 +869,17 @@ func (a *App) GetTeamIdFromQuery(query url.Values) (string, *model.AppError) {
 	return "", nil
 }
 
-func SanitizeTeam(session model.Session, team *model.Team) *model.Team {
-	if !SessionHasPermissionToTeam(session, team.Id, model.PERMISSION_MANAGE_TEAM) {
+func (a *App) SanitizeTeam(session model.Session, team *model.Team) *model.Team {
+	if !a.SessionHasPermissionToTeam(session, team.Id, model.PERMISSION_MANAGE_TEAM) {
 		team.Sanitize()
 	}
 
 	return team
 }
 
-func SanitizeTeams(session model.Session, teams []*model.Team) []*model.Team {
+func (a *App) SanitizeTeams(session model.Session, teams []*model.Team) []*model.Team {
 	for _, team := range teams {
-		SanitizeTeam(session, team)
+		a.SanitizeTeam(session, team)
 	}
 
 	return teams

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -198,17 +198,17 @@ func TestSanitizeTeam(t *testing.T) {
 	t.Run("not a user of the team", func(t *testing.T) {
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: model.NewId(),
-					Roles:  model.ROLE_TEAM_USER.Id,
+					Roles:  model.TEAM_USER_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeam(session, copyTeam())
+		sanitized := th.App.SanitizeTeam(session, copyTeam())
 		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
 			t.Fatal("should've sanitized team")
 		}
@@ -217,17 +217,17 @@ func TestSanitizeTeam(t *testing.T) {
 	t.Run("user of the team", func(t *testing.T) {
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: team.Id,
-					Roles:  model.ROLE_TEAM_USER.Id,
+					Roles:  model.TEAM_USER_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeam(session, copyTeam())
+		sanitized := th.App.SanitizeTeam(session, copyTeam())
 		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
 			t.Fatal("should've sanitized team")
 		}
@@ -236,17 +236,17 @@ func TestSanitizeTeam(t *testing.T) {
 	t.Run("team admin", func(t *testing.T) {
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: team.Id,
-					Roles:  model.ROLE_TEAM_USER.Id + " " + model.ROLE_TEAM_ADMIN.Id,
+					Roles:  model.TEAM_USER_ROLE_ID + " " + model.TEAM_ADMIN_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeam(session, copyTeam())
+		sanitized := th.App.SanitizeTeam(session, copyTeam())
 		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
@@ -255,17 +255,17 @@ func TestSanitizeTeam(t *testing.T) {
 	t.Run("team admin of another team", func(t *testing.T) {
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: model.NewId(),
-					Roles:  model.ROLE_TEAM_USER.Id + " " + model.ROLE_TEAM_ADMIN.Id,
+					Roles:  model.TEAM_USER_ROLE_ID + " " + model.TEAM_ADMIN_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeam(session, copyTeam())
+		sanitized := th.App.SanitizeTeam(session, copyTeam())
 		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
 			t.Fatal("should've sanitized team")
 		}
@@ -274,17 +274,17 @@ func TestSanitizeTeam(t *testing.T) {
 	t.Run("system admin, not a user of team", func(t *testing.T) {
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id + " " + model.ROLE_SYSTEM_ADMIN.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: model.NewId(),
-					Roles:  model.ROLE_TEAM_USER.Id,
+					Roles:  model.TEAM_USER_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeam(session, copyTeam())
+		sanitized := th.App.SanitizeTeam(session, copyTeam())
 		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
@@ -293,17 +293,17 @@ func TestSanitizeTeam(t *testing.T) {
 	t.Run("system admin, user of team", func(t *testing.T) {
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id + " " + model.ROLE_SYSTEM_ADMIN.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: team.Id,
-					Roles:  model.ROLE_TEAM_USER.Id,
+					Roles:  model.TEAM_USER_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeam(session, copyTeam())
+		sanitized := th.App.SanitizeTeam(session, copyTeam())
 		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
@@ -330,22 +330,22 @@ func TestSanitizeTeams(t *testing.T) {
 
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: teams[0].Id,
-					Roles:  model.ROLE_TEAM_USER.Id,
+					Roles:  model.TEAM_USER_ROLE_ID,
 				},
 				{
 					UserId: userId,
 					TeamId: teams[1].Id,
-					Roles:  model.ROLE_TEAM_USER.Id + " " + model.ROLE_TEAM_ADMIN.Id,
+					Roles:  model.TEAM_USER_ROLE_ID + " " + model.TEAM_ADMIN_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeams(session, teams)
+		sanitized := th.App.SanitizeTeams(session, teams)
 
 		if sanitized[0].Email != "" && sanitized[0].AllowedDomains != "" {
 			t.Fatal("should've sanitized first team")
@@ -372,17 +372,17 @@ func TestSanitizeTeams(t *testing.T) {
 
 		userId := model.NewId()
 		session := model.Session{
-			Roles: model.ROLE_SYSTEM_USER.Id + " " + model.ROLE_SYSTEM_ADMIN.Id,
+			Roles: model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID,
 			TeamMembers: []*model.TeamMember{
 				{
 					UserId: userId,
 					TeamId: teams[0].Id,
-					Roles:  model.ROLE_TEAM_USER.Id,
+					Roles:  model.TEAM_USER_ROLE_ID,
 				},
 			},
 		}
 
-		sanitized := SanitizeTeams(session, teams)
+		sanitized := th.App.SanitizeTeams(session, teams)
 
 		if sanitized[0].Email == "" && sanitized[0].AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized first team")

--- a/app/user.go
+++ b/app/user.go
@@ -179,7 +179,7 @@ func (a *App) CreateUser(user *model.User) (*model.User, *model.AppError) {
 		return nil, model.NewAppError("CreateUser", "api.user.create_user.accepted_domain.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	user.Roles = model.ROLE_SYSTEM_USER.Id
+	user.Roles = model.SYSTEM_USER_ROLE_ID
 
 	// Below is a special case where the first user in the entire
 	// system is granted the system_admin role
@@ -188,7 +188,7 @@ func (a *App) CreateUser(user *model.User) (*model.User, *model.AppError) {
 	} else {
 		count := result.Data.(int64)
 		if count <= 0 {
-			user.Roles = model.ROLE_SYSTEM_ADMIN.Id + " " + model.ROLE_SYSTEM_USER.Id
+			user.Roles = model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID
 		}
 	}
 
@@ -1235,7 +1235,7 @@ func (a *App) UpdateUserRoles(userId string, newRoles string, sendWebSocketEvent
 
 func (a *App) PermanentDeleteUser(user *model.User) *model.AppError {
 	l4g.Warn(utils.T("api.user.permanent_delete_user.attempting.warn"), user.Email, user.Id)
-	if user.IsInRole(model.ROLE_SYSTEM_ADMIN.Id) {
+	if user.IsInRole(model.SYSTEM_ADMIN_ROLE_ID) {
 		l4g.Warn(utils.T("api.user.permanent_delete_user.system_admin.warn"), user.Email)
 	}
 

--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestCreateWebhookPost(t *testing.T) {
@@ -19,12 +18,8 @@ func TestCreateWebhookPost(t *testing.T) {
 	defer th.TearDown()
 
 	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-		utils.SetDefaultRolesBasedOnConfig()
-	}()
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
-	utils.SetDefaultRolesBasedOnConfig()
 
 	hook, err := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{ChannelId: th.BasicChannel.Id})
 	if err != nil {

--- a/cmd/platform/test.go
+++ b/cmd/platform/test.go
@@ -91,7 +91,6 @@ func setupClientTests(cfg *model.Config) {
 	*cfg.ServiceSettings.EnableCustomEmoji = true
 	cfg.ServiceSettings.EnableIncomingWebhooks = false
 	cfg.ServiceSettings.EnableOutgoingWebhooks = false
-	utils.SetDefaultRolesBasedOnConfig()
 }
 
 func executeTestCommand(cmd *exec.Cmd) {

--- a/model/authorization.go
+++ b/model/authorization.go
@@ -69,24 +69,24 @@ var PERMISSION_REVOKE_USER_ACCESS_TOKEN *Permission
 // admin functions but not others
 var PERMISSION_MANAGE_SYSTEM *Permission
 
-var ROLE_SYSTEM_USER *Role
-var ROLE_SYSTEM_ADMIN *Role
-var ROLE_SYSTEM_POST_ALL *Role
-var ROLE_SYSTEM_POST_ALL_PUBLIC *Role
-var ROLE_SYSTEM_USER_ACCESS_TOKEN *Role
+const (
+	SYSTEM_USER_ROLE_ID              = "system_user"
+	SYSTEM_ADMIN_ROLE_ID             = "system_admin"
+	SYSTEM_POST_ALL_ROLE_ID          = "system_post_all"
+	SYSTEM_POST_ALL_PUBLIC_ROLE_ID   = "system_post_all_public"
+	SYSTEM_USER_ACCESS_TOKEN_ROLE_ID = "system_user_access_token"
 
-var ROLE_TEAM_USER *Role
-var ROLE_TEAM_ADMIN *Role
-var ROLE_TEAM_POST_ALL *Role
-var ROLE_TEAM_POST_ALL_PUBLIC *Role
+	TEAM_USER_ROLE_ID            = "team_user"
+	TEAM_ADMIN_ROLE_ID           = "team_admin"
+	TEAM_POST_ALL_ROLE_ID        = "team_post_all"
+	TEAM_POST_ALL_PUBLIC_ROLE_ID = "team_post_all_public"
 
-var ROLE_CHANNEL_USER *Role
-var ROLE_CHANNEL_ADMIN *Role
-var ROLE_CHANNEL_GUEST *Role
+	CHANNEL_USER_ROLE_ID  = "channel_user"
+	CHANNEL_ADMIN_ROLE_ID = "channel_admin"
+	CHANNEL_GUEST_ROLE_ID = "guest"
+)
 
-var BuiltInRoles map[string]*Role
-
-func InitalizePermissions() {
+func initializePermissions() {
 	PERMISSION_INVITE_USER = &Permission{
 		"invite_user",
 		"authentication.permissions.team_invite_user.name",
@@ -329,11 +329,12 @@ func InitalizePermissions() {
 	}
 }
 
-func InitalizeRoles() {
-	InitalizePermissions()
-	BuiltInRoles = make(map[string]*Role)
+var DefaultRoles map[string]*Role
 
-	ROLE_CHANNEL_USER = &Role{
+func initializeDefaultRoles() {
+	DefaultRoles = make(map[string]*Role)
+
+	DefaultRoles[CHANNEL_USER_ROLE_ID] = &Role{
 		"channel_user",
 		"authentication.roles.channel_user.name",
 		"authentication.roles.channel_user.description",
@@ -347,8 +348,8 @@ func InitalizeRoles() {
 			PERMISSION_USE_SLASH_COMMANDS.Id,
 		},
 	}
-	BuiltInRoles[ROLE_CHANNEL_USER.Id] = ROLE_CHANNEL_USER
-	ROLE_CHANNEL_ADMIN = &Role{
+
+	DefaultRoles[CHANNEL_ADMIN_ROLE_ID] = &Role{
 		"channel_admin",
 		"authentication.roles.channel_admin.name",
 		"authentication.roles.channel_admin.description",
@@ -356,16 +357,15 @@ func InitalizeRoles() {
 			PERMISSION_MANAGE_CHANNEL_ROLES.Id,
 		},
 	}
-	BuiltInRoles[ROLE_CHANNEL_ADMIN.Id] = ROLE_CHANNEL_ADMIN
-	ROLE_CHANNEL_GUEST = &Role{
+
+	DefaultRoles[CHANNEL_GUEST_ROLE_ID] = &Role{
 		"guest",
 		"authentication.roles.global_guest.name",
 		"authentication.roles.global_guest.description",
 		[]string{},
 	}
-	BuiltInRoles[ROLE_CHANNEL_GUEST.Id] = ROLE_CHANNEL_GUEST
 
-	ROLE_TEAM_USER = &Role{
+	DefaultRoles[TEAM_USER_ROLE_ID] = &Role{
 		"team_user",
 		"authentication.roles.team_user.name",
 		"authentication.roles.team_user.description",
@@ -376,9 +376,8 @@ func InitalizeRoles() {
 			PERMISSION_VIEW_TEAM.Id,
 		},
 	}
-	BuiltInRoles[ROLE_TEAM_USER.Id] = ROLE_TEAM_USER
 
-	ROLE_TEAM_POST_ALL = &Role{
+	DefaultRoles[TEAM_POST_ALL_ROLE_ID] = &Role{
 		"team_post_all",
 		"authentication.roles.team_post_all.name",
 		"authentication.roles.team_post_all.description",
@@ -386,9 +385,8 @@ func InitalizeRoles() {
 			PERMISSION_CREATE_POST.Id,
 		},
 	}
-	BuiltInRoles[ROLE_TEAM_POST_ALL.Id] = ROLE_TEAM_POST_ALL
 
-	ROLE_TEAM_POST_ALL_PUBLIC = &Role{
+	DefaultRoles[TEAM_POST_ALL_PUBLIC_ROLE_ID] = &Role{
 		"team_post_all_public",
 		"authentication.roles.team_post_all_public.name",
 		"authentication.roles.team_post_all_public.description",
@@ -396,9 +394,8 @@ func InitalizeRoles() {
 			PERMISSION_CREATE_POST_PUBLIC.Id,
 		},
 	}
-	BuiltInRoles[ROLE_TEAM_POST_ALL_PUBLIC.Id] = ROLE_TEAM_POST_ALL_PUBLIC
 
-	ROLE_TEAM_ADMIN = &Role{
+	DefaultRoles[TEAM_ADMIN_ROLE_ID] = &Role{
 		"team_admin",
 		"authentication.roles.team_admin.name",
 		"authentication.roles.team_admin.description",
@@ -415,9 +412,8 @@ func InitalizeRoles() {
 			PERMISSION_MANAGE_WEBHOOKS.Id,
 		},
 	}
-	BuiltInRoles[ROLE_TEAM_ADMIN.Id] = ROLE_TEAM_ADMIN
 
-	ROLE_SYSTEM_USER = &Role{
+	DefaultRoles[SYSTEM_USER_ROLE_ID] = &Role{
 		"system_user",
 		"authentication.roles.global_user.name",
 		"authentication.roles.global_user.description",
@@ -427,9 +423,8 @@ func InitalizeRoles() {
 			PERMISSION_PERMANENT_DELETE_USER.Id,
 		},
 	}
-	BuiltInRoles[ROLE_SYSTEM_USER.Id] = ROLE_SYSTEM_USER
 
-	ROLE_SYSTEM_POST_ALL = &Role{
+	DefaultRoles[SYSTEM_POST_ALL_ROLE_ID] = &Role{
 		"system_post_all",
 		"authentication.roles.system_post_all.name",
 		"authentication.roles.system_post_all.description",
@@ -437,9 +432,8 @@ func InitalizeRoles() {
 			PERMISSION_CREATE_POST.Id,
 		},
 	}
-	BuiltInRoles[ROLE_SYSTEM_POST_ALL.Id] = ROLE_SYSTEM_POST_ALL
 
-	ROLE_SYSTEM_POST_ALL_PUBLIC = &Role{
+	DefaultRoles[SYSTEM_POST_ALL_PUBLIC_ROLE_ID] = &Role{
 		"system_post_all_public",
 		"authentication.roles.system_post_all_public.name",
 		"authentication.roles.system_post_all_public.description",
@@ -447,9 +441,8 @@ func InitalizeRoles() {
 			PERMISSION_CREATE_POST_PUBLIC.Id,
 		},
 	}
-	BuiltInRoles[ROLE_SYSTEM_POST_ALL_PUBLIC.Id] = ROLE_SYSTEM_POST_ALL_PUBLIC
 
-	ROLE_SYSTEM_USER_ACCESS_TOKEN = &Role{
+	DefaultRoles[SYSTEM_USER_ACCESS_TOKEN_ROLE_ID] = &Role{
 		"system_user_access_token",
 		"authentication.roles.system_user_access_token.name",
 		"authentication.roles.system_user_access_token.description",
@@ -459,9 +452,8 @@ func InitalizeRoles() {
 			PERMISSION_REVOKE_USER_ACCESS_TOKEN.Id,
 		},
 	}
-	BuiltInRoles[ROLE_SYSTEM_USER_ACCESS_TOKEN.Id] = ROLE_SYSTEM_USER_ACCESS_TOKEN
 
-	ROLE_SYSTEM_ADMIN = &Role{
+	DefaultRoles[SYSTEM_ADMIN_ROLE_ID] = &Role{
 		"system_admin",
 		"authentication.roles.global_admin.name",
 		"authentication.roles.global_admin.description",
@@ -500,17 +492,15 @@ func InitalizeRoles() {
 							PERMISSION_READ_USER_ACCESS_TOKEN.Id,
 							PERMISSION_REVOKE_USER_ACCESS_TOKEN.Id,
 						},
-						ROLE_TEAM_USER.Permissions...,
+						DefaultRoles[TEAM_USER_ROLE_ID].Permissions...,
 					),
-					ROLE_CHANNEL_USER.Permissions...,
+					DefaultRoles[CHANNEL_USER_ROLE_ID].Permissions...,
 				),
-				ROLE_TEAM_ADMIN.Permissions...,
+				DefaultRoles[TEAM_ADMIN_ROLE_ID].Permissions...,
 			),
-			ROLE_CHANNEL_ADMIN.Permissions...,
+			DefaultRoles[CHANNEL_ADMIN_ROLE_ID].Permissions...,
 		),
 	}
-	BuiltInRoles[ROLE_SYSTEM_ADMIN.Id] = ROLE_SYSTEM_ADMIN
-
 }
 
 func RoleIdsToString(roles []string) string {
@@ -527,5 +517,6 @@ func RoleIdsToString(roles []string) string {
 }
 
 func init() {
-	InitalizeRoles()
+	initializePermissions()
+	initializeDefaultRoles()
 }

--- a/model/user.go
+++ b/model/user.go
@@ -434,7 +434,7 @@ func IsValidUserRoles(userRoles string) bool {
 }
 
 func isValidRole(roleId string) bool {
-	_, ok := BuiltInRoles[roleId]
+	_, ok := DefaultRoles[roleId]
 	return ok
 }
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -129,12 +129,12 @@ func (s SqlChannelStore) CreateDirectChannel(userId string, otherUserId string) 
 	cm1 := &model.ChannelMember{
 		UserId:      userId,
 		NotifyProps: model.GetDefaultChannelNotifyProps(),
-		Roles:       model.ROLE_CHANNEL_USER.Id,
+		Roles:       model.CHANNEL_USER_ROLE_ID,
 	}
 	cm2 := &model.ChannelMember{
 		UserId:      otherUserId,
 		NotifyProps: model.GetDefaultChannelNotifyProps(),
-		Roles:       model.ROLE_CHANNEL_USER.Id,
+		Roles:       model.CHANNEL_USER_ROLE_ID,
 	}
 
 	return s.SaveDirectChannel(channel, cm1, cm2)

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -914,7 +914,7 @@ func testUserStoreGetSystemAdminProfiles(t *testing.T, ss store.Store) {
 
 	u1 := &model.User{}
 	u1.Email = model.NewId()
-	u1.Roles = model.ROLE_SYSTEM_USER.Id + " " + model.ROLE_SYSTEM_ADMIN.Id
+	u1.Roles = model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -7,271 +7,277 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func SetDefaultRolesBasedOnConfig() {
-	// Reset the roles to default to make this logic easier
-	model.InitalizeRoles()
+func DefaultRolesBasedOnConfig(cfg *model.Config) map[string]*model.Role {
+	roles := make(map[string]*model.Role)
+	for id, role := range model.DefaultRoles {
+		copy := &model.Role{}
+		*copy = *role
+		roles[id] = copy
+	}
 
 	if IsLicensed() {
-		switch *Cfg.TeamSettings.RestrictPublicChannelCreation {
+		switch *cfg.TeamSettings.RestrictPublicChannelCreation {
 		case model.PERMISSIONS_ALL:
-			model.ROLE_TEAM_USER.Permissions = append(
-				model.ROLE_TEAM_USER.Permissions,
+			roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+				roles[model.TEAM_USER_ROLE_ID].Permissions,
 				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 			)
 		case model.PERMISSIONS_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 			)
 		}
 	} else {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_CREATE_PUBLIC_CHANNEL.Id,
 		)
 	}
 
 	if IsLicensed() {
-		switch *Cfg.TeamSettings.RestrictPublicChannelManagement {
+		switch *cfg.TeamSettings.RestrictPublicChannelManagement {
 		case model.PERMISSIONS_ALL:
-			model.ROLE_TEAM_USER.Permissions = append(
-				model.ROLE_TEAM_USER.Permissions,
+			roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+				roles[model.TEAM_USER_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 			)
 		case model.PERMISSIONS_CHANNEL_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 			)
-			model.ROLE_CHANNEL_ADMIN.Permissions = append(
-				model.ROLE_CHANNEL_ADMIN.Permissions,
+			roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 			)
 		case model.PERMISSIONS_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 			)
 		}
 	} else {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES.Id,
 		)
 	}
 
 	if IsLicensed() {
-		switch *Cfg.TeamSettings.RestrictPublicChannelDeletion {
+		switch *cfg.TeamSettings.RestrictPublicChannelDeletion {
 		case model.PERMISSIONS_ALL:
-			model.ROLE_TEAM_USER.Permissions = append(
-				model.ROLE_TEAM_USER.Permissions,
+			roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+				roles[model.TEAM_USER_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			)
 		case model.PERMISSIONS_CHANNEL_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			)
-			model.ROLE_CHANNEL_ADMIN.Permissions = append(
-				model.ROLE_CHANNEL_ADMIN.Permissions,
+			roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			)
 		case model.PERMISSIONS_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 			)
 		}
 	} else {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_DELETE_PUBLIC_CHANNEL.Id,
 		)
 	}
 
 	if IsLicensed() {
-		switch *Cfg.TeamSettings.RestrictPrivateChannelCreation {
+		switch *cfg.TeamSettings.RestrictPrivateChannelCreation {
 		case model.PERMISSIONS_ALL:
-			model.ROLE_TEAM_USER.Permissions = append(
-				model.ROLE_TEAM_USER.Permissions,
+			roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+				roles[model.TEAM_USER_ROLE_ID].Permissions,
 				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 			)
 		case model.PERMISSIONS_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 			)
 		}
 	} else {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_CREATE_PRIVATE_CHANNEL.Id,
 		)
 	}
 
 	if IsLicensed() {
-		switch *Cfg.TeamSettings.RestrictPrivateChannelManagement {
+		switch *cfg.TeamSettings.RestrictPrivateChannelManagement {
 		case model.PERMISSIONS_ALL:
-			model.ROLE_TEAM_USER.Permissions = append(
-				model.ROLE_TEAM_USER.Permissions,
+			roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+				roles[model.TEAM_USER_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 			)
 		case model.PERMISSIONS_CHANNEL_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 			)
-			model.ROLE_CHANNEL_ADMIN.Permissions = append(
-				model.ROLE_CHANNEL_ADMIN.Permissions,
+			roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 			)
 		case model.PERMISSIONS_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 			)
 		}
 	} else {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES.Id,
 		)
 	}
 
 	if IsLicensed() {
-		switch *Cfg.TeamSettings.RestrictPrivateChannelDeletion {
+		switch *cfg.TeamSettings.RestrictPrivateChannelDeletion {
 		case model.PERMISSIONS_ALL:
-			model.ROLE_TEAM_USER.Permissions = append(
-				model.ROLE_TEAM_USER.Permissions,
+			roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+				roles[model.TEAM_USER_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 			)
 		case model.PERMISSIONS_CHANNEL_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 			)
-			model.ROLE_CHANNEL_ADMIN.Permissions = append(
-				model.ROLE_CHANNEL_ADMIN.Permissions,
+			roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 			)
 		case model.PERMISSIONS_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 			)
 		}
 	} else {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id,
 		)
 	}
 
 	// Restrict permissions for Private Channel Manage Members
 	if IsLicensed() {
-		switch *Cfg.TeamSettings.RestrictPrivateChannelManageMembers {
+		switch *cfg.TeamSettings.RestrictPrivateChannelManageMembers {
 		case model.PERMISSIONS_ALL:
-			model.ROLE_CHANNEL_USER.Permissions = append(
-				model.ROLE_CHANNEL_USER.Permissions,
+			roles[model.CHANNEL_USER_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_USER_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 			)
 		case model.PERMISSIONS_CHANNEL_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 			)
-			model.ROLE_CHANNEL_ADMIN.Permissions = append(
-				model.ROLE_CHANNEL_ADMIN.Permissions,
+			roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 			)
 		case model.PERMISSIONS_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 			)
 		}
 	} else {
-		model.ROLE_CHANNEL_USER.Permissions = append(
-			model.ROLE_CHANNEL_USER.Permissions,
+		roles[model.CHANNEL_USER_ROLE_ID].Permissions = append(
+			roles[model.CHANNEL_USER_ROLE_ID].Permissions,
 			model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id,
 		)
 	}
 
-	if !*Cfg.ServiceSettings.EnableOnlyAdminIntegrations {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+	if !*cfg.ServiceSettings.EnableOnlyAdminIntegrations {
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_MANAGE_WEBHOOKS.Id,
 			model.PERMISSION_MANAGE_SLASH_COMMANDS.Id,
 		)
-		model.ROLE_SYSTEM_USER.Permissions = append(
-			model.ROLE_SYSTEM_USER.Permissions,
+		roles[model.SYSTEM_USER_ROLE_ID].Permissions = append(
+			roles[model.SYSTEM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_MANAGE_OAUTH.Id,
 		)
 	}
 
 	// Grant permissions for inviting and adding users to a team.
 	if IsLicensed() {
-		if *Cfg.TeamSettings.RestrictTeamInvite == model.PERMISSIONS_TEAM_ADMIN {
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+		if *cfg.TeamSettings.RestrictTeamInvite == model.PERMISSIONS_TEAM_ADMIN {
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_INVITE_USER.Id,
 				model.PERMISSION_ADD_USER_TO_TEAM.Id,
 			)
-		} else if *Cfg.TeamSettings.RestrictTeamInvite == model.PERMISSIONS_ALL {
-			model.ROLE_SYSTEM_USER.Permissions = append(
-				model.ROLE_SYSTEM_USER.Permissions,
+		} else if *cfg.TeamSettings.RestrictTeamInvite == model.PERMISSIONS_ALL {
+			roles[model.SYSTEM_USER_ROLE_ID].Permissions = append(
+				roles[model.SYSTEM_USER_ROLE_ID].Permissions,
 				model.PERMISSION_INVITE_USER.Id,
 				model.PERMISSION_ADD_USER_TO_TEAM.Id,
 			)
 		}
 	} else {
-		model.ROLE_TEAM_USER.Permissions = append(
-			model.ROLE_TEAM_USER.Permissions,
+		roles[model.TEAM_USER_ROLE_ID].Permissions = append(
+			roles[model.TEAM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_INVITE_USER.Id,
 			model.PERMISSION_ADD_USER_TO_TEAM.Id,
 		)
 	}
 
 	if IsLicensed() {
-		switch *Cfg.ServiceSettings.RestrictPostDelete {
+		switch *cfg.ServiceSettings.RestrictPostDelete {
 		case model.PERMISSIONS_DELETE_POST_ALL:
-			model.ROLE_CHANNEL_USER.Permissions = append(
-				model.ROLE_CHANNEL_USER.Permissions,
+			roles[model.CHANNEL_USER_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_USER_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_POST.Id,
 			)
-			model.ROLE_CHANNEL_ADMIN.Permissions = append(
-				model.ROLE_CHANNEL_ADMIN.Permissions,
+			roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.CHANNEL_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_POST.Id,
 				model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 			)
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_POST.Id,
 				model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 			)
 		case model.PERMISSIONS_DELETE_POST_TEAM_ADMIN:
-			model.ROLE_TEAM_ADMIN.Permissions = append(
-				model.ROLE_TEAM_ADMIN.Permissions,
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+				roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 				model.PERMISSION_DELETE_POST.Id,
 				model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 			)
 		}
 	} else {
-		model.ROLE_CHANNEL_USER.Permissions = append(
-			model.ROLE_CHANNEL_USER.Permissions,
+		roles[model.CHANNEL_USER_ROLE_ID].Permissions = append(
+			roles[model.CHANNEL_USER_ROLE_ID].Permissions,
 			model.PERMISSION_DELETE_POST.Id,
 		)
-		model.ROLE_TEAM_ADMIN.Permissions = append(
-			model.ROLE_TEAM_ADMIN.Permissions,
+		roles[model.TEAM_ADMIN_ROLE_ID].Permissions = append(
+			roles[model.TEAM_ADMIN_ROLE_ID].Permissions,
 			model.PERMISSION_DELETE_POST.Id,
 			model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 		)
 	}
 
-	if Cfg.TeamSettings.EnableTeamCreation {
-		model.ROLE_SYSTEM_USER.Permissions = append(
-			model.ROLE_SYSTEM_USER.Permissions,
+	if cfg.TeamSettings.EnableTeamCreation {
+		roles[model.SYSTEM_USER_ROLE_ID].Permissions = append(
+			roles[model.SYSTEM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_CREATE_TEAM.Id,
 		)
 	}
+
+	return roles
 }

--- a/utils/config.go
+++ b/utils/config.go
@@ -420,7 +420,6 @@ func LoadGlobalConfig(fileName string) *model.Config {
 	clientCfgJson, _ := json.Marshal(ClientCfg)
 	ClientCfgHash = fmt.Sprintf("%x", md5.Sum(clientCfgJson))
 
-	SetDefaultRolesBasedOnConfig()
 	SetSiteURL(*Cfg.ServiceSettings.SiteURL)
 
 	InvokeGlobalConfigListeners(&oldConfig, config)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -98,7 +98,7 @@ func TestIncomingWebhook(t *testing.T) {
 
 	a.JoinUserToTeam(team, user, "")
 
-	a.UpdateUserRoles(user.Id, model.ROLE_SYSTEM_ADMIN.Id, false)
+	a.UpdateUserRoles(user.Id, model.SYSTEM_ADMIN_ROLE_ID, false)
 	ApiClient.SetTeamId(team.Id)
 
 	channel1 := &model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}


### PR DESCRIPTION
#### Summary
Eliminating the global role state. This is mostly just find/replace changes. 99% of the references to the global roles were only to get an id. So most of this is just replacing `model.ROLE_X.Id` with a new `model.X_ROLE_ID` constant.

The other part is moving the global role map into `app.App`.

I'm also starting to delete some calls to `SetDefaultRolesBasedOnConfig` as many are no longer necessary since the roles are now refreshed after calls to `UpdateConfig`. Once I eliminate some of the license globals I hope to delete the rest of them entirely.

#### Ticket Link
N/A

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
