### PR TITLE
MM-8814: Remove implicit permission grants from post ownership.

### DIFF
--- a/app/authorization.go
+++ b/app/authorization.go
@@ -94,19 +94,6 @@ func (a *App) SessionHasPermissionToUser(session model.Session, userId string) b
 	return false
 }
 
-func (a *App) SessionHasPermissionToPost(session model.Session, postId string, permission *model.Permission) bool {
-	post, err := a.GetSinglePost(postId)
-	if err != nil {
-		return false
-	}
-
-	if post.UserId == session.UserId {
-		return true
-	}
-
-	return a.SessionHasPermissionToChannel(session, post.ChannelId, permission)
-}
-
 func (a *App) HasPermissionTo(askingUserId string, permission *model.Permission) bool {
 	user, err := a.GetUser(askingUserId)
 	if err != nil {


### PR DESCRIPTION
#### Summary
This PR removes the implicit granting of EDIT/DELETE permissions on posts when being accessed by their owners. It deliberately doesn't alter the situation as the code currently stands as to whether `XXX_POST` is a pre-requisite of `XXX_OTHERS_POSTS` or not (it appears to vary).

This is ready for review, but probably belongs in Phase 2 so don't merge it yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8814
