### PR TITLE
ABC-231: NoSQL webhook store

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -10,6 +10,8 @@ imports:
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
+- name: github.com/ccbrown/go-immutable
+  version: e9015daa17c46c136f648b80536c5f1814002fea
 - name: github.com/corpix/uarand
   version: 2b8494104d86337cdd41d0a49cbed8e4583c0ab4
 - name: github.com/davecgh/go-spew

--- a/glide.yaml
+++ b/glide.yaml
@@ -79,3 +79,4 @@ import:
   subpackages:
   - store/memstore
 - package: gopkg.in/yaml.v2
+- package: github.com/ccbrown/go-immutable

--- a/store/memorystore/driver.go
+++ b/store/memorystore/driver.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package memorystore
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/ccbrown/go-immutable"
+
+	"github.com/mattermost/mattermost-server/store/nosqlstore"
+)
+
+type Driver struct{}
+
+func (d *Driver) ObjectStore(name string, serialize func(interface{}) ([]byte, error), deserialize func([]byte) (interface{}, error)) nosqlstore.ObjectStore {
+	return &ObjectStore{
+		objects:     make(map[string][]byte),
+		serialize:   serialize,
+		deserialize: deserialize,
+	}
+}
+
+type ObjectStoreIndex struct {
+	keys   func(obj interface{}) ([]byte, []byte)
+	lookup map[string]*immutable.OrderedMap
+}
+
+type ObjectStore struct {
+	mutex       sync.RWMutex
+	objects     map[string][]byte
+	indexes     map[string]*ObjectStoreIndex
+	serialize   func(interface{}) ([]byte, error)
+	deserialize func([]byte) (interface{}, error)
+}
+
+func (s *ObjectStore) Count(index string, hashKey []byte, rangeKey *nosqlstore.RangeKey) (int, error) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	begin := s.rangeMin(index, hashKey, rangeKey)
+	end := s.rangeMax(index, hashKey, rangeKey)
+	if begin == nil {
+		return 0, nil
+	}
+	count := begin.CountGreater() - end.CountGreater() + 1
+	if rangeKey != nil {
+		if rangeKey.Offset >= count {
+			return 0, nil
+		}
+		count -= rangeKey.Offset
+		if rangeKey.Limit > 0 && count > rangeKey.Limit {
+			return rangeKey.Limit, nil
+		}
+	}
+	return count, nil
+}
+
+func (s *ObjectStore) Delete(id string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	return s.delete(id)
+}
+
+func (s *ObjectStore) delete(id string) error {
+	if obj, ok := s.objects[id]; ok {
+		for _, index := range s.indexes {
+			deserialized, err := s.deserialize(obj)
+			if err != nil {
+				return err
+			}
+			hashKey, rangeKey := index.keys(deserialized)
+			index.lookup[string(hashKey)] = index.lookup[string(hashKey)].Delete(string(rangeKey))
+		}
+		delete(s.objects, id)
+	}
+	return nil
+}
+
+func (s *ObjectStore) Get(id string, dest interface{}) error {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	if obj, ok := s.objects[id]; ok {
+		deserialized, err := s.deserialize(obj)
+		if err != nil {
+			return err
+		}
+		objv := reflect.ValueOf(deserialized)
+		destv := reflect.ValueOf(dest).Elem()
+		if destv.Type() == objv.Type() {
+			destv.Set(objv)
+		} else {
+			destv.Set(objv.Elem())
+		}
+		return nil
+	}
+
+	return nosqlstore.ErrNotFound
+}
+
+func (s *ObjectStore) insert(id string, object interface{}) error {
+	if _, ok := s.objects[id]; ok {
+		return nosqlstore.ErrAlreadyExists
+	}
+	data, err := s.serialize(object)
+	if err != nil {
+		return err
+	}
+	s.objects[id] = data
+	for _, index := range s.indexes {
+		hashKey, rangeKey := index.keys(object)
+		index.lookup[string(hashKey)] = index.lookup[string(hashKey)].Set(string(rangeKey), id)
+	}
+	return nil
+}
+
+func (s *ObjectStore) Lookup(index string, hashKey []byte, rangeKey *nosqlstore.RangeKey, dest interface{}) error {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	var ids []string
+	if err := s.iterate(index, hashKey, rangeKey, func(id string) {
+		ids = append(ids, id)
+	}); err != nil {
+		return err
+	}
+
+	v := reflect.ValueOf(dest).Elem()
+	t := reflect.TypeOf(dest).Elem()
+	v.Set(reflect.MakeSlice(t, len(ids), len(ids)))
+	for i, id := range ids {
+		obj, err := s.deserialize(s.objects[id])
+		if err != nil {
+			return err
+		}
+		v.Index(i).Set(reflect.ValueOf(obj))
+	}
+
+	return nil
+}
+
+func (s *ObjectStore) rangeMax(index string, hashKey []byte, rangeKey *nosqlstore.RangeKey) *immutable.OrderedMapElement {
+	lookup := s.indexes[index].lookup[string(hashKey)]
+
+	if rangeKey == nil || rangeKey.Max == nil {
+		return lookup.Max()
+	}
+
+	ret := lookup.MaxBefore(string(rangeKey.Max))
+	if !rangeKey.ExcludeMax {
+		var next *immutable.OrderedMapElement
+		if ret == nil {
+			next = lookup.Min()
+		} else {
+			next = ret.Next()
+		}
+		if next != nil && next.Key().(string) == string(rangeKey.Max) {
+			return next
+		}
+	}
+	return ret
+}
+
+func (s *ObjectStore) rangeMin(index string, hashKey []byte, rangeKey *nosqlstore.RangeKey) *immutable.OrderedMapElement {
+	lookup := s.indexes[index].lookup[string(hashKey)]
+
+	if rangeKey == nil || rangeKey.Min == nil {
+		return lookup.Min()
+	}
+
+	ret := lookup.MinAfter(string(rangeKey.Min))
+	if !rangeKey.ExcludeMin {
+		var prev *immutable.OrderedMapElement
+		if ret == nil {
+			prev = lookup.Max()
+		} else {
+			prev = ret.Prev()
+		}
+		if prev != nil && prev.Key().(string) == string(rangeKey.Min) {
+			return prev
+		}
+	}
+	return ret
+}
+
+func (s *ObjectStore) iterate(index string, hashKey []byte, rangeKey *nosqlstore.RangeKey, f func(string)) error {
+	var offset, limit int
+	var order nosqlstore.RangeOrder
+
+	if rangeKey != nil {
+		order = rangeKey.Order
+		offset = rangeKey.Offset
+		limit = rangeKey.Limit
+	}
+
+	if order == nosqlstore.RANGE_ORDER_ASC {
+		next := s.rangeMin(index, hashKey, rangeKey)
+
+		for i := 0; i < offset && next != nil; i++ {
+			next = next.Next()
+		}
+
+		for i := 0; next != nil; i++ {
+			if limit > 0 && i >= limit {
+				break
+			} else if rangeKey != nil && rangeKey.Max != nil {
+				cmp := strings.Compare(next.Key().(string), string(rangeKey.Max))
+				if cmp == 1 || (rangeKey.ExcludeMax && cmp == 0) {
+					break
+				}
+			}
+			f(next.Value().(string))
+			next = next.Next()
+		}
+	} else {
+		next := s.rangeMax(index, hashKey, rangeKey)
+
+		for i := 0; i < offset && next != nil; i++ {
+			next = next.Prev()
+		}
+
+		for i := 0; next != nil; i++ {
+			if limit > 0 && i >= limit {
+				break
+			} else if rangeKey != nil && rangeKey.Min != nil {
+				cmp := strings.Compare(next.Key().(string), string(rangeKey.Min))
+				if cmp == -1 || (rangeKey.ExcludeMin && cmp == 0) {
+					break
+				}
+			}
+			f(next.Value().(string))
+			next = next.Prev()
+		}
+	}
+
+	return nil
+}
+
+func (s *ObjectStore) Upsert(id string, object interface{}) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if err := s.delete(id); err != nil {
+		return err
+	}
+	return s.insert(id, object)
+}
+
+func (s *ObjectStore) AddIndex(name string, keys func(interface{}) (hashKey []byte, rangeKey []byte)) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	if s.indexes == nil {
+		s.indexes = make(map[string]*ObjectStoreIndex)
+	}
+	s.indexes[name] = &ObjectStoreIndex{
+		keys:   keys,
+		lookup: make(map[string]*immutable.OrderedMap),
+	}
+	return nil
+}

--- a/store/memorystore/driver_test.go
+++ b/store/memorystore/driver_test.go
@@ -1,0 +1,11 @@
+package memorystore
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/store/nosqlstore/nosqlstoretest"
+)
+
+func TestDriver(t *testing.T) {
+	nosqlstoretest.TestDriver(t, &Driver{})
+}

