### PR TITLE
XYZ-109: Mapping updates

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -247,7 +247,7 @@ func (a *App) trackConfig() {
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{
 		"enable_user_creation":                    cfg.TeamSettings.EnableUserCreation,
-		"enable_team_creation":                    cfg.TeamSettings.EnableTeamCreation,
+		"enable_team_creation":                    *cfg.TeamSettings.EnableTeamCreation,
 		"restrict_team_invite":                    *cfg.TeamSettings.RestrictTeamInvite,
 		"restrict_public_channel_creation":        *cfg.TeamSettings.RestrictPublicChannelCreation,
 		"restrict_private_channel_creation":       *cfg.TeamSettings.RestrictPrivateChannelCreation,

--- a/model/config.go
+++ b/model/config.go
@@ -962,7 +962,7 @@ func (s *ThemeSettings) SetDefaults() {
 type TeamSettings struct {
 	SiteName                            string
 	MaxUsersPerTeam                     *int
-	EnableTeamCreation                  bool
+	EnableTeamCreation                  *bool
 	EnableUserCreation                  bool
 	EnableOpenServer                    *bool
 	RestrictCreationToDomains           string
@@ -1084,6 +1084,10 @@ func (s *TeamSettings) SetDefaults() {
 
 	if s.ExperimentalPrimaryTeam == nil {
 		s.ExperimentalPrimaryTeam = NewString("")
+	}
+
+	if s.EnableTeamCreation == nil {
+		s.EnableTeamCreation = NewBool(true)
 	}
 }
 

--- a/utils/authorization.go
+++ b/utils/authorization.go
@@ -260,7 +260,7 @@ func SetRolePermissionsFromConfig(roles map[string]*model.Role, cfg *model.Confi
 		)
 	}
 
-	if cfg.TeamSettings.EnableTeamCreation {
+	if *cfg.TeamSettings.EnableTeamCreation {
 		roles[model.SYSTEM_USER_ROLE_ID].Permissions = append(
 			roles[model.SYSTEM_USER_ROLE_ID].Permissions,
 			model.PERMISSION_CREATE_TEAM.Id,

--- a/utils/authorization_test.go
+++ b/utils/authorization_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -112,7 +113,14 @@ func updateConfig(config *model.Config, key string, value string) {
 		v = reflect.ValueOf(config.TeamSettings)
 		field = v.FieldByName(key)
 	}
-	field.Elem().SetString(value)
+
+	switch value {
+	case "true", "false":
+		b, _ := strconv.ParseBool(value)
+		field.Elem().SetBool(b)
+	default:
+		field.Elem().SetString(value)
+	}
 }
 
 func roleHasPermission(role *model.Role, permission string) bool {

--- a/utils/config.go
+++ b/utils/config.go
@@ -354,7 +354,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string) map[string]strin
 
 	props["SiteURL"] = strings.TrimRight(*c.ServiceSettings.SiteURL, "/")
 	props["SiteName"] = c.TeamSettings.SiteName
-	props["EnableTeamCreation"] = strconv.FormatBool(c.TeamSettings.EnableTeamCreation)
+	props["EnableTeamCreation"] = strconv.FormatBool(*c.TeamSettings.EnableTeamCreation)
 	props["EnableUserCreation"] = strconv.FormatBool(c.TeamSettings.EnableUserCreation)
 	props["EnableOpenServer"] = strconv.FormatBool(*c.TeamSettings.EnableOpenServer)
 	props["RestrictDirectMessage"] = *c.TeamSettings.RestrictDirectMessage

--- a/utils/policies-roles-mapping.json
+++ b/utils/policies-roles-mapping.json
@@ -432,16 +432,6 @@
                 "shouldHave": true
             },
             {
-                "roleName": "channel_admin",
-                "permission": "delete_post",
-                "shouldHave": false
-            },
-            {
-                "roleName": "channel_admin",
-                "permission": "delete_others_posts",
-                "shouldHave": false
-            },
-            {
                 "roleName": "team_admin",
                 "permission": "delete_post",
                 "shouldHave": true
@@ -456,16 +446,6 @@
             {
                 "roleName": "channel_user",
                 "permission": "delete_post",
-                "shouldHave": false
-            },
-            {
-                "roleName": "channel_admin",
-                "permission": "delete_post",
-                "shouldHave": false
-            },
-            {
-                "roleName": "channel_admin",
-                "permission": "delete_others_posts",
                 "shouldHave": false
             },
             {
@@ -486,16 +466,6 @@
                 "shouldHave": false
             },
             {
-                "roleName": "channel_admin",
-                "permission": "delete_post",
-                "shouldHave": false
-            },
-            {
-                "roleName": "channel_admin",
-                "permission": "delete_others_posts",
-                "shouldHave": false
-            },
-            {
                 "roleName": "team_admin",
                 "permission": "delete_post",
                 "shouldHave": false
@@ -504,6 +474,58 @@
                 "roleName": "team_admin",
                 "permission": "delete_others_posts",
                 "shouldHave": false
+            }
+        ]
+    },
+    "enableTeamCreation": {
+        "true": [
+            {
+                "roleName": "system_user",
+                "permission": "create_team",
+                "shouldHave": true
+            }
+        ],
+        "false": [
+            {
+                "roleName": "system_user",
+                "permission": "create_team",
+                "shouldHave": false
+            }
+        ]
+    },
+    "enableOnlyAdminIntegrations": {
+        "true": [
+            {
+                "roleName": "team_user",
+                "permission": "manage_webhooks",
+                "shouldHave": false
+            },
+            {
+                "roleName": "team_user",
+                "permission": "manage_slash_commands",
+                "shouldHave": false
+            },
+            {
+                "roleName": "system_user",
+                "permission": "manage_oauth",
+                "shouldHave": false
+            }
+        ],
+        "false": [
+            {
+                "roleName": "team_user",
+                "permission": "manage_webhooks",
+                "shouldHave": true
+            },
+            {
+                "roleName": "team_user",
+                "permission": "manage_slash_commands",
+                "shouldHave": true
+            },
+            {
+                "roleName": "system_user",
+                "permission": "manage_oauth",
+                "shouldHave": true
             }
         ]
     }


### PR DESCRIPTION
#### Summary
Changes were made to the [config mapping](https://github.com/mattermost/mattermost-webapp/blob/advanced-permissions-phase-1/utils/policy_roles_adapter.js#L45) and this change updates the JSON used in the tests for the config-to-permissions migration. 

Also changes `ServiceSettings`' `EnableTeamCreation` field to use a pointer consistent with  `EnableOnlyAdminIntegrations` field (for ease of testing).

#### Ticket Link
[XYZ-109](https://mattermost.atlassian.net/browse/XYZ-109)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
