### PR TITLE
Add full text search support for mysql and postgres db

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1343,7 +1343,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 	} else if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
 		matchClause := fmt.Sprintf("MATCH (%s) AGAINST (:Terms IN BOOLEAN MODE)", searchType)
 		searchClause := fmt.Sprintf("AND %s", matchClause)
-		asRelevanceClause := fmt.Sprintf("%s as relevance", matchClause)
+		asRelevanceClause := fmt.Sprintf("%s AS relevance", matchClause)
 
 		searchQuery = strings.Replace(searchQuery, "AS_RELEVANCE_CLAUSE", asRelevanceClause, 1)
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -93,7 +93,7 @@ func (s SqlChannelStore) CreateIndexesIfNotExists() {
 	s.CreateIndexIfNotExists("idx_channelmembers_channel_id", "ChannelMembers", "ChannelId")
 	s.CreateIndexIfNotExists("idx_channelmembers_user_id", "ChannelMembers", "UserId")
 
-	s.CreateFullTextIndexIfNotExists("idx_channels_txt", "Channels", "Name, DisplayName")
+	s.CreateFullTextIndexIfNotExists("idx_channels_txt", "Channels", "Name, DisplayName, Purpose")
 }
 
 func (s SqlChannelStore) Save(channel *model.Channel, maxChannelsPerTeam int64) store.StoreChannel {
@@ -1318,7 +1318,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 		term = strings.Replace(term, c, "*"+c, -1)
 	}
 
-	searchType := "Name, DisplayName"
+	searchType := "Name, DisplayName, Purpose"
 	if term == "" {
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
 	} else if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
@@ -1326,7 +1326,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 		searchClause := fmt.Sprintf("AND to_tsvector(%s) @@  to_tsquery(:Terms)", postgresColumnNames)
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
 	} else if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
-		searchClause := fmt.Sprintf("AND MATCH (%s) AGAINST (:Terms IN BOOLEAN MODE)", searchType)
+		searchClause := fmt.Sprintf("AND MATCH (%s) AGAINST (:Terms IN NATURAL LANGUAGE MODE)", searchType)
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
 	}
 

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -24,10 +24,10 @@ var storeTypes = []*struct {
 		Name: "MySQL",
 		Func: storetest.NewMySQLContainer,
 	},
-	// {
-	// 	Name: "PostgreSQL",
-	// 	Func: storetest.NewPostgreSQLContainer,
-	// },
+	{
+		Name: "PostgreSQL",
+		Func: storetest.NewPostgreSQLContainer,
+	},
 }
 
 func StoreTest(t *testing.T, f func(*testing.T, store.Store)) {

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -24,10 +24,10 @@ var storeTypes = []*struct {
 		Name: "MySQL",
 		Func: storetest.NewMySQLContainer,
 	},
-	{
-		Name: "PostgreSQL",
-		Func: storetest.NewPostgreSQLContainer,
-	},
+	// {
+	// 	Name: "PostgreSQL",
+	// 	Func: storetest.NewPostgreSQLContainer,
+	// },
 }
 
 func StoreTest(t *testing.T, f func(*testing.T, store.Store)) {

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -5,6 +5,7 @@ package storetest
 
 import (
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -1772,6 +1773,13 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o9.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o9, -1))
 
+	o10 := model.Channel{}
+	o10.TeamId = o1.TeamId
+	o10.DisplayName = "Name Is FuzzySearched"
+	o10.Name = "fuzzy-searched"
+	o10.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o10, -1))
+
 	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
@@ -1807,31 +1815,33 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 		}
 	}
 
