### PR TITLE
Make SMTP server check at startup asynchronous. Fixes #8437.

### DIFF
--- a/cmd/commands/server.go
+++ b/cmd/commands/server.go
@@ -66,7 +66,7 @@ func runServer(configFileLocation string, disableConfigWatch bool, interruptChan
 	}
 	defer a.Shutdown()
 
-	utils.TestConnection(a.Config())
+	go utils.TestConnection(a.Config())
 
 	pwd, _ := os.Getwd()
 	l4g.Info(utils.T("mattermost.current_version"), model.CurrentVersion, model.BuildNumber, model.BuildDate, model.BuildHash, model.BuildHashEnterprise)


### PR DESCRIPTION
#### Summary
See more details in #8437.

When SMTP server is unavailable in such way that connection
attempt hangs (e.g. target network is down), the check at the startup will hang,
rendering the entire Mattermost server unavailable until SMTP connection attempt finally times out.

By making check asynchronous, this problem is solved.

#### Ticket Link
#8437

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
