### PR TITLE
MM-10183: Adds channel scheme API endpoint.

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -16,6 +16,7 @@ func (api *API) InitChannel() {
 	api.BaseRoutes.Channels.Handle("/direct", api.ApiSessionRequired(createDirectChannel)).Methods("POST")
 	api.BaseRoutes.Channels.Handle("/group", api.ApiSessionRequired(createGroupChannel)).Methods("POST")
 	api.BaseRoutes.Channels.Handle("/members/{user_id:[A-Za-z0-9]+}/view", api.ApiSessionRequired(viewChannel)).Methods("POST")
+	api.BaseRoutes.Channels.Handle("/{channel_id:[A-Za-z0-9]+}/schemes/{scheme_id:[A-Za-z0-9]+}", api.ApiSessionRequired(updateChannelScheme)).Methods("PUT")
 
 	api.BaseRoutes.ChannelsForTeam.Handle("", api.ApiSessionRequired(getPublicChannelsForTeam)).Methods("GET")
 	api.BaseRoutes.ChannelsForTeam.Handle("/deleted", api.ApiSessionRequired(getDeletedChannelsForTeam)).Methods("GET")
@@ -946,6 +947,55 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.LogAudit("name=" + channel.Name + " user_id=" + c.Params.UserId)
+
+	ReturnStatusOK(w)
+}
+
+func updateChannelScheme(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	c.RequireSchemeId()
+	if c.Err != nil {
+		return
+	}
+
+	if c.App.License() == nil {
+		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.team.update_channel_scheme.license.error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	scheme, err := c.App.GetScheme(c.Params.SchemeId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	if scheme.Scope != model.SCHEME_SCOPE_CHANNEL {
+		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.team.update_channel_scheme.scheme_scope.error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	channel, err := c.App.GetChannel(c.Params.ChannelId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	channel.SchemeId = &scheme.Id
+
+	_, err = c.App.UpdateChannelScheme(channel)
+	if err != nil {
+		c.Err = err
+		return
+	}
 
 	ReturnStatusOK(w)
 }

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -963,7 +963,7 @@ func updateChannelScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.App.License() == nil {
-		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.team.update_channel_scheme.license.error", nil, "", http.StatusNotImplemented)
+		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.channel.update_channel_scheme.license.error", nil, "", http.StatusNotImplemented)
 		return
 	}
 
@@ -979,7 +979,7 @@ func updateChannelScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if scheme.Scope != model.SCHEME_SCOPE_CHANNEL {
-		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.team.update_channel_scheme.scheme_scope.error", nil, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.channel.update_channel_scheme.scheme_scope.error", nil, "", http.StatusBadRequest)
 		return
 	}
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -361,15 +361,14 @@ func (a *App) UpdateChannelScheme(channel *model.Channel) (*model.Channel, *mode
 		return nil, err
 	}
 
-	a.InvalidateCacheForChannel(channel)
-
 	oldChannel.SchemeId = channel.SchemeId
 
-	if result := <-a.Srv.Store.Channel().Update(oldChannel); result.Err != nil {
-		return nil, result.Err
+	newChannel, err := a.UpdateChannel(oldChannel)
+	if err != nil {
+		return nil, err
 	}
 
-	return oldChannel, nil
+	return newChannel, nil
 }
 
 func (a *App) UpdateChannelPrivacy(oldChannel *model.Channel, user *model.User) (*model.Channel, *model.AppError) {

--- a/app/channel.go
+++ b/app/channel.go
@@ -361,6 +361,8 @@ func (a *App) UpdateChannelScheme(channel *model.Channel) (*model.Channel, *mode
 		return nil, err
 	}
 
+	a.InvalidateCacheForChannel(channel)
+
 	oldChannel.SchemeId = channel.SchemeId
 
 	if result := <-a.Srv.Store.Channel().Update(oldChannel); result.Err != nil {

--- a/app/channel.go
+++ b/app/channel.go
@@ -354,6 +354,22 @@ func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppE
 	}
 }
 
+func (a *App) UpdateChannelScheme(channel *model.Channel) (*model.Channel, *model.AppError) {
+	var oldChannel *model.Channel
+	var err *model.AppError
+	if oldChannel, err = a.GetChannel(channel.Id); err != nil {
+		return nil, err
+	}
+
+	oldChannel.SchemeId = channel.SchemeId
+
+	if result := <-a.Srv.Store.Channel().Update(oldChannel); result.Err != nil {
+		return nil, result.Err
+	}
+
+	return oldChannel, nil
+}
+
 func (a *App) UpdateChannelPrivacy(oldChannel *model.Channel, user *model.User) (*model.Channel, *model.AppError) {
 	if channel, err := a.UpdateChannel(oldChannel); err != nil {
 		return channel, err

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -381,3 +381,21 @@ func TestAddChannelMemberNoUserRequestor(t *testing.T) {
 		assert.Equal(t, user.Username, post.Props["username"])
 	}
 }
+
+func TestAppUpdateChannelScheme(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	channel := th.BasicChannel
+	mockID := model.NewString("x")
+	channel.SchemeId = mockID
+
+	updatedChannel, err := th.App.UpdateChannelScheme(channel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updatedChannel.SchemeId != mockID {
+		t.Fatal("Wrong Channel SchemeId")
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6695,6 +6695,14 @@
     "translation": "The provided role is managed by a Scheme and therefore cannot be applied directly to a Team Member"
   },
   {
+    "id": "api.channel.update_channel_scheme.license.error",
+    "translation": "License does not support updating a channel's scheme"
+  },
+  {
+    "id": "api.channel.update_channel_scheme.scheme_scope.error",
+    "translation": "Unable to set the scheme to the channel because the supplied scheme is not a channel scheme."
+  },
+  {
     "id": "store.sql_channel.get_by_scheme.app_error",
     "translation": "Unable to get the channels for the provided scheme"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -326,6 +326,10 @@ func (c *Client4) GetTimezonesRoute() string {
 	return fmt.Sprintf(c.GetSystemRoute() + "/timezones")
 }
 
+func (c *Client4) GetChannelSchemeRoute(channelId, schemeId string) string {
+	return fmt.Sprintf(c.GetChannelsRoute()+"/%v/schemes/%v", channelId, schemeId)
+}
+
 func (c *Client4) DoApiGet(url string, etag string) (*http.Response, *AppError) {
 	return c.DoApiRequest(http.MethodGet, c.ApiUrl+url, "", etag)
 }
@@ -3489,5 +3493,15 @@ func (c *Client4) GetTeamIcon(teamId, etag string) ([]byte, *Response) {
 		} else {
 			return data, BuildResponse(r)
 		}
+	}
+}
+
+// UpdateChannelScheme will update a channel's scheme.
+func (c *Client4) UpdateChannelScheme(channelId, schemeId string) (bool, *Response) {
+	if r, err := c.DoApiPut(c.GetChannelSchemeRoute(channelId, schemeId), ""); err != nil {
+		return false, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return CheckStatusOK(r), BuildResponse(r)
 	}
 }


### PR DESCRIPTION
#### Summary
Adds API endpoint to set a channel's scheme. 

This is awaiting https://github.com/mattermost/mattermost-server/pull/8615.

#### Ticket Link
[MM-10183](https://mattermost.atlassian.net/browse/MM-10183)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added [API documentation](https://github.com/mattermost/mattermost-api-reference/pull/361)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