-	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-"); result.Err != nil {
-		t.Fatal(result.Err)
-	} else {
-		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 2 {
-			t.Fatal("should return 2 channels, not including private channel")
-		}
-
-		o6Exists, o7Exists := false, false
-		for _, c := range *channels {
-			if c.Name == o6.Name {
-				o6Exists = true
+	if strings.Contains(t.Name(), model.DATABASE_DRIVER_MYSQL) {
+		if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-"); result.Err != nil {
+			t.Fatal(result.Err)
+		} else {
+			channels := result.Data.(*model.ChannelList)
+			if len(*channels) != 2 {
+				t.Fatal("should return 2 channels, not including private channel")
 			}
 
-			if c.Name == o7.Name {
-				o7Exists = true
+			o6Exists, o7Exists := false, false
+			for _, c := range *channels {
+				if c.Name == o6.Name {
+					o6Exists = true
+				}
+
+				if c.Name == o7.Name {
+					o7Exists = true
+				}
 			}
-		}
 
-		if !o6Exists {
-			t.Fatal("wrong channel returned")
-		}
+			if !o6Exists {
+				t.Fatal("wrong channel returned")
+			}
 
-		if !o7Exists {
-			t.Fatal("wrong channel returned")
+			if !o7Exists {
+				t.Fatal("wrong channel returned")
+			}
 		}
 	}
 
@@ -1886,6 +1896,27 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 
 		if !o6Exists {
 			t.Fatal("channel o6 not found")
+		}
+	}
+
+	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "Fuz"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+
+		if len(*channels) == 0 {
+			t.Fatal("should not be empty")
+		}
+
+		o10Exists := false
+		for _, c := range *channels {
+			if c.Name == o10.Name {
+				o10Exists = true
+			}
+		}
+
+		if !o10Exists {
+			t.Fatal("channel o10 not found")
 		}
 	}
 }
@@ -1980,6 +2011,13 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o10.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o10, -1))
 
+	o11 := model.Channel{}
+	o11.TeamId = o1.TeamId
+	o11.DisplayName = "Name Is FuzzySearched"
+	o11.Name = "fuzzy-searched"
+	o11.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o11, -1))
+
 	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
@@ -2006,32 +2044,33 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 			t.Fatal("should be empty")
 		}
 	}
-
-	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-"); result.Err != nil {
-		t.Fatal(result.Err)
-	} else {
-		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 2 {
-			t.Fatal("should return 2 channels, not including private channel")
-		}
-
-		o6Exists, o7Exists := false, false
-		for _, c := range *channels {
-			if c.Name == o6.Name {
-				o6Exists = true
+	if strings.Contains(t.Name(), model.DATABASE_DRIVER_MYSQL) {
+		if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-"); result.Err != nil {
+			t.Fatal(result.Err)
+		} else {
+			channels := result.Data.(*model.ChannelList)
+			if len(*channels) != 2 {
+				t.Fatal("should return 2 channels, not including private channel")
 			}
 
-			if c.Name == o7.Name {
-				o7Exists = true
+			o6Exists, o7Exists := false, false
+			for _, c := range *channels {
+				if c.Name == o6.Name {
+					o6Exists = true
+				}
+
+				if c.Name == o7.Name {
+					o7Exists = true
+				}
 			}
-		}
 
-		if !o6Exists {
-			t.Fatal("wrong channel returned")
-		}
+			if !o6Exists {
+				t.Fatal("wrong channel returned")
+			}
 
-		if !o7Exists {
-			t.Fatal("wrong channel returned")
+			if !o7Exists {
+				t.Fatal("wrong channel returned")
+			}
 		}
 	}
 
@@ -2098,6 +2137,27 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 
 		if (*channels)[0].Name != o10.Name {
 			t.Fatal("wrong channel returned")
+		}
+	}
+
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "Fuz"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+
+		if len(*channels) == 0 {
+			t.Fatal("should not be empty")
+		}
+
+		o11Exists := false
+		for _, c := range *channels {
+			if c.Name == o11.Name {
+				o11Exists = true
+			}
+		}
+
+		if !o11Exists {
+			t.Fatal("channel o11 not found")
 		}
 	}
 }

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -1764,6 +1764,14 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o8.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&o8, -1))
 
+	o9 := model.Channel{}
+	o9.TeamId = o1.TeamId
+	o9.DisplayName = "Purpose"
+	o9.Name = "purpose"
+	o9.Purpose = "This Channel is used to test the purpose."
+	o9.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o9, -1))
+
 	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
@@ -1825,6 +1833,19 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 		}
 
 		if (*channels)[0].Name != o6.Name {
+			t.Fatal("wrong channel returned")
+		}
+	}
+
+	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "used to test"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
+
+		if (*channels)[0].Name != o9.Name {
 			t.Fatal("wrong channel returned")
 		}
 	}
@@ -1922,6 +1943,14 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o9.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o9, -1))
 
+	o10 := model.Channel{}
+	o10.TeamId = o1.TeamId
+	o10.DisplayName = "Purpose"
+	o10.Name = "purpose"
+	o10.Purpose = "This Channel is used to test the purpose."
+	o10.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o10, -1))
+
 	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "ChannelA"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
