### PR TITLE
XYZ-114 Adding mandatory membership to town-square in bulk-import

### DIFF
--- a/app/import.go
+++ b/app/import.go
@@ -817,6 +817,12 @@ func (a *App) ImportUserTeams(user *model.User, data *[]UserTeamImportData) *mod
 			}
 		}
 
+		if defaultChannel, err := a.GetChannelByName(model.DEFAULT_CHANNEL, team.Id); err != nil {
+			return err
+		} else if _, err = a.addUserToChannel(user, defaultChannel, member); err != nil {
+			return err
+		}
+
 		if err := a.ImportUserChannels(user, team, member, tdata.Channels); err != nil {
 			return err
 		}


### PR DESCRIPTION
#### Summary
The bulk import feature allows you to create teams an members of the team without being member of the town-square channel. This solve that problem.

#### Ticket Link
[XYZ-114](https://mattermost.atlassian.net/browse/XYZ-114)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
