### PR TITLE
PLT-8282: call OnActivate after plugin crash, update example

### DIFF
--- a/plugin/example_hello_user_test.go
+++ b/plugin/example_hello_user_test.go
@@ -12,9 +12,10 @@ type HelloUserPlugin struct {
 	api plugin.API
 }
 
-func (p *HelloUserPlugin) OnActivate(api plugin.API) {
+func (p *HelloUserPlugin) OnActivate(api plugin.API) error {
 	// Just save api for later when we need to look up users.
 	p.api = api
+	return nil
 }
 
 func (p *HelloUserPlugin) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/plugin/pluginenv/environment.go
+++ b/plugin/pluginenv/environment.go
@@ -148,12 +148,8 @@ func (env *Environment) ActivatePlugin(id string) error {
 		if err != nil {
 			return errors.Wrapf(err, "unable to get api for plugin: %v", id)
 		}
-		if err := supervisor.Start(); err != nil {
+		if err := supervisor.Start(api); err != nil {
 			return errors.Wrapf(err, "unable to start plugin: %v", id)
-		}
-		if err := supervisor.Hooks().OnActivate(api); err != nil {
-			supervisor.Stop()
-			return errors.Wrapf(err, "unable to activate plugin: %v", id)
 		}
 
 		activePlugin.Supervisor = supervisor

--- a/plugin/supervisor.go
+++ b/plugin/supervisor.go
@@ -6,7 +6,7 @@ package plugin
 // Supervisor provides the interface for an object that controls the execution of a plugin. This
 // type is only relevant to the server, and isn't used by the plugins themselves.
 type Supervisor interface {
-	Start() error
+	Start(API) error
 	Stop() error
 	Hooks() Hooks
 }


### PR DESCRIPTION
#### Summary
`OnActivate` needs to be called again when plugins are relaunched. This moves that responsibility from the environment to the supervisor.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8282

#### Checklist
- [x] Added or updated unit tests (required for all new features)