### PR TITLE
Allow deactivation of SSO users api3

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -727,7 +727,15 @@ func updateActive(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if ruser, err := c.App.UpdateNonSSOUserActive(userId, active); err != nil {
+	var ruser *model.User
+	var err *model.AppError
+
+	if ruser, err = c.App.GetUser(userId); err != nil {
+		c.Err = err
+		return
+	}
+
+	if _, err := c.App.UpdateActive(ruser, active); err != nil {
 		c.Err = err
 	} else {
 		c.LogAuditWithUserId(ruser.Id, fmt.Sprintf("active=%v", active))


### PR DESCRIPTION
#### Summary
PR: Allow deactivation of SSO users #7952 https://github.com/mattermost/mattermost-server/pull/7952
reverted to allow deactivation of SSO user on api4 but not api3. This PR reverts those changes for api3.
The changes were originally made with this PR: PLT-7932: prevent deactivation of sso users #7759: https://github.com/mattermost/mattermost-server/pull/7759