### PR TITLE
[WIP] Add username to UserAccessTokens.getAll

### DIFF
--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -183,8 +183,8 @@ func (s SqlUserAccessTokenStore) GetAll(offset, limit int) store.StoreChannel {
 		if _, err := s.GetReplica().Select(
 			&tokens, 
 			`SELECT 
-			  UserAccessTokens.*,
-			  Users.Username
+			 	UserAccessTokens.*,
+				Users.Username
 			FROM UserAccessTokens
 				INNER JOIN Users ON UserAccessTokens.UserId = Users.Id
 			LIMIT :Limit OFFSET :Offset`,

--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -184,7 +184,7 @@ func (s SqlUserAccessTokenStore) GetAll(offset, limit int) store.StoreChannel {
 			&tokens, 
 			`SELECT 
 			  UserAccessTokens.*,
-				Users.Username
+			  Users.Username
 			FROM UserAccessTokens
 				INNER JOIN Users ON UserAccessTokens.UserId = Users.Id
 			LIMIT :Limit OFFSET :Offset`,


### PR DESCRIPTION
#### Summary

Adds the username in the data received by the endpoint `/users/tokens` for efficient searching by username (see [Jira ticket](https://mattermost.atlassian.net/browse/PLT-7793)). 

Note: I forgot to add the username in the server PR below.

#### PR Links

- [Documentation PR](https://github.com/mattermost/mattermost-api-reference/pull/318)
- [Webapp PR](https://github.com/mattermost/mattermost-webapp/pull/496)
- [Server PR](https://github.com/mattermost/mattermost-server/pull/8038)
- [Redux PR](https://github.com/mattermost/mattermost-redux/pull/356)

#### Ticket Link

- [Jira](https://mattermost.atlassian.net/browse/PLT-7793)
- [Github](https://github.com/mattermost/mattermost-server/issues/7584#issuecomment-352808489)

#### Checklist
- [x] Inner join Users table to get username
- [ ] Fix error
- [ ] Make sure tests pass
  
  
  
  
  
  
  
  
  