### PR TITLE
PLT-7537: Move channel CLI command posts system message to channel.

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -30,6 +30,7 @@ type TestHelper struct {
 
 	BasicClient  *model.Client
 	BasicTeam    *model.Team
+	BasicTeam2   *model.Team
 	BasicUser    *model.User
 	BasicUser2   *model.User
 	BasicChannel *model.Channel
@@ -142,10 +143,14 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.App.UpdateUserRoles(me.BasicUser.Id, model.SYSTEM_USER_ROLE_ID, false)
 	me.LoginBasic()
 	me.BasicTeam = me.CreateTeam(me.BasicClient)
+	me.BasicTeam2 = me.CreateTeam(me.BasicClient)
 	me.LinkUserToTeam(me.BasicUser, me.BasicTeam)
+	me.LinkUserToTeam(me.BasicUser, me.BasicTeam2)
 	me.UpdateUserToNonTeamAdmin(me.BasicUser, me.BasicTeam)
+	me.UpdateUserToNonTeamAdmin(me.BasicUser, me.BasicTeam2)
 	me.BasicUser2 = me.CreateUser(me.BasicClient)
 	me.LinkUserToTeam(me.BasicUser2, me.BasicTeam)
+	me.LinkUserToTeam(me.BasicUser2, me.BasicTeam2)
 	me.BasicClient.SetTeamId(me.BasicTeam.Id)
 	me.BasicChannel = me.CreateChannel(me.BasicClient, me.BasicTeam)
 	me.BasicPost = me.CreatePost(me.BasicClient, me.BasicChannel)

--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -30,7 +30,6 @@ type TestHelper struct {
 
 	BasicClient  *model.Client
 	BasicTeam    *model.Team
-	BasicTeam2   *model.Team
 	BasicUser    *model.User
 	BasicUser2   *model.User
 	BasicChannel *model.Channel
@@ -143,14 +142,10 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.App.UpdateUserRoles(me.BasicUser.Id, model.SYSTEM_USER_ROLE_ID, false)
 	me.LoginBasic()
 	me.BasicTeam = me.CreateTeam(me.BasicClient)
-	me.BasicTeam2 = me.CreateTeam(me.BasicClient)
 	me.LinkUserToTeam(me.BasicUser, me.BasicTeam)
-	me.LinkUserToTeam(me.BasicUser, me.BasicTeam2)
 	me.UpdateUserToNonTeamAdmin(me.BasicUser, me.BasicTeam)
-	me.UpdateUserToNonTeamAdmin(me.BasicUser, me.BasicTeam2)
 	me.BasicUser2 = me.CreateUser(me.BasicClient)
 	me.LinkUserToTeam(me.BasicUser2, me.BasicTeam)
-	me.LinkUserToTeam(me.BasicUser2, me.BasicTeam2)
 	me.BasicClient.SetTeamId(me.BasicTeam.Id)
 	me.BasicChannel = me.CreateChannel(me.BasicClient, me.BasicTeam)
 	me.BasicPost = me.CreatePost(me.BasicClient, me.BasicChannel)

--- a/app/channel.go
+++ b/app/channel.go
@@ -1378,8 +1378,16 @@ func (a *App) MoveChannel(team *model.Team, channel *model.Channel) *model.AppEr
 		}
 	}
 
-	// Change the Team ID of the channel.
+	// keep instance of the previous team
+	var previousTeam *model.Team
+	if result := <-a.Srv.Store.Team().Get(channel.TeamId); result.Err != nil {
+		return result.Err
+	} else {
+		previousTeam = result.Data.(*model.Team)
+	}
+
 	channel.TeamId = team.Id
+	channel.Header = channel.Header + " ~ " + fmt.Sprintf(utils.T("api.team.move_channel.success"), previousTeam.Name)
 	if result := <-a.Srv.Store.Channel().Update(channel); result.Err != nil {
 		return result.Err
 	}

