### PR TITLE
MM-9679: Add config for saml home realm discovery bypass

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -282,6 +282,8 @@
         "IdpUrl": "",
         "IdpDescriptorUrl": "",
         "AssertionConsumerServiceURL": "",
+        "ScopingIDPProviderId": "",
+        "ScopingIDPName": "",
         "IdpCertificateFile": "",
         "PublicCertificateFile": "",
         "PrivateKeyFile": "",

--- a/model/config.go
+++ b/model/config.go
@@ -1291,6 +1291,9 @@ type SamlSettings struct {
 	IdpDescriptorUrl            *string
 	AssertionConsumerServiceURL *string
 
+	ScopingIDPProviderId *string
+	ScopingIDPName       *string
+
 	IdpCertificateFile    *string
 	PublicCertificateFile *string
 	PrivateKeyFile        *string


### PR DESCRIPTION
#### Summary
Adds two SAML config keys: `ScopingIDPProviderId` and `ScopingIDPName`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9679

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes (https://github.com/mattermost/enterprise/pull/274)