--- a/store/memorystore/driver_test.go
+++ b/store/memorystore/driver_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package memorystore
 
 import (

--- a/store/memorystore/memorystore.go
+++ b/store/memorystore/memorystore.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package memorystore
+
+import (
+	"github.com/mattermost/mattermost-server/store/nosqlstore"
+)
+
+func New() (*nosqlstore.NoSQLStore, error) {
+	return nosqlstore.New(&Driver{})
+}

--- a/store/nosqlstore/driver.go
+++ b/store/nosqlstore/driver.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package nosqlstore
+
+import (
+	"errors"
+)
+
+var ErrAlreadyExists = errors.New("already exists")
+var ErrNotFound = errors.New("not found")
+
+type RangeOrder int
+
+const (
+	RANGE_ORDER_ASC RangeOrder = iota
+	RANGE_ORDER_DESC
+)
+
+type RangeKey struct {
+	Min        []byte
+	ExcludeMin bool
+	Max        []byte
+	ExcludeMax bool
+	Order      RangeOrder
+	Offset     int
+	Limit      int
+}
+
+func Range(min, max []byte) *RangeKey {
+	return &RangeKey{Min: min, Max: max}
+}
+
+func RangeLessThan(key []byte) *RangeKey {
+	return &RangeKey{Max: key, ExcludeMax: true}
+}
+
+func RangeLessThanOrEqualTo(key []byte) *RangeKey {
+	return &RangeKey{Max: key}
+}
+
+func RangeEqualTo(key []byte) *RangeKey {
+	return &RangeKey{Min: key, Max: key}
+}
+
+func RangeGreaterThanOrEqual(key []byte) *RangeKey {
+	return &RangeKey{Min: key}
+}
+
+func RangeGreaterThan(key []byte) *RangeKey {
+	return &RangeKey{Min: key, ExcludeMin: true}
+}
+
+func RangeSubset(offset, limit int) *RangeKey {
+	return &RangeKey{
+		Offset: offset,
+		Limit:  limit,
+	}
+}
+
+func (k RangeKey) Subset(offset, limit int) *RangeKey {
+	k.Offset = offset
+	k.Limit = limit
+	return &k
+}
+
+type LookupResult struct {
+	TotalCount *int
+}
+
+type ObjectStore interface {
+	// Count returns the number of objects indexed by the given keys.
+	Count(index string, hashKey []byte, rangeKey *RangeKey) (int, error)
+
+	// Delete deletes an object by id.
+	Delete(id string) error
+
+	// Get gets an object by id.
+	Get(id string, dest interface{}) error
+
+	// Lookup gets the objects indexed by the given keys. If no range key is given, all results in
+	// ascending order from the beginning will be returned.
+	Lookup(index string, hashKey []byte, rangeKey *RangeKey, dest interface{}) error
+
+	// Upsert inserts or updates an object.
+	Upsert(id string, object interface{}) error
+
+	// AddIndex creates a named index for each object.
+	//
+	// The function should return two elements: The hash key can be used to perform lookups based on
+	// exact matches. The range key is used to order elements matches by the hash key. Objects with
+	// the same hash key cannot have the same range key.
+	//
+	// If the index does not already exist, re-indexing will occur.
+	AddIndex(name string, keys func(interface{}) (hashKey []byte, rangeKey []byte)) error
+}
+
+type Driver interface {
+	// ObjectStore returns an object store with the given name.
+	ObjectStore(name string, serialize func(interface{}) ([]byte, error), deserialize func([]byte) (interface{}, error)) ObjectStore
+}

--- a/store/nosqlstore/encoding.go
+++ b/store/nosqlstore/encoding.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package nosqlstore
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+func Encode(args ...interface{}) []byte {
+	var buf []byte
+	for _, arg := range args {
+		switch x := arg.(type) {
+		case int:
+			buf = append(buf, EncodeInt64(int64(x))...)
+		case int64:
+			buf = append(buf, EncodeInt64(x)...)
+		case string:
+			buf = append(buf, []byte(x)...)
+		default:
+			panic(fmt.Errorf("unsupported type: %T", x))
+		}
+	}
+	return buf
+}
+
+func EncodeInt64(n int64) []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(n)+(1<<63))
+	return buf
+}

--- a/store/nosqlstore/nosqlstore.go
+++ b/store/nosqlstore/nosqlstore.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package nosqlstore
+
+import (
+	"github.com/mattermost/mattermost-server/store"
+)
+
+type NoSQLStore struct {
+	store.Store
+	WebhookStore *WebhookStore
+}
+
+func New(driver Driver) (*NoSQLStore, error) {
+	ret := &NoSQLStore{}
+	if webhookStore, err := NewWebhookStore(driver); err != nil {
+		return nil, err
+	} else {
+		ret.WebhookStore = webhookStore
+	}
+	return ret, nil
+}
+
+func (s *NoSQLStore) Webhook() store.WebhookStore {
+	return s.WebhookStore
+}

--- a/store/nosqlstore/nosqlstoretest/driver.go
+++ b/store/nosqlstore/nosqlstoretest/driver.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package nosqlstoretest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/store/nosqlstore"
+)
+
+func TestDriver(t *testing.T, driver nosqlstore.Driver) {
+	t.Run("ObjectStoreBasics", func(t *testing.T) { testObjectStoreBasics(t, driver) })
+	t.Run("ObjectStoreIndexes", func(t *testing.T) { testObjectStoreIndexes(t, driver) })
+}
+
+type testObject struct {
+	Id  string
+	Foo string
+	N   int
+}
+
+func testObjectStoreBasics(t *testing.T, driver nosqlstore.Driver) {
+	store := driver.ObjectStore("testObjectStoreBasics", json.Marshal, func(b []byte) (interface{}, error) {
+		var obj testObject
+		return &obj, json.Unmarshal(b, &obj)
+	})
+	require.NotNil(t, store)
+
+	var obj testObject
+	assert.Equal(t, nosqlstore.ErrNotFound, store.Get("foo", &obj))
+
+	assert.NoError(t, store.Upsert("theid", &testObject{
+		Id:  "theid",
+		Foo: "foo",
+	}))
+
+	assert.NoError(t, store.Get("theid", &obj))
+	assert.Equal(t, "theid", obj.Id)
+	assert.Equal(t, "foo", obj.Foo)
+
+	obj.Foo = "bar"
+
+	assert.NoError(t, store.Upsert(obj.Id, &obj))
+	assert.NoError(t, store.Get("theid", &obj))
+	assert.Equal(t, "theid", obj.Id)
+	assert.Equal(t, "bar", obj.Foo)
+
+	assert.NoError(t, store.Delete(obj.Id))
+	assert.Equal(t, nosqlstore.ErrNotFound, store.Get("theid", &obj))
+}
+
+func testObjectStoreIndexes(t *testing.T, driver nosqlstore.Driver) {
+	store := driver.ObjectStore("testObjectStoreIndexes", json.Marshal, func(b []byte) (interface{}, error) {
+		var obj testObject
+		return &obj, json.Unmarshal(b, &obj)
+	})
+	require.NotNil(t, store)
+
+	require.NoError(t, store.AddIndex("foo", func(obj interface{}) ([]byte, []byte) {
+		return []byte(obj.(*testObject).Foo), nosqlstore.Encode(obj.(*testObject).N)
+	}))
+
+	var testData []*testObject
+	for i := -5; i <= 5; i++ {
+		id := string('a' + 5 - i)
+		testData = append(testData, &testObject{
+			Id:  id,
+			Foo: "foo",
+			N:   i,
+		})
+	}
+
+	for _, obj := range testData {
+		assert.NoError(t, store.Upsert(obj.Id, obj))
+	}
+
+	var objs []*testObject
+	require.NoError(t, store.Lookup("foo", []byte("x"), nil, &objs))
+	assert.Equal(t, 0, len(objs))
+
+	require.NoError(t, store.Lookup("foo", []byte("x"), nil, &objs))
+	count, err := store.Count("foo", []byte("x"), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count)
+	assert.Equal(t, 0, len(objs))
+
+	for name, tc := range map[string]struct {
+		Range    *nosqlstore.RangeKey
+		Expected []*testObject
+	}{
+		"NilRange":    {nil, testData},
+		"SubsetRange": {nosqlstore.RangeSubset(3, 5), testData[3:8]},
+		"EqualRange":  {nosqlstore.RangeEqualTo(nosqlstore.Encode(-1)), testData[4:5]},
+	} {
+		t.Run(name, func(t *testing.T) {
+			count, err = store.Count("foo", []byte("foo"), tc.Range)
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.Expected), count)
+			require.NoError(t, store.Lookup("foo", []byte("foo"), tc.Range, &objs))
+			assert.Equal(t, len(tc.Expected), len(objs))
+			assert.Equal(t, tc.Expected, objs)
+		})
+	}
+}

