### PR TITLE
Parse emoji for the html emails

### DIFF
--- a/utils/mail.go
+++ b/utils/mail.go
@@ -230,7 +230,9 @@ func SendMailUsingConfigAdvanced(mimeTo, smtpTo string, from mail.Address, subje
 func SendMail(c *smtp.Client, mimeTo, smtpTo string, from mail.Address, subject, htmlBody string, attachments []*model.FileInfo, mimeHeaders map[string]string, fileBackend FileBackend, date time.Time) *model.AppError {
 	l4g.Debug(T("utils.mail.send_mail.sending.debug"), mimeTo, subject)
 
-	htmlMessage := "\r\n<html><body>" + htmlBody + "</body></html>"
+	htmlBodyParsed := ReplaceTextWithEmoji(htmlBody)
+
+	htmlMessage := "\r\n<html><body>" + htmlBodyParsed + "</body></html>"
 
 	txtBody, err := html2text.FromString(htmlBody)
 	if err != nil {


### PR DESCRIPTION
#### Summary
When sending notification emails and it contains emoji we don't see the emoji image in the HTML email only the text like `:tada:`.

This PR introduces the parse for system emojis in the HTML emails.

For the next near future, introduce the custom emoji if possible.

Example:
Before:
![image](https://user-images.githubusercontent.com/4115580/38874476-7269f1ee-4258-11e8-994d-80e1fcf16063.png)


After:
![image](https://user-images.githubusercontent.com/4115580/38874359-2e7a099c-4258-11e8-9569-5a899df3e316.png)


#### Ticket Link
N/A

#### Checklist
- [ ] Added or updated unit tests (required for all new features) - TBD 



Please let me know if this makes sense. otherwise feel free to close