### PR TITLE
XYZ-76: Add license check to patchRoles endpoint.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -48,6 +48,10 @@
     "translation": "September"
   },
   {
+    "id": "api.roles.patch_roles.license.error",
+    "translation": "Your current license does not support advanced permissions."
+  },
+  {
     "id": "api.admin.add_certificate.no_file.app_error",
     "translation": "No file under 'certificate' in request."
   },

--- a/model/role.go
+++ b/model/role.go
@@ -81,6 +81,41 @@ func (o *Role) Patch(patch *RolePatch) {
 	}
 }
 
+// Returns an array of permissions that are in either role.Permissions
+// or patch.Permissions, but not both.
+func PermissionsChangedByPatch(role *Role, patch *RolePatch) []string {
+	var result []string
+
+	if patch.Permissions == nil {
+		return result
+	}
+
+	roleMap := make(map[string]bool)
+	patchMap := make(map[string]bool)
+
+	for _, permission := range role.Permissions {
+		roleMap[permission] = true
+	}
+
+	for _, permission := range *patch.Permissions {
+		patchMap[permission] = true
+	}
+
+	for _, permission := range role.Permissions {
+		if !patchMap[permission] {
+			result = append(result, permission)
+		}
+	}
+
+	for _, permission := range *patch.Permissions {
+		if !roleMap[permission] {
+			result = append(result, permission)
+		}
+	}
+
+	return result
+}
+
 func (role *Role) IsValid() bool {
 	if len(role.Id) != 26 {
 		return false


### PR DESCRIPTION
#### Summary
This adds the license check to `patchRoles()`, which provides enforcement of which permissions can be set as "Advanced Permissions" and which permissions can already be set.

The list of permissions might need adjusting - I'm investigating that now.

#### Ticket Link
https://mattermost.atlassian.net/browse/XYZ-76

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
