### PR TITLE
fix version pre-check

### DIFF
--- a/scripts/prereq-check.sh
+++ b/scripts/prereq-check.sh
@@ -2,7 +2,7 @@
 check_version()
 {
     local version=$1 check=$2
-    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -nr | head -1)
+    local winner=$(echo -e "$version\n$check" | sed '/^$/d' | sort -Vr | head -1)
     [[ "$winner" = "$version" ]] && return 0
     return 1
 }


### PR DESCRIPTION
#### Disclaimer
I'm not an 'approved contributor' or anything, but this is a 1-char change. Up to you.

#### Summary
I have go 1.10 installed on my machine, when I run `make run`, it tells me:
```
WARNING! Mattermost did not find the minimum supported version of 'go' installed. Required: 1.9.2, Found: 1.10
``` 
I did not test the fix on a mac or windows, but I believe the farm will take care of that. Probably. It's a toolchain issue.

#### Ticket Link
None, but I can open one if needed.

#### Checklist
- [x] Touches critical sections of the codebase (toolchain)

Edit: `sort -V` works on macos (high sierra)