### PR TITLE
Couple fixes for serving plugin requests

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -417,9 +417,9 @@ func (a *App) ServePluginRequest(w http.ResponseWriter, r *http.Request) {
 	token := ""
 
 	authHeader := r.Header.Get(model.HEADER_AUTH)
-	if strings.HasPrefix(strings.ToUpper(authHeader), model.HEADER_BEARER+":") {
+	if strings.HasPrefix(strings.ToUpper(authHeader), model.HEADER_BEARER+" ") {
 		token = authHeader[len(model.HEADER_BEARER)+1:]
-	} else if strings.HasPrefix(strings.ToLower(authHeader), model.HEADER_TOKEN+":") {
+	} else if strings.HasPrefix(strings.ToLower(authHeader), model.HEADER_TOKEN+" ") {
 		token = authHeader[len(model.HEADER_TOKEN)+1:]
 	} else if cookie, _ := r.Cookie(model.SESSION_COOKIE_TOKEN); cookie != nil && (r.Method == "GET" || r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML) {
 		token = cookie.Value
@@ -429,7 +429,7 @@ func (a *App) ServePluginRequest(w http.ResponseWriter, r *http.Request) {
 
 	r.Header.Del("Mattermost-User-Id")
 	if token != "" {
-		if session, err := a.GetSession(token); err != nil {
+		if session, err := a.GetSession(token); err == nil {
 			r.Header.Set("Mattermost-User-Id", session.UserId)
 		}
 	}


### PR DESCRIPTION
#### Summary
Noticed when building the zoom plugin that the header `Mattermost-User-Id` was not getting set even when I had a valid session. Caused by us not reading the `Authorization` header correctly (looking for `:` instead of a space) and also a flipped condition on setting the header