### PR TITLE
MM-8006 Fix push notification content for file only messages

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -623,7 +623,9 @@ func (a *App) getPushNotificationMessage(postMessage string, wasMentioned bool, 
 	message := ""
 	category := ""
 
-	if *a.Config().EmailSettings.PushNotificationContents == model.FULL_NOTIFICATION {
+	contentsConfig := *a.Config().EmailSettings.PushNotificationContents
+
+	if contentsConfig == model.FULL_NOTIFICATION {
 		category = model.CATEGORY_CAN_REPLY
 
 		if channelType == model.CHANNEL_DIRECT {
@@ -631,7 +633,7 @@ func (a *App) getPushNotificationMessage(postMessage string, wasMentioned bool, 
 		} else {
 			message = senderName + userLocale("api.post.send_notifications_and_forget.push_in") + channelName + ": " + model.ClearMentionTags(postMessage)
 		}
-	} else if *a.Config().EmailSettings.PushNotificationContents == model.GENERIC_NO_CHANNEL_NOTIFICATION {
+	} else if contentsConfig == model.GENERIC_NO_CHANNEL_NOTIFICATION {
 		if channelType == model.CHANNEL_DIRECT {
 			category = model.CATEGORY_CAN_REPLY
 
@@ -659,6 +661,8 @@ func (a *App) getPushNotificationMessage(postMessage string, wasMentioned bool, 
 	if len(postMessage) == 0 && hasFiles {
 		if channelType == model.CHANNEL_DIRECT {
 			message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only_dm")
+		} else if contentsConfig == model.GENERIC_NO_CHANNEL_NOTIFICATION {
+			message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only_no_channel")
 		} else {
 			message = senderName + userLocale("api.post.send_notifications_and_forget.push_image_only") + channelName
 		}

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1414,6 +1414,12 @@ func TestGetPushNotificationMessage(t *testing.T) {
 			ExpectedMessage:  "user uploaded one or more files in a direct message",
 			ExpectedCategory: model.CATEGORY_CAN_REPLY,
 		},
+		"only files without channel, public channel": {
+			HasFiles:                 true,
+			PushNotificationContents: model.GENERIC_NO_CHANNEL_NOTIFICATION,
+			ChannelType:              model.CHANNEL_OPEN,
+			ExpectedMessage:          "user uploaded one or more files",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			locale := tc.Locale

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1815,6 +1815,10 @@
     "translation": " uploaded one or more files in "
   },
   {
+    "id": "api.post.send_notifications_and_forget.push_image_only_no_channel",
+    "translation": " uploaded one or more files"
+  },
+  {
     "id": "api.post.send_notifications_and_forget.push_image_only_dm",
     "translation": " uploaded one or more files in a direct message"
   },


### PR DESCRIPTION
#### Summary
Fix push notification content for file only messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8006

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json) updates