@@ -1997,6 +2026,19 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 		}
 
 		if (*channels)[0].Name != o9.Name {
+			t.Fatal("wrong channel returned")
+		}
+	}
+
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "used to test"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
+
+		if (*channels)[0].Name != o10.Name {
 			t.Fatal("wrong channel returned")
 		}
 	}

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -1815,25 +1815,43 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 			t.Fatal("should return 2 channels, not including private channel")
 		}
 
-		if (*channels)[0].Name != o7.Name {
+		o6Exists, o7Exists := false, false
+		for _, c := range *channels {
+			if c.Name == o6.Name {
+				o6Exists = true
+			}
+
+			if c.Name == o7.Name {
+				o7Exists = true
+			}
+		}
+
+		if !o6Exists {
 			t.Fatal("wrong channel returned")
 		}
 
-		if (*channels)[1].Name != o6.Name {
+		if !o7Exists {
 			t.Fatal("wrong channel returned")
 		}
 	}
 
-	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-topic"); result.Err != nil {
+	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "Off Topic"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 1 {
-			t.Fatal("should return 1 channel")
+		if len(*channels) == 0 {
+			t.Fatal("should return channels")
 		}
 
-		if (*channels)[0].Name != o6.Name {
-			t.Fatal("wrong channel returned")
+		o6Exists := false
+		for _, c := range *channels {
+			if c.Name == o6.Name {
+				o6Exists = true
+			}
+		}
+
+		if !o6Exists {
+			t.Fatal("channel o6 not found")
 		}
 	}
 
@@ -1854,9 +1872,20 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 		t.Fatal(result.Err)
 	} else {
 		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 0 {
-			t.Logf("%v\n", *channels)
-			t.Fatal("should be empty")
+
+		if len(*channels) == 0 {
+			t.Fatal("should not be empty")
+		}
+
+		o6Exists := false
+		for _, c := range *channels {
+			if c.Name == o6.Name {
+				o6Exists = true
+			}
+		}
+
+		if !o6Exists {
+			t.Fatal("channel o6 not found")
 		}
 	}
 }
@@ -1986,25 +2015,43 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 			t.Fatal("should return 2 channels, not including private channel")
 		}
 
-		if (*channels)[0].Name != o7.Name {
+		o6Exists, o7Exists := false, false
+		for _, c := range *channels {
+			if c.Name == o6.Name {
+				o6Exists = true
+			}
+
+			if c.Name == o7.Name {
+				o7Exists = true
+			}
+		}
+
+		if !o6Exists {
 			t.Fatal("wrong channel returned")
 		}
 
-		if (*channels)[1].Name != o6.Name {
+		if !o7Exists {
 			t.Fatal("wrong channel returned")
 		}
 	}
 
-	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-topic"); result.Err != nil {
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "Off Topic"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 1 {
-			t.Fatal("should return 1 channel")
+		if len(*channels) == 0 {
+			t.Fatal("should return channels")
 		}
 
-		if (*channels)[0].Name != o6.Name {
-			t.Fatal("wrong channel returned")
+		o6Exists := false
+		for _, c := range *channels {
+			if c.Name == o6.Name {
+				o6Exists = true
+			}
+		}
+
+		if !o6Exists {
+			t.Fatal("channel o6 not found")
 		}
 	}
 
@@ -2012,8 +2059,19 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 		t.Fatal(result.Err)
 	} else {
 		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 0 {
-			t.Fatal("should be empty")
+		if len(*channels) == 0 {
+			t.Fatal("should not be empty")
+		}
+
+		o6Exists := false
+		for _, c := range *channels {
+			if c.Name == o6.Name {
+				o6Exists = true
+			}
+		}
+
+		if !o6Exists {
+			t.Fatal("channel o6 not found")
 		}
 	}
 


### PR DESCRIPTION
#### Summary
Add full-text search support for channel names.  Using full text search support for mysql and postgres.

Requires adding full-text search index to the Channels table for (Name, DisplayName).

#### mysql
``` mysql
ALTER TABLE Channels
ADD FULLTEXT(Name, DisplayName);
```

#### postgres
``` postgres
Not 100% sure if postgres requires any additional changes.
```

#### Checklist
- [x] All new/modified APIs include changes to the drivers