### PR TITLE
MM-8678: add CUD support for channel members via plugins

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -652,8 +652,10 @@ func (a *App) AddChannelMember(userId string, channel *model.Channel, userReques
 	}
 
 	var userRequestor *model.User
-	if userRequestor, err = a.GetUser(userRequestorId); err != nil {
-		return nil, err
+	if userRequestorId != "" {
+		if userRequestor, err = a.GetUser(userRequestorId); err != nil {
+			return nil, err
+		}
 	}
 
 	cm, err := a.AddUserToChannel(user, channel)
@@ -661,7 +663,7 @@ func (a *App) AddChannelMember(userId string, channel *model.Channel, userReques
 		return nil, err
 	}
 
-	if userId == userRequestorId {
+	if userRequestorId == "" || userId == userRequestorId {
 		a.postJoinChannelMessage(user, channel)
 	} else {
 		a.Go(func() {
@@ -669,7 +671,9 @@ func (a *App) AddChannelMember(userId string, channel *model.Channel, userReques
 		})
 	}
 
-	a.UpdateChannelLastViewedAt([]string{channel.Id}, userRequestor.Id)
+	if userRequestor != nil {
+		a.UpdateChannelLastViewedAt([]string{channel.Id}, userRequestor.Id)
+	}
 
 	return cm, nil
 }

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -124,8 +124,28 @@ func (api *PluginAPI) UpdateChannel(channel *model.Channel) (*model.Channel, *mo
 	return api.app.UpdateChannel(channel)
 }
 
+func (api *PluginAPI) AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError) {
+	// For now, don't allow overriding these via the plugin API.
+	userRequestorId := ""
+	postRootId := ""
+
+	return api.app.AddChannelMember(userId, channel, userRequestorId, postRootId)
+}
+
 func (api *PluginAPI) GetChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {
 	return api.app.GetChannelMember(channelId, userId)
+}
+
+func (api *PluginAPI) UpdateChannelMemberRoles(channelId, userId, newRoles string) (*model.ChannelMember, *model.AppError) {
+	return api.app.UpdateChannelMemberRoles(channelId, userId, newRoles)
+}
+
+func (api *PluginAPI) UpdateChannelMemberNotifications(channelId, userId string, notifications map[string]string) (*model.ChannelMember, *model.AppError) {
+	return api.app.UpdateChannelMemberNotifyProps(notifications, channelId, userId)
+}
+
+func (api *PluginAPI) DeleteChannelMember(channelId, userId string) *model.AppError {
+	return api.app.LeaveChannel(channelId, userId)
 }
 
 func (api *PluginAPI) CreatePost(post *model.Post) (*model.Post, *model.AppError) {

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -124,10 +124,15 @@ func (api *PluginAPI) UpdateChannel(channel *model.Channel) (*model.Channel, *mo
 	return api.app.UpdateChannel(channel)
 }
 
-func (api *PluginAPI) AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError) {
+func (api *PluginAPI) AddChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {
 	// For now, don't allow overriding these via the plugin API.
 	userRequestorId := ""
 	postRootId := ""
+
+	channel, err := api.GetChannel(channelId)
+	if err != nil {
+		return nil, err
+	}
 
 	return api.app.AddChannelMember(userId, channel, userRequestorId, postRootId)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -77,8 +77,20 @@ type API interface {
 	// UpdateChannel updates a channel.
 	UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError)
 
+	// AddChannelMember creates a channel membership for a user.
+	AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError)
+
 	// GetChannelMember gets a channel membership for a user.
 	GetChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError)
+
+	// UpdateChannelMemberRoles updates a user's roles for a channel.
+	UpdateChannelMemberRoles(channelId, userId, newRoles string) (*model.ChannelMember, *model.AppError)
+
+	// UpdateChannelMemberNotifications updates a user's notification properties for a channel.
+	UpdateChannelMemberNotifications(channelId, userId string, notifications map[string]string) (*model.ChannelMember, *model.AppError)
+
+	// DeleteChannelMember deletes a channel membership for a user.
+	DeleteChannelMember(channelId, userId string) *model.AppError
 
 	// CreatePost creates a post.
 	CreatePost(post *model.Post) (*model.Post, *model.AppError)

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -78,7 +78,7 @@ type API interface {
 	UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError)
 
 	// AddChannelMember creates a channel membership for a user.
-	AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError)
+	AddChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError)
 
 	// GetChannelMember gets a channel membership for a user.
 	GetChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError)

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -223,10 +223,10 @@ func (m *API) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppE
 	return channelOut, err
 }
 
