### PR TITLE
MM-8593 Default APIv3 to disabled for new installs

### DIFF
--- a/api/apitestlib.go
+++ b/api/apitestlib.go
@@ -100,6 +100,7 @@ func setupTestHelper(enterprise bool) *TestHelper {
 		*cfg.TeamSettings.MaxUsersPerTeam = 50
 		*cfg.RateLimitSettings.Enable = false
 		cfg.EmailSettings.SendEmailNotifications = true
+		*cfg.ServiceSettings.EnableAPIv3 = true
 	})
 	prevListenAddress := *th.App.Config().ServiceSettings.ListenAddress
 	if testStore != nil {

--- a/config/default.json
+++ b/config/default.json
@@ -22,7 +22,7 @@
         "EnableOnlyAdminIntegrations": true,
         "EnablePostUsernameOverride": false,
         "EnablePostIconOverride": false,
-        "EnableAPIv3": true,
+        "EnableAPIv3": false,
         "EnableLinkPreviews": false,
         "EnableTesting": false,
         "EnableDeveloper": false,

--- a/utils/config.go
+++ b/utils/config.go
@@ -355,6 +355,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["SiteURL"] = strings.TrimRight(*c.ServiceSettings.SiteURL, "/")
 	props["WebsocketURL"] = strings.TrimRight(*c.ServiceSettings.WebsocketURL, "/")
 	props["SiteName"] = c.TeamSettings.SiteName
+	props["EnableAPIv3"] = strconv.FormatBool(*c.ServiceSettings.EnableAPIv3)
 	props["EnableTeamCreation"] = strconv.FormatBool(c.TeamSettings.EnableTeamCreation)
 	props["EnableUserCreation"] = strconv.FormatBool(c.TeamSettings.EnableUserCreation)
 	props["EnableOpenServer"] = strconv.FormatBool(*c.TeamSettings.EnableOpenServer)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -59,6 +59,7 @@ func Setup() *app.App {
 
 	a.UpdateConfig(func(cfg *model.Config) {
 		*cfg.TeamSettings.EnableOpenServer = true
+		*cfg.ServiceSettings.EnableAPIv3 = true
 	})
 
 	return a


### PR DESCRIPTION
#### Summary
* Default APIv3 to disabled for new installs
* Add EnableAPIv3 setting to client config to support related webapp changes

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8593