### PR TITLE
ABC-132: sign error page parameters

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -109,7 +109,7 @@ func Init(a *app.App, root *mux.Router) *API {
 	api.InitReaction()
 
 	// 404 on any api route before web.go has a chance to serve it
-	root.Handle("/api/{anything:.*}", http.HandlerFunc(Handle404))
+	root.Handle("/api/{anything:.*}", http.HandlerFunc(api.Handle404))
 
 	a.InitEmailBatching()
 
@@ -118,6 +118,10 @@ func Init(a *app.App, root *mux.Router) *API {
 	}
 
 	return api
+}
+
+func (api *API) Handle404(w http.ResponseWriter, r *http.Request) {
+	Handle404(api.App, w, r)
 }
 
 func ReturnStatusOK(w http.ResponseWriter) {

--- a/api/context.go
+++ b/api/context.go
@@ -229,7 +229,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if c.Err.StatusCode == http.StatusUnauthorized {
 				http.Redirect(w, r, c.GetTeamURL()+"/?redirect="+url.QueryEscape(r.URL.Path), http.StatusTemporaryRedirect)
 			} else {
-				utils.RenderWebError(c.Err, w, r)
+				utils.RenderWebAppError(w, r, c.Err, c.App.AsymmetricSigningKey())
 			}
 		}
 
@@ -434,7 +434,7 @@ func IsApiCall(r *http.Request) bool {
 	return strings.Index(r.URL.Path, "/api/") == 0
 }
 
-func Handle404(w http.ResponseWriter, r *http.Request) {
+func Handle404(a *app.App, w http.ResponseWriter, r *http.Request) {
 	err := model.NewAppError("Handle404", "api.context.404.app_error", nil, "", http.StatusNotFound)
 
 	l4g.Debug("%v: code=404 ip=%v", r.URL.Path, utils.GetIpAddress(r))
@@ -444,7 +444,7 @@ func Handle404(w http.ResponseWriter, r *http.Request) {
 		err.DetailedError = "There doesn't appear to be an api call for the url='" + r.URL.Path + "'.  Typo? are you missing a team_id or user_id as part of the url?"
 		w.Write([]byte(err.ToJson()))
 	} else {
-		utils.RenderWebError(err, w, r)
+		utils.RenderWebAppError(w, r, err, a.AsymmetricSigningKey())
 	}
 }
 

--- a/api/file.go
+++ b/api/file.go
@@ -174,12 +174,12 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		if hash != correctHash {
 			c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
-			http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+utils.T(c.Err.Message), http.StatusTemporaryRedirect)
+			utils.RenderWebAppError(w, r, c.Err, c.App.AsymmetricSigningKey())
 			return
 		}
 	} else {
 		c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
-		http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+utils.T(c.Err.Message), http.StatusTemporaryRedirect)
+		utils.RenderWebAppError(w, r, c.Err, c.App.AsymmetricSigningKey())
 		return
 	}
 

--- a/api4/file.go
+++ b/api4/file.go
@@ -281,13 +281,13 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if len(hash) == 0 {
 		c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
-		http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+utils.T(c.Err.Message), http.StatusTemporaryRedirect)
+		utils.RenderWebAppError(w, r, c.Err, c.App.AsymmetricSigningKey())
 		return
 	}
 
 	if hash != app.GeneratePublicLinkHash(info.Id, *c.App.Config().FileSettings.PublicLinkSalt) {
 		c.Err = model.NewAppError("getPublicFile", "api.file.get_file.public_invalid.app_error", nil, "", http.StatusBadRequest)
-		http.Redirect(w, r, c.GetSiteURLHeader()+"/error?message="+utils.T(c.Err.Message), http.StatusTemporaryRedirect)
+		utils.RenderWebAppError(w, r, c.Err, c.App.AsymmetricSigningKey())
 		return
 	}
 

--- a/app/config.go
+++ b/app/config.go
@@ -4,7 +4,12 @@
 package app
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/md5"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"runtime/debug"
@@ -116,8 +121,87 @@ func (a *App) InvokeConfigListeners(old, current *model.Config) {
 	}
 }
 
