### PR TITLE
Respect plugin manifest webapp bundle_path

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -173,6 +173,11 @@ func (m *Manifest) ClientManifest() *Manifest {
 	cm.Name = ""
 	cm.Description = ""
 	cm.Backend = nil
+	if cm.Webapp != nil {
+		cm.Webapp = new(ManifestWebapp)
+		*cm.Webapp = *m.Webapp
+		cm.Webapp.BundlePath = "/static/" + m.Id + "_bundle.js"
+	}
 	return cm
 }
 


### PR DESCRIPTION
#### Summary
> The path to your webapp bundle. This should be relative to the root of your bundle and the location of the manifest file.

This was actually completely ignored by the server. And if it was anything other than `/static/[plugin id]_bundle.js`, nothing would work. This fixes it, including a backwards-compatibility fallback until we update the Zoom plugin and `mdk`.

#### Ticket Link
N/A

#### Checklist
N/A