--- a/app/channel.go
+++ b/app/channel.go
@@ -1407,7 +1407,6 @@ func (a *App) postChannelMoveMessage(user *model.User, channel *model.Channel, p
 	}
 
 	if _, err := a.CreatePost(post, channel, false); err != nil {
-		fmt.Println(err)
 		return model.NewAppError("postChannelMoveMessage", "api.team.move_channel.post.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -97,7 +97,7 @@ func TestMoveChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := th.App.MoveChannel(targetTeam, channel1); err == nil {
+	if err := th.App.MoveChannel(targetTeam, channel1, th.BasicUser); err == nil {
 		t.Fatal("Should have failed due to mismatched members.")
 	}
 
@@ -105,7 +105,7 @@ func TestMoveChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := th.App.MoveChannel(targetTeam, channel1); err != nil {
+	if err := th.App.MoveChannel(targetTeam, channel1, th.BasicUser); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/cmd/platform/channel.go
+++ b/cmd/platform/channel.go
@@ -325,10 +325,11 @@ func moveChannelsCmdF(cmd *cobra.Command, args []string) error {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
 			continue
 		}
+		originTeamID := channel.TeamId
 		if err := moveChannel(a, team, channel); err != nil {
 			CommandPrintErrorln("Unable to move channel '" + channel.Name + "' error: " + err.Error())
 		} else {
-			CommandPrettyPrintln("Moved channel '" + channel.Name + "'")
+			CommandPrettyPrintln("Moved channel '" + channel.Name + "' to " + team.Name + "(" + team.Id + ") from " + originTeamID + ".")
 		}
 	}
 

--- a/cmd/platform/channel_test.go
+++ b/cmd/platform/channel_test.go
@@ -49,16 +49,22 @@ func TestMoveChannel(t *testing.T) {
 	defer th.TearDown()
 
 	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
+	basicTeam1 := th.CreateTeam(th.BasicClient)
+	basicTeam2 := th.CreateTeam(th.BasicClient)
+	basicUser := th.CreateUser(th.BasicClient)
 
-	adminEmail := th.BasicUser2.Email
-	adminUsername := th.BasicUser2.Username
-	origin := th.BasicTeam.Name + ":" + channel.Name
-	dest := th.BasicTeam2.Name
+	th.LinkUserToTeam(basicUser, basicTeam1)
+	th.LinkUserToTeam(basicUser, basicTeam2)
+
+	adminEmail := basicUser.Email
+	adminUsername := basicUser.Username
+	origin := basicTeam1.Name + ":" + channel.Name
+	dest := basicTeam2.Name
 
 	checkCommand(t, "channel", "add", origin, adminEmail)
 
 	// should fail with nill because errors are logged instead of returned when a channel does not exist
-	require.Nil(t, runCommand(t, "channel", "move", dest, th.BasicTeam.Name+":doesnotexist", "--username", adminUsername))
+	require.Nil(t, runCommand(t, "channel", "move", dest, basicTeam1.Name+":doesnotexist", "--username", adminUsername))
 
 	checkCommand(t, "channel", "move", dest, origin, "--username", adminUsername)
 }

--- a/cmd/platform/channel_test.go
+++ b/cmd/platform/channel_test.go
@@ -51,15 +51,16 @@ func TestMoveChannel(t *testing.T) {
 	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
 
 	adminEmail := th.BasicUser2.Email
+	adminUsername := th.BasicUser2.Username
 	origin := th.BasicTeam.Name + ":" + channel.Name
 	dest := th.BasicTeam2.Name
 
 	checkCommand(t, "channel", "add", origin, adminEmail)
 
 	// should fail with nill because errors are logged instead of returned when a channel does not exist
-	require.Nil(t, runCommand(t, "channel", "move", dest, th.BasicTeam.Name+":doesnotexist"))
+	require.Nil(t, runCommand(t, "channel", "move", dest, th.BasicTeam.Name+":doesnotexist", "--username", adminUsername))
 
-	checkCommand(t, "channel", "move", dest, origin)
+	checkCommand(t, "channel", "move", dest, origin, "--username", adminUsername)
 }
 
 func TestListChannels(t *testing.T) {

--- a/cmd/platform/channel_test.go
+++ b/cmd/platform/channel_test.go
@@ -48,23 +48,25 @@ func TestMoveChannel(t *testing.T) {
 	th := api.Setup().InitBasic()
 	defer th.TearDown()
 
-	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
-	basicTeam1 := th.CreateTeam(th.BasicClient)
-	basicTeam2 := th.CreateTeam(th.BasicClient)
-	basicUser := th.CreateUser(th.BasicClient)
+	client := th.BasicClient
+	team1 := th.BasicTeam
+	team2 := th.CreateTeam(client)
+	user1 := th.BasicUser
+	th.LinkUserToTeam(user1, team2)
+	channel := th.BasicChannel
 
-	th.LinkUserToTeam(basicUser, basicTeam1)
-	th.LinkUserToTeam(basicUser, basicTeam2)
+	th.LinkUserToTeam(user1, team1)
+	th.LinkUserToTeam(user1, team2)
 
-	adminEmail := basicUser.Email
-	adminUsername := basicUser.Username
-	origin := basicTeam1.Name + ":" + channel.Name
-	dest := basicTeam2.Name
+	adminEmail := user1.Email
+	adminUsername := user1.Username
+	origin := team1.Name + ":" + channel.Name
+	dest := team2.Name
 
 	checkCommand(t, "channel", "add", origin, adminEmail)
 
 	// should fail with nill because errors are logged instead of returned when a channel does not exist
-	require.Nil(t, runCommand(t, "channel", "move", dest, basicTeam1.Name+":doesnotexist", "--username", adminUsername))
+	require.Nil(t, runCommand(t, "channel", "move", dest, team1.Name+":doesnotexist", "--username", adminUsername))
 
 	checkCommand(t, "channel", "move", dest, origin, "--username", adminUsername)
 }

--- a/cmd/platform/channel_test.go
+++ b/cmd/platform/channel_test.go
@@ -44,6 +44,24 @@ func TestRemoveChannel(t *testing.T) {
 	checkCommand(t, "channel", "remove", th.BasicTeam.Name+":"+channel.Name, th.BasicUser2.Email)
 }
 
+func TestMoveChannel(t *testing.T) {
+	th := api.Setup().InitBasic()
+	defer th.TearDown()
+
+	channel := th.CreateChannel(th.BasicClient, th.BasicTeam)
+
+	adminEmail := th.BasicUser2.Email
+	origin := th.BasicTeam.Name + ":" + channel.Name
+	dest := th.BasicTeam2.Name
+
+	checkCommand(t, "channel", "add", origin, adminEmail)
+
+	// should fail with nill because errors are logged instead of returned when a channel does not exist
+	require.Nil(t, runCommand(t, "channel", "move", dest, th.BasicTeam.Name+":doesnotexist"))
+
+	checkCommand(t, "channel", "move", dest, origin)
+}
+
 func TestListChannels(t *testing.T) {
 	th := api.Setup().InitBasic()
 	defer th.TearDown()

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3139,6 +3139,10 @@
     "translation": "This channel has been moved to this team from %v."
   },
   {
+    "id": "api.team.move_channel.post.error",
+    "translation": "Failed to post channel move message."
+  },
+  {
     "id": "app.channel.post_update_channel_purpose_message.post.error",
     "translation": "Failed to post channel purpose message"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3135,6 +3135,10 @@
     "translation": "Cannot move a channel unless all its members are already members of the destination team."
   },
   {
+    "id": "api.team.move_channel.success",
+    "translation": "This channel has been moved to this team from %v."
+  },
+  {
     "id": "app.channel.post_update_channel_purpose_message.post.error",
     "translation": "Failed to post channel purpose message"
   },

--- a/model/post.go
+++ b/model/post.go
@@ -28,6 +28,7 @@ const (
 	POST_ADD_REMOVE             = "system_add_remove" // Deprecated, use POST_ADD_TO_CHANNEL or POST_REMOVE_FROM_CHANNEL instead
 	POST_ADD_TO_CHANNEL         = "system_add_to_channel"
 	POST_REMOVE_FROM_CHANNEL    = "system_remove_from_channel"
+	POST_MOVE_CHANNEL           = "system_move_channel"
 	POST_ADD_TO_TEAM            = "system_add_to_team"
 	POST_REMOVE_FROM_TEAM       = "system_remove_from_team"
 	POST_HEADER_CHANGE          = "system_header_change"
@@ -196,6 +197,7 @@ func (o *Post) IsValid() *AppError {
 		POST_LEAVE_TEAM,
 		POST_ADD_TO_CHANNEL,
 		POST_REMOVE_FROM_CHANNEL,
+		POST_MOVE_CHANNEL,
 		POST_ADD_TO_TEAM,
 		POST_REMOVE_FROM_TEAM,
 		POST_SLACK_ATTACHMENT,


### PR DESCRIPTION
##### Summary
changes the text on the success message when moving channels.
@grundleborg I updated some code but the old PR got closed so I opened a new one.

##### Ticket Link
https://mattermost.atlassian.net/browse/PLT-7537
#7876

##### Checklist

- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file changes