### PR TITLE
ABC-73 Move session clean-up to daily task

### DIFF
--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -127,7 +127,7 @@ func runServer(configFileLocation string) {
 
 	go runSecurityJob(a)
 	go runDiagnosticsJob(a)
-
+	go runSessionCleanupJob(a)
 	go runTokenCleanupJob(a)
 	go runCommandWebhookCleanupJob(a)
 
@@ -205,6 +205,13 @@ func runCommandWebhookCleanupJob(a *app.App) {
 	}, time.Hour*1)
 }
 
+func runSessionCleanupJob(a *app.App) {
+	doSessionCleanup(a)
+	model.CreateRecurringTask("Session Cleanup", func() {
+		doSessionCleanup(a)
+	}, time.Hour*24)
+}
+
 func resetStatuses(a *app.App) {
 	if result := <-a.Srv.Store.Status().ResetAll(); result.Err != nil {
 		l4g.Error(utils.T("mattermost.reset_status.error"), result.Err.Error())
@@ -227,4 +234,8 @@ func doTokenCleanup(a *app.App) {
 
 func doCommandWebhookCleanup(a *app.App) {
 	a.Srv.Store.CommandWebhook().Cleanup()
+}
+
+func doSessionCleanup(a *app.App) {
+	a.Srv.Store.Session().Cleanup()
 }

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -21,6 +21,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	SESSIONS_CLEANUP_BATCH_SIZE = 1000
+)
+
 var MaxNotificationsPerChannelDefault int64 = 1000000
 
 var serverCmd = &cobra.Command{
@@ -237,5 +241,5 @@ func doCommandWebhookCleanup(a *app.App) {
 }
 
 func doSessionCleanup(a *app.App) {
-	a.Srv.Store.Session().Cleanup()
+	a.Srv.Store.Session().Cleanup(model.GetMillis(), SESSIONS_CLEANUP_BATCH_SIZE)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -260,7 +260,7 @@ type SessionStore interface {
 	UpdateRoles(userId string, roles string) StoreChannel
 	UpdateDeviceId(id string, deviceId string, expiresAt int64) StoreChannel
 	AnalyticsSessionCount() StoreChannel
-	Cleanup()
+	Cleanup(expiryTime int64, batchSize int64)
 }
 
 type AuditStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -260,6 +260,7 @@ type SessionStore interface {
 	UpdateRoles(userId string, roles string) StoreChannel
 	UpdateDeviceId(id string, deviceId string, expiresAt int64) StoreChannel
 	AnalyticsSessionCount() StoreChannel
+	Cleanup()
 }
 
 type AuditStore interface {

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -29,9 +29,9 @@ func (_m *SessionStore) AnalyticsSessionCount() store.StoreChannel {
 	return r0
 }
 
-// Cleanup provides a mock function with given fields:
-func (_m *SessionStore) Cleanup() {
-	_m.Called()
+// Cleanup provides a mock function with given fields: expiryTime, batchSize
+func (_m *SessionStore) Cleanup(expiryTime int64, batchSize int64) {
+	_m.Called(expiryTime, batchSize)
 }
 
 // Get provides a mock function with given fields: sessionIdOrToken

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -29,6 +29,11 @@ func (_m *SessionStore) AnalyticsSessionCount() store.StoreChannel {
 	return r0
 }
 
+// Cleanup provides a mock function with given fields:
+func (_m *SessionStore) Cleanup() {
+	_m.Called()
+}
+
 // Get provides a mock function with given fields: sessionIdOrToken
 func (_m *SessionStore) Get(sessionIdOrToken string) store.StoreChannel {
 	ret := _m.Called(sessionIdOrToken)

--- a/store/storetest/session_store.go
+++ b/store/storetest/session_store.go
@@ -8,9 +8,14 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSessionStore(t *testing.T, ss store.Store) {
+	// Run serially to prevent interfering with other tests
+	testSessionCleanup(t, ss)
+
 	t.Run("Save", func(t *testing.T) { testSessionStoreSave(t, ss) })
 	t.Run("SessionGet", func(t *testing.T) { testSessionGet(t, ss) })
 	t.Run("SessionGetWithDeviceId", func(t *testing.T) { testSessionGetWithDeviceId(t, ss) })
@@ -58,7 +63,7 @@ func testSessionGet(t *testing.T, ss store.Store) {
 	if rs2 := (<-ss.Session().GetSessions(s1.UserId)); rs2.Err != nil {
 		t.Fatal(rs2.Err)
 	} else {
-		if len(rs2.Data.([]*model.Session)) != 2 {
+		if len(rs2.Data.([]*model.Session)) != 3 {
 			t.Fatal("should match len")
 		}
 	}
@@ -247,4 +252,35 @@ func testSessionCount(t *testing.T, ss store.Store) {
 			t.Fatal("should have at least 1 session")
 		}
 	}
+}
+
+func testSessionCleanup(t *testing.T, ss store.Store) {
+	s1 := model.Session{}
+	s1.UserId = model.NewId()
+	s1.ExpiresAt = 0 // never expires
+	store.Must(ss.Session().Save(&s1))
+
+	s2 := model.Session{}
+	s2.UserId = s1.UserId
+	s2.ExpiresAt = model.GetMillis() + 1000000 // expires in the future
+	store.Must(ss.Session().Save(&s2))
+
+	s3 := model.Session{}
+	s3.UserId = model.NewId()
+	s3.ExpiresAt = 1 // expired
+	store.Must(ss.Session().Save(&s3))
+
+	ss.Session().Cleanup()
+
+	err := (<-ss.Session().Get(s1.Id)).Err
+	assert.Nil(t, err)
+
+	err = (<-ss.Session().Get(s2.Id)).Err
+	assert.Nil(t, err)
+
+	err = (<-ss.Session().Get(s3.Id)).Err
+	assert.NotNil(t, err)
+
+	store.Must(ss.Session().Remove(s1.Id))
+	store.Must(ss.Session().Remove(s2.Id))
 }


### PR DESCRIPTION
#### Summary
Move session clean-up to daily task instead of on every session save and gets.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-73

#### Checklist
- [x] Added or updated unit tests (required for all new features)