### PR TITLE
[PLT-8173] Add username and profile picture to webhook set up pages

### DIFF
--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -13,6 +13,289 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
+func TestCreateIncomingWebhookForChannel(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
+	enablePostUsernameOverride := th.App.Config().ServiceSettings.EnablePostUsernameOverride
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostUsernameOverride = enablePostUsernameOverride })
+	enablePostIconOverride := th.App.Config().ServiceSettings.EnablePostIconOverride
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = enablePostIconOverride })
+
+	type TestCase struct {
+		EnableIncomingHooks        bool
+		EnablePostUsernameOverride bool
+		EnablePostIconOverride     bool
+		IncomingWebhook            model.IncomingWebhook
+
+		ExpectedError           bool
+		ExpectedIncomingWebhook *model.IncomingWebhook
+	}
+
+	for name, tc := range map[string]TestCase{
+		"webhooks not enabled": {
+			EnableIncomingHooks:        false,
+			EnablePostUsernameOverride: false,
+			EnablePostIconOverride:     false,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+
+			ExpectedError:           true,
+			ExpectedIncomingWebhook: nil,
+		},
+		"valid: username and post icon url ignored, since override not enabled": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: false,
+			EnablePostIconOverride:     false,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: ":invalid and ignored:",
+				PostIconURL:  "ignored",
+			},
+
+			ExpectedError: false,
+			ExpectedIncomingWebhook: &model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+		},
+		"invalid username, override enabled": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: true,
+			EnablePostIconOverride:     false,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: ":invalid:",
+			},
+
+			ExpectedError:           true,
+			ExpectedIncomingWebhook: nil,
+		},
+		"valid, no username or post icon url provided": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: true,
+			EnablePostIconOverride:     true,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+
+			ExpectedError: false,
+			ExpectedIncomingWebhook: &model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+		},
+		"valid, with username and post icon": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: true,
+			EnablePostIconOverride:     true,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: "valid",
+				PostIconURL:  "http://example.com/icon",
+			},
+
+			ExpectedError: false,
+			ExpectedIncomingWebhook: &model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: "valid",
+				PostIconURL:  "http://example.com/icon",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = tc.EnableIncomingHooks })
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				cfg.ServiceSettings.EnablePostUsernameOverride = tc.EnablePostUsernameOverride
+			})
+			th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = tc.EnablePostIconOverride })
+
+			createdHook, err := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &tc.IncomingWebhook)
+			if tc.ExpectedError && err == nil {
+				t.Fatal("should have failed")
+			} else if !tc.ExpectedError && err != nil {
+				t.Fatalf("should not have failed: %v", err.Error())
+			}
+			if createdHook != nil {
+				defer th.App.DeleteIncomingWebhook(createdHook.Id)
+			}
+			if tc.ExpectedIncomingWebhook == nil {
+				assert.Nil(createdHook, "expected nil webhook")
+			} else if assert.NotNil(createdHook, "expected non-nil webhook") {
+				assert.Equal(tc.ExpectedIncomingWebhook.DisplayName, createdHook.DisplayName)
+				assert.Equal(tc.ExpectedIncomingWebhook.Description, createdHook.Description)
+				assert.Equal(tc.ExpectedIncomingWebhook.ChannelId, createdHook.ChannelId)
+				assert.Equal(tc.ExpectedIncomingWebhook.PostUsername, createdHook.PostUsername)
+				assert.Equal(tc.ExpectedIncomingWebhook.PostIconURL, createdHook.PostIconURL)
+			}
+		})
+	}
+}
+
+func TestUpdateIncomingWebhook(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
+	enablePostUsernameOverride := th.App.Config().ServiceSettings.EnablePostUsernameOverride
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostUsernameOverride = enablePostUsernameOverride })
+	enablePostIconOverride := th.App.Config().ServiceSettings.EnablePostIconOverride
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = enablePostIconOverride })
+
+	type TestCase struct {
+		EnableIncomingHooks        bool
+		EnablePostUsernameOverride bool
+		EnablePostIconOverride     bool
+		IncomingWebhook            model.IncomingWebhook
+
+		ExpectedError           bool
+		ExpectedIncomingWebhook *model.IncomingWebhook
+	}
+
+	for name, tc := range map[string]TestCase{
+		"webhooks not enabled": {
+			EnableIncomingHooks:        false,
+			EnablePostUsernameOverride: false,
+			EnablePostIconOverride:     false,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+
+			ExpectedError:           true,
+			ExpectedIncomingWebhook: nil,
+		},
+		"valid: username and post icon url ignored, since override not enabled": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: false,
+			EnablePostIconOverride:     false,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: ":invalid and ignored:",
+				PostIconURL:  "ignored",
+			},
+
+			ExpectedError: false,
+			ExpectedIncomingWebhook: &model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+		},
+		"invalid username, override enabled": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: true,
+			EnablePostIconOverride:     false,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: ":invalid:",
+			},
+
+			ExpectedError:           true,
+			ExpectedIncomingWebhook: nil,
+		},
+		"valid, no username or post icon url provided": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: true,
+			EnablePostIconOverride:     true,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+
+			ExpectedError: false,
+			ExpectedIncomingWebhook: &model.IncomingWebhook{
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+			},
+		},
+		"valid, with username and post icon": {
+			EnableIncomingHooks:        true,
+			EnablePostUsernameOverride: true,
+			EnablePostIconOverride:     true,
+			IncomingWebhook: model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: "valid",
+				PostIconURL:  "http://example.com/icon",
+			},
+
+			ExpectedError: false,
+			ExpectedIncomingWebhook: &model.IncomingWebhook{
+				DisplayName:  "title",
+				Description:  "description",
+				ChannelId:    th.BasicChannel.Id,
+				PostUsername: "valid",
+				PostIconURL:  "http://example.com/icon",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
+
+			hook, err := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{
+				ChannelId: th.BasicChannel.Id,
+			})
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			defer th.App.DeleteIncomingWebhook(hook.Id)
+
+			th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = tc.EnableIncomingHooks })
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				cfg.ServiceSettings.EnablePostUsernameOverride = tc.EnablePostUsernameOverride
+			})
+			th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = tc.EnablePostIconOverride })
+
+			updatedHook, err := th.App.UpdateIncomingWebhook(hook, &tc.IncomingWebhook)
+			if tc.ExpectedError && err == nil {
+				t.Fatal("should have failed")
+			} else if !tc.ExpectedError && err != nil {
+				t.Fatalf("should not have failed: %v", err.Error())
+			}
+			if tc.ExpectedIncomingWebhook == nil {
+				assert.Nil(updatedHook, "expected nil webhook")
+			} else if assert.NotNil(updatedHook, "expected non-nil webhook") {
+				assert.Equal(tc.ExpectedIncomingWebhook.DisplayName, updatedHook.DisplayName)
+				assert.Equal(tc.ExpectedIncomingWebhook.Description, updatedHook.Description)
+				assert.Equal(tc.ExpectedIncomingWebhook.ChannelId, updatedHook.ChannelId)
+				assert.Equal(tc.ExpectedIncomingWebhook.PostUsername, updatedHook.PostUsername)
+				assert.Equal(tc.ExpectedIncomingWebhook.PostIconURL, updatedHook.PostIconURL)
+			}
+		})
+	}
+}
+
 func TestCreateWebhookPost(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1425,6 +1425,10 @@
     "translation": "Incoming webhooks have been disabled by the system admin."
   },
   {
+    "id": "api.incoming_webhook.invalid_post_username.app_error",
+    "translation": "Invalid username."
+  },
+  {
     "id": "api.ldap.init.debug",
     "translation": "Initializing LDAP API routes"
   },
