### PR TITLE
PLT-6896 per-paging for logs

### DIFF
--- a/api4/params.go
+++ b/api4/params.go
@@ -11,9 +11,11 @@ import (
 )
 
 const (
-	PAGE_DEFAULT     = 0
-	PER_PAGE_DEFAULT = 60
-	PER_PAGE_MAXIMUM = 200
+	PAGE_DEFAULT          = 0
+	PER_PAGE_DEFAULT      = 60
+	PER_PAGE_MAXIMUM      = 200
+	LOGS_PER_PAGE_DEFAULT = 10000
+	LOGS_PER_PAGE_MAXIMUM = 10000
 )
 
 type ApiParams struct {
@@ -43,6 +45,7 @@ type ApiParams struct {
 	ActionId       string
 	Page           int
 	PerPage        int
+	LogsPerPage    int
 	Permanent      bool
 }
 
@@ -163,6 +166,14 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 		params.PerPage = PER_PAGE_MAXIMUM
 	} else {
 		params.PerPage = val
+	}
+
+	if val, err := strconv.Atoi(r.URL.Query().Get("logs_per_page")); err != nil || val < 0 {
+		params.LogsPerPage = LOGS_PER_PAGE_DEFAULT
+	} else if val > LOGS_PER_PAGE_MAXIMUM {
+		params.LogsPerPage = LOGS_PER_PAGE_MAXIMUM
+	} else {
+		params.LogsPerPage = val
 	}
 
 	return params

--- a/api4/system.go
+++ b/api4/system.go
@@ -187,7 +187,7 @@ func getLogs(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	lines, err := c.App.GetLogs(c.Params.Page, c.Params.PerPage)
+	lines, err := c.App.GetLogs(c.Params.Page, c.Params.LogsPerPage)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -308,18 +308,18 @@ func TestGetLogs(t *testing.T) {
 	logs, resp := th.SystemAdminClient.GetLogs(0, 10)
 	CheckNoError(t, resp)
 
-	// if len(logs) != 10 {
-	// 	t.Log(len(logs))
-	// 	t.Fatal("wrong length")
-	// }
+	if len(logs) != 10 {
+		t.Log(len(logs))
+		t.Fatal("wrong length")
+	}
 
 	logs, resp = th.SystemAdminClient.GetLogs(1, 10)
 	CheckNoError(t, resp)
 
-	// if len(logs) != 10 {
-	// 	t.Log(len(logs))
-	// 	t.Fatal("wrong length")
-	// }
+	if len(logs) != 10 {
+		t.Log(len(logs))
+		t.Fatal("wrong length")
+	}
 
 	logs, resp = th.SystemAdminClient.GetLogs(-1, -1)
 	CheckNoError(t, resp)

--- a/app/admin.go
+++ b/app/admin.go
@@ -61,7 +61,7 @@ func (a *App) GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 
 		var newLine = []byte{'\n'}
 		var lineCount int
-		var searchPos = int64(-1)
+		const searchPos = -1
 		lineEndPos, err := file.Seek(0, io.SeekEnd)
 		if err != nil {
 			return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/admin.go
+++ b/app/admin.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -61,12 +62,12 @@ func (a *App) GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 		var newLine = []byte{'\n'}
 		var lineCount int
 		var searchPos = int64(-1)
-		lineEndPos, err := file.Seek(0, os.SEEK_END)
+		lineEndPos, err := file.Seek(0, io.SeekEnd)
 		if err != nil {
 			return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 		for {
-			pos, err := file.Seek(searchPos, os.SEEK_CUR)
+			pos, err := file.Seek(searchPos, io.SeekCurrent)
 			if err != nil {
 				return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
 			}

--- a/app/admin.go
+++ b/app/admin.go
@@ -58,16 +58,13 @@ func (a *App) GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 
 		defer file.Close()
 
-		stat, err := file.Stat()
-		if err != nil {
-			return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
-		}
-
 		var newLine = []byte{'\n'}
 		var lineCount int
 		var searchPos = int64(-1)
-		var lineEndPos = stat.Size()
-		file.Seek(lineEndPos, os.SEEK_SET)
+		lineEndPos, err := file.Seek(0, os.SEEK_END)
+		if err != nil {
+			return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
+		}
 		for {
 			pos, err := file.Seek(searchPos, os.SEEK_CUR)
 			if err != nil {

--- a/app/admin.go
+++ b/app/admin.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"bufio"
 	"os"
 	"strings"
 	"time"
@@ -20,9 +19,6 @@ import (
 )
 
 func (a *App) GetLogs(page, perPage int) ([]string, *model.AppError) {
-
-	perPage = 10000
-
 	var lines []string
 	if a.Cluster != nil && *a.Config().ClusterSettings.Enable {
 		lines = append(lines, "-----------------------------------------------------------------------------------------------------------")
@@ -62,20 +58,51 @@ func (a *App) GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 
 		defer file.Close()
 
-		offsetCount := 0
-		limitCount := 0
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			if limitCount >= perPage {
-				break
+		stat, err := file.Stat()
+		if err != nil {
+			return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		var newLine = []byte{'\n'}
+		var lineCount int
+		var searchPos = int64(-1)
+		var lineEndPos = stat.Size()
+		file.Seek(lineEndPos, os.SEEK_SET)
+		for {
+			pos, err := file.Seek(searchPos, os.SEEK_CUR)
+			if err != nil {
+				return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
 			}
 
-			if offsetCount >= page*perPage {
-				lines = append(lines, scanner.Text())
-				limitCount++
-			} else {
-				offsetCount++
+			b := make([]byte, 1)
+			_, err = file.ReadAt(b, pos)
+			if err != nil {
+				return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
 			}
+
+			if b[0] == newLine[0] || pos == 0 {
+				lineCount++
+				if lineCount > page*perPage {
+					line := make([]byte, lineEndPos-pos)
+					_, err := file.ReadAt(line, pos)
+					if err != nil {
+						return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
+					}
+					lines = append(lines, string(line))
+				}
+				if pos == 0 {
+					break
+				}
+				lineEndPos = pos
+			}
+
+			if len(lines) == perPage {
+				break
+			}
+		}
+
+		for i, j := 0, len(lines)-1; i < j; i, j = i+1, j-1 {
+			lines[i], lines[j] = lines[j], lines[i]
 		}
 	} else {
 		lines = append(lines, "")

--- a/model/client4.go
+++ b/model/client4.go
@@ -2649,7 +2649,7 @@ func (c *Client4) UploadBrandImage(data []byte) (bool, *Response) {
 
 // GetLogs page of logs as a string array.
 func (c *Client4) GetLogs(page, perPage int) ([]string, *Response) {
-	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
+	query := fmt.Sprintf("?page=%v&logs_per_page=%v", page, perPage)
 	if r, err := c.DoApiGet("/logs"+query, ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {


### PR DESCRIPTION
#### Summary
* Add new request parameter `logs_per_page`
* Set default value of per_paging for logs to 10000 (for backward compatibility)
* Read logs from end of log file
* Revert #6697

#### Ticket Link
[PLT-6896](https://mattermost.atlassian.net/browse/PLT-6896)
#6724

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
  * [PLT\-6896 Fix descriptions of \`/logs\` by kaakaa · Pull Request \#310 · mattermost/mattermost\-api\-reference](https://github.com/mattermost/mattermost-api-reference/pull/310)
- [x] All new/modified APIs include changes to the drivers