--- a/store/nosqlstore/webhook_store.go
+++ b/store/nosqlstore/webhook_store.go
@@ -1,0 +1,347 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package nosqlstore
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/store"
+)
+
+type WebhookStore struct {
+	driver           Driver
+	incomingWebhooks ObjectStore
+	outgoingWebhooks ObjectStore
+}
+
+func NewWebhookStore(driver Driver) (*WebhookStore, error) {
+	s := &WebhookStore{
+		driver: driver,
+		incomingWebhooks: driver.ObjectStore("incoming_webhooks", json.Marshal, func(b []byte) (interface{}, error) {
+			var wh model.IncomingWebhook
+			return &wh, json.Unmarshal(b, &wh)
+		}),
+		outgoingWebhooks: driver.ObjectStore("outgoing_webhooks", json.Marshal, func(b []byte) (interface{}, error) {
+			var wh model.OutgoingWebhook
+			return &wh, json.Unmarshal(b, &wh)
+		}),
+	}
+
+	for name, f := range map[string]func(wh *model.IncomingWebhook) ([]byte, []byte){
+		"delete_at": func(wh *model.IncomingWebhook) ([]byte, []byte) { return Encode(wh.DeleteAt), []byte(wh.Id) },
+		"user_id":   func(wh *model.IncomingWebhook) ([]byte, []byte) { return []byte(wh.UserId), Encode(wh.DeleteAt, wh.Id) },
+		"channel_id": func(wh *model.IncomingWebhook) ([]byte, []byte) {
+			return []byte(wh.ChannelId), Encode(wh.DeleteAt, wh.Id)
+		},
+		"team_id": func(wh *model.IncomingWebhook) ([]byte, []byte) { return []byte(wh.TeamId), Encode(wh.DeleteAt, wh.Id) },
+	} {
+		f := f
+		if err := s.incomingWebhooks.AddIndex(name, func(obj interface{}) ([]byte, []byte) {
+			return f(obj.(*model.IncomingWebhook))
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	for name, f := range map[string]func(wh *model.OutgoingWebhook) ([]byte, []byte){
+		"delete_at": func(wh *model.OutgoingWebhook) ([]byte, []byte) { return Encode(wh.DeleteAt), []byte(wh.Id) },
+		"user_id": func(wh *model.OutgoingWebhook) ([]byte, []byte) {
+			return []byte(wh.CreatorId), Encode(wh.DeleteAt, wh.Id)
+		},
+		"channel_id": func(wh *model.OutgoingWebhook) ([]byte, []byte) {
+			return []byte(wh.ChannelId), Encode(wh.DeleteAt, wh.Id)
+		},
+		"team_id": func(wh *model.OutgoingWebhook) ([]byte, []byte) { return []byte(wh.TeamId), Encode(wh.DeleteAt, wh.Id) },
+	} {
+		f := f
+		if err := s.outgoingWebhooks.AddIndex(name, func(obj interface{}) ([]byte, []byte) {
+			return f(obj.(*model.OutgoingWebhook))
+		}); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}
+
+func (s WebhookStore) InvalidateWebhookCache(webhookId string) {}
+
+func (s WebhookStore) SaveIncoming(webhook *model.IncomingWebhook) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if len(webhook.Id) > 0 {
+			result.Err = model.NewAppError("WebhookStore.SaveIncoming", "store.sql_webhooks.save_incoming.existing.app_error", nil, "id="+webhook.Id, http.StatusBadRequest)
+			return
+		}
+
+		webhook.PreSave()
+		if result.Err = webhook.IsValid(); result.Err != nil {
+			return
+		}
+
+		if err := s.incomingWebhooks.Upsert(webhook.Id, webhook); err != nil {
+			result.Err = model.NewAppError("WebhookStore.SaveIncoming", "store.sql_webhooks.save_incoming.app_error", nil, "id="+webhook.Id+", "+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = webhook
+		}
+	})
+}
+
+func (s WebhookStore) UpdateIncoming(hook *model.IncomingWebhook) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		hook.UpdateAt = model.GetMillis()
+
+		if err := s.incomingWebhooks.Upsert(hook.Id, hook); err != nil {
+			result.Err = model.NewAppError("WebhookStore.UpdateIncoming", "store.sql_webhooks.update_incoming.app_error", nil, "id="+hook.Id+", "+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = hook
+		}
+	})
+}
+
+func (s WebhookStore) GetIncoming(id string, allowFromCache bool) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhook model.IncomingWebhook
+
+		err := s.incomingWebhooks.Get(id, &webhook)
+		if err == ErrNotFound || webhook.DeleteAt > 0 {
+			result.Err = model.NewAppError("WebhookStore.GetIncoming", "store.sql_webhooks.get_incoming.app_error", nil, "id="+id, http.StatusNotFound)
+		} else if err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetIncoming", "store.sql_webhooks.get_incoming.app_error", nil, "id="+id+", err="+err.Error(), http.StatusInternalServerError)
+		}
+
+		result.Data = &webhook
+	})
+}
+
+func (s WebhookStore) DeleteIncoming(id string, time int64) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhook model.IncomingWebhook
+		if err := s.incomingWebhooks.Get(id, &webhook); err != nil {
+			result.Err = model.NewAppError("WebhookStore.DeleteIncoming", "store.sql_webhooks.delete_incoming.app_error", nil, "id="+id+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			webhook.DeleteAt = time
+			if err = s.incomingWebhooks.Upsert(id, &webhook); err != nil {
+				result.Err = model.NewAppError("WebhookStore.DeleteIncoming", "store.sql_webhooks.delete_incoming.app_error", nil, "id="+id+", err="+err.Error(), http.StatusInternalServerError)
+			}
+		}
+	})
+}
+
+func (s WebhookStore) PermanentDeleteIncomingByUser(userId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.IncomingWebhook
+		if err := s.incomingWebhooks.Lookup("user_id", []byte(userId), nil, &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.DeleteIncomingByUser", "store.sql_webhooks.permanent_delete_incoming_by_user.app_error", nil, "id="+userId+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			for _, webhook := range webhooks {
+				if err := s.incomingWebhooks.Delete(webhook.Id); err != nil {
+					result.Err = model.NewAppError("WebhookStore.DeleteIncomingByUser", "store.sql_webhooks.permanent_delete_incoming_by_user.app_error", nil, "id="+userId+", err="+err.Error(), http.StatusInternalServerError)
+					break
+				}
+			}
+		}
+	})
+}
+
+func (s WebhookStore) PermanentDeleteIncomingByChannel(channelId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.IncomingWebhook
+		if err := s.incomingWebhooks.Lookup("channel_id", []byte(channelId), nil, &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.DeleteIncomingByChannel", "store.sql_webhooks.permanent_delete_incoming_by_channel.app_error", nil, "id="+channelId+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			for _, webhook := range webhooks {
+				if err := s.incomingWebhooks.Delete(webhook.Id); err != nil {
+					result.Err = model.NewAppError("WebhookStore.DeleteIncomingByChannel", "store.sql_webhooks.permanent_delete_incoming_by_channel.app_error", nil, "id="+channelId+", err="+err.Error(), http.StatusInternalServerError)
+					break
+				}
+			}
+		}
+	})
+}
+
+func (s WebhookStore) GetIncomingList(offset, limit int) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.IncomingWebhook
+		if err := s.incomingWebhooks.Lookup("delete_at", Encode(0), RangeSubset(offset, limit), &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetIncomingList", "store.sql_webhooks.get_incoming_by_user.app_error", nil, "err="+err.Error(), http.StatusInternalServerError)
+		}
+		result.Data = webhooks
+	})
+}
+
+func (s WebhookStore) GetIncomingByTeam(teamId string, offset, limit int) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.IncomingWebhook
+		if err := s.incomingWebhooks.Lookup("team_id", []byte(teamId), RangeLessThan(Encode(1)).Subset(offset, limit), &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetIncomingByUser", "store.sql_webhooks.get_incoming_by_user.app_error", nil, "teamId="+teamId+", err="+err.Error(), http.StatusInternalServerError)
+		}
+		result.Data = webhooks
+	})
+}
+
+func (s WebhookStore) GetIncomingByChannel(channelId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.IncomingWebhook
+		if err := s.incomingWebhooks.Lookup("channel_id", []byte(channelId), RangeLessThan(Encode(1)), &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetIncomingByChannel", "store.sql_webhooks.get_incoming_by_channel.app_error", nil, "channelId="+channelId+", err="+err.Error(), http.StatusInternalServerError)
+		}
+		result.Data = webhooks
+	})
+}
+
+func (s WebhookStore) SaveOutgoing(webhook *model.OutgoingWebhook) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if len(webhook.Id) > 0 {
+			result.Err = model.NewAppError("WebhookStore.SaveOutgoing", "store.sql_webhooks.save_outgoing.override.app_error", nil, "id="+webhook.Id, http.StatusBadRequest)
+			return
+		}
+
+		webhook.PreSave()
+		if result.Err = webhook.IsValid(); result.Err != nil {
+			return
+		}
+
+		if err := s.outgoingWebhooks.Upsert(webhook.Id, webhook); err != nil {
+			result.Err = model.NewAppError("WebhookStore.SaveOutgoing", "store.sql_webhooks.save_outgoing.app_error", nil, "id="+webhook.Id+", "+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = webhook
+		}
+	})
+}
+
+func (s WebhookStore) GetOutgoing(id string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhook model.OutgoingWebhook
+
+		err := s.outgoingWebhooks.Get(id, &webhook)
+		if err == ErrNotFound || webhook.DeleteAt > 0 {
+			result.Err = model.NewAppError("WebhookStore.GetOutgoing", "store.sql_webhooks.get_outgoing.app_error", nil, "id="+id, http.StatusNotFound)
+		} else if err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetOutgoing", "store.sql_webhooks.get_outgoing.app_error", nil, "id="+id+", err="+err.Error(), http.StatusInternalServerError)
+		}
+
+		result.Data = &webhook
+	})
+}
+
+func (s WebhookStore) GetOutgoingList(offset, limit int) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.OutgoingWebhook
+		if err := s.outgoingWebhooks.Lookup("delete_at", Encode(0), RangeSubset(offset, limit), &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetOutgoingList", "store.sql_webhooks.get_outgoing_by_channel.app_error", nil, "err="+err.Error(), http.StatusInternalServerError)
+		}
+		result.Data = webhooks
+	})
+}
+
+func (s WebhookStore) GetOutgoingByChannel(channelId string, offset, limit int) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.OutgoingWebhook
+		if err := s.outgoingWebhooks.Lookup("channel_id", []byte(channelId), RangeLessThan(Encode(1)).Subset(offset, limit), &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetOutgoingByChannel", "store.sql_webhooks.get_outgoing_by_channel.app_error", nil, "channelId="+channelId+", err="+err.Error(), http.StatusInternalServerError)
+		}
+		result.Data = webhooks
+	})
+}
+
+func (s WebhookStore) GetOutgoingByTeam(teamId string, offset, limit int) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.OutgoingWebhook
+		if err := s.outgoingWebhooks.Lookup("team_id", []byte(teamId), RangeLessThan(Encode(1)).Subset(offset, limit), &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.GetOutgoingByTeam", "store.sql_webhooks.get_outgoing_by_team.app_error", nil, "teamId="+teamId+", err="+err.Error(), http.StatusInternalServerError)
+		}
+		result.Data = webhooks
+	})
+}
+
+func (s WebhookStore) DeleteOutgoing(webhookId string, time int64) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhook model.OutgoingWebhook
+		if err := s.outgoingWebhooks.Get(webhookId, &webhook); err != nil {
+			result.Err = model.NewAppError("WebhookStore.DeleteOutgoing", "store.sql_webhooks.delete_outgoing.app_error", nil, "id="+webhookId+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			webhook.DeleteAt = time
+			if err = s.outgoingWebhooks.Upsert(webhookId, &webhook); err != nil {
+				result.Err = model.NewAppError("WebhookStore.DeleteOutgoing", "store.sql_webhooks.delete_outgoing.app_error", nil, "id="+webhookId+", err="+err.Error(), http.StatusInternalServerError)
+			}
+		}
+	})
+}
+
+func (s WebhookStore) PermanentDeleteOutgoingByUser(userId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.OutgoingWebhook
+		if err := s.outgoingWebhooks.Lookup("user_id", []byte(userId), nil, &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.DeleteOutgoingByUser", "store.sql_webhooks.permanent_delete_outgoing_by_user.app_error", nil, "id="+userId+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			for _, webhook := range webhooks {
+				if err := s.outgoingWebhooks.Delete(webhook.Id); err != nil {
+					result.Err = model.NewAppError("WebhookStore.DeleteOutgoingByUser", "store.sql_webhooks.permanent_delete_outgoing_by_user.app_error", nil, "id="+userId+", err="+err.Error(), http.StatusInternalServerError)
+					break
+				}
+			}
+		}
+	})
+}
+
+func (s WebhookStore) PermanentDeleteOutgoingByChannel(channelId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var webhooks []*model.OutgoingWebhook
+		if err := s.outgoingWebhooks.Lookup("channel_id", []byte(channelId), nil, &webhooks); err != nil {
+			result.Err = model.NewAppError("WebhookStore.DeleteOutgoingByChannel", "store.sql_webhooks.permanent_delete_outgoing_by_channel.app_error", nil, "id="+channelId+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			for _, webhook := range webhooks {
+				if err := s.outgoingWebhooks.Delete(webhook.Id); err != nil {
+					result.Err = model.NewAppError("WebhookStore.DeleteOutgoingByChannel", "store.sql_webhooks.permanent_delete_outgoing_by_channel.app_error", nil, "id="+channelId+", err="+err.Error(), http.StatusInternalServerError)
+					break
+				}
+			}
+		}
+	})
+}
+
+func (s WebhookStore) UpdateOutgoing(hook *model.OutgoingWebhook) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		hook.UpdateAt = model.GetMillis()
+
+		if err := s.outgoingWebhooks.Upsert(hook.Id, hook); err != nil {
+			result.Err = model.NewAppError("WebhookStore.UpdateOutgoing", "store.sql_webhooks.update_outgoing.app_error", nil, "id="+hook.Id+", "+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = hook
+		}
+	})
+}
+
+func (s WebhookStore) AnalyticsIncomingCount(teamId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if teamId == "" {
+			if count, err := s.incomingWebhooks.Count("delete_at", Encode(0), nil); err != nil {
+				result.Err = model.NewAppError("WebhookStore.AnalyticsIncomingCount", "store.sql_webhooks.analytics_incoming_count.app_error", nil, "team_id="+teamId+", err="+err.Error(), http.StatusInternalServerError)
+			} else {
+				result.Data = int64(count)
+			}
+		} else if count, err := s.incomingWebhooks.Count("team_id", []byte(teamId), RangeLessThan(Encode(1))); err != nil {
+			result.Err = model.NewAppError("WebhookStore.AnalyticsIncomingCount", "store.sql_webhooks.analytics_incoming_count.app_error", nil, "team_id="+teamId+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = int64(count)
+		}
+	})
+}
+
+func (s WebhookStore) AnalyticsOutgoingCount(teamId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if teamId == "" {
+			if count, err := s.outgoingWebhooks.Count("delete_at", Encode(0), nil); err != nil {
+				result.Err = model.NewAppError("WebhookStore.AnalyticsOutgoingCount", "store.sql_webhooks.analytics_outgoing_count.app_error", nil, "team_id="+teamId+", err="+err.Error(), http.StatusInternalServerError)
+			} else {
+				result.Data = int64(count)
+			}
+		} else if count, err := s.outgoingWebhooks.Count("team_id", []byte(teamId), RangeLessThan(Encode(1))); err != nil {
+			result.Err = model.NewAppError("WebhookStore.AnalyticsOutgoingCount", "store.sql_webhooks.analytics_outgoing_count.app_error", nil, "team_id="+teamId+", err="+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = int64(count)
+		}
+	})
+}

