### PR TITLE
Plt 8350 fire mention when channel user count smaller or equals to max allowed number

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -935,7 +935,7 @@ func (a *App) GetMentionKeywordsInChannel(profiles map[string]*model.User, lookF
 
 		// Add @channel and @all to keywords if user has them turned on
 		if lookForSpecialMentions {
-			if int64(len(profiles)) < *a.Config().TeamSettings.MaxNotificationsPerChannel && profile.NotifyProps["channel"] == "true" {
+			if int64(len(profiles)) <= *a.Config().TeamSettings.MaxNotificationsPerChannel && profile.NotifyProps["channel"] == "true" {
 				keywords["@channel"] = append(keywords["@channel"], profile.Id)
 				keywords["@all"] = append(keywords["@all"], profile.Id)
 


### PR DESCRIPTION
#### Summary
Fire "mention" when `channel user count <= max allowed number`. 
Previously when `channel user count == max allowed number`, notification was not filed because of the wrong conditional statement in place.


#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7969

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
