### PR TITLE
ABC-228 Update GetPosts caching to work for non-60 limits

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -322,7 +322,8 @@ type etagPosts struct {
 
 func (s SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 	lastPostTimeCache.Remove(channelId)
-	lastPostsCache.Remove(channelId)
+	lastPostsCache.Remove(channelId + "30")
+	lastPostsCache.Remove(channelId + "60")
 }
 
 func (s SqlPostStore) GetEtag(channelId string, allowFromCache bool) store.StoreChannel {
@@ -439,7 +440,7 @@ func (s SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFro
 			return
 		}
 
-		if allowFromCache && offset == 0 {
+		if allowFromCache && offset == 0 && (limit == 60 || limit == 30) {
 			if cacheItem, ok := lastPostsCache.Get(fmt.Sprintf("%s%v", channelId, limit)); ok {
 				if s.metrics != nil {
 					s.metrics.IncrementMemCacheHitCounter("Last Posts Cache")
@@ -482,7 +483,7 @@ func (s SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFro
 
 			list.MakeNonNil()
 
-			if offset == 0 {
+			if offset == 0 && (limit == 60 || limit == 30) {
 				lastPostsCache.AddWithExpiresInSecs(fmt.Sprintf("%s%v", channelId, limit), list, LAST_POSTS_CACHE_SEC)
 			}
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -439,8 +439,8 @@ func (s SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFro
 			return
 		}
 
-		if allowFromCache && offset == 0 && limit == 60 {
-			if cacheItem, ok := lastPostsCache.Get(channelId); ok {
+		if allowFromCache && offset == 0 {
+			if cacheItem, ok := lastPostsCache.Get(fmt.Sprintf("%s%v", channelId, limit)); ok {
 				if s.metrics != nil {
 					s.metrics.IncrementMemCacheHitCounter("Last Posts Cache")
 				}
@@ -482,8 +482,8 @@ func (s SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFro
 
 			list.MakeNonNil()
 
-			if offset == 0 && limit == 60 {
-				lastPostsCache.AddWithExpiresInSecs(channelId, list, LAST_POSTS_CACHE_SEC)
+			if offset == 0 {
+				lastPostsCache.AddWithExpiresInSecs(fmt.Sprintf("%s%v", channelId, limit), list, LAST_POSTS_CACHE_SEC)
 			}
 
 			result.Data = list

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -322,6 +322,8 @@ type etagPosts struct {
 
 func (s SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 	lastPostTimeCache.Remove(channelId)
+
+	// Keys are "{channelid}{limit}" and caching only occurs on limits of 30 and 60
 	lastPostsCache.Remove(channelId + "30")
 	lastPostsCache.Remove(channelId + "60")
 }
@@ -440,6 +442,7 @@ func (s SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFro
 			return
 		}
 
+		// Caching only occurs on limits of 30 and 60, the common limits requested by MM clients
 		if allowFromCache && offset == 0 && (limit == 60 || limit == 30) {
 			if cacheItem, ok := lastPostsCache.Get(fmt.Sprintf("%s%v", channelId, limit)); ok {
 				if s.metrics != nil {
@@ -483,6 +486,7 @@ func (s SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFro
 
 			list.MakeNonNil()
 
+			// Caching only occurs on limits of 30 and 60, the common limits requested by MM clients
 			if offset == 0 && (limit == 60 || limit == 30) {
 				lastPostsCache.AddWithExpiresInSecs(fmt.Sprintf("%s%v", channelId, limit), list, LAST_POSTS_CACHE_SEC)
 			}


### PR DESCRIPTION
#### Summary
This wouldn't affect the loadtest results since those were using a limit of 60 but the webapp uses a limit of 30 when requesting posts so in a real environment this could have significant benefit. Note that limit has a maximum of 1000 so we won't be caching more posts than that.

Couldn't think of an easy to unit test this since the caches are in a different package from the tests. If anyone has good ideas for that, let me know.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/ABC-228