### PR TITLE
MM-9770: rewrite getParentsPosts to improve performance

### DIFF
--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -491,70 +491,70 @@ func testPostStoreGetWithChildren(t *testing.T, ss store.Store) {
 }
 
 func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
-	o1 := &model.Post{}
-	o1.ChannelId = model.NewId()
-	o1.UserId = model.NewId()
-	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	root1 := &model.Post{}
+	root1.ChannelId = model.NewId()
+	root1.UserId = model.NewId()
+	root1.Message = "zz" + model.NewId() + "b"
+	root1 = (<-ss.Post().Save(root1)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
-	o2 := &model.Post{}
-	o2.ChannelId = o1.ChannelId
-	o2.UserId = model.NewId()
-	o2.Message = "zz" + model.NewId() + "b"
-	o2.ParentId = o1.Id
-	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	root1Reply1 := &model.Post{}
+	root1Reply1.ChannelId = root1.ChannelId
+	root1Reply1.UserId = model.NewId()
+	root1Reply1.Message = "zz" + model.NewId() + "b"
+	root1Reply1.ParentId = root1.Id
+	root1Reply1.RootId = root1.Id
+	root1Reply1 = (<-ss.Post().Save(root1Reply1)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
-	o2a := &model.Post{}
-	o2a.ChannelId = o1.ChannelId
-	o2a.UserId = model.NewId()
-	o2a.Message = "zz" + model.NewId() + "b"
-	o2a.ParentId = o1.Id
-	o2a.RootId = o1.Id
-	o2a = (<-ss.Post().Save(o2a)).Data.(*model.Post)
+	root1Reply2 := &model.Post{}
+	root1Reply2.ChannelId = root1.ChannelId
+	root1Reply2.UserId = model.NewId()
+	root1Reply2.Message = "zz" + model.NewId() + "b"
+	root1Reply2.ParentId = root1.Id
+	root1Reply2.RootId = root1.Id
+	root1Reply2 = (<-ss.Post().Save(root1Reply2)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
-	o3 := &model.Post{}
-	o3.ChannelId = o1.ChannelId
-	o3.UserId = model.NewId()
-	o3.Message = "zz" + model.NewId() + "b"
-	o3.ParentId = o1.Id
-	o3.RootId = o1.Id
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	root1Reply3 := &model.Post{}
+	root1Reply3.ChannelId = root1.ChannelId
+	root1Reply3.UserId = model.NewId()
+	root1Reply3.Message = "zz" + model.NewId() + "b"
+	root1Reply3.ParentId = root1.Id
+	root1Reply3.RootId = root1.Id
+	root1Reply3 = (<-ss.Post().Save(root1Reply3)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
-	o4 := &model.Post{}
-	o4.ChannelId = o1.ChannelId
-	o4.UserId = model.NewId()
-	o4.Message = "zz" + model.NewId() + "b"
-	o4 = (<-ss.Post().Save(o4)).Data.(*model.Post)
+	root2 := &model.Post{}
+	root2.ChannelId = root1.ChannelId
+	root2.UserId = model.NewId()
+	root2.Message = "zz" + model.NewId() + "b"
+	root2 = (<-ss.Post().Save(root2)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
-	o5 := &model.Post{}
-	o5.ChannelId = o1.ChannelId
-	o5.UserId = model.NewId()
-	o5.Message = "zz" + model.NewId() + "b"
-	o5.ParentId = o4.Id
-	o5.RootId = o4.Id
-	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
+	root2Reply1 := &model.Post{}
+	root2Reply1.ChannelId = root1.ChannelId
+	root2Reply1.UserId = model.NewId()
+	root2Reply1.Message = "zz" + model.NewId() + "b"
+	root2Reply1.ParentId = root2.Id
+	root2Reply1.RootId = root2.Id
+	root2Reply1 = (<-ss.Post().Save(root2Reply1)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetPosts(o1.ChannelId, 0, 4, false)).Data.(*model.PostList)
+	r1 := (<-ss.Post().GetPosts(root1.ChannelId, 0, 4, false)).Data.(*model.PostList)
 
-	if r1.Order[0] != o5.Id {
+	if r1.Order[0] != root2Reply1.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[1] != o4.Id {
+	if r1.Order[1] != root2.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[2] != o3.Id {
+	if r1.Order[2] != root1Reply3.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[3] != o2a.Id {
+	if r1.Order[3] != root1Reply2.Id {
 		t.Fatal("invalid order")
 	}
 
@@ -562,25 +562,25 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 		t.Fatal("wrong size")
 	}
 
-	if r1.Posts[o1.Id].Message != o1.Message {
+	if r1.Posts[root1.Id].Message != root1.Message {
 		t.Fatal("Missing parent")
 	}
 
-	r2 := (<-ss.Post().GetPosts(o1.ChannelId, 0, 4, true)).Data.(*model.PostList)
+	r2 := (<-ss.Post().GetPosts(root1.ChannelId, 0, 4, true)).Data.(*model.PostList)
 
-	if r2.Order[0] != o5.Id {
+	if r2.Order[0] != root2Reply1.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r2.Order[1] != o4.Id {
+	if r2.Order[1] != root2.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r2.Order[2] != o3.Id {
+	if r2.Order[2] != root1Reply3.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r2.Order[3] != o2a.Id {
+	if r2.Order[3] != root1Reply2.Id {
 		t.Fatal("invalid order")
 	}
 
@@ -588,27 +588,27 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 		t.Fatal("wrong size")
 	}
 
-	if r2.Posts[o1.Id].Message != o1.Message {
+	if r2.Posts[root1.Id].Message != root1.Message {
 		t.Fatal("Missing parent")
 	}
 
 	// Run once to fill cache
-	<-ss.Post().GetPosts(o1.ChannelId, 0, 30, true)
+	<-ss.Post().GetPosts(root1.ChannelId, 0, 30, true)
 
-	o6 := &model.Post{}
-	o6.ChannelId = o1.ChannelId
-	o6.UserId = model.NewId()
-	o6.Message = "zz" + model.NewId() + "b"
-	o6 = (<-ss.Post().Save(o6)).Data.(*model.Post)
+	root3 := &model.Post{}
+	root3.ChannelId = root1.ChannelId
+	root3.UserId = model.NewId()
+	root3.Message = "zz" + model.NewId() + "b"
+	root3 = (<-ss.Post().Save(root3)).Data.(*model.Post)
 
 	// Should only be 6 since we hit the cache
-	r3 := (<-ss.Post().GetPosts(o1.ChannelId, 0, 30, true)).Data.(*model.PostList)
+	r3 := (<-ss.Post().GetPosts(root1.ChannelId, 0, 30, true)).Data.(*model.PostList)
 	assert.Equal(t, 6, len(r3.Order))
 
-	ss.Post().InvalidateLastPostTimeCache(o1.ChannelId)
+	ss.Post().InvalidateLastPostTimeCache(root1.ChannelId)
 
 	// Cache was invalidated, we should get all the posts
-	r4 := (<-ss.Post().GetPosts(o1.ChannelId, 0, 30, true)).Data.(*model.PostList)
+	r4 := (<-ss.Post().GetPosts(root1.ChannelId, 0, 30, true)).Data.(*model.PostList)
 	assert.Equal(t, 7, len(r4.Order))
 }
 


### PR DESCRIPTION
#### Summary
See discussion on ~developers-performance, but the basic idea here is to force the database to use the `PRIMARY` index when fetching posts instead of trying to filter down by channel and doing a scan.

Part of this change includes a proposed "bug fix" to the semantics of the query. I've broken out separate commits for first reworking the tests and then adding coverage for the new case, and I've written up the analysis on ~developers-performance, but I want to call out this point in more detail. Here's my original comments from the channel discussion:

-----

#### Fixing missing replies
The existing JOIN conditions on the query could be commented as follows:

```SQL
       -- The root post of any replies in the window
       q1.RootId = q2.Id 
       -- The reply posts to all threads intersecting with the window.
    OR q1.RootId = q2.RootId
```

however it is missing a case:

```SQL
        -- The reply posts to the window posts, themselves not in the window
    OR q1.Id = q2.RootId
```

Specifically, this handles the case where a reply to the post in the window isn't in the window
itself. In practice, given that the webapp starts at offset 0 and queries backwards on demand, any 
replies to posts in the window will have already been in a loaded window themselves. Permalinks 
at first seems like a case where this behaviour would manifest, but employs a different query
(getPostsAround) with semantics that appear to avoid this.

So the only case where this might matter is a client of the REST API building a resultset and
starting from a non-zero offset. 

-----

Despite my analysis above, we may yet want to consider retaining the old behaviour:
* existing clients might be expecting it
* each new page fetched by the webapp will return replies previously loaded by an earlier request

Thoughts? If we think the "fix" is undesirable, it's a trivial modification of the rewritten query that will only improve performance further, so there's no negative impact to the overall thrust of this PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9770

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers