### PR TITLE
MM-9868 Fixed mentioning users when followed by multiple periods

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -892,8 +892,17 @@ func GetExplicitMentions(message string, keywords map[string][]string) *Explicit
 			}
 
 			// remove trailing '.', as that is the end of a sentence
-			word = strings.TrimSuffix(word, ".")
-			if checkForMention(word) {
+			foundWithSuffix := false
+
+			for strings.HasSuffix(word, ".") {
+				word = strings.TrimSuffix(word, ".")
+				if checkForMention(word) {
+					foundWithSuffix = true
+					break
+				}
+			}
+
+			if foundWithSuffix {
 				continue
 			}
 

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -344,27 +344,36 @@ func TestGetExplicitMentions(t *testing.T) {
 				ChannelMentioned: true,
 			},
 		},
-		"Don't include potential mention that's part of an actual mention (without trailing punctuation)": {
-			Message:  "this is an message for @user.potential",
-			Keywords: map[string][]string{"@user.potential": {id1}},
+		"Don't include potential mention that's part of an actual mention (without trailing period)": {
+			Message:  "this is an message for @user.name",
+			Keywords: map[string][]string{"@user.name": {id1}},
 			Expected: &ExplicitMentions{
 				MentionedUserIds: map[string]bool{
 					id1: true,
 				},
 			},
 		},
-		"Don't include potential mention that's part of an actual mention (with trailing punctuation)": {
-			Message:  "this is an message for @user.potential.",
-			Keywords: map[string][]string{"@user.potential": {id1}},
+		"Don't include potential mention that's part of an actual mention (with trailing period)": {
+			Message:  "this is an message for @user.name.",
+			Keywords: map[string][]string{"@user.name": {id1}},
 			Expected: &ExplicitMentions{
 				MentionedUserIds: map[string]bool{
 					id1: true,
 				},
 			},
 		},
-		"Don't include potential mention that's part of an actual mention (with multiple trailing punctuation)": {
-			Message:  "this is an message for @user.potential...",
-			Keywords: map[string][]string{"@user.potential": {id1}},
+		"Don't include potential mention that's part of an actual mention (with multiple trailing periods)": {
+			Message:  "this is an message for @user.name...",
+			Keywords: map[string][]string{"@user.name": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"Don't include potential mention that's part of an actual mention (containing and followed by multiple periods)": {
+			Message:  "this is an message for @user...name...",
+			Keywords: map[string][]string{"@user...name": {id1}},
 			Expected: &ExplicitMentions{
 				MentionedUserIds: map[string]bool{
 					id1: true,

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -344,6 +344,33 @@ func TestGetExplicitMentions(t *testing.T) {
 				ChannelMentioned: true,
 			},
 		},
+		"Don't include potential mention that's part of an actual mention (without trailing punctuation)": {
+			Message:  "this is an message for @user.potential",
+			Keywords: map[string][]string{"@user.potential": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"Don't include potential mention that's part of an actual mention (with trailing punctuation)": {
+			Message:  "this is an message for @user.potential.",
+			Keywords: map[string][]string{"@user.potential": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"Don't include potential mention that's part of an actual mention (with multiple trailing punctuation)": {
+			Message:  "this is an message for @user.potential...",
+			Keywords: map[string][]string{"@user.potential": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			m := GetExplicitMentions(tc.Message, tc.Keywords)

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -344,6 +344,9 @@ func TestGetExplicitMentions(t *testing.T) {
 				ChannelMentioned: true,
 			},
 		},
+
+		// The following tests cover cases where the message mentions @user.name, so we shouldn't assume that
+		// the user might be intending to mention some @user that isn't in the channel.
 		"Don't include potential mention that's part of an actual mention (without trailing period)": {
 			Message:  "this is an message for @user.name",
 			Keywords: map[string][]string{"@user.name": {id1}},


### PR DESCRIPTION
It turns out that mentioning like `Hello @user.name.` worked, but `Hello @user.name...` did not

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9868

#### Checklist
- Added or updated unit tests (required for all new features)