### PR TITLE
MM-9779: Incorporate a Token into the invitations system

### DIFF
--- a/api/team.go
+++ b/api/team.go
@@ -183,14 +183,13 @@ func removeUserFromTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := model.MapFromJson(r.Body)
 	tokenId := params["token"]
-	data := params["data"]
 	inviteId := params["invite_id"]
 
 	var team *model.Team
 	var err *model.AppError
 
 	if len(tokenId) > 0 {
-		team, err = c.App.AddUserToTeamByToken(c.Session.UserId, tokenId, data)
+		team, err = c.App.AddUserToTeamByToken(c.Session.UserId, tokenId)
 	} else if len(inviteId) > 0 {
 		team, err = c.App.AddUserToTeamByInviteId(inviteId, c.Session.UserId)
 	} else {

--- a/api/team.go
+++ b/api/team.go
@@ -182,7 +182,7 @@ func removeUserFromTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := model.MapFromJson(r.Body)
-	tokenId := params["hash"]
+	tokenId := params["token"]
 	data := params["data"]
 	inviteId := params["invite_id"]
 

--- a/api/team.go
+++ b/api/team.go
@@ -182,15 +182,15 @@ func removeUserFromTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request) {
 	params := model.MapFromJson(r.Body)
-	hash := params["hash"]
+	tokenId := params["hash"]
 	data := params["data"]
 	inviteId := params["invite_id"]
 
 	var team *model.Team
 	var err *model.AppError
 
-	if len(hash) > 0 {
-		team, err = c.App.AddUserToTeamByHash(c.Session.UserId, hash, data)
+	if len(tokenId) > 0 {
+		team, err = c.App.AddUserToTeamByToken(c.Session.UserId, tokenId, data)
 	} else if len(inviteId) > 0 {
 		team, err = c.App.AddUserToTeamByInviteId(inviteId, c.Session.UserId)
 	} else {

--- a/api/user.go
+++ b/api/user.go
@@ -82,7 +82,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	var ruser *model.User
 	var err *model.AppError
 	if len(tokenId) > 0 {
-		ruser, err = c.App.CreateUserWithToken(user, tokenId, r.URL.Query().Get("d"))
+		ruser, err = c.App.CreateUserWithToken(user, tokenId)
 	} else if len(inviteId) > 0 {
 		ruser, err = c.App.CreateUserWithInviteId(user, inviteId)
 	} else {

--- a/api/user.go
+++ b/api/user.go
@@ -76,13 +76,13 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hash := r.URL.Query().Get("h")
+	tokenId := r.URL.Query().Get("h")
 	inviteId := r.URL.Query().Get("iid")
 
 	var ruser *model.User
 	var err *model.AppError
-	if len(hash) > 0 {
-		ruser, err = c.App.CreateUserWithHash(user, hash, r.URL.Query().Get("d"))
+	if len(tokenId) > 0 {
+		ruser, err = c.App.CreateUserWithToken(user, tokenId, r.URL.Query().Get("d"))
 	} else if len(inviteId) > 0 {
 		ruser, err = c.App.CreateUserWithInviteId(user, inviteId)
 	} else {

--- a/api/user.go
+++ b/api/user.go
@@ -76,7 +76,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenId := r.URL.Query().Get("h")
+	tokenId := r.URL.Query().Get("t")
 	inviteId := r.URL.Query().Get("iid")
 
 	var ruser *model.User

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -194,7 +194,7 @@ func TestLogin(t *testing.T) {
 	}
 
 	if _, err := Client.Login(ruser2.Data.(*model.User).Email, user2.Password); err != nil {
-		t.Fatal("From verified hash")
+		t.Fatal("From verified token")
 	}
 
 	Client.AuthToken = authToken

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -177,7 +177,7 @@ func TestLogin(t *testing.T) {
 
 	token := model.NewToken(
 		app.TOKEN_TYPE_TEAM_INVITATION,
-		model.MapToJson(map[string]string{"team": rteam2.Data.(*model.Team).Id, "email": user2.Email}),
+		model.MapToJson(map[string]string{"teamId": rteam2.Data.(*model.Team).Id, "email": user2.Email}),
 	)
 	<-th.App.Srv.Store.Token().Save(token)
 	props := make(map[string]string)

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -5,7 +5,6 @@ package api
 
 import (
 	"bytes"
-	"fmt"
 	"image"
 	"image/color"
 	"io"
@@ -176,17 +175,17 @@ func TestLogin(t *testing.T) {
 		t.Fatal("Should have errored, signed up without hashed email")
 	}
 
-	token := model.NewToken(app.TOKEN_TYPE_TEAM_INVITATION, "")
+	token := model.NewToken(
+		app.TOKEN_TYPE_TEAM_INVITATION,
+		model.MapToJson(map[string]string{"team": rteam2.Data.(*model.Team).Id, "email": user2.Email}),
+	)
 	<-th.App.Srv.Store.Token().Save(token)
 	props := make(map[string]string)
 	props["email"] = user2.Email
-	props["id"] = rteam2.Data.(*model.Team).Id
 	props["display_name"] = rteam2.Data.(*model.Team).DisplayName
-	props["token"] = token.Token
 	data := model.MapToJson(props)
-	hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
 
-	ruser2, err := Client.CreateUserFromSignup(&user2, data, hash)
+	ruser2, err := Client.CreateUserFromSignup(&user2, data, token.Token)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api4/team.go
+++ b/api4/team.go
@@ -376,15 +376,15 @@ func addTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request) {
-	hash := r.URL.Query().Get("hash")
+	tokenId := r.URL.Query().Get("hash")
 	data := r.URL.Query().Get("data")
 	inviteId := r.URL.Query().Get("invite_id")
 
 	var member *model.TeamMember
 	var err *model.AppError
 
-	if len(hash) > 0 && len(data) > 0 {
-		member, err = c.App.AddTeamMemberByHash(c.Session.UserId, hash, data)
+	if len(tokenId) > 0 && len(data) > 0 {
+		member, err = c.App.AddTeamMemberByToken(c.Session.UserId, tokenId, data)
 	} else if len(inviteId) > 0 {
 		member, err = c.App.AddTeamMemberByInviteId(inviteId, c.Session.UserId)
 	} else {

--- a/api4/team.go
+++ b/api4/team.go
@@ -376,7 +376,7 @@ func addTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request) {
-	tokenId := r.URL.Query().Get("hash")
+	tokenId := r.URL.Query().Get("token")
 	data := r.URL.Query().Get("data")
 	inviteId := r.URL.Query().Get("invite_id")
 

--- a/api4/team.go
+++ b/api4/team.go
@@ -377,14 +377,13 @@ func addTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func addUserToTeamFromInvite(c *Context, w http.ResponseWriter, r *http.Request) {
 	tokenId := r.URL.Query().Get("token")
-	data := r.URL.Query().Get("data")
 	inviteId := r.URL.Query().Get("invite_id")
 
 	var member *model.TeamMember
 	var err *model.AppError
 
-	if len(tokenId) > 0 && len(data) > 0 {
-		member, err = c.App.AddTeamMemberByToken(c.Session.UserId, tokenId, data)
+	if len(tokenId) > 0 {
+		member, err = c.App.AddTeamMemberByToken(c.Session.UserId, tokenId)
 	} else if len(inviteId) > 0 {
 		member, err = c.App.AddTeamMemberByInviteId(inviteId, c.Session.UserId)
 	} else {

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -1367,7 +1367,7 @@ func TestAddTeamMember(t *testing.T) {
 
 	token := model.NewToken(
 		app.TOKEN_TYPE_TEAM_INVITATION,
-		model.MapToJson(map[string]string{"team": team.Id}),
+		model.MapToJson(map[string]string{"teamId": team.Id}),
 	)
 	<-th.App.Srv.Store.Token().Save(token)
 	dataObject := make(map[string]string)
@@ -1418,7 +1418,7 @@ func TestAddTeamMember(t *testing.T) {
 	testId := GenerateTestId()
 	token = model.NewToken(
 		app.TOKEN_TYPE_TEAM_INVITATION,
-		model.MapToJson(map[string]string{"team": testId}),
+		model.MapToJson(map[string]string{"teamId": testId}),
 	)
 	<-th.App.Srv.Store.Token().Save(token)
 	dataObject["id"] = testId

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -1362,7 +1362,7 @@ func TestAddTeamMember(t *testing.T) {
 	_, resp = Client.AddTeamMember(team.Id, otherUser.Id)
 	CheckNoError(t, resp)
 
-	// by hash and data
+	// by token and data
 	Client.Login(otherUser.Email, otherUser.Password)
 
 	token := model.NewToken(
@@ -1371,7 +1371,9 @@ func TestAddTeamMember(t *testing.T) {
 	)
 	<-th.App.Srv.Store.Token().Save(token)
 	dataObject := make(map[string]string)
-	dataObject["id"] = team.Id
+	dataObject["email"] = otherUser.Email
+	dataObject["display_name"] = team.DisplayName
+	dataObject["name"] = team.Name
 
 	data := model.MapToJson(dataObject)
 
@@ -1421,7 +1423,9 @@ func TestAddTeamMember(t *testing.T) {
 		model.MapToJson(map[string]string{"teamId": testId}),
 	)
 	<-th.App.Srv.Store.Token().Save(token)
-	dataObject["id"] = testId
+	dataObject["email"] = otherUser.Email
+	dataObject["display_name"] = team.DisplayName
+	dataObject["name"] = team.Name
 	data = model.MapToJson(dataObject)
 
 	tm, resp = Client.AddTeamMemberFromInvite(token.Token, data, "")

--- a/api4/user.go
+++ b/api4/user.go
@@ -73,15 +73,15 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hash := r.URL.Query().Get("h")
+	tokenId := r.URL.Query().Get("h")
 	inviteId := r.URL.Query().Get("iid")
 
 	// No permission check required
 
 	var ruser *model.User
 	var err *model.AppError
-	if len(hash) > 0 {
-		ruser, err = c.App.CreateUserWithHash(user, hash, r.URL.Query().Get("d"))
+	if len(tokenId) > 0 {
+		ruser, err = c.App.CreateUserWithToken(user, tokenId, r.URL.Query().Get("d"))
 	} else if len(inviteId) > 0 {
 		ruser, err = c.App.CreateUserWithInviteId(user, inviteId)
 	} else if c.IsSystemAdmin() {

--- a/api4/user.go
+++ b/api4/user.go
@@ -81,7 +81,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	var ruser *model.User
 	var err *model.AppError
 	if len(tokenId) > 0 {
-		ruser, err = c.App.CreateUserWithToken(user, tokenId, r.URL.Query().Get("d"))
+		ruser, err = c.App.CreateUserWithToken(user, tokenId)
 	} else if len(inviteId) > 0 {
 		ruser, err = c.App.CreateUserWithInviteId(user, inviteId)
 	} else if c.IsSystemAdmin() {

--- a/api4/user.go
+++ b/api4/user.go
@@ -73,7 +73,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tokenId := r.URL.Query().Get("h")
+	tokenId := r.URL.Query().Get("t")
 	inviteId := r.URL.Query().Get("iid")
 
 	// No permission check required

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -80,7 +80,7 @@ func TestCreateUser(t *testing.T) {
 	}
 }
 
-func TestCreateUserWithHash(t *testing.T) {
+func TestCreateUserWithToken(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 	Client := th.Client
@@ -98,7 +98,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		props["name"] = th.BasicTeam.Name
 		data := model.MapToJson(props)
 
-		ruser, resp := Client.CreateUserWithHash(&user, token.Token, data)
+		ruser, resp := Client.CreateUserWithToken(&user, token.Token, data)
 		CheckNoError(t, resp)
 		CheckCreatedStatus(t, resp)
 
@@ -130,13 +130,13 @@ func TestCreateUserWithHash(t *testing.T) {
 		props["name"] = th.BasicTeam.Name
 		data := model.MapToJson(props)
 
-		_, resp := Client.CreateUserWithHash(&user, "", data)
+		_, resp := Client.CreateUserWithToken(&user, "", data)
 		CheckBadRequestStatus(t, resp)
-		CheckErrorMessage(t, resp, "api.user.create_user.missing_hash_or_data.app_error")
+		CheckErrorMessage(t, resp, "api.user.create_user.missing_token_or_data.app_error")
 
-		_, resp = Client.CreateUserWithHash(&user, token.Token, "")
+		_, resp = Client.CreateUserWithToken(&user, token.Token, "")
 		CheckBadRequestStatus(t, resp)
-		CheckErrorMessage(t, resp, "api.user.create_user.missing_hash_or_data.app_error")
+		CheckErrorMessage(t, resp, "api.user.create_user.missing_token_or_data.app_error")
 	})
 
 	t.Run("HashExpired", func(t *testing.T) {
@@ -157,7 +157,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		props["name"] = th.BasicTeam.Name
 		data := model.MapToJson(props)
 
-		_, resp := Client.CreateUserWithHash(&user, token.Token, data)
+		_, resp := Client.CreateUserWithToken(&user, token.Token, data)
 		CheckBadRequestStatus(t, resp)
 		CheckErrorMessage(t, resp, "api.user.create_user.signup_link_expired.app_error")
 	})
@@ -170,7 +170,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		props["name"] = th.BasicTeam.Name
 		data := model.MapToJson(props)
 
-		_, resp := Client.CreateUserWithHash(&user, "wrong", data)
+		_, resp := Client.CreateUserWithToken(&user, "wrong", data)
 		CheckBadRequestStatus(t, resp)
 		CheckErrorMessage(t, resp, "api.user.create_user.signup_link_invalid.app_error")
 	})
@@ -192,7 +192,7 @@ func TestCreateUserWithHash(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.EnableUserCreation = false })
 
-		_, resp := Client.CreateUserWithHash(&user, token.Token, data)
+		_, resp := Client.CreateUserWithToken(&user, token.Token, data)
 		CheckNotImplementedStatus(t, resp)
 		CheckErrorMessage(t, resp, "api.user.create_user.signup_email_disabled.app_error")
 
@@ -215,7 +215,7 @@ func TestCreateUserWithHash(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.EnableOpenServer = false })
 
-		ruser, resp := Client.CreateUserWithHash(&user, token.Token, data)
+		ruser, resp := Client.CreateUserWithToken(&user, token.Token, data)
 		CheckNoError(t, resp)
 		CheckCreatedStatus(t, resp)
 

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -114,6 +114,16 @@ func TestCreateUserWithToken(t *testing.T) {
 		if result := <-th.App.Srv.Store.Token().GetByToken(token.Token); result.Err == nil {
 			t.Fatal("The token must be deleted after be used")
 		}
+
+		if result := <-th.App.Srv.Store.Token().GetByToken(token.Token); result.Err == nil {
+			t.Fatal("The token must be deleted after be used")
+		}
+
+		if teams, err := th.App.GetTeamsForUser(ruser.Id); err != nil || len(teams) == 0 {
+			t.Fatal("The user must have teams")
+		} else if teams[0].Id != th.BasicTeam.Id {
+			t.Fatal("The user joined team must be the team provided.")
+		}
 	})
 
 	t.Run("NoHashAndNoData", func(t *testing.T) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -89,7 +89,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		token := model.NewToken(
 			app.TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		props := make(map[string]string)
@@ -120,7 +120,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Corey Hulen", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 		token := model.NewToken(
 			app.TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
@@ -145,7 +145,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		past49Hours := timeNow.Add(-49*time.Hour).UnixNano() / int64(time.Millisecond)
 		token := model.NewToken(
 			app.TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
 		)
 		token.CreateAt = past49Hours
 		<-th.App.Srv.Store.Token().Save(token)
@@ -180,7 +180,7 @@ func TestCreateUserWithToken(t *testing.T) {
 
 		token := model.NewToken(
 			app.TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
@@ -204,7 +204,7 @@ func TestCreateUserWithToken(t *testing.T) {
 
 		token := model.NewToken(
 			app.TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		props := make(map[string]string)

--- a/app/email.go
+++ b/app/email.go
@@ -272,7 +272,7 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, invites []st
 
 			token := model.NewToken(
 				TOKEN_TYPE_TEAM_INVITATION,
-				model.MapToJson(map[string]string{"team": team.Id, "email": invite}),
+				model.MapToJson(map[string]string{"teamId": team.Id, "email": invite}),
 			)
 
 			props := make(map[string]string)

--- a/app/email.go
+++ b/app/email.go
@@ -285,7 +285,7 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, invites []st
 				l4g.Error(utils.T("api.team.invite_members.send.error"), result.Err)
 				continue
 			}
-			bodyPage.Props["Link"] = fmt.Sprintf("%s/signup_user_complete/?d=%s&h=%s", siteURL, url.QueryEscape(data), url.QueryEscape(token.Token))
+			bodyPage.Props["Link"] = fmt.Sprintf("%s/signup_user_complete/?d=%s&t=%s", siteURL, url.QueryEscape(data), url.QueryEscape(token.Token))
 
 			if !a.Config().EmailSettings.SendEmailNotifications {
 				l4g.Info(utils.T("api.team.invite_members.sending.info"), invite, bodyPage.Props["Link"])

--- a/app/email.go
+++ b/app/email.go
@@ -283,6 +283,7 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, invites []st
 
 			if result := <-a.Srv.Store.Token().Save(token); result.Err != nil {
 				l4g.Error(utils.T("api.team.invite_members.send.error"), result.Err)
+				continue
 			}
 			bodyPage.Props["Link"] = fmt.Sprintf("%s/signup_user_complete/?d=%s&h=%s", siteURL, url.QueryEscape(data), url.QueryEscape(token.Token))
 

--- a/app/email.go
+++ b/app/email.go
@@ -270,13 +270,19 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, invites []st
 			bodyPage.Html["ExtraInfo"] = utils.TranslateAsHtml(utils.T, "api.templates.invite_body.extra_info",
 				map[string]interface{}{"TeamDisplayName": team.DisplayName, "TeamURL": siteURL + "/" + team.Name})
 
+			token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+
 			props := make(map[string]string)
 			props["email"] = invite
 			props["id"] = team.Id
 			props["display_name"] = team.DisplayName
 			props["name"] = team.Name
-			props["time"] = fmt.Sprintf("%v", model.GetMillis())
+			props["token"] = token.Token
 			data := model.MapToJson(props)
+
+			if result := <-a.Srv.Store.Token().Save(token); result.Err != nil {
+				l4g.Error(utils.T("api.team.invite_members.send.error"), result.Err)
+			}
 			hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, a.Config().EmailSettings.InviteSalt))
 			bodyPage.Props["Link"] = fmt.Sprintf("%s/signup_user_complete/?d=%s&h=%s", siteURL, url.QueryEscape(data), url.QueryEscape(hash))
 

--- a/app/team.go
+++ b/app/team.go
@@ -215,7 +215,7 @@ func (a *App) AddUserToTeamByTeamId(teamId string, user *model.User) *model.AppE
 	}
 }
 
-func (a *App) AddUserToTeamByToken(userId string, tokenId string, data string) (*model.Team, *model.AppError) {
+func (a *App) AddUserToTeamByToken(userId string, tokenId string) (*model.Team, *model.AppError) {
 	result := <-a.Srv.Store.Token().GetByToken(tokenId)
 	if result.Err != nil {
 		return nil, model.NewAppError("AddUserToTeamByToken", "api.user.create_user.signup_link_invalid.app_error", nil, result.Err.Error(), http.StatusBadRequest)
@@ -519,11 +519,11 @@ func (a *App) AddTeamMembers(teamId string, userIds []string, userRequestorId st
 	return members, nil
 }
 
-func (a *App) AddTeamMemberByToken(userId, tokenId, data string) (*model.TeamMember, *model.AppError) {
+func (a *App) AddTeamMemberByToken(userId, tokenId string) (*model.TeamMember, *model.AppError) {
 	var team *model.Team
 	var err *model.AppError
 
-	if team, err = a.AddUserToTeamByToken(userId, tokenId, data); err != nil {
+	if team, err = a.AddUserToTeamByToken(userId, tokenId); err != nil {
 		return nil, err
 	}
 

--- a/app/team.go
+++ b/app/team.go
@@ -223,22 +223,22 @@ func (a *App) AddUserToTeamByTeamId(teamId string, user *model.User) *model.AppE
 func (a *App) AddUserToTeamByToken(userId string, tokenId string, data string) (*model.Team, *model.AppError) {
 	result := <-a.Srv.Store.Token().GetByToken(tokenId)
 	if result.Err != nil {
-		return nil, model.NewAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_invalid.app_error", nil, result.Err.Error(), http.StatusBadRequest)
+		return nil, model.NewAppError("AddUserToTeamByToken", "api.user.create_user.signup_link_invalid.app_error", nil, result.Err.Error(), http.StatusBadRequest)
 	}
 
 	token := result.Data.(*model.Token)
 	if token.Type != TOKEN_TYPE_TEAM_INVITATION {
-		return nil, model.NewAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("AddUserToTeamByToken", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if model.GetMillis()-token.CreateAt >= TEAM_INVITATION_EXPIRY_TIME {
 		a.DeleteToken(token)
-		return nil, model.NewAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("AddUserToTeamByToken", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	tokenData := model.MapFromJson(strings.NewReader(token.Extra))
 
-	tchan := a.Srv.Store.Team().Get(tokenData["team"])
+	tchan := a.Srv.Store.Team().Get(tokenData["teamId"])
 	uchan := a.Srv.Store.User().Get(userId)
 
 	var team *model.Team

--- a/app/team.go
+++ b/app/team.go
@@ -220,8 +220,8 @@ func (a *App) AddUserToTeamByTeamId(teamId string, user *model.User) *model.AppE
 	}
 }
 
-func (a *App) AddUserToTeamByHash(userId string, hash string, data string) (*model.Team, *model.AppError) {
-	result := <-a.Srv.Store.Token().GetByToken(hash)
+func (a *App) AddUserToTeamByToken(userId string, tokenId string, data string) (*model.Team, *model.AppError) {
+	result := <-a.Srv.Store.Token().GetByToken(tokenId)
 	if result.Err != nil {
 		return nil, model.NewAppError("JoinUserToTeamByHash", "api.user.create_user.signup_link_invalid.app_error", nil, result.Err.Error(), http.StatusBadRequest)
 	}
@@ -524,11 +524,11 @@ func (a *App) AddTeamMembers(teamId string, userIds []string, userRequestorId st
 	return members, nil
 }
 
-func (a *App) AddTeamMemberByHash(userId, hash, data string) (*model.TeamMember, *model.AppError) {
+func (a *App) AddTeamMemberByToken(userId, tokenId, data string) (*model.TeamMember, *model.AppError) {
 	var team *model.Team
 	var err *model.AppError
 
-	if team, err = a.AddUserToTeamByHash(userId, hash, data); err != nil {
+	if team, err = a.AddUserToTeamByToken(userId, tokenId, data); err != nil {
 		return nil, err
 	}
 

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -4,12 +4,10 @@
 package app
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestCreateTeam(t *testing.T) {
@@ -114,71 +112,74 @@ func TestAddUserToTeamByHash(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
 	ruser, _ := th.App.CreateUser(&user)
 
-	t.Run("invalid signature", func(t *testing.T) {
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, "123", "123"); err == nil {
-			t.Fatal("Should fail on bad signature")
-		}
-	})
-
 	t.Run("invalid token", func(t *testing.T) {
-		data := model.MapToJson(map[string]string{"token": "123", "id": th.BasicTeam.Id})
-		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, hash, data); err == nil {
+		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
+		if _, err := th.App.AddUserToTeamByHash(ruser.Id, "123", data); err == nil {
 			t.Fatal("Should fail on unexisting token")
 		}
 	})
 
 	t.Run("invalid token type", func(t *testing.T) {
-		token := model.NewToken(TOKEN_TYPE_VERIFY_EMAIL, "")
+		token := model.NewToken(
+			TOKEN_TYPE_VERIFY_EMAIL,
+			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"token": token.Token, "id": th.BasicTeam.Id})
-		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, hash, data); err == nil {
+		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
+		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err == nil {
 			t.Fatal("Should fail on bad token type")
 		}
 	})
 
 	t.Run("expired token", func(t *testing.T) {
-		token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+		token := model.NewToken(
+			TOKEN_TYPE_TEAM_INVITATION,
+			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+		)
 		token.CreateAt = model.GetMillis() - TEAM_INVITATION_EXPIRY_TIME - 1
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"token": token.Token, "id": th.BasicTeam.Id})
-		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, hash, data); err == nil {
+		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
+		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err == nil {
 			t.Fatal("Should fail on expired token")
 		}
 	})
 
 	t.Run("invalid team id", func(t *testing.T) {
-		token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+		token := model.NewToken(
+			TOKEN_TYPE_TEAM_INVITATION,
+			model.MapToJson(map[string]string{"team": model.NewId()}),
+		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"token": token.Token, "id": model.NewId()})
-		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, hash, data); err == nil {
+		data := model.MapToJson(map[string]string{"id": model.NewId()})
+		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err == nil {
 			t.Fatal("Should fail on bad team id")
 		}
 	})
 
 	t.Run("invalid user id", func(t *testing.T) {
-		token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+		token := model.NewToken(
+			TOKEN_TYPE_TEAM_INVITATION,
+			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"token": token.Token, "id": th.BasicTeam.Id})
-		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
-		if _, err := th.App.AddUserToTeamByHash(model.NewId(), hash, data); err == nil {
+		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
+		if _, err := th.App.AddUserToTeamByHash(model.NewId(), token.Token, data); err == nil {
 			t.Fatal("Should fail on bad user id")
 		}
 	})
 
 	t.Run("valid request", func(t *testing.T) {
-		token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+		token := model.NewToken(
+			TOKEN_TYPE_TEAM_INVITATION,
+			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+		)
 		<-th.App.Srv.Store.Token().Save(token)
-		data := model.MapToJson(map[string]string{"token": token.Token, "id": th.BasicTeam.Id})
-		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, hash, data); err != nil {
+		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
+		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err != nil {
 			t.Log(err)
 			t.Fatal("Should add user to the team")
 		}

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -113,8 +113,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 	ruser, _ := th.App.CreateUser(&user)
 
 	t.Run("invalid token", func(t *testing.T) {
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByToken(ruser.Id, "123", data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, "123"); err == nil {
 			t.Fatal("Should fail on unexisting token")
 		}
 	})
@@ -126,8 +125,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token); err == nil {
 			t.Fatal("Should fail on bad token type")
 		}
 	})
@@ -140,8 +138,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 		token.CreateAt = model.GetMillis() - TEAM_INVITATION_EXPIRY_TIME - 1
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token); err == nil {
 			t.Fatal("Should fail on expired token")
 		}
 	})
@@ -153,8 +150,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"id": model.NewId()})
-		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token); err == nil {
 			t.Fatal("Should fail on bad team id")
 		}
 	})
@@ -166,8 +162,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByToken(model.NewId(), token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(model.NewId(), token.Token); err == nil {
 			t.Fatal("Should fail on bad user id")
 		}
 	})
@@ -178,8 +173,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err != nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token); err != nil {
 			t.Log(err)
 			t.Fatal("Should add user to the team")
 		}

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -105,7 +105,7 @@ func TestAddUserToTeam(t *testing.T) {
 	}
 }
 
-func TestAddUserToTeamByHash(t *testing.T) {
+func TestAddUserToTeamByToken(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
@@ -114,7 +114,7 @@ func TestAddUserToTeamByHash(t *testing.T) {
 
 	t.Run("invalid token", func(t *testing.T) {
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, "123", data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, "123", data); err == nil {
 			t.Fatal("Should fail on unexisting token")
 		}
 	})
@@ -127,7 +127,7 @@ func TestAddUserToTeamByHash(t *testing.T) {
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err == nil {
 			t.Fatal("Should fail on bad token type")
 		}
 	})
@@ -141,7 +141,7 @@ func TestAddUserToTeamByHash(t *testing.T) {
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err == nil {
 			t.Fatal("Should fail on expired token")
 		}
 	})
@@ -154,7 +154,7 @@ func TestAddUserToTeamByHash(t *testing.T) {
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
 		data := model.MapToJson(map[string]string{"id": model.NewId()})
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err == nil {
 			t.Fatal("Should fail on bad team id")
 		}
 	})
@@ -167,7 +167,7 @@ func TestAddUserToTeamByHash(t *testing.T) {
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByHash(model.NewId(), token.Token, data); err == nil {
+		if _, err := th.App.AddUserToTeamByToken(model.NewId(), token.Token, data); err == nil {
 			t.Fatal("Should fail on bad user id")
 		}
 	})
@@ -179,7 +179,7 @@ func TestAddUserToTeamByHash(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})
-		if _, err := th.App.AddUserToTeamByHash(ruser.Id, token.Token, data); err != nil {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token, data); err != nil {
 			t.Log(err)
 			t.Fatal("Should add user to the team")
 		}

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -122,7 +122,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 	t.Run("invalid token type", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_VERIFY_EMAIL,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
@@ -135,7 +135,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 	t.Run("expired token", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id}),
 		)
 		token.CreateAt = model.GetMillis() - TEAM_INVITATION_EXPIRY_TIME - 1
 		<-th.App.Srv.Store.Token().Save(token)
@@ -149,7 +149,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 	t.Run("invalid team id", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": model.NewId()}),
+			model.MapToJson(map[string]string{"teamId": model.NewId()}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
@@ -162,7 +162,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 	t.Run("invalid user id", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
@@ -175,7 +175,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 	t.Run("valid request", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id})

--- a/app/user.go
+++ b/app/user.go
@@ -40,7 +40,7 @@ const (
 	IMAGE_PROFILE_PIXEL_DIMENSION = 128
 )
 
-func (a *App) CreateUserWithToken(user *model.User, tokenId string, data string) (*model.User, *model.AppError) {
+func (a *App) CreateUserWithToken(user *model.User, tokenId string) (*model.User, *model.AppError) {
 	if err := a.IsUserSignUpAllowed(); err != nil {
 		return nil, err
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -40,24 +40,24 @@ const (
 	IMAGE_PROFILE_PIXEL_DIMENSION = 128
 )
 
-func (a *App) CreateUserWithHash(user *model.User, hash string, data string) (*model.User, *model.AppError) {
+func (a *App) CreateUserWithToken(user *model.User, tokenId string, data string) (*model.User, *model.AppError) {
 	if err := a.IsUserSignUpAllowed(); err != nil {
 		return nil, err
 	}
 
-	result := <-a.Srv.Store.Token().GetByToken(hash)
+	result := <-a.Srv.Store.Token().GetByToken(tokenId)
 	if result.Err != nil {
-		return nil, model.NewAppError("CreateUserWithHash", "api.user.create_user.signup_link_invalid.app_error", nil, result.Err.Error(), http.StatusBadRequest)
+		return nil, model.NewAppError("CreateUserWithToken", "api.user.create_user.signup_link_invalid.app_error", nil, result.Err.Error(), http.StatusBadRequest)
 	}
 
 	token := result.Data.(*model.Token)
 	if token.Type != TOKEN_TYPE_TEAM_INVITATION {
-		return nil, model.NewAppError("CreateUserWithHash", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("CreateUserWithToken", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if model.GetMillis()-token.CreateAt >= TEAM_INVITATION_EXPIRY_TIME {
 		a.DeleteToken(token)
-		return nil, model.NewAppError("CreateUserWithHash", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusBadRequest)
+		return nil, model.NewAppError("CreateUserWithToken", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	tokenData := model.MapFromJson(strings.NewReader(token.Extra))

--- a/app/user.go
+++ b/app/user.go
@@ -48,7 +48,7 @@ func (a *App) CreateUserWithHash(user *model.User, hash string, data string) (*m
 	props := model.MapFromJson(strings.NewReader(data))
 
 	if hash != utils.HashSha256(fmt.Sprintf("%v:%v", data, a.Config().EmailSettings.InviteSalt)) {
-		return nil, model.NewAppError("CreateUserWithHash", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusInternalServerError)
+		return nil, model.NewAppError("CreateUserWithHash", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	result := <-a.Srv.Store.Token().GetByToken(props["token"])
@@ -58,7 +58,7 @@ func (a *App) CreateUserWithHash(user *model.User, hash string, data string) (*m
 
 	token := result.Data.(*model.Token)
 	if token.Type != TOKEN_TYPE_TEAM_INVITATION {
-		return nil, model.NewAppError("CreateUserWithHash", "api.user.create_user.signup_link_expired.app_error", nil, "", http.StatusInternalServerError)
+		return nil, model.NewAppError("CreateUserWithHash", "api.user.create_user.signup_link_invalid.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if model.GetMillis()-token.CreateAt >= TEAM_INVITATION_EXPIRY_TIME {

--- a/app/user.go
+++ b/app/user.go
@@ -63,7 +63,7 @@ func (a *App) CreateUserWithToken(user *model.User, tokenId string, data string)
 	tokenData := model.MapFromJson(strings.NewReader(token.Extra))
 
 	var team *model.Team
-	if result := <-a.Srv.Store.Team().Get(tokenData["team"]); result.Err != nil {
+	if result := <-a.Srv.Store.Team().Get(tokenData["teamId"]); result.Err != nil {
 		return nil, result.Err
 	} else {
 		team = result.Data.(*model.Team)

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -429,7 +429,7 @@ func TestGetUsersByStatus(t *testing.T) {
 	})
 }
 
-func TestCreateUserWithHash(t *testing.T) {
+func TestCreateUserWithToken(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
@@ -437,7 +437,7 @@ func TestCreateUserWithHash(t *testing.T) {
 
 	t.Run("invalid token", func(t *testing.T) {
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": user.Email})
-		if _, err := th.App.CreateUserWithHash(&user, "123", data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, "123", data); err == nil {
 			t.Fatal("Should fail on unexisting token")
 		}
 	})
@@ -450,7 +450,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": user.Email})
-		if _, err := th.App.CreateUserWithHash(&user, token.Token, data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, token.Token, data); err == nil {
 			t.Fatal("Should fail on bad token type")
 		}
 	})
@@ -464,7 +464,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": user.Email})
-		if _, err := th.App.CreateUserWithHash(&user, token.Token, data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, token.Token, data); err == nil {
 			t.Fatal("Should fail on expired token")
 		}
 	})
@@ -477,7 +477,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
 		data := model.MapToJson(map[string]string{"id": model.NewId(), "email": user.Email})
-		if _, err := th.App.CreateUserWithHash(&user, token.Token, data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, token.Token, data); err == nil {
 			t.Fatal("Should fail on bad team id")
 		}
 	})
@@ -490,7 +490,7 @@ func TestCreateUserWithHash(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": invitationEmail})
-		newUser, err := th.App.CreateUserWithHash(&user, token.Token, data)
+		newUser, err := th.App.CreateUserWithToken(&user, token.Token, data)
 		if err != nil {
 			t.Log(err)
 			t.Fatal("Should add user to the team")

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -445,7 +445,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	t.Run("invalid token type", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_VERIFY_EMAIL,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
@@ -458,7 +458,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	t.Run("expired token", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": user.Email}),
 		)
 		token.CreateAt = model.GetMillis() - TEAM_INVITATION_EXPIRY_TIME - 1
 		<-th.App.Srv.Store.Token().Save(token)
@@ -472,7 +472,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	t.Run("invalid team id", func(t *testing.T) {
 		token := model.NewToken(
 			TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": model.NewId(), "email": user.Email}),
+			model.MapToJson(map[string]string{"teamId": model.NewId(), "email": user.Email}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
@@ -486,7 +486,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		invitationEmail := model.NewId() + "other-email@test.com"
 		token := model.NewToken(
 			TOKEN_TYPE_TEAM_INVITATION,
-			model.MapToJson(map[string]string{"team": th.BasicTeam.Id, "email": invitationEmail}),
+			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": invitationEmail}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": invitationEmail})

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -436,8 +436,7 @@ func TestCreateUserWithToken(t *testing.T) {
 	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
 
 	t.Run("invalid token", func(t *testing.T) {
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": user.Email})
-		if _, err := th.App.CreateUserWithToken(&user, "123", data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, "123"); err == nil {
 			t.Fatal("Should fail on unexisting token")
 		}
 	})
@@ -449,8 +448,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": user.Email})
-		if _, err := th.App.CreateUserWithToken(&user, token.Token, data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, token.Token); err == nil {
 			t.Fatal("Should fail on bad token type")
 		}
 	})
@@ -463,8 +461,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		token.CreateAt = model.GetMillis() - TEAM_INVITATION_EXPIRY_TIME - 1
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": user.Email})
-		if _, err := th.App.CreateUserWithToken(&user, token.Token, data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, token.Token); err == nil {
 			t.Fatal("Should fail on expired token")
 		}
 	})
@@ -476,8 +473,7 @@ func TestCreateUserWithToken(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 		defer th.App.DeleteToken(token)
-		data := model.MapToJson(map[string]string{"id": model.NewId(), "email": user.Email})
-		if _, err := th.App.CreateUserWithToken(&user, token.Token, data); err == nil {
+		if _, err := th.App.CreateUserWithToken(&user, token.Token); err == nil {
 			t.Fatal("Should fail on bad team id")
 		}
 	})
@@ -489,8 +485,7 @@ func TestCreateUserWithToken(t *testing.T) {
 			model.MapToJson(map[string]string{"teamId": th.BasicTeam.Id, "email": invitationEmail}),
 		)
 		<-th.App.Srv.Store.Token().Save(token)
-		data := model.MapToJson(map[string]string{"id": th.BasicTeam.Id, "email": invitationEmail})
-		newUser, err := th.App.CreateUserWithToken(&user, token.Token, data)
+		newUser, err := th.App.CreateUserWithToken(&user, token.Token)
 		if err != nil {
 			t.Log(err)
 			t.Fatal("Should add user to the team")

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -6,6 +6,7 @@ package app
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"image"
 	"image/color"
 	"math/rand"
@@ -18,6 +19,7 @@ import (
 	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/model/gitlab"
+	"github.com/mattermost/mattermost-server/utils"
 )
 
 func TestIsUsernameTaken(t *testing.T) {
@@ -425,6 +427,80 @@ func TestGetUsersByStatus(t *testing.T) {
 
 		if usersByStatus[2].Id != offlineUser1.Id && usersByStatus[3].Id != offlineUser2.Id {
 			t.Fatal("expected to receive offline users last")
+		}
+	})
+}
+
+func TestCreateUserWithHash(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
+
+	t.Run("invalid signature", func(t *testing.T) {
+		if _, err := th.App.CreateUserWithHash(&user, "123", "123"); err == nil {
+			t.Fatal("Should fail on bad signature")
+		}
+	})
+
+	t.Run("invalid token", func(t *testing.T) {
+		data := model.MapToJson(map[string]string{"token": "123", "id": th.BasicTeam.Id, "email": user.Email})
+		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
+		if _, err := th.App.CreateUserWithHash(&user, hash, data); err == nil {
+			t.Fatal("Should fail on unexisting token")
+		}
+	})
+
+	t.Run("invalid token type", func(t *testing.T) {
+		token := model.NewToken(TOKEN_TYPE_VERIFY_EMAIL, "")
+		<-th.App.Srv.Store.Token().Save(token)
+		defer th.App.DeleteToken(token)
+		data := model.MapToJson(map[string]string{"token": token.Token, "id": th.BasicTeam.Id, "email": user.Email})
+		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
+		if _, err := th.App.CreateUserWithHash(&user, hash, data); err == nil {
+			t.Fatal("Should fail on bad token type")
+		}
+	})
+
+	t.Run("expired token", func(t *testing.T) {
+		token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+		token.CreateAt = model.GetMillis() - TEAM_INVITATION_EXPIRY_TIME - 1
+		<-th.App.Srv.Store.Token().Save(token)
+		defer th.App.DeleteToken(token)
+		data := model.MapToJson(map[string]string{"token": token.Token, "id": th.BasicTeam.Id, "email": user.Email})
+		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
+		if _, err := th.App.CreateUserWithHash(&user, hash, data); err == nil {
+			t.Fatal("Should fail on expired token")
+		}
+	})
+
+	t.Run("invalid team id", func(t *testing.T) {
+		token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+		<-th.App.Srv.Store.Token().Save(token)
+		defer th.App.DeleteToken(token)
+		data := model.MapToJson(map[string]string{"token": token.Token, "id": model.NewId(), "email": user.Email})
+		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
+		if _, err := th.App.CreateUserWithHash(&user, hash, data); err == nil {
+			t.Fatal("Should fail on bad team id")
+		}
+	})
+
+	t.Run("valid request", func(t *testing.T) {
+		token := model.NewToken(TOKEN_TYPE_TEAM_INVITATION, "")
+		<-th.App.Srv.Store.Token().Save(token)
+		invitationEmail := model.NewId() + "other-email@test.com"
+		data := model.MapToJson(map[string]string{"token": token.Token, "id": th.BasicTeam.Id, "email": invitationEmail})
+		hash := utils.HashSha256(fmt.Sprintf("%v:%v", data, th.App.Config().EmailSettings.InviteSalt))
+		newUser, err := th.App.CreateUserWithHash(&user, hash, data)
+		if err != nil {
+			t.Log(err)
+			t.Fatal("Should add user to the team")
+		}
+		if newUser.Email != invitationEmail {
+			t.Fatal("The user email must be the invitation one")
+		}
+		if result := <-th.App.Srv.Store.Token().GetByToken(token.Token); result.Err == nil {
+			t.Fatal("The token must be deleted after be used")
 		}
 	})
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2851,8 +2851,8 @@
     "translation": "Encountered an issue joining default channels user_id=%s, team_id=%s, err=%v"
   },
   {
-    "id": "api.user.create_user.missing_token_or_data.app_error",
-    "translation": "Missing Token or URL query data."
+    "id": "api.user.create_user.missing_token.app_error",
+    "translation": "Missing Token."
   },
   {
     "id": "api.user.create_user.missing_invite_id.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2851,8 +2851,8 @@
     "translation": "Encountered an issue joining default channels user_id=%s, team_id=%s, err=%v"
   },
   {
-    "id": "api.user.create_user.missing_hash_or_data.app_error",
-    "translation": "Missing Hash or URL query data."
+    "id": "api.user.create_user.missing_token_or_data.app_error",
+    "translation": "Missing Token or URL query data."
   },
   {
     "id": "api.user.create_user.missing_invite_id.app_error",

--- a/model/client.go
+++ b/model/client.go
@@ -377,11 +377,11 @@ func (c *Client) AddUserToTeam(teamId string, userId string) (*Result, *AppError
 }
 
 // AddUserToTeamFromInvite adds a user to a team based off data provided in an invite link.
-// Either hash and dataToHash are required or inviteId is required.
-func (c *Client) AddUserToTeamFromInvite(hash, dataToHash, inviteId string) (*Result, *AppError) {
+// Either token and data are required or inviteId is required.
+func (c *Client) AddUserToTeamFromInvite(token, inviteData, inviteId string) (*Result, *AppError) {
 	data := make(map[string]string)
-	data["hash"] = hash
-	data["data"] = dataToHash
+	data["token"] = token
+	data["data"] = inviteData
 	data["invite_id"] = inviteId
 	if r, err := c.DoApiPost("/teams/add_user_to_team_from_invite", MapToJson(data)); err != nil {
 		return nil, err
@@ -438,7 +438,7 @@ func (c *Client) UpdateTeam(team *Team) (*Result, *AppError) {
 // User Routes Section
 
 // CreateUser creates a user in the system based on the provided user struct.
-func (c *Client) CreateUser(user *User, hash string) (*Result, *AppError) {
+func (c *Client) CreateUser(user *User, token string) (*Result, *AppError) {
 	if r, err := c.DoApiPost("/users/create", user.ToJson()); err != nil {
 		return nil, err
 	} else {
@@ -448,11 +448,11 @@ func (c *Client) CreateUser(user *User, hash string) (*Result, *AppError) {
 	}
 }
 
-// CreateUserWithInvite creates a user based on the provided user struct. Either the hash and
+// CreateUserWithInvite creates a user based on the provided user struct. Either the token and
 // data strings or the inviteId is required from the invite.
-func (c *Client) CreateUserWithInvite(user *User, hash string, data string, inviteId string) (*Result, *AppError) {
+func (c *Client) CreateUserWithInvite(user *User, token string, data string, inviteId string) (*Result, *AppError) {
 
-	url := "/users/create?d=" + url.QueryEscape(data) + "&h=" + url.QueryEscape(hash) + "&iid=" + url.QueryEscape(inviteId)
+	url := "/users/create?d=" + url.QueryEscape(data) + "&t=" + url.QueryEscape(token) + "&iid=" + url.QueryEscape(inviteId)
 
 	if r, err := c.DoApiPost(url, user.ToJson()); err != nil {
 		return nil, err
@@ -463,8 +463,8 @@ func (c *Client) CreateUserWithInvite(user *User, hash string, data string, invi
 	}
 }
 
-func (c *Client) CreateUserFromSignup(user *User, data string, hash string) (*Result, *AppError) {
-	if r, err := c.DoApiPost("/users/create?d="+url.QueryEscape(data)+"&h="+hash, user.ToJson()); err != nil {
+func (c *Client) CreateUserFromSignup(user *User, data string, token string) (*Result, *AppError) {
+	if r, err := c.DoApiPost("/users/create?d="+url.QueryEscape(data)+"&t="+token, user.ToJson()); err != nil {
 		return nil, err
 	} else {
 		defer closeBody(r)

--- a/model/client4.go
+++ b/model/client4.go
@@ -530,13 +530,13 @@ func (c *Client4) CreateUser(user *User) (*User, *Response) {
 	}
 }
 
-// CreateUserWithToken creates a user in the system based on the provided user struct and tokenId created.
-func (c *Client4) CreateUserWithToken(user *User, tokenId, data string) (*User, *Response) {
+// CreateUserWithToken creates a user in the system based on the provided tokenId.
+func (c *Client4) CreateUserWithToken(user *User, tokenId string) (*User, *Response) {
 	var query string
-	if tokenId != "" && data != "" {
-		query = fmt.Sprintf("?d=%v&t=%v", url.QueryEscape(data), tokenId)
+	if tokenId != "" {
+		query = fmt.Sprintf("?t=%v", tokenId)
 	} else {
-		err := NewAppError("MissingHashOrData", "api.user.create_user.missing_token_or_data.app_error", nil, "", http.StatusBadRequest)
+		err := NewAppError("MissingHashOrData", "api.user.create_user.missing_token.app_error", nil, "", http.StatusBadRequest)
 		return nil, &Response{StatusCode: err.StatusCode, Error: err}
 	}
 	if r, err := c.DoApiPost(c.GetUsersRoute()+query, user.ToJson()); err != nil {
@@ -1341,15 +1341,15 @@ func (c *Client4) AddTeamMember(teamId, userId string) (*TeamMember, *Response) 
 
 // AddTeamMemberFromInvite adds a user to a team and return a team member using an invite id
 // or an invite token/data pair.
-func (c *Client4) AddTeamMemberFromInvite(token, data, inviteId string) (*TeamMember, *Response) {
+func (c *Client4) AddTeamMemberFromInvite(token, inviteId string) (*TeamMember, *Response) {
 	var query string
 
 	if inviteId != "" {
 		query += fmt.Sprintf("?invite_id=%v", inviteId)
 	}
 
-	if token != "" && data != "" {
-		query += fmt.Sprintf("?token=%v&data=%v", token, data)
+	if token != "" {
+		query += fmt.Sprintf("?token=%v", token)
 	}
 
 	if r, err := c.DoApiPost(c.GetTeamsRoute()+"/members/invite"+query, ""); err != nil {

--- a/model/client4.go
+++ b/model/client4.go
@@ -534,7 +534,7 @@ func (c *Client4) CreateUser(user *User) (*User, *Response) {
 func (c *Client4) CreateUserWithToken(user *User, tokenId, data string) (*User, *Response) {
 	var query string
 	if tokenId != "" && data != "" {
-		query = fmt.Sprintf("?d=%v&h=%v", url.QueryEscape(data), tokenId)
+		query = fmt.Sprintf("?d=%v&t=%v", url.QueryEscape(data), tokenId)
 	} else {
 		err := NewAppError("MissingHashOrData", "api.user.create_user.missing_token_or_data.app_error", nil, "", http.StatusBadRequest)
 		return nil, &Response{StatusCode: err.StatusCode, Error: err}
@@ -545,12 +545,6 @@ func (c *Client4) CreateUserWithToken(user *User, tokenId, data string) (*User, 
 		defer closeBody(r)
 		return UserFromJson(r.Body), BuildResponse(r)
 	}
-}
-
-// CreateUserWithHash creates a user in the system based on the provided user struct and hash created.
-// Maintained for backward compatibility
-func (c *Client4) CreateUserWithHash(user *User, hash, data string) (*User, *Response) {
-	return c.CreateUserWithToken(user, hash, data)
 }
 
 // CreateUserWithInviteId creates a user in the system based on the provided invited id.
@@ -1346,16 +1340,16 @@ func (c *Client4) AddTeamMember(teamId, userId string) (*TeamMember, *Response) 
 }
 
 // AddTeamMemberFromInvite adds a user to a team and return a team member using an invite id
-// or an invite hash/data pair.
-func (c *Client4) AddTeamMemberFromInvite(hash, dataToHash, inviteId string) (*TeamMember, *Response) {
+// or an invite token/data pair.
+func (c *Client4) AddTeamMemberFromInvite(token, data, inviteId string) (*TeamMember, *Response) {
 	var query string
 
 	if inviteId != "" {
 		query += fmt.Sprintf("?invite_id=%v", inviteId)
 	}
 
-	if hash != "" && dataToHash != "" {
-		query += fmt.Sprintf("?hash=%v&data=%v", hash, dataToHash)
+	if token != "" && data != "" {
+		query += fmt.Sprintf("?token=%v&data=%v", token, data)
 	}
 
 	if r, err := c.DoApiPost(c.GetTeamsRoute()+"/members/invite"+query, ""); err != nil {

--- a/model/client4.go
+++ b/model/client4.go
@@ -530,13 +530,13 @@ func (c *Client4) CreateUser(user *User) (*User, *Response) {
 	}
 }
 
-// CreateUserWithHash creates a user in the system based on the provided user struct and hash created.
-func (c *Client4) CreateUserWithHash(user *User, hash, data string) (*User, *Response) {
+// CreateUserWithToken creates a user in the system based on the provided user struct and tokenId created.
+func (c *Client4) CreateUserWithToken(user *User, tokenId, data string) (*User, *Response) {
 	var query string
-	if hash != "" && data != "" {
-		query = fmt.Sprintf("?d=%v&h=%v", url.QueryEscape(data), hash)
+	if tokenId != "" && data != "" {
+		query = fmt.Sprintf("?d=%v&h=%v", url.QueryEscape(data), tokenId)
 	} else {
-		err := NewAppError("MissingHashOrData", "api.user.create_user.missing_hash_or_data.app_error", nil, "", http.StatusBadRequest)
+		err := NewAppError("MissingHashOrData", "api.user.create_user.missing_token_or_data.app_error", nil, "", http.StatusBadRequest)
 		return nil, &Response{StatusCode: err.StatusCode, Error: err}
 	}
 	if r, err := c.DoApiPost(c.GetUsersRoute()+query, user.ToJson()); err != nil {
@@ -545,6 +545,12 @@ func (c *Client4) CreateUserWithHash(user *User, hash, data string) (*User, *Res
 		defer closeBody(r)
 		return UserFromJson(r.Body), BuildResponse(r)
 	}
+}
+
+// CreateUserWithHash creates a user in the system based on the provided user struct and hash created.
+// Maintained for backward compatibility
+func (c *Client4) CreateUserWithHash(user *User, hash, data string) (*User, *Response) {
+	return c.CreateUserWithToken(user, hash, data)
 }
 
 // CreateUserWithInviteId creates a user in the system based on the provided invited id.


### PR DESCRIPTION
#### Summary
It binds each invitation to a token, avoiding the invitations re-use.

#### Ticket Link
[MM-9779](https://mattermost.atlassian.net/browse/MM-9779)
PR for the API documentation mattermost/mattermost-api-reference#349

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers