### PR TITLE
Use channelId instead of channel name to print an error message

### DIFF
--- a/app/command_mute.go
+++ b/app/command_mute.go
@@ -40,7 +40,7 @@ func (me *MuteProvider) DoCommand(a *App, args *model.CommandArgs, message strin
 	var noChannelErr *model.AppError
 
 	if channel, noChannelErr = a.GetChannel(args.ChannelId); noChannelErr != nil {
-		return &model.CommandResponse{Text: args.T("api.command_mute.error", map[string]interface{}{"Channel": channel.DisplayName}), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{Text: args.T("api.command_mute.error", map[string]interface{}{"Channel": args.ChannelId}), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
 	channelName := ""


### PR DESCRIPTION
#### Summary
Fixes a possible error in the mute_command when a channel could not be found by it's id. The issue was found by @cpanato during a code review of https://github.com/mattermost/mattermost-server/pull/7713