### PR TITLE
Revert "add individual platform packaging targets (#8366)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server stop-client stop-server restart restart-server restart-client start-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist setup-mac prepare-enteprise run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows package-common package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests
+.PHONY: build package run stop run-client run-server stop-client stop-server restart restart-server restart-client start-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist setup-mac prepare-enteprise run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows internal-test-web-client vet run-server-for-web-client-tests
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/build/release.mk
+++ b/build/release.mk
@@ -32,7 +32,9 @@ build-client:
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) build
 
-package-common:
+package:
+	@ echo Packaging mattermost
+
 	@# Remove any old files
 	rm -Rf $(DIST_ROOT)
 
@@ -69,7 +71,9 @@ endif
 	cp NOTICE.txt $(DIST_PATH)
 	cp README.md $(DIST_PATH)
 
-package-osx: package-common
+	@# ----- PLATFORM SPECIFIC -----
+
+	@# Make osx package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
 	cp $(GOPATH)/bin/platform $(DIST_PATH)/bin # from native bin dir, not cross-compiled
@@ -81,7 +85,7 @@ endif
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/platform
 
-package-windows: package-common
+	@# Make windows package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
 	cp $(GOPATH)/bin/platform.exe $(DIST_PATH)/bin # from native bin dir, not cross-compiled
@@ -93,7 +97,7 @@ endif
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/platform.exe
 
-package-linux: package-common
+	@# Make linux package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
 	cp $(GOPATH)/bin/platform $(DIST_PATH)/bin # from native bin dir, not cross-compiled
@@ -104,5 +108,3 @@ endif
 	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-linux-amd64.tar.gz mattermost
 	@# Don't clean up native package so dev machines will have an unzipped package available
 	@#rm -f $(DIST_PATH)/bin/platform
-
-package: package-linux package-windows package-osx


### PR DESCRIPTION
This reverts commit f0f4f68defef1e9360394ba740c57cff7124dc9c.

This doesn't work because the targets need to be run in order. This breaks the windows build and causes local builds to not have a binary available unzipped. 