### PR TITLE
ABC-55 User based rate limiting

### DIFF
--- a/api4/context.go
+++ b/api4/context.go
@@ -99,38 +99,14 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c.IpAddress = utils.GetIpAddress(r)
 	c.Params = ApiParamsFromRequest(r)
 
-	token := ""
-	isTokenFromQueryString := false
+	token, tokenLocation := app.ParseAuthTokenFromRequest(r)
 
-	// Attempt to parse token out of the header
-	authHeader := r.Header.Get(model.HEADER_AUTH)
-	if len(authHeader) > 6 && strings.ToUpper(authHeader[0:6]) == model.HEADER_BEARER {
-		// Default session token
-		token = authHeader[7:]
-
-	} else if len(authHeader) > 5 && strings.ToLower(authHeader[0:5]) == model.HEADER_TOKEN {
-		// OAuth token
-		token = authHeader[6:]
-	}
-
-	// Attempt to parse the token from the cookie
-	if len(token) == 0 {
-		if cookie, err := r.Cookie(model.SESSION_COOKIE_TOKEN); err == nil {
-			token = cookie.Value
-
-			if h.requireSession && !h.trustRequester {
-				if r.Header.Get(model.HEADER_REQUESTED_WITH) != model.HEADER_REQUESTED_WITH_XML {
-					c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token+" Appears to be a CSRF attempt", http.StatusUnauthorized)
-					token = ""
-				}
-			}
+	// CSRF Check
+	if tokenLocation == app.TokenLocationCookie && h.requireSession && !h.trustRequester {
+		if r.Header.Get(model.HEADER_REQUESTED_WITH) != model.HEADER_REQUESTED_WITH_XML {
+			c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token+" Appears to be a CSRF attempt", http.StatusUnauthorized)
+			token = ""
 		}
-	}
-
-	// Attempt to parse token out of the query string
-	if len(token) == 0 {
-		token = r.URL.Query().Get("access_token")
-		isTokenFromQueryString = true
 	}
 
 	c.SetSiteURLHeader(app.GetProtocol(r) + "://" + r.Host)
@@ -153,10 +129,15 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if h.requireSession {
 				c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token, http.StatusUnauthorized)
 			}
-		} else if !session.IsOAuth && isTokenFromQueryString {
+		} else if !session.IsOAuth && tokenLocation == app.TokenLocationQueryString {
 			c.Err = model.NewAppError("ServeHTTP", "api.context.token_provided.app_error", nil, "token="+token, http.StatusUnauthorized)
 		} else {
 			c.Session = *session
+		}
+
+		// Rate limit by UserID
+		if c.App.Srv.RateLimiter != nil && c.App.Srv.RateLimiter.UserIdRateLimit(c.Session.UserId, w) {
+			return
 		}
 	}
 

--- a/app/authentication_test.go
+++ b/app/authentication_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAuthTokenFromRequest(t *testing.T) {
+	cases := []struct {
+		header           string
+		cookie           string
+		query            string
+		expectedToken    string
+		expectedLocation TokenLocation
+	}{
+		{"", "", "", "", TokenLocationNotFound},
+		{"token mytoken", "", "", "mytoken", TokenLocationHeader},
+		{"BEARER mytoken", "", "", "mytoken", TokenLocationHeader},
+		{"", "mytoken", "", "mytoken", TokenLocationCookie},
+		{"", "", "mytoken", "mytoken", TokenLocationQueryString},
+	}
+
+	for testnum, tc := range cases {
+		pathname := "/test/here"
+		if tc.query != "" {
+			pathname += "?access_token=" + tc.query
+		}
+		req := httptest.NewRequest("GET", pathname, nil)
+		if tc.header != "" {
+			req.Header.Add(model.HEADER_AUTH, tc.header)
+		}
+		if tc.cookie != "" {
+			req.AddCookie(&http.Cookie{
+				Name:  model.SESSION_COOKIE_TOKEN,
+				Value: tc.cookie,
+			})
+		}
+
+		token, location := ParseAuthTokenFromRequest(req)
+
+		require.Equal(t, tc.expectedToken, token, "Wrong token on test "+strconv.Itoa(testnum))
+		require.Equal(t, tc.expectedLocation, location, "Wrong location on test "+strconv.Itoa(testnum))
+	}
+}

