### PR TITLE
MM-8823: Checks for 'read_channel' permission on search results.

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -473,7 +473,7 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	startTime := time.Now()
 
-	posts, err := c.App.SearchPostsInTeam(terms, c.Session.UserId, c.TeamId, isOrSearch)
+	posts, err := c.App.SearchPostsInTeam(model.ParseSearchParams(terms), c.Session.UserId, c.TeamId, isOrSearch)
 
 	elapsedTime := float64(time.Since(startTime)) / float64(time.Second)
 	metrics := c.App.Metrics

--- a/app/authorization.go
+++ b/app/authorization.go
@@ -214,3 +214,7 @@ func (a *App) RolesGrantPermission(roleNames []string, permissionId string) bool
 
 	return false
 }
+
+func (a *App) HasTeamOrSystemContextPermission(teamID string, userID string, permission *model.Permission) bool {
+	return (a.HasPermissionToTeam(userID, teamID, permission) || a.HasPermissionTo(userID, permission))
+}

--- a/app/channel.go
+++ b/app/channel.go
@@ -1032,6 +1032,14 @@ func (a *App) JoinChannel(channel *model.Channel, userId string) *model.AppError
 	return nil
 }
 
+func (a *App) ChannelsWithChannelContextPermission(userId string, permissionName string) (*model.ChannelList, *model.AppError) {
+	if result := <-a.Srv.Store.Channel().ChannelsWithChannelContextPermission(userId, permissionName); result.Err != nil {
+		return nil, result.Err
+	} else {
+		return result.Data.(*model.ChannelList), nil
+	}
+}
+
 func (a *App) postJoinChannelMessage(user *model.User, channel *model.Channel) *model.AppError {
 	post := &model.Post{
 		ChannelId: channel.Id,

--- a/app/post.go
+++ b/app/post.go
@@ -591,9 +591,7 @@ func (a *App) DeletePostFiles(post *model.Post) {
 	}
 }
 
-func (a *App) SearchPostsInTeam(terms string, userId string, teamId string, isOrSearch bool) (*model.PostList, *model.AppError) {
-	paramsList := model.ParseSearchParams(terms)
-
+func (a *App) SearchPostsInTeam(paramsList []*model.SearchParams, userId string, teamId string, isOrSearch bool) (*model.PostList, *model.AppError) {
 	esInterface := a.Elasticsearch
 	if license := a.License(); esInterface != nil && *a.Config().ElasticsearchSettings.EnableSearching && license != nil && *license.Features.Elasticsearch {
 		finalParamsList := []*model.SearchParams{}

--- a/model/role.go
+++ b/model/role.go
@@ -124,10 +124,10 @@ func (role *Role) IsValid() bool {
 		return false
 	}
 
-	return role.IsValidWithoutId()
+	return role.IsValidForCreate()
 }
 
-func (role *Role) IsValidWithoutId() bool {
+func (role *Role) IsValidForCreate() bool {
 	if !IsValidRoleName(role.Name) {
 		return false
 	}

--- a/store/sqlstore/role_supplier.go
+++ b/store/sqlstore/role_supplier.go
@@ -79,7 +79,7 @@ func (s *SqlSupplier) RoleSave(ctx context.Context, role *model.Role, hints ...s
 	result := store.NewSupplierResult()
 
 	// Check the role is valid before proceeding.
-	if !role.IsValidWithoutId() {
+	if !role.IsValidForCreate() {
 		result.Err = model.NewAppError("SqlRoleStore.Save", "store.sql_role.save.invalid_role.app_error", nil, "", http.StatusBadRequest)
 		return result
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -161,6 +161,7 @@ type ChannelStore interface {
 	GetMembersByIds(channelId string, userIds []string) StoreChannel
 	AnalyticsDeletedTypeCount(teamId string, channelType string) StoreChannel
 	GetChannelUnread(channelId, userId string) StoreChannel
+	ChannelsWithChannelContextPermission(userID, permissionName string) StoreChannel
 	ClearCaches()
 }
 

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -806,3 +806,19 @@ func (_m *ChannelStore) UpdateMember(member *model.ChannelMember) store.StoreCha
 
 	return r0
 }
+
+// ChannelsWithChannelContextPermission provides a mock function with given fields: channelIds
+func (_m *ChannelStore) ChannelsWithChannelContextPermission(userID string, permissionName string) store.StoreChannel {
+	ret := _m.Called(userID, permissionName)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+		r0 = rf(userID, permissionName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}


### PR DESCRIPTION
#### Summary
When searching, if user does not have system-level or team-level `read_channel` permission then this PR does some extra checks to ensure that search results are only returned for posts that are in channels in which the user has `read_channel` permission (at the channel level).

Nothing really changes for users with `read_channel` at the system or team level.

Essentially this leverages the existing 'in:channel-name' filtering for ElasticSearch, Postgres, and MySQL.

If based on the query and the users permissions the user can't read any channels then their search is set to an empty string.

Here's the query in MySql and Postgres to get the Channels with `read_channel` permission (at the channel context).

New query added:
```sql
-- postgres
explain select channels.* from (
    select userid, channelid, unnest(string_to_array(roles, ' ')) as rolename from channelmembers
) x
left join channels on channelid = channels.id
left join roles on roles.name = x.rolename
where string_to_array(roles.permissions, ' ') && '{read_channel}'::text[]
and userid = 'jwedp8tbubn68mzbf3ufw1xczo';
```
```
                                                  QUERY PLAN
--------------------------------------------------------------------------------------------------------------
 Nested Loop Left Join  (cost=15.69..29.29 rows=1 width=282)
   ->  Hash Left Join  (cost=15.42..28.70 rows=1 width=27)
         Hash Cond: ((unnest(string_to_array((channelmembers.roles)::text, ' '::text))) = (roles.name)::text)
         Filter: (string_to_array((roles.permissions)::text, ' '::text) && '{read_channel}'::text[])
         ->  Bitmap Heap Scan on channelmembers  (cost=4.30..12.32 rows=300 width=69)
               Recheck Cond: ((userid)::text = 'jwedp8tbubn68mzbf3ufw1xczo'::text)
               ->  Bitmap Index Scan on idx_channelmembers_user_id  (cost=0.00..4.29 rows=3 width=0)
                     Index Cond: ((userid)::text = 'jwedp8tbubn68mzbf3ufw1xczo'::text)
         ->  Hash  (cost=10.50..10.50 rows=50 width=662)
               ->  Seq Scan on roles  (cost=0.00..10.50 rows=50 width=662)
   ->  Index Scan using channels_pkey on channels  (cost=0.27..0.58 rows=1 width=282)
         Index Cond: ((channelmembers.channelid)::text = (id)::text)
(12 rows)
```


```sql
-- mysql
explain select Channels.* from (
select
ChannelId, UserId, trim(substring_index(substring_index(B.Roles, ' ', ns.n), ' ', -1)) as rolename
from (
select 1 as n union all select 2 union all
select 3 union all
select 4 union all
select 5 union all
select 6 union all
select 7 union all
select 8 union all
select 9 union all
select 10 union all
select 11
) ns
inner join ChannelMembers B ON ns.n <= char_length(B.Roles) - char_length(replace(B.Roles, ' ', '')) + 1
) x
left join Channels on ChannelId = Channels.Id
left join Roles on Roles.name = x.rolename
where Roles.Permissions REGEXP '[[:<:]]read_channel[[:>:]]'
and UserId = 'jwedp8tbubn68mzbf3ufw1xczo';
```

```
+----+-------------+------------+------------+--------+----------------------------+----------------------------+---------+-----------------------------+------+----------+----------------------------------------------------+
| id | select_type | table      | partitions | type   | possible_keys              | key                        | key_len | ref                         | rows | filtered | Extra                                              |
+----+-------------+------------+------------+--------+----------------------------+----------------------------+---------+-----------------------------+------+----------+----------------------------------------------------+
|  1 | PRIMARY     | B          | NULL       | ref    | idx_channelmembers_user_id | idx_channelmembers_user_id | 106     | const                       |    1 |   100.00 | NULL                                               |
|  1 | PRIMARY     | Channels   | NULL       | eq_ref | PRIMARY                    | PRIMARY                    | 106     | mattermost_test.B.ChannelId |    1 |   100.00 | NULL                                               |
|  1 | PRIMARY     | <derived3> | NULL       | ALL    | NULL                       | NULL                       | NULL    | NULL                        |   11 |    33.33 | Using where; Using join buffer (Block Nested Loop) |
|  1 | PRIMARY     | Roles      | NULL       | ref    | Name                       | Name                       | 259     | func                        |    1 |   100.00 | Using index condition; Using where                 |
|  3 | DERIVED     | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
|  4 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
|  5 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
|  6 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
|  7 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
|  8 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
|  9 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
| 10 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
| 11 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
| 12 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
| 13 | UNION       | NULL       | NULL       | NULL   | NULL                       | NULL                       | NULL    | NULL                        | NULL |     NULL | No tables used                                     |
+----+-------------+------------+------------+--------+----------------------------+----------------------------+---------+-----------------------------+------+----------+----------------------------------------------------+
15 rows in set, 1 warning (0.00 sec)
```

Obviously this will be slower than the existing search because some extra checks need to be made.

#### Ticket Link
[MM-8823](https://mattermost.atlassian.net/browse/MM-8823)

#### Checklist
- [x] Added or updated unit tests (required for all new features)