### PR TITLE
Eliminate utils.SetLicense calls

### DIFF
--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -409,6 +409,7 @@ func TestUpdateChannel(t *testing.T) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	})
+	th.App.SetLicense(model.NewTestLicense())
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
 		t.Fatal("should have errored not team admin")
@@ -1571,6 +1572,7 @@ func TestAddChannelMember(t *testing.T) {
 
 	th.MakeUserChannelAdmin(user1, channel5)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	if _, err := Client.AddChannelMember(channel5.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1590,6 +1592,7 @@ func TestAddChannelMember(t *testing.T) {
 
 	th.UpdateUserToTeamAdmin(user1, team)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	if _, err := Client.AddChannelMember(channel6.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1722,6 +1725,7 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	th.MakeUserChannelAdmin(user1, channel5)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	if _, err := Client.RemoveChannelMember(channel5.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1742,6 +1746,7 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	th.UpdateUserToTeamAdmin(user1, team)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	if _, err := Client.RemoveChannelMember(channel6.Id, user2.Id); err != nil {
 		t.Fatal(err)

--- a/api/channel_test.go
+++ b/api/channel_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/store/sqlstore"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestCreateChannel(t *testing.T) {
@@ -97,23 +96,9 @@ func TestCreateChannel(t *testing.T) {
 		t.Fatal("Should have errored out on direct channel type")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	restrictPublicChannel := *th.App.Config().TeamSettings.RestrictPublicChannelManagement
-	restrictPrivateChannel := *th.App.Config().TeamSettings.RestrictPrivateChannelManagement
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = restrictPublicChannel })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
-	th.App.SetDefaultRolesBasedOnConfig()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
+	th.App.SetLicense(model.NewTestLicense())
 
 	channel2 := &model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel3 := &model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
@@ -130,7 +115,6 @@ func TestCreateChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_TEAM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic2()
 	channel2.Name = "zz" + model.NewId() + "a"
@@ -160,7 +144,6 @@ func TestCreateChannel(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel2.Name = "zz" + model.NewId() + "a"
 	channel3.Name = "zz" + model.NewId() + "a"
@@ -181,9 +164,7 @@ func TestCreateChannel(t *testing.T) {
 	}
 
 	// Check that if unlicensed the policy restriction is not enforced.
-	utils.SetIsLicensed(false)
-	utils.SetLicense(nil)
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(nil)
 
 	channel4 := model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel5 := model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
@@ -196,7 +177,6 @@ func TestCreateChannel(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelCreation = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelCreation = model.PERMISSIONS_ALL })
-	th.App.SetDefaultRolesBasedOnConfig()
 }
 
 func TestCreateDirectChannel(t *testing.T) {
@@ -367,23 +347,9 @@ func TestUpdateChannel(t *testing.T) {
 		t.Fatal("should have failed - channel deleted")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	restrictPublicChannel := *th.App.Config().TeamSettings.RestrictPublicChannelManagement
-	restrictPrivateChannel := *th.App.Config().TeamSettings.RestrictPrivateChannelManagement
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = restrictPublicChannel })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	channel2 := th.CreateChannel(Client, team)
 	channel3 := th.CreatePrivateChannel(Client, team)
@@ -404,14 +370,8 @@ func TestUpdateChannel(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.MakeUserChannelUser(th.BasicUser, channel2)
 	th.MakeUserChannelUser(th.BasicUser, channel3)
 	sqlstore.ClearChannelCaches()
@@ -447,14 +407,8 @@ func TestUpdateChannel(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
 		t.Fatal("should have errored not team admin")
@@ -477,14 +431,8 @@ func TestUpdateChannel(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannel(channel2); err == nil {
 		t.Fatal("should have errored not system admin")
@@ -503,9 +451,7 @@ func TestUpdateChannel(t *testing.T) {
 	}
 
 	// Check that if unlicensed the policy restriction is not enforced.
-	utils.SetIsLicensed(false)
-	utils.SetLicense(nil)
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(nil)
 
 	if _, err := Client.UpdateChannel(channel2); err != nil {
 		t.Fatal(err)
@@ -618,23 +564,9 @@ func TestUpdateChannelHeader(t *testing.T) {
 		t.Fatal("should have errored non-channel member trying to update header")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	restrictPublicChannel := *th.App.Config().TeamSettings.RestrictPublicChannelManagement
-	restrictPrivateChannel := *th.App.Config().TeamSettings.RestrictPrivateChannelManagement
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = restrictPublicChannel })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	th.LoginBasic()
 	channel2 := th.CreateChannel(Client, team)
@@ -659,11 +591,8 @@ func TestUpdateChannelHeader(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.MakeUserChannelUser(th.BasicUser, channel2)
 	th.MakeUserChannelUser(th.BasicUser, channel3)
 	sqlstore.ClearChannelCaches()
@@ -688,11 +617,8 @@ func TestUpdateChannelHeader(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelHeader(data2); err == nil {
 		t.Fatal("should have errored not team admin")
@@ -715,11 +641,8 @@ func TestUpdateChannelHeader(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelHeader(data2); err == nil {
 		t.Fatal("should have errored not system admin")
@@ -741,9 +664,7 @@ func TestUpdateChannelHeader(t *testing.T) {
 	}
 
 	// Check that if unlicensed the policy restriction is not enforced.
-	utils.SetIsLicensed(false)
-	utils.SetLicense(nil)
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(nil)
 
 	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
 		t.Fatal(err)
@@ -814,23 +735,9 @@ func TestUpdateChannelPurpose(t *testing.T) {
 		t.Fatal("should have errored non-channel member trying to update purpose")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	restrictPublicChannel := *th.App.Config().TeamSettings.RestrictPublicChannelManagement
-	restrictPrivateChannel := *th.App.Config().TeamSettings.RestrictPrivateChannelManagement
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = restrictPublicChannel })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	th.LoginBasic()
 	channel2 := th.CreateChannel(Client, team)
@@ -855,11 +762,8 @@ func TestUpdateChannelPurpose(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.MakeUserChannelUser(th.BasicUser, channel2)
 	th.MakeUserChannelUser(th.BasicUser, channel3)
 	sqlstore.ClearChannelCaches()
@@ -884,11 +788,8 @@ func TestUpdateChannelPurpose(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_TEAM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_TEAM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelPurpose(data2); err == nil {
 		t.Fatal("should have errored not team admin")
@@ -911,11 +812,8 @@ func TestUpdateChannelPurpose(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.UpdateChannelPurpose(data2); err == nil {
 		t.Fatal("should have errored not system admin")
@@ -937,9 +835,7 @@ func TestUpdateChannelPurpose(t *testing.T) {
 	}
 
 	// Check that if unlicensed the policy restriction is not enforced.
-	utils.SetIsLicensed(false)
-	utils.SetLicense(nil)
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(nil)
 	if _, err := SystemAdminClient.UpdateChannelHeader(data2); err != nil {
 		t.Fatal(err)
 	}
@@ -1400,23 +1296,9 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal("should have failed - channel already deleted")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	restrictPublicChannel := *th.App.Config().TeamSettings.RestrictPublicChannelManagement
-	restrictPrivateChannel := *th.App.Config().TeamSettings.RestrictPrivateChannelManagement
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = restrictPublicChannel })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = restrictPrivateChannel })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelManagement = model.PERMISSIONS_ALL })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManagement = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	th.LoginSystemAdmin()
 	th.LinkUserToTeam(th.BasicUser, team)
@@ -1438,16 +1320,10 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
 
@@ -1498,16 +1374,11 @@ func TestDeleteChannel(t *testing.T) {
 	th.UpdateUserToNonTeamAdmin(th.BasicUser, team)
 	th.App.InvalidateAllCaches()
 
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
+	th.App.SetLicense(model.NewTestLicense())
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_TEAM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
 
@@ -1537,16 +1408,10 @@ func TestDeleteChannel(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
-	})
-	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginSystemAdmin()
 
@@ -1578,9 +1443,7 @@ func TestDeleteChannel(t *testing.T) {
 	}
 
 	// Check that if unlicensed the policy restriction is not enforced.
-	utils.SetIsLicensed(false)
-	utils.SetLicense(nil)
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(nil)
 
 	channel2 = th.CreateChannel(Client, team)
 	channel3 = th.CreatePrivateChannel(Client, team)
@@ -1595,10 +1458,6 @@ func TestDeleteChannel(t *testing.T) {
 	if _, err := Client.DeleteChannel(channel3.Id); err != nil {
 		t.Fatal(err)
 	}
-
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPublicChannelDeletion = model.PERMISSIONS_ALL })
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelDeletion = model.PERMISSIONS_ALL })
-	th.App.SetDefaultRolesBasedOnConfig()
 }
 
 func TestGetChannelStats(t *testing.T) {
@@ -1675,16 +1534,9 @@ func TestAddChannelMember(t *testing.T) {
 	}
 
 	// Test policy does not apply to TE.
-	restrictPrivateChannel := *th.App.Config().TeamSettings.RestrictPrivateChannelManageMembers
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.TeamSettings.RestrictPrivateChannelManageMembers = restrictPrivateChannel
-		})
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel3 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel3 = Client.Must(th.SystemAdminClient.CreateChannel(channel3)).Data.(*model.Channel)
@@ -1694,18 +1546,8 @@ func TestAddChannelMember(t *testing.T) {
 	}
 
 	// Add a license
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	// Check that a regular channel user can add other users.
 	channel4 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
@@ -1719,10 +1561,6 @@ func TestAddChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel5 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel5 = Client.Must(th.SystemAdminClient.CreateChannel(channel5)).Data.(*model.Channel)
@@ -1733,10 +1571,6 @@ func TestAddChannelMember(t *testing.T) {
 
 	th.MakeUserChannelAdmin(user1, channel5)
 	th.App.InvalidateAllCaches()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.AddChannelMember(channel5.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1746,10 +1580,6 @@ func TestAddChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel6 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel6 = Client.Must(th.SystemAdminClient.CreateChannel(channel6)).Data.(*model.Channel)
@@ -1760,10 +1590,6 @@ func TestAddChannelMember(t *testing.T) {
 
 	th.UpdateUserToTeamAdmin(user1, team)
 	th.App.InvalidateAllCaches()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.AddChannelMember(channel6.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1773,10 +1599,6 @@ func TestAddChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel7 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel7 = Client.Must(th.SystemAdminClient.CreateChannel(channel7)).Data.(*model.Channel)
@@ -1860,16 +1682,9 @@ func TestRemoveChannelMember(t *testing.T) {
 	th.LoginBasic()
 
 	// Test policy does not apply to TE.
-	restrictPrivateChannel := *th.App.Config().TeamSettings.RestrictPrivateChannelManageMembers
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.TeamSettings.RestrictPrivateChannelManageMembers = restrictPrivateChannel
-		})
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel3 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel3 = Client.Must(th.SystemAdminClient.CreateChannel(channel3)).Data.(*model.Channel)
@@ -1880,18 +1695,8 @@ func TestRemoveChannelMember(t *testing.T) {
 	}
 
 	// Add a license
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	// Check that a regular channel user can remove other users.
 	channel4 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
@@ -1906,10 +1711,6 @@ func TestRemoveChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_CHANNEL_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel5 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel5 = Client.Must(th.SystemAdminClient.CreateChannel(channel5)).Data.(*model.Channel)
@@ -1921,9 +1722,6 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	th.MakeUserChannelAdmin(user1, channel5)
 	th.App.InvalidateAllCaches()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
 
 	if _, err := Client.RemoveChannelMember(channel5.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1933,10 +1731,6 @@ func TestRemoveChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_TEAM_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel6 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel6 = Client.Must(th.SystemAdminClient.CreateChannel(channel6)).Data.(*model.Channel)
@@ -1948,10 +1742,6 @@ func TestRemoveChannelMember(t *testing.T) {
 
 	th.UpdateUserToTeamAdmin(user1, team)
 	th.App.InvalidateAllCaches()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.RemoveChannelMember(channel6.Id, user2.Id); err != nil {
 		t.Fatal(err)
@@ -1961,10 +1751,6 @@ func TestRemoveChannelMember(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.RestrictPrivateChannelManageMembers = model.PERMISSIONS_SYSTEM_ADMIN
 	})
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	channel7 := &model.Channel{DisplayName: "A Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel7 = Client.Must(th.SystemAdminClient.CreateChannel(channel7)).Data.(*model.Channel)

--- a/api/post_test.go
+++ b/api/post_test.go
@@ -160,20 +160,8 @@ func TestCreatePost(t *testing.T) {
 		}
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	disableTownSquareReadOnly := th.App.Config().TeamSettings.ExperimentalTownSquareIsReadOnly
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = disableTownSquareReadOnly })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = true })
-	th.App.SetDefaultRolesBasedOnConfig()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
+	th.App.SetLicense(model.NewTestLicense())
 
 	defaultChannel := store.Must(th.App.Srv.Store.Channel().GetByName(team.Id, model.DEFAULT_CHANNEL, true)).(*model.Channel)
 	defaultPost := &model.Post{
@@ -466,16 +454,7 @@ func TestUpdatePost(t *testing.T) {
 	}
 
 	// Test licensed policy controls for edit post
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-
+	th.App.SetLicense(model.NewTestLicense())
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = model.ALLOW_EDIT_POST_NEVER })
 
 	post4 := &model.Post{ChannelId: channel1.Id, Message: "zz" + model.NewId() + "a", RootId: rpost1.Data.(*model.Post).Id}
@@ -966,7 +945,6 @@ func TestDeletePosts(t *testing.T) {
 	team1 := th.BasicTeam
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.RestrictPostDelete = model.PERMISSIONS_DELETE_POST_ALL })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	time.Sleep(10 * time.Millisecond)
 	post1 := &model.Post{ChannelId: channel1.Id, Message: "zz" + model.NewId() + "a"}
@@ -1021,15 +999,7 @@ func TestDeletePosts(t *testing.T) {
 	}
 
 	// Test licensed policy controls for delete post
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
+	th.App.SetLicense(model.NewTestLicense())
 
 	th.UpdateUserToTeamAdmin(th.BasicUser2, th.BasicTeam)
 
@@ -1044,7 +1014,6 @@ func TestDeletePosts(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.RestrictPostDelete = model.PERMISSIONS_DELETE_POST_TEAM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 
@@ -1069,7 +1038,6 @@ func TestDeletePosts(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.RestrictPostDelete = model.PERMISSIONS_DELETE_POST_SYSTEM_ADMIN
 	})
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 
@@ -1088,9 +1056,7 @@ func TestDeletePosts(t *testing.T) {
 	}
 
 	// Check that if unlicensed the policy restriction is not enforced.
-	utils.SetIsLicensed(false)
-	utils.SetLicense(nil)
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(nil)
 
 	time.Sleep(10 * time.Millisecond)
 	post7 := &model.Post{ChannelId: channel1.Id, Message: "zz" + model.NewId() + "a"}

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -139,20 +139,8 @@ func TestAddUserToTeam(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Restore config/license at end of test case.
-	restrictTeamInvite := *th.App.Config().TeamSettings.RestrictTeamInvite
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
-
 	// Set the config so that only team admins can add a user to a team.
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Test without the EE license to see that the permission restriction is ignored.
 	user3 := th.CreateUser(th.BasicClient)
@@ -161,10 +149,7 @@ func TestAddUserToTeam(t *testing.T) {
 	}
 
 	// Add an EE license.
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	// Check that a regular user can't add someone to the team.
 	user4 := th.CreateUser(th.BasicClient)
@@ -176,10 +161,6 @@ func TestAddUserToTeam(t *testing.T) {
 	th.UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	user5 := th.CreateUser(th.BasicClient)
 	if _, err := th.BasicClient.AddUserToTeam(th.BasicTeam.Id, user5.Id); err != nil {
@@ -188,7 +169,6 @@ func TestAddUserToTeam(t *testing.T) {
 
 	// Change permission level to System Admin
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Should not work as team admin.
 	user6 := th.CreateUser(th.BasicClient)
@@ -565,13 +545,7 @@ func TestInviteMembers(t *testing.T) {
 		t.Fatal("Should have errored out on no invites to send")
 	}
 
-	restrictTeamInvite := *th.App.Config().TeamSettings.RestrictTeamInvite
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic2()
 	th.LinkUserToTeam(th.BasicUser2, team)
@@ -580,17 +554,7 @@ func TestInviteMembers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 
 	if _, err := Client.InviteMembers(invites); err == nil {
 		t.Fatal("should have errored not team admin and licensed")
@@ -606,7 +570,6 @@ func TestInviteMembers(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.InviteMembers(invites); err == nil {
 		t.Fatal("should have errored not system admin and licensed")

--- a/api/team_test.go
+++ b/api/team_test.go
@@ -160,6 +160,7 @@ func TestAddUserToTeam(t *testing.T) {
 	// Should work as team admin.
 	th.UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
 
 	user5 := th.CreateUser(th.BasicClient)

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -1889,17 +1889,7 @@ func TestUpdateMfa(t *testing.T) {
 
 	Client := th.BasicClient
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-	}()
-	utils.SetIsLicensed(false)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	if utils.License().Features.MFA == nil {
-		utils.License().Features.MFA = new(bool)
-	}
+	th.App.SetLicense(nil)
 
 	team := model.Team{DisplayName: "Name", Name: "z-z-" + model.NewId() + "a", Email: "test@nowhere.com", Type: model.TEAM_OPEN}
 	rteam, _ := Client.CreateTeam(&team)
@@ -1925,8 +1915,7 @@ func TestUpdateMfa(t *testing.T) {
 		t.Fatal("should have failed - not licensed")
 	}
 
-	utils.SetIsLicensed(true)
-	*utils.License().Features.MFA = true
+	th.App.SetLicense(model.NewTestLicense("mfa"))
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = true })
 
 	if _, err := Client.UpdateMfa(true, "123456"); err == nil {

--- a/api/webhook_test.go
+++ b/api/webhook_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestCreateIncomingHook(t *testing.T) {
@@ -93,7 +92,6 @@ func TestCreateIncomingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.CreateIncomingWebhook(hook); err != nil {
 		t.Fatal(err)
@@ -133,7 +131,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := createIncomingWebhook(channel1.Id, Client, t)
 
@@ -217,7 +214,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 
 	t.Run("OnlyAdminIntegrationsDisabled", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-		th.App.SetDefaultRolesBasedOnConfig()
 
 		t.Run("UpdateHookOfSameUser", func(t *testing.T) {
 			sameUserHook := &model.IncomingWebhook{ChannelId: channel1.Id, UserId: user2.Id}
@@ -240,7 +236,6 @@ func TestUpdateIncomingHook(t *testing.T) {
 	})
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Logout()
 	th.UpdateUserToTeamAdmin(user2, team)
@@ -324,7 +319,6 @@ func TestListIncomingHooks(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook1 := &model.IncomingWebhook{ChannelId: channel1.Id}
 	hook1 = Client.Must(Client.CreateIncomingWebhook(hook1)).Data.(*model.IncomingWebhook)
@@ -351,7 +345,6 @@ func TestListIncomingHooks(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.ListIncomingWebhooks(); err != nil {
 		t.Fatal(err)
@@ -376,7 +369,6 @@ func TestDeleteIncomingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.IncomingWebhook{ChannelId: channel1.Id}
 	hook = Client.Must(Client.CreateIncomingWebhook(hook)).Data.(*model.IncomingWebhook)
@@ -410,7 +402,6 @@ func TestDeleteIncomingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.DeleteIncomingWebhook(hook.Id); err == nil {
 		t.Fatal("should have failed - not creator or team admin")
@@ -447,7 +438,6 @@ func TestCreateOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 
@@ -518,7 +508,6 @@ func TestCreateOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.CreateOutgoingWebhook(hook); err != nil {
 		t.Fatal(err)
@@ -551,7 +540,6 @@ func TestListOutgoingHooks(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook1 := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook1 = Client.Must(Client.CreateOutgoingWebhook(hook1)).Data.(*model.OutgoingWebhook)
@@ -578,7 +566,6 @@ func TestListOutgoingHooks(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.ListOutgoingWebhooks(); err != nil {
 		t.Fatal(err)
@@ -609,7 +596,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := createOutgoingWebhook(channel1.Id, []string{"http://nowhere.com"}, []string{"cats"}, Client, t)
 	createOutgoingWebhook(channel1.Id, []string{"http://nowhere.com"}, []string{"dogs"}, Client, t)
@@ -683,7 +669,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 	hook2 := createOutgoingWebhook(channel1.Id, []string{"http://nowhereelse.com"}, []string{"dogs"}, Client, t)
 
 	if _, err := Client.UpdateOutgoingWebhook(hook2); err != nil {
@@ -691,7 +676,6 @@ func TestUpdateOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	Client.Logout()
 	th.LinkUserToTeam(user3, team)
@@ -779,7 +763,6 @@ func TestDeleteOutgoingHook(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook = Client.Must(Client.CreateOutgoingWebhook(hook)).Data.(*model.OutgoingWebhook)
@@ -813,7 +796,6 @@ func TestDeleteOutgoingHook(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	if _, err := Client.DeleteOutgoingWebhook(hook.Id); err == nil {
 		t.Fatal("should have failed - not creator or team admin")
@@ -848,7 +830,6 @@ func TestRegenOutgoingHookToken(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook := &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook = Client.Must(Client.CreateOutgoingWebhook(hook)).Data.(*model.OutgoingWebhook)
@@ -883,7 +864,6 @@ func TestRegenOutgoingHookToken(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	hook = &model.OutgoingWebhook{ChannelId: channel1.Id, CallbackURLs: []string{"http://nowhere.com"}}
 	hook = Client.Must(Client.CreateOutgoingWebhook(hook)).Data.(*model.OutgoingWebhook)
@@ -917,10 +897,6 @@ func TestIncomingWebhooks(t *testing.T) {
 	user2 := th.CreateUser(Client)
 	th.LinkUserToTeam(user2, team)
 
-	enableIncomingHooks := th.App.Config().ServiceSettings.EnableIncomingWebhooks
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = enableIncomingHooks })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
 
 	hook := &model.IncomingWebhook{ChannelId: channel1.Id}
@@ -962,20 +938,8 @@ func TestIncomingWebhooks(t *testing.T) {
 		t.Fatal("should not have failed -- ExperimentalTownSquareIsReadOnly is false and it's not a read only channel")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	disableTownSquareReadOnly := th.App.Config().TeamSettings.ExperimentalTownSquareIsReadOnly
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = disableTownSquareReadOnly })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.ExperimentalTownSquareIsReadOnly = true })
-	th.App.SetDefaultRolesBasedOnConfig()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
+	th.App.SetLicense(model.NewTestLicense())
 
 	if _, err := th.BasicClient.DoPost(url, fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"%s\"}", model.DEFAULT_CHANNEL), "application/json"); err == nil {
 		t.Fatal("should have failed -- ExperimentalTownSquareIsReadOnly is true and it's a read only channel")

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -927,6 +927,7 @@ func TestDeleteChannel(t *testing.T) {
 	// successful delete by team admin
 	th.UpdateUserToTeamAdmin(user, team)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
 	CheckNoError(t, resp)
@@ -940,6 +941,7 @@ func TestDeleteChannel(t *testing.T) {
 	})
 	th.UpdateUserToNonTeamAdmin(user, team)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	// channels created by SystemAdmin
 	publicChannel6 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
@@ -969,6 +971,7 @@ func TestDeleteChannel(t *testing.T) {
 	// successful delete by team admin
 	th.UpdateUserToTeamAdmin(th.BasicUser, team)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
 	CheckNoError(t, resp)
@@ -1009,6 +1012,7 @@ func TestDeleteChannel(t *testing.T) {
 	// cannot delete by team admin
 	th.UpdateUserToTeamAdmin(th.BasicUser, team)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
 	CheckForbiddenStatus(t, resp)
@@ -1814,6 +1818,7 @@ func TestAddChannelMember(t *testing.T) {
 
 	th.MakeUserChannelAdmin(user, privateChannel)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	Client.Login(user.Username, user.Password)
 	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)
@@ -1838,6 +1843,7 @@ func TestAddChannelMember(t *testing.T) {
 
 	th.UpdateUserToTeamAdmin(user, team)
 	th.App.InvalidateAllCaches()
+	th.App.SetLicense(model.NewTestLicense())
 
 	Client.Login(user.Username, user.Password)
 	_, resp = Client.AddChannelMember(privateChannel.Id, user3.Id)

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestCreatePost(t *testing.T) {
@@ -130,20 +129,8 @@ func testCreatePostWithOutgoingHook(
 	team := th.BasicTeam
 	channel := th.BasicChannel
 
-	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
-	allowedInternalConnections := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
-		th.App.SetDefaultRolesBasedOnConfig()
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
-		})
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
 	})
@@ -489,21 +476,8 @@ func TestUpdatePost(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	allowEditPost := *th.App.Config().ServiceSettings.AllowEditPost
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = allowEditPost })
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-
+	th.App.SetLicense(model.NewTestLicense())
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = model.ALLOW_EDIT_POST_ALWAYS })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	post := &model.Post{ChannelId: channel.Id, Message: "zz" + model.NewId() + "a"}
 	rpost, resp := Client.CreatePost(post)
@@ -574,21 +548,8 @@ func TestPatchPost(t *testing.T) {
 	Client := th.Client
 	channel := th.BasicChannel
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	allowEditPost := *th.App.Config().ServiceSettings.AllowEditPost
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = allowEditPost })
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-
+	th.App.SetLicense(model.NewTestLicense())
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowEditPost = model.ALLOW_EDIT_POST_ALWAYS })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	post := &model.Post{
 		ChannelId:    channel.Id,

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -68,13 +68,7 @@ func TestCreateTeam(t *testing.T) {
 	CheckUnauthorizedStatus(t, resp)
 
 	// Update permission
-	enableTeamCreation := th.App.Config().TeamSettings.EnableTeamCreation
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableTeamCreation = enableTeamCreation })
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableTeamCreation = false })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	th.LoginBasic()
 	_, resp = Client.CreateTeam(team)
@@ -1292,20 +1286,8 @@ func TestAddTeamMember(t *testing.T) {
 
 	Client.Logout()
 
-	// Check effects of config and license changes.
-	restrictTeamInvite := *th.App.Config().TeamSettings.RestrictTeamInvite
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
-
 	// Set the config so that only team admins can add a user to a team.
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Test without the EE license to see that the permission restriction is ignored.
@@ -1313,10 +1295,7 @@ func TestAddTeamMember(t *testing.T) {
 	CheckNoError(t, resp)
 
 	// Add an EE license.
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 	th.LoginBasic()
 
 	// Check that a regular user can't add someone to the team.
@@ -1327,10 +1306,6 @@ func TestAddTeamMember(t *testing.T) {
 	th.UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a team admin.
@@ -1339,7 +1314,6 @@ func TestAddTeamMember(t *testing.T) {
 
 	// Change permission level to System Admin
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Should not work as team admin.
 	_, resp = Client.AddTeamMember(team.Id, otherUser.Id)
@@ -1353,21 +1327,12 @@ func TestAddTeamMember(t *testing.T) {
 	th.UpdateUserToNonTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a regular user.
 	_, resp = Client.AddTeamMember(team.Id, otherUser.Id)
 	CheckNoError(t, resp)
 
-	// Reset config and license.
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
-	utils.SetIsLicensed(isLicensed)
-	utils.SetLicense(license)
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// by hash and data
@@ -1506,20 +1471,8 @@ func TestAddTeamMembers(t *testing.T) {
 
 	Client.Logout()
 
-	// Check effects of config and license changes.
-	restrictTeamInvite := *th.App.Config().TeamSettings.RestrictTeamInvite
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = restrictTeamInvite })
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.SetDefaultRolesBasedOnConfig()
-	}()
-
 	// Set the config so that only team admins can add a user to a team.
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Test without the EE license to see that the permission restriction is ignored.
@@ -1527,10 +1480,7 @@ func TestAddTeamMembers(t *testing.T) {
 	CheckNoError(t, resp)
 
 	// Add an EE license.
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
+	th.App.SetLicense(model.NewTestLicense())
 	th.LoginBasic()
 
 	// Check that a regular user can't add someone to the team.
@@ -1541,10 +1491,6 @@ func TestAddTeamMembers(t *testing.T) {
 	th.UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a team admin.
@@ -1553,7 +1499,6 @@ func TestAddTeamMembers(t *testing.T) {
 
 	// Change permission level to System Admin
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_SYSTEM_ADMIN })
-	th.App.SetDefaultRolesBasedOnConfig()
 
 	// Should not work as team admin.
 	_, resp = Client.AddTeamMembers(team.Id, userList)
@@ -1567,10 +1512,6 @@ func TestAddTeamMembers(t *testing.T) {
 	th.UpdateUserToNonTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_ALL })
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	th.App.SetDefaultRolesBasedOnConfig()
 	th.LoginBasic()
 
 	// Should work as a regular user.
@@ -1929,10 +1870,6 @@ func TestInviteUsersToTeam(t *testing.T) {
 		}
 	}
 
-	restrictCreationToDomains := th.App.Config().TeamSettings.RestrictCreationToDomains
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.RestrictCreationToDomains = restrictCreationToDomains })
-	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.RestrictCreationToDomains = "@example.com" })
 
 	err := th.App.InviteNewUsersToTeam(emailList, th.BasicTeam.Id, th.BasicUser.Id)

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -1306,6 +1306,7 @@ func TestAddTeamMember(t *testing.T) {
 	th.UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
+	th.App.SetLicense(model.NewTestLicense())
 	th.LoginBasic()
 
 	// Should work as a team admin.
@@ -1327,6 +1328,7 @@ func TestAddTeamMember(t *testing.T) {
 	th.UpdateUserToNonTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_ALL })
+	th.App.SetLicense(model.NewTestLicense())
 	th.LoginBasic()
 
 	// Should work as a regular user.
@@ -1491,6 +1493,7 @@ func TestAddTeamMembers(t *testing.T) {
 	th.UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_TEAM_ADMIN })
+	th.App.SetLicense(model.NewTestLicense())
 	th.LoginBasic()
 
 	// Should work as a team admin.
@@ -1512,6 +1515,7 @@ func TestAddTeamMembers(t *testing.T) {
 	th.UpdateUserToNonTeamAdmin(th.BasicUser, th.BasicTeam)
 	th.App.InvalidateAllCaches()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictTeamInvite = model.PERMISSIONS_ALL })
+	th.App.SetLicense(model.NewTestLicense())
 	th.LoginBasic()
 
 	// Should work as a regular user.

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1566,18 +1566,7 @@ func TestUpdateUserMfa(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	enableMfa := *th.App.Config().ServiceSettings.EnableMultifactorAuthentication
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = enableMfa })
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	*utils.License().Features.MFA = true
+	th.App.SetLicense(model.NewTestLicense("mfa"))
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = true })
 
 	session, _ := th.App.GetSession(Client.AuthToken)
@@ -1612,18 +1601,7 @@ func TestCheckUserMfa(t *testing.T) {
 		t.Fatal("should be false - mfa not active")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	enableMfa := *th.App.Config().ServiceSettings.EnableMultifactorAuthentication
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = enableMfa })
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	*utils.License().Features.MFA = true
+	th.App.SetLicense(model.NewTestLicense("mfa"))
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = true })
 
 	th.LoginBasic()
@@ -1659,18 +1637,7 @@ func TestGenerateMfaSecret(t *testing.T) {
 	_, resp = Client.GenerateMfaSecret("junk")
 	CheckBadRequestStatus(t, resp)
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	enableMfa := *th.App.Config().ServiceSettings.EnableMultifactorAuthentication
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = enableMfa })
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	*utils.License().Features.MFA = true
+	th.App.SetLicense(model.NewTestLicense("mfa"))
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = true })
 
 	_, resp = Client.GenerateMfaSecret(model.NewId())
@@ -2187,19 +2154,7 @@ func TestSwitchAccount(t *testing.T) {
 		t.Fatal("bad link")
 	}
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	enableAuthenticationTransfer := *th.App.Config().ServiceSettings.ExperimentalEnableAuthenticationTransfer
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer = enableAuthenticationTransfer
-		})
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
+	th.App.SetLicense(model.NewTestLicense())
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer = false })
 
 	sr = &model.SwitchRequest{

--- a/app/app.go
+++ b/app/app.go
@@ -88,6 +88,9 @@ func New(options ...Option) (*App, error) {
 		panic("Only one App should exist at a time. Did you forget to call Shutdown()?")
 	}
 
+	// TODO: remove this once utils global license state is eliminated
+	utils.SetLicense(nil)
+
 	app := &App{
 		goroutineExitSignal: make(chan struct{}, 1),
 		Srv: &Server{

--- a/app/config.go
+++ b/app/config.go
@@ -254,11 +254,3 @@ func (a *App) Desanitize(cfg *model.Config) {
 		cfg.SqlSettings.DataSourceSearchReplicas[i] = actual.SqlSettings.DataSourceSearchReplicas[i]
 	}
 }
-
-// License returns the currently active license or nil if the application is unlicensed.
-func (a *App) License() *model.License {
-	if utils.IsLicensed() {
-		return utils.License()
-	}
-	return nil
-}

--- a/app/license.go
+++ b/app/license.go
@@ -59,7 +59,7 @@ func (a *App) SaveLicense(licenseBytes []byte) (*model.License, *model.AppError)
 			}
 		}
 
-		if ok := utils.SetLicense(license); !ok {
+		if ok := a.SetLicense(license); !ok {
 			return nil, model.NewAppError("addLicense", model.EXPIRED_LICENSE_ERROR, nil, "", http.StatusBadRequest)
 		}
 
@@ -100,6 +100,20 @@ func (a *App) SaveLicense(licenseBytes []byte) (*model.License, *model.AppError)
 	}
 
 	return license, nil
+}
+
+// License returns the currently active license or nil if the application is unlicensed.
+func (a *App) License() *model.License {
+	if utils.IsLicensed() {
+		return utils.License()
+	}
+	return nil
+}
+
+func (a *App) SetLicense(license *model.License) bool {
+	ok := utils.SetLicense(license)
+	a.SetDefaultRolesBasedOnConfig()
+	return ok
 }
 
 func (a *App) RemoveLicense() *model.AppError {

--- a/app/session_test.go
+++ b/app/session_test.go
@@ -48,18 +48,7 @@ func TestGetSessionIdleTimeoutInMinutes(t *testing.T) {
 
 	session, _ = th.App.CreateSession(session)
 
-	isLicensed := utils.IsLicensed()
-	license := utils.License()
-	timeout := *th.App.Config().ServiceSettings.SessionIdleTimeoutInMinutes
-	defer func() {
-		utils.SetIsLicensed(isLicensed)
-		utils.SetLicense(license)
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.SessionIdleTimeoutInMinutes = timeout })
-	}()
-	utils.SetIsLicensed(true)
-	utils.SetLicense(&model.License{Features: &model.Features{}})
-	utils.License().Features.SetDefaults()
-	*utils.License().Features.Compliance = true
+	th.App.SetLicense(model.NewTestLicense("compliance"))
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.SessionIdleTimeoutInMinutes = 5 })
 
 	rsession, err := th.App.GetSession(session.Token)

