### PR TITLE
ABC-85 Handle missed case with ExperimentalEnableDefaultChannelLeaveJoinMessages setting

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -63,7 +63,7 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, channelRole s
 			l4g.Warn("Failed to update ChannelMemberHistory table %v", result.Err)
 		}
 
-		if *a.Config().ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages == true {
+		if *a.Config().ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages {
 			if requestor == nil {
 				if err := a.postJoinTeamMessage(user, townSquare); err != nil {
 					l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)

--- a/app/team.go
+++ b/app/team.go
@@ -616,13 +616,15 @@ func (a *App) LeaveTeam(team *model.Team, user *model.User, requestorId string) 
 		channel = result.Data.(*model.Channel)
 	}
 
-	if requestorId == user.Id {
-		if err := a.postLeaveTeamMessage(user, channel); err != nil {
-			l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
-		}
-	} else {
-		if err := a.PostRemoveFromChannelMessage(user.Id, user, channel); err != nil {
-			l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
+	if *a.Config().ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages {
+		if requestorId == user.Id {
+			if err := a.postLeaveTeamMessage(user, channel); err != nil {
+				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
+			}
+		} else {
+			if err := a.PostRemoveFromChannelMessage(user.Id, user, channel); err != nil {
+				l4g.Error(utils.T("api.channel.post_user_add_remove_message_and_forget.error"), err)
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Summary
Fixes a case missed in #7961 where leaving the team would still post in town-square when `ExperimentalEnableDefaultChannelLeaveJoinMessages` was set to false.

Heads-up @csduarte and @dmeza in case you need to cherry pick this

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-85