### PR TITLE
MM-9556 Added ability to upload files without a multipart request

### DIFF
--- a/api/file.go
+++ b/api/file.go
@@ -76,7 +76,7 @@ func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resStruct, err := c.App.UploadFiles(c.TeamId, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
+	resStruct, err := c.App.UploadMultipartFiles(c.TeamId, channelId, c.Session.UserId, m.File["files"], m.Value["client_ids"])
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/context.go
+++ b/api4/context.go
@@ -447,6 +447,18 @@ func (c *Context) RequireFileId() *Context {
 	return c
 }
 
+func (c *Context) RequireFilename() *Context {
+	if c.Err != nil {
+		return c
+	}
+
+	if len(c.Params.Filename) == 0 {
+		c.SetInvalidUrlParam("filename")
+	}
+
+	return c
+}
+
 func (c *Context) RequirePluginId() *Context {
 	if c.Err != nil {
 		return c

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/store"
 )
 
-func TestUploadFile(t *testing.T) {
+func TestUploadFileAsMultipart(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 	Client := th.Client
@@ -119,6 +119,117 @@ func TestUploadFile(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.EnableFileAttachments = false })
 
 	_, resp = th.SystemAdminClient.UploadFile(data, channel.Id, "test.png")
+	if resp.StatusCode != http.StatusNotImplemented && resp.StatusCode != 0 {
+		// This should return an HTTP 501, but it occasionally causes the http client itself to error
+		t.Fatalf("should've returned HTTP 501 or failed completely, got %v instead", resp.StatusCode)
+	}
+}
+
+func TestUploadFileAsRequestBody(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+
+	user := th.BasicUser
+	channel := th.BasicChannel
+
+	var uploadInfo *model.FileInfo
+	var data []byte
+	var err error
+	if data, err = readTestFile("test.png"); err != nil {
+		t.Fatal(err)
+	} else if fileResp, resp := Client.UploadFileAsRequestBody(data, channel.Id, "test.png"); resp.Error != nil {
+		t.Fatal(resp.Error)
+	} else if len(fileResp.FileInfos) != 1 {
+		t.Fatal("should've returned a single file infos")
+	} else {
+		uploadInfo = fileResp.FileInfos[0]
+	}
+
+	// The returned file info from the upload call will be missing some fields that will be stored in the database
+	if uploadInfo.CreatorId != user.Id {
+		t.Fatal("file should be assigned to user")
+	} else if uploadInfo.PostId != "" {
+		t.Fatal("file shouldn't have a post")
+	} else if uploadInfo.Path != "" {
+		t.Fatal("file path should not be set on returned info")
+	} else if uploadInfo.ThumbnailPath != "" {
+		t.Fatal("file thumbnail path should not be set on returned info")
+	} else if uploadInfo.PreviewPath != "" {
+		t.Fatal("file preview path should not be set on returned info")
+	}
+
+	var info *model.FileInfo
+	if result := <-th.App.Srv.Store.FileInfo().Get(uploadInfo.Id); result.Err != nil {
+		t.Fatal(result.Err)
+	} else {
+		info = result.Data.(*model.FileInfo)
+	}
+
+	if info.Id != uploadInfo.Id {
+		t.Fatal("file id from response should match one stored in database")
+	} else if info.CreatorId != user.Id {
+		t.Fatal("file should be assigned to user")
+	} else if info.PostId != "" {
+		t.Fatal("file shouldn't have a post")
+	} else if info.Path == "" {
+		t.Fatal("file path should be set in database")
+	} else if info.ThumbnailPath == "" {
+		t.Fatal("file thumbnail path should be set in database")
+	} else if info.PreviewPath == "" {
+		t.Fatal("file preview path should be set in database")
+	}
+
+	date := time.Now().Format("20060102")
+
+	// This also makes sure that the relative path provided above is sanitized out
+	expectedPath := fmt.Sprintf("%v/teams/%v/channels/%v/users/%v/%v/test.png", date, FILE_TEAM_ID, channel.Id, user.Id, info.Id)
+	if info.Path != expectedPath {
+		t.Logf("file is saved in %v", info.Path)
+		t.Fatalf("file should've been saved in %v", expectedPath)
+	}
+
+	expectedThumbnailPath := fmt.Sprintf("%v/teams/%v/channels/%v/users/%v/%v/test_thumb.jpg", date, FILE_TEAM_ID, channel.Id, user.Id, info.Id)
+	if info.ThumbnailPath != expectedThumbnailPath {
+		t.Logf("file thumbnail is saved in %v", info.ThumbnailPath)
+		t.Fatalf("file thumbnail should've been saved in %v", expectedThumbnailPath)
+	}
+
+	expectedPreviewPath := fmt.Sprintf("%v/teams/%v/channels/%v/users/%v/%v/test_preview.jpg", date, FILE_TEAM_ID, channel.Id, user.Id, info.Id)
+	if info.PreviewPath != expectedPreviewPath {
+		t.Logf("file preview is saved in %v", info.PreviewPath)
+		t.Fatalf("file preview should've been saved in %v", expectedPreviewPath)
+	}
+
+	// Wait a bit for files to ready
+	time.Sleep(2 * time.Second)
+
+	if err := th.cleanupTestFile(info); err != nil {
+		t.Fatal(err)
+	}
+
+	_, resp := Client.UploadFileAsRequestBody(data, model.NewId(), "test.png")
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = Client.UploadFileAsRequestBody(data, "../../junk", "test.png")
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, model.NewId(), "test.png")
+	CheckForbiddenStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, "../../junk", "test.png")
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, channel.Id, "test.png")
+	CheckNoError(t, resp)
+
+	enableFileAttachments := *th.App.Config().FileSettings.EnableFileAttachments
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.EnableFileAttachments = enableFileAttachments })
+	}()
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.EnableFileAttachments = false })
+
+	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, channel.Id, "test.png")
 	if resp.StatusCode != http.StatusNotImplemented && resp.StatusCode != 0 {
 		// This should return an HTTP 501, but it occasionally causes the http client itself to error
 		t.Fatalf("should've returned HTTP 501 or failed completely, got %v instead", resp.StatusCode)

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -119,7 +119,9 @@ func TestUploadFileAsMultipart(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.EnableFileAttachments = false })
 
 	_, resp = th.SystemAdminClient.UploadFile(data, channel.Id, "test.png")
