### PR TITLE
Minor text changes to /open, /join and /mute slash commands

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1028,7 +1028,7 @@
   },
   {
     "id": "api.command_mute.error",
-    "translation": "Could not find the channel {{.Channel}}."
+    "translation": "Could not find the channel {{.Channel}}. Please use the <a href=\"https://about.mattermost.com/default-channel-handle-documentation/\">channel handle</a> to identify channels."
   },
   {
     "id": "api.command_mute.success_mute",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -904,11 +904,11 @@
   },
   {
     "id": "api.command_mute.error",
-    "translation": "Could not find the channel {{.Channel}}."
+    "translation": "Could not find the channel {{.Channel}}. Please use the [channel handle](https://about.mattermost.com/default-channel-handle-documentation) to identify channels."
   },
   {
     "id": "api.command_mute.hint",
-    "translation": "[channel]"
+    "translation": "~[channel]"
   },
   {
     "id": "api.command_mute.name",
@@ -1041,38 +1041,6 @@
   {
     "id": "api.command_shrug.name",
     "translation": "shrug"
-  },
-  {
-    "id": "api.command_mute.desc",
-    "translation": "Turns off desktop, email and push notifications for the current channel or the [channel] specified."
-  },
-  {
-    "id": "api.command_mute.hint",
-    "translation": "~[channel]"
-  },
-  {
-    "id": "api.command_mute.name",
-    "translation": "mute"
-  },
-  {
-    "id": "api.command_mute.error",
-    "translation": "Could not find the channel {{.Channel}}. Please use the [channel handle](https://about.mattermost.com/default-channel-handle-documentation) to identify channels."
-  },
-  {
-    "id": "api.command_mute.success_mute",
-    "translation": "You will not receive notifications for {{.Channel}} until channel mute is turned off."
-  },
-  {
-    "id": "api.command_mute.success_unmute",
-    "translation": "{{.Channel}} is no longer muted."
-  },
-  {
-    "id": "api.command_mute.success_mute_direct_msg",
-    "translation": "You will not receive notifications for this channel until channel mute is turned off."
-  },
-  {
-    "id": "api.command_mute.success_unmute_direct_msg",
-    "translation": "This channel is no longer muted."
   },
   {
     "id": "api.compliance.init.debug",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1028,7 +1028,7 @@
   },
   {
     "id": "api.command_mute.error",
-    "translation": "Could not find the channel {{.Channel}}. Please use the <a href=\"https://about.mattermost.com/default-channel-handle-documentation/\">channel handle</a> to identify channels."
+    "translation": "Could not find the channel {{.Channel}}. Please use the [channel handle](https://about.mattermost.com/default-channel-handle-documentation) to identify channels."
   },
   {
     "id": "api.command_mute.success_mute",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -800,7 +800,7 @@
   },
   {
     "id": "api.command_join.hint",
-    "translation": "[channel-name]"
+    "translation": "~[channel]"
   },
   {
     "id": "api.command_join.list.app_error",
@@ -1020,7 +1020,7 @@
   },
   {
     "id": "api.command_mute.hint",
-    "translation": "[channel]"
+    "translation": "~[channel]"
   },
   {
     "id": "api.command_mute.name",


### PR DESCRIPTION
#### Summary
Minor text changes to slash commands. Discussed in UX channel.

1) In autocomplete entry for /mute, /join and /open slash commands, add `~` in front of [channel] similar to `@[username]` to make the channel linking more discoverable

![image](https://user-images.githubusercontent.com/13119842/38217420-4bbd4216-369c-11e8-8538-f483255c5e0b.png)

2) Update error message when channel cannot be found in /mute command.

#### Ticket Link
N/A

#### Checklist
- [X] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
