### PR TITLE
issue #7775: Do not auto-join 'off-topic' channel if it is private

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -78,8 +78,7 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, channelRole s
 
 	if result := <-a.Srv.Store.Channel().GetByName(teamId, "off-topic", true); result.Err != nil {
 		err = result.Err
-	} else {
-		offTopic := result.Data.(*model.Channel)
+	} else if offTopic := result.Data.(*model.Channel); offTopic.Type == model.CHANNEL_OPEN {
 
 		cm := &model.ChannelMember{
 			ChannelId:   offTopic.Id,


### PR DESCRIPTION
#### Summary
Do not auto-join 'off-topic' channel if it is private channel.
This PR contains server side change for issue #7775 

Corresponding client side PR:
https://github.com/mattermost/mattermost-webapp/pull/418

#### Ticket Link
#7775 

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
