### PR TITLE
PLT-7338: Revisit team model

### DIFF
--- a/api/team.go
+++ b/api/team.go
@@ -233,7 +233,7 @@ func getTeamByName(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	} else {
-		if (!team.AllowOpenInvite || team.Type != model.TEAM_OPEN) && c.Session.GetTeamByTeamId(team.Id) == nil {
+		if team.Type != model.TEAM_OPEN && c.Session.GetTeamByTeamId(team.Id) == nil {
 			if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
 				c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 				return

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -373,7 +373,7 @@ func TestGetAllTeamListings(t *testing.T) {
 
 	Client := th.BasicClient
 
-	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN, AllowOpenInvite: true}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
 	Client.Logout()
@@ -416,12 +416,11 @@ func TestGetAllTeamListingsSanitization(t *testing.T) {
 
 	var team *model.Team
 	if res, err := th.BasicClient.CreateTeam(&model.Team{
-		DisplayName:     t.Name() + "_1",
-		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
-		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
-		AllowOpenInvite: true,
+		DisplayName:    t.Name() + "_1",
+		Name:           GenerateTestTeamName(),
+		Email:          GenerateTestEmail(),
+		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	}); err != nil {
 		t.Fatal(err)
 	} else {
@@ -430,12 +429,11 @@ func TestGetAllTeamListingsSanitization(t *testing.T) {
 
 	var team2 *model.Team
 	if res, err := th.SystemAdminClient.CreateTeam(&model.Team{
-		DisplayName:     t.Name() + "_2",
-		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
-		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
-		AllowOpenInvite: true,
+		DisplayName:    t.Name() + "_2",
+		Name:           GenerateTestTeamName(),
+		Email:          GenerateTestEmail(),
+		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	}); err != nil {
 		t.Fatal(err)
 	} else {
@@ -1110,13 +1108,13 @@ func TestGetTeamByName(t *testing.T) {
 
 	Client := th.BasicClient
 
-	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN, AllowOpenInvite: false}
+	team := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN}
 	team = Client.Must(Client.CreateTeam(team)).Data.(*model.Team)
 
-	team2 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN, AllowOpenInvite: true}
+	team2 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN}
 	team2 = Client.Must(Client.CreateTeam(team2)).Data.(*model.Team)
 
-	team3 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_INVITE, AllowOpenInvite: true}
+	team3 := &model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_INVITE}
 	team3 = Client.Must(Client.CreateTeam(team3)).Data.(*model.Team)
 
 	if _, err := Client.GetTeamByName(team.Name); err != nil {

--- a/api4/team.go
+++ b/api4/team.go
@@ -82,7 +82,7 @@ func getTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	} else {
-		if (!team.AllowOpenInvite || team.Type != model.TEAM_OPEN) && !c.App.SessionHasPermissionToTeam(c.Session, team.Id, model.PERMISSION_VIEW_TEAM) {
+		if team.Type != model.TEAM_OPEN && !c.App.SessionHasPermissionToTeam(c.Session, team.Id, model.PERMISSION_VIEW_TEAM) {
 			c.SetPermissionError(model.PERMISSION_VIEW_TEAM)
 			return
 		}
@@ -104,7 +104,7 @@ func getTeamByName(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	} else {
-		if (!team.AllowOpenInvite || team.Type != model.TEAM_OPEN) && !c.App.SessionHasPermissionToTeam(c.Session, team.Id, model.PERMISSION_VIEW_TEAM) {
+		if team.Type != model.TEAM_OPEN && !c.App.SessionHasPermissionToTeam(c.Session, team.Id, model.PERMISSION_VIEW_TEAM) {
 			c.SetPermissionError(model.PERMISSION_VIEW_TEAM)
 			return
 		}

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -148,10 +148,10 @@ func TestGetTeam(t *testing.T) {
 
 	th.LoginTeamAdmin()
 
-	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: false}
+	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN}
 	rteam2, _ := Client.CreateTeam(team2)
 
-	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE, AllowOpenInvite: true}
+	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE}
 	rteam3, _ := Client.CreateTeam(team3)
 
 	th.LoginBasic()
@@ -259,7 +259,7 @@ func TestUpdateTeam(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	team := &model.Team{DisplayName: "Name", Description: "Some description", AllowOpenInvite: false, InviteId: "inviteid0", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Description: "Some description", InviteId: "inviteid0", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN}
 	team, _ = Client.CreateTeam(team)
 
 	team.Description = "updated description"
@@ -393,7 +393,7 @@ func TestPatchTeam(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	team := &model.Team{DisplayName: "Name", Description: "Some description", CompanyName: "Some company name", AllowOpenInvite: false, InviteId: "inviteid0", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "Name", Description: "Some description", CompanyName: "Some company name", InviteId: "inviteid0", Name: "z-z-" + model.NewId() + "a", Email: "success+" + model.NewId() + "@simulator.amazonses.com", Type: model.TEAM_OPEN}
 	team, _ = Client.CreateTeam(team)
 
 	patch := &model.TeamPatch{}
@@ -419,8 +419,16 @@ func TestPatchTeam(t *testing.T) {
 	if rteam.InviteId != "inviteid1" {
 		t.Fatal("InviteId did not update properly")
 	}
-	if !rteam.AllowOpenInvite {
-		t.Fatal("AllowOpenInvite did not update properly")
+	if rteam.Type != model.TEAM_OPEN {
+		t.Fatal("Team Type did not update properly")
+	}
+
+	patch.Type = model.NewString(model.TEAM_INVITE)
+	rteam, resp = Client.PatchTeam(team.Id, patch)
+	CheckNoError(t, resp)
+
+	if rteam.Type != model.TEAM_INVITE {
+		t.Fatal("Team Type did not update properly")
 	}
 
 	_, resp = Client.PatchTeam("junk", patch)
@@ -567,7 +575,7 @@ func TestGetAllTeams(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	team := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: true}
+	team := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN}
 	_, resp := Client.CreateTeam(team)
 	CheckNoError(t, resp)
 
@@ -580,7 +588,7 @@ func TestGetAllTeams(t *testing.T) {
 	}
 
 	for _, rt := range rrteams {
-		if !rt.AllowOpenInvite {
+		if rt.Type != model.TEAM_OPEN {
 			t.Fatal("not all teams are open")
 		}
 	}
@@ -589,7 +597,7 @@ func TestGetAllTeams(t *testing.T) {
 	CheckNoError(t, resp)
 
 	for _, rt := range rrteams {
-		if !rt.AllowOpenInvite {
+		if rt.Type != model.TEAM_OPEN {
 			t.Fatal("not all teams are open")
 		}
 	}
@@ -625,21 +633,19 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 	defer th.TearDown()
 
 	team, resp := th.Client.CreateTeam(&model.Team{
-		DisplayName:     t.Name() + "_1",
-		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
-		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
-		AllowOpenInvite: true,
+		DisplayName:    t.Name() + "_1",
+		Name:           GenerateTestTeamName(),
+		Email:          GenerateTestEmail(),
+		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 	team2, resp := th.SystemAdminClient.CreateTeam(&model.Team{
-		DisplayName:     t.Name() + "_2",
-		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
-		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
-		AllowOpenInvite: true,
+		DisplayName:    t.Name() + "_2",
+		Name:           GenerateTestTeamName(),
+		Email:          GenerateTestEmail(),
+		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -719,10 +725,10 @@ func TestGetTeamByName(t *testing.T) {
 
 	th.LoginTeamAdmin()
 
-	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: false}
+	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN}
 	rteam2, _ := Client.CreateTeam(team2)
 
-	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE, AllowOpenInvite: true}
+	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE}
 	rteam3, _ := Client.CreateTeam(team3)
 
 	th.LoginBasic()
@@ -789,7 +795,7 @@ func TestSearchAllTeams(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 	oTeam := th.BasicTeam
-	oTeam.AllowOpenInvite = true
+	oTeam.Type = model.TEAM_OPEN
 
 	if updatedTeam, err := th.App.UpdateTeam(oTeam); err != nil {
 		t.Fatal(err)

--- a/app/import.go
+++ b/app/import.go
@@ -339,8 +339,11 @@ func (a *App) ImportTeam(data *TeamImportData, dryRun bool) *model.AppError {
 		team.Description = *data.Description
 	}
 
-	if data.AllowOpenInvite != nil {
-		team.AllowOpenInvite = *data.AllowOpenInvite
+	// AllowOpenInvite is deprecated. Until fully removed, it will be based on type
+	if data.AllowOpenInvite != nil && *data.AllowOpenInvite {
+		team.Type = model.TEAM_OPEN
+	} else {
+		team.Type = model.TEAM_INVITE
 	}
 
 	if team.Id == "" {

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -1224,7 +1224,7 @@ func TestImportImportTeam(t *testing.T) {
 	if team, err := th.App.GetTeamByName(*data.Name); err != nil {
 		t.Fatalf("Failed to get team from database.")
 	} else {
-		if team.DisplayName != *data.DisplayName || team.Type != *data.Type || team.Description != *data.Description || team.AllowOpenInvite != *data.AllowOpenInvite {
+		if team.DisplayName != *data.DisplayName || team.Type != *data.Type || team.Description != *data.Description {
 			t.Fatalf("Imported team properties do not match import data.")
 		}
 	}
@@ -1253,7 +1253,7 @@ func TestImportImportTeam(t *testing.T) {
 	if team, err := th.App.GetTeamByName(*data.Name); err != nil {
 		t.Fatalf("Failed to get team from database.")
 	} else {
-		if team.DisplayName != *data.DisplayName || team.Type != *data.Type || team.Description != *data.Description || team.AllowOpenInvite != *data.AllowOpenInvite {
+		if team.DisplayName != *data.DisplayName || team.Type != *data.Type || team.Description != *data.Description {
 			t.Fatalf("Updated team properties do not match import data.")
 		}
 	}

--- a/app/team.go
+++ b/app/team.go
@@ -96,9 +96,11 @@ func (a *App) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
 	oldTeam.DisplayName = team.DisplayName
 	oldTeam.Description = team.Description
 	oldTeam.InviteId = team.InviteId
-	oldTeam.AllowOpenInvite = team.AllowOpenInvite
 	oldTeam.CompanyName = team.CompanyName
 	oldTeam.AllowedDomains = team.AllowedDomains
+
+	// AllowOpenInvite is deprecated. Until fully removed, it will be based on type
+	oldTeam.AllowOpenInvite = team.Type == model.TEAM_OPEN
 
 	if result := <-a.Srv.Store.Team().Update(oldTeam); result.Err != nil {
 		return nil, result.Err

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -202,7 +202,7 @@ func (s SqlTeamStore) SearchOpen(term string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var teams []*model.Team
 
-		if _, err := s.GetReplica().Select(&teams, "SELECT * FROM Teams WHERE Type = 'O' AND AllowOpenInvite = true AND (Name LIKE :Term OR DisplayName LIKE :Term)", map[string]interface{}{"Term": term + "%"}); err != nil {
+		if _, err := s.GetReplica().Select(&teams, "SELECT * FROM Teams WHERE Type = 'O' AND (Name LIKE :Term OR DisplayName LIKE :Term)", map[string]interface{}{"Term": term + "%"}); err != nil {
 			result.Err = model.NewAppError("SqlTeamStore.SearchOpen", "store.sql_team.search_open_team.app_error", nil, "term="+term+", "+err.Error(), http.StatusInternalServerError)
 		}
 


### PR DESCRIPTION
#### Summary
Deprecated `Team.AllowOpenInvite` in favour of `Team.Type` property. These two properties were being used interchangeably in the code, leading to a lot of places that checked both properties.

In this PR, I've removed uses of `Team.AllowOpenInvite` in favour of `Team.Type`, and I've added code during Team update and save operations that sets `Team.AllowOpenInvite` based on the value of `Team.Type`. The goal is to make the deprecated `Team.AllowOpenInvite` property effectively read-only until we decide to remove it entirely.

The only API change was to add a `Type` field to the `TeamPatch` request object. I still need to update the drivers and documentation to make note of the fact that the `AllowOpenInvite` field of that object has been deprecated. 

There will also be a webapp PR incoming that changes all uses of `AllowOpenInvite` over to `Type`.

#### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7338

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers