### PR TITLE
ABC-173: introduce Normalize(Username|Email)

### DIFF
--- a/model/compliance.go
+++ b/model/compliance.go
@@ -52,7 +52,7 @@ func (me *Compliance) PreSave() {
 	}
 
 	me.Count = 0
-	me.Emails = strings.ToLower(me.Emails)
+	me.Emails = NormalizeEmail(me.Emails)
 	me.Keywords = strings.ToLower(me.Keywords)
 
 	me.CreateAt = GetMillis()

--- a/model/user.go
+++ b/model/user.go
@@ -162,6 +162,14 @@ func InvalidUserError(fieldName string, userId string) *AppError {
 	return NewAppError("User.IsValid", id, nil, details, http.StatusBadRequest)
 }
 
+func NormalizeUsername(username string) string {
+	return strings.ToLower(username)
+}
+
+func NormalizeEmail(email string) string {
+	return strings.ToLower(email)
+}
+
 // PreSave will set the Id and Username if missing.  It will also fill
 // in the CreateAt, UpdateAt times.  It will also hash the password.  It should
 // be run before saving the user to the db.
@@ -178,8 +186,8 @@ func (u *User) PreSave() {
 		u.AuthData = nil
 	}
 
-	u.Username = strings.ToLower(u.Username)
-	u.Email = strings.ToLower(u.Email)
+	u.Username = NormalizeUsername(u.Username)
+	u.Email = NormalizeEmail(u.Email)
 
 	u.CreateAt = GetMillis()
 	u.UpdateAt = u.CreateAt
@@ -207,8 +215,8 @@ func (u *User) PreSave() {
 
 // PreUpdate should be run before updating the user in the db.
 func (u *User) PreUpdate() {
-	u.Username = strings.ToLower(u.Username)
-	u.Email = strings.ToLower(u.Email)
+	u.Username = NormalizeUsername(u.Username)
+	u.Email = NormalizeEmail(u.Email)
 	u.UpdateAt = GetMillis()
 
 	if u.AuthData != nil && *u.AuthData == "" {
@@ -563,7 +571,7 @@ func IsValidUsername(s string) bool {
 }
 
 func CleanUsername(s string) string {
-	s = strings.ToLower(strings.Replace(s, " ", "-", -1))
+	s = NormalizeUsername(strings.Replace(s, " ", "-", -1))
 
 	for _, value := range reservedName {
 		if s == value {

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -243,6 +243,30 @@ func TestValidUsername(t *testing.T) {
 	}
 }
 
+func TestNormalizeUsername(t *testing.T) {
+	if NormalizeUsername("Spin-punch") != "spin-punch" {
+		t.Fatal("didn't normalize username properly")
+	}
+	if NormalizeUsername("PUNCH") != "punch" {
+		t.Fatal("didn't normalize username properly")
+	}
+	if NormalizeUsername("spin") != "spin" {
+		t.Fatal("didn't normalize username properly")
+	}
+}
+
+func TestNormalizeEmail(t *testing.T) {
+	if NormalizeEmail("TEST@EXAMPLE.COM") != "test@example.com" {
+		t.Fatal("didn't normalize email properly")
+	}
+	if NormalizeEmail("TEST2@example.com") != "test2@example.com" {
+		t.Fatal("didn't normalize email properly")
+	}
+	if NormalizeEmail("test3@example.com") != "test3@example.com" {
+		t.Fatal("didn't normalize email properly")
+	}
+}
+
 func TestCleanUsername(t *testing.T) {
 	if CleanUsername("Spin-punch") != "spin-punch" {
 		t.Fatal("didn't clean name properly")


### PR DESCRIPTION
#### Summary
This centralizes the source of truth on the rules for username / email
processing instead of scattering `strings.ToLower` invocations.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-173

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes: https://github.com/mattermost/enterprise/pull/253