### PR TITLE
Disable config watching during CLI tests

### DIFF
--- a/cmd/platform/platform_test.go
+++ b/cmd/platform/platform_test.go
@@ -27,7 +27,7 @@ func execArgs(t *testing.T, args []string) []string {
 		baseParts[0] = fmt.Sprintf("%v-%v-%v", baseParts[0], t.Name(), coverprofileCounters[t.Name()])
 		ret = append(ret, "-test.coverprofile", filepath.Join(dir, strings.Join(baseParts, ".")))
 	}
-	return append(append(ret, "--"), args...)
+	return append(append(ret, "--", "--disableconfigwatch"), args...)
 }
 
 func checkCommand(t *testing.T, args ...string) string {


### PR DESCRIPTION
#### Summary
This (kinda) fixes the race condition that caused this failure: https://build.mattermost.com/job/mattermost-platform-pr-split/1041/

Whenever the configuration is reloaded, the logger is reconfigured. Reconfiguring the logger has a decent chance of blowing things up any time there are other goroutines that may be using it. This doesn't fix that. That's a more difficult thing to fix (but I am working on it).

This just disables the config watching during the CLI tests since it's really not necessary and it'll ensure we won't see the problem again for them.

#### Ticket Link
N/A

#### Checklist
N/A
  