### PR TITLE
[PLT-8173] Strip the post_ prefix on incoming webhook overrides.

### DIFF
--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -425,8 +425,8 @@ func TestUpdateIncomingHook(t *testing.T) {
 		createdHook.DisplayName = "hook2"
 		createdHook.Description = "description"
 		createdHook.ChannelId = th.BasicChannel2.Id
-		createdHook.PostUsername = "username"
-		createdHook.PostIconURL = "icon"
+		createdHook.Username = "username"
+		createdHook.IconURL = "icon"
 
 		updatedHook, resp := th.SystemAdminClient.UpdateIncomingWebhook(createdHook)
 		CheckNoError(t, resp)
@@ -443,11 +443,11 @@ func TestUpdateIncomingHook(t *testing.T) {
 				t.Fatal("Hook channel is not updated")
 			}
 
-			if updatedHook.PostUsername != "" {
+			if updatedHook.Username != "" {
 				t.Fatal("Hook username was incorrectly updated")
 			}
 
-			if updatedHook.PostIconURL != "" {
+			if updatedHook.IconURL != "" {
 				t.Fatal("Hook icon was incorrectly updated")
 			}
 		} else {
@@ -465,8 +465,8 @@ func TestUpdateIncomingHook(t *testing.T) {
 		createdHook.DisplayName = "hook2"
 		createdHook.Description = "description"
 		createdHook.ChannelId = th.BasicChannel2.Id
-		createdHook.PostUsername = "username"
-		createdHook.PostIconURL = "icon"
+		createdHook.Username = "username"
+		createdHook.IconURL = "icon"
 
 		updatedHook, resp := th.SystemAdminClient.UpdateIncomingWebhook(createdHook)
 		CheckNoError(t, resp)
@@ -483,11 +483,11 @@ func TestUpdateIncomingHook(t *testing.T) {
 				t.Fatal("Hook channel is not updated")
 			}
 
-			if updatedHook.PostUsername != "username" {
+			if updatedHook.Username != "username" {
 				t.Fatal("Hook username is not updated")
 			}
 
-			if updatedHook.PostIconURL != "icon" {
+			if updatedHook.IconURL != "icon" {
 				t.Fatal("Hook icon is not updated")
 			}
 		} else {

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -278,14 +278,14 @@ func (a *App) CreateIncomingWebhookForChannel(creatorId string, channel *model.C
 	hook.TeamId = channel.TeamId
 
 	if !a.Config().ServiceSettings.EnablePostUsernameOverride {
-		hook.PostUsername = ""
+		hook.Username = ""
 	}
 	if !a.Config().ServiceSettings.EnablePostIconOverride {
-		hook.PostIconURL = ""
+		hook.IconURL = ""
 	}
 
-	if hook.PostUsername != "" && !model.IsValidUsername(hook.PostUsername) {
-		return nil, model.NewAppError("CreateIncomingWebhookForChannel", "api.incoming_webhook.invalid_post_username.app_error", nil, "", http.StatusBadRequest)
+	if hook.Username != "" && !model.IsValidUsername(hook.Username) {
+		return nil, model.NewAppError("CreateIncomingWebhookForChannel", "api.incoming_webhook.invalid_username.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if result := <-a.Srv.Store.Webhook().SaveIncoming(hook); result.Err != nil {
@@ -301,14 +301,14 @@ func (a *App) UpdateIncomingWebhook(oldHook, updatedHook *model.IncomingWebhook)
 	}
 
 	if !a.Config().ServiceSettings.EnablePostUsernameOverride {
-		updatedHook.PostUsername = oldHook.PostUsername
+		updatedHook.Username = oldHook.Username
 	}
 	if !a.Config().ServiceSettings.EnablePostIconOverride {
-		updatedHook.PostIconURL = oldHook.PostIconURL
+		updatedHook.IconURL = oldHook.IconURL
 	}
 
-	if updatedHook.PostUsername != "" && !model.IsValidUsername(updatedHook.PostUsername) {
-		return nil, model.NewAppError("UpdateIncomingWebhook", "api.incoming_webhook.invalid_post_username.app_error", nil, "", http.StatusBadRequest)
+	if updatedHook.Username != "" && !model.IsValidUsername(updatedHook.Username) {
+		return nil, model.NewAppError("UpdateIncomingWebhook", "api.incoming_webhook.invalid_username.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	updatedHook.Id = oldHook.Id
@@ -630,12 +630,12 @@ func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookReq
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", nil, "", http.StatusForbidden)
 	}
 
-	overrideUsername := hook.PostUsername
+	overrideUsername := hook.Username
 	if req.Username != "" {
 		overrideUsername = req.Username
 	}
 
-	overrideIconUrl := hook.PostIconURL
+	overrideIconUrl := hook.IconURL
 	if req.IconURL != "" {
 		overrideIconUrl = req.IconURL
 	}

--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -53,11 +53,11 @@ func TestCreateIncomingWebhookForChannel(t *testing.T) {
 			EnablePostUsernameOverride: false,
 			EnablePostIconOverride:     false,
 			IncomingWebhook: model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: ":invalid and ignored:",
-				PostIconURL:  "ignored",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    ":invalid and ignored:",
+				IconURL:     "ignored",
 			},
 
 			ExpectedError: false,
@@ -72,10 +72,10 @@ func TestCreateIncomingWebhookForChannel(t *testing.T) {
 			EnablePostUsernameOverride: true,
 			EnablePostIconOverride:     false,
 			IncomingWebhook: model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: ":invalid:",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    ":invalid:",
 			},
 
 			ExpectedError:           true,
@@ -103,20 +103,20 @@ func TestCreateIncomingWebhookForChannel(t *testing.T) {
 			EnablePostUsernameOverride: true,
 			EnablePostIconOverride:     true,
 			IncomingWebhook: model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: "valid",
-				PostIconURL:  "http://example.com/icon",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    "valid",
+				IconURL:     "http://example.com/icon",
 			},
 
 			ExpectedError: false,
 			ExpectedIncomingWebhook: &model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: "valid",
-				PostIconURL:  "http://example.com/icon",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    "valid",
+				IconURL:     "http://example.com/icon",
 			},
 		},
 	} {
@@ -144,8 +144,8 @@ func TestCreateIncomingWebhookForChannel(t *testing.T) {
 				assert.Equal(tc.ExpectedIncomingWebhook.DisplayName, createdHook.DisplayName)
 				assert.Equal(tc.ExpectedIncomingWebhook.Description, createdHook.Description)
 				assert.Equal(tc.ExpectedIncomingWebhook.ChannelId, createdHook.ChannelId)
-				assert.Equal(tc.ExpectedIncomingWebhook.PostUsername, createdHook.PostUsername)
-				assert.Equal(tc.ExpectedIncomingWebhook.PostIconURL, createdHook.PostIconURL)
+				assert.Equal(tc.ExpectedIncomingWebhook.Username, createdHook.Username)
+				assert.Equal(tc.ExpectedIncomingWebhook.IconURL, createdHook.IconURL)
 			}
 		})
 	}
@@ -191,11 +191,11 @@ func TestUpdateIncomingWebhook(t *testing.T) {
 			EnablePostUsernameOverride: false,
 			EnablePostIconOverride:     false,
 			IncomingWebhook: model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: ":invalid and ignored:",
-				PostIconURL:  "ignored",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    ":invalid and ignored:",
+				IconURL:     "ignored",
 			},
 
 			ExpectedError: false,
@@ -210,10 +210,10 @@ func TestUpdateIncomingWebhook(t *testing.T) {
 			EnablePostUsernameOverride: true,
 			EnablePostIconOverride:     false,
 			IncomingWebhook: model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: ":invalid:",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    ":invalid:",
 			},
 
 			ExpectedError:           true,
@@ -241,20 +241,20 @@ func TestUpdateIncomingWebhook(t *testing.T) {
 			EnablePostUsernameOverride: true,
 			EnablePostIconOverride:     true,
 			IncomingWebhook: model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: "valid",
-				PostIconURL:  "http://example.com/icon",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    "valid",
+				IconURL:     "http://example.com/icon",
 			},
 
 			ExpectedError: false,
 			ExpectedIncomingWebhook: &model.IncomingWebhook{
-				DisplayName:  "title",
-				Description:  "description",
-				ChannelId:    th.BasicChannel.Id,
-				PostUsername: "valid",
-				PostIconURL:  "http://example.com/icon",
+				DisplayName: "title",
+				Description: "description",
+				ChannelId:   th.BasicChannel.Id,
+				Username:    "valid",
+				IconURL:     "http://example.com/icon",
 			},
 		},
 	} {
@@ -289,8 +289,8 @@ func TestUpdateIncomingWebhook(t *testing.T) {
 				assert.Equal(tc.ExpectedIncomingWebhook.DisplayName, updatedHook.DisplayName)
 				assert.Equal(tc.ExpectedIncomingWebhook.Description, updatedHook.Description)
 				assert.Equal(tc.ExpectedIncomingWebhook.ChannelId, updatedHook.ChannelId)
-				assert.Equal(tc.ExpectedIncomingWebhook.PostUsername, updatedHook.PostUsername)
-				assert.Equal(tc.ExpectedIncomingWebhook.PostIconURL, updatedHook.PostIconURL)
+				assert.Equal(tc.ExpectedIncomingWebhook.Username, updatedHook.Username)
+				assert.Equal(tc.ExpectedIncomingWebhook.IconURL, updatedHook.IconURL)
 			}
 		})
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1425,7 +1425,7 @@
     "translation": "Incoming webhooks have been disabled by the system admin."
   },
   {
-    "id": "api.incoming_webhook.invalid_post_username.app_error",
+    "id": "api.incoming_webhook.invalid_username.app_error",
     "translation": "Invalid username."
   },
   {
@@ -4987,7 +4987,7 @@
     "translation": "Invalid username"
   },
   {
-    "id": "model.incoming_hook.post_icon_url.app_error",
+    "id": "model.incoming_hook.icon_url.app_error",
     "translation": "Invalid post icon"
   },
   {

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -16,17 +16,17 @@ const (
 )
 
 type IncomingWebhook struct {
-	Id           string `json:"id"`
-	CreateAt     int64  `json:"create_at"`
-	UpdateAt     int64  `json:"update_at"`
-	DeleteAt     int64  `json:"delete_at"`
-	UserId       string `json:"user_id"`
-	ChannelId    string `json:"channel_id"`
-	TeamId       string `json:"team_id"`
-	DisplayName  string `json:"display_name"`
-	Description  string `json:"description"`
-	PostUsername string `json:"post_username"`
-	PostIconURL  string `json:"post_icon_url"`
+	Id          string `json:"id"`
+	CreateAt    int64  `json:"create_at"`
+	UpdateAt    int64  `json:"update_at"`
+	DeleteAt    int64  `json:"delete_at"`
+	UserId      string `json:"user_id"`
+	ChannelId   string `json:"channel_id"`
+	TeamId      string `json:"team_id"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+	Username    string `json:"username"`
+	IconURL     string `json:"icon_url"`
 }
 
 type IncomingWebhookRequest struct {
@@ -114,12 +114,12 @@ func (o *IncomingWebhook) IsValid() *AppError {
 		return NewAppError("IncomingWebhook.IsValid", "model.incoming_hook.description.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	if len(o.PostUsername) > 64 {
+	if len(o.Username) > 64 {
 		return NewAppError("IncomingWebhook.IsValid", "model.incoming_hook.username.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	if len(o.PostIconURL) > 1024 {
-		return NewAppError("IncomingWebhook.IsValid", "model.incoming_hook.post_icon_url.app_error", nil, "", http.StatusBadRequest)
+	if len(o.IconURL) > 1024 {
+		return NewAppError("IncomingWebhook.IsValid", "model.incoming_hook.icon_url.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/incoming_webhook_test.go
+++ b/model/incoming_webhook_test.go
@@ -90,22 +90,22 @@ func TestIncomingWebhookIsValid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	o.PostUsername = strings.Repeat("1", 65)
+	o.Username = strings.Repeat("1", 65)
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
 	}
 
-	o.PostUsername = strings.Repeat("1", 64)
+	o.Username = strings.Repeat("1", 64)
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}
 
-	o.PostIconURL = strings.Repeat("1", 1025)
+	o.IconURL = strings.Repeat("1", 1025)
 	if err := o.IsValid(); err == nil {
 		t.Fatal("should be invalid")
 	}
 
-	o.PostIconURL = strings.Repeat("1", 1024)
+	o.IconURL = strings.Repeat("1", 1024)
 	if err := o.IsValid(); err != nil {
 		t.Fatal(err)
 	}

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -328,8 +328,12 @@ func UpgradeDatabaseToVersion46(sqlStore SqlStore) {
 	//TODO: Uncomment folowing when version 4.6 is released
 	//if shouldPerformUpgrade(sqlStore, VERSION_4_5_0, VERSION_4_6_0) {
 
-	sqlStore.CreateColumnIfNotExists("IncomingWebhooks", "PostUsername", "varchar(64)", "varchar(64)", "")
-	sqlStore.CreateColumnIfNotExists("IncomingWebhooks", "PostIconURL", "varchar(1024)", "varchar(1024)", "")
+	//TODO: Remove these remove calls when version 4.6 is released. The columns were renamed.
+	sqlStore.RemoveColumnIfExists("IncomingWebhooks", "PostUsername")
+	sqlStore.RemoveColumnIfExists("IncomingWebhooks", "PostIconURL")
+
+	sqlStore.CreateColumnIfNotExists("IncomingWebhooks", "Username", "varchar(64)", "varchar(64)", "")
+	sqlStore.CreateColumnIfNotExists("IncomingWebhooks", "IconURL", "varchar(1024)", "varchar(1024)", "")
 
 	//saveSchemaVersion(sqlStore, VERSION_4_6_0)
 	//}


### PR DESCRIPTION
#### Summary
This addresses some feedback from https://github.com/mattermost/mattermost-api-reference/pull/315, tweaking nomenclature related to https://github.com/mattermost/mattermost-server/issues/7880.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7880

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
