### PR TITLE
PLT-8522 Added separate messages for being removed from channel or team

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -68,7 +68,7 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, channelRole s
 				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 			}
 		} else {
-			if err := a.PostAddToTeamMessage(requestor, user, townSquare, ""); err != nil {
+			if err := a.postAddToTeamMessage(requestor, user, townSquare, ""); err != nil {
 				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 			}
 		}
@@ -1058,7 +1058,7 @@ func (a *App) PostAddToChannelMessage(user *model.User, addedUser *model.User, c
 	return nil
 }
 
-func (a *App) PostAddToTeamMessage(user *model.User, addedUser *model.User, channel *model.Channel, postRootId string) *model.AppError {
+func (a *App) postAddToTeamMessage(user *model.User, addedUser *model.User, channel *model.Channel, postRootId string) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
 		Message:   fmt.Sprintf(utils.T("api.team.add_user_to_team.added"), addedUser.Username, user.Username),
@@ -1078,10 +1078,10 @@ func (a *App) PostAddToTeamMessage(user *model.User, addedUser *model.User, chan
 	return nil
 }
 
-func (a *App) PostRemoveFromChannelMessage(removerUserId string, removedUser *model.User, channel *model.Channel) *model.AppError {
+func (a *App) postRemoveFromChannelMessage(removerUserId string, removedUser *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,
-		Message:   fmt.Sprintf(utils.T("api.team.remove_user_from_team.removed"), removedUser.Username),
+		Message:   fmt.Sprintf(utils.T("api.channel.remove_member.removed"), removedUser.Username),
 		Type:      model.POST_REMOVE_FROM_CHANNEL,
 		UserId:    removerUserId,
 		Props: model.StringInterface{
@@ -1149,7 +1149,7 @@ func (a *App) RemoveUserFromChannel(userIdToRemove string, removerUserId string,
 		a.postLeaveChannelMessage(user, channel)
 	} else {
 		a.Go(func() {
-			a.PostRemoveFromChannelMessage(removerUserId, user, channel)
+			a.postRemoveFromChannelMessage(removerUserId, user, channel)
 		})
 	}
 

--- a/app/team.go
+++ b/app/team.go
@@ -621,7 +621,7 @@ func (a *App) LeaveTeam(team *model.Team, user *model.User, requestorId string) 
 			l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 		}
 	} else {
-		if err := a.PostRemoveFromChannelMessage(user.Id, user, channel); err != nil {
+		if err := a.postRemoveFromTeamMessage(user, channel); err != nil {
 			l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
 		}
 	}
@@ -667,6 +667,24 @@ func (a *App) postLeaveTeamMessage(user *model.User, channel *model.Channel) *mo
 
 	if _, err := a.CreatePost(post, channel, false); err != nil {
 		return model.NewAppError("postRemoveFromChannelMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
+}
+
+func (a *App) postRemoveFromTeamMessage(user *model.User, channel *model.Channel) *model.AppError {
+	post := &model.Post{
+		ChannelId: channel.Id,
+		Message:   fmt.Sprintf(utils.T("api.team.remove_user_from_team.removed"), user.Username),
+		Type:      model.POST_REMOVE_FROM_TEAM,
+		UserId:    user.Id,
+		Props: model.StringInterface{
+			"removedUsername": user.Username,
+		},
+	}
+
+	if _, err := a.CreatePost(post, channel, false); err != nil {
+		return model.NewAppError("postRemoveFromTeamMessage", "api.channel.post_user_add_remove_message_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil

--- a/model/post.go
+++ b/model/post.go
@@ -24,8 +24,9 @@ const (
 	POST_LEAVE_TEAM            = "system_leave_team"
 	POST_ADD_REMOVE            = "system_add_remove" // Deprecated, use POST_ADD_TO_CHANNEL or POST_REMOVE_FROM_CHANNEL instead
 	POST_ADD_TO_CHANNEL        = "system_add_to_channel"
-	POST_ADD_TO_TEAM           = "system_add_to_team"
 	POST_REMOVE_FROM_CHANNEL   = "system_remove_from_channel"
+	POST_ADD_TO_TEAM           = "system_add_to_team"
+	POST_REMOVE_FROM_TEAM      = "system_remove_from_team"
 	POST_HEADER_CHANGE         = "system_header_change"
 	POST_DISPLAYNAME_CHANGE    = "system_displayname_change"
 	POST_PURPOSE_CHANGE        = "system_purpose_change"
@@ -177,11 +178,12 @@ func (o *Post) IsValid() *AppError {
 		POST_ADD_REMOVE,
 		POST_JOIN_CHANNEL,
 		POST_LEAVE_CHANNEL,
-		POST_LEAVE_TEAM,
-		POST_REMOVE_FROM_CHANNEL,
-		POST_ADD_TO_CHANNEL,
-		POST_ADD_TO_TEAM,
 		POST_JOIN_TEAM,
+		POST_LEAVE_TEAM,
+		POST_ADD_TO_CHANNEL,
+		POST_REMOVE_FROM_CHANNEL,
+		POST_ADD_TO_TEAM,
+		POST_REMOVE_FROM_TEAM,
 		POST_SLACK_ATTACHMENT,
 		POST_HEADER_CHANGE,
 		POST_PURPOSE_CHANGE,


### PR DESCRIPTION
The previous PR changed this so that the "user was removed from channel" message said "user was removed from team", and that message was posted for both actions. This splits them out so that there's a proper "user was removed from team" message.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-8522

#### Checklist
- Has UI changes
