### PR TITLE
When ExperimentalPrimaryTeam is set then when a new user signsup with…

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -142,6 +142,17 @@ func (a *App) CreateUserFromSignup(user *model.User) (*model.User, *model.AppErr
 	if err != nil {
 		return nil, err
 	}
+	if *a.Config().TeamSettings.ExperimentalPrimaryTeam != "" {
+		var team *model.Team
+		var err *model.AppError
+		if team, err = a.GetTeamByName(*a.Config().TeamSettings.ExperimentalPrimaryTeam); err != nil {
+			return nil, err
+		}
+
+		if err := a.JoinUserToTeam(team, ruser, ""); err != nil {
+			return nil, err
+		}
+	}
 
 	if err := a.SendWelcomeEmail(ruser.Id, ruser.Email, ruser.EmailVerified, ruser.Locale, utils.GetSiteURL()); err != nil {
 		l4g.Error(err.Error())


### PR DESCRIPTION
#### Summary
This change joins new users to the default team if there's a team defined in config `ExperimentalPrimaryTeam`. This config assumes that new users will be part of this primary team.

When config to have a `ExperimentalPrimaryTeam` was added this change was pushed back pushed back. 
https://github.com/mattermost/mattermost-server/pull/8039/files
https://github.com/mattermost/mattermost-server/pull/7846

cc @esethna @lindalumitchell @dmeza 