### PR TITLE
[PLT-8531] Redirect error URI when OAuth SSO is setup but account creation is disabled

### DIFF
--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -559,7 +559,7 @@ func signupWithOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !c.App.Config().TeamSettings.EnableUserCreation {
-		c.Err = model.NewAppError("signupWithOAuth", "api.oauth.singup_with_oauth.disabled.app_error", nil, "", http.StatusNotImplemented)
+		http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+url.QueryEscape(utils.T("api.oauth.singup_with_oauth.disabled.app_error")), http.StatusTemporaryRedirect)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Redirect error URI when OAuth SSO is setup but account creation is disabled.

Note: I think the client app should not show `Create one now` in the first place whenever account creation is disabled. The only downside is that the user will never know if account creation is disabled by the system admin.

#### Ticket Link
Jira ticket: [PLT-8531](https://mattermost.atlassian.net/browse/PLT-8531)

#### Checklist
- [x] Touches critical sections of the codebase (auth error redirect)
