### PR TITLE
Remove `go Publish(...)` idiom

### DIFF
--- a/api/post.go
+++ b/api/post.go
@@ -136,10 +136,7 @@ func saveIsPinnedPost(c *Context, w http.ResponseWriter, r *http.Request, isPinn
 
 			message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_EDITED, "", rpost.ChannelId, "", nil)
 			message.Add("post", c.App.PostWithProxyAddedToImageURLs(rpost).ToJson())
-
-			c.App.Go(func() {
-				c.App.Publish(message)
-			})
+			c.App.Publish(message)
 
 			c.App.InvalidateCacheForChannelPosts(rpost.ChannelId)
 

--- a/api/websocket_test.go
+++ b/api/websocket_test.go
@@ -227,7 +227,7 @@ func TestWebSocketEvent(t *testing.T) {
 	}
 
 	evt2 := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_TYPING, "", "somerandomid", "", nil)
-	go th.App.Publish(evt2)
+	th.App.Publish(evt2)
 	time.Sleep(300 * time.Millisecond)
 
 	eventHit = false

--- a/app/channel.go
+++ b/app/channel.go
@@ -545,7 +545,6 @@ func (a *App) DeleteChannel(channel *model.Channel, userId string) *model.AppErr
 
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_DELETED, channel.TeamId, "", "", nil)
 		message.Add("channel_id", channel.Id)
-
 		a.Publish(message)
 	}
 
@@ -1166,17 +1165,13 @@ func (a *App) removeUserFromChannel(userIdToRemove string, removerUserId string,
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_REMOVED, "", channel.Id, "", nil)
 	message.Add("user_id", userIdToRemove)
 	message.Add("remover_id", removerUserId)
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 
 	// because the removed user no longer belongs to the channel we need to send a separate websocket event
 	userMsg := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_REMOVED, "", "", userIdToRemove, nil)
 	userMsg.Add("channel_id", channel.Id)
 	userMsg.Add("remover_id", removerUserId)
-	a.Go(func() {
-		a.Publish(userMsg)
-	})
+	a.Publish(userMsg)
 
 	return nil
 }
@@ -1246,9 +1241,7 @@ func (a *App) UpdateChannelLastViewedAt(channelIds []string, userId string) *mod
 		for _, channelId := range channelIds {
 			message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_VIEWED, "", "", userId, nil)
 			message.Add("channel_id", channelId)
-			a.Go(func() {
-				a.Publish(message)
-			})
+			a.Publish(message)
 		}
 	}
 
@@ -1325,9 +1318,7 @@ func (a *App) ViewChannel(view *model.ChannelView, userId string, clearPushNotif
 	if *a.Config().ServiceSettings.EnableChannelViewedMessages && model.IsValidId(view.ChannelId) {
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_VIEWED, "", "", userId, nil)
 		message.Add("channel_id", view.ChannelId)
-		a.Go(func() {
-			a.Publish(message)
-		})
+		a.Publish(message)
 	}
 
 	return times, nil

--- a/app/command_expand_collapse.go
+++ b/app/command_expand_collapse.go
@@ -74,9 +74,7 @@ func (a *App) setCollapsePreference(args *model.CommandArgs, isCollapse bool) *m
 
 	socketMessage := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_PREFERENCE_CHANGED, "", "", args.UserId, nil)
 	socketMessage.Add("preference", pref.ToJson())
-	a.Go(func() {
-		a.Publish(socketMessage)
-	})
+	a.Publish(socketMessage)
 
 	var rmsg string
 

--- a/app/emoji.go
+++ b/app/emoji.go
@@ -60,7 +60,6 @@ func (a *App) CreateEmoji(sessionUserId string, emoji *model.Emoji, multiPartIma
 	} else {
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_EMOJI_ADDED, "", "", "", nil)
 		message.Add("emoji", emoji.ToJson())
-
 		a.Publish(message)
 		return result.Data.(*model.Emoji), nil
 	}