-	if resp.StatusCode != http.StatusNotImplemented && resp.StatusCode != 0 {
+	if resp.StatusCode == 0 {
+		t.Log("file upload request failed completely")
+	} else if resp.StatusCode != http.StatusNotImplemented {
 		// This should return an HTTP 501, but it occasionally causes the http client itself to error
 		t.Fatalf("should've returned HTTP 501 or failed completely, got %v instead", resp.StatusCode)
 	}
@@ -212,13 +214,23 @@ func TestUploadFileAsRequestBody(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	_, resp = Client.UploadFileAsRequestBody(data, "../../junk", "test.png")
-	CheckBadRequestStatus(t, resp)
+	if resp.StatusCode == 0 {
+		t.Log("file upload request failed completely")
+	} else if resp.StatusCode != http.StatusBadRequest {
+		// This should return an HTTP 400, but it occasionally causes the http client itself to error
+		t.Fatalf("should've returned HTTP 400 or failed completely, got %v instead", resp.StatusCode)
+	}
 
 	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, model.NewId(), "test.png")
 	CheckForbiddenStatus(t, resp)
 
 	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, "../../junk", "test.png")
-	CheckBadRequestStatus(t, resp)
+	if resp.StatusCode == 0 {
+		t.Log("file upload request failed completely")
+	} else if resp.StatusCode != http.StatusBadRequest {
+		// This should return an HTTP 400, but it occasionally causes the http client itself to error
+		t.Fatalf("should've returned HTTP 400 or failed completely, got %v instead", resp.StatusCode)
+	}
 
 	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, channel.Id, "test.png")
 	CheckNoError(t, resp)
@@ -230,7 +242,9 @@ func TestUploadFileAsRequestBody(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.EnableFileAttachments = false })
 
 	_, resp = th.SystemAdminClient.UploadFileAsRequestBody(data, channel.Id, "test.png")
