### PR TITLE
Websocket custom dialer support

### DIFF
--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -29,7 +29,13 @@ type WebSocketClient struct {
 // NewWebSocketClient constructs a new WebSocket client with convenience
 // methods for talking to the server.
 func NewWebSocketClient(url, authToken string) (*WebSocketClient, *AppError) {
-	conn, _, err := websocket.DefaultDialer.Dial(url+API_URL_SUFFIX_V3+"/users/websocket", nil)
+	return NewWebSocketClientWithDialer(url, authToken, websocket.DefaultDialer)
+}
+
+// NewWebSocketClientWithDialer constructs a new WebSocket client with convienence
+// methods for talking to the server using a custom dialer.
+func NewWebSocketClientWithDialer(url, authToken string, dialer *websocket.Dialer) (*WebSocketClient, *AppError) {
+	conn, _, err := dialer.Dial(url+API_URL_SUFFIX_V3+"/users/websocket", nil)
 	if err != nil {
 		return nil, NewAppError("NewWebSocketClient", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
@@ -54,7 +60,13 @@ func NewWebSocketClient(url, authToken string) (*WebSocketClient, *AppError) {
 // NewWebSocketClient4 constructs a new WebSocket client with convenience
 // methods for talking to the server. Uses the v4 endpoint.
 func NewWebSocketClient4(url, authToken string) (*WebSocketClient, *AppError) {
-	conn, _, err := websocket.DefaultDialer.Dial(url+API_URL_SUFFIX+"/websocket", nil)
+	return NewWebSocketClient4WithDialer(url, authToken, websocket.DefaultDialer)
+}
+
+// NewWebSocketClient4WithDialer constructs a new WebSocket client with convienence
+// methods for talking to the server using a custom dialer. Uses the v4 endpoint.
+func NewWebSocketClient4WithDialer(url, authToken string, dialer *websocket.Dialer) (*WebSocketClient, *AppError) {
+	conn, _, err := dialer.Dial(url+API_URL_SUFFIX+"/websocket", nil)
 	if err != nil {
 		return nil, NewAppError("NewWebSocketClient4", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
@@ -77,8 +89,12 @@ func NewWebSocketClient4(url, authToken string) (*WebSocketClient, *AppError) {
 }
 
 func (wsc *WebSocketClient) Connect() *AppError {
+	return wsc.ConnectWithDialer(websocket.DefaultDialer)
+}
+
+func (wsc *WebSocketClient) ConnectWithDialer(dialer *websocket.Dialer) *AppError {
 	var err error
-	wsc.Conn, _, err = websocket.DefaultDialer.Dial(wsc.ConnectUrl, nil)
+	wsc.Conn, _, err = dialer.Dial(wsc.ConnectUrl, nil)
 	if err != nil {
 		return NewAppError("Connect", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
@@ -165,3 +181,4 @@ func (wsc *WebSocketClient) GetStatusesByIds(userIds []string) {
 	}
 	wsc.SendMessage("get_statuses_by_ids", data)
 }
+

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -29,12 +29,12 @@ type WebSocketClient struct {
 // NewWebSocketClient constructs a new WebSocket client with convenience
 // methods for talking to the server.
 func NewWebSocketClient(url, authToken string) (*WebSocketClient, *AppError) {
-	return NewWebSocketClientWithDialer(url, authToken, websocket.DefaultDialer)
+	return NewWebSocketClientWithDialer(websocket.DefaultDialer, url, authToken)
 }
 
-// NewWebSocketClientWithDialer constructs a new WebSocket client with convienence
+// NewWebSocketClientWithDialer constructs a new WebSocket client with convenience
 // methods for talking to the server using a custom dialer.
-func NewWebSocketClientWithDialer(url, authToken string, dialer *websocket.Dialer) (*WebSocketClient, *AppError) {
+func NewWebSocketClientWithDialer(dialer *websocket.Dialer, url, authToken string) (*WebSocketClient, *AppError) {
 	conn, _, err := dialer.Dial(url+API_URL_SUFFIX_V3+"/users/websocket", nil)
 	if err != nil {
 		return nil, NewAppError("NewWebSocketClient", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
@@ -60,12 +60,12 @@ func NewWebSocketClientWithDialer(url, authToken string, dialer *websocket.Diale
 // NewWebSocketClient4 constructs a new WebSocket client with convenience
 // methods for talking to the server. Uses the v4 endpoint.
 func NewWebSocketClient4(url, authToken string) (*WebSocketClient, *AppError) {
-	return NewWebSocketClient4WithDialer(url, authToken, websocket.DefaultDialer)
+	return NewWebSocketClient4WithDialer(websocket.DefaultDialer, url, authToken)
 }
 
-// NewWebSocketClient4WithDialer constructs a new WebSocket client with convienence
+// NewWebSocketClient4WithDialer constructs a new WebSocket client with convenience
 // methods for talking to the server using a custom dialer. Uses the v4 endpoint.
-func NewWebSocketClient4WithDialer(url, authToken string, dialer *websocket.Dialer) (*WebSocketClient, *AppError) {
+func NewWebSocketClient4WithDialer(dialer *websocket.Dialer, url, authToken string) (*WebSocketClient, *AppError) {
 	conn, _, err := dialer.Dial(url+API_URL_SUFFIX+"/websocket", nil)
 	if err != nil {
 		return nil, NewAppError("NewWebSocketClient4", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -181,4 +181,3 @@ func (wsc *WebSocketClient) GetStatusesByIds(userIds []string) {
 	}
 	wsc.SendMessage("get_statuses_by_ids", data)
 }
-


### PR DESCRIPTION
#### Summary
If one wishes to change something in the HTTP client, for example System Proxy, Insecure connection or compression, one could change or override the HttpClient.

But the same can't be done to the WebSocket, as it is always using gorilla's DefaultDialer (with system proxy always used).

Now custom dialers can be passed, with no proxy for example, with the default API signature unharmed (with the default one is still used).

#### Ticket Link
None

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
