### PR TITLE
ICU-753 Remove special behaviour for group messages in generic push notifications

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -566,8 +566,6 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 		channelName = senderName
 	}
 
-	userLocale := utils.GetUserTranslations(user.Locale)
-
 	msg := model.PushNotification{}
 	if badge := <-a.Srv.Store.User().GetUnreadCount(user.Id); badge.Err != nil {
 		msg.Badge = 1
@@ -596,44 +594,10 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 		msg.FromWebhook = fw
 	}
 
-	if *a.Config().EmailSettings.PushNotificationContents == model.FULL_NOTIFICATION {
-		msg.Category = model.CATEGORY_CAN_REPLY
-		if channel.Type == model.CHANNEL_DIRECT {
-			msg.Message = senderName + ": " + model.ClearMentionTags(post.Message)
-		} else {
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_in") + channelName + ": " + model.ClearMentionTags(post.Message)
-		}
-	} else if *a.Config().EmailSettings.PushNotificationContents == model.GENERIC_NO_CHANNEL_NOTIFICATION {
-		if channel.Type == model.CHANNEL_DIRECT {
-			msg.Category = model.CATEGORY_CAN_REPLY
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
-		} else if wasMentioned {
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention_no_channel")
-		} else {
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_non_mention_no_channel")
-		}
-	} else {
-		if channel.Type == model.CHANNEL_DIRECT {
-			msg.Category = model.CATEGORY_CAN_REPLY
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
-		} else if wasMentioned {
-			msg.Category = model.CATEGORY_CAN_REPLY
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention") + channelName
-		} else {
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_non_mention") + channelName
-		}
-	}
+	userLocale := utils.GetUserTranslations(user.Locale)
+	hasFiles := post.FileIds != nil && len(post.FileIds) > 0
 
-	// If the post only has images then push an appropriate message
-	if len(post.Message) == 0 && post.FileIds != nil && len(post.FileIds) > 0 {
-		if channel.Type == model.CHANNEL_DIRECT {
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only_dm")
-		} else {
-			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only") + channelName
-		}
-	}
-
-	//l4g.Debug("Sending push notification for user %v with msg of '%v'", user.Id, msg.Message)
+	msg.Message, msg.Category = a.getPushNotificationMessage(post.Message, wasMentioned, hasFiles, senderName, channelName, channel.Type, userLocale)
 
 	for _, session := range sessions {
 		tmpMessage := *model.PushNotificationFromJson(strings.NewReader(msg.ToJson()))
@@ -653,6 +617,54 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 	}
 
 	return nil
