### PR TITLE
[PLT-8494] Add delete_team websocket event

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -104,7 +104,7 @@ func (a *App) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
 		return nil, result.Err
 	}
 
-	a.sendUpdatedTeamEvent(oldTeam)
+	a.sendTeamEvent(oldTeam, model.WEBSOCKET_EVENT_UPDATE_TEAM)
 
 	return oldTeam, nil
 }
@@ -122,17 +122,17 @@ func (a *App) PatchTeam(teamId string, patch *model.TeamPatch) (*model.Team, *mo
 		return nil, err
 	}
 
-	a.sendUpdatedTeamEvent(updatedTeam)
+	a.sendTeamEvent(updatedTeam, model.WEBSOCKET_EVENT_UPDATE_TEAM)
 
 	return updatedTeam, nil
 }
 
-func (a *App) sendUpdatedTeamEvent(team *model.Team) {
+func (a *App) sendTeamEvent(team *model.Team, event string) {
 	sanitizedTeam := &model.Team{}
 	*sanitizedTeam = *team
 	sanitizedTeam.Sanitize()
 
-	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_UPDATE_TEAM, "", "", "", nil)
+	message := model.NewWebSocketEvent(event, "", "", "", nil)
 	message.Add("team", sanitizedTeam.ToJson())
 	a.Go(func() {
 		a.Publish(message)
@@ -833,6 +833,8 @@ func (a *App) SoftDeleteTeam(teamId string) *model.AppError {
 	if result := <-a.Srv.Store.Team().Update(team); result.Err != nil {
 		return result.Err
 	}
+
+	a.sendTeamEvent(team, model.WEBSOCKET_EVENT_DELETE_TEAM)
 
 	return nil
 }

--- a/app/team.go
+++ b/app/team.go
@@ -820,6 +820,8 @@ func (a *App) PermanentDeleteTeam(team *model.Team) *model.AppError {
 		return result.Err
 	}
 
+	a.sendTeamEvent(team, model.WEBSOCKET_EVENT_DELETE_TEAM)
+
 	return nil
 }
 

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -22,6 +22,7 @@ const (
 	WEBSOCKET_EVENT_ADDED_TO_TEAM       = "added_to_team"
 	WEBSOCKET_EVENT_LEAVE_TEAM          = "leave_team"
 	WEBSOCKET_EVENT_UPDATE_TEAM         = "update_team"
+	WEBSOCKET_EVENT_DELETE_TEAM         = "delete_team"
 	WEBSOCKET_EVENT_USER_ADDED          = "user_added"
 	WEBSOCKET_EVENT_USER_UPDATED        = "user_updated"
 	WEBSOCKET_EVENT_USER_ROLE_UPDATED   = "user_role_updated"


### PR DESCRIPTION
#### Summary
`app.SoftDeleteTeam` - Add `delete_team` websocket event to notify client (especially those currently viewing the team) whenever a team is deleted, so that client will be able to redirect to his other team membership 

Note: Should I add same WS event to `app.PermanentDeleteTeam`. I didn't add it since it's something we'll remove (?) in the future.

#### Ticket Link
Jira ticket: [PLT-8494](https://mattermost.atlassian.net/browse/PLT-8494)

#### Checklist
- [ ] Added or updated unit tests (would like to add test for `sendTeamEvent` but not particularly sure how to intercept the websocket message)
- [x] Touches critical sections of the codebase (websocket)
- [x] With mattermost-webapp(https://github.com/mattermost/mattermost-webapp/pull/611)
- [x] With mattermost-redux (https://github.com/mattermost/mattermost-redux/pull/359)
- [x] With mattermost-mobile (to follow link)
