### PR TITLE
ABC-176 Prevent changing PluginSettings.EnableUploads through the API

### DIFF
--- a/api/admin.go
+++ b/api/admin.go
@@ -108,6 +108,9 @@ func saveConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Do not allow plugin uploads to be toggled through the API
+	cfg.PluginSettings.EnableUploads = c.App.GetConfig().PluginSettings.EnableUploads
+
 	err := c.App.SaveConfig(cfg, true)
 	if err != nil {
 		c.Err = err

--- a/api/admin_test.go
+++ b/api/admin_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetLogs(t *testing.T) {
@@ -149,6 +150,18 @@ func TestSaveConfig(t *testing.T) {
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = true })
+
+	// Should not be able to modify PluginSettings.EnableUploads
+	oldEnableUploads := *th.App.GetConfig().PluginSettings.EnableUploads
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.PluginSettings.EnableUploads = !oldEnableUploads
+
+	if _, err := th.SystemAdminClient.SaveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, oldEnableUploads, *th.App.Config().PluginSettings.EnableUploads)
 }
 
 func TestRecycleDatabaseConnection(t *testing.T) {

--- a/api4/system.go
+++ b/api4/system.go
@@ -121,6 +121,9 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Do not allow plugin uploads to be toggled through the API
+	cfg.PluginSettings.EnableUploads = c.App.GetConfig().PluginSettings.EnableUploads
+
 	err := c.App.SaveConfig(cfg, true)
 	if err != nil {
 		c.Err = err

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -142,20 +142,21 @@ func TestUpdateConfig(t *testing.T) {
 		}
 	}
 
-	// Should not be able to modify PluginSettings.EnableUploads
-	oldEnableUploads := *th.App.GetConfig().PluginSettings.EnableUploads
-	*cfg.PluginSettings.EnableUploads = !oldEnableUploads
+	t.Run("Should not be able to modify PluginSettings.EnableUploads", func(t *testing.T) {
+		oldEnableUploads := *th.App.GetConfig().PluginSettings.EnableUploads
+		*cfg.PluginSettings.EnableUploads = !oldEnableUploads
 
-	cfg, resp = th.SystemAdminClient.UpdateConfig(cfg)
-	CheckNoError(t, resp)
-	assert.Equal(t, oldEnableUploads, *cfg.PluginSettings.EnableUploads)
-	assert.Equal(t, oldEnableUploads, *th.App.GetConfig().PluginSettings.EnableUploads)
+		cfg, resp = th.SystemAdminClient.UpdateConfig(cfg)
+		CheckNoError(t, resp)
+		assert.Equal(t, oldEnableUploads, *cfg.PluginSettings.EnableUploads)
+		assert.Equal(t, oldEnableUploads, *th.App.GetConfig().PluginSettings.EnableUploads)
 
-	cfg.PluginSettings.EnableUploads = nil
-	cfg, resp = th.SystemAdminClient.UpdateConfig(cfg)
-	CheckNoError(t, resp)
-	assert.Equal(t, oldEnableUploads, *cfg.PluginSettings.EnableUploads)
-	assert.Equal(t, oldEnableUploads, *th.App.GetConfig().PluginSettings.EnableUploads)
+		cfg.PluginSettings.EnableUploads = nil
+		cfg, resp = th.SystemAdminClient.UpdateConfig(cfg)
+		CheckNoError(t, resp)
+		assert.Equal(t, oldEnableUploads, *cfg.PluginSettings.EnableUploads)
+		assert.Equal(t, oldEnableUploads, *th.App.GetConfig().PluginSettings.EnableUploads)
+	})
 }
 
 func TestGetOldClientConfig(t *testing.T) {

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -7,6 +7,7 @@ import (
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetPing(t *testing.T) {
@@ -106,9 +107,10 @@ func TestUpdateConfig(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	cfg := th.App.GetConfig()
+	cfg, resp := th.SystemAdminClient.GetConfig()
+	CheckNoError(t, resp)
 
-	_, resp := Client.UpdateConfig(cfg)
+	_, resp = Client.UpdateConfig(cfg)
 	CheckForbiddenStatus(t, resp)
 
 	SiteName := th.App.Config().TeamSettings.SiteName
@@ -139,6 +141,21 @@ func TestUpdateConfig(t *testing.T) {
 			t.Fatal()
 		}
 	}
+
+	// Should not be able to modify PluginSettings.EnableUploads
+	oldEnableUploads := *th.App.GetConfig().PluginSettings.EnableUploads
+	*cfg.PluginSettings.EnableUploads = !oldEnableUploads
+
+	cfg, resp = th.SystemAdminClient.UpdateConfig(cfg)
+	CheckNoError(t, resp)
+	assert.Equal(t, oldEnableUploads, *cfg.PluginSettings.EnableUploads)
+	assert.Equal(t, oldEnableUploads, *th.App.GetConfig().PluginSettings.EnableUploads)
+
+	cfg.PluginSettings.EnableUploads = nil
+	cfg, resp = th.SystemAdminClient.UpdateConfig(cfg)
+	CheckNoError(t, resp)
+	assert.Equal(t, oldEnableUploads, *cfg.PluginSettings.EnableUploads)
+	assert.Equal(t, oldEnableUploads, *th.App.GetConfig().PluginSettings.EnableUploads)
 }
 
 func TestGetOldClientConfig(t *testing.T) {


### PR DESCRIPTION
#### Summary
Prevent changing PluginSettings.EnableUploads through the API. Follow-up webapp PR will remove the setting from the UI.

#### Ticket Link
https://mattermost.atlassian.net/browse/ABC-176

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (mattermost/mattermost-api-reference#333)