### PR TITLE
[GH-7775] Add api to convert a channel from public to private and restrict that to system_admin

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -27,6 +27,7 @@ func (api *API) InitChannel() {
 	api.BaseRoutes.Channel.Handle("", api.ApiSessionRequired(getChannel)).Methods("GET")
 	api.BaseRoutes.Channel.Handle("", api.ApiSessionRequired(updateChannel)).Methods("PUT")
 	api.BaseRoutes.Channel.Handle("/patch", api.ApiSessionRequired(patchChannel)).Methods("PUT")
+	api.BaseRoutes.Channel.Handle("/convert", api.ApiSessionRequired(convertChannelToPrivate)).Methods("POST")
 	api.BaseRoutes.Channel.Handle("/restore", api.ApiSessionRequired(restoreChannel)).Methods("POST")
 	api.BaseRoutes.Channel.Handle("", api.ApiSessionRequired(deleteChannel)).Methods("DELETE")
 	api.BaseRoutes.Channel.Handle("/stats", api.ApiSessionRequired(getChannelStats)).Methods("GET")
@@ -119,7 +120,6 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	oldChannel.Purpose = channel.Purpose
 
 	oldChannelDisplayName := oldChannel.DisplayName
-	oldChannelType := oldChannel.Type
 
 	if len(channel.DisplayName) > 0 {
 		oldChannel.DisplayName = channel.DisplayName
@@ -143,14 +143,48 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		if oldChannelType == model.CHANNEL_OPEN && channel.Type == model.CHANNEL_PRIVATE {
-			if err := c.App.PostConvertChannelToPrivate(c.Session.UserId, channel); err != nil {
-				l4g.Error(err.Error())
-			}
-		}
-
 		c.LogAudit("name=" + channel.Name)
 		w.Write([]byte(oldChannel.ToJson()))
+	}
+}
+
+func convertChannelToPrivate(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	oldPublicChannel, err := c.App.GetChannel(c.Params.ChannelId)
+	if err != nil {
+		c.Err = err
+		return
+	} else if oldPublicChannel.Type == model.CHANNEL_PRIVATE {
+		c.Err = model.NewAppError("convertChannelToPrivate", "api.channel.convert_channel_to_private.private_channel_error", nil, "", http.StatusBadRequest)
+		return
+	} else if oldPublicChannel.Name == model.DEFAULT_CHANNEL {
+		c.Err = model.NewAppError("convertChannelToPrivate", "api.channel.convert_channel_to_private.default_channel_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	var user *model.User
+	if user, err = c.App.GetUser(c.Session.UserId); err != nil {
+		c.Err = err
+		return
+	}
+
+	oldPublicChannel.Type = model.CHANNEL_PRIVATE
+
+	if rchannel, err := c.App.UpdateChannelPrivacy(oldPublicChannel, user); err != nil {
+		c.Err = err
+		return
+	} else {
+		c.LogAudit("name=" + rchannel.Name)
+		w.Write([]byte(rchannel.ToJson()))
 	}
 }
 

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -897,6 +897,46 @@ func TestDeleteChannel(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 }
 
+func TestConvertChannelToPrivate(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+
+	defaultChannel, _ := th.App.GetChannelByName(model.DEFAULT_CHANNEL, th.BasicTeam.Id)
+	_, resp := Client.ConvertChannelToPrivate(defaultChannel.Id)
+	CheckForbiddenStatus(t, resp)
+
+	privateChannel := th.CreatePrivateChannel()
+	_, resp = Client.ConvertChannelToPrivate(privateChannel.Id)
+	CheckForbiddenStatus(t, resp)
+
+	publicChannel := th.CreatePublicChannel()
+	_, resp = Client.ConvertChannelToPrivate(publicChannel.Id)
+	CheckForbiddenStatus(t, resp)
+
+	th.LoginTeamAdmin()
+	_, resp = Client.ConvertChannelToPrivate(publicChannel.Id)
+	CheckForbiddenStatus(t, resp)
+
+	rchannel, resp := th.SystemAdminClient.ConvertChannelToPrivate(privateChannel.Id)
+	CheckBadRequestStatus(t, resp)
+	if rchannel != nil {
+		t.Fatal("should not return a channel")
+	}
+
+	rchannel, resp = th.SystemAdminClient.ConvertChannelToPrivate(defaultChannel.Id)
+	CheckBadRequestStatus(t, resp)
+	if rchannel != nil {
+		t.Fatal("should not return a channel")
+	}
+
+	rchannel, resp = th.SystemAdminClient.ConvertChannelToPrivate(publicChannel.Id)
+	CheckOKStatus(t, resp)
+	if rchannel.Type != model.CHANNEL_PRIVATE {
+		t.Fatal("channel should be converted from public to private")
+	}
+}
+
 func TestRestoreChannel(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()

--- a/app/channel.go
+++ b/app/channel.go
@@ -817,34 +817,6 @@ func (a *App) PostUpdateChannelDisplayNameMessage(userId string, channel *model.
 	return nil
 }
 
-func (a *App) PostConvertChannelToPrivate(userId string, channel *model.Channel) *model.AppError {
-	uc := a.Srv.Store.User().Get(userId)
-
-	if uresult := <-uc; uresult.Err != nil {
-		return model.NewAppError("PostConvertChannelToPrivate", "api.channel.post_convert_channel_to_private.retrieve_user.error", nil, uresult.Err.Error(), http.StatusBadRequest)
-	} else {
-		user := uresult.Data.(*model.User)
-
-		message := fmt.Sprintf(utils.T("api.channel.post_convert_channel_to_private.updated_from"), user.Username)
-
-		post := &model.Post{
-			ChannelId: channel.Id,
-			Message:   message,
-			Type:      model.POST_CONVERT_CHANNEL,
-			UserId:    userId,
-			Props: model.StringInterface{
-				"username": user.Username,
-			},
-		}
-
-		if _, err := a.CreatePost(post, channel, false); err != nil {
-			return model.NewAppError("PostConvertChannelToPrivate", "api.channel.post_convert_channel_to_private.create_post.error", nil, err.Error(), http.StatusInternalServerError)
-		}
-	}
-
-	return nil
-}
-
 func (a *App) GetChannel(channelId string) (*model.Channel, *model.AppError) {
 	if result := <-a.Srv.Store.Channel().Get(channelId, true); result.Err != nil && result.Err.Id == "store.sql_channel.get.existing.app_error" {
 		result.Err.StatusCode = http.StatusNotFound

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -216,6 +216,14 @@
     "translation": "This channel has been converted to a Private Channel."
   },
   {
+    "id": "api.channel.convert_channel_to_private.default_channel_error",
+    "translation": "This default channel cannot be converted into a private channel."
+  },
+  {
+    "id": "api.channel.convert_channel_to_private.private_channel_error",
+    "translation": "The channel requested to convert is already a private channel."
+  },
+  {
     "id": "api.channel.create_channel.direct_channel.app_error",
     "translation": "Must use createDirectChannel API service for direct message channel creation"
   },
@@ -330,18 +338,6 @@
   {
     "id": "api.channel.leave.left",
     "translation": "%v left the channel."
-  },
-  {
-    "id": "api.channel.post_convert_channel_to_private.create_post.error",
-    "translation": "Failed to post channel conversion to private message"
-  },
-  {
-    "id": "api.channel.post_convert_channel_to_private.retrieve_user.error",
-    "translation": "Failed to retrieve user while converting the channel from public to private"
-  },
-  {
-    "id": "api.channel.post_convert_channel_to_private.updated_from",
-    "translation": "%s converted the channel from public to private"
   },
   {
     "id": "api.channel.post_update_channel_displayname_message_and_forget.create_post.error",

--- a/model/client4.go
+++ b/model/client4.go
@@ -1491,6 +1491,16 @@ func (c *Client4) PatchChannel(channelId string, patch *ChannelPatch) (*Channel,
 	}
 }
 
+// ConvertChannelToPrivate converts public to private channel.
+func (c *Client4) ConvertChannelToPrivate(channelId string) (*Channel, *Response) {
+	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/convert", ""); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return ChannelFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // RestoreChannel restores a previously deleted channel. Any missing fields are not updated.
 func (c *Client4) RestoreChannel(channelId string) (*Channel, *Response) {
 	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/restore", ""); err != nil {


### PR DESCRIPTION
#### Summary
Reference: as commented at https://pre-release.mattermost.com/core/pl/6idfy8buebgaibcd7ymkhzqfrc

- Add APIv4 to convert a channel from public to private and restrict that to system_admin (not added to APIv3)
- re: posting a message after channel conversion - reverted https://github.com/mattermost/mattermost-server/pull/8501 in favor of existing [postChannelPrivacyMessage](https://github.com/mattermost/mattermost-server/blob/master/app/channel.go#L373) which is being used in CMD 

#### Ticket Link
GitHub issue: https://github.com/mattermost/mattermost-server/issues/7775

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs) - to follow
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates

