### PR TITLE
PLT-7917: add Channels DeactivateAt column

### DIFF
--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -57,24 +57,6 @@ func TestSendNotifications(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	th.App.UpdateActive(th.BasicUser2, false)
-	th.App.InvalidateAllCaches()
-
-	post3, err := th.App.CreatePostMissingChannel(&model.Post{
-		UserId:    th.BasicUser.Id,
-		ChannelId: dm.Id,
-		Message:   "dm message",
-	}, true)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = th.App.SendNotifications(post3, th.BasicTeam, dm, th.BasicUser, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestGetExplicitMentions(t *testing.T) {

--- a/app/post.go
+++ b/app/post.go
@@ -104,6 +104,10 @@ func (a *App) CreatePostMissingChannel(post *model.Post, triggerWebhooks bool) (
 }
 
 func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhooks bool) (*model.Post, *model.AppError) {
+	if channel.DeactivateAt > 0 {
+		return nil, model.NewAppError("CreatePost", "api.post.create_post.deactivated", nil, "", http.StatusForbidden)
+	}
+
 	post.SanitizeProps()
 
 	var pchan store.StoreChannel

--- a/app/user.go
+++ b/app/user.go
@@ -900,6 +900,9 @@ func (a *App) UpdateActive(user *model.User, active bool) (*model.User, *model.A
 		if extra := <-a.Srv.Store.Channel().ExtraUpdateByUser(user.Id, model.GetMillis()); extra.Err != nil {
 			return nil, extra.Err
 		}
+		if updateActive := <-a.Srv.Store.Channel().UpdateActiveByUser(user.Id, model.GetMillis()); updateActive.Err != nil {
+			return nil, updateActive.Err
+		}
 
 		ruser := result.Data.([2]*model.User)[0]
 		options := a.Config().GetSanitizeOptions()

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1657,6 +1657,10 @@
     "translation": "Invalid ChannelId for RootId parameter"
   },
   {
+    "id": "api.post.create_post.deactivated",
+    "translation": "This channel has been deactivated and is read-only."
+  },
+  {
     "id": "api.post.create_post.last_viewed.error",
     "translation": "Encountered error updating last viewed, channel_id=%s, user_id=%s, err=%v"
   },
@@ -5717,6 +5721,10 @@
   {
     "id": "store.sql_channel.update.updating.app_error",
     "translation": "We encountered an error updating the channel"
+  },
+  {
+    "id": "store.sql_channel.update_active.app_error",
+    "translation": "We couldn't update the deactivate time"
   },
   {
     "id": "store.sql_channel.update_last_viewed_at.app_error",

--- a/model/channel.go
+++ b/model/channel.go
@@ -46,6 +46,10 @@ type Channel struct {
 	TotalMsgCount int64  `json:"total_msg_count"`
 	ExtraUpdateAt int64  `json:"extra_update_at"`
 	CreatorId     string `json:"creator_id"`
+
+	// If the channel is a group or direct channel with one or more deactivated user, this is the time that
+	// the first user was deactivated.
+	DeactivateAt int64 `json:"deactivate_at"`
 }
 
 type ChannelPatch struct {

--- a/store/store.go
+++ b/store/store.go
@@ -156,6 +156,7 @@ type ChannelStore interface {
 	GetMembersByIds(channelId string, userIds []string) StoreChannel
 	AnalyticsDeletedTypeCount(teamId string, channelType string) StoreChannel
 	GetChannelUnread(channelId, userId string) StoreChannel
+	UpdateActiveByUser(userId string, time int64) StoreChannel
 }
 
 type PostStore interface {

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -754,6 +754,22 @@ func (_m *ChannelStore) Update(channel *model.Channel) store.StoreChannel {
 	return r0
 }
 
+// UpdateActiveByUser provides a mock function with given fields: userId, time
+func (_m *ChannelStore) UpdateActiveByUser(userId string, time int64) store.StoreChannel {
+	ret := _m.Called(userId, time)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+		r0 = rf(userId, time)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // UpdateLastViewedAt provides a mock function with given fields: channelIds, userId
 func (_m *ChannelStore) UpdateLastViewedAt(channelIds []string, userId string) store.StoreChannel {
 	ret := _m.Called(channelIds, userId)

--- a/store/storetest/mocks/SqlStore.go
+++ b/store/storetest/mocks/SqlStore.go
@@ -143,6 +143,20 @@ func (_m *SqlStore) CreateColumnIfNotExists(tableName string, columnName string,
 	return r0
 }
 
+// CreateCompositeIndexIfNotExists provides a mock function with given fields: indexName, tableName, columnNames
+func (_m *SqlStore) CreateCompositeIndexIfNotExists(indexName string, tableName string, columnNames []string) bool {
+	ret := _m.Called(indexName, tableName, columnNames)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, []string) bool); ok {
+		r0 = rf(indexName, tableName, columnNames)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // CreateFullTextIndexIfNotExists provides a mock function with given fields: indexName, tableName, columnName
 func (_m *SqlStore) CreateFullTextIndexIfNotExists(indexName string, tableName string, columnName string) bool {
 	ret := _m.Called(indexName, tableName, columnName)


### PR DESCRIPTION
#### Summary
This adds a `deactivate_at` field to direct and group channels that indicates whether a channel is deactivated and if so, is set to the time it was deactivated.

Functionally, nothing changes except that new posts can no longer be made in deactivated channels. (@jasonblais verify that this is desired)

I think this is all the server-side stuff I need for this "Deactivated DMs" ticket. The sidebar display will be a function of this and the "open time" user preference that I added not too long ago for auto-closing DMs.

**TODO:**

* Add a websocket event though to ensure immediate client updates.
* The `IN` subquery is really slow. Replacing that with a join or even just `(SELECT * FROM (...) as subquery)` makes it much, much faster.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7917

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