--- a/app/ratelimit.go
+++ b/app/ratelimit.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+
+	l4g "github.com/alecthomas/log4go"
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/utils"
+	throttled "gopkg.in/throttled/throttled.v2"
+	"gopkg.in/throttled/throttled.v2/store/memstore"
+)
+
+type RateLimiter struct {
+	throttledRateLimiter *throttled.GCRARateLimiter
+	useAuth              bool
+	useIP                bool
+	header               string
+}
+
+func NewRateLimiter(settings *model.RateLimitSettings) *RateLimiter {
+	store, err := memstore.New(*settings.MemoryStoreSize)
+	if err != nil {
+		l4g.Critical(utils.T("api.server.start_server.rate_limiting_memory_store"))
+		return nil
+	}
+
+	quota := throttled.RateQuota{
+		MaxRate:  throttled.PerSec(*settings.PerSec),
+		MaxBurst: *settings.MaxBurst,
+	}
+
+	throttledRateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+	if err != nil {
+		l4g.Critical(utils.T("api.server.start_server.rate_limiting_rate_limiter"))
+		return nil
+	}
+
+	return &RateLimiter{
+		throttledRateLimiter: throttledRateLimiter,
+		useAuth:              *settings.VaryByUser,
+		useIP:                *settings.VaryByRemoteAddr,
+		header:               settings.VaryByHeader,
+	}
+}
+
+func (rl *RateLimiter) GenerateKey(r *http.Request) string {
+	key := ""
+
+	if rl.useAuth {
+		token, tokenLocation := ParseAuthTokenFromRequest(r)
+		if tokenLocation != TokenLocationNotFound {
+			key += token
+		} else if rl.useIP { // If we don't find an authentication token and IP based is enabled, fall back to IP
+			key += utils.GetIpAddress(r)
+		}
+	} else if rl.useIP { // Only if Auth based is not enabed do we use a plain IP based
+		key += utils.GetIpAddress(r)
+	}
+
+	// Note that most of the time the user won't have to set this because the utils.GetIpAddress above tries the
+	// most common headers anyway.
+	if rl.header != "" {
+		key += strings.ToLower(r.Header.Get(rl.header))
+	}
+
+	return key
+}
+
+func (rl *RateLimiter) RateLimitWriter(key string, w http.ResponseWriter) bool {
+	limited, context, err := rl.throttledRateLimiter.RateLimit(key, 1)
+	if err != nil {
+		l4g.Critical("Internal server error when rate limiting. Rate Limiting broken. Error:" + err.Error())
+		return false
+	}
+
+	setRateLimitHeaders(w, context)
+
+	if limited {
+		l4g.Error("Denied due to throttling settings code=429 key=%v", key)
+		http.Error(w, "limit exceeded", 429)
+	}
+
+	return limited
+}
+
+func (rl *RateLimiter) UserIdRateLimit(userId string, w http.ResponseWriter) bool {
+	if rl.useAuth {
+		if rl.RateLimitWriter(userId, w) {
+			return true
+		}
+	}
+	return false
+}
+
+func (rl *RateLimiter) RateLimitHandler(wrappedHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := rl.GenerateKey(r)
+		limited := rl.RateLimitWriter(key, w)
+
+		if !limited {
+			wrappedHandler.ServeHTTP(w, r)
+		}
+	})
+}
+
+// Copied from https://github.com/throttled/throttled http.go
+func setRateLimitHeaders(w http.ResponseWriter, context throttled.RateLimitResult) {
+	if v := context.Limit; v >= 0 {
+		w.Header().Add("X-RateLimit-Limit", strconv.Itoa(v))
+	}
+
+	if v := context.Remaining; v >= 0 {
+		w.Header().Add("X-RateLimit-Remaining", strconv.Itoa(v))
+	}
+
+	if v := context.ResetAfter; v >= 0 {
+		vi := int(math.Ceil(v.Seconds()))
+		w.Header().Add("X-RateLimit-Reset", strconv.Itoa(vi))
+	}
+
+	if v := context.RetryAfter; v >= 0 {
+		vi := int(math.Ceil(v.Seconds()))
+		w.Header().Add("Retry-After", strconv.Itoa(vi))
+	}
+}

