### PR TITLE
[PLT-7793] Added /users/tokens endpoint

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -58,8 +58,8 @@ func (api *API) InitUser() {
 	api.BaseRoutes.User.Handle("/audits", api.ApiSessionRequired(getUserAudits)).Methods("GET")
 
 	api.BaseRoutes.User.Handle("/tokens", api.ApiSessionRequired(createUserAccessToken)).Methods("POST")
-	api.BaseRoutes.User.Handle("/tokens", api.ApiSessionRequired(getUserAccessTokens)).Methods("GET")
-	api.BaseRoutes.Users.Handle("/tokens/all", api.ApiSessionRequired(getAllUserAccessTokens)).Methods("GET")
+	api.BaseRoutes.User.Handle("/tokens", api.ApiSessionRequired(getUserAccessTokensForUser)).Methods("GET")
+	api.BaseRoutes.Users.Handle("/tokens", api.ApiSessionRequired(getUserAccessTokens)).Methods("GET")
 	api.BaseRoutes.Users.Handle("/tokens/{token_id:[A-Za-z0-9]+}", api.ApiSessionRequired(getUserAccessToken)).Methods("GET")
 	api.BaseRoutes.Users.Handle("/tokens/revoke", api.ApiSessionRequired(revokeUserAccessToken)).Methods("POST")
 	api.BaseRoutes.Users.Handle("/tokens/disable", api.ApiSessionRequired(disableUserAccessToken)).Methods("POST")
@@ -1241,13 +1241,13 @@ func createUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(accessToken.ToJson()))
 }
 
-func getAllUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) {
+func getUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return
 	}
 
-	accessTokens, err := c.App.GetAllUserAccessTokens(c.Params.Page, c.Params.PerPage)
+	accessTokens, err := c.App.GetUserAccessTokens(c.Params.Page, c.Params.PerPage)
 	if err != nil {
 		c.Err = err
 		return
@@ -1256,7 +1256,7 @@ func getAllUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) 
 	w.Write([]byte(model.UserAccessTokenListToJson(accessTokens)))
 }
 
