### PR TITLE
PLT-8312: Use combined LIKE/Full Text search for channels.

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1332,21 +1332,16 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
 	} else {
 		// Prepare the LIKE portion of the query.
-		var likeSearchTerms []string
-		for i, term := range []string{term} {
-			var searchFields []string
-			for _, field := range []string{"Name", "DisplayName"} {
-				if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
-					searchFields = append(searchFields, fmt.Sprintf("lower(%s) LIKE lower(%s) escape '*' ", field, fmt.Sprintf(":Term%d", i)))
-				} else {
-					searchFields = append(searchFields, fmt.Sprintf("%s LIKE %s escape '*' ", field, fmt.Sprintf(":Term%d", i)))
-				}
+		var searchFields []string
+		for _, field := range []string{"Name", "DisplayName"} {
+			if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+				searchFields = append(searchFields, fmt.Sprintf("lower(%s) LIKE lower(%s) escape '*' ", field, ":LikeTerm"))
+			} else {
+				searchFields = append(searchFields, fmt.Sprintf("%s LIKE %s escape '*' ", field, ":LikeTerm"))
 			}
-			likeSearchTerms = append(likeSearchTerms, fmt.Sprintf("(%s)", strings.Join(searchFields, " OR ")))
-			parameters[fmt.Sprintf("Term%d", i)] = fmt.Sprintf("%s%%", term)
 		}
-
-		likeSearchClause := strings.Join(likeSearchTerms, " AND ")
+		likeSearchClause := fmt.Sprintf("(%s)", strings.Join(searchFields, " OR "))
+		parameters["LikeTerm"] = fmt.Sprintf("%s%%", likeSearchClause)
 
 		// Prepare the FULLTEXT portion of the query.
 		if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
@@ -1361,7 +1356,7 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 
 			fulltextTerm = strings.Join(splitTerm, " ")
 
-			fulltextSearchClause := fmt.Sprintf("(%s) @@  to_tsquery('simple', :Term)", "Name || ' ' || DisplayName")
+			fulltextSearchClause := fmt.Sprintf("(%s) @@  to_tsquery('simple', :FulltextTerm)", "Name || ' ' || DisplayName")
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "AND ("+likeSearchClause+" OR "+fulltextSearchClause+")", 1)
 		} else if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
 			splitTerm := strings.Fields(fulltextTerm)
@@ -1371,14 +1366,12 @@ func (s SqlChannelStore) performSearch(searchQuery string, term string, paramete
 
 			fulltextTerm = strings.Join(splitTerm, " ")
 
-			fulltextSearchClause := fmt.Sprintf("MATCH(%s) AGAINST (:Term IN BOOLEAN MODE)", "Name, DisplayName")
+			fulltextSearchClause := fmt.Sprintf("MATCH(%s) AGAINST (:FulltextTerm IN BOOLEAN MODE)", "Name, DisplayName")
 			searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", fmt.Sprintf("AND (%s OR %s)", likeSearchClause, fulltextSearchClause), 1)
 		}
 	}
 
-	l4g.Debug(searchQuery)
-
-	parameters["Term"] = fulltextTerm
+	parameters["FulltextTerm"] = fulltextTerm
 
 	var channels model.ChannelList
 

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1022,13 +1022,28 @@ func (us SqlUserStore) SearchInChannel(channelId string, term string, options ma
 	})
 }
 
