### PR TITLE
Moved team icon upgrade code to 4.9 since it didn't make it in for 4.8

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -368,7 +368,6 @@ func UpgradeDatabaseToVersion471(sqlStore SqlStore) {
 
 func UpgradeDatabaseToVersion48(sqlStore SqlStore) {
 	if shouldPerformUpgrade(sqlStore, VERSION_4_7_1, VERSION_4_8_0) {
-		sqlStore.CreateColumnIfNotExists("Teams", "LastTeamIconUpdate", "bigint", "bigint", "0")
 		saveSchemaVersion(sqlStore, VERSION_4_8_0)
 	}
 }
@@ -376,6 +375,7 @@ func UpgradeDatabaseToVersion48(sqlStore SqlStore) {
 func UpgradeDatabaseToVersion49(sqlStore SqlStore) {
 	//TODO: Uncomment the following condition when version 4.9.0 is released
 	//if shouldPerformUpgrade(sqlStore, VERSION_4_8_0, VERSION_4_9_0) {
+	sqlStore.CreateColumnIfNotExists("Teams", "LastTeamIconUpdate", "bigint", "bigint", "0")
 	//	saveSchemaVersion(sqlStore, VERSION_4_9_0)
 	//}
 }


### PR DESCRIPTION
Probably should have done this with #8408 but didn't notice it until after the reviews had happened.