### PR TITLE
add app shutdown to make sure the goroutines finish and all process are closed

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1043,9 +1043,11 @@ func (a *App) UpdateUser(user *model.User, sendNotifications bool) (*model.User,
 				})
 
 				if a.Config().EmailSettings.RequireEmailVerification {
-					if err := a.SendEmailVerification(rusers[0]); err != nil {
-						l4g.Error(err.Error())
-					}
+					a.Go(func() {
+						if err := a.SendEmailVerification(rusers[0]); err != nil {
+							l4g.Error(err.Error())
+						}
+					})
 				}
 			}
 

--- a/cmd/commands/channel.go
+++ b/cmd/commands/channel.go
@@ -136,6 +136,7 @@ func createChannelCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	name, errn := command.Flags().GetString("name")
 	if errn != nil || name == "" {
@@ -185,6 +186,7 @@ func removeChannelUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
@@ -218,6 +220,7 @@ func addChannelUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
@@ -251,6 +254,7 @@ func archiveChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one channel to archive.")
@@ -275,6 +279,7 @@ func deleteChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one channel to delete.")
@@ -315,6 +320,7 @@ func moveChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Enter the destination team and at least one channel to move.")
@@ -389,6 +395,7 @@ func listChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one team.")
@@ -423,6 +430,7 @@ func restoreChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one channel.")
@@ -447,6 +455,7 @@ func modifyChannelCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) != 1 {
 		return errors.New("Enter at one channel to modify.")

--- a/cmd/commands/command.go
+++ b/cmd/commands/command.go
@@ -36,6 +36,7 @@ func moveCommandCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Enter the destination team and at least one comamnd to move.")

--- a/cmd/commands/import.go
+++ b/cmd/commands/import.go
@@ -51,6 +51,7 @@ func slackImportCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) != 2 {
 		return errors.New("Incorrect number of arguments.")
@@ -86,6 +87,7 @@ func bulkImportCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	apply, err := command.Flags().GetBool("apply")
 	if err != nil {

--- a/cmd/commands/ldap.go
+++ b/cmd/commands/ldap.go
@@ -34,6 +34,7 @@ func ldapSyncCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if ldapI := a.Ldap; ldapI != nil {
 		job, err := ldapI.StartSynchronizeJob(true)

--- a/cmd/commands/license.go
+++ b/cmd/commands/license.go
@@ -34,6 +34,7 @@ func uploadLicenseCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) != 1 {
 		return errors.New("Enter one license file to upload")

--- a/cmd/commands/message_export.go
+++ b/cmd/commands/message_export.go
@@ -35,6 +35,7 @@ func messageExportCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if !*a.Config().MessageExportSettings.EnableExport {
 		return errors.New("ERROR: The message export feature is not enabled")

--- a/cmd/commands/reset.go
+++ b/cmd/commands/reset.go
@@ -29,6 +29,7 @@ func resetCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	confirmFlag, _ := command.Flags().GetBool("confirm")
 	if !confirmFlag {

--- a/cmd/commands/roles.go
+++ b/cmd/commands/roles.go
@@ -44,6 +44,7 @@ func makeSystemAdminCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one user.")
@@ -68,6 +69,7 @@ func makeMemberCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one user.")

--- a/cmd/commands/sampledata.go
+++ b/cmd/commands/sampledata.go
@@ -134,6 +134,8 @@ func sampleDataCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
+
 	seed, err := command.Flags().GetInt64("seed")
 	if err != nil {
 		return errors.New("Invalid seed parameter")

--- a/cmd/commands/team.go
+++ b/cmd/commands/team.go
@@ -83,6 +83,7 @@ func createTeamCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	name, errn := command.Flags().GetString("name")
 	if errn != nil || name == "" {
@@ -119,6 +120,7 @@ func removeUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
@@ -152,6 +154,7 @@ func addUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Not enough arguments.")
@@ -185,6 +188,7 @@ func deleteTeamsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Not enough arguments.")
@@ -231,6 +235,7 @@ func listTeamsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	teams, err2 := a.GetAllTeams()
 	if err2 != nil {

--- a/cmd/commands/user.go
+++ b/cmd/commands/user.go
@@ -254,12 +254,14 @@ func userActivateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	changeUsersActiveStatus(a, args, true)
+
 	return nil
 }
 
@@ -293,12 +295,14 @@ func userDeactivateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
 
 	changeUsersActiveStatus(a, args, false)
+
 	return nil
 }
 
@@ -307,6 +311,7 @@ func userCreateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	username, erru := command.Flags().GetString("username")
 	if erru != nil || username == "" {
@@ -352,6 +357,7 @@ func userInviteCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Expected at least two arguments. See help text for details.")
@@ -391,6 +397,7 @@ func resetUserPasswordCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) != 2 {
 		return errors.New("Expected two arguments. See help text for details.")
@@ -414,6 +421,7 @@ func updateUserEmailCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	newEmail := args[1]
 
@@ -432,7 +440,7 @@ func updateUserEmailCmdF(command *cobra.Command, args []string) error {
 
 	user.Email = newEmail
 	_, errUpdate := a.UpdateUser(user, true)
-	if err != nil {
+	if errUpdate != nil {
 		return errUpdate
 	}
 
@@ -444,6 +452,7 @@ func resetUserMfaCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -469,6 +478,7 @@ func deleteUserCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -510,6 +520,7 @@ func deleteAllUsersCommandF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) > 0 {
 		return errors.New("Expected zero arguments.")
@@ -536,6 +547,7 @@ func deleteAllUsersCommandF(command *cobra.Command, args []string) error {
 	}
 
 	cmd.CommandPrettyPrintln("All user accounts successfully deleted.")
+
 	return nil
 }
 
@@ -551,6 +563,7 @@ func migrateAuthToLdapCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	fromAuth := args[0]
 	matchField := args[2]
@@ -587,6 +600,7 @@ func migrateAuthToSamlCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	dryRunFlag, _ := command.Flags().GetBool("dryRun")
 	autoFlag, _ := command.Flags().GetBool("auto")
@@ -642,6 +656,7 @@ func verifyUserCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -667,6 +682,7 @@ func searchUserCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")


### PR DESCRIPTION
#### Summary
When running a command sometimes we can have some goroutines running in parallel, with the 
 `a.shutdown` we wait for all routines to finish

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9720


