### PR TITLE
XYZ-73: Removes EnableOnlyAdminIntegrations.

### DIFF
--- a/api/command_test.go
+++ b/api/command_test.go
@@ -202,13 +202,10 @@ func TestDeleteCommand(t *testing.T) {
 	Client := th.SystemAdminClient
 
 	enableCommands := *th.App.Config().ServiceSettings.EnableCommands
-	onlyAdminIntegration := *th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCommands = enableCommands })
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = onlyAdminIntegration })
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCommands = true })
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = false })
 
 	cmd := &model.Command{URL: "http://nowhere.com", Method: model.COMMAND_METHOD_POST, Trigger: "trigger"}
 	cmd = Client.Must(Client.CreateCommand(cmd)).Data.(*model.Command)

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -131,17 +131,14 @@ func testCreatePostWithOutgoingHook(
 	channel := th.BasicChannel
 
 	enableOutgoingHooks := th.App.Config().ServiceSettings.EnableOutgoingWebhooks
-	enableAdminOnlyHooks := th.App.Config().ServiceSettings.EnableOnlyAdminIntegrations
 	allowedInternalConnections := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = enableOutgoingHooks })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOnlyAdminIntegrations = enableAdminOnlyHooks })
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
 		})
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOnlyAdminIntegrations = true })
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
 	})


### PR DESCRIPTION
#### Summary
Removes the last removable instances of `EnableOnlyAdminIntegrations` on the server for Phase 1 of Advanced Permissions. There are other instances but they can't be removed because of the migration, etc.

#### Ticket Link
[XYZ-73](https://mattermost.atlassian.net/browse/XYZ-73)

#### Checklist
- [x] Added or updated unit tests (required for all new features)