### PR TITLE
MM-8180 Improve error message for testing smtp connections

### DIFF
--- a/app/admin.go
+++ b/app/admin.go
@@ -243,7 +243,7 @@ func (a *App) TestEmail(userId string, cfg *model.Config) *model.AppError {
 		T := utils.GetUserTranslations(user.Locale)
 		license := a.License()
 		if err := utils.SendMailUsingConfig(user.Email, T("api.admin.test_email.subject"), T("api.admin.test_email.body"), cfg, license != nil && *license.Features.Compliance); err != nil {
-			return err
+			return model.NewAppError("testEmail", "app.admin.test_email.failure", map[string]interface{}{"Error": err.Error()}, "", http.StatusInternalServerError)
 		}
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7328,11 +7328,15 @@
   },
   {
     "id": "utils.mail.send_mail.from_address.app_error",
-    "translation": "Notification From Address setting is missing or invalid."
+    "translation": "Error setting from address"
   },
   {
     "id": "utils.mail.send_mail.msg.app_error",
     "translation": "Failed to write email message"
+  },
+  {
+    "id": "app.admin.test_email.failure",
+    "translation": "Connection unsuccessful: {{.Error}}"
   },
   {
     "id": "utils.mail.send_mail.msg_data.app_error",
@@ -7344,7 +7348,7 @@
   },
   {
     "id": "utils.mail.send_mail.to_address.app_error",
-    "translation": "Notification To Address setting is missing or invalid."
+    "translation": "Error setting to address"
   },
   {
     "id": "utils.mail.test.configured.error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7328,7 +7328,7 @@
   },
   {
     "id": "utils.mail.send_mail.from_address.app_error",
-    "translation": "Error setting from address"
+    "translation": "Error setting \"From Address\""
   },
   {
     "id": "utils.mail.send_mail.msg.app_error",
@@ -7348,7 +7348,7 @@
   },
   {
     "id": "utils.mail.send_mail.to_address.app_error",
-    "translation": "Error setting to address"
+    "translation": "Error setting \"To Address\""
   },
   {
     "id": "utils.mail.test.configured.error",


### PR DESCRIPTION
#### Summary
This exposes the detailed error (which will be the actual error from the SMTP server) to the system admin when they're testing SMTP connections. It's not perfect or super clean error message but it would be a lot of mana to clean it up anymore and beyond the scope of this bug ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8180