-	if resp.StatusCode != http.StatusNotImplemented && resp.StatusCode != 0 {
+	if resp.StatusCode == 0 {
+		t.Log("file upload request failed completely")
+	} else if resp.StatusCode != http.StatusNotImplemented {
 		// This should return an HTTP 501, but it occasionally causes the http client itself to error
 		t.Fatalf("should've returned HTTP 501 or failed completely, got %v instead", resp.StatusCode)
 	}

--- a/api4/params.go
+++ b/api4/params.go
@@ -27,6 +27,7 @@ type ApiParams struct {
 	ChannelId      string
 	PostId         string
 	FileId         string
+	Filename       string
 	PluginId       string
 	CommandId      string
 	HookId         string
@@ -54,6 +55,7 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 	params := &ApiParams{}
 
 	props := mux.Vars(r)
+	query := r.URL.Query()
 
 	if val, ok := props["user_id"]; ok {
 		params.UserId = val
@@ -73,6 +75,8 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 
 	if val, ok := props["channel_id"]; ok {
 		params.ChannelId = val
+	} else {
+		params.ChannelId = query.Get("channel_id")
 	}
 
 	if val, ok := props["post_id"]; ok {
@@ -82,6 +86,8 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 	if val, ok := props["file_id"]; ok {
 		params.FileId = val
 	}
+
+	params.Filename = query.Get("filename")
 
 	if val, ok := props["plugin_id"]; ok {
 		params.PluginId = val
@@ -151,17 +157,17 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 		params.ActionId = val
 	}
 
-	if val, err := strconv.Atoi(r.URL.Query().Get("page")); err != nil || val < 0 {
+	if val, err := strconv.Atoi(query.Get("page")); err != nil || val < 0 {
 		params.Page = PAGE_DEFAULT
 	} else {
 		params.Page = val
 	}
 
-	if val, err := strconv.ParseBool(r.URL.Query().Get("permanent")); err != nil {
+	if val, err := strconv.ParseBool(query.Get("permanent")); err != nil {
 		params.Permanent = val
 	}
 
-	if val, err := strconv.Atoi(r.URL.Query().Get("per_page")); err != nil || val < 0 {
+	if val, err := strconv.Atoi(query.Get("per_page")); err != nil || val < 0 {
 		params.PerPage = PER_PAGE_DEFAULT
 	} else if val > PER_PAGE_MAXIMUM {
 		params.PerPage = PER_PAGE_MAXIMUM
@@ -169,7 +175,7 @@ func ApiParamsFromRequest(r *http.Request) *ApiParams {
 		params.PerPage = val
 	}
 
-	if val, err := strconv.Atoi(r.URL.Query().Get("logs_per_page")); err != nil || val < 0 {
+	if val, err := strconv.Atoi(query.Get("logs_per_page")); err != nil || val < 0 {
 		params.LogsPerPage = LOGS_PER_PAGE_DEFAULT
 	} else if val > LOGS_PER_PAGE_MAXIMUM {
 		params.LogsPerPage = LOGS_PER_PAGE_MAXIMUM

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1369,6 +1369,10 @@
     "translation": "Unable to upload file. Header cannot be parsed."
   },
   {
+    "id": "api.file.upload_file.incorrect_number_of_files.app_error",
+    "translation": "Unable to upload files. Incorrect number of files specified."
+  },
+  {
     "id": "api.file.upload_file.large_image.app_error",
     "translation": "File above maximum dimensions could not be uploaded: {{.Filename}}"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -1915,7 +1915,8 @@ func (c *Client4) DoPostAction(postId, actionId string) (bool, *Response) {
 
 // File Section
 
-// UploadFile will upload a file to a channel, to be later attached to a post.
+// UploadFile will upload a file to a channel using a multipart request, to be later attached to a post.
+// This method is functionally equivalent to Client4.UploadFileAsRequestBody.
 func (c *Client4) UploadFile(data []byte, channelId string, filename string) (*FileUploadResponse, *Response) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -1937,6 +1938,12 @@ func (c *Client4) UploadFile(data []byte, channelId string, filename string) (*F
 	}
 
 	return c.DoUploadFile(c.GetFilesRoute(), body.Bytes(), writer.FormDataContentType())
+}
+
+// UploadFileAsRequestBody will upload a file to a channel as the body of a request, to be later attached
+// to a post. This method is functionally equivalent to Client4.UploadFile.
+func (c *Client4) UploadFileAsRequestBody(data []byte, channelId string, filename string) (*FileUploadResponse, *Response) {
+	return c.DoUploadFile(c.GetFilesRoute()+fmt.Sprintf("?channel_id=%v&filename=%v", url.QueryEscape(channelId), url.QueryEscape(filename)), data, http.DetectContentType(data))
 }
 
 // GetFile gets the bytes for a file by id.


### PR DESCRIPTION
This is the new file upload endpoint for use in the iOS share extension. Instead of being a separate route, it adds additional handling to the existing file upload endpoint so that it supports uploading a single file with the channel_id and filename specified as query parameters. This is as opposed to the original behaviour which just uses a multipart request to upload any number of files.

Elias will be the one making the changes to the redux library so that these can be used from the share extension.

API Reference PR: https://github.com/mattermost/mattermost-api-reference/pull/335

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9556

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- Added or updated unit tests (required for all new features)
- Added API documentation (required for all new APIs)
- All new/modified APIs include changes to the drivers
- Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates