### PR TITLE
XYZ-87: GlobalRelay DM Exports do not Include Channel Name

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -225,6 +225,14 @@ func (a *App) createDirectChannel(userId string, otherUserId string) (*model.Cha
 		}
 	} else {
 		channel := result.Data.(*model.Channel)
+
+		if result := <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(userId, channel.Id, model.GetMillis()); result.Err != nil {
+			l4g.Warn("Failed to update ChannelMemberHistory table %v", result.Err)
+		}
+		if result := <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(otherUserId, channel.Id, model.GetMillis()); result.Err != nil {
+			l4g.Warn("Failed to update ChannelMemberHistory table %v", result.Err)
+		}
+
 		return channel, nil
 	}
 }
@@ -1421,7 +1429,16 @@ func (a *App) GetDirectChannel(userId1, userId2 string) (*model.Channel, *model.
 		}
 		a.InvalidateCacheForUser(userId1)
 		a.InvalidateCacheForUser(userId2)
-		return result.Data.(*model.Channel), nil
+
+		channel := result.Data.(*model.Channel)
+		if result := <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(userId1, channel.Id, model.GetMillis()); result.Err != nil {
+			l4g.Warn("Failed to update ChannelMemberHistory table %v", result.Err)
+		}
+		if result := <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(userId2, channel.Id, model.GetMillis()); result.Err != nil {
+			l4g.Warn("Failed to update ChannelMemberHistory table %v", result.Err)
+		}
+
+		return channel, nil
 	} else if result.Err != nil {
 		return nil, model.NewAppError("GetOrCreateDMChannel", "web.incoming_webhook.channel.app_error", nil, "err="+result.Err.Message, result.Err.StatusCode)
 	}

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -244,7 +244,7 @@ func TestCreateDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 		t.Fatal("Failed to create direct channel. Error: " + err.Message)
 	} else {
 		// there should be a ChannelMemberHistory record for both users
-		histories := store.Must(th.App.Srv.Store.ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)).([]*model.ChannelMemberHistory)
+		histories := store.Must(th.App.Srv.Store.ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)).([]*model.ChannelMemberHistoryResult)
 		assert.Len(t, histories, 2)
 
 		historyId0 := histories[0].UserId
@@ -272,7 +272,7 @@ func TestGetDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 		t.Fatal("Failed to create direct channel. Error: " + err.Message)
 	} else {
 		// there should be a ChannelMemberHistory record for both users
-		histories := store.Must(th.App.Srv.Store.ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)).([]*model.ChannelMemberHistory)
+		histories := store.Must(th.App.Srv.Store.ChannelMemberHistory().GetUsersInChannelDuring(model.GetMillis()-100, model.GetMillis()+100, channel.Id)).([]*model.ChannelMemberHistoryResult)
 		assert.Len(t, histories, 2)
 
 		historyId0 := histories[0].UserId

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -255,7 +255,7 @@ func TestCreateDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 		case user2.Id:
 			assert.Equal(t, user1.Id, historyId1)
 		default:
-			t.Fatal("Unexpected user id %s in ChannelMemberHistory table", historyId0)
+			t.Fatal("Unexpected user id " + historyId0 + " in ChannelMemberHistory table")
 		}
 	}
 }
@@ -283,7 +283,7 @@ func TestGetDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 		case user2.Id:
 			assert.Equal(t, user1.Id, historyId1)
 		default:
-			t.Fatal("Unexpected user id %s in ChannelMemberHistory table", historyId0)
+			t.Fatal("Unexpected user id " + historyId0 + " in ChannelMemberHistory table")
 		}
 	}
 }

--- a/store/sqlstore/compliance_store.go
+++ b/store/sqlstore/compliance_store.go
@@ -223,7 +223,11 @@ func (s SqlComplianceStore) MessageExport(after int64, limit int) store.StoreCha
 				Posts.Type AS PostType,
 				Posts.FileIds AS PostFileIds,
 				Channels.Id AS ChannelId,
-				Channels.DisplayName AS ChannelDisplayName,
+				CASE 
+					WHEN Channels.Type = 'D' THEN 'Direct Message'
+					WHEN Channels.Type = 'G' THEN 'Group Message'
+					ELSE Channels.DisplayName
+				END AS ChannelDisplayName,
 				Users.Id AS UserId,
 				Users.Email AS UserEmail,
 				Users.Username


### PR DESCRIPTION
#### Summary
Two fixes:
* `ChannelMemberHistory` records are now created for DM channels
* DM and GM channels are given pretty names in Compliance Exports, since the channel members are listed at the start of the export, so there's no need to use unique display names for them

#### Ticket Link
https://mattermost.atlassian.net/browse/XYZ-87

#### Checklist
- [x] Added or updated unit tests (required for all new features)