--- a/app/post.go
+++ b/app/post.go
@@ -84,9 +84,7 @@ func (a *App) CreatePostAsUser(post *model.Post) (*model.Post, *model.AppError) 
 			if *a.Config().ServiceSettings.EnableChannelViewedMessages {
 				message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_VIEWED, "", "", post.UserId, nil)
 				message.Add("channel_id", post.ChannelId)
-				a.Go(func() {
-					a.Publish(message)
-				})
+				a.Publish(message)
 			}
 		}
 
@@ -314,10 +312,7 @@ func (a *App) SendEphemeralPost(userId string, post *model.Post) *model.Post {
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_EPHEMERAL_MESSAGE, "", post.ChannelId, userId, nil)
 	message.Add("post", a.PostWithProxyAddedToImageURLs(post).ToJson())
-
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 
 	return post
 }
@@ -424,10 +419,7 @@ func (a *App) PatchPost(postId string, patch *model.PostPatch) (*model.Post, *mo
 func (a *App) sendUpdatedPostEvent(post *model.Post) {
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_EDITED, "", post.ChannelId, "", nil)
 	message.Add("post", a.PostWithProxyAddedToImageURLs(post).ToJson())
-
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 }
 
 func (a *App) GetPostsPage(channelId string, page int, perPage int) (*model.PostList, *model.AppError) {
@@ -567,10 +559,8 @@ func (a *App) DeletePost(postId string) (*model.Post, *model.AppError) {
 
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", post.ChannelId, "", nil)
 		message.Add("post", a.PostWithProxyAddedToImageURLs(post).ToJson())
+		a.Publish(message)
 
-		a.Go(func() {
-			a.Publish(message)
-		})
 		a.Go(func() {
 			a.DeletePostFiles(post)
 		})

--- a/app/preference.go
+++ b/app/preference.go
@@ -55,9 +55,7 @@ func (a *App) UpdatePreferences(userId string, preferences model.Preferences) *m
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_PREFERENCES_CHANGED, "", "", userId, nil)
 	message.Add("preferences", preferences.ToJson())
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 
 	return nil
 }
@@ -80,9 +78,7 @@ func (a *App) DeletePreferences(userId string, preferences model.Preferences) *m
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_PREFERENCES_DELETED, "", "", userId, nil)
 	message.Add("preferences", preferences.ToJson())
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 
 	return nil
 }

