### PR TITLE
MM-10133 Suppress confusing personal access token message in invalid session error

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -63,7 +63,7 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 		var err *model.AppError
 		session, err = a.createSessionForUserAccessToken(token)
 		if err != nil {
-			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, err.Error(), http.StatusUnauthorized)
+			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, "", http.StatusUnauthorized)
 		}
 	}
 
@@ -280,6 +280,7 @@ func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Sessio
 
 	var user *model.User
 	if result := <-a.Srv.Store.User().Get(token.UserId); result.Err != nil {
+		l4g.Error(result.Err.Error())
 		return nil, result.Err
 	} else {
 		user = result.Data.(*model.User)
@@ -301,6 +302,7 @@ func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Sessio
 	session.SetExpireInDays(model.SESSION_USER_ACCESS_TOKEN_EXPIRY)
 
 	if result := <-a.Srv.Store.Session().Save(session); result.Err != nil {
+		l4g.Error(result.Err.Error())
 		return nil, result.Err
 	} else {
 		session := result.Data.(*model.Session)

--- a/app/session.go
+++ b/app/session.go
@@ -63,7 +63,13 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 		var err *model.AppError
 		session, err = a.createSessionForUserAccessToken(token)
 		if err != nil {
-			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, "", http.StatusUnauthorized)
+			detailedError := ""
+			statusCode := http.StatusUnauthorized
+			if err.Id != "app.user_access_token.invalid_or_missing" {
+				detailedError = err.Error()
+				statusCode = err.StatusCode
+			}
+			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, detailedError, statusCode)
 		}
 	}
 
@@ -280,7 +286,6 @@ func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Sessio
 
 	var user *model.User
 	if result := <-a.Srv.Store.User().Get(token.UserId); result.Err != nil {
-		l4g.Error(result.Err.Error())
 		return nil, result.Err
 	} else {
 		user = result.Data.(*model.User)
@@ -302,7 +307,6 @@ func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Sessio
 	session.SetExpireInDays(model.SESSION_USER_ACCESS_TOKEN_EXPIRY)
 
 	if result := <-a.Srv.Store.Session().Save(session); result.Err != nil {
-		l4g.Error(result.Err.Error())
 		return nil, result.Err
 	} else {
 		session := result.Data.(*model.Session)


### PR DESCRIPTION
#### Summary
Even if personal access tokens were disabled the error message made it look like there was one being used here. The solution is just suppress that unhelpful error message and add logging for any errors that we would need to worry about.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10133