### PR TITLE
PLT-8314: Test Message Export Against S3 Bucket

### DIFF
--- a/model/config_test.go
+++ b/model/config_test.go
@@ -6,8 +6,6 @@ package model
 import (
 	"testing"
 
-	"os"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,31 +98,9 @@ func TestMessageExportSettingsIsValidBatchSizeInvalid(t *testing.T) {
 		EnableExport:        NewBool(true),
 		ExportFromTimestamp: NewInt64(0),
 		DailyRunTime:        NewString("15:04"),
-		FileLocation:        NewString("foo"),
 	}
 
 	// should fail fast because batch size isn't set
-	require.Error(t, mes.isValid(*fs))
-}
-
-func TestMessageExportSettingsIsValidFileLocationInvalid(t *testing.T) {
-	fs := &FileSettings{}
-	mes := &MessageExportSettings{
-		EnableExport:        NewBool(true),
-		ExportFromTimestamp: NewInt64(0),
-		DailyRunTime:        NewString("15:04"),
-		BatchSize:           NewInt(100),
-	}
-
-	// should fail fast because FileLocation isn't set
-	require.Error(t, mes.isValid(*fs))
-
-	// if using the local file driver, there are more rules for FileLocation
-	fs.DriverName = NewString(IMAGE_DRIVER_LOCAL)
-	fs.Directory, _ = os.Getwd()
-	mes.FileLocation = NewString("")
-
-	// should fail fast because file location is not relative to basepath
 	require.Error(t, mes.isValid(*fs))
 }
 
@@ -136,7 +112,6 @@ func TestMessageExportSettingsIsValid(t *testing.T) {
 		EnableExport:        NewBool(true),
 		ExportFromTimestamp: NewInt64(0),
 		DailyRunTime:        NewString("15:04"),
-		FileLocation:        NewString("foo"),
 		BatchSize:           NewInt(100),
 	}
 
