### PR TITLE
MM-8729 Remove query to update channel extra_update_at field on user activation/deactivation

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -898,10 +898,6 @@ func (a *App) UpdateActive(user *model.User, active bool) (*model.User, *model.A
 			}
 		}
 
-		if extra := <-a.Srv.Store.Channel().ExtraUpdateByUser(user.Id, model.GetMillis()); extra.Err != nil {
-			return nil, extra.Err
-		}
-
 		ruser := result.Data.([2]*model.User)[0]
 		options := a.Config().GetSanitizeOptions()
 		options["passwordupdate"] = false

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1248,19 +1248,6 @@ func (s SqlChannelStore) AnalyticsDeletedTypeCount(teamId string, channelType st
 	})
 }
 
-func (s SqlChannelStore) ExtraUpdateByUser(userId string, time int64) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		_, err := s.GetMaster().Exec(
-			`UPDATE Channels SET ExtraUpdateAt = :Time
-			WHERE Id IN (SELECT ChannelId FROM ChannelMembers WHERE UserId = :UserId);`,
-			map[string]interface{}{"UserId": userId, "Time": time})
-
-		if err != nil {
-			result.Err = model.NewAppError("SqlChannelStore.extraUpdated", "store.sql_channel.extra_updated.app_error", nil, "user_id="+userId+", "+err.Error(), http.StatusInternalServerError)
-		}
-	})
-}
-
 func (s SqlChannelStore) GetMembersForUser(teamId string, userId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		members := &model.ChannelMembers{}

--- a/store/store.go
+++ b/store/store.go
@@ -153,7 +153,6 @@ type ChannelStore interface {
 	UpdateLastViewedAt(channelIds []string, userId string) StoreChannel
 	IncrementMentionCount(channelId string, userId string) StoreChannel
 	AnalyticsTypeCount(teamId string, channelType string) StoreChannel
-	ExtraUpdateByUser(userId string, time int64) StoreChannel
 	GetMembersForUser(teamId string, userId string) StoreChannel
 	AutocompleteInTeam(teamId string, term string) StoreChannel
 	SearchInTeam(teamId string, term string) StoreChannel

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -43,7 +43,6 @@ func TestChannelStore(t *testing.T, ss store.Store) {
 	t.Run("GetMember", func(t *testing.T) { testGetMember(t, ss) })
 	t.Run("GetMemberForPost", func(t *testing.T) { testChannelStoreGetMemberForPost(t, ss) })
 	t.Run("GetMemberCount", func(t *testing.T) { testGetMemberCount(t, ss) })
-	t.Run("UpdateExtrasByUser", func(t *testing.T) { testUpdateExtrasByUser(t, ss) })
 	t.Run("SearchMore", func(t *testing.T) { testChannelStoreSearchMore(t, ss) })
 	t.Run("SearchInTeam", func(t *testing.T) { testChannelStoreSearchInTeam(t, ss) })
 	t.Run("GetMembersByIds", func(t *testing.T) { testChannelStoreGetMembersByIds(t, ss) })
@@ -1638,54 +1637,6 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 		t.Fatalf("failed to get member count: %v", result.Err)
 	} else if result.Data.(int64) != 2 {
 		t.Fatalf("got incorrect member count %v", result.Data)
-	}
-}
-
-func testUpdateExtrasByUser(t *testing.T, ss store.Store) {
-	teamId := model.NewId()
-
-	c1 := model.Channel{
-		TeamId:      teamId,
-		DisplayName: "Channel1",
-		Name:        "zz" + model.NewId() + "b",
-		Type:        model.CHANNEL_OPEN,
-	}
-	store.Must(ss.Channel().Save(&c1, -1))
-
-	c2 := model.Channel{
-		TeamId:      teamId,
-		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
-		Type:        model.CHANNEL_OPEN,
-	}
-	store.Must(ss.Channel().Save(&c2, -1))
-
-	u1 := &model.User{
-		Email:    model.NewId(),
-		DeleteAt: 0,
-	}
-	store.Must(ss.User().Save(u1))
-	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
-
-	m1 := model.ChannelMember{
-		ChannelId:   c1.Id,
-		UserId:      u1.Id,
-		NotifyProps: model.GetDefaultChannelNotifyProps(),
-	}
-	store.Must(ss.Channel().SaveMember(&m1))
-
-	u1.DeleteAt = model.GetMillis()
-	store.Must(ss.User().Update(u1, true))
-
-	if result := <-ss.Channel().ExtraUpdateByUser(u1.Id, u1.DeleteAt); result.Err != nil {
-		t.Fatalf("failed to update extras by user: %v", result.Err)
-	}
-
-	u1.DeleteAt = 0
-	store.Must(ss.User().Update(u1, true))
-
-	if result := <-ss.Channel().ExtraUpdateByUser(u1.Id, u1.DeleteAt); result.Err != nil {
-		t.Fatalf("failed to update extras by user: %v", result.Err)
 	}
 }
 

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -98,22 +98,6 @@ func (_m *ChannelStore) Delete(channelId string, time int64) store.StoreChannel 
 	return r0
 }
 
