### PR TITLE
Fix prerequisites checker so 1.10 > 1.9

### DIFF
--- a/scripts/prereq-check.sh
+++ b/scripts/prereq-check.sh
@@ -2,7 +2,7 @@
 check_version()
 {
     local version=$1 check=$2
-    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -Vr | head -1)
+    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -t. -s -k 1,1nr -k 2,2nr -k 3,3nr -k 4,4nr | head -1)
     [[ "$winner" = "$version" ]] && return 0
     return 1
 }

--- a/scripts/prereq-check.sh
+++ b/scripts/prereq-check.sh
@@ -2,7 +2,7 @@
 check_version()
 {
     local version=$1 check=$2
-    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -nr | head -1)
+    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -Vr | head -1)
     [[ "$winner" = "$version" ]] && return 0
     return 1
 }


### PR DESCRIPTION
#### Summary
Fixes prerequisites version checking by using `sort -t.` to use dot as separator instead of `sort -n` in `scripts/prereq-check.sh`.

#### Ticket Link
[https://github.com/mattermost/mattermost-server/issues/8333](https://github.com/mattermost/mattermost-server/issues/8333)

#### Checklist
- [x] Ran make check-style to check for style errors (required for all pull requests)
- [x] Made sure `make check-prereqs` works now
![screenshot from 2018-02-21 11-13-43](https://user-images.githubusercontent.com/412857/36474689-92c865aa-16f8-11e8-9fc3-51941f902304.png)
