### PR TITLE
Issue #7877: post change channel privacy message

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -343,6 +343,47 @@ func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppE
 	}
 }
 
+func (a *App) UpdateChannelPrivacy(oldChannel *model.Channel, user *model.User) (*model.Channel, *model.AppError) {
+	if channel, err := a.UpdateChannel(oldChannel); err != nil {
+		return channel, err
+	} else {
+		if err := a.postChannelPrivacyMessage(user, channel); err != nil {
+			if channel.Type == model.CHANNEL_OPEN {
+				channel.Type = model.CHANNEL_PRIVATE
+			} else {
+				channel.Type = model.CHANNEL_OPEN
+			}
+			// revert to previous channel privacy
+			a.UpdateChannel(channel)
+			return channel, err
+		}
+
+		return channel, nil
+	}
+}
+
+func (a *App) postChannelPrivacyMessage(user *model.User, channel *model.Channel) *model.AppError {
+	privacy := (map[string]string{
+		model.CHANNEL_OPEN:    "private_to_public",
+		model.CHANNEL_PRIVATE: "public_to_private",
+	})[channel.Type]
+	post := &model.Post{
+		ChannelId: channel.Id,
+		Message:   fmt.Sprintf(utils.T("api.channel.change_channel_privacy." + privacy)),
+		Type:      model.POST_CHANGE_CHANNEL_PRIVACY,
+		UserId:    user.Id,
+		Props: model.StringInterface{
+			"username": user.Username,
+		},
+	}
+
+	if _, err := a.CreatePost(post, channel, false); err != nil {
+		return model.NewAppError("postChannelPrivacyMessage", "api.channel.post_channel_privacy_message.error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
+}
+
 func (a *App) RestoreChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 	if result := <-a.Srv.Store.Channel().Restore(channel.Id, model.GetMillis()); result.Err != nil {
 		return nil, result.Err

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -190,6 +190,21 @@ func TestCreateChannelPrivate(t *testing.T) {
 	assert.Equal(t, privateChannel.Id, histories[0].ChannelId)
 }
 
+func TestUpdateChannelPrivacy(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	privateChannel := th.createChannel(th.BasicTeam, model.CHANNEL_PRIVATE)
+	privateChannel.Type = model.CHANNEL_OPEN
+
+	if publicChannel, err := th.App.UpdateChannelPrivacy(privateChannel, th.BasicUser); err != nil {
+		t.Fatal("Failed to update channel privacy. Error: " + err.Error())
+	} else {
+		assert.Equal(t, publicChannel.Id, privateChannel.Id)
+		assert.Equal(t, publicChannel.Type, model.CHANNEL_OPEN)
+	}
+}
+
 func TestCreateGroupChannel(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()

--- a/cmd/platform/channel.go
+++ b/cmd/platform/channel.go
@@ -110,6 +110,7 @@ func init() {
 
 	modifyChannelCmd.Flags().Bool("private", false, "Convert the channel to a private channel")
 	modifyChannelCmd.Flags().Bool("public", false, "Convert the channel to a public channel")
+	modifyChannelCmd.Flags().String("username", "", "Required. Username who changes the channel privacy.")
 
 	channelCmd.AddCommand(
 		channelCreateCmd,
@@ -438,6 +439,11 @@ func modifyChannelCmdF(cmd *cobra.Command, args []string) error {
 		return errors.New("Enter at one channel to modify.")
 	}
 
+	username, erru := cmd.Flags().GetString("username")
+	if erru != nil || username == "" {
+		return errors.New("Username is required")
+	}
+
 	public, _ := cmd.Flags().GetBool("public")
 	private, _ := cmd.Flags().GetBool("private")
 
@@ -459,8 +465,9 @@ func modifyChannelCmdF(cmd *cobra.Command, args []string) error {
 		channel.Type = model.CHANNEL_PRIVATE
 	}
 
-	if _, err := a.UpdateChannel(channel); err != nil {
-		return errors.New("Failed to update channel '" + args[0] + "' - " + err.Error())
+	user := getUserFromUserArg(a, username)
+	if _, err := a.UpdateChannelPrivacy(channel, user); err != nil {
+		return errors.New("Failed to update channel ('" + args[0] + "') privacy - " + err.Error())
 	}
 
 	return nil

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -316,6 +316,14 @@
     "translation": "%v has left the channel."
   },
   {
+    "id": "api.channel.change_channel_privacy.private_to_public",
+    "translation": "This channel has been converted to a Public Channel and can be joined by any team member."
+  },
+  {
+    "id": "api.channel.change_channel_privacy.public_to_private",
+    "translation": "This channel has been converted to a Private Channel."
+  },
+  {
     "id": "api.channel.post_update_channel_displayname_message_and_forget.create_post.error",
     "translation": "Failed to post displayname update message"
   },

--- a/model/post.go
+++ b/model/post.go
@@ -13,32 +13,33 @@ import (
 )
 
 const (
-	POST_SYSTEM_MESSAGE_PREFIX = "system_"
-	POST_DEFAULT               = ""
-	POST_SLACK_ATTACHMENT      = "slack_attachment"
-	POST_SYSTEM_GENERIC        = "system_generic"
-	POST_JOIN_LEAVE            = "system_join_leave" // Deprecated, use POST_JOIN_CHANNEL or POST_LEAVE_CHANNEL instead
-	POST_JOIN_CHANNEL          = "system_join_channel"
-	POST_LEAVE_CHANNEL         = "system_leave_channel"
-	POST_JOIN_TEAM             = "system_join_team"
-	POST_LEAVE_TEAM            = "system_leave_team"
-	POST_ADD_REMOVE            = "system_add_remove" // Deprecated, use POST_ADD_TO_CHANNEL or POST_REMOVE_FROM_CHANNEL instead
-	POST_ADD_TO_CHANNEL        = "system_add_to_channel"
-	POST_ADD_TO_TEAM           = "system_add_to_team"
-	POST_REMOVE_FROM_CHANNEL   = "system_remove_from_channel"
-	POST_HEADER_CHANGE         = "system_header_change"
-	POST_DISPLAYNAME_CHANGE    = "system_displayname_change"
-	POST_PURPOSE_CHANGE        = "system_purpose_change"
-	POST_CHANNEL_DELETED       = "system_channel_deleted"
-	POST_EPHEMERAL             = "system_ephemeral"
-	POST_FILEIDS_MAX_RUNES     = 150
-	POST_FILENAMES_MAX_RUNES   = 4000
-	POST_HASHTAGS_MAX_RUNES    = 1000
-	POST_MESSAGE_MAX_RUNES     = 4000
-	POST_PROPS_MAX_RUNES       = 8000
-	POST_PROPS_MAX_USER_RUNES  = POST_PROPS_MAX_RUNES - 400 // Leave some room for system / pre-save modifications
-	POST_CUSTOM_TYPE_PREFIX    = "custom_"
-	PROPS_ADD_CHANNEL_MEMBER   = "add_channel_member"
+	POST_SYSTEM_MESSAGE_PREFIX  = "system_"
+	POST_DEFAULT                = ""
+	POST_SLACK_ATTACHMENT       = "slack_attachment"
+	POST_SYSTEM_GENERIC         = "system_generic"
+	POST_JOIN_LEAVE             = "system_join_leave" // Deprecated, use POST_JOIN_CHANNEL or POST_LEAVE_CHANNEL instead
+	POST_JOIN_CHANNEL           = "system_join_channel"
+	POST_LEAVE_CHANNEL          = "system_leave_channel"
+	POST_JOIN_TEAM              = "system_join_team"
+	POST_LEAVE_TEAM             = "system_leave_team"
+	POST_ADD_REMOVE             = "system_add_remove" // Deprecated, use POST_ADD_TO_CHANNEL or POST_REMOVE_FROM_CHANNEL instead
+	POST_ADD_TO_CHANNEL         = "system_add_to_channel"
+	POST_ADD_TO_TEAM            = "system_add_to_team"
+	POST_REMOVE_FROM_CHANNEL    = "system_remove_from_channel"
+	POST_HEADER_CHANGE          = "system_header_change"
+	POST_DISPLAYNAME_CHANGE     = "system_displayname_change"
+	POST_PURPOSE_CHANGE         = "system_purpose_change"
+	POST_CHANNEL_DELETED        = "system_channel_deleted"
+	POST_EPHEMERAL              = "system_ephemeral"
+	POST_CHANGE_CHANNEL_PRIVACY = "system_change_chan_privacy"
+	POST_FILEIDS_MAX_RUNES      = 150
+	POST_FILENAMES_MAX_RUNES    = 4000
+	POST_HASHTAGS_MAX_RUNES     = 1000
+	POST_MESSAGE_MAX_RUNES      = 4000
+	POST_PROPS_MAX_RUNES        = 8000
+	POST_PROPS_MAX_USER_RUNES   = POST_PROPS_MAX_RUNES - 400 // Leave some room for system / pre-save modifications
+	POST_CUSTOM_TYPE_PREFIX     = "custom_"
+	PROPS_ADD_CHANNEL_MEMBER    = "add_channel_member"
 )
 
 type Post struct {
@@ -186,7 +187,8 @@ func (o *Post) IsValid() *AppError {
 		POST_HEADER_CHANGE,
 		POST_PURPOSE_CHANGE,
 		POST_DISPLAYNAME_CHANGE,
-		POST_CHANNEL_DELETED:
+		POST_CHANNEL_DELETED,
+		POST_CHANGE_CHANNEL_PRIVACY:
 	default:
 		if !strings.HasPrefix(o.Type, POST_CUSTOM_TYPE_PREFIX) {
 			return NewAppError("Post.IsValid", "model.post.is_valid.type.app_error", nil, "id="+o.Type, http.StatusBadRequest)


### PR DESCRIPTION
#### Summary
Post a System message to the affected channel.

This PR will change command semantic from:
`$ platform channel modify myteam:mychannel --private`
 to:
 `$ platform channel modify myteam:mychannel --private --username`
The reason is described at #7877 issue.

#### Ticket Link
#7877 

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates