### PR TITLE
MM-9967 Fixing DB load causing user logout.

### DIFF
--- a/api4/context.go
+++ b/api4/context.go
@@ -125,8 +125,10 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		if err != nil {
 			l4g.Info(utils.T("api.context.invalid_session.error"), err.Error())
-			c.RemoveSessionCookie(w, r)
-			if h.requireSession {
+			if err.StatusCode == http.StatusInternalServerError {
+				c.Err = err
+			} else if h.requireSession {
+				c.RemoveSessionCookie(w, r)
 				c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token, http.StatusUnauthorized)
 			}
 		} else if !session.IsOAuth && tokenLocation == app.TokenLocationQueryString {

--- a/app/session.go
+++ b/app/session.go
@@ -54,6 +54,8 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 					a.AddSessionToCache(session)
 				}
 			}
+		} else if sessionResult.Err.StatusCode == http.StatusInternalServerError {
+			return nil, sessionResult.Err
 		}
 	}
 


### PR DESCRIPTION
Under high load, if the DB timed out or returned some random error when fetching the user's session, they would be logged out because the internal server error generated would be lost to one that says unauthorized. This would cause the user's cookie to be deleted. This fixes that by returning the DB error.