### PR TITLE
XYZ-106: Compliance Export is not able to distinguish between two different file uploads that have the same file name

### DIFF
--- a/utils/mail.go
+++ b/utils/mail.go
@@ -157,19 +157,18 @@ func sendMail(mimeTo, smtpTo string, from mail.Address, subject, htmlBody string
 		}
 
 		for _, fileInfo := range attachments {
+			bytes, err := fileBackend.ReadFile(fileInfo.Path)
+			if err != nil {
+				return err
+			}
+
 			m.Attach(fileInfo.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-				bytes, err := fileBackend.ReadFile(fileInfo.Path)
-				if err != nil {
-					return err
-				}
 				if _, err := writer.Write(bytes); err != nil {
 					return model.NewAppError("SendMail", "utils.mail.sendMail.attachments.write_error", nil, err.Error(), http.StatusInternalServerError)
 				}
 				return nil
 			}))
-
 		}
-
 	}
 
 	conn, err1 := connectToSMTPServer(config)


### PR DESCRIPTION
#### Summary
Modified advanced mail implementation to properly support multiple attachments with the same file name. My initial implementation had some scoping issues that caused two distinct files that had the same file name to be treated incorrectly. Rather than attaching each file to the email, one of the files was attached multiple times.

#### Ticket Link
https://mattermost.atlassian.net/browse/XYZ-106

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has [enterprise changes](https://github.com/mattermost/enterprise/pull/265)