### PR TITLE
MM-9731: Register additional gob types to support arrays and dicts in post props

### DIFF
--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -610,4 +610,6 @@ func ConnectAPI(conn io.ReadWriteCloser, muxer *Muxer) *RemoteAPI {
 
 func init() {
 	gob.Register([]*model.SlackAttachment{})
+	gob.Register([]interface{}{})
+	gob.Register(map[string]interface{}{})
 }


### PR DESCRIPTION
#### Summary
Required to support passing of certain posts through the plugin API: https://github.com/mattermost/mattermost-server/issues/8401

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9731
https://github.com/mattermost/mattermost-server/issues/8401

#### Checklist
- [x] Added or updated unit tests (required for all new features)