### PR TITLE
Initialize timezone to a default state

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -211,7 +211,7 @@ func (u *User) PreSave() {
 	}
 
 	if u.Timezone == nil {
-		u.Timezone = make(map[string]string)
+		u.Timezone = DefaultUserTimezone()
 	}
 
 	if len(u.Password) > 0 {

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -39,6 +39,10 @@ func TestUserPreSave(t *testing.T) {
 	if user.Timezone == nil {
 		t.Fatal("Timezone is nil")
 	}
+
+	if user.Timezone["useAutomaticTimezone"] != "true" {
+		t.Fatal("Timezone is not set to default")
+	}
 }
 
 func TestUserPreUpdate(t *testing.T) {


### PR DESCRIPTION
#### Summary
This change adds a default state to a nil timezone field.

https://github.com/mattermost/mattermost-server/pull/8547
Unfortunately, the above PR breaks mattermost-redux logic.

#### Ticket Link
None

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)