### PR TITLE
Add list command to teams command in CLI

### DIFF
--- a/cmd/commands/team.go
+++ b/cmd/commands/team.go
@@ -232,11 +232,11 @@ func listTeamsCmdF(command *cobra.Command, args []string) error {
 		return err
 	}
 
-	result := <-a.Srv.Store.Team().GetAll()
-	if result.Err != nil {
-		return result.Err
+	teams, err2 := a.GetAllTeams()
+	if err2 != nil {
+		return err2
 	}
-	teams := result.Data.([]*model.Team)
+
 	for _, team := range teams {
 		cmd.CommandPrettyPrintln(team.Name)
 	}

--- a/cmd/commands/team.go
+++ b/cmd/commands/team.go
@@ -52,6 +52,14 @@ Permanently deletes a team along with all related information including posts fr
 	RunE:    deleteTeamsCmdF,
 }
 
+var ListTeamsCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "List all teams.",
+	Long:    `List all teams on the server.`,
+	Example: "  team list",
+	RunE:    listTeamsCmdF,
+}
+
 func init() {
 	TeamCreateCmd.Flags().String("name", "", "Team Name")
 	TeamCreateCmd.Flags().String("display_name", "", "Team Display Name")
@@ -65,6 +73,7 @@ func init() {
 		RemoveUsersCmd,
 		AddUsersCmd,
 		DeleteTeamsCmd,
+		ListTeamsCmd,
 	)
 	cmd.RootCmd.AddCommand(TeamCmd)
 }
@@ -215,4 +224,22 @@ func deleteTeamsCmdF(command *cobra.Command, args []string) error {
 
 func deleteTeam(a *app.App, team *model.Team) *model.AppError {
 	return a.PermanentDeleteTeam(team)
+}
+
+func listTeamsCmdF(command *cobra.Command, args []string) error {
+	a, err := cmd.InitDBCommandContextCobra(command)
+	if err != nil {
+		return err
+	}
+
+	result := <-a.Srv.Store.Team().GetAll()
+	if result.Err != nil {
+		return result.Err
+	}
+	teams := result.Data.([]*model.Team)
+	for _, team := range teams {
+		cmd.CommandPrettyPrintln(team.Name)
+	}
+
+	return nil
 }

--- a/cmd/commands/team_test.go
+++ b/cmd/commands/team_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/api"
@@ -76,5 +77,22 @@ func TestLeaveTeam(t *testing.T) {
 		if len(teamMembers) > 0 {
 			t.Fatal("Shouldn't be in team")
 		}
+	}
+}
+
+func TestListTeams(t *testing.T) {
+	th := api.Setup().InitBasic()
+	defer th.TearDown()
+
+	id := model.NewId()
+	name := "name" + id
+	displayName := "Name " + id
+
+	cmd.CheckCommand(t, "team", "create", "--name", name, "--display_name", displayName)
+
+	output := cmd.CheckCommand(t, "team", "list", th.BasicTeam.Name, th.BasicUser.Email)
+
+	if !strings.Contains(string(output), name) {
+		t.Fatal("should have the created team")
 	}
 }


### PR DESCRIPTION
#### Summary
The team command hasn't a way to get the list of teams, so is harder to work
only with the comand line. Now you can list your teams, and start to do actions
on your channels based on that.

#### Ticket Link
No ticket

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)