--- a/app/status.go
+++ b/app/status.go
@@ -221,9 +221,7 @@ func (a *App) BroadcastStatus(status *model.Status) {
 	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", status.UserId, nil)
 	event.Add("status", status.Status)
 	event.Add("user_id", status.UserId)
-	a.Go(func() {
-		a.Publish(event)
-	})
+	a.Publish(event)
 }
 
 func (a *App) SetStatusOffline(userId string, manual bool) {
@@ -247,9 +245,7 @@ func (a *App) SetStatusOffline(userId string, manual bool) {
 	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", status.UserId, nil)
 	event.Add("status", model.STATUS_OFFLINE)
 	event.Add("user_id", status.UserId)
-	a.Go(func() {
-		a.Publish(event)
-	})
+	a.Publish(event)
 }
 
 func (a *App) SetStatusAwayIfNeeded(userId string, manual bool) {
@@ -290,9 +286,7 @@ func (a *App) SetStatusAwayIfNeeded(userId string, manual bool) {
 	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", status.UserId, nil)
 	event.Add("status", model.STATUS_AWAY)
 	event.Add("user_id", status.UserId)
-	a.Go(func() {
-		a.Publish(event)
-	})
+	a.Publish(event)
 }
 
 func (a *App) SetStatusDoNotDisturb(userId string) {
@@ -318,9 +312,7 @@ func (a *App) SetStatusDoNotDisturb(userId string) {
 	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_STATUS_CHANGE, "", "", status.UserId, nil)
 	event.Add("status", model.STATUS_DND)
 	event.Add("user_id", status.UserId)
-	a.Go(func() {
-		a.Publish(event)
-	})
+	a.Publish(event)
 }
 
 func GetStatusFromCache(userId string) *model.Status {

--- a/app/team.go
+++ b/app/team.go
@@ -134,9 +134,7 @@ func (a *App) sendTeamEvent(team *model.Team, event string) {
 
 	message := model.NewWebSocketEvent(event, "", "", "", nil)
 	message.Add("team", sanitizedTeam.ToJson())
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 }
 
 func (a *App) UpdateTeamMemberRoles(teamId string, userId string, newRoles string) (*model.TeamMember, *model.AppError) {
@@ -173,10 +171,7 @@ func (a *App) UpdateTeamMemberRoles(teamId string, userId string, newRoles strin
 func (a *App) sendUpdatedMemberRoleEvent(userId string, member *model.TeamMember) {
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_MEMBERROLE_UPDATED, "", "", userId, nil)
 	message.Add("member", member.ToJson())
-
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 }
 
 func (a *App) AddUserToTeam(teamId string, userId string, userRequestorId string) (*model.Team, *model.AppError) {

--- a/app/user.go
+++ b/app/user.go
@@ -202,9 +202,7 @@ func (a *App) CreateUser(user *model.User) (*model.User, *model.AppError) {
 		// This message goes to everyone, so the teamId, channelId and userId are irrelevant
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_NEW_USER, "", "", "", nil)
 		message.Add("user_id", ruser.Id)
-		a.Go(func() {
-			a.Publish(message)
-		})
+		a.Publish(message)
 
 		return ruser, nil
 	}
@@ -832,7 +830,6 @@ func (a *App) SetProfileImageFromFile(userId string, file multipart.File) *model
 
 		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
 		message.Add("user", user)
-
 		a.Publish(message)
 	}
 
@@ -1002,9 +999,7 @@ func (a *App) sendUpdatedUserEvent(user model.User, asAdmin bool) {
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
 	message.Add("user", user)
-	a.Go(func() {
-		a.Publish(message)
-	})
+	a.Publish(message)
 }
 
 func (a *App) UpdateUser(user *model.User, sendNotifications bool) (*model.User, *model.AppError) {

--- a/wsapi/user.go
+++ b/wsapi/user.go
@@ -29,7 +29,7 @@ func (api *API) userTyping(req *model.WebSocketRequest) (map[string]interface{},
 	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_TYPING, "", channelId, "", omitUsers)
 	event.Add("parent_id", parentId)
 	event.Add("user_id", req.Session.UserId)
-	go api.App.Publish(event)
+	api.App.Publish(event)
 
 	return nil, nil
 }

--- a/wsapi/webrtc.go
+++ b/wsapi/webrtc.go
@@ -20,7 +20,7 @@ func (api *API) webrtcMessage(req *model.WebSocketRequest) (map[string]interface
 
 	event := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_WEBRTC, "", "", toUserId, nil)
 	event.Data = req.Data
-	go api.App.Publish(event)
+	api.App.Publish(event)
 
 	return nil, nil
 }


### PR DESCRIPTION
#### Summary
I traced the Git history back to the origin of this and it seems to me like the `go Publish(...)` calls were remnants of `store.PublishAndForget()`, which originally had a totally different implementation. I don't believe they actually improve performance anymore as `Publish` doesn't do anything that takes any significant amount of time. The only exception is if the hub's broadcast queue (of 4096 messages) is full. In that case, goroutines will now block until the channel can receive a new message. I think this is actually preferable behavior. Spinning up a new goroutine wouldn't really buy us any actually performance gains anyways. The queue is full because resources are under contention, and the server's performance will still suffer just as much regardless, but in far less predictable ways (goroutines will be more subject to barging or other scheduling issues).

In my tests there was no significant impact on performance. But the code is obviously cleaner, and there's the advantage of sequential `Publish` calls on the same server being guaranteed to publish messages in order.

#### Ticket Link
N/A

#### Checklist
N/A