### PR TITLE
Fix linux cap header structure

### DIFF
--- a/plugin/rpcplugin/sandbox/sandbox_linux.go
+++ b/plugin/rpcplugin/sandbox/sandbox_linux.go
@@ -267,7 +267,7 @@ func pivotRoot(newRoot string) error {
 func dropInheritableCapabilities() error {
 	type capHeader struct {
 		version uint32
-		pid     int
+		pid     int32
 	}
 
 	type capData struct {


### PR DESCRIPTION
#### Summary
The `pid` field should be 4 bytes. With Go 1.9, the build just happens to work. With Go 1.10, the padding between the `version` and `pid` fields happens to be non-zero, and the syscalls fail.

I can update the build slaves to 1.10 once this is merged.

#### Ticket Link
N/A

#### Checklist
N/A