### PR TITLE
Handle RateLimiter initialization errors

### DIFF
--- a/app/ratelimit_test.go
+++ b/app/ratelimit_test.go
@@ -25,6 +25,21 @@ func genRateLimitSettings(useAuth, useIP bool, header string) *model.RateLimitSe
 	}
 }
 
+func TestNewRateLimiterSuccess(t *testing.T) {
+	settings := genRateLimitSettings(false, false, "")
+	rateLimiter, err := NewRateLimiter(settings)
+	require.NotNil(t, rateLimiter)
+	require.NoError(t, err)
+}
+
+func TestNewRateLimiterFailure(t *testing.T) {
+	invalidSettings := genRateLimitSettings(false, false, "")
+	invalidSettings.MaxBurst = model.NewInt(-100)
+	rateLimiter, err := NewRateLimiter(invalidSettings)
+	require.Nil(t, rateLimiter)
+	require.Error(t, err)
+}
+
 func TestGenerateKey(t *testing.T) {
 	cases := []struct {
 		useAuth         bool
@@ -58,7 +73,7 @@ func TestGenerateKey(t *testing.T) {
 			req.Header.Set(tc.header, tc.headerResult)
 		}
 
-		rateLimiter := NewRateLimiter(genRateLimitSettings(tc.useAuth, tc.useIP, tc.header))
+		rateLimiter, _ := NewRateLimiter(genRateLimitSettings(tc.useAuth, tc.useIP, tc.header))
 
 		key := rateLimiter.GenerateKey(req)
 

--- a/app/server.go
+++ b/app/server.go
@@ -124,9 +124,14 @@ func (a *App) StartServer() {
 	if *a.Config().RateLimitSettings.Enable {
 		l4g.Info(utils.T("api.server.start_server.rate.info"))
 
-		a.Srv.RateLimiter = NewRateLimiter(&a.Config().RateLimitSettings)
+		rateLimiter, err := NewRateLimiter(&a.Config().RateLimitSettings)
+		if err != nil {
+			l4g.Critical(err.Error())
+			return
+		}
 
-		handler = a.Srv.RateLimiter.RateLimitHandler(handler)
+		a.Srv.RateLimiter = rateLimiter
+		handler = rateLimiter.RateLimitHandler(handler)
 	}
 
 	a.Srv.Server = &http.Server{


### PR DESCRIPTION
#### Summary

Currently, initialization errors occurring in `NewRateLimiter` make the function return a nil reference – which is de-referenced just after by the caller, making the server crash.

This PR propagates the error to the caller, which can then log it properly.

It prepares a future PR that will propagate the handful of critical server initialization errors to the command line handler.

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has enterprise changes
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