-var escapeUserSearchChar = []string{
+var escapeLikeSearchChar = []string{
 	"%",
 	"_",
 }
 
-var ignoreUserSearchChar = []string{
+var ignoreLikeSearchChar = []string{
 	"*",
+}
+
+var spaceFulltextSearchChar = []string{
+	"<",
+	">",
+	"+",
+	"-",
+	"(",
+	")",
+	"~",
+	":",
+	"*",
+	"\"",
+	"!",
+	"@",
 }
 
 func generateSearchQuery(searchQuery string, terms []string, fields []string, parameters map[string]interface{}, isPostgreSQL bool) string {
@@ -1054,12 +1069,12 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options ma
 	result := store.StoreResult{}
 
 	// These chars must be removed from the like query.
-	for _, c := range ignoreUserSearchChar {
+	for _, c := range ignoreLikeSearchChar {
 		term = strings.Replace(term, c, "", -1)
 	}
 
 	// These chars must be escaped in the like query.
-	for _, c := range escapeUserSearchChar {
+	for _, c := range escapeLikeSearchChar {
 		term = strings.Replace(term, c, "*"+c, -1)
 	}
 

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -1830,17 +1830,17 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	}
 
 	/*
-	// Disabling this check as it will fail on PostgreSQL as we have "liberalised" channel matching to deal with
-	// Full-Text Stemming Limitations.
-	if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-topics"); result.Err != nil {
-		t.Fatal(result.Err)
-	} else {
-		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 0 {
-			t.Logf("%v\n", *channels)
-			t.Fatal("should be empty")
+		// Disabling this check as it will fail on PostgreSQL as we have "liberalised" channel matching to deal with
+		// Full-Text Stemming Limitations.
+		if result := <-ss.Channel().SearchMore(m1.UserId, o1.TeamId, "off-topics"); result.Err != nil {
+			t.Fatal(result.Err)
+		} else {
+			channels := result.Data.(*model.ChannelList)
+			if len(*channels) != 0 {
+				t.Logf("%v\n", *channels)
+				t.Fatal("should be empty")
+			}
 		}
-	}
 	*/
 }
 
@@ -1998,247 +1998,247 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	}
 
 	/*
-	// Disabling this check as it will fail on PostgreSQL as we have "liberalised" channel matching to deal with
-	// Full-Text Stemming Limitations.
-	if result := <-ss.Channel().SearchMore(m1.
-	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-topics"); result.Err != nil {
+		// Disabling this check as it will fail on PostgreSQL as we have "liberalised" channel matching to deal with
+		// Full-Text Stemming Limitations.
+		if result := <-ss.Channel().SearchMore(m1.
+		if result := <-ss.Channel().SearchInTeam(o1.TeamId, "off-topics"); result.Err != nil {
+			t.Fatal(result.Err)
+		} else {
+			channels := result.Data.(*model.ChannelList)
+			if len(*channels) != 0 {
+				t.Fatal("should be empty")
+			}
+		}
+	*/
+
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "town square"); result.Err != nil {
 		t.Fatal(result.Err)
 	} else {
 		channels := result.Data.(*model.ChannelList)
-		if len(*channels) != 0 {
-			t.Fatal("should be empty")
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
+
+		if (*channels)[0].Name != o9.Name {
+			t.Fatal("wrong channel returned")
 		}
 	}
-	*/
 
-if result := <-ss.Channel().SearchInTeam(o1.TeamId, "town square"); result.Err != nil {
-	t.Fatal(result.Err)
-} else {
-	channels := result.Data.(*model.ChannelList)
-	if len(*channels) != 1 {
-		t.Fatal("should return 1 channel")
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "the"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		t.Log(channels.ToJson())
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
+
+		if (*channels)[0].Name != o10.Name {
+			t.Fatal("wrong channel returned")
+		}
 	}
 
-	if (*channels)[0].Name != o9.Name {
-		t.Fatal("wrong channel returned")
-	}
-}
+	if result := <-ss.Channel().SearchInTeam(o1.TeamId, "Mobile"); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		channels := result.Data.(*model.ChannelList)
+		t.Log(channels.ToJson())
+		if len(*channels) != 1 {
+			t.Fatal("should return 1 channel")
+		}
 
-if result := <-ss.Channel().SearchInTeam(o1.TeamId, "the"); result.Err != nil {
-	t.Fatal(result.Err)
-} else {
-	channels := result.Data.(*model.ChannelList)
-	t.Log(channels.ToJson())
-	if len(*channels) != 1 {
-		t.Fatal("should return 1 channel")
+		if (*channels)[0].Name != o11.Name {
+			t.Fatal("wrong channel returned")
+		}
 	}
-
-	if (*channels)[0].Name != o10.Name {
-		t.Fatal("wrong channel returned")
-	}
-}
-
-if result := <-ss.Channel().SearchInTeam(o1.TeamId, "Mobile"); result.Err != nil {
-	t.Fatal(result.Err)
-} else {
-	channels := result.Data.(*model.ChannelList)
-	t.Log(channels.ToJson())
-	if len(*channels) != 1 {
-		t.Fatal("should return 1 channel")
-	}
-
-	if (*channels)[0].Name != o11.Name {
-		t.Fatal("wrong channel returned")
-	}
-}
 }
 
 func testChannelStoreGetMembersByIds(t *testing.T, ss store.Store) {
-o1 := model.Channel{}
-o1.TeamId = model.NewId()
-o1.DisplayName = "ChannelA"
-o1.Name = "zz" + model.NewId() + "b"
-o1.Type = model.CHANNEL_OPEN
-store.Must(ss.Channel().Save(&o1, -1))
+	o1 := model.Channel{}
+	o1.TeamId = model.NewId()
+	o1.DisplayName = "ChannelA"
+	o1.Name = "zz" + model.NewId() + "b"
+	o1.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o1, -1))
 
