### PR TITLE
Added t.Helper to CheckXStatus test functions

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"reflect"
-	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -496,6 +495,8 @@ func GenerateTestId() string {
 }
 
 func CheckUserSanitization(t *testing.T, user *model.User) {
+	t.Helper()
+
 	if user.Password != "" {
 		t.Fatal("password wasn't blank")
 	}
@@ -510,6 +511,8 @@ func CheckUserSanitization(t *testing.T, user *model.User) {
 }
 
 func CheckTeamSanitization(t *testing.T, team *model.Team) {
+	t.Helper()
+
 	if team.Email != "" {
 		t.Fatal("email wasn't blank")
 	}
@@ -520,13 +523,13 @@ func CheckTeamSanitization(t *testing.T, team *model.Team) {
 }
 
 func CheckEtag(t *testing.T, data interface{}, resp *model.Response) {
+	t.Helper()
+
 	if !reflect.ValueOf(data).IsNil() {
-		debug.PrintStack()
 		t.Fatal("etag data was not nil")
 	}
 
 	if resp.StatusCode != http.StatusNotModified {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusNotModified))
 		t.Fatal("wrong status code for etag")
@@ -534,15 +537,17 @@ func CheckEtag(t *testing.T, data interface{}, resp *model.Response) {
 }
 
 func CheckNoError(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error != nil {
-		debug.PrintStack()
 		t.Fatal("Expected no error, got " + resp.Error.Error())
 	}
 }
 
 func CheckCreatedStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.StatusCode != http.StatusCreated {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusCreated))
 		t.Fatal("wrong status code")
@@ -550,14 +555,14 @@ func CheckCreatedStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckForbiddenStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with status:" + strconv.Itoa(http.StatusForbidden))
 		return
 	}
 
 	if resp.StatusCode != http.StatusForbidden {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusForbidden))
 		t.Fatal("wrong status code")
@@ -565,14 +570,14 @@ func CheckForbiddenStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckUnauthorizedStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with status:" + strconv.Itoa(http.StatusUnauthorized))
 		return
 	}
 
 	if resp.StatusCode != http.StatusUnauthorized {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusUnauthorized))
 		t.Fatal("wrong status code")
@@ -580,14 +585,14 @@ func CheckUnauthorizedStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckNotFoundStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with status:" + strconv.Itoa(http.StatusNotFound))
 		return
 	}
 
 	if resp.StatusCode != http.StatusNotFound {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusNotFound))
 		t.Fatal("wrong status code")
@@ -595,14 +600,14 @@ func CheckNotFoundStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckBadRequestStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with status:" + strconv.Itoa(http.StatusBadRequest))
 		return
 	}
 
 	if resp.StatusCode != http.StatusBadRequest {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusBadRequest))
 		t.Fatal("wrong status code")
@@ -610,14 +615,14 @@ func CheckBadRequestStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckNotImplementedStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with status:" + strconv.Itoa(http.StatusNotImplemented))
 		return
 	}
 
 	if resp.StatusCode != http.StatusNotImplemented {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusNotImplemented))
 		t.Fatal("wrong status code")
@@ -625,6 +630,8 @@ func CheckNotImplementedStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckOKStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	CheckNoError(t, resp)
 
 	if resp.StatusCode != http.StatusOK {
@@ -633,14 +640,14 @@ func CheckOKStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckErrorMessage(t *testing.T, resp *model.Response, errorId string) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with message:" + errorId)
 		return
 	}
 
 	if resp.Error.Id != errorId {
-		debug.PrintStack()
 		t.Log("actual: " + resp.Error.Id)
 		t.Log("expected: " + errorId)
 		t.Fatal("incorrect error message")
@@ -648,14 +655,14 @@ func CheckErrorMessage(t *testing.T, resp *model.Response, errorId string) {
 }
 
 func CheckInternalErrorStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with status:" + strconv.Itoa(http.StatusInternalServerError))
 		return
 	}
 
 	if resp.StatusCode != http.StatusInternalServerError {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusInternalServerError))
 		t.Fatal("wrong status code")
@@ -663,14 +670,14 @@ func CheckInternalErrorStatus(t *testing.T, resp *model.Response) {
 }
 
 func CheckPayLoadTooLargeStatus(t *testing.T, resp *model.Response) {
+	t.Helper()
+
 	if resp.Error == nil {
-		debug.PrintStack()
 		t.Fatal("should have errored with status:" + strconv.Itoa(http.StatusRequestEntityTooLarge))
 		return
 	}
 
 	if resp.StatusCode != http.StatusRequestEntityTooLarge {
-		debug.PrintStack()
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusRequestEntityTooLarge))
 		t.Fatal("wrong status code")


### PR DESCRIPTION
Using `t.Helper()` makes it so that the line that calls these functions is displayed when a test fails rather than the line in apitestlib.go. This means we can also stop manually printing the stack trace on failure