### PR TITLE
MM-9688: Better error message for plugin enabling in HA mode

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -318,6 +318,9 @@ func (a *App) EnablePlugin(id string) *model.AppError {
 	})
 
 	if err := a.SaveConfig(a.Config(), true); err != nil {
+		if err.Id == "ent.cluster.save_config.error" {
+			return model.NewAppError("EnablePlugin", "app.plugin.cluster.save_config.app_error", nil, "", http.StatusInternalServerError)
+		}
 		return model.NewAppError("EnablePlugin", "app.plugin.config.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3708,7 +3708,7 @@
   },
   {
     "id": "app.plugin.cluster.save_config.app_error",
-    "translation": "The plugin configuration in your config.json file must be updated manually when using ReadOnlyConfig in HA mode."
+    "translation": "The plugin configuration in your config.json file must be updated manually when using ReadOnlyConfig with clustering enabled."
   },
   {
     "id": "app.plugin.deactivate.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3707,6 +3707,10 @@
     "translation": "Error saving plugin state in config"
   },
   {
+    "id": "app.plugin.cluster.save_config.app_error",
+    "translation": "The plugin configuration in your config.json file must be updated manually when using ReadOnlyConfig in HA mode."
+  },
+  {
     "id": "app.plugin.deactivate.app_error",
     "translation": "Unable to deactivate plugin"
   },


### PR DESCRIPTION
#### Summary
We just decided we were gonna try to improve the error message, right? Not really much else we can do if the config is read-only.

Before:

> [2018/02/22 20:26:52 UTC] [EROR] failed to enable prepackaged plugin: EnablePlugin: Error saving plugin state in config, saveConfig: System Console is set to read-only when High Availability is enabled unless ReadOnlyConfig is disabled in the configuration file.

After:

> [2018/03/09 15:57:57 CST] [EROR] failed to enable prepackaged plugin: EnablePlugin: The plugin configuration in your config.json file must be updated manually when using ReadOnlyConfig with clustering enabled.

Maybe a little more straight-forward. :-/ Open to suggestions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9688

#### Checklist
N/A