-// ExtraUpdateByUser provides a mock function with given fields: userId, time
-func (_m *ChannelStore) ExtraUpdateByUser(userId string, time int64) store.StoreChannel {
-	ret := _m.Called(userId, time)
-
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
-		r0 = rf(userId, time)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
-		}
-	}
-
-	return r0
-}
-
 // Get provides a mock function with given fields: id, allowFromCache
 func (_m *ChannelStore) Get(id string, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(id, allowFromCache)

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -461,13 +461,13 @@ func (_m *TeamStore) UpdateDisplayName(name string, teamId string) store.StoreCh
 	return r0
 }
 
-// UpdateMember provides a mock function with given fields: member
-func (_m *TeamStore) UpdateMember(member *model.TeamMember) store.StoreChannel {
-	ret := _m.Called(member)
+// UpdateLastTeamIconUpdate provides a mock function with given fields: teamId, curTime
+func (_m *TeamStore) UpdateLastTeamIconUpdate(teamId string, curTime int64) store.StoreChannel {
+	ret := _m.Called(teamId, curTime)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(*model.TeamMember) store.StoreChannel); ok {
-		r0 = rf(member)
+	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+		r0 = rf(teamId, curTime)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)
@@ -477,13 +477,13 @@ func (_m *TeamStore) UpdateMember(member *model.TeamMember) store.StoreChannel {
 	return r0
 }
 
-// UpdateLastTeamIconUpdate provides a mock function with given fields: teamId
-func (_m *TeamStore) UpdateLastTeamIconUpdate(teamId string, curTime int64) store.StoreChannel {
-	ret := _m.Called(teamId)
+// UpdateMember provides a mock function with given fields: member
+func (_m *TeamStore) UpdateMember(member *model.TeamMember) store.StoreChannel {
+	ret := _m.Called(member)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
-		r0 = rf(teamId, curTime)
+	if rf, ok := ret.Get(0).(func(*model.TeamMember) store.StoreChannel); ok {
+		r0 = rf(member)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)


### PR DESCRIPTION
#### Summary
Per the ticket description, Shift was seeing a lot of the following error when deactivating users:
```bash
[2018/01/02 10:03:51 UTC] [EROR] Problem updating members last updated time id=<chanid> err=SqlChannelStore.extraUpdated: store.sql_channel.extra_updated.app_error, id=<id>, context deadline exceeded
```
The error was coming from the `ExtraUpdateByUser` query. This query would update the `channel.ExtraUpdateAt` timestamp field for every channel the user was in. From what I can remember and tell by grep'ing through the code, the original use of this field was for calculating the etag for an old endpoint `GET /api/v3/teams/tid/channels/cid/extra_info`. [This big PR from a year ago](https://github.com/mattermost/mattermost-server/commit/365b8b465e8a53ebb2da2bf3aef659ac81a2bc6a#diff-8dd82193ed1818214d8f122b0308060cL60) removed all usages of that etag.

I also inspected our clients to make sure we were not relying on that field anywhere. We weren't.

My proposal is to remove this query now (covered by this PR) since `ExtraUpdateAt` is not used for anything, then at the proper chance deprecate and remove the `ExtraUpdateAt` field from the channel model ([ticket here](https://mattermost.atlassian.net/browse/MM-9739)).

I did run some load tests to attempt to replicate Shift's issue, with mixed results. With a 4k channels, 20k users DB under high load I could reproduce the error but only in conjunction with many similar errors. The `ExtraUpdateByUser` did show up regularly in the slow query logs during these tests. What I couldn't reproduce was getting this error in isolation, without many other queries failing on exceeding the context deadline.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8729