### PR TITLE
Remove fmt.Println trace on api4 tests

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -298,8 +298,7 @@ func (me *TestHelper) CreateUserWithClient(client *model.Client4) *model.User {
 	}
 
 	utils.DisableDebugLogForTest()
-	ruser, r := client.CreateUser(user)
-	fmt.Println(r)
+	ruser, _ := client.CreateUser(user)
 	ruser.Password = "Password1"
 	store.Must(me.App.Srv.Store.User().VerifyEmail(ruser.Id))
 	utils.EnableDebugLogForTest()


### PR DESCRIPTION
#### Summary
I'm 2/5 about it, but looks like a debug print forgotten there.