### PR TITLE
Add plugin slash command support

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -46,7 +46,7 @@ func TestPlugin(t *testing.T) {
 		*cfg.PluginSettings.EnableUploads = true
 	})
 
-	th.App.InitPlugins(pluginDir, webappDir)
+	th.App.InitPlugins(pluginDir, webappDir, nil)
 	defer func() {
 		th.App.ShutDownPlugins()
 		th.App.PluginEnv = nil

--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	l4g "github.com/alecthomas/log4go"
@@ -60,6 +61,9 @@ type App struct {
 	sessionCache        *utils.Cache
 	roles               map[string]*model.Role
 	configListenerId    string
+
+	pluginCommands     []*PluginCommand
+	pluginCommandsLock sync.RWMutex
 }
 
 var appCount = 0

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -4,15 +4,21 @@
 package app
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"time"
 
+	l4g "github.com/alecthomas/log4go"
+
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/mattermost/mattermost-server/plugin/pluginenv"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/store/sqlstore"
 	"github.com/mattermost/mattermost-server/store/storetest"
 	"github.com/mattermost/mattermost-server/utils"
-
-	l4g "github.com/alecthomas/log4go"
 )
 
 type TestHelper struct {
@@ -22,6 +28,9 @@ type TestHelper struct {
 	BasicUser2   *model.User
 	BasicChannel *model.Channel
 	BasicPost    *model.Post
+
+	tempWorkspace string
+	pluginHooks   map[string]plugin.Hooks
 }
 
 type persistentTestStore struct {
@@ -54,7 +63,8 @@ func setupTestHelper(enterprise bool) *TestHelper {
 	}
 
 	th := &TestHelper{
-		App: New(options...),
+		App:         New(options...),
+		pluginHooks: make(map[string]plugin.Hooks),
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.MaxUsersPerTeam = 50 })
@@ -221,6 +231,63 @@ func (me *TestHelper) TearDown() {
 	me.App.Shutdown()
 	if err := recover(); err != nil {
 		StopTestStore()
+		panic(err)
+	}
+	if me.tempWorkspace != "" {
+		os.RemoveAll(me.tempWorkspace)
+	}
+}
+
+type mockPluginSupervisor struct {
+	hooks plugin.Hooks
+}
+
+func (s *mockPluginSupervisor) Start() error {
+	return nil
+}
+
+func (s *mockPluginSupervisor) Stop() error {
+	return nil
+}
+
+func (s *mockPluginSupervisor) Hooks() plugin.Hooks {
+	return s.hooks
+}
+
+func (me *TestHelper) InstallPlugin(manifest *model.Manifest, hooks plugin.Hooks) {
+	if me.tempWorkspace == "" {
+		dir, err := ioutil.TempDir("", "apptest")
+		if err != nil {
+			panic(err)
+		}
+		me.tempWorkspace = dir
+	}
+
+	pluginDir := filepath.Join(me.tempWorkspace, "plugins")
+	webappDir := filepath.Join(me.tempWorkspace, "webapp")
+	me.App.InitPlugins(pluginDir, webappDir, func(bundle *model.BundleInfo) (plugin.Supervisor, error) {
+		if hooks, ok := me.pluginHooks[bundle.Manifest.Id]; ok {
+			return &mockPluginSupervisor{hooks}, nil
+		}
+		return pluginenv.DefaultSupervisorProvider(bundle)
+	})
+
+	me.pluginHooks[manifest.Id] = hooks
+
+	manifestCopy := *manifest
+	if manifestCopy.Backend == nil {
+		manifestCopy.Backend = &model.ManifestBackend{}
+	}
+	manifestBytes, err := json.Marshal(&manifestCopy)
+	if err != nil {
+		panic(err)
+	}
+
+	if err := os.MkdirAll(filepath.Join(pluginDir, manifest.Id), 0700); err != nil {
+		panic(err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(pluginDir, manifest.Id, "plugin.json"), manifestBytes, 0600); err != nil {
 		panic(err)
 	}
 }

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -242,8 +242,8 @@ type mockPluginSupervisor struct {
 	hooks plugin.Hooks
 }
 
-func (s *mockPluginSupervisor) Start() error {
-	return nil
+func (s *mockPluginSupervisor) Start(api plugin.API) error {
+	return s.hooks.OnActivate(api)
 }
 
 func (s *mockPluginSupervisor) Stop() error {

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -34,6 +34,15 @@ func (api *PluginAPI) LoadPluginConfiguration(dest interface{}) error {
 	}
 }
 
+func (api *PluginAPI) RegisterCommand(command *model.Command) error {
+	return api.app.RegisterPluginCommand(api.id, command)
+}
+
+func (api *PluginAPI) UnregisterCommand(teamId, trigger string) error {
+	api.app.UnregisterPluginCommand(api.id, teamId, trigger)
+	return nil
+}
+
 func (api *PluginAPI) CreateTeam(team *model.Team) (*model.Team, *model.AppError) {
 	return api.app.CreateTeam(team)
 }

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -75,10 +75,10 @@ func runServer(configFileLocation string) {
 		a.LoadLicense()
 	}
 
-	a.InitPlugins(*a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
+	a.InitPlugins(*a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory, nil)
 	utils.AddConfigListener(func(prevCfg, cfg *model.Config) {
 		if *cfg.PluginSettings.Enable {
-			a.InitPlugins(*cfg.PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
+			a.InitPlugins(*cfg.PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory, nil)
 		} else {
 			a.ShutDownPlugins()
 		}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4263,10 +4263,6 @@
     "translation": "Current working directory is %v"
   },
   {
-    "id": "model.plugin_command.duplicate.app_error",
-    "translation": "A command with this trigger already exists."
-  },
-  {
     "id": "model.plugin_command.error.app_error",
     "translation": "An error occurred while trying to execute this command."
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4263,6 +4263,14 @@
     "translation": "Current working directory is %v"
   },
   {
+    "id": "model.plugin_command.duplicate.app_error",
+    "translation": "A command with this trigger already exists."
+  },
+  {
+    "id": "model.plugin_command.error.app_error",
+    "translation": "An error occurred while trying to execute this command."
+  },
+  {
     "id": "model.plugin_key_value.is_valid.plugin_id.app_error",
     "translation": "Invalid plugin ID, must be more than {{.Min}} and a of maximum {{.Max}} characters long."
   },

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -16,6 +16,13 @@ type API interface {
 	// struct that the configuration JSON can be unmarshalled to.
 	LoadPluginConfiguration(dest interface{}) error
 
+	// RegisterCommand registers a custom slash command. When the command is triggered, your plugin
+	// can fulfill it via the ExecuteCommand hook.
+	RegisterCommand(command *model.Command) error
+
+	// UnregisterCommand unregisters a command previously registered via RegisterCommand.
+	UnregisterCommand(teamId, trigger string) error
+
 	// CreateUser creates a user.
 	CreateUser(user *model.User) (*model.User, *model.AppError)
 

--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -5,6 +5,8 @@ package plugin
 
 import (
 	"net/http"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 // Methods from the Hooks interface can be used by a plugin to respond to events. Methods are likely
@@ -30,4 +32,8 @@ type Hooks interface {
 	// The Mattermost-User-Id header will be present if (and only if) the request is by an
 	// authenticated user.
 	ServeHTTP(http.ResponseWriter, *http.Request)
+
+	// ExecuteCommand executes a command that has been previously registered via the RegisterCommand
+	// API.
+	ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError)
 }

--- a/plugin/pluginenv/environment_test.go
+++ b/plugin/pluginenv/environment_test.go
@@ -355,3 +355,52 @@ func TestEnvironment_ConcurrentHookInvocations(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestEnvironment_HooksForPlugins(t *testing.T) {
+	dir := initTmpDir(t, map[string]string{
+		"foo/plugin.json": `{"id": "foo", "backend": {}}`,
+	})
+	defer os.RemoveAll(dir)
+
+	var provider MockProvider
+	defer provider.AssertExpectations(t)
+
+	env, err := New(
+		SearchPath(dir),
+		APIProvider(provider.API),
+		SupervisorProvider(provider.Supervisor),
+	)
+	require.NoError(t, err)
+	defer env.Shutdown()
+
+	var api struct{ plugin.API }
+	var supervisor MockSupervisor
+	defer supervisor.AssertExpectations(t)
+	var hooks plugintest.Hooks
+	defer hooks.AssertExpectations(t)
+
+	provider.On("API").Return(&api, nil)
+	provider.On("Supervisor").Return(&supervisor, nil)
+
+	supervisor.On("Start").Return(nil)
+	supervisor.On("Stop").Return(nil)
+	supervisor.On("Hooks").Return(&hooks)
+
+	hooks.On("OnActivate", &api).Return(nil)
+	hooks.On("OnDeactivate").Return(nil)
+	hooks.On("ExecuteCommand", mock.AnythingOfType("*model.CommandArgs")).Return(&model.CommandResponse{
+		Text: "bar",
+	}, nil)
+
+	assert.NoError(t, env.ActivatePlugin("foo"))
+	assert.Equal(t, env.ActivePluginIds(), []string{"foo"})
+
+	resp, appErr, err := env.HooksForPlugin("foo").ExecuteCommand(&model.CommandArgs{
+		Command: "/foo",
+	})
+	assert.Equal(t, "bar", resp.Text)
+	assert.Nil(t, appErr)
+	assert.NoError(t, err)
+
+	assert.Empty(t, env.Shutdown())
+}

--- a/plugin/pluginenv/environment_test.go
+++ b/plugin/pluginenv/environment_test.go
@@ -382,11 +382,10 @@ func TestEnvironment_HooksForPlugins(t *testing.T) {
 	provider.On("API").Return(&api, nil)
 	provider.On("Supervisor").Return(&supervisor, nil)
 
-	supervisor.On("Start").Return(nil)
+	supervisor.On("Start", &api).Return(nil)
 	supervisor.On("Stop").Return(nil)
 	supervisor.On("Hooks").Return(&hooks)
 
-	hooks.On("OnActivate", &api).Return(nil)
 	hooks.On("OnDeactivate").Return(nil)
 	hooks.On("ExecuteCommand", mock.AnythingOfType("*model.CommandArgs")).Return(&model.CommandResponse{
 		Text: "bar",

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -30,6 +30,22 @@ func (m *API) LoadPluginConfiguration(dest interface{}) error {
 	return ret.Error(0)
 }
 
+func (m *API) RegisterCommand(command *model.Command) error {
+	ret := m.Called(command)
+	if f, ok := ret.Get(0).(func(*model.Command) error); ok {
+		return f(command)
+	}
+	return ret.Error(0)
+}
+
+func (m *API) UnregisterCommand(teamId, trigger string) error {
+	ret := m.Called(teamId, trigger)
+	if f, ok := ret.Get(0).(func(string, string) error); ok {
+		return f(teamId, trigger)
+	}
+	return ret.Error(0)
+}
+
 func (m *API) CreateUser(user *model.User) (*model.User, *model.AppError) {
 	ret := m.Called(user)
 	if f, ok := ret.Get(0).(func(*model.User) (*model.User, *model.AppError)); ok {

--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -32,6 +32,14 @@ func (api *LocalAPI) LoadPluginConfiguration(args struct{}, reply *[]byte) error
 	return nil
 }
 
+func (api *LocalAPI) RegisterCommand(args *model.Command, reply *APITeamReply) error {
+	return api.api.RegisterCommand(args)
+}
+
+func (api *LocalAPI) UnregisterCommand(args *APIUnregisterCommandArgs, reply *APITeamReply) error {
+	return api.api.UnregisterCommand(args.TeamId, args.Trigger)
+}
+
 type APIErrorReply struct {
 	Error *model.AppError
 }
@@ -342,6 +350,22 @@ func (api *RemoteAPI) LoadPluginConfiguration(dest interface{}) error {
 		return err
 	}
 	return json.Unmarshal(config, dest)
+}
+
+func (api *RemoteAPI) RegisterCommand(command *model.Command) error {
+	return api.client.Call("LocalAPI.RegisterCommand", command, nil)
+}
+
+type APIUnregisterCommandArgs struct {
+	TeamId  string
+	Trigger string
+}
+
+func (api *RemoteAPI) UnregisterCommand(teamId, trigger string) error {
+	return api.client.Call("LocalAPI.UnregisterCommand", &APIUnregisterCommandArgs{
+		TeamId:  teamId,
+		Trigger: trigger,
+	}, nil)
 }
 
 func (api *RemoteAPI) CreateUser(user *model.User) (*model.User, *model.AppError) {

--- a/plugin/rpcplugin/api_test.go
+++ b/plugin/rpcplugin/api_test.go
@@ -2,6 +2,7 @@ package rpcplugin
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
@@ -83,6 +84,16 @@ func TestAPI(t *testing.T) {
 		assert.NoError(t, remote.LoadPluginConfiguration(&config))
 		assert.Equal(t, "foo", config.Foo)
 		assert.Equal(t, "baz", config.Bar.Baz)
+
+		api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(fmt.Errorf("foo")).Once()
+		assert.Error(t, remote.RegisterCommand(&model.Command{}))
+		api.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil).Once()
+		assert.NoError(t, remote.RegisterCommand(&model.Command{}))
+
+		api.On("UnregisterCommand", "team", "trigger").Return(fmt.Errorf("foo")).Once()
+		assert.Error(t, remote.UnregisterCommand("team", "trigger"))
+		api.On("UnregisterCommand", "team", "trigger").Return(nil).Once()
+		assert.NoError(t, remote.UnregisterCommand("team", "trigger"))
 
 		api.On("CreateChannel", mock.AnythingOfType("*model.Channel")).Return(func(c *model.Channel) (*model.Channel, *model.AppError) {
 			c.Id = "thechannelid"

--- a/plugin/rpcplugin/hooks_test.go
+++ b/plugin/rpcplugin/hooks_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 )
@@ -79,6 +80,17 @@ func TestHooks(t *testing.T) {
 		body, err := ioutil.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "bar", string(body))
+
+		hooks.On("ExecuteCommand", &model.CommandArgs{
+			Command: "/foo",
+		}).Return(&model.CommandResponse{
+			Text: "bar",
+		}, nil)
+		commandResponse, appErr := hooks.ExecuteCommand(&model.CommandArgs{
+			Command: "/foo",
+		})
+		assert.Equal(t, "bar", commandResponse.Text)
+		assert.Nil(t, appErr)
 	}))
 }
 


### PR DESCRIPTION
#### Summary

* Adds two new plugin APIs: `RegisterCommand` and `UnregisterCommand`.
* Adds a new plugin Hook: `ExecuteCommand`

So now plugins can implement slash commands:

```go
type HelloUserPlugin struct {}

func (p *HelloUserPlugin) OnActivate(api plugin.API) error {
	api.RegisterCommand(&model.Command{
		Trigger: "pcmd",
	})
	return nil
}

func (p *HelloUserPlugin) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
	if args.Command == "/pcmd" {
		return &model.CommandResponse{
			ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
			Text:         "hello!",
		}, nil
	}
	return nil, model.NewAppError("ExecuteCommand", "this is an error", nil, "", http.StatusBadRequest)
}
```

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates