### PR TITLE
fix user timezone initialization

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -211,7 +211,7 @@ func (u *User) PreSave() {
 	}
 
 	if u.Timezone == nil {
-		u.Props = make(map[string]string)
+		u.Timezone = make(map[string]string)
 	}
 
 	if len(u.Password) > 0 {

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -36,6 +36,9 @@ func TestUserPreSave(t *testing.T) {
 	user := User{Password: "test"}
 	user.PreSave()
 	user.Etag(true, true)
+	if user.Timezone == nil {
+		t.Fatal("Timezone is nil")
+	}
 }
 
 func TestUserPreUpdate(t *testing.T) {


### PR DESCRIPTION
#### Summary
On PreSave, need to ensure TimeZone isn't left as `NULL` when saving to the database. Found this while load testing and creating the admin user via the platform commands.

#### Ticket Link
None.

#### Checklist
- [x] Added or updated unit tests (required for all new features)