### PR TITLE
Fixed missing error in log message

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -225,7 +225,7 @@ func (a *App) UpdateLastActivityAtIfNeeded(session model.Session) {
 	}
 
 	if result := <-a.Srv.Store.Session().UpdateLastActivityAt(session.Id, now); result.Err != nil {
-		l4g.Error(utils.T("api.status.last_activity.error"), session.UserId, session.Id)
+		l4g.Error(utils.T("api.status.last_activity.error"), session.UserId, session.Id, result.Err)
 	}
 
 	session.LastActivityAt = now


### PR DESCRIPTION
The error message expects to receive three parameters (the user id, session id, and error), but we were only passing in the two

```
Failed to update LastActivityAt for user_id=%v and session_id=%v, err=%v
```