@@ -4977,6 +4981,14 @@
   {
     "id": "model.incoming_hook.id.app_error",
     "translation": "Invalid Id"
+  },
+  {
+    "id": "model.incoming_hook.username.app_error",
+    "translation": "Invalid username"
+  },
+  {
+    "id": "model.incoming_hook.post_icon_url.app_error",
+    "translation": "Invalid post icon"
   },
   {
     "id": "model.incoming_hook.team_id.app_error",

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -16,15 +16,17 @@ const (
 )
 
 type IncomingWebhook struct {
-	Id          string `json:"id"`
-	CreateAt    int64  `json:"create_at"`
-	UpdateAt    int64  `json:"update_at"`
-	DeleteAt    int64  `json:"delete_at"`
-	UserId      string `json:"user_id"`
-	ChannelId   string `json:"channel_id"`
-	TeamId      string `json:"team_id"`
-	DisplayName string `json:"display_name"`
-	Description string `json:"description"`
+	Id           string `json:"id"`
+	CreateAt     int64  `json:"create_at"`
+	UpdateAt     int64  `json:"update_at"`
+	DeleteAt     int64  `json:"delete_at"`
+	UserId       string `json:"user_id"`
+	ChannelId    string `json:"channel_id"`
+	TeamId       string `json:"team_id"`
+	DisplayName  string `json:"display_name"`
+	Description  string `json:"description"`
+	PostUsername string `json:"post_username"`
+	PostIconURL  string `json:"post_icon_url"`
 }
 
 type IncomingWebhookRequest struct {
@@ -110,6 +112,14 @@ func (o *IncomingWebhook) IsValid() *AppError {
 
 	if len(o.Description) > 128 {
 		return NewAppError("IncomingWebhook.IsValid", "model.incoming_hook.description.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(o.PostUsername) > 64 {
+		return NewAppError("IncomingWebhook.IsValid", "model.incoming_hook.username.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(o.PostIconURL) > 1024 {
+		return NewAppError("IncomingWebhook.IsValid", "model.incoming_hook.post_icon_url.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/incoming_webhook_test.go
+++ b/model/incoming_webhook_test.go
@@ -89,6 +89,26 @@ func TestIncomingWebhookIsValid(t *testing.T) {
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}
+
+	o.PostUsername = strings.Repeat("1", 65)
+	if err := o.IsValid(); err == nil {
+		t.Fatal("should be invalid")
+	}
+
+	o.PostUsername = strings.Repeat("1", 64)
+	if err := o.IsValid(); err != nil {
+		t.Fatal(err)
+	}
+
+	o.PostIconURL = strings.Repeat("1", 1025)
+	if err := o.IsValid(); err == nil {
+		t.Fatal("should be invalid")
+	}
+
+	o.PostIconURL = strings.Repeat("1", 1024)
+	if err := o.IsValid(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestIncomingWebhookPreSave(t *testing.T) {

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -328,6 +328,9 @@ func UpgradeDatabaseToVersion46(sqlStore SqlStore) {
 	//TODO: Uncomment folowing when version 4.6 is released
 	//if shouldPerformUpgrade(sqlStore, VERSION_4_5_0, VERSION_4_6_0) {
 
+	sqlStore.CreateColumnIfNotExists("IncomingWebhooks", "PostUsername", "varchar(64)", "varchar(64)", "")
+	sqlStore.CreateColumnIfNotExists("IncomingWebhooks", "PostIconURL", "varchar(1024)", "varchar(1024)", "")
+
 	//saveSchemaVersion(sqlStore, VERSION_4_6_0)
 	//}
 }


### PR DESCRIPTION
#### Summary
This issue exposes a Username and Profile Picture configuration for incoming webhooks to override the defaults:

![image](https://user-images.githubusercontent.com/1023171/34320019-b8c540b2-e7bd-11e7-9438-3888af9ceb7f.png)

It remains possible to override the Username and Profile Picture when posting the webhook. These settings are tied to the "Enable integrations to override usernames" and "Enable integrations to override profile picture icons" configurations respectively.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7880

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [X] Added API documentation (required for all new APIs): https://github.com/mattermost/mattermost-api-reference/pull/315
- [x] All new/modified APIs include changes to the drivers
- [x] Has UI changes: https://github.com/mattermost/mattermost-webapp/pull/514
- [x] Includes text changes and localization file