### PR TITLE
MM-8604: emit config/license websocket events

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"runtime"
-	"strconv"
 
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-server/model"
@@ -246,14 +245,7 @@ func getClientConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	respCfg := map[string]string{}
-	for k, v := range c.App.ClientConfig() {
-		respCfg[k] = v
-	}
-
-	respCfg["NoAccounts"] = strconv.FormatBool(c.App.IsFirstUserAccount())
-
-	w.Write([]byte(model.MapToJson(respCfg)))
+	w.Write([]byte(model.MapToJson(c.App.ClientConfigWithNoAccounts())))
 }
 
 func getClientLicense(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/app/app.go
+++ b/app/app.go
@@ -131,8 +131,24 @@ func New(options ...Option) (outApp *App, outErr error) {
 
 	app.configListenerId = app.AddConfigListener(func(_, _ *model.Config) {
 		app.configOrLicenseListener()
+
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CONFIG_CHANGED, "", "", "", nil)
+
+		message.Add("config", app.ClientConfigWithNoAccounts())
+		app.Go(func() {
+			app.Publish(message)
+		})
 	})
-	app.licenseListenerId = app.AddLicenseListener(app.configOrLicenseListener)
+	app.licenseListenerId = app.AddLicenseListener(func() {
+		app.configOrLicenseListener()
+
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_LICENSE_CHANGED, "", "", "", nil)
+		message.Add("license", app.GetSanitizedClientLicense())
+		app.Go(func() {
+			app.Publish(message)
+		})
+
+	})
 	app.regenerateClientConfig()
 	app.setDefaultRolesBasedOnConfig()
 

--- a/app/config.go
+++ b/app/config.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"net/url"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	l4g "github.com/alecthomas/log4go"
@@ -34,6 +35,7 @@ func (a *App) UpdateConfig(f func(*model.Config)) {
 	updated := old.Clone()
 	f(updated)
 	a.config.Store(updated)
+
 	a.InvokeConfigListeners(old, updated)
 }
 
@@ -268,4 +270,17 @@ func (a *App) GetCookieDomain() string {
 
 func (a *App) GetSiteURL() string {
 	return a.siteURL
+}
+
+// ClientConfigWithNoAccounts gets the configuration in a format suitable for sending to the client.
+func (a *App) ClientConfigWithNoAccounts() map[string]string {
+	respCfg := map[string]string{}
+	for k, v := range a.ClientConfig() {
+		respCfg[k] = v
+	}
+
+	// NoAccounts is not actually part of the configuration, but is expected by the client.
+	respCfg["NoAccounts"] = strconv.FormatBool(a.IsFirstUserAccount())
+
+	return respCfg
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -63,3 +63,13 @@ func TestAsymmetricSigningKey(t *testing.T) {
 	assert.NotNil(t, th.App.AsymmetricSigningKey())
 	assert.NotEmpty(t, th.App.ClientConfig()["AsymmetricSigningPublicKey"])
 }
+
+func TestClientConfigWithNoAccounts(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	config := th.App.ClientConfigWithNoAccounts()
+	if _, ok := config["NoAccounts"]; !ok {
+		t.Fatal("expected NoAccounts in returned config")
+	}
+}

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -44,6 +44,8 @@ const (
 	WEBSOCKET_EVENT_CHANNEL_VIEWED      = "channel_viewed"
 	WEBSOCKET_EVENT_PLUGIN_ACTIVATED    = "plugin_activated"   // EXPERIMENTAL - SUBJECT TO CHANGE
 	WEBSOCKET_EVENT_PLUGIN_DEACTIVATED  = "plugin_deactivated" // EXPERIMENTAL - SUBJECT TO CHANGE
+	WEBSOCKET_EVENT_LICENSE_CHANGED     = "license_changed"
+	WEBSOCKET_EVENT_CONFIG_CHANGED      = "config_changed"
 )
 
 type WebSocketMessage interface {


### PR DESCRIPTION
#### Summary
Emit new websocket events whenever the license or configuration changes. This will eventually allow us to stop reloading the webapp when these change and react purely to the Redux state changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8604

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)