### PR TITLE
Remove the index on Channels.DisplayName (v4.7)

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -9,10 +9,11 @@ import (
 	"strings"
 )
 
-// This is a list of all the current viersions including any patches.
-// It should be maitained in chronological order with most current
+// This is a list of all the current versions including any patches.
+// It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"4.7.2",
 	"4.7.1",
 	"4.7.0",
 	"4.6.0",

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -82,7 +82,6 @@ func NewSqlChannelStore(sqlStore SqlStore, metrics einterfaces.MetricsInterface)
 func (s SqlChannelStore) CreateIndexesIfNotExists() {
 	s.CreateIndexIfNotExists("idx_channels_team_id", "Channels", "TeamId")
 	s.CreateIndexIfNotExists("idx_channels_name", "Channels", "Name")
-	s.CreateIndexIfNotExists("idx_channels_displayname", "Channels", "DisplayName")
 	s.CreateIndexIfNotExists("idx_channels_update_at", "Channels", "UpdateAt")
 	s.CreateIndexIfNotExists("idx_channels_create_at", "Channels", "CreateAt")
 	s.CreateIndexIfNotExists("idx_channels_delete_at", "Channels", "DeleteAt")

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	VERSION_4_7_2            = "4.7.2"
 	VERSION_4_7_1            = "4.7.1"
 	VERSION_4_7_0            = "4.7.0"
 	VERSION_4_6_0            = "4.6.0"
@@ -66,6 +67,7 @@ func UpgradeDatabase(sqlStore SqlStore) {
 	UpgradeDatabaseToVersion46(sqlStore)
 	UpgradeDatabaseToVersion47(sqlStore)
 	UpgradeDatabaseToVersion471(sqlStore)
+	UpgradeDatabaseToVersion472(sqlStore)
 
 	// If the SchemaVersion is empty this this is the first time it has ran
 	// so lets set it to the current version.
@@ -359,5 +361,12 @@ func UpgradeDatabaseToVersion471(sqlStore SqlStore) {
 	if shouldPerformUpgrade(sqlStore, VERSION_4_7_0, VERSION_4_7_1) {
 		sqlStore.RemoveColumnIfExists("ChannelMemberHistory", "Email")
 		saveSchemaVersion(sqlStore, VERSION_4_7_1)
+	}
+}
+
+func UpgradeDatabaseToVersion472(sqlStore SqlStore) {
+	if shouldPerformUpgrade(sqlStore, VERSION_4_7_1, VERSION_4_7_2) {
+		sqlStore.RemoveIndexIfExists("idx_channels_displayname", "Channels")
+		saveSchemaVersion(sqlStore, VERSION_4_7_2)
 	}
 }


### PR DESCRIPTION
#### Summary
As outlined in [this discussion](https://pre-release.mattermost.com/core/pl/uw5bwmkb6irkbkn6pk9rkzpytr), this index causes issues with MySQL's query planner, leading to full table scans in a case where it would have made more sense to leverage a filesort.

This is the version of this change backported to 4.7.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9965

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