--- a/store/nosqlstore/webhook_store_test.go
+++ b/store/nosqlstore/webhook_store_test.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package nosqlstore_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/store/memorystore"
+	"github.com/mattermost/mattermost-server/store/storetest"
+)
+
+func TestWebhookStore(t *testing.T) {
+	s, err := memorystore.New()
+	require.NoError(t, err)
+	storetest.TestWebhookStore(t, s)
+}

--- a/store/storetest/webhook_store.go
+++ b/store/storetest/webhook_store.go
@@ -296,11 +296,11 @@ func testWebhookStoreGetOutgoingList(t *testing.T, ss store.Store) {
 		found2 := false
 
 		for _, hook := range hooks {
-			if hook.CreateAt != o1.CreateAt {
+			if hook.Id == o1.Id {
 				found1 = true
 			}
 
-			if hook.CreateAt != o2.CreateAt {
+			if hook.Id != o2.Id {
 				found2 = true
 			}
 		}

--- a/vendor/github.com/ccbrown/go-immutable/.travis.yml
+++ b/vendor/github.com/ccbrown/go-immutable/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+script:
+  - go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+  - go vet ./...
+  - '! gofmt -s -d . 2>&1 | read'
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/vendor/github.com/ccbrown/go-immutable/LICENSE
+++ b/vendor/github.com/ccbrown/go-immutable/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Christopher Brown
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/ccbrown/go-immutable/README.md
+++ b/vendor/github.com/ccbrown/go-immutable/README.md
@@ -1,0 +1,11 @@
+# Immutable [![Build Status](https://travis-ci.org/ccbrown/go-immutable.svg?branch=master)](https://travis-ci.org/ccbrown/go-immutable) [![codecov](https://codecov.io/gh/ccbrown/go-immutable/branch/master/graph/badge.svg)](https://codecov.io/gh/ccbrown/go-immutable) [![Documentation](https://godoc.org/github.com/ccbrown/go-immutable?status.svg)](https://godoc.org/github.com/ccbrown/go-immutable)
+
+A collection of fast, general-purpose immutable data structures.
+
+## Data Structures
+
+All data structures are fully persistent and safe for concurrent use. Unless otherwise noted, time complexities are worst-case (not amortized).
+
+* Stack: Last in, first out. Constant time operations.
+* Queue: First in, first out. Constant time operations.
+* Ordered Map: Map with in-order iteration. Logarithmic time operations.

--- a/vendor/github.com/ccbrown/go-immutable/lazy_list.go
+++ b/vendor/github.com/ccbrown/go-immutable/lazy_list.go
@@ -1,0 +1,40 @@
+package immutable
+
+import (
+	"sync"
+)
+
+type lazyList struct {
+	value      interface{}
+	lazyNext   func() *lazyList
+	next       *lazyList
+	evaluation sync.Once
+}
+
+func newLazyList(front interface{}, next func() *lazyList) *lazyList {
+	return &lazyList{
+		value:    front,
+		lazyNext: next,
+	}
+}
+
+func (l *lazyList) Front() interface{} {
+	return l.value
+}
+
+func (l *lazyList) PopFront() *lazyList {
+	l.evaluation.Do(func() {
+		if l.lazyNext != nil {
+			l.next = l.lazyNext()
+			l.lazyNext = nil
+		}
+	})
+	return l.next
+}
+
+func (l *lazyList) PushFront(value interface{}) *lazyList {
+	return &lazyList{
+		value: value,
+		next:  l,
+	}
+}

--- a/vendor/github.com/ccbrown/go-immutable/ordered_map.go
+++ b/vendor/github.com/ccbrown/go-immutable/ordered_map.go
@@ -1,0 +1,610 @@
+package immutable
+
+import (
+	"strings"
+)
+
+const (
+	orderedMapNegativeBlack = -1
+	orderedMapRed           = 0
+	orderedMapBlack         = 1
+	orderedMapDoubleBlack   = 2
+)
+
+// OrderedMap implements an ordered map.
+//
+// Nil and the zero value for OrderedMap are both empty maps.
+type OrderedMap struct {
+	len          int
+	color        int
+	left         *OrderedMap
+	right        *OrderedMap
+	key          interface{}
+	value        interface{}
+	lessThanFunc func(interface{}, interface{}) bool
+}
+
+// Empty returns true if the map is empty.
+//
+// Complexity: O(1) worst-case
+func (m *OrderedMap) Empty() bool {
+	return m == nil || m.key == nil
+}
+
+// Len returns the number of elements in the map.
+//
+// Complexity: O(1) worst-case
+func (m *OrderedMap) Len() int {
+	if m == nil {
+		return 0
+	}
+	return m.len
+}
+
+// Get returns the value associated with the given key if set.
+//
+// Complexity: O(log n) worst-case
+func (m *OrderedMap) Get(key interface{}) (interface{}, bool) {
+	l := m.lessThanFuncOrEqual(key, nil)
+	if l == nil {
+		return nil, false
+	}
+	if !m.lessThanFunc(l.key, key) {
+		return l.value, true
+	}
+	return nil, false
+}
+
+// Set associates a value with the given key.
+//
+// Only the built-in types may be used as keys. Once a value is set within a map, all subsequent
+// operations must use the same key type.
+//
+// Complexity: O(log n) worst-case
+func (m *OrderedMap) Set(key, value interface{}) *OrderedMap {
+	ret := m.insert(key, value)
+	ret.color = orderedMapBlack
+	return ret
+}
+
+// Delete removes a key from the map.
+//
+// Complexity: O(log n) worst-case
+func (m *OrderedMap) Delete(key interface{}) *OrderedMap {
+	if ret, _ := m.delete(key); !ret.Empty() {
+		ret.color = orderedMapBlack
+		return ret
+	}
+	return nil
+}
+
+// Min returns the minimum element in the map.
+//
+// Complexity: O(log n) worst-case
+func (m *OrderedMap) Min() *OrderedMapElement {
+	return m.min(nil)
+}
+
+// Max returns the maximum element in the map.
+//
+// Complexity: O(log n) worst-case
+func (m *OrderedMap) Max() *OrderedMapElement {
+	return m.max(nil)
+}
+
+// MinAfter returns the minimum element in the map that is greater than the given key.
+//
+// Complexity: O(log n) worst-case
+func (m *OrderedMap) MinAfter(key interface{}) *OrderedMapElement {
+	return m.minGreaterThan(key, nil)
+}
+
+// MaxBefore returns the maximum element in the map that is less than the given key.
+//
+// Complexity: O(log n) worst-case
+func (m *OrderedMap) MaxBefore(key interface{}) *OrderedMapElement {
+	return m.maxLessThan(key, nil)
+}
+
+func (m *OrderedMap) min(lineage *Stack) *OrderedMapElement {
+	if m.Empty() {
+		return nil
+	} else if m.left != nil {
+		return m.left.min(lineage.Push(m))
+	}
+	return &OrderedMapElement{
+		lineage: lineage,
+		element: m,
+	}
+}
+
+func (m *OrderedMap) max(lineage *Stack) *OrderedMapElement {
+	if m.Empty() {
+		return nil
+	} else if m.right != nil {
+		return m.right.max(lineage.Push(m))
+	}
+	return &OrderedMapElement{
+		lineage: lineage,
+		element: m,
+	}
+}
+
+func (m *OrderedMap) minGreaterThan(key interface{}, lineage *Stack) *OrderedMapElement {
+	if m.Empty() {
+		return nil
+	} else if m.lessThanFunc(key, m.key) {
+		if m.left != nil {
+			if r := m.left.minGreaterThan(key, lineage.Push(m)); r != nil {
+				return r
+			}
+		}
+		return &OrderedMapElement{
+			lineage: lineage,
+			element: m,
+		}
+	} else if m.lessThanFunc(m.key, key) {
+		return m.right.minGreaterThan(key, lineage.Push(m))
+	}
+	return m.right.min(lineage.Push(m))
+}
+
+func (m *OrderedMap) maxLessThan(key interface{}, lineage *Stack) *OrderedMapElement {
+	if m.Empty() {
+		return nil
+	} else if m.lessThanFunc(m.key, key) {
+		if m.right != nil {
+			if r := m.right.maxLessThan(key, lineage.Push(m)); r != nil {
+				return r
+			}
+		}
+		return &OrderedMapElement{
+			lineage: lineage,
+			element: m,
+		}
+	} else if m.lessThanFunc(key, m.key) {
+		return m.left.maxLessThan(key, lineage.Push(m))
+	}
+	return m.left.max(lineage.Push(m))
+}
+
+func (m *OrderedMap) delete(key interface{}) (*OrderedMap, bool) {
+	if m.Empty() {
+		return m, false
+	} else if m.lessThanFunc(key, m.key) {
+		if left, didDelete := m.left.delete(key); didDelete {
+			return m.adopt(left, m.right).bubble(), true
+		}
+		return m, false
+	} else if m.lessThanFunc(m.key, key) {
+		if right, didDelete := m.right.delete(key); didDelete {
+			return m.adopt(m.left, right).bubble(), true
+		}
+		return m, false
+	}
+	return m.remove(), true
+}
+
+func (m *OrderedMap) adopt(left, right *OrderedMap) *OrderedMap {
+	return &OrderedMap{
+		len:          1 + left.Len() + right.Len(),
+		color:        m.color,
+		left:         left,
+		right:        right,
+		key:          m.key,
+		value:        m.value,
+		lessThanFunc: m.lessThanFunc,
+	}
+}
+
+func (m *OrderedMap) lessThanFuncOrEqual(key interface{}, candidate *OrderedMap) *OrderedMap {
+	if m.Empty() {
+		return candidate
+	} else if m.lessThanFunc(key, m.key) {
+		return m.left.lessThanFuncOrEqual(key, candidate)
+	}
+	return m.right.lessThanFuncOrEqual(key, m)
+}
+
+func (m *OrderedMap) insert(key, value interface{}) *OrderedMap {
+	if m.Empty() {
+		return &OrderedMap{
+			len:          1,
+			color:        orderedMapRed,
+			key:          key,
+			value:        value,
+			lessThanFunc: builtInLessThan(key),
+		}
+	} else if m.lessThanFunc(key, m.key) {
+		return m.adopt(m.left.insert(key, value), m.right).balanceLeft()
+	} else if m.lessThanFunc(m.key, key) {
+		return m.adopt(m.left, m.right.insert(key, value)).balanceRight()
+	}
+	return &OrderedMap{
+		len:          m.len,
+		color:        m.color,
+		left:         m.left,
+		right:        m.right,
+		key:          m.key,
+		value:        value,
+		lessThanFunc: m.lessThanFunc,
+	}
+}
+
+func (m *OrderedMap) balanceLeft() *OrderedMap {
+	if m.color >= orderedMapBlack && m.left != nil {
+		if m.left.color == orderedMapRed {
+			if m.left.left != nil && m.left.left.color == orderedMapRed {
+				return &OrderedMap{
+					len:   m.len,
+					color: m.color - 1,
+					left: &OrderedMap{
+						len:          m.left.left.len,
+						color:        orderedMapBlack,
+						left:         m.left.left.left,
+						right:        m.left.left.right,
+						key:          m.left.left.key,
+						value:        m.left.left.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					right: &OrderedMap{
+						len:          1 + m.left.right.Len() + m.right.Len(),
+						color:        orderedMapBlack,
+						left:         m.left.right,
+						right:        m.right,
+						key:          m.key,
+						value:        m.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					key:          m.left.key,
+					value:        m.left.value,
+					lessThanFunc: m.lessThanFunc,
+				}
+			} else if m.left.right != nil && m.left.right.color == orderedMapRed {
+				return &OrderedMap{
+					len:   m.len,
+					color: m.color - 1,
+					left: &OrderedMap{
+						len:          1 + m.left.left.Len() + m.left.right.left.Len(),
+						color:        orderedMapBlack,
+						left:         m.left.left,
+						right:        m.left.right.left,
+						key:          m.left.key,
+						value:        m.left.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					right: &OrderedMap{
+						len:          1 + m.left.right.right.Len() + m.right.Len(),
+						color:        orderedMapBlack,
+						left:         m.left.right.right,
+						right:        m.right,
+						key:          m.key,
+						value:        m.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					key:          m.left.right.key,
+					value:        m.left.right.value,
+					lessThanFunc: m.lessThanFunc,
+				}
+			}
+		} else if m.left.color == orderedMapNegativeBlack {
+			left := &OrderedMap{
+				len:          1 + m.left.left.Len() + m.left.right.left.Len(),
+				color:        orderedMapBlack,
+				left:         m.left.left.redden(),
+				right:        m.left.right.left,
+				key:          m.left.key,
+				value:        m.left.value,
+				lessThanFunc: m.lessThanFunc,
+			}
+			left = left.balanceLeft()
+			right := &OrderedMap{
+				len:          1 + m.left.right.right.Len() + m.right.Len(),
+				color:        orderedMapBlack,
+				left:         m.left.right.right,
+				right:        m.right,
+				key:          m.key,
+				value:        m.value,
+				lessThanFunc: m.lessThanFunc,
+			}
+			return &OrderedMap{
+				len:          1 + left.Len() + right.Len(),
+				color:        orderedMapBlack,
+				left:         left,
+				right:        right,
+				key:          m.left.right.key,
+				value:        m.left.right.value,
+				lessThanFunc: m.lessThanFunc,
+			}
+		}
+	}
+	return m
+}
+
+func (m *OrderedMap) balanceRight() *OrderedMap {
+	if m.color >= orderedMapBlack && m.right != nil {
+		if m.right.color == orderedMapRed {
+			if m.right.left != nil && m.right.left.color == orderedMapRed {
+				return &OrderedMap{
+					len:   m.len,
+					color: m.color - 1,
+					left: &OrderedMap{
+						len:          1 + m.left.Len() + m.right.left.left.Len(),
+						color:        orderedMapBlack,
+						left:         m.left,
+						right:        m.right.left.left,
+						key:          m.key,
+						value:        m.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					right: &OrderedMap{
+						len:          1 + m.right.left.right.Len() + m.right.right.Len(),
+						color:        orderedMapBlack,
+						left:         m.right.left.right,
+						right:        m.right.right,
+						key:          m.right.key,
+						value:        m.right.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					key:          m.right.left.key,
+					value:        m.right.left.value,
+					lessThanFunc: m.lessThanFunc,
+				}
+			} else if m.right.right != nil && m.right.right.color == orderedMapRed {
+				return &OrderedMap{
+					len:   m.len,
+					color: m.color - 1,
+					left: &OrderedMap{
+						len:          1 + m.left.Len() + m.right.left.Len(),
+						color:        orderedMapBlack,
+						left:         m.left,
+						right:        m.right.left,
+						key:          m.key,
+						value:        m.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					right: &OrderedMap{
+						len:          m.right.right.len,
+						color:        orderedMapBlack,
+						left:         m.right.right.left,
+						right:        m.right.right.right,
+						key:          m.right.right.key,
+						value:        m.right.right.value,
+						lessThanFunc: m.lessThanFunc,
+					},
+					key:          m.right.key,
+					value:        m.right.value,
+					lessThanFunc: m.lessThanFunc,
+				}
+			}
+		} else if m.right.color == orderedMapNegativeBlack {
+			left := &OrderedMap{
+				len:          1 + m.left.Len() + m.right.left.left.Len(),
+				color:        orderedMapBlack,
+				left:         m.left,
+				right:        m.right.left.left,
+				key:          m.key,
+				value:        m.value,
+				lessThanFunc: m.lessThanFunc,
+			}
+			right := &OrderedMap{
+				len:          1 + m.right.left.right.Len() + m.right.right.Len(),
+				color:        orderedMapBlack,
+				left:         m.right.left.right,
+				right:        m.right.right.redden(),
+				key:          m.right.key,
+				value:        m.right.value,
+				lessThanFunc: m.lessThanFunc,
+			}
+			right = right.balanceRight()
+			return &OrderedMap{
+				len:          1 + left.Len() + right.Len(),
+				color:        orderedMapBlack,
+				left:         left,
+				right:        right,
+				key:          m.right.left.key,
+				value:        m.right.left.value,
+				lessThanFunc: m.lessThanFunc,
+			}
+		}
+	}
+	return m
+}
+
+var doubleBlackLeaf = &OrderedMap{color: orderedMapDoubleBlack}
+
+func (m *OrderedMap) remove() *OrderedMap {
+	if !m.left.Empty() && !m.right.Empty() {
+		left, removed := m.left.removeMax()
+		reduced := &OrderedMap{
+			len:          m.len - 1,
+			color:        m.color,
+			left:         left,
+			right:        m.right,
+			key:          removed.key,
+			value:        removed.value,
+			lessThanFunc: m.lessThanFunc,
+		}
+		return reduced.bubble()
+	}
+	var child *OrderedMap
+	if !m.left.Empty() {
+		child = m.left
+	} else if !m.right.Empty() {
+		child = m.right
+	} else {
+		if m.color == orderedMapRed {
+			return nil
+		}
+		return doubleBlackLeaf
+	}
+	ret := *child
+	ret.color = orderedMapBlack
+	return &ret
+}
+
+func (m *OrderedMap) removeMax() (result, removed *OrderedMap) {
+	if m.right == nil {
+		return m.remove(), m
+	}
+	right, removed := m.right.removeMax()
+	return m.adopt(m.left, right).bubble(), removed
+}
+
+func (m *OrderedMap) redden() *OrderedMap {
+	if m == doubleBlackLeaf {
+		return nil
+	}
+	ret := *m
+	ret.color--
+	return &ret
+}
+
+func (m *OrderedMap) bubble() *OrderedMap {
+	if (m.left != nil && m.left.color == orderedMapDoubleBlack) || (m.right != nil && m.right.color == orderedMapDoubleBlack) {
+		unbalanced := &OrderedMap{
+			len:          m.len,
+			color:        m.color + 1,
+			left:         m.left.redden(),
+			right:        m.right.redden(),
+			key:          m.key,
+			value:        m.value,
+			lessThanFunc: m.lessThanFunc,
+		}
+		if m.left != nil && m.left.color == orderedMapDoubleBlack {
+			return unbalanced.balanceRight()
+		}
+		return unbalanced.balanceLeft()
+	}
+	return m
+}
+
+// OrderedMapElement represents a key-value pair and can be used to iterate over elements in a map.
+type OrderedMapElement struct {
+	lineage *Stack
+	element *OrderedMap
+}
+
+// Key returns the key of the represented element.
+func (e *OrderedMapElement) Key() interface{} {
+	return e.element.key
+}
+
+// Value returns the value of the represented element.
+func (e *OrderedMapElement) Value() interface{} {
+	return e.element.value
+}
+
+// Next returns the next element in the map.
+//
+// Complexity: O(log n) worst-case, amortized O(1) if iterating over the entire map
+func (e *OrderedMapElement) Next() *OrderedMapElement {
+	if !e.element.right.Empty() {
+		lineage := e.lineage.Push(e.element)
+		m := e.element.right
+		for !m.Empty() && m.left != nil {
+			lineage = lineage.Push(m)
+			m = m.left
+		}
+		return &OrderedMapElement{
+			lineage: lineage,
+			element: m,
+		}
+	}
+	for l := e.lineage; !l.Empty(); l = l.Pop() {
+		if e.element.lessThanFunc(e.element.key, l.Peek().(*OrderedMap).key) {
+			return &OrderedMapElement{
+				lineage: l.Pop(),
+				element: l.Peek().(*OrderedMap),
+			}
+		}
+	}
+	return nil
+}
+
+// Prev returns the previous element in the map.
+//
+// Complexity: O(log n) worst-case, amortized O(1) if iterating over an entire map
+func (e *OrderedMapElement) Prev() *OrderedMapElement {
+	if !e.element.left.Empty() {
+		lineage := e.lineage.Push(e.element)
+		m := e.element.left
+		for !m.Empty() && m.right != nil {
+			lineage = lineage.Push(m)
+			m = m.right
+		}
+		return &OrderedMapElement{
+			lineage: lineage,
+			element: m,
+		}
+	}
+	for l := e.lineage; !l.Empty(); l = l.Pop() {
+		if e.element.lessThanFunc(l.Peek().(*OrderedMap).key, e.element.key) {
+			return &OrderedMapElement{
+				lineage: l.Pop(),
+				element: l.Peek().(*OrderedMap),
+			}
+		}
+	}
+	return nil
+}
+
+// CountLess returns the number of elements that are less than this element.
+//
+// Complexity: O(log n) worst-case
+func (e *OrderedMapElement) CountLess() int {
+	count := e.element.left.Len()
+	for l := e.lineage; !l.Empty(); l = l.Pop() {
+		if e.element.lessThanFunc(l.Peek().(*OrderedMap).key, e.element.key) {
+			count += 1 + l.Peek().(*OrderedMap).left.Len()
+		}
+	}
+	return count
+}
+
+// CountGreater returns the number of elements that are greater than this element.
+//
+// Complexity: O(log n) worst-case
+func (e *OrderedMapElement) CountGreater() int {
+	count := e.element.right.Len()
+	for l := e.lineage; !l.Empty(); l = l.Pop() {
+		if e.element.lessThanFunc(e.element.key, l.Peek().(*OrderedMap).key) {
+			count += 1 + l.Peek().(*OrderedMap).right.Len()
+		}
+	}
+	return count
+}
+
+func builtInLessThan(value interface{}) func(interface{}, interface{}) bool {
+	switch value.(type) {
+	case int:
+		return func(a, b interface{}) bool { return a.(int) < b.(int) }
+	case int8:
+		return func(a, b interface{}) bool { return a.(int8) < b.(int8) }
+	case int16:
+		return func(a, b interface{}) bool { return a.(int16) < b.(int16) }
+	case int32:
+		return func(a, b interface{}) bool { return a.(int32) < b.(int32) }
+	case int64:
+		return func(a, b interface{}) bool { return a.(int64) < b.(int64) }
+	case uint:
+		return func(a, b interface{}) bool { return a.(uint) < b.(uint) }
+	case uint8:
+		return func(a, b interface{}) bool { return a.(uint8) < b.(uint8) }
+	case uint16:
+		return func(a, b interface{}) bool { return a.(uint16) < b.(uint16) }
+	case uint32:
+		return func(a, b interface{}) bool { return a.(uint32) < b.(uint32) }
+	case uint64:
+		return func(a, b interface{}) bool { return a.(uint64) < b.(uint64) }
+	case uintptr:
+		return func(a, b interface{}) bool { return a.(uintptr) < b.(uintptr) }
+	case float32:
+		return func(a, b interface{}) bool { return a.(float32) < b.(float32) }
+	case float64:
+		return func(a, b interface{}) bool { return a.(float64) < b.(float64) }
+	case string:
+		return func(a, b interface{}) bool { return strings.Compare(a.(string), b.(string)) == -1 }
+	}
+	panic("invalid type")
+}

--- a/vendor/github.com/ccbrown/go-immutable/ordered_map_test.go
+++ b/vendor/github.com/ccbrown/go-immutable/ordered_map_test.go
@@ -1,0 +1,279 @@
+package immutable
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderedMap(t *testing.T) {
+	var m *OrderedMap
+	assert.True(t, m.Empty())
+	assert.Equal(t, 0, m.Len())
+	require.NoError(t, m.invariant())
+
+	m = m.Set("foo", "bar")
+	assert.False(t, m.Empty())
+	assert.Equal(t, 1, m.Len())
+	require.NoError(t, m.invariant())
+
+	v, ok := m.Get("foo")
+	assert.True(t, ok)
+	assert.Equal(t, "bar", v)
+
+	_, ok = m.Get("fom")
+	assert.False(t, ok)
+
+	_, ok = m.Get("fop")
+	assert.False(t, ok)
+
+	m = m.Set("qux", "quux")
+	assert.False(t, m.Empty())
+	assert.Equal(t, 2, m.Len())
+	require.NoError(t, m.invariant())
+
+	v, ok = m.Get("foo")
+	assert.True(t, ok)
+	assert.Equal(t, "bar", v)
+	m = m.Delete("foo")
+	assert.Equal(t, 1, m.Len())
+	_, ok = m.Get("foo")
+	assert.False(t, ok)
+	v, ok = m.Get("qux")
+	assert.True(t, ok)
+	assert.Equal(t, "quux", v)
+}
+
+func TestOrderedMap_KeyTypes(t *testing.T) {
+	var m *OrderedMap
+
+	for _, keys := range [][]interface{}{
+		{int(1), int(2)},
+		{int8(1), int8(2)},
+		{int16(1), int16(2)},
+		{int32(1), int32(2)},
+		{int64(1), int64(2)},
+		{uint(1), uint(2)},
+		{uint8(1), uint8(2)},
+		{uint16(1), uint16(2)},
+		{uint32(1), uint32(2)},
+		{uint64(1), uint64(2)},
+		{uintptr(1), uintptr(2)},
+		{float32(1), float32(2)},
+		{float64(1), float64(2)},
+		{"1", "2"},
+	} {
+		t.Run(fmt.Sprintf("%T", keys[0]), func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				kv := m.Set(keys[0], 1).Set(keys[1], 2).Min()
+				assert.Equal(t, keys[0], kv.Key())
+				assert.Equal(t, keys[1], kv.Next().Key())
+			})
+		})
+	}
+
+	t.Run("struct", func(t *testing.T) {
+		assert.Panics(t, func() {
+			m.Set(struct{}{}, 1)
+		})
+	})
+}
+
+func TestOrderedMap_Delete(t *testing.T) {
+	var m *OrderedMap
+	for i := 0; i < 50; i++ {
+		m = m.Set(i, i)
+		require.NoError(t, m.invariant())
+		for j := 0; j <= i; j++ {
+			m2 := m.Delete(j)
+			require.NoError(t, m2.invariant(), fmt.Sprintf("i=%v,j=%v", i, j))
+			k := 0
+			for kv := m2.Min(); kv != nil; kv = kv.Next() {
+				if k == j {
+					k++
+				}
+				assert.Equal(t, k, kv.Key(), fmt.Sprintf("i=%v,j=%v", i, j))
+				assert.Equal(t, k, kv.Value(), fmt.Sprintf("i=%v,j=%v", i, j))
+				k++
+			}
+		}
+	}
+}
+
+func TestOrderedMap_MinAfter(t *testing.T) {
+	var m *OrderedMap
+	for i := 0; i < 40; i += 2 {
+		m = m.Set(i, i)
+		assert.Nil(t, m.MinAfter(i))
+		for j := -1; j < i; j++ {
+			kv := m.MinAfter(j)
+			require.NotNil(t, kv, fmt.Sprintf("i=%v,j=%v", i, j))
+			expected := (j + 1) + ((j + 1) % 2)
+			assert.Equal(t, expected, kv.Key())
+			if expected+2 <= i {
+				assert.Equal(t, expected+2, kv.Next().Key())
+			}
+		}
+	}
+}
+
+func TestOrderedMap_MaxBefore(t *testing.T) {
+	var m *OrderedMap
+	for i := 0; i < 40; i += 2 {
+		m = m.Set(i, i)
+		assert.Nil(t, m.MaxBefore(0))
+		for j := 1; j <= i+1; j++ {
+			kv := m.MaxBefore(j)
+			require.NotNil(t, kv, fmt.Sprintf("i=%v,j=%v", i, j))
+			expected := (j - 1) - ((j + 1) % 2)
+			assert.Equal(t, expected, kv.Key())
+			if expected+2 <= i {
+				assert.Equal(t, expected+2, kv.Next().Key())
+			}
+		}
+	}
+}
+
+func TestOrderedMap_Iteration(t *testing.T) {
+	var m *OrderedMap
+	assert.Nil(t, m.Min())
+
+	for i := 0; i < 1000; i++ {
+		m = m.Set(i, i*2)
+	}
+
+	e := m.Min()
+	for i := 0; i < 1000; i++ {
+		assert.NotNil(t, e)
+		assert.Equal(t, i, e.Key())
+		assert.Equal(t, i*2, e.Value())
+		assert.Equal(t, i, e.CountLess())
+		assert.Equal(t, 1000-i-1, e.CountGreater())
+		e = e.Next()
+	}
+	assert.Nil(t, e)
+
+	e = m.Max()
+	for i := 999; i >= 0; i-- {
+		assert.NotNil(t, e)
+		assert.Equal(t, i, e.Key())
+		assert.Equal(t, i*2, e.Value())
+		e = e.Prev()
+	}
+	assert.Nil(t, e)
+}
+
+func TestOrderedMap_Fuzz(t *testing.T) {
+	ref := make(map[int]int)
+	var m *OrderedMap
+	assert.True(t, m.Empty())
+	for i := 0; i < 100000; i++ {
+		k := rand.Intn(500)
+		if rand.Intn(3) == 0 {
+			delete(ref, k)
+			m = m.Delete(k)
+			assert.Equal(t, len(ref), m.Len(), "after delete")
+			require.NoError(t, m.invariant(), "after delete")
+		} else {
+			v := rand.Int()
+			ref[k] = v
+			m = m.Set(k, v)
+			assert.Equal(t, len(ref), m.Len(), "after set")
+			require.NoError(t, m.invariant(), "after set")
+		}
+	}
+	for k, refv := range ref {
+		v, ok := m.Get(k)
+		assert.True(t, ok)
+		assert.Equal(t, refv, v)
+	}
+}
+
+var orderedMapValueResult interface{}
+
+func BenchmarkOrderedMap_Get(b *testing.B) {
+	for _, n := range []int{100, 10000, 1000000} {
+		m := &OrderedMap{}
+		for i := 0; i < n; i++ {
+			m = m.Set(i, "foo")
+		}
+		b.Run(fmt.Sprintf("n=%v", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				v, _ := m.Get(i % n)
+				orderedMapValueResult = v
+			}
+		})
+	}
+}
+
+var orderedMapResult *OrderedMap
+
+func BenchmarkOrderedMap_Set(b *testing.B) {
+	for _, n := range []int{100, 10000, 1000000} {
+		m := &OrderedMap{}
+		for i := 0; i < n; i++ {
+			m = m.Set(i, "foo")
+		}
+		b.Run(fmt.Sprintf("n=%v", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				orderedMapResult = m.Set(i%n, "bar")
+			}
+		})
+	}
+}
+
+func (m *OrderedMap) invariant() error {
+	_, err := m.invariantInfo()
+	return err
+}
+
+type orderedMapInvariantInfo struct {
+	BlackDepth int
+}
+
+func (m *OrderedMap) invariantInfo() (*orderedMapInvariantInfo, error) {
+	if m == nil {
+		return &orderedMapInvariantInfo{
+			BlackDepth: 0,
+		}, nil
+	}
+
+	if m == doubleBlackLeaf {
+		return nil, fmt.Errorf("double black leaf")
+	}
+	if m.color != orderedMapRed && m.color != orderedMapBlack {
+		return nil, fmt.Errorf("invalid node color: %v", m.color)
+	}
+	if m.key == nil {
+		return nil, fmt.Errorf("nil key")
+	}
+	if m.color == orderedMapRed && ((m.left != nil && m.left.color == orderedMapRed) || (m.right != nil && m.right.color == orderedMapRed)) {
+		return nil, fmt.Errorf("red node has red child")
+	}
+
+	left, err := m.left.invariantInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	right, err := m.right.invariantInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	if left.BlackDepth != right.BlackDepth {
+		return nil, fmt.Errorf("unbalanced black depths")
+	}
+
+	info := &orderedMapInvariantInfo{
+		BlackDepth: left.BlackDepth,
+	}
+	if m.color == orderedMapBlack {
+		info.BlackDepth++
+	}
+
+	return info, nil
+}

--- a/vendor/github.com/ccbrown/go-immutable/queue.go
+++ b/vendor/github.com/ccbrown/go-immutable/queue.go
@@ -1,0 +1,55 @@
+package immutable
+
+func queueRotate(f *lazyList, r *Stack, s *lazyList) *lazyList {
+	if f == nil {
+		return s.PushFront(r.Peek())
+	}
+	return newLazyList(f.Front(), func() *lazyList {
+		return queueRotate(f.PopFront(), r.Pop(), s.PushFront(r.Peek()))
+	})
+}
+
+func queueExec(f *lazyList, r *Stack, s *lazyList) *Queue {
+	if s == nil {
+		f2 := queueRotate(f, r, nil)
+		return &Queue{f2, nil, f2}
+	}
+	return &Queue{f, r, s.PopFront()}
+}
+
+// Queue implements a first in, first out container.
+//
+// Nil and the zero value for Queue are both empty queues.
+type Queue struct {
+	f *lazyList
+	r *Stack
+	s *lazyList
+}
+
+// Empty returns true if the queue is empty.
+//
+// Complexity: O(1) worst-case
+func (q *Queue) Empty() bool {
+	return q == nil || q.f == nil
+}
+
+// Front returns the item at the front of the queue.
+//
+// Complexity: O(1) worst-case
+func (q *Queue) Front() interface{} {
+	return q.f.Front()
+}
+
+// PopFront removes the item at the front of the queue.
+//
+// Complexity: O(1) worst-case
+func (q *Queue) PopFront() *Queue {
+	return queueExec(q.f.PopFront(), q.r, q.s)
+}
+
+// PushBack pushes an item onto the back of the queue.
+//
+// Complexity: O(1) worst-case
+func (q *Queue) PushBack(value interface{}) *Queue {
+	return queueExec(q.f, q.r.Push(value), q.s)
+}

--- a/vendor/github.com/ccbrown/go-immutable/queue_test.go
+++ b/vendor/github.com/ccbrown/go-immutable/queue_test.go
@@ -1,0 +1,55 @@
+package immutable
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQueue(t *testing.T) {
+	var q Queue
+	assert.True(t, q.Empty())
+	q2 := q.PushBack("foo")
+	assert.True(t, q.Empty())
+	assert.False(t, q2.Empty())
+	assert.Equal(t, q2.Front(), "foo")
+	q3 := q2.PushBack("bar")
+	assert.Equal(t, q3.Front(), "foo")
+	assert.Equal(t, q3.PopFront().Front(), "bar")
+	q4 := q3.PushBack("baz")
+	assert.Equal(t, q4.Front(), "foo")
+	assert.Equal(t, q4.PopFront().Front(), "bar")
+	assert.Equal(t, q4.PopFront().PopFront().Front(), "baz")
+	assert.True(t, q4.PopFront().PopFront().PopFront().Empty())
+}
+
+var queueResult *Queue
+
+func BenchmarkQueue_PushBack(b *testing.B) {
+	for _, n := range []int{100, 10000, 1000000} {
+		q := &Queue{}
+		for i := 0; i < n; i++ {
+			q = q.PushBack("foo")
+		}
+		b.Run(fmt.Sprintf("n=%v", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				queueResult = q.PushBack("foo")
+			}
+		})
+	}
+}
+
+func BenchmarkQueue_PopFront(b *testing.B) {
+	for _, n := range []int{100, 10000, 200000} {
+		q := &Queue{}
+		for i := 0; i < n; i++ {
+			q = q.PushBack(i)
+		}
+		b.Run(fmt.Sprintf("n=%v", n), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				queueResult = q.PopFront()
+			}
+		})
+	}
+}

--- a/vendor/github.com/ccbrown/go-immutable/stack.go
+++ b/vendor/github.com/ccbrown/go-immutable/stack.go
@@ -1,0 +1,43 @@
+package immutable
+
+// Stack implements a last in, first out container.
+//
+// Nil and the zero value for Stack are both empty stacks.
+type Stack struct {
+	top    interface{}
+	bottom *Stack
+}
+
+// Empty returns true if the stack is empty.
+//
+// Complexity: O(1) worst-case
+func (s *Stack) Empty() bool {
+	return s == nil || s.bottom == nil
+}
+
+// Peek returns the top item on the stack.
+//
+// Complexity: O(1) worst-case
+func (s *Stack) Peek() interface{} {
+	return s.top
+}
+
+// Pop removes the top item from the stack.
+//
+// Complexity: O(1) worst-case
+func (s *Stack) Pop() *Stack {
+	return s.bottom
+}
+
+// Push places an item onto the top of the stack.
+//
+// Complexity: O(1) worst-case
+func (s *Stack) Push(value interface{}) *Stack {
+	if s == nil {
+		s = &Stack{}
+	}
+	return &Stack{
+		top:    value,
+		bottom: s,
+	}
+}

--- a/vendor/github.com/ccbrown/go-immutable/stack_test.go
+++ b/vendor/github.com/ccbrown/go-immutable/stack_test.go
@@ -1,0 +1,19 @@
+package immutable
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStack(t *testing.T) {
+	var s Stack
+	assert.True(t, s.Empty())
+	s2 := s.Push("foo")
+	assert.True(t, s.Empty())
+	assert.False(t, s2.Empty())
+	assert.Equal(t, s2.Peek(), "foo")
+	s3 := s2.Push("bar")
+	assert.Equal(t, s3.Peek(), "bar")
+	assert.Equal(t, s3.Pop().Peek(), "foo")
+}


### PR DESCRIPTION
#### Summary
This is a NoSQL webhook store implementation. It's an easy first target for NoSQL: no joins or multi-table queries. Once this is merged, I'll add a "hybrid" store implementation that uses NoSQL where possible and falls back to another store implementation as needed. Then I'll start filling in post store functionality so we can hopefully start to see some measurable differences in load tests (and probably unit tests as well). 

It's not particularly optimized, but most operations are at least faster / more scalable than MySQL.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-231

#### Checklist
- [x] Added or updated unit tests (required for all new features)