-m1 := &model.ChannelMember{ChannelId: o1.Id, UserId: model.NewId(), NotifyProps: model.GetDefaultChannelNotifyProps()}
-store.Must(ss.Channel().SaveMember(m1))
+	m1 := &model.ChannelMember{ChannelId: o1.Id, UserId: model.NewId(), NotifyProps: model.GetDefaultChannelNotifyProps()}
+	store.Must(ss.Channel().SaveMember(m1))
 
-if r := <-ss.Channel().GetMembersByIds(m1.ChannelId, []string{m1.UserId}); r.Err != nil {
-	t.Fatal(r.Err)
-} else {
-	rm1 := (*r.Data.(*model.ChannelMembers))[0]
+	if r := <-ss.Channel().GetMembersByIds(m1.ChannelId, []string{m1.UserId}); r.Err != nil {
+		t.Fatal(r.Err)
+	} else {
+		rm1 := (*r.Data.(*model.ChannelMembers))[0]
 
-	if rm1.ChannelId != m1.ChannelId {
-		t.Fatal("bad team id")
+		if rm1.ChannelId != m1.ChannelId {
+			t.Fatal("bad team id")
+		}
+
+		if rm1.UserId != m1.UserId {
+			t.Fatal("bad user id")
+		}
 	}
 
-	if rm1.UserId != m1.UserId {
-		t.Fatal("bad user id")
+	m2 := &model.ChannelMember{ChannelId: o1.Id, UserId: model.NewId(), NotifyProps: model.GetDefaultChannelNotifyProps()}
+	store.Must(ss.Channel().SaveMember(m2))
+
+	if r := <-ss.Channel().GetMembersByIds(m1.ChannelId, []string{m1.UserId, m2.UserId, model.NewId()}); r.Err != nil {
+		t.Fatal(r.Err)
+	} else {
+		rm := (*r.Data.(*model.ChannelMembers))
+
+		if len(rm) != 2 {
+			t.Fatal("return wrong number of results")
+		}
 	}
-}
 
-m2 := &model.ChannelMember{ChannelId: o1.Id, UserId: model.NewId(), NotifyProps: model.GetDefaultChannelNotifyProps()}
-store.Must(ss.Channel().SaveMember(m2))
-
-if r := <-ss.Channel().GetMembersByIds(m1.ChannelId, []string{m1.UserId, m2.UserId, model.NewId()}); r.Err != nil {
-	t.Fatal(r.Err)
-} else {
-	rm := (*r.Data.(*model.ChannelMembers))
-
-	if len(rm) != 2 {
-		t.Fatal("return wrong number of results")
+	if r := <-ss.Channel().GetMembersByIds(m1.ChannelId, []string{}); r.Err == nil {
+		t.Fatal("empty user ids - should have failed")
 	}
-}
-
-if r := <-ss.Channel().GetMembersByIds(m1.ChannelId, []string{}); r.Err == nil {
-	t.Fatal("empty user ids - should have failed")
-}
 }
 
 func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
-o1 := model.Channel{}
-o1.TeamId = model.NewId()
-o1.DisplayName = "ChannelA"
-o1.Name = "zz" + model.NewId() + "b"
-o1.Type = model.CHANNEL_OPEN
-store.Must(ss.Channel().Save(&o1, -1))
+	o1 := model.Channel{}
+	o1.TeamId = model.NewId()
+	o1.DisplayName = "ChannelA"
+	o1.Name = "zz" + model.NewId() + "b"
+	o1.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o1, -1))
 
-o2 := model.Channel{}
-o2.TeamId = model.NewId()
-o2.DisplayName = "Channel2"
-o2.Name = "zz" + model.NewId() + "b"
-o2.Type = model.CHANNEL_OPEN
-store.Must(ss.Channel().Save(&o2, -1))
+	o2 := model.Channel{}
+	o2.TeamId = model.NewId()
+	o2.DisplayName = "Channel2"
+	o2.Name = "zz" + model.NewId() + "b"
+	o2.Type = model.CHANNEL_OPEN
+	store.Must(ss.Channel().Save(&o2, -1))
 
-p3 := model.Channel{}
-p3.TeamId = model.NewId()
-p3.DisplayName = "Channel3"
-p3.Name = "zz" + model.NewId() + "b"
-p3.Type = model.CHANNEL_PRIVATE
-store.Must(ss.Channel().Save(&p3, -1))
+	p3 := model.Channel{}
+	p3.TeamId = model.NewId()
+	p3.DisplayName = "Channel3"
+	p3.Name = "zz" + model.NewId() + "b"
+	p3.Type = model.CHANNEL_PRIVATE
+	store.Must(ss.Channel().Save(&p3, -1))
 
