### PR TITLE
PLT-8723: Fix DeadLock on reactions insertions

### DIFF
--- a/store/sqlstore/supplier_reactions.go
+++ b/store/sqlstore/supplier_reactions.go
@@ -134,7 +134,7 @@ func (s *SqlSupplier) ReactionDeleteAllWithEmojiName(ctx context.Context, emojiN
 	}
 
 	for _, reaction := range reactions {
-		if _, err := s.GetMaster().Exec(UPDATE_POST_HAS_REACTIONS_QUERY,
+		if _, err := s.GetMaster().Exec(UPDATE_POST_HAS_REACTIONS_ON_DELETE_QUERY,
 			map[string]interface{}{"PostId": reaction.PostId, "UpdateAt": model.GetMillis()}); err != nil {
 			l4g.Warn(utils.T("store.sql_reaction.delete_all_with_emoji_name.update_post.warn"), reaction.PostId, err.Error())
 		}
@@ -174,7 +174,7 @@ func saveReactionAndUpdatePost(transaction *gorp.Transaction, reaction *model.Re
 		return err
 	}
 
-	return updatePostForReactions(transaction, reaction.PostId)
+	return updatePostForReactionsOnInsert(transaction, reaction.PostId)
 }
 
 func deleteReactionAndUpdatePost(transaction *gorp.Transaction, reaction *model.Reaction) error {
@@ -189,12 +189,12 @@ func deleteReactionAndUpdatePost(transaction *gorp.Transaction, reaction *model.
 		return err
 	}
 
-	return updatePostForReactions(transaction, reaction.PostId)
+	return updatePostForReactionsOnDelete(transaction, reaction.PostId)
 }
 
 const (
 	// Set HasReactions = true if and only if the post has reactions, update UpdateAt only if HasReactions changes
-	UPDATE_POST_HAS_REACTIONS_QUERY = `UPDATE
+	UPDATE_POST_HAS_REACTIONS_ON_DELETE_QUERY = `UPDATE
 			Posts
 		SET
 			UpdateAt = (CASE
@@ -206,8 +206,25 @@ const (
 			Id = :PostId`
 )
 
-func updatePostForReactions(transaction *gorp.Transaction, postId string) error {
-	_, err := transaction.Exec(UPDATE_POST_HAS_REACTIONS_QUERY, map[string]interface{}{"PostId": postId, "UpdateAt": model.GetMillis()})
+func updatePostForReactionsOnDelete(transaction *gorp.Transaction, postId string) error {
+	_, err := transaction.Exec(UPDATE_POST_HAS_REACTIONS_ON_DELETE_QUERY, map[string]interface{}{"PostId": postId, "UpdateAt": model.GetMillis()})
+
+	return err
+}
+
+func updatePostForReactionsOnInsert(transaction *gorp.Transaction, postId string) error {
+	_, err := transaction.Exec(
+		`UPDATE
+			Posts
+		SET
+			UpdateAt = (CASE
+				WHEN HasReactions != True THEN :UpdateAt
+				ELSE UpdateAt
+			END),
+			HasReactions = True
+		WHERE
+			Id = :PostId`,
+		map[string]interface{}{"PostId": postId, "UpdateAt": model.GetMillis()})
 
 	return err
 }

--- a/store/sqlstore/supplier_reactions.go
+++ b/store/sqlstore/supplier_reactions.go
@@ -217,13 +217,10 @@ func updatePostForReactionsOnInsert(transaction *gorp.Transaction, postId string
 		`UPDATE
 			Posts
 		SET
-			UpdateAt = (CASE
-				WHEN HasReactions != True THEN :UpdateAt
-				ELSE UpdateAt
-			END),
-			HasReactions = True
+			HasReactions = True,
+			UpdateAt = :UpdateAt
 		WHERE
-			Id = :PostId`,
+			Id = :PostId AND HasReactions = False`,
 		map[string]interface{}{"PostId": postId, "UpdateAt": model.GetMillis()})
 
 	return err


### PR DESCRIPTION
#### Summary
Fix the DeadLock on reactions insertions (it only happens when a lot or reactions and posts are created in parallel with sampledata command). It fix the DeadLock for insertion, but there still the posibility of the DeadLock on deletion.

This solve the problem of parallel workers inserting data with sampledata or bulk_import into mysql with reactions.

And maybe it can go into the release.

#### Ticket Link
[PLT-8723](https://mattermost.atlassian.net/browse/PLT-8723)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)