### PR TITLE
update email test in the driver to be able to send the config in the body

### DIFF
--- a/model/client4.go
+++ b/model/client4.go
@@ -2098,8 +2098,8 @@ func (c *Client4) GetPing() (string, *Response) {
 }
 
 // TestEmail will attempt to connect to the configured SMTP server.
-func (c *Client4) TestEmail() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetTestEmailRoute(), ""); err != nil {
+func (c *Client4) TestEmail(config *Config) (bool, *Response) {
+	if r, err := c.DoApiPost(c.GetTestEmailRoute(), config.ToJson()); err != nil {
 		return false, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)


### PR DESCRIPTION
#### Summary
doing the implementation for the S3 file storage, I realize that the driver for email test connection does not expect to send the config. But actually, we are sending that. this update the driver and the tests

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs) - PR: https://github.com/mattermost/mattermost-api-reference/pull/342