-u1 := &model.User{}
-u1.Email = model.NewId()
-u1.Nickname = model.NewId()
-store.Must(ss.User().Save(u1))
+	u1 := &model.User{}
+	u1.Email = model.NewId()
+	u1.Nickname = model.NewId()
+	store.Must(ss.User().Save(u1))
 
-u2 := &model.User{}
-u2.Email = model.NewId()
-u2.Nickname = model.NewId()
-store.Must(ss.User().Save(u2))
+	u2 := &model.User{}
+	u2.Email = model.NewId()
+	u2.Nickname = model.NewId()
+	store.Must(ss.User().Save(u2))
 
-var d4 *model.Channel
-if result := <-ss.Channel().CreateDirectChannel(u1.Id, u2.Id); result.Err != nil {
-	t.Fatalf(result.Err.Error())
-} else {
-	d4 = result.Data.(*model.Channel)
-}
-
-var openStartCount int64
-if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
-	t.Fatal(result.Err.Error())
-} else {
-	openStartCount = result.Data.(int64)
-}
-
-var privateStartCount int64
-if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "P"); result.Err != nil {
-	t.Fatal(result.Err.Error())
-} else {
-	privateStartCount = result.Data.(int64)
-}
-
-var directStartCount int64
-if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "D"); result.Err != nil {
-	t.Fatal(result.Err.Error())
-} else {
-	directStartCount = result.Data.(int64)
-}
-
-store.Must(ss.Channel().Delete(o1.Id, model.GetMillis()))
-store.Must(ss.Channel().Delete(o2.Id, model.GetMillis()))
-store.Must(ss.Channel().Delete(p3.Id, model.GetMillis()))
-store.Must(ss.Channel().Delete(d4.Id, model.GetMillis()))
-
-if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
-	t.Fatal(result.Err.Error())
-} else {
-	if result.Data.(int64) != openStartCount+2 {
-		t.Fatalf("Wrong open channel deleted count.")
+	var d4 *model.Channel
+	if result := <-ss.Channel().CreateDirectChannel(u1.Id, u2.Id); result.Err != nil {
+		t.Fatalf(result.Err.Error())
+	} else {
+		d4 = result.Data.(*model.Channel)
 	}
-}
 
-if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "P"); result.Err != nil {
-	t.Fatal(result.Err.Error())
-} else {
-	if result.Data.(int64) != privateStartCount+1 {
-		t.Fatalf("Wrong private channel deleted count.")
+	var openStartCount int64
+	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
+		t.Fatal(result.Err.Error())
+	} else {
+		openStartCount = result.Data.(int64)
 	}
-}
 
-if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "D"); result.Err != nil {
-	t.Fatal(result.Err.Error())
-} else {
-	if result.Data.(int64) != directStartCount+1 {
-		t.Fatalf("Wrong direct channel deleted count.")
+	var privateStartCount int64
+	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "P"); result.Err != nil {
+		t.Fatal(result.Err.Error())
+	} else {
+		privateStartCount = result.Data.(int64)
 	}
-}
+
+	var directStartCount int64
+	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "D"); result.Err != nil {
+		t.Fatal(result.Err.Error())
+	} else {
+		directStartCount = result.Data.(int64)
+	}
+
+	store.Must(ss.Channel().Delete(o1.Id, model.GetMillis()))
+	store.Must(ss.Channel().Delete(o2.Id, model.GetMillis()))
+	store.Must(ss.Channel().Delete(p3.Id, model.GetMillis()))
+	store.Must(ss.Channel().Delete(d4.Id, model.GetMillis()))
+
+	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
+		t.Fatal(result.Err.Error())
+	} else {
+		if result.Data.(int64) != openStartCount+2 {
+			t.Fatalf("Wrong open channel deleted count.")
+		}
+	}
+
+	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "P"); result.Err != nil {
+		t.Fatal(result.Err.Error())
+	} else {
+		if result.Data.(int64) != privateStartCount+1 {
+			t.Fatalf("Wrong private channel deleted count.")
+		}
+	}
+
+	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "D"); result.Err != nil {
+		t.Fatal(result.Err.Error())
+	} else {
+		if result.Data.(int64) != directStartCount+1 {
+			t.Fatalf("Wrong direct channel deleted count.")
+		}
+	}
 }
 
 func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
