### PR TITLE
ABC-179: check email verification last

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -1159,7 +1159,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	} else {
-		if err := c.App.CheckUserAdditionalAuthenticationCriteria(user, ""); err != nil {
+		if err := c.App.CheckUserAllAuthenticationCriteria(user, ""); err != nil {
 			c.Err = err
 			c.Err.StatusCode = http.StatusFound
 			return

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -189,7 +189,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	if _, err := Client.Login(ruser2.Data.(*model.User).Email, user2.Password); err != nil {
-		t.Fatal("From verfied hash")
+		t.Fatal("From verified hash")
 	}
 
 	Client.AuthToken = authToken
@@ -201,10 +201,10 @@ func TestLogin(t *testing.T) {
 		Password:    "passwd1",
 		AuthService: model.USER_AUTH_SERVICE_LDAP,
 	}
-	user3 = Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
-	store.Must(th.App.Srv.Store.User().VerifyEmail(user3.Id))
+	ruser3 := Client.Must(Client.CreateUser(user3, "")).Data.(*model.User)
+	store.Must(th.App.Srv.Store.User().VerifyEmail(ruser3.Id))
 
-	if _, err := Client.Login(user3.Id, user3.Password); err == nil {
+	if _, err := Client.Login(ruser3.Id, user3.Password); err == nil {
 		t.Fatal("AD/LDAP user should not be able to log in with AD/LDAP disabled")
 	}
 }

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
@@ -204,6 +206,41 @@ func TestLogin(t *testing.T) {
 
 	if _, err := Client.Login(user3.Id, user3.Password); err == nil {
 		t.Fatal("AD/LDAP user should not be able to log in with AD/LDAP disabled")
+	}
+}
+
+func TestLoginUnverifiedEmail(t *testing.T) {
+	assert := assert.New(t)
+
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	Client := th.BasicClient
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.EmailSettings.EnableSignInWithEmail = true
+		cfg.EmailSettings.RequireEmailVerification = true
+	})
+
+	Client.Logout()
+
+	user := &model.User{
+		Email:         strings.ToLower(model.NewId()) + "success+test@simulator.amazonses.com",
+		Nickname:      "Corey Hulen",
+		Username:      "corey" + model.NewId(),
+		Password:      "passwd1",
+		EmailVerified: false,
+	}
+	user = Client.Must(Client.CreateUser(user, "")).Data.(*model.User)
+
+	_, err := Client.Login(user.Email, user.Password+"invalid")
+	if assert.NotNil(err) {
+		assert.Equal("api.user.check_user_password.invalid.app_error", err.Id)
+	}
+
+	_, err = Client.Login(user.Email, "passwd1")
+	if assert.NotNil(err) {
+		assert.Equal("api.user.login.not_verified.app_error", err.Id)
 	}
 }
 


### PR DESCRIPTION
#### Summary
This change changes the authentication checks to be:
* "preflight checks"
** mfa
** not disabled
** login attempts
* password
* "postflight checks"
** email verified

Checking whether the email is verified or not last avoids the weird edge
case where entering any bogus password for an account with an unverified
email shows a message about verifying the email and offering to resend.

Also fix a unit test assertion error along with a typo.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-179

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