+// EnsureAsymmetricSigningKey ensures that an asymmetric signing key exists and future calls to
+// AsymmetricSigningKey will always return a valid signing key.
+func (a *App) ensureAsymmetricSigningKey() error {
+	if a.asymmetricSigningKey != nil {
+		return nil
+	}
+
+	var key *model.SystemAsymmetricSigningKey
+
+	result := <-a.Srv.Store.System().GetByName(model.SYSTEM_ASYMMETRIC_SIGNING_KEY)
+	if result.Err == nil {
+		if err := json.Unmarshal([]byte(result.Data.(*model.System).Value), &key); err != nil {
+			return err
+		}
+	}
+
+	if key == nil {
+		newECDSAKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return err
+		}
+		newKey := &model.SystemAsymmetricSigningKey{
+			ECDSAKey: &model.SystemECDSAKey{
+				Curve: "P-256",
+				X:     newECDSAKey.X,
+				Y:     newECDSAKey.Y,
+				D:     newECDSAKey.D,
+			},
+		}
+		system := &model.System{
+			Name: model.SYSTEM_ASYMMETRIC_SIGNING_KEY,
+		}
+		v, err := json.Marshal(newKey)
+		if err != nil {
+			return err
+		}
+		system.Value = string(v)
+		if result = <-a.Srv.Store.System().Save(system); result.Err != nil {
+			key = newKey
+		}
+	}
+
+	if key == nil {
+		result := <-a.Srv.Store.System().GetByName(model.SYSTEM_ASYMMETRIC_SIGNING_KEY)
+		if result.Err != nil {
+			return result.Err
+		} else if err := json.Unmarshal([]byte(result.Data.(*model.System).Value), &key); err != nil {
+			return err
+		}
+	}
+
+	var curve elliptic.Curve
+	switch key.ECDSAKey.Curve {
+	case "P-256":
+		curve = elliptic.P256()
+	default:
+		return fmt.Errorf("unknown curve: " + key.ECDSAKey.Curve)
+	}
+	a.asymmetricSigningKey = &ecdsa.PrivateKey{
+		PublicKey: ecdsa.PublicKey{
+			Curve: curve,
+			X:     key.ECDSAKey.X,
+			Y:     key.ECDSAKey.Y,
+		},
+		D: key.ECDSAKey.D,
+	}
+	a.regenerateClientConfig()
+	return nil
+}
+
+// AsymmetricSigningKey will return a private key that can be used for asymmetric signing.
+func (a *App) AsymmetricSigningKey() *ecdsa.PrivateKey {
+	return a.asymmetricSigningKey
+}
+
 func (a *App) regenerateClientConfig() {
 	a.clientConfig = utils.GenerateClientConfig(a.Config(), a.DiagnosticId())
+	if key := a.AsymmetricSigningKey(); key != nil {
+		der, _ := x509.MarshalPKIXPublicKey(&key.PublicKey)
+		a.clientConfig["AsymmetricSigningPublicKey"] = base64.StdEncoding.EncodeToString(der)
+	}
 	clientConfigJSON, _ := json.Marshal(a.clientConfig)
 	a.clientConfigHash = fmt.Sprintf("%x", md5.Sum(clientConfigJSON))
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -6,6 +6,8 @@ package app
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -53,4 +55,11 @@ func TestConfigListener(t *testing.T) {
 	} else if !listener2Called {
 		t.Fatal("listener 2 should've been called")
 	}
+}
+
+func TestAsymmetricSigningKey(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	assert.NotNil(t, th.App.AsymmetricSigningKey())
+	assert.NotEmpty(t, th.App.ClientConfig()["AsymmetricSigningPublicKey"])
 }

