### PR TITLE
MM-9661: tweak post message size log

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6456,7 +6456,7 @@
   },
   {
     "id": "store.sql_post.query_max_post_size.max_post_size_bytes",
-    "translation": "Post.Message supports at most %d bytes"
+    "translation": "Post.Message supports at most %d characters (%d bytes)"
   },
   {
     "id": "store.sql_post.save.app_error",

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1269,8 +1269,6 @@ func (s *SqlPostStore) determineMaxPostSize() int {
 		l4g.Warn(utils.T("store.sql_post.query_max_post_size.unrecognized_driver"))
 	}
 
-	l4g.Trace(utils.T("store.sql_post.query_max_post_size.max_post_size_bytes"), maxPostSizeBytes)
-
 	// Assume a worst-case representation of four bytes per rune.
 	maxPostSize = int(maxPostSizeBytes) / 4
 
@@ -1280,6 +1278,8 @@ func (s *SqlPostStore) determineMaxPostSize() int {
 	if maxPostSize < model.POST_MESSAGE_MAX_RUNES_V1 {
 		maxPostSize = model.POST_MESSAGE_MAX_RUNES_V1
 	}
+
+	l4g.Info(utils.T("store.sql_post.query_max_post_size.max_post_size_bytes"), maxPostSize, maxPostSizeBytes)
 
 	return maxPostSize
 }


### PR DESCRIPTION
#### Summary
Call out the number of supported characters explicitly, moving the byte limit to parentheses. This also makes the log an INFO log so as to avoid having to describe enabling the TRACE level in the migration document.

(I suspect the TRACE level should be reserved for things the customer would normally never want to see outside of a deeper investigation.)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9661

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
