### PR TITLE
Expose vendored mock package with plugintest/mock

### DIFF
--- a/plugin/plugintest/mock/mock.go
+++ b/plugin/plugintest/mock/mock.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+// This package provides aliases for the contents of "github.com/stretchr/testify/mock". Because
+// external packages can't import our vendored dependencies, this is necessary for them to be able
+// to fully utilize the plugintest package.
+package mock
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	Anything = mock.Anything
+)
+
+type Arguments = mock.Arguments
+type AnythingOfTypeArgument = mock.AnythingOfTypeArgument
+type Call = mock.Call
+type Mock = mock.Mock
+type TestingT = mock.TestingT
+
+func AnythingOfType(t string) AnythingOfTypeArgument {
+	return mock.AnythingOfType(t)
+}
+
+func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
+	return mock.AssertExpectationsForObjects(t, testObjects...)
+}
+
+func MatchedBy(fn interface{}) interface{} {
+	return mock.MatchedBy(fn)
+}

--- a/plugin/plugintest/plugintest.go
+++ b/plugin/plugintest/plugintest.go
@@ -42,4 +42,7 @@
 //
 // The mocks are created using testify's mock package:
 // https://godoc.org/github.com/stretchr/testify/mock
+//
+// If you need to import the mock package, you can import it with
+// "github.com/mattermost/mattermost-server/plugin/plugintest/mock".
 package plugintest


### PR DESCRIPTION
#### Summary
So this is a little weird, but I don't think there's any other way to make this kind of thing compile:

https://github.com/mattermost/mattermost-plugin-jira/blob/master/plugin_test.go

The problem is that we vendor testify/mock, and external packages can't import our vendored packages. So to be able to use things like `mock.AnythingOfType` with the plugintest mocks, we have to expose it like this.

#### Ticket Link
N/A

#### Checklist
N/A