### PR TITLE
XYZ-104: Can join a team with email invite link after regenerating the invite code

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -1250,7 +1250,7 @@ func TestAddTeamMember(t *testing.T) {
 	tm, resp := Client.AddTeamMember(team.Id, otherUser.Id)
 	CheckForbiddenStatus(t, resp)
 	if resp.Error == nil {
-		t.Fatalf("Error is nhul")
+		t.Fatalf("Error is nil")
 	}
 	Client.Logout()
 
@@ -1376,6 +1376,7 @@ func TestAddTeamMember(t *testing.T) {
 	dataObject := make(map[string]string)
 	dataObject["time"] = fmt.Sprintf("%v", model.GetMillis())
 	dataObject["id"] = team.Id
+	dataObject["invite_id"] = team.InviteId
 
 	data := model.MapToJson(dataObject)
 	hashed := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))

--- a/app/email.go
+++ b/app/email.go
@@ -276,6 +276,7 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, invites []st
 			props["display_name"] = team.DisplayName
 			props["name"] = team.Name
 			props["time"] = fmt.Sprintf("%v", model.GetMillis())
+			props["invite_id"] = team.InviteId
 			data := model.MapToJson(props)
 			hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, a.Config().EmailSettings.InviteSalt))
 			bodyPage.Props["Link"] = fmt.Sprintf("%s/signup_user_complete/?d=%s&h=%s", siteURL, url.QueryEscape(data), url.QueryEscape(hash))

--- a/app/team.go
+++ b/app/team.go
@@ -234,6 +234,11 @@ func (a *App) AddUserToTeamByHash(userId string, hash string, data string) (*mod
 		team = result.Data.(*model.Team)
 	}
 
+	// verify that the team's invite id hasn't been changed since the invite was sent
+	if team.InviteId != props["invite_id"] {
+		return nil, model.NewAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_mismatched_invite_id.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	var user *model.User
 	if result := <-uchan; result.Err != nil {
 		return nil, result.Err

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2203,10 +2203,6 @@
     "translation": "The signup link has expired"
   },
   {
-    "id": "api.team.create_team_from_signup.invalid_link.app_error",
-    "translation": "The signup link does not appear to be valid"
-  },
-  {
     "id": "api.team.create_team_from_signup.unavailable.app_error",
     "translation": "This URL is unavailable. Please try another."
   },
@@ -2705,6 +2701,10 @@
   {
     "id": "api.user.create_user.signup_link_expired.app_error",
     "translation": "The signup link has expired"
+  },
+  {
+    "id": "api.user.create_user.signup_link_mismatched_invite_id.app_error",
+    "translation": "The signup link does not appear to be valid"
   },
   {
     "id": "api.user.create_user.signup_link_invalid.app_error",
@@ -7295,10 +7295,6 @@
     "translation": "Signup"
   },
   {
-    "id": "web.signup_team_complete.invalid_link.app_error",
-    "translation": "The signup link does not appear to be valid"
-  },
-  {
     "id": "web.signup_team_complete.link_expired.app_error",
     "translation": "The signup link has expired"
   },
@@ -7313,10 +7309,6 @@
   {
     "id": "web.signup_user_complete.link_expired.app_error",
     "translation": "The signup link has expired"
-  },
-  {
-    "id": "web.signup_user_complete.link_invalid.app_error",
-    "translation": "The signup link does not appear to be valid"
   },
   {
     "id": "web.signup_user_complete.no_invites.app_error",


### PR DESCRIPTION
#### Summary
Added invite_id field to email invite url, along with validation of this field on the server. 

#### Test Steps
Log into the test server with two users in different browsers. Both users should be on the same team
* With UserA:
  * From the team menu, select "Create a new Team" and follow the steps to create a second team on the server
  * From the team menu, select "Team Settings", verify that "Allow any user with an account on this server to join this team" is set to "No"
  * From the team menu, select "Send Email Invite" and send an invite to UserB
  * From the team menu, select "Team Settings", expand the "Invite Code" section, click on "Regenerate Code", and then click on "Save"
  * Log into UserB's email account and verify that the invite email arrived. Copy the invite link out of it.
* With UserB
  * Verify that you are still logged into the server and a member of the original team
  * Verify that you cannot switch to the other team that UserA created
  * Paste the link from the email into your address bar
  * Instead of ending up in Town Square on the team that UserA created, UserB should be shown an error message because the link should be invalid since the invite id was changed after the email was sent.

#### Ticket Link
https://mattermost.atlassian.net/browse/XYZ-104

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
