### PR TITLE
PLT-7127: Generate nonce for web root

### DIFF
--- a/utils/client.go
+++ b/utils/client.go
@@ -25,7 +25,7 @@ func (r *ClientRoot) Serve(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-cache, max-age=31556926, public")
+	w.Header().Set("Cache-Control", "no-cache")
 
 	r.watcher.Templates().Execute(w, &ClientRootData{
 		Nonce: model.NewId(),

--- a/utils/client.go
+++ b/utils/client.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package utils
+
+import (
+	"net/http"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+type ClientRoot struct {
+	allowSameOriginFrame bool
+	watcher              *HTMLTemplateWatcher
+}
+
+type ClientRootData struct {
+	Nonce string
+}
+
+func (r *ClientRoot) Serve(w http.ResponseWriter, _ *http.Request) {
+	if r.allowSameOriginFrame {
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		w.Header().Add("Content-Security-Policy", "frame-ancestors 'self'")
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, max-age=31556926, public")
+
+	r.watcher.Templates().Execute(w, &ClientRootData{
+		Nonce: model.NewId(),
+	})
+}
+
+func (r *ClientRoot) Close() {
+	r.watcher.Close()
+}
+
+func NewClientRoot(templatePath string, allowSameOriginFrame bool) (*ClientRoot, error) {
+	watcher, err := NewHTMLTemplateWatcherFile(templatePath)
+	if err != nil {
+		return nil, err
+	}
+	return &ClientRoot{
+		allowSameOriginFrame: allowSameOriginFrame,
+		watcher:              watcher,
+	}, nil
+}

--- a/utils/html.go
+++ b/utils/html.go
@@ -24,7 +24,18 @@ type HTMLTemplateWatcher struct {
 func NewHTMLTemplateWatcher(directory string) (*HTMLTemplateWatcher, error) {
 	templatesDir, _ := FindDir(directory)
 	l4g.Debug(T("api.api.init.parsing_templates.debug"), templatesDir)
+	return newHTMLTemplateWatcher(directory, func() (*template.Template, error) {
+		return template.ParseGlob(templatesDir + "*.html")
+	})
+}
 
+func NewHTMLTemplateWatcherFile(file string) (*HTMLTemplateWatcher, error) {
+	return newHTMLTemplateWatcher(file, func() (*template.Template, error) {
+		return template.ParseFiles(file)
+	})
+}
+
+func newHTMLTemplateWatcher(watchPath string, loadTemplates func() (*template.Template, error)) (*HTMLTemplateWatcher, error) {
 	ret := &HTMLTemplateWatcher{
 		stop:    make(chan struct{}),
 		stopped: make(chan struct{}),
@@ -35,11 +46,11 @@ func NewHTMLTemplateWatcher(directory string) (*HTMLTemplateWatcher, error) {
 		return nil, err
 	}
 
-	if err = watcher.Add(templatesDir); err != nil {
+	if err = watcher.Add(watchPath); err != nil {
 		return nil, err
 	}
 
-	if htmlTemplates, err := template.ParseGlob(templatesDir + "*.html"); err != nil {
+	if htmlTemplates, err := loadTemplates(); err != nil {
 		return nil, err
 	} else {
 		ret.templates.Store(htmlTemplates)
@@ -56,7 +67,7 @@ func NewHTMLTemplateWatcher(directory string) (*HTMLTemplateWatcher, error) {
 			case event := <-watcher.Events:
 				if event.Op&fsnotify.Write == fsnotify.Write {
 					l4g.Info(T("web.reparse_templates.info"), event.Name)
-					if htmlTemplates, err := template.ParseGlob(templatesDir + "*.html"); err != nil {
+					if htmlTemplates, err := loadTemplates(); err != nil {
 						l4g.Error(T("web.parsing_templates.error"), err)
 					} else {
 						ret.templates.Store(htmlTemplates)

--- a/utils/html.go
+++ b/utils/html.go
@@ -24,7 +24,7 @@ type HTMLTemplateWatcher struct {
 func NewHTMLTemplateWatcher(directory string) (*HTMLTemplateWatcher, error) {
 	templatesDir, _ := FindDir(directory)
 	l4g.Debug(T("api.api.init.parsing_templates.debug"), templatesDir)
-	return newHTMLTemplateWatcher(directory, func() (*template.Template, error) {
+	return newHTMLTemplateWatcher(templatesDir, func() (*template.Template, error) {
 		return template.ParseGlob(templatesDir + "*.html")
 	})
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -66,23 +66,6 @@ func TearDown(a *app.App) {
 	}
 }
 
-/* Test disabled for now so we don't requrie the client to build. Maybe re-enable after client gets moved out.
-func TestStatic(t *testing.T) {
-	Setup()
-
-	// add a short delay to make sure the server is ready to receive requests
-	time.Sleep(1 * time.Second)
-
-	resp, err := http.Get(URL + "/static/root.html")
-
-	if err != nil {
-		t.Fatalf("got error while trying to get static files %v", err)
-	} else if resp.StatusCode != http.StatusOK {
-		t.Fatalf("couldn't get static files %v", resp.StatusCode)
-	}
-}
-*/
-
 func TestIncomingWebhook(t *testing.T) {
 	a := Setup()
 	defer TearDown(a)


### PR DESCRIPTION
#### Summary
This ticket has been floating around in my backlog for a while and is a big win for security.

This PR renders the web app's root.html as an HTML template. When rendering, it provides a nonce suitable for use in content security policies.

This PR alone shouldn't change the behavior of anything.

See https://github.com/mattermost/mattermost-webapp/pull/539

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7127

#### Checklist
N/A
  
  