### PR TITLE
Fix reaction test

### DIFF
--- a/api4/reaction_test.go
+++ b/api4/reaction_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"reflect"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/mattermost/mattermost-server/model"
 )
@@ -180,20 +180,15 @@ func TestGetReactions(t *testing.T) {
 	rr, resp := Client.GetReactions(postId)
 	CheckNoError(t, resp)
 
-	if len(rr) != 5 {
-		t.Fatal("reactions should returned correct length")
-	}
-
-	if !reflect.DeepEqual(rr, reactions) {
-		t.Fatal("reactions should have matched")
+	assert.Len(t, rr, 5)
+	for _, r := range reactions {
+		assert.Contains(t, reactions, r)
 	}
 
 	rr, resp = Client.GetReactions("junk")
 	CheckBadRequestStatus(t, resp)
 
-	if len(rr) != 0 {
-		t.Fatal("reactions should return empty")
-	}
+	assert.Empty(t, rr)
 
 	_, resp = Client.GetReactions(GenerateTestId())
 	CheckForbiddenStatus(t, resp)


### PR DESCRIPTION
#### Summary
Fails at high speeds ([example](https://build.mattermost.com/job/mattermost-platform-pr-split/932/consoleFull)). If two or more of the reactions have the same CreateAt time, the order that they're returned in is undefined. So `reflect.DeepEqual` can't be used like this.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)