-o1 := store.Must(ss.Channel().Save(&model.Channel{
-	TeamId:      model.NewId(),
-	DisplayName: "Name",
-	Name:        "zz" + model.NewId() + "b",
-	Type:        model.CHANNEL_OPEN,
-}, -1)).(*model.Channel)
+	o1 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      model.NewId(),
+		DisplayName: "Name",
+		Name:        "zz" + model.NewId() + "b",
+		Type:        model.CHANNEL_OPEN,
+	}, -1)).(*model.Channel)
 
-p1 := store.Must(ss.Post().Save(&model.Post{
-	UserId:    model.NewId(),
-	ChannelId: o1.Id,
-	Message:   "test",
-	IsPinned:  true,
-})).(*model.Post)
+	p1 := store.Must(ss.Post().Save(&model.Post{
+		UserId:    model.NewId(),
+		ChannelId: o1.Id,
+		Message:   "test",
+		IsPinned:  true,
+	})).(*model.Post)
 
-if r1 := <-ss.Channel().GetPinnedPosts(o1.Id); r1.Err != nil {
-	t.Fatal(r1.Err)
-} else if r1.Data.(*model.PostList).Posts[p1.Id] == nil {
-	t.Fatal("didn't return relevant pinned posts")
-}
+	if r1 := <-ss.Channel().GetPinnedPosts(o1.Id); r1.Err != nil {
+		t.Fatal(r1.Err)
+	} else if r1.Data.(*model.PostList).Posts[p1.Id] == nil {
+		t.Fatal("didn't return relevant pinned posts")
+	}
 
-o2 := store.Must(ss.Channel().Save(&model.Channel{
-	TeamId:      model.NewId(),
-	DisplayName: "Name",
-	Name:        "zz" + model.NewId() + "b",
-	Type:        model.CHANNEL_OPEN,
-}, -1)).(*model.Channel)
+	o2 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      model.NewId(),
+		DisplayName: "Name",
+		Name:        "zz" + model.NewId() + "b",
+		Type:        model.CHANNEL_OPEN,
+	}, -1)).(*model.Channel)
 
-store.Must(ss.Post().Save(&model.Post{
-	UserId:    model.NewId(),
-	ChannelId: o2.Id,
-	Message:   "test",
-}))
+	store.Must(ss.Post().Save(&model.Post{
+		UserId:    model.NewId(),
+		ChannelId: o2.Id,
+		Message:   "test",
+	}))
 
-if r2 := <-ss.Channel().GetPinnedPosts(o2.Id); r2.Err != nil {
-	t.Fatal(r2.Err)
-} else if len(r2.Data.(*model.PostList).Posts) != 0 {
-	t.Fatal("wasn't supposed to return posts")
-}
+	if r2 := <-ss.Channel().GetPinnedPosts(o2.Id); r2.Err != nil {
+		t.Fatal(r2.Err)
+	} else if len(r2.Data.(*model.PostList).Posts) != 0 {
+		t.Fatal("wasn't supposed to return posts")
+	}
 }
 
 func testChannelStoreMaxChannelsPerTeam(t *testing.T, ss store.Store) {
-channel := &model.Channel{
-	TeamId:      model.NewId(),
-	DisplayName: "Channel",
-	Name:        model.NewId(),
-	Type:        model.CHANNEL_OPEN,
-}
-result := <-ss.Channel().Save(channel, 0)
-assert.NotEqual(t, nil, result.Err)
-assert.Equal(t, result.Err.Id, "store.sql_channel.save_channel.limit.app_error")
+	channel := &model.Channel{
+		TeamId:      model.NewId(),
+		DisplayName: "Channel",
+		Name:        model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}
+	result := <-ss.Channel().Save(channel, 0)
+	assert.NotEqual(t, nil, result.Err)
+	assert.Equal(t, result.Err.Id, "store.sql_channel.save_channel.limit.app_error")
 
-channel.Id = ""
-result = <-ss.Channel().Save(channel, 1)
-assert.Nil(t, result.Err)
+	channel.Id = ""
+	result = <-ss.Channel().Save(channel, 1)
+	assert.Nil(t, result.Err)
 }


### PR DESCRIPTION
#### Summary
This PR partially reverts the switch to LIKE searching from FULLTEXT searching when searching for channels. The intention is to get the best of both worlds - matching on any word in the channel name, not just the first, but also being able to search stop words. This is achieved by combining both search techniques with an `OR` in a single query.

There is one small draw back with this: in order to be able to match on full words, not just their stems, in PostgreSQL, we need to relax the strict matching criteria. This means, for example that typing `~off-topics` into the search will match the channel name with `off-topic`. This limitation is not applicable on MySQL.

#### Ticket Link

https://mattermost.atlassian.net/browse/PLT-8312

#### Checklist
- [x] Added or updated unit tests (required for all new features)

  