--- a/model/system.go
+++ b/model/system.go
@@ -6,14 +6,16 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"math/big"
 )
 
 const (
-	SYSTEM_DIAGNOSTIC_ID        = "DiagnosticId"
-	SYSTEM_RAN_UNIT_TESTS       = "RanUnitTests"
-	SYSTEM_LAST_SECURITY_TIME   = "LastSecurityTime"
-	SYSTEM_ACTIVE_LICENSE_ID    = "ActiveLicenseId"
-	SYSTEM_LAST_COMPLIANCE_TIME = "LastComplianceTime"
+	SYSTEM_DIAGNOSTIC_ID          = "DiagnosticId"
+	SYSTEM_RAN_UNIT_TESTS         = "RanUnitTests"
+	SYSTEM_LAST_SECURITY_TIME     = "LastSecurityTime"
+	SYSTEM_ACTIVE_LICENSE_ID      = "ActiveLicenseId"
+	SYSTEM_LAST_COMPLIANCE_TIME   = "LastComplianceTime"
+	SYSTEM_ASYMMETRIC_SIGNING_KEY = "AsymmetricSigningKey"
 )
 
 type System struct {
@@ -30,4 +32,15 @@ func SystemFromJson(data io.Reader) *System {
 	var o *System
 	json.NewDecoder(data).Decode(&o)
 	return o
+}
+
+type SystemAsymmetricSigningKey struct {
+	ECDSAKey *SystemECDSAKey `json:"ecdsa_key,omitempty"`
+}
+
+type SystemECDSAKey struct {
+	Curve string   `json:"curve"`
+	X     *big.Int `json:"x"`
+	Y     *big.Int `json:"y"`
+	D     *big.Int `json:"d,omitempty"`
 }

--- a/utils/api.go
+++ b/utils/api.go
@@ -4,6 +4,9 @@
 package utils
 
 import (
+	"crypto"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -32,13 +35,25 @@ func OriginChecker(allowedOrigins string) func(*http.Request) bool {
 	}
 }
 
-func RenderWebError(err *model.AppError, w http.ResponseWriter, r *http.Request) {
-	status := http.StatusTemporaryRedirect
-	if err.StatusCode != http.StatusInternalServerError {
-		status = err.StatusCode
-	}
+func RenderWebAppError(w http.ResponseWriter, r *http.Request, err *model.AppError, s crypto.Signer) {
+	RenderWebError(w, r, err.StatusCode, url.Values{
+		"message": []string{err.Message},
+	}, s)
+}
 
-	destination := strings.TrimRight(GetSiteURL(), "/") + "/error?message=" + url.QueryEscape(err.Message)
+func RenderWebError(w http.ResponseWriter, r *http.Request, status int, params url.Values, s crypto.Signer) {
+	queryString := params.Encode()
+
+	h := crypto.SHA256
+	sum := h.New()
+	sum.Write([]byte("/error?" + queryString))
+	signature, err := s.Sign(rand.Reader, sum.Sum(nil), h)
+	if err != nil {
+		http.Error(w, "", http.StatusInternalServerError)
+		return
+	}
+	destination := strings.TrimRight(GetSiteURL(), "/") + "/error?" + queryString + "&s=" + base64.URLEncoding.EncodeToString(signature)
+
 	if status >= 300 && status < 400 {
 		http.Redirect(w, r, destination, status)
 		return

--- a/utils/api_test.go
+++ b/utils/api_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package utils
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderWebError(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://foo", nil)
+	w := httptest.NewRecorder()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	RenderWebError(w, r, http.StatusTemporaryRedirect, url.Values{
+		"foo": []string{"bar"},
+	}, key)
+
+	resp := w.Result()
+	location, err := url.Parse(resp.Header.Get("Location"))
+	require.NoError(t, err)
+	require.NotEmpty(t, location.Query().Get("s"))
+
+	type ecdsaSignature struct {
+		R, S *big.Int
+	}
+	var rs ecdsaSignature
+	s, err := base64.URLEncoding.DecodeString(location.Query().Get("s"))
+	require.NoError(t, err)
+	_, err = asn1.Unmarshal(s, &rs)
+	require.NoError(t, err)
+
+	assert.Equal(t, "bar", location.Query().Get("foo"))
+	h := sha256.Sum256([]byte("/error?foo=bar"))
+	assert.True(t, ecdsa.Verify(&key.PublicKey, h[:], rs.R, rs.S))
+}

--- a/web/web.go
+++ b/web/web.go
@@ -94,7 +94,7 @@ func root(c *api.Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if api.IsApiCall(r) {
-		api.Handle404(w, r)
+		api.Handle404(c.App, w, r)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Sign error page parameters so client can verify they're from the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-132

#### Checklist
- [x] Added or updated unit tests (required for all new features)