### PR TITLE
Set default for DefaultTeamName setting if not present in config

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -1021,6 +1021,10 @@ func (s *TeamSettings) SetDefaults() {
 	if s.ExperimentalTownSquareIsReadOnly == nil {
 		s.ExperimentalTownSquareIsReadOnly = NewBool(false)
 	}
+
+	if s.DefaultTeamName == nil {
+		s.DefaultTeamName = NewString("")
+	}
 }
 
 type ClientRequirements struct {


### PR DESCRIPTION
#### Summary
Set default for DefaultTeamName setting if not present in config.