### PR TITLE
ICU-573 Allow flag on file upload to trigger unexcape of filename

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -76,7 +76,7 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resStruct, err := c.App.UploadFiles(c.TeamId, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
+	resStruct, err := c.App.UploadFiles(c.TeamId, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"], false)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/file.go
+++ b/api4/file.go
@@ -88,7 +88,11 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resStruct, err := c.App.UploadFiles(FILE_TEAM_ID, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
+	var fileNameIsEncoded = false
+	if val, ok := props["encoded_filename"]; ok {
+		fileNameIsEncoded = val[0] == "true"
+	}
+	resStruct, err := c.App.UploadFiles(FILE_TEAM_ID, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"], fileNameIsEncoded)
 	if err != nil {
 		c.Err = err
 		return


### PR DESCRIPTION
Summary
PLEASE REVIEW CLOSELY. FIRST GOLANG PR.

I check for a custom header, `encoded_filename` and, if present, I attempt to unescape the filename before saving. If the unescape fails I save the escaped version.

Related PRs
https://github.com/mattermost/mattermost-api-reference/pull/326
https://github.com/mattermost/mattermost-mobile/pull/1383

Ticket Link
https://mattermost.atlassian.net/browse/ICU-573


#### Checklist


- [] Added or updated unit tests (required for all new features) **Need help on writing proper tests here.**
- [x] Added API documentation (required for all new APIs)
- [] All new/modified APIs include changes to the drivers **And I don't know what this means.**