### PR TITLE
Optimize LRU purging

### DIFF
--- a/utils/lru_test.go
+++ b/utils/lru_test.go
@@ -11,24 +11,13 @@ import "testing"
 import "time"
 
 func TestLRU(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		evictCounter += 1
-	}
-	l, err := NewLruWithEvict(128, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
+	l := NewLru(128)
 
 	for i := 0; i < 256; i++ {
 		l.Add(i, i)
 	}
 	if l.Len() != 128 {
 		t.Fatalf("bad len: %v", l.Len())
-	}
-
-	if evictCounter != 128 {
-		t.Fatalf("bad evict count: %v", evictCounter)
 	}
 
 	for i, k := range l.Keys() {
@@ -70,26 +59,6 @@ func TestLRU(t *testing.T) {
 	}
 	if _, ok := l.Get(200); ok {
 		t.Fatalf("should contain nothing")
-	}
-}
-
-// test that Add return true/false if an eviction occurred
-func TestLRUAdd(t *testing.T) {
-	evictCounter := 0
-	onEvicted := func(k interface{}, v interface{}) {
-		evictCounter += 1
-	}
-
-	l, err := NewLruWithEvict(1, onEvicted)
-	if err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	if l.Add(1, 1) || evictCounter != 0 {
-		t.Errorf("should not have an eviction")
-	}
-	if !l.Add(2, 2) || evictCounter != 1 {
-		t.Errorf("should have an eviction")
 	}
 }
 


### PR DESCRIPTION
#### Summary
This removes some of the stuff we weren't using from the LRU and uses a generation-based approach to purging the LRU rather than releasing and reallocating the underlying map's memory.

Previously, every call to `InvalidateAllCachesSkipSend` would allocate multiple megabytes of memory for large maps on each call. Now, rather than reallocating the maps, a counter is simply incremented.

The change is extremely apparent in the heap profiles, and somewhat apparent in the CPU profiles (reducing garbage collection time a bit). End-of-test reports show improvements in response times as well.

[lrultafter.txt](https://github.com/mattermost/mattermost-server/files/1765286/lrultafter.txt)
[lrultbefore.txt](https://github.com/mattermost/mattermost-server/files/1765287/lrultbefore.txt)
[lruheapbefore.pb.gz](https://github.com/mattermost/mattermost-server/files/1765288/lruheapbefore.pb.gz)
[lruheapafter.pb.gz](https://github.com/mattermost/mattermost-server/files/1765289/lruheapafter.pb.gz)
[lrucpuafter.pb.gz](https://github.com/mattermost/mattermost-server/files/1765290/lrucpuafter.pb.gz)
[lrucpubefore.pb.gz](https://github.com/mattermost/mattermost-server/files/1765291/lrucpubefore.pb.gz)

#### Ticket Link
N/A

#### Checklist
N/A