--- a/model/license.go
+++ b/model/license.go
@@ -173,6 +173,23 @@ func (l *License) ToJson() string {
 	return string(b)
 }
 
+// NewTestLicense returns a license that expires in the future and has the given features.
+func NewTestLicense(features ...string) *License {
+	ret := &License{
+		ExpiresAt: GetMillis() + 90*24*60*60*1000,
+	}
+	ret.Features.SetDefaults()
+
+	featureMap := map[string]bool{}
+	for _, feature := range features {
+		featureMap[feature] = true
+	}
+	featureJson, _ := json.Marshal(featureMap)
+	json.Unmarshal(featureJson, &ret.Features)
+
+	return ret
+}
+
 func LicenseFromJson(data io.Reader) *License {
 	var o *License
 	json.NewDecoder(data).Decode(&o)

--- a/model/license.go
+++ b/model/license.go
@@ -177,6 +177,7 @@ func (l *License) ToJson() string {
 func NewTestLicense(features ...string) *License {
 	ret := &License{
 		ExpiresAt: GetMillis() + 90*24*60*60*1000,
+		Features:  &Features{},
 	}
 	ret.Features.SetDefaults()
 

--- a/model/license.go
+++ b/model/license.go
@@ -177,6 +177,7 @@ func (l *License) ToJson() string {
 func NewTestLicense(features ...string) *License {
 	ret := &License{
 		ExpiresAt: GetMillis() + 90*24*60*60*1000,
+		Customer:  &Customer{},
 		Features:  &Features{},
 	}
 	ret.Features.SetDefaults()


### PR DESCRIPTION
#### Summary
I love deleting code.

This adds an `(*app.App)SetLicense` function and replaces all calls to `utils.SetLicense`. It also deletes a bunch of crap that we don't need any more. There's no longer any need to restore the config or license state at the end of a test, and there's no need to call `SetDefaultRolesBasedOnConfig` (in a future PR I'll remove the remaining calls and make it a private method).

As a convenience for testing, there's also a new `model.NewTestLicense(features ...string)` function, which can be used to set up a test license with a one liner:

```go
th.App.SetLicense(model.NewTestLicense("mfa"))
```

There's a lot more stuff to delete in future PRs. And of course, I'll finish eliminating the license globals entirely after another PR or two hopefully.

#### Ticket Link
N/A

#### Checklist
N/A