### PR TITLE
ICU-669 Ensure all URLs returned from OpenGraph are absolute

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -749,16 +749,16 @@ func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
 		l4g.Error("GetOpenGraphMetadata processing failed for url=%v with err=%v", requestURL, err.Error())
 	}
 
-	og = makeOpenGraphURLsAbsolute(og, requestURL)
+	makeOpenGraphURLsAbsolute(og, requestURL)
 
 	return og
 }
 
-func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) *opengraph.OpenGraph {
+func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) {
 	parsedRequestURL, err := url.Parse(requestURL)
 	if err != nil {
 		l4g.Warn("makeOpenGraphURLsAbsolute failed to parse url=%v", requestURL)
-		return og
+		return
 	}
 
 	makeURLAbsolute := func(resultURL string) string {
@@ -776,10 +776,7 @@ func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) *open
 			return resultURL
 		}
 
-		parsedResultURL.Scheme = parsedRequestURL.Scheme
-		parsedResultURL.Host = parsedRequestURL.Host
-
-		return parsedResultURL.String()
+		return parsedRequestURL.ResolveReference(parsedResultURL).String()
 	}
 
 	og.URL = makeURLAbsolute(og.URL)
@@ -798,8 +795,6 @@ func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) *open
 		video.URL = makeURLAbsolute(video.URL)
 		video.SecureURL = makeURLAbsolute(video.SecureURL)
 	}
-
-	return og
 }
 
 func (a *App) DoPostAction(postId string, actionId string, userId string) *model.AppError {

--- a/app/post.go
+++ b/app/post.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -734,18 +735,68 @@ func (a *App) GetFileInfosForPost(postId string, readFromMaster bool) ([]*model.
 	return infos, nil
 }
 
-func (a *App) GetOpenGraphMetadata(url string) *opengraph.OpenGraph {
+func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
 	og := opengraph.NewOpenGraph()
 
-	res, err := a.HTTPClient(false).Get(url)
+	res, err := a.HTTPClient(false).Get(requestURL)
 	if err != nil {
-		l4g.Error("GetOpenGraphMetadata request failed for url=%v with err=%v", url, err.Error())
+		l4g.Error("GetOpenGraphMetadata request failed for url=%v with err=%v", requestURL, err.Error())
 		return og
 	}
 	defer consumeAndClose(res)
 
 	if err := og.ProcessHTML(res.Body); err != nil {
-		l4g.Error("GetOpenGraphMetadata processing failed for url=%v with err=%v", url, err.Error())
+		l4g.Error("GetOpenGraphMetadata processing failed for url=%v with err=%v", requestURL, err.Error())
+	}
+
+	og = makeOpenGraphURLsAbsolute(og, requestURL)
+
+	return og
+}
+
+func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) *opengraph.OpenGraph {
+	parsedRequestURL, err := url.Parse(requestURL)
+	if err != nil {
+		l4g.Warn("makeOpenGraphURLsAbsolute failed to parse url=%v", requestURL)
+		return og
+	}
+
+	makeURLAbsolute := func(resultURL string) string {
+		if resultURL == "" {
+			return resultURL
+		}
+
+		parsedResultURL, err := url.Parse(resultURL)
+		if err != nil {
+			l4g.Warn("makeOpenGraphURLsAbsolute failed to parse result url=%v", resultURL)
+			return resultURL
+		}
+
+		if parsedResultURL.IsAbs() {
+			return resultURL
+		}
+
+		parsedResultURL.Scheme = parsedRequestURL.Scheme
+		parsedResultURL.Host = parsedRequestURL.Host
+
+		return parsedResultURL.String()
+	}
+
+	og.URL = makeURLAbsolute(og.URL)
+
+	for _, image := range og.Images {
+		image.URL = makeURLAbsolute(image.URL)
+		image.SecureURL = makeURLAbsolute(image.SecureURL)
+	}
+
+	for _, audio := range og.Audios {
+		audio.URL = makeURLAbsolute(audio.URL)
+		audio.SecureURL = makeURLAbsolute(audio.SecureURL)
+	}
+
+	for _, video := range og.Videos {
+		video.URL = makeURLAbsolute(video.URL)
+		video.SecureURL = makeURLAbsolute(video.SecureURL)
 	}
 
 	return og

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -336,7 +336,7 @@ func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
 					t.Fatalf("incorrect image url, expected %v, got %v", tc.ImageURL, og.Images[0].URL)
 				}
 			} else if tc.ImageURL != "" {
-				t.Fatal("missing image url, expected %v, got nothing", tc.ImageURL)
+				t.Fatalf("missing image url, expected %v, got nothing", tc.ImageURL)
 			}
 		})
 	}

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -271,7 +271,7 @@ func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
 			URL:        "https://example.com/apps/mattermost",
 			ImageURL:   "https://images.example.com/image.png",
 		},
-		"relative URLs": {
+		"URLs starting with /": {
 			HTML: `
 				<html>
 					<head>
@@ -283,7 +283,7 @@ func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
 			URL:        "http://example.com/apps/mattermost",
 			ImageURL:   "http://example.com/image.png",
 		},
-		"relative URLs with HTTPS": {
+		"HTTPS URLs starting with /": {
 			HTML: `
 				<html>
 					<head>
@@ -306,6 +306,18 @@ func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
 			URL:        "http://example.com/apps/mattermost",
 			ImageURL:   "",
 		},
+		"relative URLs": {
+			HTML: `
+				<html>
+					<head>
+						<meta property="og:url" content="index.html">
+						<meta property="og:image" content="../resources/image.png">
+					</head>
+				</html>`,
+			RequestURL: "http://example.com/content/index.html",
+			URL:        "http://example.com/content/index.html",
+			ImageURL:   "http://example.com/resources/image.png",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			og := opengraph.NewOpenGraph()
@@ -313,7 +325,7 @@ func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			og = makeOpenGraphURLsAbsolute(og, tc.RequestURL)
+			makeOpenGraphURLsAbsolute(og, tc.RequestURL)
 
 			if og.URL != tc.URL {
 				t.Fatalf("incorrect url, expected %v, got %v", tc.URL, og.URL)


### PR DESCRIPTION
It sounds like web sites should only be including absolute URLs in their OpenGraph metadata, but since that isn't the case in practice, we can have the server fix that before it reaches the clients.

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-669

#### Checklist
- Added or updated unit tests (required for all new features)