### PR TITLE
Finally remove utils.Cfg

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -5,6 +5,8 @@ package api
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"os"
 	"strings"

--- a/api/oauth_test.go
+++ b/api/oauth_test.go
@@ -88,8 +88,6 @@ func TestOAuthRegisterApp(t *testing.T) {
 		t.Fatal("should have failed. not enough permissions")
 	}
 
-	adminOnly := *th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
 
 	th.LoginBasic()
@@ -741,9 +739,6 @@ func TestOAuthComplete(t *testing.T) {
 
 	// We are going to use mattermost as the provider emulating gitlab
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOAuthServiceProvider = true })
-
-	adminOnly := *th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = adminOnly })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
 
 	oauthApp := &model.OAuthApp{

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -66,7 +66,7 @@ func TestCreateTeamSanitization(t *testing.T) {
 		team := &model.Team{
 			DisplayName:    t.Name() + "_1",
 			Name:           GenerateTestTeamName(),
-			Email:          GenerateTestEmail(),
+			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
 			AllowedDomains: "simulator.amazonses.com",
 		}
@@ -84,7 +84,7 @@ func TestCreateTeamSanitization(t *testing.T) {
 		team := &model.Team{
 			DisplayName:    t.Name() + "_2",
 			Name:           GenerateTestTeamName(),
-			Email:          GenerateTestEmail(),
+			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
 			AllowedDomains: "simulator.amazonses.com",
 		}
@@ -304,7 +304,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 	if res, err := th.BasicClient.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	}); err != nil {
@@ -317,7 +317,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 	if res, err := th.SystemAdminClient.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_2",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	}); err != nil {
@@ -418,7 +418,7 @@ func TestGetAllTeamListingsSanitization(t *testing.T) {
 	if res, err := th.BasicClient.CreateTeam(&model.Team{
 		DisplayName:     t.Name() + "_1",
 		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
+		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
 		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
@@ -432,7 +432,7 @@ func TestGetAllTeamListingsSanitization(t *testing.T) {
 	if res, err := th.SystemAdminClient.CreateTeam(&model.Team{
 		DisplayName:     t.Name() + "_2",
 		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
+		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
 		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
@@ -665,7 +665,7 @@ func TestUpdateTeamSanitization(t *testing.T) {
 	if res, err := th.BasicClient.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	}); err != nil {
@@ -772,7 +772,7 @@ func TestGetMyTeamSanitization(t *testing.T) {
 	if res, err := th.BasicClient.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	}); err != nil {
@@ -1192,7 +1192,7 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 	if res, err := th.BasicClient.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	}); err != nil {

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -323,7 +323,7 @@ func TestCreatePostPublic(t *testing.T) {
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "#hashtag a" + model.NewId() + "a"}
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_USER_ROLE_ID}
+	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_USER_ROLE_ID}
 
 	ruser, resp := Client.CreateUser(&user)
 	CheckNoError(t, resp)
@@ -368,7 +368,7 @@ func TestCreatePostAll(t *testing.T) {
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, Message: "#hashtag a" + model.NewId() + "a"}
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_USER_ROLE_ID}
+	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Joram Wilander", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_USER_ROLE_ID}
 
 	directChannel, _ := th.App.CreateDirectChannel(th.BasicUser.Id, th.BasicUser2.Id)
 

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -91,7 +91,7 @@ func TestCreateTeamSanitization(t *testing.T) {
 		team := &model.Team{
 			DisplayName:    t.Name() + "_1",
 			Name:           GenerateTestTeamName(),
-			Email:          GenerateTestEmail(),
+			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
 			AllowedDomains: "simulator.amazonses.com",
 		}
@@ -109,7 +109,7 @@ func TestCreateTeamSanitization(t *testing.T) {
 		team := &model.Team{
 			DisplayName:    t.Name() + "_2",
 			Name:           GenerateTestTeamName(),
-			Email:          GenerateTestEmail(),
+			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
 			AllowedDomains: "simulator.amazonses.com",
 		}
@@ -148,10 +148,10 @@ func TestGetTeam(t *testing.T) {
 
 	th.LoginTeamAdmin()
 
-	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: false}
+	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: false}
 	rteam2, _ := Client.CreateTeam(team2)
 
-	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE, AllowOpenInvite: true}
+	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_INVITE, AllowOpenInvite: true}
 	rteam3, _ := Client.CreateTeam(team3)
 
 	th.LoginBasic()
@@ -178,7 +178,7 @@ func TestGetTeamSanitization(t *testing.T) {
 	team, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -359,7 +359,7 @@ func TestUpdateTeamSanitization(t *testing.T) {
 	team, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -458,7 +458,7 @@ func TestPatchTeamSanitization(t *testing.T) {
 	team, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -492,7 +492,7 @@ func TestSoftDeleteTeam(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN}
 	team, _ = Client.CreateTeam(team)
 
 	ok, resp := Client.SoftDeleteTeam(team.Id)
@@ -534,7 +534,7 @@ func TestPermanentDeleteTeam(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN}
+	team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN}
 	team, _ = Client.CreateTeam(team)
 
 	ok, resp := Client.PermanentDeleteTeam(team.Id)
@@ -567,7 +567,7 @@ func TestGetAllTeams(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	team := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: true}
+	team := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: true}
 	_, resp := Client.CreateTeam(team)
 	CheckNoError(t, resp)
 
@@ -627,7 +627,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 	team, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:     t.Name() + "_1",
 		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
+		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
 		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
@@ -636,7 +636,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 	team2, resp := th.SystemAdminClient.CreateTeam(&model.Team{
 		DisplayName:     t.Name() + "_2",
 		Name:            GenerateTestTeamName(),
-		Email:           GenerateTestEmail(),
+		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
 		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
@@ -722,10 +722,10 @@ func TestGetTeamByName(t *testing.T) {
 
 	th.LoginTeamAdmin()
 
-	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: false}
+	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN, AllowOpenInvite: false}
 	rteam2, _ := Client.CreateTeam(team2)
 
-	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE, AllowOpenInvite: true}
+	team3 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_INVITE, AllowOpenInvite: true}
 	rteam3, _ := Client.CreateTeam(team3)
 
 	th.LoginBasic()
@@ -745,7 +745,7 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 	team, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -800,7 +800,7 @@ func TestSearchAllTeams(t *testing.T) {
 		oTeam.UpdateAt = updatedTeam.UpdateAt
 	}
 
-	pTeam := &model.Team{DisplayName: "PName", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE}
+	pTeam := &model.Team{DisplayName: "PName", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_INVITE}
 	Client.CreateTeam(pTeam)
 
 	rteams, resp := Client.SearchTeams(&model.TeamSearch{Term: oTeam.Name})
@@ -876,7 +876,7 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 	team, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -884,7 +884,7 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 	team2, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_2",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -954,7 +954,7 @@ func TestGetTeamsForUser(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: GenerateTestEmail(), Type: model.TEAM_INVITE}
+	team2 := &model.Team{DisplayName: "Name", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_INVITE}
 	rteam2, _ := Client.CreateTeam(team2)
 
 	teams, resp := Client.GetTeamsForUser(th.BasicUser.Id, "")
@@ -998,7 +998,7 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 	team, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_1",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -1006,7 +1006,7 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 	team2, resp := th.Client.CreateTeam(&model.Team{
 		DisplayName:    t.Name() + "_2",
 		Name:           GenerateTestTeamName(),
-		Email:          GenerateTestEmail(),
+		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
 		AllowedDomains: "simulator.amazonses.com",
 	})
@@ -1881,8 +1881,8 @@ func TestInviteUsersToTeam(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 
-	user1 := GenerateTestEmail()
-	user2 := GenerateTestEmail()
+	user1 := th.GenerateTestEmail()
+	user2 := th.GenerateTestEmail()
 
 	emailList := []string{user1, user2}
 

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -23,7 +23,7 @@ func TestCreateUser(t *testing.T) {
 	Client := th.Client
 	AdminClient := th.SystemAdminClient
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 	ruser, resp := Client.CreateUser(&user)
 	CheckNoError(t, resp)
@@ -52,7 +52,7 @@ func TestCreateUser(t *testing.T) {
 	CheckErrorMessage(t, resp, "store.sql_user.save.email_exists.app_error")
 	CheckBadRequestStatus(t, resp)
 
-	ruser.Email = GenerateTestEmail()
+	ruser.Email = th.GenerateTestEmail()
 	ruser.Username = user.Username
 	_, resp = Client.CreateUser(ruser)
 	CheckErrorMessage(t, resp, "store.sql_user.save.username_exists.app_error")
@@ -66,7 +66,7 @@ func TestCreateUser(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = false })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = false })
 
-	user2 := &model.User{Email: GenerateTestEmail(), Password: "Password1", Username: GenerateTestUsername()}
+	user2 := &model.User{Email: th.GenerateTestEmail(), Password: "Password1", Username: GenerateTestUsername()}
 	_, resp = AdminClient.CreateUser(user2)
 	CheckNoError(t, resp)
 
@@ -87,7 +87,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	Client := th.Client
 
 	t.Run("CreateWithHashHappyPath", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		props := make(map[string]string)
 		props["email"] = user.Email
 		props["id"] = th.BasicTeam.Id
@@ -113,7 +113,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("NoHashAndNoData", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		props := make(map[string]string)
 		props["email"] = user.Email
 		props["id"] = th.BasicTeam.Id
@@ -133,7 +133,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("HashExpired", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		timeNow := time.Now()
 		past49Hours := timeNow.Add(-49*time.Hour).UnixNano() / int64(time.Millisecond)
 
@@ -152,7 +152,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("WrongHash", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		props := make(map[string]string)
 		props["email"] = user.Email
 		props["id"] = th.BasicTeam.Id
@@ -168,7 +168,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("EnableUserCreationDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		props := make(map[string]string)
 		props["email"] = user.Email
@@ -189,7 +189,7 @@ func TestCreateUserWithHash(t *testing.T) {
 	})
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		props := make(map[string]string)
 		props["email"] = user.Email
@@ -225,7 +225,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	AdminClient := th.SystemAdminClient
 
 	t.Run("CreateWithInviteIdHappyPath", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -245,7 +245,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("WrongInviteId", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		inviteId := model.NewId()
 
@@ -255,7 +255,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("NoInviteId", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		_, resp := Client.CreateUserWithInviteId(&user, "")
 		CheckBadRequestStatus(t, resp)
@@ -263,7 +263,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("ExpiredInviteId", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		inviteId := th.BasicTeam.InviteId
 
@@ -277,7 +277,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("EnableUserCreationDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = false })
 
@@ -291,7 +291,7 @@ func TestCreateUserWithInviteId(t *testing.T) {
 	})
 
 	t.Run("EnableOpenServerDisable", func(t *testing.T) {
-		user := model.User{Email: GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = false })
 
@@ -471,7 +471,7 @@ func TestGetUserByEmail(t *testing.T) {
 	_, resp = Client.GetUserByEmail(GenerateTestUsername(), "")
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.GetUserByEmail(GenerateTestEmail(), "")
+	_, resp = Client.GetUserByEmail(th.GenerateTestEmail(), "")
 	CheckNotFoundStatus(t, resp)
 
 	// Check against privacy config settings
@@ -964,7 +964,7 @@ func TestUpdateUser(t *testing.T) {
 	th.App.AddSessionToCache(session)
 
 	ruser.Id = user.Id
-	ruser.Email = GenerateTestEmail()
+	ruser.Email = th.GenerateTestEmail()
 	_, resp = Client.UpdateUser(ruser)
 	CheckForbiddenStatus(t, resp)
 
@@ -1047,7 +1047,7 @@ func TestPatchUser(t *testing.T) {
 	session.IsOAuth = true
 	th.App.AddSessionToCache(session)
 
-	patch.Email = model.NewString(GenerateTestEmail())
+	patch.Email = model.NewString(th.GenerateTestEmail())
 	_, resp = Client.PatchUser(user.Id, patch)
 	CheckForbiddenStatus(t, resp)
 
@@ -2070,7 +2070,7 @@ func TestVerifyUserEmail(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	user := model.User{Email: GenerateTestEmail(), Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
+	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
 	ruser, resp := Client.CreateUser(&user)
 
@@ -2105,7 +2105,7 @@ func TestSendVerificationEmail(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	// Even non-existent emails should return 200 OK
-	_, resp = Client.SendVerificationEmail(GenerateTestEmail())
+	_, resp = Client.SendVerificationEmail(th.GenerateTestEmail())
 	CheckNoError(t, resp)
 
 	Client.Logout()
@@ -2450,20 +2450,20 @@ func TestGetUserAccessToken(t *testing.T) {
 	if len(rtokens) != 2 {
 		t.Fatal("should have 2 tokens")
 	}
-	
-	_, resp = Client.GetUserAccessTokens(0,100)
+
+	_, resp = Client.GetUserAccessTokens(0, 100)
 	CheckForbiddenStatus(t, resp)
-	
-	rtokens, resp = AdminClient.GetUserAccessTokens(1,1)
+
+	rtokens, resp = AdminClient.GetUserAccessTokens(1, 1)
 	CheckNoError(t, resp)
-	
+
 	if len(rtokens) != 1 {
 		t.Fatal("should have 1 token")
 	}
-	
-	rtokens, resp = AdminClient.GetUserAccessTokens(0,2)
+
+	rtokens, resp = AdminClient.GetUserAccessTokens(0, 2)
 	CheckNoError(t, resp)
-	
+
 	if len(rtokens) != 2 {
 		t.Fatal("should have 2 tokens")
 	}
@@ -2474,42 +2474,42 @@ func TestSearchUserAccessToken(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 	AdminClient := th.SystemAdminClient
-	
+
 	testDescription := "test token"
-	
+
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = true })
-	
+
 	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
 	token, resp := Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
-	
+
 	_, resp = Client.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: token.Id})
 	CheckForbiddenStatus(t, resp)
-	
+
 	rtokens, resp := AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: th.BasicUser.Id})
 	CheckNoError(t, resp)
-	
+
 	if len(rtokens) != 1 {
 		t.Fatal("should have 1 tokens")
 	}
-	
+
 	rtokens, resp = AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: token.Id})
 	CheckNoError(t, resp)
-	
+
 	if len(rtokens) != 1 {
 		t.Fatal("should have 1 tokens")
 	}
-	
+
 	rtokens, resp = AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: th.BasicUser.Username})
 	CheckNoError(t, resp)
-	
+
 	if len(rtokens) != 1 {
 		t.Fatal("should have 1 tokens")
 	}
-	
+
 	rtokens, resp = AdminClient.SearchUserAccessTokens(&model.UserAccessTokenSearch{Term: "not found"})
 	CheckNoError(t, resp)
-	
+
 	if len(rtokens) != 0 {
 		t.Fatal("should have 0 tokens")
 	}
@@ -2567,8 +2567,6 @@ func TestDisableUserAccessToken(t *testing.T) {
 
 	testDescription := "test token"
 
-	enableUserAccessTokens := *th.App.Config().ServiceSettings.EnableUserAccessTokens
-	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
 	*th.App.Config().ServiceSettings.EnableUserAccessTokens = true
 
 	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)
@@ -2612,8 +2610,6 @@ func TestEnableUserAccessToken(t *testing.T) {
 
 	testDescription := "test token"
 
-	enableUserAccessTokens := *th.App.Config().ServiceSettings.EnableUserAccessTokens
-	defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableUserAccessTokens = enableUserAccessTokens })
 	*th.App.Config().ServiceSettings.EnableUserAccessTokens = true
 
 	th.App.UpdateUserRoles(th.BasicUser.Id, model.SYSTEM_USER_ROLE_ID+" "+model.SYSTEM_USER_ACCESS_TOKEN_ROLE_ID, false)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -60,16 +60,10 @@ func TestUpdateConfig(t *testing.T) {
 	th := Setup()
 	defer th.TearDown()
 
-	prev := *th.App.Config().ServiceSettings.SiteURL
-	defer th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ServiceSettings.SiteURL = prev
-	})
-
 	listener := th.App.AddConfigListener(func(old, current *model.Config) {
 		assert.Equal(t, prev, *old.ServiceSettings.SiteURL)
 		assert.Equal(t, "foo", *current.ServiceSettings.SiteURL)
 	})
-	defer th.App.RemoveConfigListener(listener)
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.SiteURL = "foo"

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -60,7 +60,9 @@ func TestUpdateConfig(t *testing.T) {
 	th := Setup()
 	defer th.TearDown()
 
-	listener := th.App.AddConfigListener(func(old, current *model.Config) {
+	prev := *th.App.Config().ServiceSettings.SiteURL
+
+	th.App.AddConfigListener(func(old, current *model.Config) {
 		assert.Equal(t, prev, *old.ServiceSettings.SiteURL)
 		assert.Equal(t, "foo", *current.ServiceSettings.SiteURL)
 	})

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -13,7 +13,6 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 
-	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 	"github.com/mattermost/mattermost-server/plugin/pluginenv"
@@ -75,7 +74,7 @@ func setupTestHelper(enterprise bool) *TestHelper {
 		panic(err)
 	}
 
-	options := []app.Option{app.ConfigFile(tempConfig.Name()), app.DisableConfigWatch}
+	options := []Option{ConfigFile(tempConfig.Name()), DisableConfigWatch}
 	if testStore != nil {
 		options = append(options, StoreOverride(testStore))
 	}

--- a/app/config.go
+++ b/app/config.go
@@ -27,7 +27,6 @@ func (a *App) UpdateConfig(f func(*model.Config)) {
 	updated := old.Clone()
 	f(updated)
 	a.config.Store(updated)
-	utils.Cfg = updated
 	a.InvokeConfigListeners(old, updated)
 }
 
@@ -48,7 +47,6 @@ func (a *App) LoadConfig(configFile string) *model.AppError {
 	utils.ConfigureLog(&cfg.LogSettings)
 
 	a.config.Store(cfg)
-	utils.Cfg = cfg
 
 	utils.SetSiteURL(*cfg.ServiceSettings.SiteURL)
 

--- a/app/diagnostics_test.go
+++ b/app/diagnostics_test.go
@@ -155,9 +155,7 @@ func TestDiagnostics(t *testing.T) {
 	})
 
 	t.Run("SendDailyDiagnosticsDisabled", func(t *testing.T) {
-		oldSetting := *th.App.Config().LogSettings.EnableDiagnostics
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.LogSettings.EnableDiagnostics = false })
-		defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.LogSettings.EnableDiagnostics = oldSetting })
 
 		th.App.SendDailyDiagnostics()
 

--- a/app/license.go
+++ b/app/license.go
@@ -23,7 +23,7 @@ func (a *App) LoadLicense() {
 
 	if len(licenseId) != 26 {
 		// Lets attempt to load the file from disk since it was missing from the DB
-		license, licenseBytes := utils.GetAndValidateLicenseFileFromDisk()
+		license, licenseBytes := utils.GetAndValidateLicenseFileFromDisk(*a.Config().ServiceSettings.LicenseFileLocation)
 
 		if license != nil {
 			if _, err := a.SaveLicense(licenseBytes); err != nil {

--- a/app/oauth_test.go
+++ b/app/oauth_test.go
@@ -49,10 +49,6 @@ func TestOAuthDeleteApp(t *testing.T) {
 	th := Setup()
 	defer th.TearDown()
 
-	oldSetting := th.App.Config().ServiceSettings.EnableOAuthServiceProvider
-	defer th.App.UpdateConfig(func(cfg *model.Config) {
-		cfg.ServiceSettings.EnableOAuthServiceProvider = oldSetting
-	})
 	th.App.Config().ServiceSettings.EnableOAuthServiceProvider = true
 
 	a1 := &model.OAuthApp{}

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -88,10 +88,6 @@ func TestCreateOAuthUser(t *testing.T) {
 
 	th.App.PermanentDeleteUser(user)
 
-	userCreation := th.App.Config().TeamSettings.EnableUserCreation
-	defer th.App.UpdateConfig(func(cfg *model.Config) {
-		cfg.TeamSettings.EnableUserCreation = userCreation
-	})
 	th.App.Config().TeamSettings.EnableUserCreation = false
 
 	_, err = th.App.CreateOAuthUser(model.USER_AUTH_SERVICE_GITLAB, strings.NewReader(json), th.BasicTeam.Id)

--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -17,13 +17,6 @@ func TestCreateIncomingWebhookForChannel(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-	enablePostUsernameOverride := th.App.Config().ServiceSettings.EnablePostUsernameOverride
-	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostUsernameOverride = enablePostUsernameOverride })
-	enablePostIconOverride := th.App.Config().ServiceSettings.EnablePostIconOverride
-	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = enablePostIconOverride })
-
 	type TestCase struct {
 		EnableIncomingHooks        bool
 		EnablePostUsernameOverride bool
@@ -154,13 +147,6 @@ func TestCreateIncomingWebhookForChannel(t *testing.T) {
 func TestUpdateIncomingWebhook(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
-
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-	enablePostUsernameOverride := th.App.Config().ServiceSettings.EnablePostUsernameOverride
-	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostUsernameOverride = enablePostUsernameOverride })
-	enablePostIconOverride := th.App.Config().ServiceSettings.EnablePostIconOverride
-	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = enablePostIconOverride })
 
 	type TestCase struct {
 		EnableIncomingHooks        bool
@@ -300,8 +286,6 @@ func TestCreateWebhookPost(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 
 	hook, err := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{ChannelId: th.BasicChannel.Id})

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -209,7 +209,7 @@ func doSecurity(a *app.App) {
 }
 
 func doDiagnostics(a *app.App) {
-	if *utils.Cfg.LogSettings.EnableDiagnostics {
+	if *a.Config().LogSettings.EnableDiagnostics {
 		a.SendDailyDiagnostics()
 	}
 }

--- a/jobs/server.go
+++ b/jobs/server.go
@@ -61,7 +61,7 @@ func (srv *JobServer) LoadLicense() {
 
 	if len(licenseId) != 26 {
 		// Lets attempt to load the file from disk since it was missing from the DB
-		_, licenseBytes = utils.GetAndValidateLicenseFileFromDisk()
+		_, licenseBytes = utils.GetAndValidateLicenseFileFromDisk(*srv.ConfigService.Config().ServiceSettings.LicenseFileLocation)
 	} else {
 		if result := <-srv.Store.License().Get(licenseId); result.Err == nil {
 			record := result.Data.(*model.LicenseRecord)

--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -55,7 +55,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a client for tests to use
-	client := model.NewClient("http://localhost" + *utils.Cfg.ServiceSettings.ListenAddress)
+	client := model.NewClient("http://localhost" + *c.App.Config().ServiceSettings.ListenAddress)
 
 	// Check for username parameter and create a user if present
 	username, ok1 := params["username"]
@@ -118,7 +118,7 @@ func manualTest(c *api.Context, w http.ResponseWriter, r *http.Request) {
 			Name:     model.SESSION_COOKIE_TOKEN,
 			Value:    client.AuthToken,
 			Path:     "/",
-			MaxAge:   *utils.Cfg.ServiceSettings.SessionLengthWebInDays * 60 * 60 * 24,
+			MaxAge:   *c.App.Config().ServiceSettings.SessionLengthWebInDays * 60 * 60 * 24,
 			HttpOnly: true,
 		}
 		http.SetCookie(w, sessionCookie)

--- a/utils/config.go
+++ b/utils/config.go
@@ -35,7 +35,6 @@ const (
 
 var originalDisableDebugLvl l4g.Level = l4g.DEBUG
 var siteURL = ""
-var Cfg *model.Config
 
 func GetSiteURL() string {
 	return siteURL

--- a/utils/license.go
+++ b/utils/license.go
@@ -168,8 +168,8 @@ func ValidateLicense(signed []byte) (bool, string) {
 	return true, string(plaintext)
 }
 
-func GetAndValidateLicenseFileFromDisk() (*model.License, []byte) {
-	fileName := GetLicenseFileLocation(*Cfg.ServiceSettings.LicenseFileLocation)
+func GetAndValidateLicenseFileFromDisk(location string) (*model.License, []byte) {
+	fileName := GetLicenseFileLocation(location)
 
 	if _, err := os.Stat(fileName); err != nil {
 		l4g.Debug("We could not find the license key in the database or on disk at %v", fileName)


### PR DESCRIPTION
#### Summary
This finally eliminates `utils.Cfg` and makes each test run with its own temporary config file (so you don't have to worry about reverting config changes after tests).

#### Ticket Link
N/A

#### Checklist
N/A