### PR TITLE
Add tests for the `platform server` command

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -86,7 +86,7 @@ var appCount = 0
 
 // New creates a new App. You must call Shutdown when you're done with it.
 // XXX: For now, only one at a time is allowed as some resources are still shared.
-func New(options ...Option) (*App, error) {
+func New(options ...Option) (outApp *App, outErr error) {
 	appCount++
 	if appCount > 1 {
 		panic("Only one App should exist at a time. Did you forget to call Shutdown()?")
@@ -103,6 +103,11 @@ func New(options ...Option) (*App, error) {
 		clientConfig:     make(map[string]string),
 		licenseListeners: map[string]func(){},
 	}
+	defer func() {
+		if outErr != nil {
+			app.Shutdown()
+		}
+	}()
 
 	for _, option := range options {
 		option(app)
@@ -110,18 +115,15 @@ func New(options ...Option) (*App, error) {
 
 	if utils.T == nil {
 		if err := utils.TranslationsPreInit(); err != nil {
-			app.Shutdown()
 			return nil, errors.Wrapf(err, "unable to load Mattermost translation files")
 		}
 	}
 	model.AppErrorInit(utils.T)
 	if err := app.LoadConfig(app.configFile); err != nil {
-		app.Shutdown()
 		return nil, err
 	}
 	app.EnableConfigWatch()
 	if err := utils.InitTranslations(app.Config().LocalizationSettings); err != nil {
-		app.Shutdown()
 		return nil, errors.Wrapf(err, "unable to load Mattermost translation files")
 	}
 
@@ -150,7 +152,6 @@ func New(options ...Option) (*App, error) {
 
 	app.Srv.Store = app.newStore()
 	if err := app.ensureAsymmetricSigningKey(); err != nil {
-		app.Shutdown()
 		return nil, errors.Wrapf(err, "unable to ensure asymmetric signing key")
 	}
 

--- a/cmd/platform/server_test.go
+++ b/cmd/platform/server_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/jobs"
+	"github.com/mattermost/mattermost-server/utils"
+	"github.com/stretchr/testify/require"
+)
+
+type ServerTestHelper struct {
+	configPath         string
+	disableConfigWatch bool
+	interruptChan      chan os.Signal
+	originalInterval   int
+}
+
+func SetupServerTest() *ServerTestHelper {
+	// Build a channel that will be used by the server to receive system signals…
+	interruptChan := make(chan os.Signal, 1)
+	// …and sent it immediately a SIGINT value.
+	// This will make the server loop stop as soon as it started successfully.
+	interruptChan <- syscall.SIGINT
+
+	// Let jobs poll for termination every 0.2s (instead of every 15s by default)
+	// Otherwise we would have to wait the whole polling duration before the test
+	// terminates.
+	originalInterval := jobs.DEFAULT_WATCHER_POLLING_INTERVAL
+	jobs.DEFAULT_WATCHER_POLLING_INTERVAL = 200
+
+	th := &ServerTestHelper{
+		configPath:         utils.FindConfigFile("config.json"),
+		disableConfigWatch: true,
+		interruptChan:      interruptChan,
+		originalInterval:   originalInterval,
+	}
+	return th
+}
+
+func (th *ServerTestHelper) TearDownServerTest() {
+	jobs.DEFAULT_WATCHER_POLLING_INTERVAL = th.originalInterval
+}
+
+func TestRunServerSuccess(t *testing.T) {
+	th := SetupServerTest()
+	defer th.TearDownServerTest()
+
+	err := runServer(th.configPath, th.disableConfigWatch, th.interruptChan)
+	require.NoError(t, err)
+}
+
+func TestRunServerInvalidConfigFile(t *testing.T) {
+	th := SetupServerTest()
+	defer th.TearDownServerTest()
+
+	// Start the server with an unreadable config file
+	unreadableConfigFile, err := ioutil.TempFile("", "mattermost-unreadable-config-file-")
+	if err != nil {
+		panic(err)
+	}
+	os.Chmod(unreadableConfigFile.Name(), 0200)
+	defer os.Remove(unreadableConfigFile.Name())
+
+	err = runServer(unreadableConfigFile.Name(), th.disableConfigWatch, th.interruptChan)
+	require.Error(t, err)
+}

--- a/jobs/jobs_watcher.go
+++ b/jobs/jobs_watcher.go
@@ -11,9 +11,9 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-const (
-	DEFAULT_WATCHER_POLLING_INTERVAL = 15000
-)
+// Default polling interval for jobs termination.
+// (Defining as `var` rather than `const` allows tests to lower the interval.)
+var DEFAULT_WATCHER_POLLING_INTERVAL = 15000
 
 type Watcher struct {
 	srv     *JobServer


### PR DESCRIPTION
#### Summary

Add tests for the `platform server` command. The tests ensure that the server will start and stop normally when correctly configured; and that it will return a proper error in case of (for instance) an invalid configuration file.

Writing the tests uncovered an issue in the code (that I introduced in #8204): when the App initialization fails and an error is returned, some of the app state is left dirty (notably `appCount` is not decremented).

The impact is quite limited, as during normal usage an initialization error makes the program terminate quickly afterwards (so not cleaning up isn't an issue). However, during tests, we may create more than one App instance. This PR fixes the issue by ensuring the app cleans itself when encountering an initialization error, before returning the error to the caller.

**Implementation notes:** as the `platform server` command only exits when interrupted by a signal, it is not possible to test it as the other cobra commands. Instead we directly test the actual command function.

The internal command handler is slightly refactored to take a channel in argument, and registers it as the signal handler. Nothing really different—except than controlling this channel from the outside allows the test suite to send the system signal itself, thus preventing the server to run forever.

#### Ticket Link

n/a

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)