### PR TITLE
MM-8825: Make consistent INVITE_USER and ADD_USER_TO_TEAM permissions checking

### DIFF
--- a/api/team.go
+++ b/api/team.go
@@ -121,6 +121,11 @@ func inviteMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !c.App.SessionHasPermissionToTeam(c.Session, c.TeamId, model.PERMISSION_ADD_USER_TO_TEAM) {
+		c.SetPermissionError(model.PERMISSION_INVITE_USER)
+		return
+	}
+
 	if err := c.App.InviteNewUsersToTeam(invites.ToEmailList(), c.TeamId, c.Session.UserId); err != nil {
 		c.Err = err
 		return


### PR DESCRIPTION
#### Summary
Check for ADD_USER_TO_TEAM also in the API 3 endpoint.

#### Ticket Link
[MM-8825](https://mattermost.atlassian.net/browse/MM-8825)