### PR TITLE
XYZ-111: Check max users per team on re-join after leave a team

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3127,6 +3127,10 @@
     "translation": "Invalid {{.Name}} parameter"
   },
   {
+    "id": "app.team.join_user_to_team.max_accounts.app_error",
+    "translation": "This team has reached the maximum number of allowed accounts. Contact your systems administrator to set a higher limit."
+  },
+  {
     "id": "app.channel.create_channel.no_team_id.app_error",
     "translation": "Must specify the team ID to create a channel"
   },


### PR DESCRIPTION
#### Summary
Check MaxUsersPerTeam when the user "re-join" after leave a team (before that it only check when is a new join).

#### Ticket Link
[XYZ-111](https://mattermost.atlassian.net/browse/XYZ-111)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)