### PR TITLE
[MM-9703] Push notifications are sent for own DM's

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -55,10 +55,15 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 
 	if channel.Type == model.CHANNEL_DIRECT {
 		var otherUserId string
-		if userIds := strings.Split(channel.Name, "__"); userIds[0] == post.UserId {
-			otherUserId = userIds[1]
-		} else {
-			otherUserId = userIds[0]
+
+		userIds := strings.Split(channel.Name, "__")
+
+		if userIds[0] != userIds[1] {
+			if userIds[0] == post.UserId {
+				otherUserId = userIds[1]
+			} else {
+				otherUserId = userIds[0]
+			}
 		}
 
 		if _, ok := profileMap[otherUserId]; ok {


### PR DESCRIPTION
#### Summary
Push notifications are sent for own DM's.
If you receive a webhook notification it will send push/email notification. if you write your own messages it will not send any notification.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-9703

