### PR TITLE
Return an error code to the shell if an error occurs when running `platform server`

### DIFF
--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -28,9 +28,10 @@ const (
 var MaxNotificationsPerChannelDefault int64 = 1000000
 
 var serverCmd = &cobra.Command{
-	Use:   "server",
-	Short: "Run the Mattermost server",
-	RunE:  runServerCmd,
+	Use:          "server",
+	Short:        "Run the Mattermost server",
+	RunE:         runServerCmd,
+	SilenceUsage: true,
 }
 
 func runServerCmd(cmd *cobra.Command, args []string) error {
@@ -41,11 +42,10 @@ func runServerCmd(cmd *cobra.Command, args []string) error {
 
 	disableConfigWatch, _ := cmd.Flags().GetBool("disableconfigwatch")
 
-	runServer(config, disableConfigWatch)
-	return nil
+	return runServer(config, disableConfigWatch)
 }
 
-func runServer(configFileLocation string, disableConfigWatch bool) {
+func runServer(configFileLocation string, disableConfigWatch bool) error {
 	options := []app.Option{app.ConfigFile(configFileLocation)}
 	if disableConfigWatch {
 		options = append(options, app.DisableConfigWatch)
@@ -54,7 +54,7 @@ func runServer(configFileLocation string, disableConfigWatch bool) {
 	a, err := app.New(options...)
 	if err != nil {
 		l4g.Error(err.Error())
-		return
+		return err
 	}
 	defer a.Shutdown()
 
@@ -172,6 +172,8 @@ func runServer(configFileLocation string, disableConfigWatch bool) {
 
 	a.Jobs.StopSchedulers()
 	a.Jobs.StopWorkers()
+
+	return nil
 }
 
 func runSecurityJob(a *app.App) {


### PR DESCRIPTION
#### Summary

Currently, if an error occurs when starting the server using `platform server`, the command exit with a 0 exit code (i.e. "success") – although the server failed to launch.

This means it is not possible to know whether the server started successfully or not. From the shell point of view, it started successfully and existed very quickly. Additionally, no error message is printed to the console.

```shell
$ rm config/config.json
$ if bin/platform server; then echo "Success"; else echo "Failure"; fi
Success
# The server actually failed to launch, but there is no way to know it (besides a message in the log file)
```

With this change, the `platform server` command simply reports its errors to `cobra`. When an error occurs while initializing the app (like a missing or invalid configuration file, or missing locales), cobra prints the error to the console, and the shell command exits with a "-1" exit code.

This allow shell scripts to properly detect the startup failure, and to react to it.

```shell
$ rm config/config.json
$ if bin/platform server; then echo "Success"; else echo "Failure"; fi
Error: LoadConfig: Error decoding config file=config.json, err=While parsing config: invalid character ':' after top-level value,
Failure
# The server failed to launch, and it is possible to react to it in a script.
# (The error message is still added to the log file, but also printed
# on the console, as part of cobra's standard behavior.)
```

More importantly, in production, **it allows the service launcher (like `init` or `systemd`) to know whether the server launched successfully**, or if it needs to try again, how many times (depending on the service configuration), and so on.

#### Ticket Link

n/a

#### Checklist

- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)