### PR TITLE
PLT-8354: Fix user search error when terms end up as empty space.

### DIFF
--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1078,7 +1078,7 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 		searchQuery = strings.Replace(searchQuery, "INACTIVE_CLAUSE", "AND Users.DeleteAt = 0", 1)
 	}
 
-	if term == "" {
+	if strings.TrimSpace(term) == "" {
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
 	} else {
 		isPostgreSQL := us.DriverName() == model.DATABASE_DRIVER_POSTGRES

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 )
@@ -1817,6 +1819,10 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 			t.Fatal("should have found user")
 		}
 	}
+
+	// Check PLT-8354 - search that ends up with just space for terms doesn't error.
+	r1 := <-ss.User().SearchWithoutTeam("* ", searchOptions)
+	assert.Nil(t, r1.Err)
 }
 
 func testUserStoreSearchWithoutTeam(t *testing.T, ss store.Store) {


### PR DESCRIPTION
#### Summary

Fix user search so it doesn't error when the cleaned-up query ends up just being whitespace.

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-8354

#### Checklist
- [x] Added or updated unit tests (required for all new features)