+}
+
+func (a *App) getPushNotificationMessage(postMessage string, wasMentioned bool, hasFiles bool, senderName string, channelName string, channelType string, userLocale i18n.TranslateFunc) (string, string) {
+	message := ""
+	category := ""
+
+	if *a.Config().EmailSettings.PushNotificationContents == model.FULL_NOTIFICATION {
+		category = model.CATEGORY_CAN_REPLY
+
+		if channelType == model.CHANNEL_DIRECT {
+			message = senderName + ": " + model.ClearMentionTags(postMessage)
+		} else {
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_in") + channelName + ": " + model.ClearMentionTags(postMessage)
+		}
+	} else if *a.Config().EmailSettings.PushNotificationContents == model.GENERIC_NO_CHANNEL_NOTIFICATION {
+		if channelType == model.CHANNEL_DIRECT {
+			category = model.CATEGORY_CAN_REPLY
+
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
+		} else if wasMentioned {
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention_no_channel")
+		} else {
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_non_mention_no_channel")
+		}
+	} else {
+		if channelType == model.CHANNEL_DIRECT {
+			category = model.CATEGORY_CAN_REPLY
+
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
+		} else if wasMentioned {
+			category = model.CATEGORY_CAN_REPLY
+
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention") + channelName
+		} else {
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_non_mention") + channelName
+		}
+	}
+
+	// If the post only has images then push an appropriate message
+	if len(message) == 0 && hasFiles {
+		if channelType == model.CHANNEL_DIRECT {
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only_dm")
+		} else {
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only") + channelName
+		}
+	}
+
+	return message, category
 }
 
 func (a *App) ClearPushNotification(userId string, channelId string) {

--- a/app/notification.go
+++ b/app/notification.go
@@ -656,7 +656,7 @@ func (a *App) getPushNotificationMessage(postMessage string, wasMentioned bool, 
 	}
 
 	// If the post only has images then push an appropriate message
-	if len(message) == 0 && hasFiles {
+	if len(postMessage) == 0 && hasFiles {
 		if channelType == model.CHANNEL_DIRECT {
 			message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only_dm")
 		} else {

--- a/app/notification.go
+++ b/app/notification.go
@@ -607,7 +607,7 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 		if channel.Type == model.CHANNEL_DIRECT {
 			msg.Category = model.CATEGORY_CAN_REPLY
 			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
-		} else if wasMentioned || channel.Type == model.CHANNEL_GROUP {
+		} else if wasMentioned {
 			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention_no_channel")
 		} else {
 			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_non_mention_no_channel")
@@ -616,7 +616,7 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 		if channel.Type == model.CHANNEL_DIRECT {
 			msg.Category = model.CATEGORY_CAN_REPLY
 			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_message")
-		} else if wasMentioned || channel.Type == model.CHANNEL_GROUP {
+		} else if wasMentioned {
 			msg.Category = model.CATEGORY_CAN_REPLY
 			msg.Message = senderName + userLocale("api.post.send_notifications_and_forget.push_mention") + channelName
 		} else {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1345,6 +1345,30 @@ func TestGetPushNotificationMessage(t *testing.T) {
 			ExpectedMessage:          "user sent you a direct message",
 			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
 		},
+		"only files, public channel": {
+			HasFiles:         true,
+			ChannelType:      model.CHANNEL_OPEN,
+			ExpectedMessage:  "user uploaded one or more files in channel",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"only files, private channel": {
+			HasFiles:         true,
+			ChannelType:      model.CHANNEL_PRIVATE,
+			ExpectedMessage:  "user uploaded one or more files in channel",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"only files, group message channel": {
+			HasFiles:         true,
+			ChannelType:      model.CHANNEL_GROUP,
+			ExpectedMessage:  "user uploaded one or more files in channel",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"only files, direct message channel": {
+			HasFiles:         true,
+			ChannelType:      model.CHANNEL_DIRECT,
+			ExpectedMessage:  "user uploaded one or more files in a direct message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			locale := tc.Locale

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1166,3 +1166,214 @@ func TestGetNotificationEmailBodyGenericNotificationDirectChannel(t *testing.T) 
 		t.Fatal("Expected email text '" + teamURL + "'. Got " + body)
 	}
 }
+
+func TestGetPushNotificationMessage(t *testing.T) {
+	th := Setup()
+	defer th.TearDown()
+
+	for name, tc := range map[string]struct {
+		Message                  string
+		WasMentioned             bool
+		HasFiles                 bool
+		Locale                   string
+		PushNotificationContents string
+		ChannelType              string
+
+		ExpectedMessage  string
+		ExpectedCategory string
+	}{
+		"full message, public channel, no mention": {
+			Message:          "this is a message",
+			ChannelType:      model.CHANNEL_OPEN,
+			ExpectedMessage:  "user in channel: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"full message, public channel, mention": {
+			Message:          "this is a message",
+			WasMentioned:     true,
+			ChannelType:      model.CHANNEL_OPEN,
+			ExpectedMessage:  "user in channel: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"full message, private channel, no mention": {
+			Message:          "this is a message",
+			ChannelType:      model.CHANNEL_PRIVATE,
+			ExpectedMessage:  "user in channel: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"full message, private channel, mention": {
+			Message:          "this is a message",
+			WasMentioned:     true,
+			ChannelType:      model.CHANNEL_PRIVATE,
+			ExpectedMessage:  "user in channel: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"full message, group message channel, no mention": {
+			Message:          "this is a message",
+			ChannelType:      model.CHANNEL_GROUP,
+			ExpectedMessage:  "user in channel: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"full message, group message channel, mention": {
+			Message:          "this is a message",
+			WasMentioned:     true,
+			ChannelType:      model.CHANNEL_GROUP,
+			ExpectedMessage:  "user in channel: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"full message, direct message channel, no mention": {
+			Message:          "this is a message",
+			ChannelType:      model.CHANNEL_DIRECT,
+			ExpectedMessage:  "user: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"full message, direct message channel, mention": {
+			Message:          "this is a message",
+			WasMentioned:     true,
+			ChannelType:      model.CHANNEL_DIRECT,
+			ExpectedMessage:  "user: this is a message",
+			ExpectedCategory: model.CATEGORY_CAN_REPLY,
+		},
+		"generic message with channel, public channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_OPEN,
+			ExpectedMessage:          "user posted in channel",
+		},
+		"generic message with channel, public channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_OPEN,
+			ExpectedMessage:          "user mentioned you in channel",
+			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
+		},
+		"generic message with channel, private channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_PRIVATE,
+			ExpectedMessage:          "user posted in channel",
+		},
+		"generic message with channel, private channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_PRIVATE,
+			ExpectedMessage:          "user mentioned you in channel",
+			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
+		},
+		"generic message with channel, group message channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_GROUP,
+			ExpectedMessage:          "user posted in channel",
+		},
+		"generic message with channel, group message channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_GROUP,
+			ExpectedMessage:          "user mentioned you in channel",
+			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
+		},
+		"generic message with channel, direct message channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_DIRECT,
+			ExpectedMessage:          "user sent you a direct message",
+			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
+		},
+		"generic message with channel, direct message channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NOTIFICATION,
+			ChannelType:              model.CHANNEL_DIRECT,
+			ExpectedMessage:          "user sent you a direct message",
+			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
+		},
+		"generic message without channel, public channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_OPEN,
+			ExpectedMessage:          "user posted a message",
+		},
+		"generic message without channel, public channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_OPEN,
+			ExpectedMessage:          "user mentioned you",
+		},
+		"generic message without channel, private channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_PRIVATE,
+			ExpectedMessage:          "user posted a message",
+		},
+		"generic message without channel, private channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_PRIVATE,
+			ExpectedMessage:          "user mentioned you",
+		},
+		"generic message without channel, group message channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_GROUP,
+			ExpectedMessage:          "user posted a message",
+		},
+		"generic message without channel, group message channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_GROUP,
+			ExpectedMessage:          "user mentioned you",
+		},
+		"generic message without channel, direct message channel, no mention": {
+			Message:                  "this is a message",
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_DIRECT,
+			ExpectedMessage:          "user sent you a direct message",
+			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
+		},
+		"generic message without channel, direct message channel, mention": {
+			Message:                  "this is a message",
+			WasMentioned:             true,
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_DIRECT,
+			ExpectedMessage:          "user sent you a direct message",
+			ExpectedCategory:         model.CATEGORY_CAN_REPLY,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			locale := tc.Locale
+			if locale == "" {
+				locale = "en"
+			}
+
+			pushNotificationContents := tc.PushNotificationContents
+			if pushNotificationContents == "" {
+				pushNotificationContents = model.FULL_NOTIFICATION
+			}
+
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				*cfg.EmailSettings.PushNotificationContents = pushNotificationContents
+			})
+
+			if actualMessage, actualCategory := th.App.getPushNotificationMessage(
+				tc.Message,
+				tc.WasMentioned,
+				tc.HasFiles,
+				"user",
+				"channel",
+				tc.ChannelType,
+				utils.GetUserTranslations(locale),
+			); actualMessage != tc.ExpectedMessage {
+				t.Fatalf("Received incorrect push notification message `%v`, expected `%v`", actualMessage, tc.ExpectedMessage)
+			} else if actualCategory != tc.ExpectedCategory {
+				t.Fatalf("Received incorrect push notification category `%v`, expected `%v`", actualCategory, tc.ExpectedCategory)
+			}
+		})
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1812,11 +1812,11 @@
   },
   {
     "id": "api.post.send_notifications_and_forget.push_image_only",
-    "translation": " Uploaded one or more files in "
+    "translation": " uploaded one or more files in "
   },
   {
     "id": "api.post.send_notifications_and_forget.push_image_only_dm",
-    "translation": " Uploaded one or more files in a direct message"
+    "translation": " uploaded one or more files in a direct message"
   },
   {
     "id": "api.post.send_notifications_and_forget.push_in",


### PR DESCRIPTION
For these messages, we treated GMs as if you were always being mentioned. This removes that behaviour and adds a load of tests for this.

I also changed the case of a couple of the messages since they were resulting in messages like "Joe Uploaded files" instead of "Joe uploaded files"

#### Ticket Link
https://mattermost.atlassian.net/browse/ICU-753

#### Checklist
- Added or updated unit tests (required for all new features)
- Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
