### PR TITLE
Send systemd READY notification

### DIFF
--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -174,6 +175,8 @@ func runServer(configFileLocation string, disableConfigWatch bool, interruptChan
 		a.Jobs.StartSchedulers()
 	}
 
+	notifyReady()
+
 	// wait for kill signal before attempting to gracefully shutdown
 	// the running service
 	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
@@ -242,6 +245,35 @@ func doDiagnostics(a *app.App) {
 	if *a.Config().LogSettings.EnableDiagnostics {
 		a.SendDailyDiagnostics()
 	}
+}
+
+func notifyReady() {
+	// If the environment vars provide a systemd notification socket,
+	// notify systemd that the server is ready.
+	systemdSocket := os.Getenv("NOTIFY_SOCKET")
+	if systemdSocket != "" {
+		l4g.Info("Sending systemd READY notification.")
+
+		err := sendSystemdReadyNotification(systemdSocket)
+		if err != nil {
+			l4g.Error(err.Error())
+		}
+	}
+}
+
+func sendSystemdReadyNotification(socketPath string) error {
+	msg := "READY=1"
+	addr := &net.UnixAddr{
+		Name: socketPath,
+		Net:  "unixgram",
+	}
+	conn, err := net.DialUnix(addr.Net, nil, addr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_, err = conn.Write([]byte(msg))
+	return err
 }
 
 func doTokenCleanup(a *app.App) {


### PR DESCRIPTION
#### Summary

When managed by `systemd`, notify when the server is actually ready to receive network connections.

#### Details

Currently, when starting Mattermost programmatically, it's hard to tell when the server is actually ready to receive network connections. This is cumbersome:

- for monitoring: the systemd service status is "running" although the server is still booting ;
- for programmatic use: when a script needs to know when the server is ready to perform further actions.

To improve this, systemd allow processes to tell when they started successfully. The launcher waits for this notification before reporting the service as successfully launched.

The way processes notify systemd is by sending a `READY=1` string over a standard unix socket, whose path is provided in an environment var.

The systemd service is then told to [expect this notification](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=):

```diff
 [Service]
-Type=simple
+Type=notify
 ExecStart=/home/vagrant/go/bin/platform
```

Now, when starting the server, systemd will actually wait for the server to be ready before returning the control to the shell.

Additionally, during this time, querying the server status with `service mattermost status` will report the service as "activating" – before transitioning to "running" when the server is ready.

#### Ticket Link

n/a

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
