### PR TITLE
Isolating configuration, sending emails and connection to SMTP.

### DIFF
--- a/utils/mail.go
+++ b/utils/mail.go
@@ -28,14 +28,17 @@ func encodeRFC2047Word(s string) string {
 
 type authChooser struct {
 	smtp.Auth
-	Config *model.Config
+	SmtpUsername string
+	SmtpPassword string
+	SmtpServer   string
+	SmtpPort     string
 }
 
 func (a *authChooser) Start(server *smtp.ServerInfo) (string, []byte, error) {
-	a.Auth = LoginAuth(a.Config.EmailSettings.SMTPUsername, a.Config.EmailSettings.SMTPPassword, a.Config.EmailSettings.SMTPServer+":"+a.Config.EmailSettings.SMTPPort)
+	a.Auth = LoginAuth(a.SmtpUsername, a.SmtpPassword, a.SmtpServer+":"+a.SmtpPort)
 	for _, method := range server.Auth {
 		if method == "PLAIN" {
-			a.Auth = smtp.PlainAuth("", a.Config.EmailSettings.SMTPUsername, a.Config.EmailSettings.SMTPPassword, a.Config.EmailSettings.SMTPServer+":"+a.Config.EmailSettings.SMTPPort)
+			a.Auth = smtp.PlainAuth("", a.SmtpUsername, a.SmtpPassword, a.SmtpServer+":"+a.SmtpPort)
 			break
 		}
 	}
@@ -76,22 +79,22 @@ func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
 	return nil, nil
 }
 
-func connectToSMTPServer(config *model.Config) (net.Conn, *model.AppError) {
+func ConnectToSMTPServerAdvanced(connectionSecurity string, skipCertVerification bool, smtpServer string, smtpPort string) (net.Conn, *model.AppError) {
 	var conn net.Conn
 	var err error
 
-	if config.EmailSettings.ConnectionSecurity == model.CONN_SECURITY_TLS {
+	if connectionSecurity == model.CONN_SECURITY_TLS {
 		tlsconfig := &tls.Config{
-			InsecureSkipVerify: *config.EmailSettings.SkipServerCertificateVerification,
-			ServerName:         config.EmailSettings.SMTPServer,
+			InsecureSkipVerify: skipCertVerification,
+			ServerName:         smtpServer,
 		}
 
-		conn, err = tls.Dial("tcp", config.EmailSettings.SMTPServer+":"+config.EmailSettings.SMTPPort, tlsconfig)
+		conn, err = tls.Dial("tcp", smtpServer+":"+smtpPort, tlsconfig)
 		if err != nil {
 			return nil, model.NewAppError("SendMail", "utils.mail.connect_smtp.open_tls.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else {
-		conn, err = net.Dial("tcp", config.EmailSettings.SMTPServer+":"+config.EmailSettings.SMTPPort)
+		conn, err = net.Dial("tcp", smtpServer+":"+smtpPort)
 		if err != nil {
 			return nil, model.NewAppError("SendMail", "utils.mail.connect_smtp.open.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
@@ -100,14 +103,22 @@ func connectToSMTPServer(config *model.Config) (net.Conn, *model.AppError) {
 	return conn, nil
 }
 
-func newSMTPClient(conn net.Conn, config *model.Config) (*smtp.Client, *model.AppError) {
-	c, err := smtp.NewClient(conn, config.EmailSettings.SMTPServer+":"+config.EmailSettings.SMTPPort)
+func ConnectToSMTPServer(config *model.Config) (net.Conn, *model.AppError) {
+	return ConnectToSMTPServerAdvanced(
+		config.EmailSettings.ConnectionSecurity,
+		*config.EmailSettings.SkipServerCertificateVerification,
+		config.EmailSettings.SMTPServer,
+		config.EmailSettings.SMTPPort,
+	)
+}
+
+func NewSMTPClientAdvanced(conn net.Conn, connectionSecurity string, skipCertVerification bool, smtpServer string, smtpPort string, hostname string, auth bool, smtpUsername string, smtpPassword string) (*smtp.Client, *model.AppError) {
+	c, err := smtp.NewClient(conn, smtpServer+":"+smtpPort)
 	if err != nil {
 		l4g.Error(T("utils.mail.new_client.open.error"), err)
 		return nil, model.NewAppError("SendMail", "utils.mail.connect_smtp.open_tls.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
-	hostname := GetHostnameFromSiteURL(*config.ServiceSettings.SiteURL)
 	if hostname != "" {
 		err := c.Hello(hostname)
 		if err != nil {
@@ -116,20 +127,34 @@ func newSMTPClient(conn net.Conn, config *model.Config) (*smtp.Client, *model.Ap
 		}
 	}
 
-	if config.EmailSettings.ConnectionSecurity == model.CONN_SECURITY_STARTTLS {
+	if connectionSecurity == model.CONN_SECURITY_STARTTLS {
 		tlsconfig := &tls.Config{
-			InsecureSkipVerify: *config.EmailSettings.SkipServerCertificateVerification,
-			ServerName:         config.EmailSettings.SMTPServer,
+			InsecureSkipVerify: skipCertVerification,
+			ServerName:         smtpServer,
 		}
 		c.StartTLS(tlsconfig)
 	}
 
-	if *config.EmailSettings.EnableSMTPAuth {
-		if err = c.Auth(&authChooser{Config: config}); err != nil {
+	if auth {
+		if err = c.Auth(&authChooser{SmtpUsername: smtpUsername, SmtpPassword: smtpPassword, SmtpServer: smtpServer, SmtpPort: smtpPort}); err != nil {
 			return nil, model.NewAppError("SendMail", "utils.mail.new_client.auth.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
 	return c, nil
+}
+
+func NewSMTPClient(conn net.Conn, config *model.Config) (*smtp.Client, *model.AppError) {
+	return NewSMTPClientAdvanced(
+		conn,
+		config.EmailSettings.ConnectionSecurity,
+		*config.EmailSettings.SkipServerCertificateVerification,
+		config.EmailSettings.SMTPServer,
+		config.EmailSettings.SMTPPort,
+		GetHostnameFromSiteURL(*config.ServiceSettings.SiteURL),
+		*config.EmailSettings.EnableSMTPAuth,
+		config.EmailSettings.SMTPUsername,
+		config.EmailSettings.SMTPPassword,
+	)
 }
 
 func TestConnection(config *model.Config) {
@@ -137,14 +162,14 @@ func TestConnection(config *model.Config) {
 		return
 	}
 
-	conn, err1 := connectToSMTPServer(config)
+	conn, err1 := ConnectToSMTPServer(config)
 	if err1 != nil {
 		l4g.Error(T("utils.mail.test.configured.error"), T(err1.Message), err1.DetailedError)
 		return
 	}
 	defer conn.Close()
 
-	c, err2 := newSMTPClient(conn, config)
+	c, err2 := NewSMTPClient(conn, config)
 	if err2 != nil {
 		l4g.Error(T("utils.mail.test.configured.error"), T(err2.Message), err2.DetailedError)
 		return
@@ -155,19 +180,38 @@ func TestConnection(config *model.Config) {
 
 func SendMailUsingConfig(to, subject, htmlBody string, config *model.Config, enableComplianceFeatures bool) *model.AppError {
 	fromMail := mail.Address{Name: config.EmailSettings.FeedbackName, Address: config.EmailSettings.FeedbackEmail}
-	return sendMail(to, to, fromMail, subject, htmlBody, nil, nil, config, enableComplianceFeatures)
+
+	return SendMailUsingConfigAdvanced(to, to, fromMail, subject, htmlBody, nil, nil, config, enableComplianceFeatures)
 }
 
 // allows for sending an email with attachments and differing MIME/SMTP recipients
 func SendMailUsingConfigAdvanced(mimeTo, smtpTo string, from mail.Address, subject, htmlBody string, attachments []*model.FileInfo, mimeHeaders map[string]string, config *model.Config, enableComplianceFeatures bool) *model.AppError {
-	return sendMail(mimeTo, smtpTo, from, subject, htmlBody, attachments, mimeHeaders, config, enableComplianceFeatures)
-}
-
-func sendMail(mimeTo, smtpTo string, from mail.Address, subject, htmlBody string, attachments []*model.FileInfo, mimeHeaders map[string]string, config *model.Config, enableComplianceFeatures bool) *model.AppError {
 	if !config.EmailSettings.SendEmailNotifications || len(config.EmailSettings.SMTPServer) == 0 {
 		return nil
 	}
 
+	conn, err1 := ConnectToSMTPServer(config)
+	if err1 != nil {
+		return err1
+	}
+	defer conn.Close()
+
+	c, err2 := NewSMTPClient(conn, config)
+	if err2 != nil {
+		return err2
+	}
+	defer c.Quit()
+	defer c.Close()
+
+	fileBackend, err := NewFileBackend(&config.FileSettings, enableComplianceFeatures)
+	if err != nil {
+		return err
+	}
+
+	return SendMail(c, mimeTo, smtpTo, from, subject, htmlBody, attachments, mimeHeaders, fileBackend)
+}
+
+func SendMail(c *smtp.Client, mimeTo, smtpTo string, from mail.Address, subject, htmlBody string, attachments []*model.FileInfo, mimeHeaders map[string]string, fileBackend FileBackend) *model.AppError {
 	l4g.Debug(T("utils.mail.send_mail.sending.debug"), mimeTo, subject)
 
 	htmlMessage := "\r\n<html><body>" + htmlBody + "</body></html>"
@@ -197,11 +241,6 @@ func sendMail(mimeTo, smtpTo string, from mail.Address, subject, htmlBody string
 	m.AddAlternative("text/html", htmlMessage)
 
 	if attachments != nil {
-		fileBackend, err := NewFileBackend(&config.FileSettings, enableComplianceFeatures)
-		if err != nil {
-			return err
-		}
-
 		for _, fileInfo := range attachments {
 			bytes, err := fileBackend.ReadFile(fileInfo.Path)
 			if err != nil {
@@ -216,19 +255,6 @@ func sendMail(mimeTo, smtpTo string, from mail.Address, subject, htmlBody string
 			}))
 		}
 	}
-
-	conn, err1 := connectToSMTPServer(config)
-	if err1 != nil {
-		return err1
-	}
-	defer conn.Close()
-
-	c, err2 := newSMTPClient(conn, config)
-	if err2 != nil {
-		return err2
-	}
-	defer c.Quit()
-	defer c.Close()
 
 	if err := c.Mail(from.Address); err != nil {
 		return model.NewAppError("SendMail", "utils.mail.send_mail.from_address.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/utils/mail.go
+++ b/utils/mail.go
@@ -83,18 +83,19 @@ func ConnectToSMTPServerAdvanced(connectionSecurity string, skipCertVerification
 	var conn net.Conn
 	var err error
 
+	smtpAddress := smtpServer + ":" + smtpPort
 	if connectionSecurity == model.CONN_SECURITY_TLS {
 		tlsconfig := &tls.Config{
 			InsecureSkipVerify: skipCertVerification,
 			ServerName:         smtpServer,
 		}
 
-		conn, err = tls.Dial("tcp", smtpServer+":"+smtpPort, tlsconfig)
+		conn, err = tls.Dial("tcp", smtpAddress, tlsconfig)
 		if err != nil {
 			return nil, model.NewAppError("SendMail", "utils.mail.connect_smtp.open_tls.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	} else {
-		conn, err = net.Dial("tcp", smtpServer+":"+smtpPort)
+		conn, err = net.Dial("tcp", smtpAddress)
 		if err != nil {
 			return nil, model.NewAppError("SendMail", "utils.mail.connect_smtp.open.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}

--- a/utils/mail.go
+++ b/utils/mail.go
@@ -191,15 +191,15 @@ func SendMailUsingConfigAdvanced(mimeTo, smtpTo string, from mail.Address, subje
 		return nil
 	}
 
-	conn, err1 := ConnectToSMTPServer(config)
-	if err1 != nil {
-		return err1
+	conn, err := ConnectToSMTPServer(config)
+	if err != nil {
+		return err
 	}
 	defer conn.Close()
 
-	c, err2 := NewSMTPClient(conn, config)
-	if err2 != nil {
-		return err2
+	c, err := NewSMTPClient(conn, config)
+	if err != nil {
+		return err
 	}
 	defer c.Quit()
 	defer c.Close()

--- a/utils/mail_test.go
+++ b/utils/mail_test.go
@@ -44,24 +44,28 @@ func TestMailConnectionAdvanced(t *testing.T) {
 	require.Nil(t, err)
 
 	if conn, err := ConnectToSMTPServerAdvanced(
-		cfg.EmailSettings.ConnectionSecurity,
-		*cfg.EmailSettings.SkipServerCertificateVerification,
-		cfg.EmailSettings.SMTPServer,
-		cfg.EmailSettings.SMTPPort,
+		&SmtpConnectionInfo{
+			ConnectionSecurity:   cfg.EmailSettings.ConnectionSecurity,
+			SkipCertVerification: *cfg.EmailSettings.SkipServerCertificateVerification,
+			SmtpServer:           cfg.EmailSettings.SMTPServer,
+			SmtpPort:             cfg.EmailSettings.SMTPPort,
+		},
 	); err != nil {
 		t.Log(err)
 		t.Fatal("Should connect to the STMP Server")
 	} else {
 		if _, err1 := NewSMTPClientAdvanced(
 			conn,
-			cfg.EmailSettings.ConnectionSecurity,
-			*cfg.EmailSettings.SkipServerCertificateVerification,
-			cfg.EmailSettings.SMTPServer,
-			cfg.EmailSettings.SMTPPort,
 			GetHostnameFromSiteURL(*cfg.ServiceSettings.SiteURL),
-			*cfg.EmailSettings.EnableSMTPAuth,
-			cfg.EmailSettings.SMTPUsername,
-			cfg.EmailSettings.SMTPPassword,
+			&SmtpConnectionInfo{
+				ConnectionSecurity:   cfg.EmailSettings.ConnectionSecurity,
+				SkipCertVerification: *cfg.EmailSettings.SkipServerCertificateVerification,
+				SmtpServer:           cfg.EmailSettings.SMTPServer,
+				SmtpPort:             cfg.EmailSettings.SMTPPort,
+				Auth:                 *cfg.EmailSettings.EnableSMTPAuth,
+				SmtpUsername:         cfg.EmailSettings.SMTPUsername,
+				SmtpPassword:         cfg.EmailSettings.SMTPPassword,
+			},
 		); err1 != nil {
 			t.Log(err)
 			t.Fatal("Should get new smtp client")
@@ -69,10 +73,12 @@ func TestMailConnectionAdvanced(t *testing.T) {
 	}
 
 	if _, err := ConnectToSMTPServerAdvanced(
-		cfg.EmailSettings.ConnectionSecurity,
-		*cfg.EmailSettings.SkipServerCertificateVerification,
-		"wrongServer",
-		"553",
+		&SmtpConnectionInfo{
+			ConnectionSecurity:   cfg.EmailSettings.ConnectionSecurity,
+			SkipCertVerification: *cfg.EmailSettings.SkipServerCertificateVerification,
+			SmtpServer:           "wrongServer",
+			SmtpPort:             "553",
+		},
 	); err == nil {
 		t.Log(err)
 		t.Fatal("Should not to the STMP Server")
@@ -218,10 +224,12 @@ func TestSendMailUsingConfigAdvanced(t *testing.T) {
 
 func TestAuthMethods(t *testing.T) {
 	auth := &authChooser{
-		SmtpUsername: "test",
-		SmtpPassword: "fakepass",
-		SmtpServer:   "fakeserver",
-		SmtpPort:     "25",
+		connectionInfo: &SmtpConnectionInfo{
+			SmtpUsername: "test",
+			SmtpPassword: "fakepass",
+			SmtpServer:   "fakeserver",
+			SmtpPort:     "25",
+		},
 	}
 	tests := []struct {
 		desc   string


### PR DESCRIPTION
#### Summary
Splitting the email sending process in 2 steps, create the client connection to the SMTP server and, send the email. This allow to send various emails using the same connection (needed to global relay email sends). Besides, I have removed the hard dependency between the configuration and the email sending, because I need to send emails through other SMTP server (the Global Relay server), so I can't use the default email configuration.

#### Ticket Link
[MM-8838](https://mattermost.atlassian.net/browse/MM-8838) and [MM-8826](https://mattermost.atlassian.net/browse/MM-8826)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes (It will have enterprise changes, but doesn't depends on it)
- [x] Touches critical sections of the codebase (touch email sending, so can affect to all the email notifications)
