### PR TITLE
MM-9853 Fix Team invite does not carry through SAML login

### DIFF
--- a/api/user.go
+++ b/api/user.go
@@ -1170,7 +1170,11 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 			teamId := relayProps["team_id"]
 			if len(teamId) > 0 {
 				c.App.Go(func() {
-					c.App.AddDirectChannels(teamId, user)
+					if err := c.App.AddUserToTeamByTeamId(teamId, user); err != nil {
+						l4g.Error(err.Error())
+					} else {
+						c.App.AddDirectChannels(teamId, user)
+					}
 				})
 			}
 		case model.OAUTH_ACTION_EMAIL_TO_SSO:


### PR DESCRIPTION
#### Summary
When a SAML user is invited to a Team we are now making sure the user joins the team

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9853

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
