### PR TITLE
Add localized timestamp support for email notification

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -497,6 +497,14 @@ func (u *User) IsSAMLUser() bool {
 	return u.AuthService == USER_AUTH_SERVICE_SAML
 }
 
+func (u *User) GetPreferredTimezone() string {
+	if u.Timezone["useAutomaticTimezone"] == "true" {
+		return u.Timezone["automaticTimezone"]
+	}
+
+	return u.Timezone["manualTimezone"]
+}
+
 // UserFromJson will decode the input and return a User
 func UserFromJson(data io.Reader) *User {
 	var user *User


### PR DESCRIPTION
#### Summary
Add localized timestamp support for email notifications
Also, added support to respect `use_military_time` preference

#### Screenshots
<img width="316" alt="screen shot 2018-04-24 at 5 40 43 pm" src="https://user-images.githubusercontent.com/6182543/39257045-81b1e2a2-487e-11e8-80dc-ff45a01eacbe.png">
<img width="294" alt="screen shot 2018-04-24 at 5 33 39 pm" src="https://user-images.githubusercontent.com/6182543/39257046-81c9e3ca-487e-11e8-8e9a-3cb8f6116d9b.png">

* User timezone set to **America/Denver** . 
* Time from screenshots: 3pm Denver vs 5pm NewYork

**Direct Message**
**12 Hour Format**
<img width="694" alt="screen shot 2018-04-24 at 5 32 45 pm" src="https://user-images.githubusercontent.com/6182543/39256713-998922f6-487d-11e8-91d6-02a5a04f375f.png">

**24 Hour Format**
<img width="683" alt="screen shot 2018-04-24 at 5 33 59 pm" src="https://user-images.githubusercontent.com/6182543/39256711-994cd4fe-487d-11e8-8006-062d9c5b0ece.png">

**Group Message**
<img width="692" alt="screen shot 2018-04-24 at 5 32 53 pm" src="https://user-images.githubusercontent.com/6182543/39256712-99682088-487d-11e8-8e7b-6a0a5126c209.png">
**Public Channel**
<img width="684" alt="screen shot 2018-04-24 at 5 36 49 pm" src="https://user-images.githubusercontent.com/6182543/39256710-9925c76a-487d-11e8-92cd-784d3a2d8473.png">
**Private Channel**
<img width="684" alt="screen shot 2018-04-24 at 5 36 59 pm" src="https://user-images.githubusercontent.com/6182543/39256709-990fb920-487d-11e8-93f6-9319837e5472.png">