--- a/app/ratelimit_test.go
+++ b/app/ratelimit_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/require"
+)
+
+func genRateLimitSettings(useAuth, useIP bool, header string) *model.RateLimitSettings {
+	return &model.RateLimitSettings{
+		Enable:           model.NewBool(true),
+		PerSec:           model.NewInt(10),
+		MaxBurst:         model.NewInt(100),
+		MemoryStoreSize:  model.NewInt(10000),
+		VaryByRemoteAddr: model.NewBool(useIP),
+		VaryByUser:       model.NewBool(useAuth),
+		VaryByHeader:     header,
+	}
+}
+
+func TestGenerateKey(t *testing.T) {
+	cases := []struct {
+		useAuth         bool
+		useIP           bool
+		header          string
+		authTokenResult string
+		ipResult        string
+		headerResult    string
+		expectedKey     string
+	}{
+		{false, false, "", "", "", "", ""},
+		{true, false, "", "resultkey", "notme", "notme", "resultkey"},
+		{false, true, "", "notme", "resultkey", "notme", "resultkey"},
+		{false, false, "myheader", "notme", "notme", "resultkey", "resultkey"},
+		{true, true, "", "resultkey", "ipaddr", "notme", "resultkey"},
+		{true, true, "", "", "ipaddr", "notme", "ipaddr"},
+		{true, true, "myheader", "resultkey", "ipaddr", "hadd", "resultkeyhadd"},
+		{true, true, "myheader", "", "ipaddr", "hadd", "ipaddrhadd"},
+	}
+
+	for testnum, tc := range cases {
+		req := httptest.NewRequest("GET", "/", nil)
+		if tc.authTokenResult != "" {
+			req.AddCookie(&http.Cookie{
+				Name:  model.SESSION_COOKIE_TOKEN,
+				Value: tc.authTokenResult,
+			})
+		}
+		req.RemoteAddr = tc.ipResult + ":80"
+		if tc.headerResult != "" {
+			req.Header.Set(tc.header, tc.headerResult)
+		}
+
+		rateLimiter := NewRateLimiter(genRateLimitSettings(tc.useAuth, tc.useIP, tc.header))
+
+		key := rateLimiter.GenerateKey(req)
+
+		require.Equal(t, tc.expectedKey, key, "Wrong key on test "+strconv.Itoa(testnum))
+	}
+}

--- a/config/default.json
+++ b/config/default.json
@@ -180,6 +180,7 @@
         "MaxBurst": 100,
         "MemoryStoreSize": 10000,
         "VaryByRemoteAddr": true,
+        "VaryByUser": false,
         "VaryByHeader": ""
     },
     "PrivacySettings": {

--- a/model/config.go
+++ b/model/config.go
@@ -802,7 +802,8 @@ type RateLimitSettings struct {
 	PerSec           *int
 	MaxBurst         *int
 	MemoryStoreSize  *int
-	VaryByRemoteAddr bool
+	VaryByRemoteAddr *bool
+	VaryByUser       *bool
 	VaryByHeader     string
 }
 
@@ -821,6 +822,14 @@ func (s *RateLimitSettings) SetDefaults() {
 
 	if s.MemoryStoreSize == nil {
 		s.MemoryStoreSize = NewInt(10000)
+	}
+
+	if s.VaryByRemoteAddr == nil {
+		s.VaryByRemoteAddr = NewBool(true)
+	}
+
+	if s.VaryByUser == nil {
+		s.VaryByUser = NewBool(false)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Adding user based rate limiting. 
Two stage. Will rate limit on token and on userID. 


#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
