### PR TITLE
Split make package target into platform-specific sub-targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server stop-client stop-server restart restart-server restart-client start-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist setup-mac prepare-enteprise run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows internal-test-web-client vet run-server-for-web-client-tests
+.PHONY: build package package-common package-osx package-windows package-linux run stop run-client run-server stop-client stop-server restart restart-server restart-client start-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist setup-mac prepare-enteprise run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows internal-test-web-client vet run-server-for-web-client-tests
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/build/release.mk
+++ b/build/release.mk
@@ -20,7 +20,9 @@ build-client:
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) build
 
-package:
+package: package-common package-osx package-windows package-linux
+
+package-common:
 	@ echo Packaging mattermost
 
 	@# Remove any old files
@@ -61,6 +63,7 @@ endif
 
 	@# ----- PLATFORM SPECIFIC -----
 
+package-osx: package-common
 	@# Make osx package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
@@ -73,6 +76,7 @@ endif
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/platform
 
+package-windows: package-common
 	@# Make windows package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
@@ -85,6 +89,7 @@ endif
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/platform.exe
 
+package-linux: package-common
 	@# Make linux package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")


### PR DESCRIPTION
#### Summary
> It is currently not possible to build and package Mattermost only for one specific platform, instead one has to build (and package) Mattermost for all supported plattforms.

#### Ticket Link
Fixes #8314.