### PR TITLE
[Fix tests] Wait for goroutines to finish before shutting down server

### DIFF
--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -130,11 +130,21 @@ func runServer(configFileLocation string, disableConfigWatch bool, interruptChan
 
 	a.EnsureDiagnosticId()
 
-	go runSecurityJob(a)
-	go runDiagnosticsJob(a)
-	go runSessionCleanupJob(a)
-	go runTokenCleanupJob(a)
-	go runCommandWebhookCleanupJob(a)
+	a.Go(func() {
+		runSecurityJob(a)
+	})
+	a.Go(func() {
+		runDiagnosticsJob(a)
+	})
+	a.Go(func() {
+		runSessionCleanupJob(a)
+	})
+	a.Go(func() {
+		runTokenCleanupJob(a)
+	})
+	a.Go(func() {
+		runCommandWebhookCleanupJob(a)
+	})
 
 	if complianceI := a.Compliance; complianceI != nil {
 		complianceI.StartComplianceDailyJob()


### PR DESCRIPTION
#### Summary

Currently, when running the tests locally, they might panic on `cmd/platform/server_test.go` with a segfault.

This is because when running the tests, the server instance will shutdown while some jobs spawned through a goroutine are still running. This may crash the test harness, as the jobs try to access a shut down app instance.

Fortunately the fix is easy: we just have to use the same App goroutine-counting facility used in the rest of this function's code. This will ensure that on shutdown the app waits for this goroutines to be finished before returning the control to the caller.

#### Test logs before

```shell
$ go test -v -run=TestRunServer ./cmd/platform/
# First test is starting
=== RUN   TestRunServerSuccess
# snip
[2018/02/13 06:24:36 GMT] [INFO] Starting Server...
[2018/02/13 06:24:36 GMT] [INFO] Server is listening on [::]:8065
# snip
[2018/02/13 06:24:36 GMT] [INFO] Stopped workers
[2018/02/13 06:24:36 GMT] [INFO] Stopping Server...
[2018/02/13 06:24:36 GMT] [INFO] stopping websocket hub connections
[2018/02/13 06:24:36 GMT] [INFO] Closing SqlStore
# The test passed – but goroutines are still running in the background…
--- PASS: TestRunServerSuccess (0.99s)
# Start the second test.
=== RUN   TestRunServerInvalidConfigFile
# Oops, we still receive log messages from background goroutines of the first test. Not good.
[2018/02/13 06:24:36 GMT] [INFO] Server stopped
# The second test correctly print an error message and exits early. Good.
[2018/02/13 06:24:36 GMT] [CRIT] LoadConfig: Error decoding config file=/tmp/mattermost-unreadable-config-file-405744123, err=open /tmp/mattermost-unreadable-config-file-405744123: permission denied,
# But here a null pointer dereference happens, in diagnostics.go.
# This was the code still running in a goroutine from the first test,
# and it just tried to access a shut down server.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc8b8aa]

goroutine 2318 [running]:
github.com/mattermost/mattermost-server/app.(*App).trackActivity(0xc420084480)
	/home/vagrant/go/src/github.com/mattermost/mattermost-server/app/diagnostics.go:160 +0x4ea
github.com/mattermost/mattermost-server/app.(*App).SendDailyDiagnostics(0xc420084480)
	/home/vagrant/go/src/github.com/mattermost/mattermost-server/app/diagnostics.go:59 +0x11c
github.com/mattermost/mattermost-server/cmd/platform.doDiagnostics(0xc420084480)
	/home/vagrant/go/src/github.com/mattermost/mattermost-server/cmd/platform/server.go:236 +0xd3
github.com/mattermost/mattermost-server/cmd/platform.runDiagnosticsJob(0xc420084480)
	/home/vagrant/go/src/github.com/mattermost/mattermost-server/cmd/platform/server.go:197 +0x2f
created by github.com/mattermost/mattermost-server/cmd/platform.runServer
	/home/vagrant/go/src/github.com/mattermost/mattermost-server/cmd/platform/server.go:135 +0xb02
exit status 2
FAIL	github.com/mattermost/mattermost-server/cmd/platform	1.076s
$
```

### Test logs after

```shell
$ go test -v -run=TestRunServer ./cmd/platform/
# First test is starting
=== RUN   TestRunServerSuccess
# snip
[2018/02/13 07:20:34 GMT] [INFO] Starting Server...
[2018/02/13 07:20:34 GMT] [INFO] Server is listening on [::]:8065
# snip
[2018/02/13 06:24:36 GMT] [INFO] Stopped workers
[2018/02/13 06:24:36 GMT] [INFO] Stopping Server...
[2018/02/13 06:24:36 GMT] [INFO] stopping websocket hub connections
[2018/02/13 06:24:36 GMT] [INFO] Closing SqlStore
[2018/02/13 06:24:36 GMT] [INFO] Server stopped
# The test passed; all goroutines executed before the server stopped
--- PASS: TestRunServerSuccess (0.72s)
# Second test is starting
=== RUN   TestRunServerInvalidConfigFile
--- PASS: TestRunServerInvalidConfigFile (0.00s)
PASS
ok  	github.com/mattermost/mattermost-server/cmd/platform	0.754s
$
```