### PR TITLE
[PLT-7793] Add /users/tokens/search endpoint

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1247,7 +1247,6 @@ func searchUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) 
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return
 	}
-	
 	props := model.UserAccessTokenSearchFromJson(r.Body)
 	if props == nil {
 		c.SetInvalidParam("user_access_token_search")
@@ -1258,7 +1257,6 @@ func searchUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) 
 		c.SetInvalidParam("term")
 		return
 	}
-	
 	accessTokens, err := c.App.SearchUserAccessTokens(props.Term)
 	if err != nil {
 		c.Err = err

--- a/api4/user.go
+++ b/api4/user.go
@@ -60,6 +60,7 @@ func (api *API) InitUser() {
 	api.BaseRoutes.User.Handle("/tokens", api.ApiSessionRequired(createUserAccessToken)).Methods("POST")
 	api.BaseRoutes.User.Handle("/tokens", api.ApiSessionRequired(getUserAccessTokensForUser)).Methods("GET")
 	api.BaseRoutes.Users.Handle("/tokens", api.ApiSessionRequired(getUserAccessTokens)).Methods("GET")
+	api.BaseRoutes.Users.Handle("/tokens/search", api.ApiSessionRequired(searchUserAccessTokens)).Methods("POST")
 	api.BaseRoutes.Users.Handle("/tokens/{token_id:[A-Za-z0-9]+}", api.ApiSessionRequired(getUserAccessToken)).Methods("GET")
 	api.BaseRoutes.Users.Handle("/tokens/revoke", api.ApiSessionRequired(revokeUserAccessToken)).Methods("POST")
 	api.BaseRoutes.Users.Handle("/tokens/disable", api.ApiSessionRequired(disableUserAccessToken)).Methods("POST")
@@ -1239,6 +1240,32 @@ func createUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("success - token_id=" + accessToken.Id)
 	w.Write([]byte(accessToken.ToJson()))
+}
+
+func searchUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+	
+	props := model.UserAccessTokenSearchFromJson(r.Body)
+	if props == nil {
+		c.SetInvalidParam("user_access_token_search")
+		return
+	}
+
+	if len(props.Term) == 0 {
+		c.SetInvalidParam("term")
+		return
+	}
+	
+	accessTokens, err := c.App.SearchUserAccessTokens(props.Term)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	w.Write([]byte(model.UserAccessTokenListToJson(accessTokens)))
 }
 
 func getUserAccessTokens(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2469,6 +2469,52 @@ func TestGetUserAccessToken(t *testing.T) {
 	}
 }
 
+func TestSearchUserAccessToken(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+	AdminClient := th.SystemAdminClient
+	
+	testDescription := "test token"
+	
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
+	
+	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
+	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
+	CheckNoError(t, resp)
+	
+	_, resp = Client.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: token.Id})
+	CheckForbiddenStatus(t, resp)
+	
+	rtokens, resp := AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: th.BasicUser.Id})
+	CheckNoError(t, resp)
+	
+	if len(rtokens) != 1 {
+		t.Fatal("should have 1 tokens")
+	}
+	
+	rtokens, resp = AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: token.Id})
+	CheckNoError(t, resp)
+	
+	if len(rtokens) != 1 {
+		t.Fatal("should have 1 tokens")
+	}
+	
+	rtokens, resp = AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: th.BasicUser.Username})
+	CheckNoError(t, resp)
+	
+	if len(rtokens) != 1 {
+		t.Fatal("should have 1 tokens")
+	}
+	
+	rtokens, resp = AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: "not found"})
+	CheckNoError(t, resp)
+	
+	if len(rtokens) != 0 {
+		t.Fatal("should have 0 tokens")
+	}
+}
+
 func TestRevokeUserAccessToken(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()

--- a/app/session.go
+++ b/app/session.go
@@ -393,3 +393,15 @@ func (a *App) GetUserAccessToken(tokenId string, sanitize bool) (*model.UserAcce
 		return token, nil
 	}
 }
