### PR TITLE
rename DefaultTeamName to ExperimentalPrimaryTeam

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -83,7 +83,7 @@
         "EnableConfirmNotificationsToChannel": true,
         "TeammateNameDisplay": "username",
         "ExperimentalTownSquareIsReadOnly": false,
-        "DefaultTeamName": ""
+        "ExperimentalPrimaryTeam": ""
     },
     "ClientRequirements": {
         "AndroidLatestVersion": "",

--- a/model/config.go
+++ b/model/config.go
@@ -940,7 +940,7 @@ type TeamSettings struct {
 	EnableConfirmNotificationsToChannel *bool
 	TeammateNameDisplay                 *string
 	ExperimentalTownSquareIsReadOnly    *bool
-	DefaultTeamName                     *string
+	ExperimentalPrimaryTeam             *string
 }
 
 func (s *TeamSettings) SetDefaults() {
@@ -1037,8 +1037,8 @@ func (s *TeamSettings) SetDefaults() {
 		s.ExperimentalTownSquareIsReadOnly = NewBool(false)
 	}
 
-	if s.DefaultTeamName == nil {
-		s.DefaultTeamName = NewString("")
+	if s.ExperimentalPrimaryTeam == nil {
+		s.ExperimentalPrimaryTeam = NewString("")
 	}
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -463,7 +463,7 @@ func getClientConfig(c *model.Config) map[string]string {
 	props["RestrictPrivateChannelManageMembers"] = *c.TeamSettings.RestrictPrivateChannelManageMembers
 	props["EnableXToLeaveChannelsFromLHS"] = strconv.FormatBool(*c.TeamSettings.EnableXToLeaveChannelsFromLHS)
 	props["TeammateNameDisplay"] = *c.TeamSettings.TeammateNameDisplay
-	props["DefaultTeamName"] = *c.TeamSettings.DefaultTeamName
+	props["ExperimentalPrimaryTeam"] = *c.TeamSettings.ExperimentalPrimaryTeam
 
 	props["AndroidLatestVersion"] = c.ClientRequirements.AndroidLatestVersion
 	props["AndroidMinVersion"] = c.ClientRequirements.AndroidMinVersion


### PR DESCRIPTION
#### Summary
Rename DefaultTeamName to ExperimentalPrimaryTeam based on discussion on `webapp` PR: https://github.com/mattermost/mattermost-webapp/pull/334