### PR TITLE
Remove global config watcher

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -64,7 +64,7 @@ func StopTestStore() {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
-	options := []app.Option{app.DisableConfigWatcher}
+	options := []app.Option{app.DisableConfigWatch}
 	if testStore != nil {
 		options = append(options, app.StoreOverride(testStore))
 	}

--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -69,8 +69,13 @@ func setupTestHelper(enterprise bool) *TestHelper {
 		options = append(options, app.StoreOverride(testStore))
 	}
 
+	a, err := app.New(options...)
+	if err != nil {
+		panic(err)
+	}
+
 	th := &TestHelper{
-		App: app.New(options...),
+		App: a,
 	}
 	th.originalConfig = th.App.Config().Clone()
 

--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -64,7 +64,7 @@ func StopTestStore() {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
-	var options []app.Option
+	options := []app.Option{app.DisableConfigWatcher}
 	if testStore != nil {
 		options = append(options, app.StoreOverride(testStore))
 	}

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -73,7 +73,7 @@ func StopTestStore() {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
-	options := []app.Option{app.DisableConfigWatcher}
+	options := []app.Option{app.DisableConfigWatch}
 	if testStore != nil {
 		options = append(options, app.StoreOverride(testStore))
 	}

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -73,7 +73,7 @@ func StopTestStore() {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
-	var options []app.Option
+	options := []app.Option{app.DisableConfigWatcher}
 	if testStore != nil {
 		options = append(options, app.StoreOverride(testStore))
 	}

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -78,8 +78,13 @@ func setupTestHelper(enterprise bool) *TestHelper {
 		options = append(options, app.StoreOverride(testStore))
 	}
 
+	a, err := app.New(options...)
+	if err != nil {
+		panic(err)
+	}
+
 	th := &TestHelper{
-		App: app.New(options...),
+		App: a,
 	}
 	th.originalConfig = th.App.Config().Clone()
 

--- a/app/admin.go
+++ b/app/admin.go
@@ -173,13 +173,13 @@ func (a *App) SaveConfig(cfg *model.Config, sendConfigChangeClusterMessage bool)
 		return model.NewAppError("saveConfig", "ent.cluster.save_config.error", nil, "", http.StatusForbidden)
 	}
 
-	utils.DisableConfigWatch()
+	a.DisableConfigWatch()
 	a.UpdateConfig(func(update *model.Config) {
 		*update = *cfg
 	})
 	a.PersistConfig()
 	a.ReloadConfig()
-	utils.EnableConfigWatch()
+	a.EnableConfigWatch()
 
 	if a.Metrics != nil {
 		if *a.Config().MetricsSettings.Enable {

--- a/app/app.go
+++ b/app/app.go
@@ -175,6 +175,8 @@ func (a *App) Shutdown() {
 	utils.RemoveConfigListener(a.configListenerId)
 	utils.RemoveLicenseListener(a.licenseListenerId)
 	l4g.Info(utils.T("api.server.stop_server.stopped.info"))
+
+	a.DisableConfigWatch()
 }
 
 var accountMigrationInterface func(*App) einterfaces.AccountMigrationInterface

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	l4g "github.com/alecthomas/log4go"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store/storetest"
@@ -47,7 +48,8 @@ func TestMain(m *testing.M) {
 
 func TestAppRace(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		a := New()
+		a, err := New()
+		require.NoError(t, err)
 		a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })
 		a.StartServer()
 		a.Shutdown()

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -57,7 +57,7 @@ func StopTestStore() {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
-	options := []Option{DisableConfigWatcher}
+	options := []Option{DisableConfigWatch}
 	if testStore != nil {
 		options = append(options, StoreOverride(testStore))
 	}

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -57,7 +57,7 @@ func StopTestStore() {
 }
 
 func setupTestHelper(enterprise bool) *TestHelper {
-	var options []Option
+	options := []Option{DisableConfigWatcher}
 	if testStore != nil {
 		options = append(options, StoreOverride(testStore))
 	}

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -62,8 +62,13 @@ func setupTestHelper(enterprise bool) *TestHelper {
 		options = append(options, StoreOverride(testStore))
 	}
 
+	a, err := New(options...)
+	if err != nil {
+		panic(err)
+	}
+
 	th := &TestHelper{
-		App:         New(options...),
+		App:         a,
 		pluginHooks: make(map[string]plugin.Hooks),
 	}
 

--- a/app/config.go
+++ b/app/config.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"runtime/debug"
+
+	l4g "github.com/alecthomas/log4go"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/utils"
+)
+
+func (a *App) Config() *model.Config {
+	return utils.Cfg
+}
+
+func (a *App) UpdateConfig(f func(*model.Config)) {
+	old := utils.Cfg.Clone()
+	f(utils.Cfg)
+	utils.InvokeGlobalConfigListeners(old, utils.Cfg)
+}
+
+func (a *App) PersistConfig() {
+	utils.SaveConfig(a.ConfigFileName(), a.Config())
+}
+
+func (a *App) ReloadConfig() {
+	debug.FreeOSMemory()
+	utils.LoadGlobalConfig(a.ConfigFileName())
+
+	// start/restart email batching job if necessary
+	a.InitEmailBatching()
+}
+
+func (a *App) ConfigFileName() string {
+	return utils.CfgFileName
+}
+
+func (a *App) ClientConfig() map[string]string {
+	return a.clientConfig
+}
+
+func (a *App) ClientConfigHash() string {
+	return a.clientConfigHash
+}
+
+func (a *App) EnableConfigWatch() {
+	if a.configWatcher == nil && !a.disableConfigWatch {
+		configWatcher, err := utils.NewConfigWatcher(utils.CfgFileName)
+		if err != nil {
+			l4g.Error(err)
+		}
+		a.configWatcher = configWatcher
+	}
+}
+
+func (a *App) DisableConfigWatch() {
+	if a.configWatcher != nil {
+		a.configWatcher.Close()
+		a.configWatcher = nil
+	}
+}
+
+func (a *App) regenerateClientConfig() {
+	a.clientConfig = utils.GenerateClientConfig(a.Config(), a.DiagnosticId())
+	clientConfigJSON, _ := json.Marshal(a.clientConfig)
+	a.clientConfigHash = fmt.Sprintf("%x", md5.Sum(clientConfigJSON))
+}

--- a/app/options.go
+++ b/app/options.go
@@ -35,3 +35,7 @@ func ConfigFile(file string) Option {
 		a.configFile = file
 	}
 }
+
+func DisableConfigWatch(a *App) {
+	a.disableConfigWatch = true
+}

--- a/cmd/platform/init.go
+++ b/cmd/platform/init.go
@@ -31,13 +31,13 @@ func initDBCommandContext(configFileLocation string) (*app.App, error) {
 	}
 	model.AppErrorInit(utils.T)
 
-	if err := utils.InitAndLoadConfig(configFileLocation); err != nil {
+	utils.ConfigureCmdLineLog()
+
+	a, err := app.New(app.ConfigFile(configFileLocation))
+	if err != nil {
 		return nil, err
 	}
 
-	utils.ConfigureCmdLineLog()
-
-	a := app.New(app.ConfigFile(configFileLocation))
 	if model.BuildEnterpriseReady == "true" {
 		a.LoadLicense()
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -38,7 +38,7 @@ func StopTestStore() {
 }
 
 func Setup() *app.App {
-	a, err := app.New(app.StoreOverride(testStore), app.DisableConfigWatcher)
+	a, err := app.New(app.StoreOverride(testStore), app.DisableConfigWatch)
 	if err != nil {
 		panic(err)
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -38,7 +38,7 @@ func StopTestStore() {
 }
 
 func Setup() *app.App {
-	a, err := app.New(app.StoreOverride(testStore))
+	a, err := app.New(app.StoreOverride(testStore), app.DisableConfigWatcher)
 	if err != nil {
 		panic(err)
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -38,7 +38,10 @@ func StopTestStore() {
 }
 
 func Setup() *app.App {
-	a := app.New(app.StoreOverride(testStore))
+	a, err := app.New(app.StoreOverride(testStore))
+	if err != nil {
+		panic(err)
+	}
 	prevListenAddress := *a.Config().ServiceSettings.ListenAddress
 	a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })
 	a.StartServer()


### PR DESCRIPTION
#### Summary
* `utils.watcher`, `utils.CfgDisableConfigWatch`, `utils.InitializeConfigWatch`, `utils.DisableConfigWatch`, and `utils.EnableConfigWatch` are all gone.
* The code from the above now lives in the `utils.ConfigWatcher` struct.
* `app.App` instances now own `utils.ConfigWatcher` instances.
* `app.New` can now return an error instead of a new `App` instance. This is to preserve the old error behavior after the above changes.
* Config-related `app.App` methods have been moved to a new file, app/config.go.
* `utils.LoadGlobalConfig` has been split. The reusable stuff is now in `utils.LoadConfig`.

#### Ticket Link
N/A

#### Checklist
N/A
  