### PR TITLE
ABC-90 Add POST /emoji/search and GET /emoji/autocomplete API endpoints

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -184,7 +184,7 @@ func Init(a *app.App, root *mux.Router, full bool) *API {
 	api.BaseRoutes.DataRetention = api.BaseRoutes.ApiRoot.PathPrefix("/data_retention").Subrouter()
 
 	api.BaseRoutes.Emojis = api.BaseRoutes.ApiRoot.PathPrefix("/emoji").Subrouter()
-	api.BaseRoutes.Emoji = api.BaseRoutes.Emojis.PathPrefix("/{emoji_id:[A-Za-z0-9]+}").Subrouter()
+	api.BaseRoutes.Emoji = api.BaseRoutes.ApiRoot.PathPrefix("/emoji/{emoji_id:[A-Za-z0-9]+}").Subrouter()
 
 	api.BaseRoutes.ReactionByNameForPostForUser = api.BaseRoutes.PostForUser.PathPrefix("/reactions/{emoji_name:[A-Za-z0-9\\_\\-\\+]+}").Subrouter()
 

--- a/api4/emoji.go
+++ b/api4/emoji.go
@@ -11,6 +11,10 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
+const (
+	EMOJI_MAX_AUTOCOMPLETE_ITEMS = 100
+)
+
 func (api *API) InitEmoji() {
 	api.BaseRoutes.Emojis.Handle("", api.ApiSessionRequired(createEmoji)).Methods("POST")
 	api.BaseRoutes.Emojis.Handle("", api.ApiSessionRequired(getEmojiList)).Methods("GET")
@@ -194,7 +198,7 @@ func autocompleteEmojis(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	emojis, err := c.App.SearchEmoji(name, true, 100)
+	emojis, err := c.App.SearchEmoji(name, true, EMOJI_MAX_AUTOCOMPLETE_ITEMS)
 	if err != nil {
 		c.Err = err
 		return

--- a/app/emoji.go
+++ b/app/emoji.go
@@ -134,11 +134,11 @@ func (a *App) DeleteEmoji(emoji *model.Emoji) *model.AppError {
 
 func (a *App) GetEmoji(emojiId string) (*model.Emoji, *model.AppError) {
 	if !*a.Config().ServiceSettings.EnableCustomEmoji {
-		return nil, model.NewAppError("deleteEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
+		return nil, model.NewAppError("GetEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	if len(*a.Config().FileSettings.DriverName) == 0 {
-		return nil, model.NewAppError("deleteImage", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
+		return nil, model.NewAppError("GetEmoji", "api.emoji.storage.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	if result := <-a.Srv.Store.Emoji().Get(emojiId, false); result.Err != nil {
@@ -166,6 +166,18 @@ func (a *App) GetEmojiImage(emojiId string) (imageByte []byte, imageType string,
 		}
 
 		return img, imageType, nil
+	}
+}
+
+func (a *App) SearchEmoji(name string, prefixOnly bool, limit int) ([]*model.Emoji, *model.AppError) {
+	if !*a.Config().ServiceSettings.EnableCustomEmoji {
+		return nil, model.NewAppError("SearchEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
+	}
+
+	if result := <-a.Srv.Store.Emoji().Search(name, prefixOnly, limit); result.Err != nil {
+		return nil, result.Err
+	} else {
+		return result.Data.([]*model.Emoji), nil
 	}
 }
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -3070,6 +3070,27 @@ func (c *Client4) GetEmojiImage(emojiId string) ([]byte, *Response) {
 	}
 }
 
+// SearchEmoji returns a list of emoji matching some search criteria.
+func (c *Client4) SearchEmoji(search *EmojiSearch) ([]*Emoji, *Response) {
+	if r, err := c.DoApiPost(c.GetEmojisRoute()+"/search", search.ToJson()); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return EmojiListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
+// AutocompleteEmoji returns a list of emoji starting with or matching name.
+func (c *Client4) AutocompleteEmoji(name string, etag string) ([]*Emoji, *Response) {
+	query := fmt.Sprintf("?name=%v", name)
+	if r, err := c.DoApiGet(c.GetEmojisRoute()+"/autocomplete"+query, ""); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return EmojiListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // Reaction Section
 
 // SaveReaction saves an emoji reaction for a post. Returns the saved reaction if successful, otherwise an error will be returned.

--- a/model/emoji_search.go
+++ b/model/emoji_search.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type EmojiSearch struct {
+	Term       string `json:"term"`
+	PrefixOnly bool   `json:"prefix_only"`
+}
+
+func (es *EmojiSearch) ToJson() string {
+	b, err := json.Marshal(es)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func EmojiSearchFromJson(data io.Reader) *EmojiSearch {
+	decoder := json.NewDecoder(data)
+	var es EmojiSearch
+	err := decoder.Decode(&es)
+	if err == nil {
+		return &es
+	} else {
+		return nil
+	}
+}

--- a/model/emoji_search_test.go
+++ b/model/emoji_search_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEmojiSearchJson(t *testing.T) {
+	emojiSearch := EmojiSearch{Term: NewId()}
+	json := emojiSearch.ToJson()
+	remojiSearch := EmojiSearchFromJson(strings.NewReader(json))
+
+	if emojiSearch.Term != remojiSearch.Term {
+		t.Fatal("Terms do not match")
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -393,6 +393,7 @@ type EmojiStore interface {
 	GetByName(name string) StoreChannel
 	GetList(offset, limit int, sort string) StoreChannel
 	Delete(id string, time int64) StoreChannel
+	Search(name string, prefixOnly bool, limit int) StoreChannel
 }
 
 type StatusStore interface {

--- a/store/storetest/mocks/EmojiStore.go
+++ b/store/storetest/mocks/EmojiStore.go
@@ -92,3 +92,19 @@ func (_m *EmojiStore) Save(emoji *model.Emoji) store.StoreChannel {
 
 	return r0
 }
+
+// Search provides a mock function with given fields: name, prefixOnly, limit
+func (_m *EmojiStore) Search(name string, prefixOnly bool, limit int) store.StoreChannel {
+	ret := _m.Called(name, prefixOnly, limit)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, bool, int) store.StoreChannel); ok {
+		r0 = rf(name, prefixOnly, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}


### PR DESCRIPTION
#### Summary
Add POST /emoji/search and GET /emoji/autocomplete API endpoints.

These are split into two different endpoints because:
* Consistency with other search endpoints, all others are also POSTs
* Don't want to miss out on the benefits of GET for performance important actions like autocompleting (browser/proxy caching, etc.)
* Consistency with user search/autocomplete endpoints

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-90

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#323)
- [x] All new/modified APIs include changes to the drivers