@@ -149,7 +124,6 @@ func TestMessageExportSetDefaults(t *testing.T) {
 	mes.SetDefaults()
 
 	require.False(t, *mes.EnableExport)
-	require.Equal(t, "export", *mes.FileLocation)
 	require.Equal(t, "01:00", *mes.DailyRunTime)
 	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
 	require.Equal(t, 10000, *mes.BatchSize)
@@ -162,7 +136,6 @@ func TestMessageExportSetDefaultsExportEnabledExportFromTimestampNil(t *testing.
 	mes.SetDefaults()
 
 	require.True(t, *mes.EnableExport)
-	require.Equal(t, "export", *mes.FileLocation)
 	require.Equal(t, "01:00", *mes.DailyRunTime)
 	require.NotEqual(t, int64(0), *mes.ExportFromTimestamp)
 	require.True(t, *mes.ExportFromTimestamp <= GetMillis())
@@ -177,7 +150,6 @@ func TestMessageExportSetDefaultsExportEnabledExportFromTimestampZero(t *testing
 	mes.SetDefaults()
 
 	require.True(t, *mes.EnableExport)
-	require.Equal(t, "export", *mes.FileLocation)
 	require.Equal(t, "01:00", *mes.DailyRunTime)
 	require.NotEqual(t, int64(0), *mes.ExportFromTimestamp)
 	require.True(t, *mes.ExportFromTimestamp <= GetMillis())
@@ -192,7 +164,6 @@ func TestMessageExportSetDefaultsExportEnabledExportFromTimestampNonZero(t *test
 	mes.SetDefaults()
 
 	require.True(t, *mes.EnableExport)
-	require.Equal(t, "export", *mes.FileLocation)
 	require.Equal(t, "01:00", *mes.DailyRunTime)
 	require.Equal(t, int64(12345), *mes.ExportFromTimestamp)
 	require.Equal(t, 10000, *mes.BatchSize)
@@ -205,7 +176,6 @@ func TestMessageExportSetDefaultsExportDisabledExportFromTimestampNil(t *testing
 	mes.SetDefaults()
 
 	require.False(t, *mes.EnableExport)
-	require.Equal(t, "export", *mes.FileLocation)
 	require.Equal(t, "01:00", *mes.DailyRunTime)
 	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
 	require.Equal(t, 10000, *mes.BatchSize)
@@ -219,7 +189,6 @@ func TestMessageExportSetDefaultsExportDisabledExportFromTimestampZero(t *testin
 	mes.SetDefaults()
 
 	require.False(t, *mes.EnableExport)
-	require.Equal(t, "export", *mes.FileLocation)
 	require.Equal(t, "01:00", *mes.DailyRunTime)
 	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
 	require.Equal(t, 10000, *mes.BatchSize)
@@ -233,7 +202,6 @@ func TestMessageExportSetDefaultsExportDisabledExportFromTimestampNonZero(t *tes
 	mes.SetDefaults()
 
 	require.False(t, *mes.EnableExport)
-	require.Equal(t, "export", *mes.FileLocation)
 	require.Equal(t, "01:00", *mes.DailyRunTime)
 	require.Equal(t, int64(0), *mes.ExportFromTimestamp)
 	require.Equal(t, 10000, *mes.BatchSize)

--- a/utils/file.go
+++ b/utils/file.go
@@ -21,6 +21,9 @@ func CopyFile(src, dst string) (err error) {
 	}
 	defer in.Close()
 
+	if err = os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
+		return
+	}
 	out, err := os.Create(dst)
 	if err != nil {
 		return

--- a/utils/file_backend_test.go
+++ b/utils/file_backend_test.go
@@ -51,9 +51,9 @@ func TestS3FileBackendTestSuite(t *testing.T) {
 	suite.Run(t, &FileBackendTestSuite{
 		settings: model.FileSettings{
 			DriverName:              model.NewString(model.IMAGE_DRIVER_S3),
-			AmazonS3AccessKeyId:     "minioaccesskey",
-			AmazonS3SecretAccessKey: "miniosecretkey",
-			AmazonS3Bucket:          "mattermost-test",
+			AmazonS3AccessKeyId:     model.MINIO_ACCESS_KEY,
+			AmazonS3SecretAccessKey: model.MINIO_SECRET_KEY,
+			AmazonS3Bucket:          model.MINIO_BUCKET,
 			AmazonS3Endpoint:        s3Endpoint,
 			AmazonS3SSL:             model.NewBool(false),
 		},
@@ -90,6 +90,26 @@ func (s *FileBackendTestSuite) TestCopyFile() {
 	b := []byte("test")
 	path1 := "tests/" + model.NewId()
 	path2 := "tests/" + model.NewId()
+
+	err := s.backend.WriteFile(b, path1)
+	s.Nil(err)
+	defer s.backend.RemoveFile(path1)
+
+	err = s.backend.CopyFile(path1, path2)
+	s.Nil(err)
+	defer s.backend.RemoveFile(path2)
+
+	_, err = s.backend.ReadFile(path1)
+	s.Nil(err)
+
+	_, err = s.backend.ReadFile(path2)
+	s.Nil(err)
+}
+
+func (s *FileBackendTestSuite) TestCopyFileToDirectoryThatDoesntExist() {
+	b := []byte("test")
+	path1 := "tests/" + model.NewId()
+	path2 := "tests/newdirectory/" + model.NewId()
 
 	err := s.backend.WriteFile(b, path1)
 	s.Nil(err)


### PR DESCRIPTION
#### Summary
Removed export directory config setting, in favour of hard-coding it to an 'export' directory under the local file directory. Improved the local file backend copy implementation to implicitly create the destination directory if it's missing

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8314

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] [Has enterprise changes](https://github.com/mattermost/enterprise/pull/247)
- [x] [Has UI changes](https://github.com/mattermost/mattermost-webapp/pull/390)