### PR TITLE
ABC-210: Fix image url replacement for blank urls

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -890,7 +890,7 @@ func (a *App) ImageProxyAdder() func(string) string {
 	}
 
 	return func(url string) string {
-		if strings.HasPrefix(url, proxyURL) {
+		if url == "" || strings.HasPrefix(url, proxyURL) {
 			return url
 		}
 

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -211,6 +211,12 @@ func TestImageProxy(t *testing.T) {
 			ImageURL:        "http://mydomain.com/myimage",
 			ProxiedImageURL: "https://127.0.0.1/x1000/http://mydomain.com/myimage",
 		},
+		"willnorris/imageproxy_EmptyImageURL": {
+			ProxyType:       "willnorris/imageproxy",
+			ProxyURL:        "https://127.0.0.1",
+			ImageURL:        "",
+			ProxiedImageURL: "",
+		},
 		"willnorris/imageproxy_WithSigning": {
 			ProxyType:       "willnorris/imageproxy",
 			ProxyURL:        "https://127.0.0.1",


### PR DESCRIPTION
#### Summary
I originally thought this was a recursion issue since my test string also included deeply nested block quotes. Then I realized Go has an infinite stack size. 🤦‍♂️ This is why automated fuzzing is one of my goals.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-210

#### Checklist
- [x] Added or updated unit tests (required for all new features)