### PR TITLE
MM-8710: Web Hub optimizations

### DIFF
--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -170,7 +170,9 @@ func (a *App) Publish(message *model.WebSocketEvent) {
 
 func (a *App) PublishSkipClusterSend(message *model.WebSocketEvent) {
 	if message.Broadcast.UserId != "" {
-		a.GetHubForUserId(message.Broadcast.UserId).Broadcast(message)
+		if len(a.Hubs) != 0 {
+			a.GetHubForUserId(message.Broadcast.UserId).Broadcast(message)
+		}
 	} else {
 		for _, hub := range a.Hubs {
 			hub.Broadcast(message)

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -30,7 +30,6 @@ type Hub struct {
 	// See https://github.com/mattermost/mattermost-server/pull/7281
 	connectionCount int64
 	app             *App
-	connections     []*WebConn
 	connectionIndex int
 	register        chan *WebConn
 	unregister      chan *WebConn
@@ -376,7 +375,7 @@ func (h *Hub) Start() {
 			select {
 			case webCon := <-h.register:
 				connections.Add(webCon)
-				atomic.StoreInt64(&h.connectionCount, int64(len(h.connections)))
+				atomic.StoreInt64(&h.connectionCount, int64(len(connections.All())))
 			case webCon := <-h.unregister:
 				connections.Remove(webCon)
 

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -59,10 +60,9 @@ type WebsocketBroadcast struct {
 }
 
 type precomputedWebSocketEventJSON struct {
-	*WebSocketEvent
-	Event     json.RawMessage `json:"event"`
-	Data      json.RawMessage `json:"data"`
-	Broadcast json.RawMessage `json:"broadcast"`
+	Event     json.RawMessage
+	Data      json.RawMessage
+	Broadcast json.RawMessage
 }
 
 type WebSocketEvent struct {
@@ -106,10 +106,7 @@ func (o *WebSocketEvent) EventType() string {
 
 func (o *WebSocketEvent) ToJson() string {
 	if o.precomputedJSON != nil {
-		precomputedJSON := *o.precomputedJSON
-		precomputedJSON.WebSocketEvent = o
-		b, _ := json.Marshal(&precomputedJSON)
-		return string(b)
+		return fmt.Sprintf(`{"event": %s, "data": %s, "broadcast": %s, "seq": %d}`, o.precomputedJSON.Event, o.precomputedJSON.Data, o.precomputedJSON.Broadcast, o.Sequence)
 	}
 	b, _ := json.Marshal(o)
 	return string(b)

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -81,10 +81,9 @@ func (m *WebSocketEvent) PrecomputeJSON() {
 	data, _ := json.Marshal(m.Data)
 	broadcast, _ := json.Marshal(m.Broadcast)
 	m.precomputedJSON = &precomputedWebSocketEventJSON{
-		WebSocketEvent: m,
-		Event:          json.RawMessage(event),
-		Data:           json.RawMessage(data),
-		Broadcast:      json.RawMessage(broadcast),
+		Event:     json.RawMessage(event),
+		Data:      json.RawMessage(data),
+		Broadcast: json.RawMessage(broadcast),
 	}
 }
 
@@ -107,7 +106,9 @@ func (o *WebSocketEvent) EventType() string {
 
 func (o *WebSocketEvent) ToJson() string {
 	if o.precomputedJSON != nil {
-		b, _ := json.Marshal(o.precomputedJSON)
+		precomputedJSON := *o.precomputedJSON
+		precomputedJSON.WebSocketEvent = o
+		b, _ := json.Marshal(&precomputedJSON)
 		return string(b)
 	}
 	b, _ := json.Marshal(o)

--- a/model/websocket_message_test.go
+++ b/model/websocket_message_test.go
@@ -76,14 +76,27 @@ func BenchmarkWebSocketEvent_ToJson(b *testing.B) {
 		event.Data[NewId()] = NewId()
 	}
 
-	b.Run("OnDemand", func(b *testing.B) {
+	b.Run("SerializedNTimes", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			stringSink = event.ToJson()
 		}
 	})
 
+	b.Run("PrecomputedNTimes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			event.PrecomputeJSON()
+		}
+	})
+
+	b.Run("PrecomputedAndSerializedNTimes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			event.PrecomputeJSON()
+			stringSink = event.ToJson()
+		}
+	})
+
 	event.PrecomputeJSON()
-	b.Run("Precomputed", func(b *testing.B) {
+	b.Run("PrecomputedOnceAndSerializedNTimes", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			stringSink = event.ToJson()
 		}

--- a/model/websocket_message_test.go
+++ b/model/websocket_message_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWebSocketEvent(t *testing.T) {
@@ -53,4 +55,37 @@ func TestWebSocketResponse(t *testing.T) {
 	if m.Data["RootId"] != result.Data["RootId"] {
 		t.Fatal("Ids do not match")
 	}
+}
+
+func TestWebSocketEvent_PrecomputeJSON(t *testing.T) {
+	event := NewWebSocketEvent(WEBSOCKET_EVENT_POSTED, "foo", "bar", "baz", nil)
+	event.Sequence = 7
+
+	before := event.ToJson()
+	event.PrecomputeJSON()
+	after := event.ToJson()
+
+	assert.JSONEq(t, before, after)
+}
+
+var stringSink string
+
+func BenchmarkWebSocketEvent_ToJson(b *testing.B) {
+	event := NewWebSocketEvent(WEBSOCKET_EVENT_POSTED, "foo", "bar", "baz", nil)
+	for i := 0; i < 100; i++ {
+		event.Data[NewId()] = NewId()
+	}
+
+	b.Run("OnDemand", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			stringSink = event.ToJson()
+		}
+	})
+
+	event.PrecomputeJSON()
+	b.Run("Precomputed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			stringSink = event.ToJson()
+		}
+	})
 }


### PR DESCRIPTION
#### Summary
* This greatly optimizes web socket events destined for a single user (such as the "channel viewed" event). Instead of iterating through every connection of every hub, sending of these events iterates only through the destination user's connections in the user's hub.
* This precomputes the raw JSON for websocket events. So the event fields (except for `Sequence`) are now only serialized once when sent to thousands of users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8710

#### Checklist
- [x] Added or updated unit tests (required for all new features)