### PR TITLE
MM-9843: improve semantics around Forward80To443

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1955,6 +1955,14 @@
     "translation": "Server is initializing..."
   },
   {
+    "id": "api.server.start_server.forward80to443.disabled_while_using_lets_encrypt",
+    "translation": "Must enable Forward80To443 when using LetsEncrypt"
+  },
+  {
+    "id": "api.server.start_server.forward80to443.enabled_but_listening_on_wrong_port",
+    "translation": "Cannot forward port 80 to port 443 while listening on port %s: disable Forward80To443 if using a proxy server"
+  },
+  {
     "id": "api.server.start_server.listening.info",
     "translation": "Server is listening on %v"
   },


### PR DESCRIPTION
#### Summary
Customers with Forward80To443 enabled but not actually listening on :443 (because they had an Nginx instance listening there and on port 80) would get an instance of Mattermost that ran but didn't listen on anything. This PR improves semantics around this setting, making the following changes:
* If Forward80To443 is true, but not configured to listen on 443, fail to start the server with an error message.
* If Forward80To443 is false and LetsEncrypt is true, fail to start the server with an error message.

It's accompanied by a corresponding webapp change: https://github.com/mattermost/mattermost-server/pull/8496

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9843

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates