### PR TITLE
PLT-8198: Set the message export timestamp to the date feature was enabled, and remove the setting from the System Console

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -1534,6 +1534,14 @@ func (s *MessageExportSettings) SetDefaults() {
 		s.ExportFromTimestamp = NewInt64(0)
 	}
 
+	if s.EnableExport != nil && *s.EnableExport && *s.ExportFromTimestamp == int64(0) {
+		// when the feature is enabled via the System Console, use the current timestamp as the start time for future exports
+		s.ExportFromTimestamp = NewInt64(GetMillis())
+	} else if s.EnableExport != nil && !*s.EnableExport {
+		// when the feature is disabled, reset the timestamp so that the timestamp will be set if the feature is re-enabled
+		s.ExportFromTimestamp = NewInt64(0)
+	}
+
 	if s.BatchSize == nil {
 		s.BatchSize = NewInt(10000)
 	}
@@ -2040,7 +2048,7 @@ func (mes *MessageExportSettings) isValid(fs FileSettings) *AppError {
 		return NewAppError("Config.IsValid", "model.config.is_valid.message_export.enable.app_error", nil, "", http.StatusBadRequest)
 	}
 	if *mes.EnableExport {
-		if mes.ExportFromTimestamp == nil || *mes.ExportFromTimestamp < 0 || *mes.ExportFromTimestamp > time.Now().Unix() {
+		if mes.ExportFromTimestamp == nil || *mes.ExportFromTimestamp < 0 || *mes.ExportFromTimestamp > GetMillis() {
 			return NewAppError("Config.IsValid", "model.config.is_valid.message_export.export_from.app_error", nil, "", http.StatusBadRequest)
 		} else if mes.DailyRunTime == nil {
 			return NewAppError("Config.IsValid", "model.config.is_valid.message_export.daily_runtime.app_error", nil, "", http.StatusBadRequest)

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -143,3 +143,98 @@ func TestMessageExportSettingsIsValid(t *testing.T) {
 	// should pass because everything is valid
 	require.Nil(t, mes.isValid(*fs))
 }
+
+func TestMessageExportSetDefaults(t *testing.T) {
+	mes := &MessageExportSettings{}
+	mes.SetDefaults()
+
+	require.False(t, *mes.EnableExport)
+	require.Equal(t, "export", *mes.FileLocation)
+	require.Equal(t, "01:00", *mes.DailyRunTime)
+	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
+	require.Equal(t, 10000, *mes.BatchSize)
+}
+
+func TestMessageExportSetDefaultsExportEnabledExportFromTimestampNil(t *testing.T) {
+	mes := &MessageExportSettings{
+		EnableExport: NewBool(true),
+	}
+	mes.SetDefaults()
+
+	require.True(t, *mes.EnableExport)
+	require.Equal(t, "export", *mes.FileLocation)
+	require.Equal(t, "01:00", *mes.DailyRunTime)
+	require.NotEqual(t, int64(0), *mes.ExportFromTimestamp)
+	require.True(t, *mes.ExportFromTimestamp <= GetMillis())
+	require.Equal(t, 10000, *mes.BatchSize)
+}
+
+func TestMessageExportSetDefaultsExportEnabledExportFromTimestampZero(t *testing.T) {
+	mes := &MessageExportSettings{
+		EnableExport:        NewBool(true),
+		ExportFromTimestamp: NewInt64(0),
+	}
+	mes.SetDefaults()
+
+	require.True(t, *mes.EnableExport)
+	require.Equal(t, "export", *mes.FileLocation)
+	require.Equal(t, "01:00", *mes.DailyRunTime)
+	require.NotEqual(t, int64(0), *mes.ExportFromTimestamp)
+	require.True(t, *mes.ExportFromTimestamp <= GetMillis())
+	require.Equal(t, 10000, *mes.BatchSize)
+}
+
+func TestMessageExportSetDefaultsExportEnabledExportFromTimestampNonZero(t *testing.T) {
+	mes := &MessageExportSettings{
+		EnableExport:        NewBool(true),
+		ExportFromTimestamp: NewInt64(12345),
+	}
+	mes.SetDefaults()
+
+	require.True(t, *mes.EnableExport)
+	require.Equal(t, "export", *mes.FileLocation)
+	require.Equal(t, "01:00", *mes.DailyRunTime)
+	require.Equal(t, int64(12345), *mes.ExportFromTimestamp)
+	require.Equal(t, 10000, *mes.BatchSize)
+}
+
+func TestMessageExportSetDefaultsExportDisabledExportFromTimestampNil(t *testing.T) {
+	mes := &MessageExportSettings{
+		EnableExport: NewBool(false),
+	}
+	mes.SetDefaults()
+
+	require.False(t, *mes.EnableExport)
+	require.Equal(t, "export", *mes.FileLocation)
+	require.Equal(t, "01:00", *mes.DailyRunTime)
+	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
+	require.Equal(t, 10000, *mes.BatchSize)
+}
+
+func TestMessageExportSetDefaultsExportDisabledExportFromTimestampZero(t *testing.T) {
+	mes := &MessageExportSettings{
+		EnableExport:        NewBool(false),
+		ExportFromTimestamp: NewInt64(0),
+	}
+	mes.SetDefaults()
+
+	require.False(t, *mes.EnableExport)
+	require.Equal(t, "export", *mes.FileLocation)
+	require.Equal(t, "01:00", *mes.DailyRunTime)
+	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
+	require.Equal(t, 10000, *mes.BatchSize)
+}
+
+func TestMessageExportSetDefaultsExportDisabledExportFromTimestampNonZero(t *testing.T) {
+	mes := &MessageExportSettings{
+		EnableExport:        NewBool(false),
+		ExportFromTimestamp: NewInt64(12345),
+	}
+	mes.SetDefaults()
+
+	require.False(t, *mes.EnableExport)
+	require.Equal(t, "export", *mes.FileLocation)
+	require.Equal(t, "01:00", *mes.DailyRunTime)
+	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
+	require.Equal(t, 10000, *mes.BatchSize)
+}


### PR DESCRIPTION
#### Summary
Changed config behaviour such that exportFromTimestamp is set/unset when message export is enabled/disabled

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8198

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] [Has UI changes](https://github.com/mattermost/mattermost-webapp/pull/385)