+
+func (a *App) SearchUserAccessTokens(term string) ([]*model.UserAccessToken, *model.AppError) {
+	if result := <-a.Srv.Store.UserAccessToken().Search(term); result.Err != nil {
+		return nil, result.Err
+	} else {
+		tokens := result.Data.([]*model.UserAccessToken)
+		for _, token := range tokens {
+			token.Token = ""
+		}
+		return tokens, nil
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6791,6 +6791,10 @@
     "translation": "We couldn't get the personal access tokens by user"
   },
   {
+    "id": "store.sql_user_access_token.search.app_error",
+    "translation": "We encountered an error searching user access tokens"
+  },
+  {
     "id": "store.sql_user_access_token.save.app_error",
     "translation": "We couldn't save the personal access token"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -1092,6 +1092,16 @@ func (c *Client4) RevokeUserAccessToken(tokenId string) (bool, *Response) {
 	}
 }
 
+// SearchUserAccessTokens returns user access tokens matching the provided search term.
+func (c *Client4) SearchUserAccessTokens(search *UserAccessTokenSearch) ([]*UserAccessToken, *Response) {
+	if r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/search", search.ToJson()); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // DisableUserAccessToken will disable a user access token by id. Must have the
 // 'revoke_user_access_token' permission and if disabling for another user, must have the
 // 'edit_other_users' permission.

--- a/model/user_access_token_search.go
+++ b/model/user_access_token_search.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type UserAccessTokenSearch struct {
+	Term string `json:"term"`
+}
+
+// ToJson convert a UserAccessTokenSearch to json string
+func (c *UserAccessTokenSearch) ToJson() string {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return ""
+	}
+
+	return string(b)
+}
+
+// UserAccessTokenSearchJson decodes the input and returns a UserAccessTokenSearch
+func UserAccessTokenSearchFromJson(data io.Reader) *UserAccessTokenSearch {
+	decoder := json.NewDecoder(data)
+	var cs UserAccessTokenSearch
+	err := decoder.Decode(&cs)
+	if err == nil {
+		return &cs
+	}
+
+	return nil
+}

--- a/model/user_access_token_search_test.go
+++ b/model/user_access_token_search_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserAccessTokenSearchJson(t *testing.T) {
+	userAccessTokenSearch := UserAccessTokenSearch{Term: NewId()}
+	json := userAccessTokenSearch.ToJson()
+	ruserAccessTokenSearch := UserAccessTokenSearchFromJson(strings.NewReader(json))
+
+	if userAccessTokenSearch.Term != ruserAccessTokenSearch.Term {
+		t.Fatal("Terms do not match")
+	}
+}

--- a/model/user_access_token_test.go
+++ b/model/user_access_token_test.go
@@ -12,7 +12,6 @@ func TestUserAccessTokenJson(t *testing.T) {
 	a1 := UserAccessToken{}
 	a1.UserId = NewId()
 	a1.Token = NewId()
-
 	json := a1.ToJson()
 	ra1 := UserAccessTokenFromJson(strings.NewReader(json))
 

--- a/model/user_access_token_test.go
+++ b/model/user_access_token_test.go
@@ -12,6 +12,7 @@ func TestUserAccessTokenJson(t *testing.T) {
 	a1 := UserAccessToken{}
 	a1.UserId = NewId()
 	a1.Token = NewId()
+
 	json := a1.ToJson()
 	ra1 := UserAccessTokenFromJson(strings.NewReader(json))
 

--- a/store/store.go
+++ b/store/store.go
@@ -449,6 +449,7 @@ type UserAccessTokenStore interface {
 	GetAll(offset int, limit int) StoreChannel
 	GetByToken(tokenString string) StoreChannel
 	GetByUser(userId string, page, perPage int) StoreChannel
+	Search(term string) StoreChannel
 	UpdateTokenEnable(tokenId string) StoreChannel
 	UpdateTokenDisable(tokenId string) StoreChannel
 }

--- a/store/storetest/mocks/UserAccessTokenStore.go
+++ b/store/storetest/mocks/UserAccessTokenStore.go
@@ -109,6 +109,22 @@ func (_m *UserAccessTokenStore) GetByUser(userId string, page int, perPage int) 
 	return r0
 }
 
+// Search provides a mock function with given fields:
+func (_m *UserAccessTokenStore) Search(term string) store.StoreChannel {
+	ret := _m.Called(term)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+		r0 = rf(term)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Save provides a mock function with given fields: token
 func (_m *UserAccessTokenStore) Save(token *model.UserAccessToken) store.StoreChannel {
 	ret := _m.Called(token)

--- a/store/storetest/user_access_token_store.go
+++ b/store/storetest/user_access_token_store.go
@@ -13,6 +13,7 @@ import (
 func TestUserAccessTokenStore(t *testing.T, ss store.Store) {
 	t.Run("UserAccessTokenSaveGetDelete", func(t *testing.T) { testUserAccessTokenSaveGetDelete(t, ss) })
 	t.Run("UserAccessTokenDisableEnable", func(t *testing.T) { testUserAccessTokenDisableEnable(t, ss) })
+	t.Run("UserAccessTokenSearch", func(t *testing.T) { testUserAccessTokenSearch(t, ss) })
 }
 
 func testUserAccessTokenSaveGetDelete(t *testing.T, ss store.Store) {
@@ -129,4 +130,46 @@ func testUserAccessTokenDisableEnable(t *testing.T, ss store.Store) {
 	if err := (<-ss.UserAccessToken().UpdateTokenEnable(uat.Id)).Err; err != nil {
 		t.Fatal(err)
 	}
+}
+
+func testUserAccessTokenSearch(t *testing.T, ss store.Store) {
+	u1 := model.User{}
+	u1.Email = model.NewId()
+	u1.Username = model.NewId()
+	
+	store.Must(ss.User().Save(&u1))
+	
+	uat := &model.UserAccessToken{
+		Token:       model.NewId(),
+		UserId:      u1.Id,
+		Description: "testtoken",
+	}
+
+	s1 := model.Session{}
+	s1.UserId = uat.UserId
+	s1.Token = uat.Token
+
+	store.Must(ss.Session().Save(&s1))
+	
+	if result := <-ss.UserAccessToken().Save(uat); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+
+	if result := <-ss.UserAccessToken().Search(uat.Id); result.Err != nil {
+ 		t.Fatal(result.Err)
+ 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+ 		t.Fatal("received incorrect number of tokens after search")
+ 	}
+	
+	if result := <-ss.UserAccessToken().Search(uat.UserId); result.Err != nil {
+ 		t.Fatal(result.Err)
+ 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+ 		t.Fatal("received incorrect number of tokens after search")
+ 	}
+	
+	if result := <-ss.UserAccessToken().Search(u1.Username); result.Err != nil {
+ 		t.Fatal(result.Err)
+ 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+ 		t.Fatal("received incorrect number of tokens after search")
+ 	}
 }

--- a/store/storetest/user_access_token_store.go
+++ b/store/storetest/user_access_token_store.go
@@ -136,9 +136,9 @@ func testUserAccessTokenSearch(t *testing.T, ss store.Store) {
 	u1 := model.User{}
 	u1.Email = model.NewId()
 	u1.Username = model.NewId()
-	
+
 	store.Must(ss.User().Save(&u1))
-	
+
 	uat := &model.UserAccessToken{
 		Token:       model.NewId(),
 		UserId:      u1.Id,
@@ -150,26 +150,26 @@ func testUserAccessTokenSearch(t *testing.T, ss store.Store) {
 	s1.Token = uat.Token
 
 	store.Must(ss.Session().Save(&s1))
-	
+
 	if result := <-ss.UserAccessToken().Save(uat); result.Err != nil {
 		t.Fatal(result.Err)
 	}
 
 	if result := <-ss.UserAccessToken().Search(uat.Id); result.Err != nil {
- 		t.Fatal(result.Err)
- 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
- 		t.Fatal("received incorrect number of tokens after search")
- 	}
-	
+		t.Fatal(result.Err)
+	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+		t.Fatal("received incorrect number of tokens after search")
+	}
+
 	if result := <-ss.UserAccessToken().Search(uat.UserId); result.Err != nil {
- 		t.Fatal(result.Err)
- 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
- 		t.Fatal("received incorrect number of tokens after search")
- 	}
-	
+		t.Fatal(result.Err)
+	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+		t.Fatal("received incorrect number of tokens after search")
+	}
+
 	if result := <-ss.UserAccessToken().Search(u1.Username); result.Err != nil {
- 		t.Fatal(result.Err)
- 	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
- 		t.Fatal("received incorrect number of tokens after search")
- 	}
+		t.Fatal(result.Err)
+	} else if received := result.Data.([]*model.UserAccessToken); len(received) != 1 {
+		t.Fatal("received incorrect number of tokens after search")
+	}
 }


### PR DESCRIPTION
#### Summary

Adds a new endpoint called `/users/tokens/search` which gets all tokens based on the search term if one has the `manage_system` permission.

#### PR Links

- [Documentation PR](https://github.com/mattermost/mattermost-api-reference/pull/320)
- [Webapp PR](https://github.com/mattermost/mattermost-webapp/pull/496)
- [Server PR](https://github.com/mattermost/mattermost-server/pull/8088)
- Redux PR

#### Ticket Link

- [Jira](https://mattermost.atlassian.net/browse/PLT-7793)
- [Github](https://github.com/mattermost/mattermost-server/issues/7584#issuecomment-352808489)

#### Checklist

- [x] Added route
- [x] Added handler
- [x] Updated store
- [x] Added or updated unit tests (required for all new features)
- [x] [Added documentation](https://github.com/mattermost/mattermost-api-reference/pull/320)
- [x] Has UI changes
- [x] Touches critical sections of the codebase (access tokens)
- [x] Run `make test` for sanity check
- [x] Run `make check-style`
- [x] Tested with postman / curl
- [x] Add i18n string
