### PR TITLE
MM-10122: Adds a mention for added-to-channel messages even when 'use…

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1140,10 +1140,10 @@ func (a *App) PostAddToChannelMessage(user *model.User, addedUser *model.User, c
 		UserId:    user.Id,
 		RootId:    postRootId,
 		Props: model.StringInterface{
-			"userId":        user.Id,
-			"username":      user.Username,
-			"addedUserId":   addedUser.Id,
-			"addedUsername": addedUser.Username,
+			"userId":                       user.Id,
+			"username":                     user.Username,
+			model.POST_PROPS_ADDED_USER_ID: addedUser.Id,
+			"addedUsername":                addedUser.Username,
 		},
 	}
 
@@ -1162,10 +1162,10 @@ func (a *App) postAddToTeamMessage(user *model.User, addedUser *model.User, chan
 		UserId:    user.Id,
 		RootId:    postRootId,
 		Props: model.StringInterface{
-			"userId":        user.Id,
-			"username":      user.Username,
-			"addedUserId":   addedUser.Id,
-			"addedUsername": addedUser.Username,
+			"userId":                       user.Id,
+			"username":                     user.Username,
+			model.POST_PROPS_ADDED_USER_ID: addedUser.Id,
+			"addedUsername":                addedUser.Username,
 		},
 	}
 

--- a/app/notification.go
+++ b/app/notification.go
@@ -89,6 +89,17 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 		keywords := a.GetMentionKeywordsInChannel(profileMap, post.Type != model.POST_HEADER_CHANGE && post.Type != model.POST_PURPOSE_CHANGE)
 
 		m := GetExplicitMentions(post.Message, keywords)
+
+		// Add an implicit mention when a user is added to a channel
+		// even if the user has set 'username mentions' to false in account settings.
+		if post.Type == model.POST_ADD_TO_CHANNEL {
+			val := post.Props[model.POST_PROPS_ADDED_USER_ID]
+			if val != nil {
+				uid := val.(string)
+				m.MentionedUserIds[uid] = true
+			}
+		}
+
 		mentionedUserIds, hereNotification, channelNotification, allNotification = m.MentionedUserIds, m.HereMentioned, m.ChannelMentioned, m.AllMentioned
 
 		// get users that have comment thread mentions enabled

--- a/model/post.go
+++ b/model/post.go
@@ -49,6 +49,7 @@ const (
 	POST_PROPS_MAX_USER_RUNES   = POST_PROPS_MAX_RUNES - 400 // Leave some room for system / pre-save modifications
 	POST_CUSTOM_TYPE_PREFIX     = "custom_"
 	PROPS_ADD_CHANNEL_MEMBER    = "add_channel_member"
+	POST_PROPS_ADDED_USER_ID    = "addedUserId"
 )
 
 type Post struct {


### PR DESCRIPTION
…rname mentions' are disabled.

#### Summary
Adds a mention when a user is added to a public or private channel even if 'username mentions' is disabled in account settings.

#### Ticket Link
[MM-10122](https://mattermost.atlassian.net/browse/MM-10122)

#### Checklist
n/a