-func getUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) {
+func getUserAccessTokensForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.RequireUserId()
 	if c.Err != nil {
 		return

--- a/api4/user.go
+++ b/api4/user.go
@@ -56,7 +56,7 @@ func (api *API) InitUser() {
 	api.BaseRoutes.User.Handle("/sessions/revoke/all", api.ApiSessionRequired(revokeAllSessionsForUser)).Methods("POST")
 	api.BaseRoutes.Users.Handle("/sessions/device", api.ApiSessionRequired(attachDeviceId)).Methods("PUT")
 	api.BaseRoutes.User.Handle("/audits", api.ApiSessionRequired(getUserAudits)).Methods("GET")
-	
+
 	api.BaseRoutes.User.Handle("/tokens", api.ApiSessionRequired(createUserAccessToken)).Methods("POST")
 	api.BaseRoutes.User.Handle("/tokens", api.ApiSessionRequired(getUserAccessTokens)).Methods("GET")
 	api.BaseRoutes.Users.Handle("/tokens/all", api.ApiSessionRequired(getAllUserAccessTokens)).Methods("GET")
@@ -1246,7 +1246,7 @@ func getAllUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) 
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return
 	}
-	
+
 	accessTokens, err := c.App.GetAllUserAccessTokens(c.Params.Page, c.Params.PerPage)
 	if err != nil {
 		c.Err = err

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2394,7 +2394,7 @@ func TestGetUserAccessToken(t *testing.T) {
 	testDescription := "test token"
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
-
+	
 	_, resp := Client.GetUserAccessToken("123")
 	CheckBadRequestStatus(t, resp)
 
@@ -2447,6 +2447,26 @@ func TestGetUserAccessToken(t *testing.T) {
 	rtokens, resp = AdminClient.GetUserAccessTokensForUser(th.BasicUser.Id, 0, 100)
 	CheckNoError(t, resp)
 
+	if len(rtokens) != 2 {
+		t.Fatal("should have 2 tokens")
+	}
+	
+	_, resp = Client.GetAllUserAccessTokens(0,100)
+	CheckForbiddenStatus(t, resp)
+	
+	_, resp = AdminClient.GetAllUserAccessTokens(0,100)
+	CheckNoError(t, resp)
+	
+	rtokens, resp = AdminClient.GetAllUserAccessTokens(1,1)
+	CheckNoError(t, resp)
+	
+	if len(rtokens) != 1 {
+		t.Fatal("should have 1 tokens")
+	}
+	
+	rtokens, resp = AdminClient.GetAllUserAccessTokens(0,2)
+	CheckNoError(t, resp)
+	
 	if len(rtokens) != 2 {
 		t.Fatal("should have 2 tokens")
 	}

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2458,7 +2458,7 @@ func TestGetUserAccessToken(t *testing.T) {
 	CheckNoError(t, resp)
 	
 	if len(rtokens) != 1 {
-		t.Fatal("should have 1 tokens")
+		t.Fatal("should have 1 token")
 	}
 	
 	rtokens, resp = AdminClient.GetUserAccessTokens(0,2)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2394,7 +2394,7 @@ func TestGetUserAccessToken(t *testing.T) {
 	testDescription := "test token"
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
-	
+
 	_, resp := Client.GetUserAccessToken("123")
 	CheckBadRequestStatus(t, resp)
 

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2451,17 +2451,17 @@ func TestGetUserAccessToken(t *testing.T) {
 		t.Fatal("should have 2 tokens")
 	}
 	
-	_, resp = Client.GetAllUserAccessTokens(0,100)
+	_, resp = Client.GetUserAccessTokens(0,100)
 	CheckForbiddenStatus(t, resp)
 	
-	rtokens, resp = AdminClient.GetAllUserAccessTokens(1,1)
+	rtokens, resp = AdminClient.GetUserAccessTokens(1,1)
 	CheckNoError(t, resp)
 	
 	if len(rtokens) != 1 {
 		t.Fatal("should have 1 tokens")
 	}
 	
-	rtokens, resp = AdminClient.GetAllUserAccessTokens(0,2)
+	rtokens, resp = AdminClient.GetUserAccessTokens(0,2)
 	CheckNoError(t, resp)
 	
 	if len(rtokens) != 2 {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2454,9 +2454,6 @@ func TestGetUserAccessToken(t *testing.T) {
 	_, resp = Client.GetAllUserAccessTokens(0,100)
 	CheckForbiddenStatus(t, resp)
 	
-	_, resp = AdminClient.GetAllUserAccessTokens(0,100)
-	CheckNoError(t, resp)
-	
 	rtokens, resp = AdminClient.GetAllUserAccessTokens(1,1)
 	CheckNoError(t, resp)
 	

--- a/app/session.go
+++ b/app/session.go
@@ -356,7 +356,7 @@ func (a *App) EnableUserAccessToken(token *model.UserAccessToken) *model.AppErro
 	return nil
 }
 
-func (a *App) GetAllUserAccessTokens(page, perPage int) ([]*model.UserAccessToken, *model.AppError) {
+func (a *App) GetUserAccessTokens(page, perPage int) ([]*model.UserAccessToken, *model.AppError) {
 	if result := <-a.Srv.Store.UserAccessToken().GetAll(page*perPage, perPage); result.Err != nil {
 		return nil, result.Err
 	} else {

--- a/app/session.go
+++ b/app/session.go
@@ -356,6 +356,19 @@ func (a *App) EnableUserAccessToken(token *model.UserAccessToken) *model.AppErro
 	return nil
 }
 
+func (a *App) GetAllUserAccessTokens(page, perPage int) ([]*model.UserAccessToken, *model.AppError) {
+	if result := <-a.Srv.Store.UserAccessToken().GetAll(page*perPage, perPage); result.Err != nil {
+		return nil, result.Err
+	} else {
+		tokens := result.Data.([]*model.UserAccessToken)
+		for _, token := range tokens {
+			token.Token = ""
+		}
+
+		return tokens, nil
+	}
+}
+
 func (a *App) GetUserAccessTokensForUser(userId string, page, perPage int) ([]*model.UserAccessToken, *model.AppError) {
 	if result := <-a.Srv.Store.UserAccessToken().GetByUser(userId, page*perPage, perPage); result.Err != nil {
 		return nil, result.Err

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6783,6 +6783,10 @@
     "translation": "We couldn't get the personal access token by token"
   },
   {
+    "id": "store.sql_user_access_token.get_all.app_error",
+    "translation": "We couldn't get all personal access tokens"
+  },
+  {
     "id": "store.sql_user_access_token.get_by_user.app_error",
     "translation": "We couldn't get the personal access tokens by user"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -82,8 +82,8 @@ func (c *Client4) GetUserRoute(userId string) string {
 	return fmt.Sprintf(c.GetUsersRoute()+"/%v", userId)
 }
 
-func (c *Client4) GetAllUserAccessTokensRoute() string {
-	return fmt.Sprintf(c.GetUsersRoute() + "/tokens/all")
+func (c *Client4) GetUserAccessTokensRoute() string {
+	return fmt.Sprintf(c.GetUsersRoute() + "/tokens")
 }
 
 func (c *Client4) GetUserAccessTokenRoute(tokenId string) string {
@@ -1039,12 +1039,12 @@ func (c *Client4) CreateUserAccessToken(userId, description string) (*UserAccess
 	}
 }
 
-// GetAllUserAccessToken will get a all access token's id, description, is_active
+// GetUserAccessTokens will get a page of access tokens' id, description, is_active
 // and the user_id in the system. The actual token will not be returned. Must have
 // the 'manage_system' permission.
-func (c *Client4) GetAllUserAccessTokens(page int, perPage int) ([]*UserAccessToken, *Response) {
+func (c *Client4) GetUserAccessTokens(page int, perPage int) ([]*UserAccessToken, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetAllUserAccessTokensRoute()+query, ""); err != nil {
+	if r, err := c.DoApiGet(c.GetUserAccessTokensRoute()+query, ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)
@@ -1052,7 +1052,7 @@ func (c *Client4) GetAllUserAccessTokens(page int, perPage int) ([]*UserAccessTo
 	}
 }
 
-// GetUserAccessToken will get a user access token's id, description, is_active
+// GetUserAccessToken will get a user access tokens' id, description, is_active
 // and the user_id of the user it is for. The actual token will not be returned.
 // Must have the 'read_user_access_token' permission and if getting for another
 // user, must have the 'edit_other_users' permission.

--- a/model/client4.go
+++ b/model/client4.go
@@ -83,7 +83,7 @@ func (c *Client4) GetUserRoute(userId string) string {
 }
 
 func (c *Client4) GetAllUserAccessTokensRoute() string {
-	return fmt.Sprintf(c.GetUsersRoute()+"/tokens/all")
+	return fmt.Sprintf(c.GetUsersRoute() + "/tokens/all")
 }
 
 func (c *Client4) GetUserAccessTokenRoute(tokenId string) string {
@@ -1039,8 +1039,8 @@ func (c *Client4) CreateUserAccessToken(userId, description string) (*UserAccess
 	}
 }
 
-// GetAllUserAccessToken will get a all access token's id, description, is_active 
-// and the user_id in the system. The actual token will not be returned. Must have  
+// GetAllUserAccessToken will get a all access token's id, description, is_active
+// and the user_id in the system. The actual token will not be returned. Must have
 // the 'manage_system' permission.
 func (c *Client4) GetAllUserAccessTokens(page int, perPage int) ([]*UserAccessToken, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
@@ -1052,7 +1052,7 @@ func (c *Client4) GetAllUserAccessTokens(page int, perPage int) ([]*UserAccessTo
 	}
 }
 
-// GetUserAccessToken will get a user access token's id, description, is_active 
+// GetUserAccessToken will get a user access token's id, description, is_active
 // and the user_id of the user it is for. The actual token will not be returned.
 // Must have the 'read_user_access_token' permission and if getting for another
 // user, must have the 'edit_other_users' permission.

--- a/model/client4.go
+++ b/model/client4.go
@@ -82,6 +82,10 @@ func (c *Client4) GetUserRoute(userId string) string {
 	return fmt.Sprintf(c.GetUsersRoute()+"/%v", userId)
 }
 
+func (c *Client4) GetAllUserAccessTokensRoute() string {
+	return fmt.Sprintf(c.GetUsersRoute()+"/tokens/all")
+}
+
 func (c *Client4) GetUserAccessTokenRoute(tokenId string) string {
 	return fmt.Sprintf(c.GetUsersRoute()+"/tokens/%v", tokenId)
 }
@@ -1035,10 +1039,23 @@ func (c *Client4) CreateUserAccessToken(userId, description string) (*UserAccess
 	}
 }
 
-// GetUserAccessToken will get a user access token's id, description and the user_id
-// of the user it is for. The actual token will not be returned. Must have the
-// 'read_user_access_token' permission and if getting for another user, must have the
-// 'edit_other_users' permission.
+// GetAllUserAccessToken will get a all access token's id, description, is_active 
+// and the user_id in the system. The actual token will not be returned. Must have  
+// the 'manage_system' permission.
+func (c *Client4) GetAllUserAccessTokens(page int, perPage int) ([]*UserAccessToken, *Response) {
+	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
+	if r, err := c.DoApiGet(c.GetAllUserAccessTokensRoute()+query, ""); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// GetUserAccessToken will get a user access token's id, description, is_active 
+// and the user_id of the user it is for. The actual token will not be returned.
+// Must have the 'read_user_access_token' permission and if getting for another
+// user, must have the 'edit_other_users' permission.
 func (c *Client4) GetUserAccessToken(tokenId string) (*UserAccessToken, *Response) {
 	if r, err := c.DoApiGet(c.GetUserAccessTokenRoute(tokenId), ""); err != nil {
 		return nil, BuildErrorResponse(r, err)

--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -171,6 +171,18 @@ func (s SqlUserAccessTokenStore) Get(tokenId string) store.StoreChannel {
 	})
 }
 
+func (s SqlUserAccessTokenStore) GetAll(offset, limit int) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		tokens := []*model.UserAccessToken{}
+
+		if _, err := s.GetReplica().Select(&tokens, "SELECT * FROM UserAccessTokens LIMIT :Limit OFFSET :Offset", map[string]interface{}{"Offset": offset, "Limit": limit}); err != nil {
+			result.Err = model.NewAppError("SqlUserAccessTokenStore.GetAll", "store.sql_user_access_token.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		result.Data = tokens
+	})
+}
+
 func (s SqlUserAccessTokenStore) GetByToken(tokenString string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		token := model.UserAccessToken{}

--- a/store/store.go
+++ b/store/store.go
@@ -446,6 +446,7 @@ type UserAccessTokenStore interface {
 	Delete(tokenId string) StoreChannel
 	DeleteAllForUser(userId string) StoreChannel
 	Get(tokenId string) StoreChannel
+	GetAll(offset int, limit int) StoreChannel
 	GetByToken(tokenString string) StoreChannel
 	GetByUser(userId string, page, perPage int) StoreChannel
 	UpdateTokenEnable(tokenId string) StoreChannel

--- a/store/storetest/mocks/UserAccessTokenStore.go
+++ b/store/storetest/mocks/UserAccessTokenStore.go
@@ -61,6 +61,22 @@ func (_m *UserAccessTokenStore) Get(tokenId string) store.StoreChannel {
 	return r0
 }
 
+// GetAll provides a mock function with given fields:
+func (_m *UserAccessTokenStore) GetAll(page int, perPage int) store.StoreChannel {
+	ret := _m.Called(page, perPage)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(int, int) store.StoreChannel); ok {
+		r0 = rf(page, perPage)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetByToken provides a mock function with given fields: tokenString
 func (_m *UserAccessTokenStore) GetByToken(tokenString string) store.StoreChannel {
 	ret := _m.Called(tokenString)

--- a/store/storetest/user_access_token_store.go
+++ b/store/storetest/user_access_token_store.go
@@ -53,6 +53,12 @@ func testUserAccessTokenSaveGetDelete(t *testing.T, ss store.Store) {
 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
 		t.Fatal("received incorrect number of tokens after save")
 	}
+	
+	if result := <-ss.UserAccessToken().GetAll(0, 100); result.Err != nil {
+		t.Fatal(result.Err)
+	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+		t.Fatal("received incorrect number of tokens after save")
+	}
 
 	if result := <-ss.UserAccessToken().Delete(uat.Id); result.Err != nil {
 		t.Fatal(result.Err)

--- a/store/storetest/user_access_token_store.go
+++ b/store/storetest/user_access_token_store.go
@@ -53,7 +53,7 @@ func testUserAccessTokenSaveGetDelete(t *testing.T, ss store.Store) {
 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
 		t.Fatal("received incorrect number of tokens after save")
 	}
-	
+
 	if result := <-ss.UserAccessToken().GetAll(0, 100); result.Err != nil {
 		t.Fatal(result.Err)
 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {


### PR DESCRIPTION
#### Summary
Adds a new endpoint called `/users/tokens` which gets all tokens for all users if one has the `manage_system` permission.

#### PR Links

- [Documentation PR](https://github.com/mattermost/mattermost-api-reference/pull/318)
- [Webapp PR](https://github.com/mattermost/mattermost-webapp/pull/496)
- [Server PR](https://github.com/mattermost/mattermost-server/pull/8038)
- Redux PR

#### Ticket Link

- [Jira](https://mattermost.atlassian.net/browse/PLT-7793)
- [Github](https://github.com/mattermost/mattermost-server/issues/7584#issuecomment-352808489)

#### Checklist
- [x] Added route
- [x] Added handler
- [x] Updated store
- [x] Added or updated unit tests (required for all new features)
- [x] [Added documentation](https://github.com/mattermost/mattermost-api-reference/pull/318)
- [x] Has UI changes
- [x] Touches critical sections of the codebase (access tokens)
- [x] Run `make test` for sanity check
- [x] Run `make check-style`
- [x] Tested with postman / curl
- [x] Rename end point to `/users/tokens`
- [x] Add i18n string

  
  
  
  
  