### PR TITLE
Fix panics caused by race in notification code

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -179,6 +179,10 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 
 	if a.Config().EmailSettings.SendEmailNotifications {
 		for _, id := range mentionedUsersList {
+			if profileMap[id] == nil {
+				continue
+			}
+
 			userAllowsEmails := profileMap[id].NotifyProps[model.EMAIL_NOTIFY_PROP] != "false"
 			if channelEmail, ok := channelMemberNotifyPropsMap[id][model.EMAIL_NOTIFY_PROP]; ok {
 				if channelEmail != model.CHANNEL_NOTIFY_DEFAULT {
@@ -279,6 +283,10 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 
 	if sendPushNotifications {
 		for _, id := range mentionedUsersList {
+			if profileMap[id] == nil {
+				continue
+			}
+
 			var status *model.Status
 			var err *model.AppError
 			if status, err = a.GetStatus(id); err != nil {
@@ -291,6 +299,10 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 		}
 
 		for _, id := range allActivityPushUserIds {
+			if profileMap[id] == nil {
+				continue
+			}
+
 			if _, ok := mentionedUserIds[id]; !ok {
 				var status *model.Status
 				var err *model.AppError

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -23,6 +23,8 @@ func TestSendNotifications(t *testing.T) {
 		UserId:    th.BasicUser.Id,
 		ChannelId: th.BasicChannel.Id,
 		Message:   "@" + th.BasicUser2.Username,
+		Type:      model.POST_ADD_TO_CHANNEL,
+		Props:     map[string]interface{}{model.POST_PROPS_ADDED_USER_ID: "junk"},
 	}, true)
 
 	if err != nil {


### PR DESCRIPTION
#### Summary
There exists a race where if a user was removed from a channel while they were getting notified of an action in that channel, we might not have their profile in `profileMap` but would continue to assume that we did. I believe this race existed without #8648 but it at least made it much easier to hit 