### PR TITLE
Don't proxy same-site image urls

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -876,6 +876,10 @@ func (a *App) imageProxyConfig() (proxyType, proxyURL, options, siteURL string) 
 		proxyURL += "/"
 	}
 
+	if siteURL[len(siteURL)-1] != '/' {
+		siteURL += "/"
+	}
+
 	if cfg.ServiceSettings.ImageProxyOptions != nil {
 		options = *cfg.ServiceSettings.ImageProxyOptions
 	}
@@ -890,12 +894,12 @@ func (a *App) ImageProxyAdder() func(string) string {
 	}
 
 	return func(url string) string {
-		if url == "" || strings.HasPrefix(url, proxyURL) {
+		if url == "" || strings.HasPrefix(url, siteURL) || strings.HasPrefix(url, proxyURL) {
 			return url
 		}
 
 		if url[0] == '/' {
-			url = siteURL + url
+			url = siteURL + url[1:]
 		}
 
 		switch proxyType {

--- a/app/post.go
+++ b/app/post.go
@@ -876,7 +876,7 @@ func (a *App) imageProxyConfig() (proxyType, proxyURL, options, siteURL string) 
 		proxyURL += "/"
 	}
 
-	if siteURL[len(siteURL)-1] != '/' {
+	if siteURL == "" || siteURL[len(siteURL)-1] != '/' {
 		siteURL += "/"
 	}
 

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -190,6 +190,10 @@ func TestImageProxy(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.SiteURL = "http://mymattermost.com"
+	})
+
 	for name, tc := range map[string]struct {
 		ProxyType       string
 		ProxyURL        string
@@ -210,6 +214,12 @@ func TestImageProxy(t *testing.T) {
 			ProxyOptions:    "x1000",
 			ImageURL:        "http://mydomain.com/myimage",
 			ProxiedImageURL: "https://127.0.0.1/x1000/http://mydomain.com/myimage",
+		},
+		"willnorris/imageproxy_SameSite": {
+			ProxyType:       "willnorris/imageproxy",
+			ProxyURL:        "https://127.0.0.1",
+			ImageURL:        "http://mymattermost.com/myimage",
+			ProxiedImageURL: "http://mymattermost.com/myimage",
 		},
 		"willnorris/imageproxy_EmptyImageURL": {
 			ProxyType:       "willnorris/imageproxy",


### PR DESCRIPTION
#### Summary
This doesn't work:

```
https://image-proxy.mattermost.com//https://pre-release.mattermost.com/plugins/memes/templates/success-kid.jpg?text=assigned&text=chrome+testing
```

The auth headers are stripped as the request passes through the proxy.

I think it's reasonable to not proxy any images hosted on the Mattermost installation itself, and it facilitates authenticated / dynamically generated images from plugins (e.g. dank memes).

#### Ticket Link
N/A

#### Checklist
N/A