### PR TITLE
[MM-10046] Fix out of channel mentions for mentioned word with valid punctuations

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -897,7 +897,9 @@ func GetExplicitMentions(message string, keywords map[string][]string) *Explicit
 				continue
 			}
 
-			if strings.ContainsAny(word, ".-:") {
+			if _, ok := systemMentions[word]; !ok && strings.HasPrefix(word, "@") {
+				ret.OtherPotentialMentions = append(ret.OtherPotentialMentions, word[1:])
+			} else if strings.ContainsAny(word, ".-:") {
 				// This word contains a character that may be the end of a sentence, so split further
 				splitWords := strings.FieldsFunc(word, func(c rune) bool {
 					return c == '.' || c == '-' || c == ':'
@@ -908,15 +910,9 @@ func GetExplicitMentions(message string, keywords map[string][]string) *Explicit
 						continue
 					}
 					if _, ok := systemMentions[splitWord]; !ok && strings.HasPrefix(splitWord, "@") {
-						username := splitWord[1:]
-						ret.OtherPotentialMentions = append(ret.OtherPotentialMentions, username)
+						ret.OtherPotentialMentions = append(ret.OtherPotentialMentions, splitWord[1:])
 					}
 				}
-			}
-
-			if _, ok := systemMentions[word]; !ok && strings.HasPrefix(word, "@") {
-				username := word[1:]
-				ret.OtherPotentialMentions = append(ret.OtherPotentialMentions, username)
 			}
 		}
 	}

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -234,6 +234,12 @@ func TestGetExplicitMentions(t *testing.T) {
 				OtherPotentialMentions: []string{"potential"},
 			},
 		},
+		"PotentialOutOfChannelUserWithPeriod": {
+			Message: "this is an message for @potential.user",
+			Expected: &ExplicitMentions{
+				OtherPotentialMentions: []string{"potential.user"},
+			},
+		},
 		"InlineCode": {
 			Message:  "`this shouldn't mention @channel at all`",
 			Keywords: map[string][]string{},


### PR DESCRIPTION
#### Summary
Where `@test.example` and `@test` are users, posting out of channel mention of "@test.example" will determine that `@test.example` is mentioned but not `@test`.
Initially I thought that it can't always be the case because there's a possibility that the user might intend to mention `@test`. However, after preliminary change, I am convinced that it is `@test.example` since our client is already doing it.
This change somehow aligned the behavior of server and client.

Fix out of channel mentions for mentioned word with valid punctuations by:
- when a `word` starts with `@`, add it to potential mentions (e.g. `@test.example`)
- if not, split the word if with valid punctuations and check at-mention (e.g. `test.@example` will get `@example`)

#### Ticket Link
Jira ticket: [MM-10046](https://mattermost.atlassian.net/browse/MM-10046)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