-func (m *API) AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError) {
-	ret := m.Called(channel, userId)
-	if f, ok := ret.Get(0).(func(_ *model.Channel, _ string) (*model.ChannelMember, *model.AppError)); ok {
-		return f(channel, userId)
+func (m *API) AddChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {
+	ret := m.Called(channelId, userId)
+	if f, ok := ret.Get(0).(func(_, _ string) (*model.ChannelMember, *model.AppError)); ok {
+		return f(channelId, userId)
 	}
 	member, _ := ret.Get(0).(*model.ChannelMember)
 	err, _ := ret.Get(1).(*model.AppError)

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -223,6 +223,16 @@ func (m *API) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppE
 	return channelOut, err
 }
 
+func (m *API) AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError) {
+	ret := m.Called(channel, userId)
+	if f, ok := ret.Get(0).(func(_ *model.Channel, _ string) (*model.ChannelMember, *model.AppError)); ok {
+		return f(channel, userId)
+	}
+	member, _ := ret.Get(0).(*model.ChannelMember)
+	err, _ := ret.Get(1).(*model.AppError)
+	return member, err
+}
+
 func (m *API) GetChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {
 	ret := m.Called(channelId, userId)
 	if f, ok := ret.Get(0).(func(_, _ string) (*model.ChannelMember, *model.AppError)); ok {
@@ -231,6 +241,35 @@ func (m *API) GetChannelMember(channelId, userId string) (*model.ChannelMember, 
 	member, _ := ret.Get(0).(*model.ChannelMember)
 	err, _ := ret.Get(1).(*model.AppError)
 	return member, err
+}
+
+func (m *API) UpdateChannelMemberRoles(channelId, userId, newRoles string) (*model.ChannelMember, *model.AppError) {
+	ret := m.Called(channelId, userId, newRoles)
+	if f, ok := ret.Get(0).(func(_, _, _ string) (*model.ChannelMember, *model.AppError)); ok {
+		return f(channelId, userId, newRoles)
+	}
+	member, _ := ret.Get(0).(*model.ChannelMember)
+	err, _ := ret.Get(1).(*model.AppError)
+	return member, err
+}
+
+func (m *API) UpdateChannelMemberNotifications(channelId, userId string, notifications map[string]string) (*model.ChannelMember, *model.AppError) {
+	ret := m.Called(channelId, userId, notifications)
+	if f, ok := ret.Get(0).(func(_, _ string, _ map[string]string) (*model.ChannelMember, *model.AppError)); ok {
+		return f(channelId, userId, notifications)
+	}
+	member, _ := ret.Get(0).(*model.ChannelMember)
+	err, _ := ret.Get(1).(*model.AppError)
+	return member, err
+}
+
+func (m *API) DeleteChannelMember(channelId, userId string) *model.AppError {
+	ret := m.Called(channelId, userId)
+	if f, ok := ret.Get(0).(func(_, _ string) *model.AppError); ok {
+		return f(channelId, userId)
+	}
+	err, _ := ret.Get(0).(*model.AppError)
+	return err
 }
 
 func (m *API) CreatePost(post *model.Post) (*model.Post, *model.AppError) {

--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -164,8 +164,8 @@ type APIGetGroupChannelArgs struct {
 }
 
 type APIAddChannelMemberArgs struct {
-	Channel *model.Channel
-	UserId  string
+	ChannelId string
+	UserId    string
 }
 
 type APIGetChannelMemberArgs struct {
@@ -262,7 +262,7 @@ func (api *LocalAPI) UpdateChannel(args *model.Channel, reply *APIChannelReply) 
 }
 
 func (api *LocalAPI) AddChannelMember(args *APIAddChannelMemberArgs, reply *APIChannelMemberReply) error {
-	member, err := api.api.AddChannelMember(args.Channel, args.UserId)
+	member, err := api.api.AddChannelMember(args.ChannelId, args.UserId)
 	*reply = APIChannelMemberReply{
 		ChannelMember: member,
 		Error:         err,
@@ -577,11 +577,11 @@ func (api *RemoteAPI) UpdateChannel(channel *model.Channel) (*model.Channel, *mo
 	return reply.Channel, reply.Error
 }
 
-func (api *RemoteAPI) AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError) {
+func (api *RemoteAPI) AddChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {
 	var reply APIChannelMemberReply
 	if err := api.client.Call("LocalAPI.AddChannelMember", &APIAddChannelMemberArgs{
-		Channel: channel,
-		UserId:  userId,
+		ChannelId: channelId,
+		UserId:    userId,
 	}, &reply); err != nil {
 		return nil, model.NewAppError("RemoteAPI.AddChannelMember", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
 	}

--- a/plugin/rpcplugin/api.go
+++ b/plugin/rpcplugin/api.go
@@ -163,7 +163,29 @@ type APIGetGroupChannelArgs struct {
 	UserIds []string
 }
 
+type APIAddChannelMemberArgs struct {
+	Channel *model.Channel
+	UserId  string
+}
+
 type APIGetChannelMemberArgs struct {
+	ChannelId string
+	UserId    string
+}
+
+type APIUpdateChannelMemberRolesArgs struct {
+	ChannelId string
+	UserId    string
+	NewRoles  string
+}
+
+type APIUpdateChannelMemberNotificationsArgs struct {
+	ChannelId     string
+	UserId        string
+	Notifications map[string]string
+}
+
+type APIDeleteChannelMemberArgs struct {
 	ChannelId string
 	UserId    string
 }
@@ -239,11 +261,46 @@ func (api *LocalAPI) UpdateChannel(args *model.Channel, reply *APIChannelReply) 
 	return nil
 }
 
+func (api *LocalAPI) AddChannelMember(args *APIAddChannelMemberArgs, reply *APIChannelMemberReply) error {
+	member, err := api.api.AddChannelMember(args.Channel, args.UserId)
+	*reply = APIChannelMemberReply{
+		ChannelMember: member,
+		Error:         err,
+	}
+	return nil
+}
+
 func (api *LocalAPI) GetChannelMember(args *APIGetChannelMemberArgs, reply *APIChannelMemberReply) error {
 	member, err := api.api.GetChannelMember(args.ChannelId, args.UserId)
 	*reply = APIChannelMemberReply{
 		ChannelMember: member,
 		Error:         err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) UpdateChannelMemberRoles(args *APIUpdateChannelMemberRolesArgs, reply *APIChannelMemberReply) error {
+	member, err := api.api.UpdateChannelMemberRoles(args.ChannelId, args.UserId, args.NewRoles)
+	*reply = APIChannelMemberReply{
+		ChannelMember: member,
+		Error:         err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) UpdateChannelMemberNotifications(args *APIUpdateChannelMemberNotificationsArgs, reply *APIChannelMemberReply) error {
+	member, err := api.api.UpdateChannelMemberNotifications(args.ChannelId, args.UserId, args.Notifications)
+	*reply = APIChannelMemberReply{
+		ChannelMember: member,
+		Error:         err,
+	}
+	return nil
+}
+
+func (api *LocalAPI) DeleteChannelMember(args *APIDeleteChannelMemberArgs, reply *APIErrorReply) error {
+	err := api.api.DeleteChannelMember(args.ChannelId, args.UserId)
+	*reply = APIErrorReply{
+		Error: err,
 	}
 	return nil
 }
@@ -520,6 +577,17 @@ func (api *RemoteAPI) UpdateChannel(channel *model.Channel) (*model.Channel, *mo
 	return reply.Channel, reply.Error
 }
 
+func (api *RemoteAPI) AddChannelMember(channel *model.Channel, userId string) (*model.ChannelMember, *model.AppError) {
+	var reply APIChannelMemberReply
+	if err := api.client.Call("LocalAPI.AddChannelMember", &APIAddChannelMemberArgs{
+		Channel: channel,
+		UserId:  userId,
+	}, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.AddChannelMember", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.ChannelMember, reply.Error
+}
+
 func (api *RemoteAPI) GetChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {
 	var reply APIChannelMemberReply
 	if err := api.client.Call("LocalAPI.GetChannelMember", &APIGetChannelMemberArgs{
@@ -529,6 +597,41 @@ func (api *RemoteAPI) GetChannelMember(channelId, userId string) (*model.Channel
 		return nil, model.NewAppError("RemoteAPI.GetChannelMember", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
 	}
 	return reply.ChannelMember, reply.Error
+}
+
+func (api *RemoteAPI) UpdateChannelMemberRoles(channelId, userId, newRoles string) (*model.ChannelMember, *model.AppError) {
+	var reply APIChannelMemberReply
+	if err := api.client.Call("LocalAPI.UpdateChannelMemberRoles", &APIUpdateChannelMemberRolesArgs{
+		ChannelId: channelId,
+		UserId:    userId,
+		NewRoles:  newRoles,
+	}, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.UpdateChannelMemberRoles", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.ChannelMember, reply.Error
+}
+
+func (api *RemoteAPI) UpdateChannelMemberNotifications(channelId, userId string, notifications map[string]string) (*model.ChannelMember, *model.AppError) {
+	var reply APIChannelMemberReply
+	if err := api.client.Call("LocalAPI.UpdateChannelMemberNotifications", &APIUpdateChannelMemberNotificationsArgs{
+		ChannelId:     channelId,
+		UserId:        userId,
+		Notifications: notifications,
+	}, &reply); err != nil {
+		return nil, model.NewAppError("RemoteAPI.UpdateChannelMemberNotifications", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.ChannelMember, reply.Error
+}
+
+func (api *RemoteAPI) DeleteChannelMember(channelId, userId string) *model.AppError {
+	var reply APIErrorReply
+	if err := api.client.Call("LocalAPI.DeleteChannelMember", &APIDeleteChannelMemberArgs{
+		ChannelId: channelId,
+		UserId:    userId,
+	}, &reply); err != nil {
+		return model.NewAppError("RemoteAPI.DeleteChannelMember", "plugin.rpcplugin.invocation.error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+	return reply.Error
 }
 
 func (api *RemoteAPI) CreatePost(post *model.Post) (*model.Post, *model.AppError) {

--- a/plugin/rpcplugin/api_test.go
+++ b/plugin/rpcplugin/api_test.go
@@ -128,9 +128,30 @@ func TestAPI(t *testing.T) {
 		assert.Equal(t, testChannel, channel)
 		assert.Nil(t, err)
 
-		api.On("GetChannelMember", "thechannelid", "theuserid").Return(testChannelMember, nil).Once()
-		member, err := remote.GetChannelMember("thechannelid", "theuserid")
+		api.On("AddChannelMember", testChannel, "theuserid").Return(testChannelMember, nil).Once()
+		member, err := remote.AddChannelMember(testChannel, "theuserid")
 		assert.Equal(t, testChannelMember, member)
+		assert.Nil(t, err)
+
+		api.On("GetChannelMember", "thechannelid", "theuserid").Return(testChannelMember, nil).Once()
+		member, err = remote.GetChannelMember("thechannelid", "theuserid")
+		assert.Equal(t, testChannelMember, member)
+		assert.Nil(t, err)
+
+		api.On("UpdateChannelMemberRoles", testChannel.Id, "theuserid", model.CHANNEL_ADMIN_ROLE_ID).Return(testChannelMember, nil).Once()
+		member, err = remote.UpdateChannelMemberRoles(testChannel.Id, "theuserid", model.CHANNEL_ADMIN_ROLE_ID)
+		assert.Equal(t, testChannelMember, member)
+		assert.Nil(t, err)
+
+		notifications := map[string]string{}
+		notifications[model.MARK_UNREAD_NOTIFY_PROP] = model.CHANNEL_MARK_UNREAD_MENTION
+		api.On("UpdateChannelMemberNotifications", testChannel.Id, "theuserid", notifications).Return(testChannelMember, nil).Once()
+		member, err = remote.UpdateChannelMemberNotifications(testChannel.Id, "theuserid", notifications)
+		assert.Equal(t, testChannelMember, member)
+		assert.Nil(t, err)
+
+		api.On("DeleteChannelMember", "thechannelid", "theuserid").Return(nil).Once()
+		err = remote.DeleteChannelMember("thechannelid", "theuserid")
 		assert.Nil(t, err)
 
 		api.On("CreateUser", mock.AnythingOfType("*model.User")).Return(func(u *model.User) (*model.User, *model.AppError) {

--- a/plugin/rpcplugin/api_test.go
+++ b/plugin/rpcplugin/api_test.go
@@ -128,8 +128,8 @@ func TestAPI(t *testing.T) {
 		assert.Equal(t, testChannel, channel)
 		assert.Nil(t, err)
 
-		api.On("AddChannelMember", testChannel, "theuserid").Return(testChannelMember, nil).Once()
-		member, err := remote.AddChannelMember(testChannel, "theuserid")
+		api.On("AddChannelMember", testChannel.Id, "theuserid").Return(testChannelMember, nil).Once()
+		member, err := remote.AddChannelMember(testChannel.Id, "theuserid")
 		assert.Equal(t, testChannelMember, member)
 		assert.Nil(t, err)
 


### PR DESCRIPTION
#### Summary
This effectively exposes AddChannelMember, UpdateChannelMemberRoles,
UpdateChannelMemberNotifyProps and LeaveChannel via the plugin API.

It also modifies the semantics of AddChannelMember to explicitly allow
for an empty user requestor, left as such for now via the plugin API.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8678

#### Checklist
- [x] Added or updated unit tests (required for all new features)