### PR TITLE
PLT-8233: Purge ChannelMemberHistory Data when Data Retention Job runs

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4443,7 +4443,7 @@
     "translation": "Failed to get records"
   },
   {
-    "id": "store.sql_channel_member_history.purge_history_before.app_error",
+    "id": "store.sql_channel_member_history.permanent_delete_batch.app_error",
     "translation": "Failed to purge records"
   },
   {

--- a/store/sqlstore/channel_member_history_store.go
+++ b/store/sqlstore/channel_member_history_store.go
@@ -89,7 +89,7 @@ func (s SqlChannelMemberHistoryStore) GetUsersInChannelDuring(startTime int64, e
 func (s SqlChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64, limit int64) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var query string
-		if s.DriverName() == "postgres" {
+		if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
 			query =
 				`DELETE FROM ChannelMemberHistory
 				 WHERE ctid IN (

--- a/store/store.go
+++ b/store/store.go
@@ -165,7 +165,8 @@ type ChannelMemberHistoryStore interface {
 	LogJoinEvent(userId string, channelId string, joinTime int64) StoreChannel
 	LogLeaveEvent(userId string, channelId string, leaveTime int64) StoreChannel
 	GetUsersInChannelDuring(startTime int64, endTime int64, channelId string) StoreChannel
-	PurgeHistoryBefore(time int64, channelId string) StoreChannel
+	PermanentDeleteBatch(endTime int64, limit int64) StoreChannel
+	PermanentDeleteBatchForChannel(channelId string, endTime int64, limit int64) StoreChannel
 }
 
 type PostStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -166,7 +166,6 @@ type ChannelMemberHistoryStore interface {
 	LogLeaveEvent(userId string, channelId string, leaveTime int64) StoreChannel
 	GetUsersInChannelDuring(startTime int64, endTime int64, channelId string) StoreChannel
 	PermanentDeleteBatch(endTime int64, limit int64) StoreChannel
-	PermanentDeleteBatchForChannel(channelId string, endTime int64, limit int64) StoreChannel
 }
 
 type PostStore interface {

--- a/store/storetest/mocks/ChannelMemberHistoryStore.go
+++ b/store/storetest/mocks/ChannelMemberHistoryStore.go
@@ -60,13 +60,29 @@ func (_m *ChannelMemberHistoryStore) LogLeaveEvent(userId string, channelId stri
 	return r0
 }
 
-// PurgeHistoryBefore provides a mock function with given fields: time, channelId
-func (_m *ChannelMemberHistoryStore) PurgeHistoryBefore(time int64, channelId string) store.StoreChannel {
-	ret := _m.Called(time, channelId)
+// PermanentDeleteBatch provides a mock function with given fields: endTime, limit
+func (_m *ChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64, limit int64) store.StoreChannel {
+	ret := _m.Called(endTime, limit)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(int64, string) store.StoreChannel); ok {
-		r0 = rf(time, channelId)
+	if rf, ok := ret.Get(0).(func(int64, int64) store.StoreChannel); ok {
+		r0 = rf(endTime, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+// PermanentDeleteBatchForChannel provides a mock function with given fields: channelId, endTime, limit
+func (_m *ChannelMemberHistoryStore) PermanentDeleteBatchForChannel(channelId string, endTime int64, limit int64) store.StoreChannel {
+	ret := _m.Called(channelId, endTime, limit)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, int64, int64) store.StoreChannel); ok {
+		r0 = rf(channelId, endTime, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/mocks/ChannelMemberHistoryStore.go
+++ b/store/storetest/mocks/ChannelMemberHistoryStore.go
@@ -75,19 +75,3 @@ func (_m *ChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64, limit i
 
 	return r0
 }
-
-// PermanentDeleteBatchForChannel provides a mock function with given fields: channelId, endTime, limit
-func (_m *ChannelMemberHistoryStore) PermanentDeleteBatchForChannel(channelId string, endTime int64, limit int64) store.StoreChannel {
-	ret := _m.Called(channelId, endTime, limit)
-
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64, int64) store.StoreChannel); ok {
-		r0 = rf(channelId, endTime, limit)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
-		}
-	}
-
-	return r0
-}


### PR DESCRIPTION
#### Summary
Changed the way that the purge method in the ChannelMemberHistory store works to better follow the pattern used in other stores that can be cleaned up by the Data Retention job. 

In order to get the tests to run cleanly, I had to differentiate between purging all records, and purging records for a specific channel, because all tests share the database, and permanent deletes can trash data that other tests depend on.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8233

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] [Has enterprise changes](https://github.com/mattermost/enterprise/pull/245)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
