### PR TITLE
MM-9795: Fix theme chooser for non-EE builds

### DIFF
--- a/utils/config.go
+++ b/utils/config.go
@@ -527,7 +527,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 
 		props["EnableThemeSelection"] = "true"
 		props["AllowCustomThemes"] = "true"
-		
+
 		if *license.Features.ThemeManagement {
 			props["EnableThemeSelection"] = strconv.FormatBool(*c.ThemeSettings.EnableThemeSelection)
 			props["DefaultTheme"] = *c.ThemeSettings.DefaultTheme

--- a/utils/config.go
+++ b/utils/config.go
@@ -525,6 +525,9 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 			props["AllowBannerDismissal"] = strconv.FormatBool(*c.AnnouncementSettings.AllowBannerDismissal)
 		}
 
+		props["EnableThemeSelection"] = true
+		props["AllowCustomThemes"] = true 
+		
 		if *license.Features.ThemeManagement {
 			props["EnableThemeSelection"] = strconv.FormatBool(*c.ThemeSettings.EnableThemeSelection)
 			props["DefaultTheme"] = *c.ThemeSettings.DefaultTheme

--- a/utils/config.go
+++ b/utils/config.go
@@ -452,6 +452,9 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	hasImageProxy := c.ServiceSettings.ImageProxyType != nil && *c.ServiceSettings.ImageProxyType != "" && c.ServiceSettings.ImageProxyURL != nil && *c.ServiceSettings.ImageProxyURL != ""
 	props["HasImageProxy"] = strconv.FormatBool(hasImageProxy)
 
+	props["EnableThemeSelection"] = "true"
+	props["AllowCustomThemes"] = "true"
+
 	if license != nil {
 		props["ExperimentalTownSquareIsReadOnly"] = strconv.FormatBool(*c.TeamSettings.ExperimentalTownSquareIsReadOnly)
 		props["ExperimentalEnableAuthenticationTransfer"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableAuthenticationTransfer)
@@ -524,9 +527,6 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 			props["BannerTextColor"] = *c.AnnouncementSettings.BannerTextColor
 			props["AllowBannerDismissal"] = strconv.FormatBool(*c.AnnouncementSettings.AllowBannerDismissal)
 		}
-
-		props["EnableThemeSelection"] = "true"
-		props["AllowCustomThemes"] = "true"
 
 		if *license.Features.ThemeManagement {
 			props["EnableThemeSelection"] = strconv.FormatBool(*c.ThemeSettings.EnableThemeSelection)

--- a/utils/config.go
+++ b/utils/config.go
@@ -525,8 +525,8 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 			props["AllowBannerDismissal"] = strconv.FormatBool(*c.AnnouncementSettings.AllowBannerDismissal)
 		}
 
-		props["EnableThemeSelection"] = true
-		props["AllowCustomThemes"] = true 
+		props["EnableThemeSelection"] = "true"
+		props["AllowCustomThemes"] = "true"
 		
 		if *license.Features.ThemeManagement {
 			props["EnableThemeSelection"] = strconv.FormatBool(*c.ThemeSettings.EnableThemeSelection)


### PR DESCRIPTION
#### Summary
Fix theme chooser not working at all on non-EE builds and allow EE builds to enforce theme/disable theme chooser.
Discussion here: https://pre-release.mattermost.com/core/pl/9tm7f8b36jrobmg37omzhkuucc
