### PR TITLE
Fix roles table ID max length so MySQL 5.6 doesn't fail.

### DIFF
--- a/store/sqlstore/role_supplier.go
+++ b/store/sqlstore/role_supplier.go
@@ -67,6 +67,7 @@ func (role Role) ToModel() *model.Role {
 func initSqlSupplierRoles(sqlStore SqlStore) {
 	for _, db := range sqlStore.GetAllConns() {
 		table := db.AddTableWithName(Role{}, "Roles").SetKeys(false, "Id")
+		table.ColMap("Id").SetMaxSize(26)
 		table.ColMap("Name").SetMaxSize(64).SetUnique(true)
 		table.ColMap("DisplayName").SetMaxSize(128)
 		table.ColMap("Description").SetMaxSize(1024)


### PR DESCRIPTION
Fixes startup on MySQL < 5.7

This should bring pre-release back to life.