### PR TITLE
PLT-3658 Support for Slack attachments in outgoing webhook response (#7774)

### DIFF
--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -46,12 +46,13 @@ type OutgoingWebhookPayload struct {
 }
 
 type OutgoingWebhookResponse struct {
-	Text         *string         `json:"text"`
-	Username     string          `json:"username"`
-	IconURL      string          `json:"icon_url"`
-	Props        StringInterface `json:"props"`
-	Type         string          `json:"type"`
-	ResponseType string          `json:"response_type"`
+	Text         *string            `json:"text"`
+	Username     string             `json:"username"`
+	IconURL      string             `json:"icon_url"`
+	Props        StringInterface    `json:"props"`
+	Attachments  []*SlackAttachment `json:"attachments"`
+	Type         string             `json:"type"`
+	ResponseType string             `json:"response_type"`
 }
 
 const OUTGOING_HOOK_RESPONSE_TYPE_COMMENT = "comment"


### PR DESCRIPTION
#### Summary
This PR adds support for Slack attachments for outgoing webhook responses.
It also adds support for mentions with <@userid> and announcement tokens (eg. <!here>) in the outgoing webhook responses as implemented in #7615 

#### Ticket Link
The GitHub issue opened for this ticket is #7774 
