### PR TITLE
ABC-239 Increase OAuth2 state parameter limit

### DIFF
--- a/model/authorize.go
+++ b/model/authorize.go
@@ -62,7 +62,7 @@ func (ad *AuthData) IsValid() *AppError {
 		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.redirect_uri.app_error", nil, "client_id="+ad.ClientId, http.StatusBadRequest)
 	}
 
-	if len(ad.State) > 128 {
+	if len(ad.State) > 1024 {
 		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.state.app_error", nil, "client_id="+ad.ClientId, http.StatusBadRequest)
 	}
 

--- a/model/authorize_test.go
+++ b/model/authorize_test.go
@@ -115,7 +115,7 @@ func TestAuthIsValid(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ad.Scope = NewRandomString(129)
+	ad.Scope = NewRandomString(1025)
 	if err := ad.IsValid(); err == nil {
 		t.Fatal("Should have failed invalid Scope")
 	}

--- a/store/sqlstore/oauth_store.go
+++ b/store/sqlstore/oauth_store.go
@@ -35,7 +35,7 @@ func NewSqlOAuthStore(sqlStore SqlStore) store.OAuthStore {
 		tableAuth.ColMap("ClientId").SetMaxSize(26)
 		tableAuth.ColMap("Code").SetMaxSize(128)
 		tableAuth.ColMap("RedirectUri").SetMaxSize(256)
-		tableAuth.ColMap("State").SetMaxSize(128)
+		tableAuth.ColMap("State").SetMaxSize(1024)
 		tableAuth.ColMap("Scope").SetMaxSize(128)
 
 		tableAccess := db.AddTableWithName(model.AccessData{}, "OAuthAccessData").SetKeys(false, "Token")

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -343,6 +343,7 @@ func UpgradeDatabaseToVersion46(sqlStore SqlStore) {
 func UpgradeDatabaseToVersion47(sqlStore SqlStore) {
 	if shouldPerformUpgrade(sqlStore, VERSION_4_6_0, VERSION_4_7_0) {
 		sqlStore.AlterColumnTypeIfExists("Users", "Position", "varchar(128)", "varchar(128)")
+		sqlStore.AlterColumnTypeIfExists("OAuthAuthData", "State", "varchar(1024)", "varchar(1024)")
 		saveSchemaVersion(sqlStore, VERSION_4_7_0)
 	}
 }


### PR DESCRIPTION
#### Summary
Increase OAuth2 state parameter limit from 128 to 1024.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-239