### PR TITLE
MM-8681 Adding config settings necessary for using CloudFront.

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1076,6 +1076,7 @@ func attachDeviceId(c *Context, w http.ResponseWriter, r *http.Request) {
 		MaxAge:   maxAge,
 		Expires:  expiresAt,
 		HttpOnly: true,
+		Domain:   c.App.GetCookieDomain(),
 		Secure:   secure,
 	}
 

--- a/app/config.go
+++ b/app/config.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"runtime/debug"
 
 	l4g "github.com/alecthomas/log4go"
@@ -253,4 +254,13 @@ func (a *App) Desanitize(cfg *model.Config) {
 	for i := range cfg.SqlSettings.DataSourceSearchReplicas {
 		cfg.SqlSettings.DataSourceSearchReplicas[i] = actual.SqlSettings.DataSourceSearchReplicas[i]
 	}
+}
+
+func (a *App) GetCookieDomain() string {
+	if *a.Config().ServiceSettings.AllowCookiesForSubdomains {
+		if siteURL, err := url.Parse(*a.Config().ServiceSettings.SiteURL); err == nil {
+			return siteURL.Hostname()
+		}
+	}
+	return ""
 }

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -243,6 +243,8 @@ func (a *App) trackConfig() {
 		"isdefault_image_proxy_type":                              isDefault(*cfg.ServiceSettings.ImageProxyType, ""),
 		"isdefault_image_proxy_url":                               isDefault(*cfg.ServiceSettings.ImageProxyURL, ""),
 		"isdefault_image_proxy_options":                           isDefault(*cfg.ServiceSettings.ImageProxyOptions, ""),
+		"websocket_url":                                           isDefault(*cfg.ServiceSettings.WebsocketURL, ""),
+		"allow_cookies_for_subdomains":                            *cfg.ServiceSettings.AllowCookiesForSubdomains,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{

--- a/app/login.go
+++ b/app/login.go
@@ -113,6 +113,7 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 		secure = true
 	}
 
+	domain := a.GetCookieDomain()
 	expiresAt := time.Unix(model.GetMillis()/1000+int64(maxAge), 0)
 	sessionCookie := &http.Cookie{
 		Name:     model.SESSION_COOKIE_TOKEN,
@@ -121,6 +122,7 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 		MaxAge:   maxAge,
 		Expires:  expiresAt,
 		HttpOnly: true,
+		Domain:   domain,
 		Secure:   secure,
 	}
 
@@ -130,6 +132,7 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 		Path:    "/",
 		MaxAge:  maxAge,
 		Expires: expiresAt,
+		Domain:  domain,
 		Secure:  secure,
 	}
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,6 +1,7 @@
 {
     "ServiceSettings": {
         "SiteURL": "http://localhost:8065",
+        "WebsocketURL": "",
         "LicenseFileLocation": "",
         "ListenAddress": ":8065",
         "ConnectionSecurity": "",
@@ -32,6 +33,7 @@
         "EnforceMultifactorAuthentication": false,
         "EnableUserAccessTokens": false,
         "AllowCorsFrom": "",
+        "AllowCookiesForSubdomains": false,
         "SessionLengthWebInDays": 30,
         "SessionLengthMobileInDays": 30,
         "SessionLengthSSOInDays": 30,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4963,6 +4963,10 @@
     "translation": "Site URL must be a valid URL and start with http:// or https://"
   },
   {
+    "id": "model.config.is_valid.websocket_url.app_error",
+    "translation": "Websocket URL must be a valid URL and start with ws:// or wss://"
+  },
+  {
     "id": "model.config.is_valid.site_url_email_batching.app_error",
     "translation": "Unable to enable email batching when SiteURL isn't set."
   },

--- a/model/config.go
+++ b/model/config.go
@@ -165,6 +165,7 @@ const (
 
 type ServiceSettings struct {
 	SiteURL                                           *string
+	WebsocketURL                                      *string
 	LicenseFileLocation                               *string
 	ListenAddress                                     *string
 	ConnectionSecurity                                *string
@@ -196,6 +197,7 @@ type ServiceSettings struct {
 	EnforceMultifactorAuthentication                  *bool
 	EnableUserAccessTokens                            *bool
 	AllowCorsFrom                                     *string
+	AllowCookiesForSubdomains                         *bool
 	SessionLengthWebInDays                            *int
 	SessionLengthMobileInDays                         *int
 	SessionLengthSSOInDays                            *int
@@ -230,6 +232,10 @@ type ServiceSettings struct {
 func (s *ServiceSettings) SetDefaults() {
 	if s.SiteURL == nil {
 		s.SiteURL = NewString(SERVICE_SETTINGS_DEFAULT_SITE_URL)
+	}
+
+	if s.WebsocketURL == nil {
+		s.WebsocketURL = NewString("")
 	}
 
 	if s.LicenseFileLocation == nil {
@@ -386,6 +392,10 @@ func (s *ServiceSettings) SetDefaults() {
 
 	if s.AllowCorsFrom == nil {
 		s.AllowCorsFrom = NewString(SERVICE_SETTINGS_DEFAULT_ALLOW_CORS_FROM)
+	}
+
+	if s.AllowCookiesForSubdomains == nil {
+		s.AllowCookiesForSubdomains = NewBool(false)
 	}
 
 	if s.WebserverMode == nil {
@@ -1778,6 +1788,10 @@ func (o *Config) IsValid() *AppError {
 		return NewAppError("Config.IsValid", "model.config.is_valid.cluster_email_batching.app_error", nil, "", http.StatusBadRequest)
 	}
 
+	if len(*o.ServiceSettings.SiteURL) == 0 && *o.ServiceSettings.AllowCookiesForSubdomains {
+		return NewAppError("Config.IsValid", "Allowing cookies for subdomains requires SiteURL to be set.", nil, "", http.StatusBadRequest)
+	}
+
 	if err := o.TeamSettings.isValid(); err != nil {
 		return err
 	}
@@ -2082,6 +2096,12 @@ func (ss *ServiceSettings) isValid() *AppError {
 	if len(*ss.SiteURL) != 0 {
 		if _, err := url.ParseRequestURI(*ss.SiteURL); err != nil {
 			return NewAppError("Config.IsValid", "model.config.is_valid.site_url.app_error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	if len(*ss.WebsocketURL) != 0 {
+		if _, err := url.ParseRequestURI(*ss.WebsocketURL); err != nil {
+			return NewAppError("Config.IsValid", "model.config.is_valid.websocket_url.app_error", nil, "", http.StatusBadRequest)
 		}
 	}
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -353,6 +353,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["BuildEnterpriseReady"] = model.BuildEnterpriseReady
 
 	props["SiteURL"] = strings.TrimRight(*c.ServiceSettings.SiteURL, "/")
+	props["WebsocketURL"] = strings.TrimRight(*c.ServiceSettings.WebsocketURL, "/")
 	props["SiteName"] = c.TeamSettings.SiteName
 	props["EnableTeamCreation"] = strconv.FormatBool(c.TeamSettings.EnableTeamCreation)
 	props["EnableUserCreation"] = strconv.FormatBool(c.TeamSettings.EnableUserCreation)


### PR DESCRIPTION
Adds two configuration settings:

1. AllowCookiesForSubdomains, which set's the Domain parameter on our cookies, which allows the browser to send the cookies to subdomains as well. 
2. WebsocketURL, allows the server to instruct clients where they should try to connect by websockets to. 

Combined these allow the bypass of a main proxy server or CDN such as cloudfront that does not support websockets by using a websocket subdomain (like ws.pre-release.mattermost.com for example).

Accomplishing this with a redirect was not possible because the Chrome browser does not appear to follow websocket redirects. (I did not check other browser behavior)

Documentation PR for using these settings with CloudFront can be found here: https://github.com/mattermost/docs/pull/1796