### PR TITLE
Allow deactivation of SSO users

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -683,10 +683,18 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ruser, err := c.App.UpdateNonSSOUserActive(c.Params.UserId, active); err != nil {
+	var user *model.User
+	var err *model.AppError
+
+	if user, err = c.App.GetUser(c.Params.UserId); err != nil {
+		c.Err = err
+		return
+	}
+
+	if _, err := c.App.UpdateActive(user, active); err != nil {
 		c.Err = err
 	} else {
-		c.LogAuditWithUserId(ruser.Id, fmt.Sprintf("active=%v", active))
+		c.LogAuditWithUserId(user.Id, fmt.Sprintf("active=%v", active))
 		ReturnStatusOK(w)
 	}
 }

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1163,6 +1163,13 @@ func TestUpdateUserActive(t *testing.T) {
 
 	_, resp = SystemAdminClient.UpdateUserActive(user.Id, false)
 	CheckNoError(t, resp)
+
+	authData := model.NewId()
+	result := <-th.App.Srv.Store.User().UpdateAuthData(user.Id, "random", &authData, "", true)
+	require.Nil(t, result.Err)
+
+	_, resp = SystemAdminClient.UpdateUserActive(user.Id, false)
+	CheckNoError(t, resp)
 }
 
 func TestGetUsers(t *testing.T) {
@@ -2123,7 +2130,9 @@ func TestSwitchAccount(t *testing.T) {
 	defer func() {
 		utils.SetIsLicensed(isLicensed)
 		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer = enableAuthenticationTransfer })
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer = enableAuthenticationTransfer
+		})
 	}()
 	utils.SetIsLicensed(true)
 	utils.SetLicense(&model.License{Features: &model.Features{}})

--- a/cmd/platform/user.go
+++ b/cmd/platform/user.go
@@ -184,8 +184,8 @@ func changeUserActiveStatus(a *app.App, user *model.User, userArg string, activa
 	if user == nil {
 		return fmt.Errorf("Can't find user '%v'", userArg)
 	}
-	if user.IsLDAPUser() {
-		return errors.New("You can not modify the activation status of AD/LDAP accounts. Please modify through the AD/LDAP server.")
+	if user.IsSSOUser() {
+		fmt.Println("You must also deactivate this user in the SSO provider or they will be reactivated on next login or sync.")
 	}
 	if _, err := a.UpdateActive(user, activate); err != nil {
 		return fmt.Errorf("Unable to change activation status of user: %v", userArg)


### PR DESCRIPTION
#### Summary
Allow deactivation of SSO users through the API and CLI.

Needs PM review on the text printed when deactivating an SSO user through the CLI:
```
You must also deactivate this user in the SSO provider or they will be reactivated on next login or sync.
```

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8100

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#311)
- [x] Has UI changes (mattermost/mattermost-webapp#423)