### PR TITLE
ABC-153: don't use http redirects with 4xx/5xx status codes

### DIFF
--- a/app/oauth.go
+++ b/app/oauth.go
@@ -564,7 +564,7 @@ func generateOAuthStateTokenExtra(email, action, cookie string) string {
 
 func (a *App) GetAuthorizationCode(w http.ResponseWriter, r *http.Request, service string, props map[string]string, loginHint string) (string, *model.AppError) {
 	sso := a.Config().GetSSOService(service)
-	if sso != nil && !sso.Enable {
+	if sso == nil || !sso.Enable {
 		return "", model.NewAppError("GetAuthorizationCode", "api.user.get_authorization_code.unsupported.app_error", nil, "service="+service, http.StatusNotImplemented)
 	}
 

--- a/utils/api.go
+++ b/utils/api.go
@@ -49,5 +49,5 @@ func RenderWebError(err *model.AppError, w http.ResponseWriter, r *http.Request)
 	fmt.Fprintln(w, `<body onload="window.location = '`+template.HTMLEscapeString(template.JSEscapeString(destination))+`'">`)
 	fmt.Fprintln(w, `<noscript><meta http-equiv="refresh" content="0; url=`+template.HTMLEscapeString(destination)+`"></noscript>`)
 	fmt.Fprintln(w, `<a href="`+template.HTMLEscapeString(destination)+`" style="color: #c0c0c0;">...</a>`)
-	fmt.Fprintln(w, `<body></html>`)
+	fmt.Fprintln(w, `</body></html>`)
 }

--- a/utils/api.go
+++ b/utils/api.go
@@ -4,6 +4,8 @@
 package utils
 
 import (
+	"fmt"
+	"html/template"
 	"net/http"
 	"net/url"
 	"strings"
@@ -31,18 +33,21 @@ func OriginChecker(allowedOrigins string) func(*http.Request) bool {
 }
 
 func RenderWebError(err *model.AppError, w http.ResponseWriter, r *http.Request) {
-	message := err.Message
-	details := err.DetailedError
-
 	status := http.StatusTemporaryRedirect
 	if err.StatusCode != http.StatusInternalServerError {
 		status = err.StatusCode
 	}
 
-	http.Redirect(
-		w,
-		r,
-		"/error?message="+url.QueryEscape(message)+
-			"&details="+url.QueryEscape(details),
-		status)
+	destination := strings.TrimRight(GetSiteURL(), "/") + "/error?message=" + url.QueryEscape(err.Message)
+	if status >= 300 && status < 400 {
+		http.Redirect(w, r, destination, status)
+		return
+	}
+
+	w.WriteHeader(status)
+	fmt.Fprintln(w, `<!DOCTYPE html><html><head></head>`)
+	fmt.Fprintln(w, `<body onload="window.location = '`+template.HTMLEscapeString(template.JSEscapeString(destination))+`'">`)
+	fmt.Fprintln(w, `<noscript><meta http-equiv="refresh" content="0; url=`+template.HTMLEscapeString(destination)+`"></noscript>`)
+	fmt.Fprintln(w, `<a href="`+template.HTMLEscapeString(destination)+`" style="color: #c0c0c0;">...</a>`)
+	fmt.Fprintln(w, `<body></html>`)
 }


### PR DESCRIPTION
#### Summary
> The Location response header indicates the URL to redirect a page to. It only provides a meaning when served with a 3xx (redirection) or 201 (created) status response.

– https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location

Browsers and clients have varying/undefined behavior when the header is used with other status codes.

This uses HTML redirects for 4xx/5xx status codes.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-153

#### Checklist
N/A