### PR TITLE
Foregrounds development server.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ run-server: start-docker ## Starts the server.
 	@echo Running mattermost for development
 
 	mkdir -p $(BUILD_WEBAPP_DIR)/dist/files
-	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) --disableconfigwatch &
+	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) --disableconfigwatch
 
 run-cli: start-docker ## Runs CLI.
 	@echo Running mattermost for development
@@ -448,7 +448,7 @@ restart-client: | stop-client run-client ## Restarts the webapp.
 
 run-job-server: ## Runs the background job server.
 	@echo Running job server for development
-	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) jobserver --disableconfigwatch &
+	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) jobserver --disableconfigwatch
 
 config-ldap: ## Configures LDAP.
 	@echo Setting up configuration for local LDAP

--- a/Makefile
+++ b/Makefile
@@ -448,7 +448,7 @@ restart-client: | stop-client run-client ## Restarts the webapp.
 
 run-job-server: ## Runs the background job server.
 	@echo Running job server for development
-	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) jobserver --disableconfigwatch
+	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) jobserver --disableconfigwatch &
 
 config-ldap: ## Configures LDAP.
 	@echo Setting up configuration for local LDAP


### PR DESCRIPTION
#### Summary
Often `make stop` doesn't successfully stop the processes and it slows down development to have to find and kill the processes manually where `ctrl+c` in the terminal would work perfectly if the processes were in the foreground.

The mobile app already does this, I believe.

#### Ticket Link
n/a

#### Checklist
n/a