### PR TITLE
PLT-8352 Don't omit current user from updated user WS event

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -972,9 +972,7 @@ func (a *App) PatchUser(userId string, patch *model.UserPatch, asAdmin bool) (*m
 func (a *App) sendUpdatedUserEvent(user model.User, asAdmin bool) {
 	a.SanitizeProfile(&user, asAdmin)
 
-	omitUsers := make(map[string]bool, 1)
-	omitUsers[user.Id] = true
-	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", omitUsers)
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
 	message.Add("user", user)
 	a.Go(func() {
 		a.Publish(message)


### PR DESCRIPTION
#### Summary
This will allow other clients (tabs, mobile, etc.) to be notified of updates to the logged-in user, instead of just other users.

#### Ticket Link
Server portion of https://mattermost.atlassian.net/browse/PLT-8352