### PR TITLE
Change absolute url to relative url on command responses

### DIFF
--- a/app/command_groupmsg.go
+++ b/app/command_groupmsg.go
@@ -114,7 +114,7 @@ func (me *groupmsgProvider) DoCommand(a *App, args *model.CommandArgs, message s
 		return &model.CommandResponse{Text: args.T("api.command_groupmsg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + groupChannel.Name, Text: "", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	return &model.CommandResponse{GotoLocation: "/" + team.Name + "/channels/" + groupChannel.Name, Text: "", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }
 
 func groupMsgUsernames(message string) ([]string, string) {

--- a/app/command_join.go
+++ b/app/command_join.go
@@ -58,7 +58,7 @@ func (me *JoinProvider) DoCommand(a *App, args *model.CommandArgs, message strin
 				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 			}
 
-			return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + channel.Name}
+			return &model.CommandResponse{GotoLocation: "/" + team.Name + "/channels/" + channel.Name}
 		}
 	}
 

--- a/app/command_leave.go
+++ b/app/command_leave.go
@@ -51,5 +51,5 @@ func (me *LeaveProvider) DoCommand(a *App, args *model.CommandArgs, message stri
 		return &model.CommandResponse{Text: args.T("api.command_leave.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + model.DEFAULT_CHANNEL, Text: args.T("api.command_leave.success"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	return &model.CommandResponse{GotoLocation: "/" + team.Name + "/channels/" + model.DEFAULT_CHANNEL, Text: args.T("api.command_leave.success"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }

--- a/app/command_msg.go
+++ b/app/command_msg.go
@@ -104,5 +104,5 @@ func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string
 		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + channelName, Text: "", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	return &model.CommandResponse{GotoLocation: "/" + team.Name + "/channels/" + channelName, Text: "", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 }

--- a/app/command_msg_test.go
+++ b/app/command_msg_test.go
@@ -27,5 +27,5 @@ func TestMsgProvider(t *testing.T) {
 	}, "@"+th.BasicUser2.Username+" hello")
 	channelName := model.GetDMNameFromIds(th.BasicUser.Id, th.BasicUser2.Id)
 	assert.Equal(t, "", resp.Text)
-	assert.Equal(t, "http://test.url/"+team.Name+"/channels/"+channelName, resp.GotoLocation)
+	assert.Equal(t, "/"+team.Name+"/channels/"+channelName, resp.GotoLocation)
 }


### PR DESCRIPTION
This solve some warning in the webapp (but I'm not sure if it affects to other clients). The RN client looks like has no reference to GotoLocation and matterhorn neigther.

Looks like the webapp client handle both cases correctly here: https://github.com/mattermost/mattermost-webapp/blob/v4.4.2/actions/channel_actions.jsx#L123