### PR TITLE
Make system messages always use "User did something" instead of "User has done something"

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -681,7 +681,7 @@ func (a *App) postRemoveFromTeamMessage(user *model.User, channel *model.Channel
 		Type:      model.POST_REMOVE_FROM_TEAM,
 		UserId:    user.Id,
 		Props: model.StringInterface{
-			"removedUsername": user.Username,
+			"username": user.Username,
 		},
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -153,7 +153,7 @@
   },
   {
     "id": "api.channel.add_member.added",
-    "translation": "%v added to the channel by %v"
+    "translation": "%v added to the channel by %v."
   },
   {
     "id": "api.channel.add_member.find_channel.app_error",
@@ -233,7 +233,7 @@
   },
   {
     "id": "api.channel.delete_channel.archived",
-    "translation": "%v has archived the channel."
+    "translation": "%v archived the channel."
   },
   {
     "id": "api.channel.delete_channel.cannot.app_error",
@@ -297,7 +297,7 @@
   },
   {
     "id": "api.channel.join_channel.post_and_forget",
-    "translation": "%v has joined the channel."
+    "translation": "%v joined the channel."
   },
   {
     "id": "api.channel.leave.default.app_error",
@@ -313,7 +313,7 @@
   },
   {
     "id": "api.channel.leave.left",
-    "translation": "%v has left the channel."
+    "translation": "%v left the channel."
   },
   {
     "id": "api.channel.change_channel_privacy.private_to_public",
@@ -369,7 +369,7 @@
   },
   {
     "id": "api.channel.remove_member.removed",
-    "translation": "%v was removed from the channel."
+    "translation": "%v removed from the channel."
   },
   {
     "id": "api.channel.remove_member.unable.app_error",
@@ -2184,7 +2184,7 @@
   },
   {
     "id": "api.team.add_user_to_team.added",
-    "translation": "%v added to the team by %v"
+    "translation": "%v added to the team by %v."
   },
   {
     "id": "api.team.add_user_to_team.missing_parameter.app_error",
@@ -2320,7 +2320,7 @@
   },
   {
     "id": "api.team.remove_user_from_team.removed",
-    "translation": "%v was removed from the team."
+    "translation": "%v removed from the team."
   },
   {
     "id": "api.team.signup_team.email_disabled.app_error",


### PR DESCRIPTION
These changes are sort of a follow up to https://mattermost.atlassian.net/browse/PLT-6217 to deal with the inconsistent tenses between system messages ("User added to channel" vs "User was removed from channel"). It also makes sure they all end with periods where applicable.

This is waiting for the changes to release-4.6 containing https://github.com/mattermost/mattermost-server/pull/8078 to be merged into master. The changes specific to this PR are https://github.com/mattermost/mattermost-server/commit/1045ec0aa9918bea036c94f44edb1706a95c7816

#### Checklist
- Includes text changes and localization file ([.../i18n/en.json]
  