### PR TITLE
ICU-715 Change ExperimentalGroupUnreadChannels setting to allow for default on/off

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -57,7 +57,7 @@
         "CloseUnusedDirectMessages": false,
         "EnableTutorial": true,
         "ExperimentalEnableDefaultChannelLeaveJoinMessages": true,
-        "ExperimentalGroupUnreadChannels": false,
+        "ExperimentalGroupUnreadChannels": "disabled",
         "ImageProxyType": "",
         "ImageProxyOptions": "",
         "ImageProxyURL": ""

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4759,6 +4759,10 @@
     "translation": "Invalid thumbnail width for file settings.  Must be a positive number."
   },
   {
+    "id": "model.config.is_valid.group_unread_channels.app_error",
+    "translation": "Invalid group unread channels for service settings. Must be 'disabled', 'default_on', or 'default_off'."
+  },
+  {
     "id": "model.config.is_valid.image_proxy_type.app_error",
     "translation": "Invalid image proxy type for service settings."
   },

--- a/model/config.go
+++ b/model/config.go
@@ -69,6 +69,10 @@ const (
 	ALLOW_EDIT_POST_NEVER      = "never"
 	ALLOW_EDIT_POST_TIME_LIMIT = "time_limit"
 
+	GROUP_UNREAD_CHANNELS_DISABLED    = "disabled"
+	GROUP_UNREAD_CHANNELS_DEFAULT_ON  = "default_on"
+	GROUP_UNREAD_CHANNELS_DEFAULT_OFF = "default_off"
+
 	EMAIL_BATCHING_BUFFER_SIZE = 256
 	EMAIL_BATCHING_INTERVAL    = 30
 
@@ -214,7 +218,7 @@ type ServiceSettings struct {
 	EnablePreviewFeatures                             *bool
 	EnableTutorial                                    *bool
 	ExperimentalEnableDefaultChannelLeaveJoinMessages *bool
-	ExperimentalGroupUnreadChannels                   *bool
+	ExperimentalGroupUnreadChannels                   *string
 	ImageProxyType                                    *string
 	ImageProxyURL                                     *string
 	ImageProxyOptions                                 *string
@@ -424,7 +428,11 @@ func (s *ServiceSettings) SetDefaults() {
 	}
 
 	if s.ExperimentalGroupUnreadChannels == nil {
-		s.ExperimentalGroupUnreadChannels = NewBool(false)
+		s.ExperimentalGroupUnreadChannels = NewString(GROUP_UNREAD_CHANNELS_DISABLED)
+	} else if *s.ExperimentalGroupUnreadChannels == "0" {
+		s.ExperimentalGroupUnreadChannels = NewString(GROUP_UNREAD_CHANNELS_DISABLED)
+	} else if *s.ExperimentalGroupUnreadChannels == "1" {
+		s.ExperimentalGroupUnreadChannels = NewString(GROUP_UNREAD_CHANNELS_DEFAULT_ON)
 	}
 
 	if s.ImageProxyType == nil {
@@ -2068,6 +2076,12 @@ func (ss *ServiceSettings) isValid() *AppError {
 
 	if len(*ss.ListenAddress) == 0 {
 		return NewAppError("Config.IsValid", "model.config.is_valid.listen_address.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if *ss.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED &&
+		*ss.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DEFAULT_ON &&
+		*ss.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DEFAULT_OFF {
+		return NewAppError("Config.IsValid", "model.config.is_valid.group_unread_channels.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	switch *ss.ImageProxyType {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -36,6 +36,38 @@ func TestConfigDefaultFileSettingsS3SSE(t *testing.T) {
 	}
 }
 
+func TestConfigDefaultServiceSettingsExperimentalGroupUnreadChannels(t *testing.T) {
+	c1 := Config{}
+	c1.SetDefaults()
+
+	if *c1.ServiceSettings.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED {
+		t.Fatal("ServiceSettings.ExperimentalGroupUnreadChannels should default to 'disabled'")
+	}
+
+	// This setting was briefly a boolean, so ensure that those values still work as expected
+	c1 = Config{
+		ServiceSettings: ServiceSettings{
+			ExperimentalGroupUnreadChannels: NewString("1"),
+		},
+	}
+	c1.SetDefaults()
+
+	if *c1.ServiceSettings.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DEFAULT_ON {
+		t.Fatal("ServiceSettings.ExperimentalGroupUnreadChannels should set true to 'default on'")
+	}
+
+	c1 = Config{
+		ServiceSettings: ServiceSettings{
+			ExperimentalGroupUnreadChannels: NewString("0"),
+		},
+	}
+	c1.SetDefaults()
+
+	if *c1.ServiceSettings.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED {
+		t.Fatal("ServiceSettings.ExperimentalGroupUnreadChannels should set false to 'disabled'")
+	}
+}
+
 func TestMessageExportSettingsIsValidEnableExportNotSet(t *testing.T) {
 	fs := &FileSettings{}
 	mes := &MessageExportSettings{}

--- a/utils/config.go
+++ b/utils/config.go
@@ -397,7 +397,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string) map[string]strin
 	props["EnablePreviewFeatures"] = strconv.FormatBool(*c.ServiceSettings.EnablePreviewFeatures)
 	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
 	props["ExperimentalEnableDefaultChannelLeaveJoinMessages"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages)
-	props["ExperimentalGroupUnreadChannels"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalGroupUnreadChannels)
+	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
 
 	props["SendEmailNotifications"] = strconv.FormatBool(c.EmailSettings.SendEmailNotifications)
 	props["SendPushNotifications"] = strconv.FormatBool(*c.EmailSettings.SendPushNotifications)


### PR DESCRIPTION
There's some code in there as well to make sure that it still accepts true/false values for any servers like pre-release that are running off master.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-715

#### Checklist
- Added or updated unit tests (required for all new features)
- Has UI changes
- Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
