### PR TITLE
ABC-79: Optimize channel autocomplete query

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1255,6 +1255,14 @@ func (a *App) UpdateChannelLastViewedAt(channelIds []string, userId string) *mod
 	return nil
 }
 
+func (a *App) AutocompleteChannels(teamId string, term string) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().AutocompleteInTeam(teamId, term); result.Err != nil {
+		return nil, result.Err
+	} else {
+		return result.Data.(*model.ChannelList), nil
+	}
+}
+
 func (a *App) SearchChannels(teamId string, term string) (*model.ChannelList, *model.AppError) {
 	if result := <-a.Srv.Store.Channel().SearchInTeam(teamId, term); result.Err != nil {
 		return nil, result.Err

--- a/store/store.go
+++ b/store/store.go
@@ -154,6 +154,7 @@ type ChannelStore interface {
 	AnalyticsTypeCount(teamId string, channelType string) StoreChannel
 	ExtraUpdateByUser(userId string, time int64) StoreChannel
 	GetMembersForUser(teamId string, userId string) StoreChannel
+	AutocompleteInTeam(teamId string, term string) StoreChannel
 	SearchInTeam(teamId string, term string) StoreChannel
 	SearchMore(userId string, teamId string, term string) StoreChannel
 	GetMembersByIds(channelId string, userIds []string) StoreChannel

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -45,6 +45,22 @@ func (_m *ChannelStore) AnalyticsTypeCount(teamId string, channelType string) st
 	return r0
 }
 
+// AutocompleteInTeam provides a mock function with given fields: teamId, term
+func (_m *ChannelStore) AutocompleteInTeam(teamId string, term string) store.StoreChannel {
+	ret := _m.Called(teamId, term)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+		r0 = rf(teamId, term)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // CreateDirectChannel provides a mock function with given fields: userId, otherUserId
 func (_m *ChannelStore) CreateDirectChannel(userId string, otherUserId string) store.StoreChannel {
 	ret := _m.Called(userId, otherUserId)

--- a/store/storetest/mocks/UserAccessTokenStore.go
+++ b/store/storetest/mocks/UserAccessTokenStore.go
@@ -61,13 +61,13 @@ func (_m *UserAccessTokenStore) Get(tokenId string) store.StoreChannel {
 	return r0
 }
 
-// GetAll provides a mock function with given fields:
-func (_m *UserAccessTokenStore) GetAll(page int, perPage int) store.StoreChannel {
-	ret := _m.Called(page, perPage)
+// GetAll provides a mock function with given fields: offset, limit
+func (_m *UserAccessTokenStore) GetAll(offset int, limit int) store.StoreChannel {
+	ret := _m.Called(offset, limit)
 
 	var r0 store.StoreChannel
 	if rf, ok := ret.Get(0).(func(int, int) store.StoreChannel); ok {
-		r0 = rf(page, perPage)
+		r0 = rf(offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)
@@ -109,13 +109,13 @@ func (_m *UserAccessTokenStore) GetByUser(userId string, page int, perPage int) 
 	return r0
 }
 
-// Search provides a mock function with given fields:
-func (_m *UserAccessTokenStore) Search(term string) store.StoreChannel {
-	ret := _m.Called(term)
+// Save provides a mock function with given fields: token
+func (_m *UserAccessTokenStore) Save(token *model.UserAccessToken) store.StoreChannel {
+	ret := _m.Called(token)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
-		r0 = rf(term)
+	if rf, ok := ret.Get(0).(func(*model.UserAccessToken) store.StoreChannel); ok {
+		r0 = rf(token)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)
@@ -125,13 +125,13 @@ func (_m *UserAccessTokenStore) Search(term string) store.StoreChannel {
 	return r0
 }
 
-// Save provides a mock function with given fields: token
-func (_m *UserAccessTokenStore) Save(token *model.UserAccessToken) store.StoreChannel {
-	ret := _m.Called(token)
+// Search provides a mock function with given fields: term
+func (_m *UserAccessTokenStore) Search(term string) store.StoreChannel {
+	ret := _m.Called(term)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(*model.UserAccessToken) store.StoreChannel); ok {
-		r0 = rf(token)
+	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+		r0 = rf(term)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)


### PR DESCRIPTION
#### Summary
As discussed in [this very long thread](https://pre-release.mattermost.com/core/pl/3nzompitxpfi8do54r1xtb7ooa), this changes the autocomplete query to return an arbitrary subset of results rather than the first X in the complete, sorted result set.

The impact on some autocomplete searches on my local database with over ~400,000 in-team channels prefixed with "channel":

| Search Term | Before | After |
|-|-|-|
| ~ | 7.65s | 0.021s |
| ~c | 9.48s | 2.83s |
| ~ch | 9.34s | 1.89s |
| ~cha | 10.60s | 1.48s |
| ~t | 7.68s | 0.592s |
| ~to | 8.32s | 0.027s |
| ~tow | 7.37s | 0.023s |

There are more things I could do to reduce those "~c..." cases down to a few milliseconds as well, but I'm suspecting that 400,000+ matching channels is not the norm, so it would probably be premature to put much effort into that.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-79

I'm going to close this ticket with this PR as I think this resolves the biggest issues (The user performance isn't anywhere near as bad as the channel performance was.). We can create new issues as needed.

#### Checklist
N/A