### PR TITLE
MM-10182 & MM-10183: Adds channel scheme and team scheme API endpoint.

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -15,7 +15,7 @@ func (api *API) InitChannel() {
 	api.BaseRoutes.Channels.Handle("/direct", api.ApiSessionRequired(createDirectChannel)).Methods("POST")
 	api.BaseRoutes.Channels.Handle("/group", api.ApiSessionRequired(createGroupChannel)).Methods("POST")
 	api.BaseRoutes.Channels.Handle("/members/{user_id:[A-Za-z0-9]+}/view", api.ApiSessionRequired(viewChannel)).Methods("POST")
-	api.BaseRoutes.Channels.Handle("/{channel_id:[A-Za-z0-9]+}/schemes", api.ApiSessionRequired(updateChannelScheme)).Methods("PUT")
+	api.BaseRoutes.Channels.Handle("/{channel_id:[A-Za-z0-9]+}/scheme", api.ApiSessionRequired(updateChannelScheme)).Methods("PUT")
 
 	api.BaseRoutes.ChannelsForTeam.Handle("", api.ApiSessionRequired(getPublicChannelsForTeam)).Methods("GET")
 	api.BaseRoutes.ChannelsForTeam.Handle("/deleted", api.ApiSessionRequired(getDeletedChannelsForTeam)).Methods("GET")

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -15,6 +15,7 @@ func (api *API) InitChannel() {
 	api.BaseRoutes.Channels.Handle("/direct", api.ApiSessionRequired(createDirectChannel)).Methods("POST")
 	api.BaseRoutes.Channels.Handle("/group", api.ApiSessionRequired(createGroupChannel)).Methods("POST")
 	api.BaseRoutes.Channels.Handle("/members/{user_id:[A-Za-z0-9]+}/view", api.ApiSessionRequired(viewChannel)).Methods("POST")
+	api.BaseRoutes.Channels.Handle("/{channel_id:[A-Za-z0-9]+}/schemes", api.ApiSessionRequired(updateChannelScheme)).Methods("PUT")
 
 	api.BaseRoutes.ChannelsForTeam.Handle("", api.ApiSessionRequired(getPublicChannelsForTeam)).Methods("GET")
 	api.BaseRoutes.ChannelsForTeam.Handle("/deleted", api.ApiSessionRequired(getDeletedChannelsForTeam)).Methods("GET")
@@ -945,6 +946,56 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.LogAudit("name=" + channel.Name + " user_id=" + c.Params.UserId)
+
+	ReturnStatusOK(w)
+}
+
+func updateChannelScheme(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	schemeID := model.SchemeIDFromJson(r.Body)
+	if schemeID == nil || len(*schemeID) != 26 {
+		c.SetInvalidParam("scheme_id")
+		return
+	}
+
+	if c.App.License() == nil {
+		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.channel.update_channel_scheme.license.error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if !c.App.SessionHasPermissionToChannel(c.Session, c.Params.ChannelId, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	scheme, err := c.App.GetScheme(*schemeID)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	if scheme.Scope != model.SCHEME_SCOPE_CHANNEL {
+		c.Err = model.NewAppError("Api4.UpdateChannelScheme", "api.channel.update_channel_scheme.scheme_scope.error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	channel, err := c.App.GetChannel(c.Params.ChannelId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	channel.SchemeId = &scheme.Id
+
+	_, err = c.App.UpdateChannelScheme(channel)
+	if err != nil {
+		c.Err = err
+		return
+	}
 
 	ReturnStatusOK(w)
 }

--- a/api4/team.go
+++ b/api4/team.go
@@ -20,7 +20,7 @@ const (
 func (api *API) InitTeam() {
 	api.BaseRoutes.Teams.Handle("", api.ApiSessionRequired(createTeam)).Methods("POST")
 	api.BaseRoutes.Teams.Handle("", api.ApiSessionRequired(getAllTeams)).Methods("GET")
-	api.BaseRoutes.Teams.Handle("/{team_id:[A-Za-z0-9]+}/schemes", api.ApiSessionRequired(updateTeamScheme)).Methods("PUT")
+	api.BaseRoutes.Teams.Handle("/{team_id:[A-Za-z0-9]+}/scheme", api.ApiSessionRequired(updateTeamScheme)).Methods("PUT")
 	api.BaseRoutes.Teams.Handle("/search", api.ApiSessionRequired(searchTeams)).Methods("POST")
 	api.BaseRoutes.TeamsForUser.Handle("", api.ApiSessionRequired(getTeamsForUser)).Methods("GET")
 	api.BaseRoutes.TeamsForUser.Handle("/unread", api.ApiSessionRequired(getTeamsUnreadForUser)).Methods("GET")

--- a/api4/team.go
+++ b/api4/team.go
@@ -20,6 +20,7 @@ const (
 func (api *API) InitTeam() {
 	api.BaseRoutes.Teams.Handle("", api.ApiSessionRequired(createTeam)).Methods("POST")
 	api.BaseRoutes.Teams.Handle("", api.ApiSessionRequired(getAllTeams)).Methods("GET")
+	api.BaseRoutes.Teams.Handle("/{team_id:[A-Za-z0-9]+}/schemes", api.ApiSessionRequired(updateTeamScheme)).Methods("PUT")
 	api.BaseRoutes.Teams.Handle("/search", api.ApiSessionRequired(searchTeams)).Methods("POST")
 	api.BaseRoutes.TeamsForUser.Handle("", api.ApiSessionRequired(getTeamsForUser)).Methods("GET")
 	api.BaseRoutes.TeamsForUser.Handle("/unread", api.ApiSessionRequired(getTeamsUnreadForUser)).Methods("GET")
@@ -831,5 +832,55 @@ func removeTeamIcon(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	c.LogAudit("")
+	ReturnStatusOK(w)
+}
+
+func updateTeamScheme(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireTeamId()
+	if c.Err != nil {
+		return
+	}
+
+	schemeID := model.SchemeIDFromJson(r.Body)
+	if schemeID == nil || len(*schemeID) != 26 {
+		c.SetInvalidParam("scheme_id")
+		return
+	}
+
+	if c.App.License() == nil {
+		c.Err = model.NewAppError("Api4.UpdateTeamScheme", "api.team.update_team_scheme.license.error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if !c.App.SessionHasPermissionToTeam(c.Session, c.Params.TeamId, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	scheme, err := c.App.GetScheme(*schemeID)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	if scheme.Scope != model.SCHEME_SCOPE_TEAM {
+		c.Err = model.NewAppError("Api4.UpdateTeamScheme", "api.team.update_team_scheme.scheme_scope.error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	team, err := c.App.GetTeam(c.Params.TeamId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	team.SchemeId = &scheme.Id
+
+	_, err = c.App.UpdateTeamScheme(team)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
 	ReturnStatusOK(w)
 }

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2052,3 +2052,67 @@ func TestRemoveTeamIcon(t *testing.T) {
 	_, resp = Client.RemoveTeamIcon(team.Id)
 	CheckForbiddenStatus(t, resp)
 }
+
+func TestUpdateTeamScheme(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+
+	th.App.SetLicense(model.NewTestLicense(""))
+
+	team := &model.Team{
+		DisplayName:     "Name",
+		Description:     "Some description",
+		CompanyName:     "Some company name",
+		AllowOpenInvite: false,
+		InviteId:        "inviteid0",
+		Name:            "z-z-" + model.NewId() + "a",
+		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
+		Type:            model.TEAM_OPEN,
+	}
+	team, _ = th.SystemAdminClient.CreateTeam(team)
+
+	teamScheme := &model.Scheme{
+		Name:        "Name",
+		Description: "Some description",
+		Scope:       model.SCHEME_SCOPE_TEAM,
+	}
+	teamScheme, _ = th.SystemAdminClient.CreateScheme(teamScheme)
+	channelScheme := &model.Scheme{
+		Name:        "Name",
+		Description: "Some description",
+		Scope:       model.SCHEME_SCOPE_CHANNEL,
+	}
+	channelScheme, _ = th.SystemAdminClient.CreateScheme(channelScheme)
+
+	// Test the setup/base case.
+	_, resp := th.SystemAdminClient.UpdateTeamScheme(team.Id, teamScheme.Id)
+	CheckNoError(t, resp)
+
+	// Test various invalid team and scheme id combinations.
+	_, resp = th.SystemAdminClient.UpdateTeamScheme(team.Id, "x")
+	CheckBadRequestStatus(t, resp)
+	_, resp = th.SystemAdminClient.UpdateTeamScheme("x", teamScheme.Id)
+	CheckBadRequestStatus(t, resp)
+	_, resp = th.SystemAdminClient.UpdateTeamScheme("x", "x")
+	CheckBadRequestStatus(t, resp)
+
+	// Test that permissions are required.
+	_, resp = th.Client.UpdateTeamScheme(team.Id, teamScheme.Id)
+	CheckForbiddenStatus(t, resp)
+
+	// Test that a license is requried.
+	th.App.SetLicense(nil)
+	_, resp = th.SystemAdminClient.UpdateTeamScheme(team.Id, teamScheme.Id)
+	CheckNotImplementedStatus(t, resp)
+	th.App.SetLicense(model.NewTestLicense(""))
+
+	// Test an invalid scheme scope.
+	_, resp = th.SystemAdminClient.UpdateTeamScheme(team.Id, channelScheme.Id)
+	fmt.Printf("resp: %+v\n", resp)
+	CheckBadRequestStatus(t, resp)
+
+	// Test that an unauthenticated user gets rejected.
+	th.SystemAdminClient.Logout()
+	_, resp = th.SystemAdminClient.UpdateTeamScheme(team.Id, teamScheme.Id)
+	CheckUnauthorizedStatus(t, resp)
+}

--- a/app/channel.go
+++ b/app/channel.go
@@ -354,6 +354,23 @@ func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppE
 	}
 }
 
+func (a *App) UpdateChannelScheme(channel *model.Channel) (*model.Channel, *model.AppError) {
+	var oldChannel *model.Channel
+	var err *model.AppError
+	if oldChannel, err = a.GetChannel(channel.Id); err != nil {
+		return nil, err
+	}
+
+	oldChannel.SchemeId = channel.SchemeId
+
+	newChannel, err := a.UpdateChannel(oldChannel)
+	if err != nil {
+		return nil, err
+	}
+
+	return newChannel, nil
+}
+
 func (a *App) UpdateChannelPrivacy(oldChannel *model.Channel, user *model.User) (*model.Channel, *model.AppError) {
 	if channel, err := a.UpdateChannel(oldChannel); err != nil {
 		return channel, err

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -381,3 +381,21 @@ func TestAddChannelMemberNoUserRequestor(t *testing.T) {
 		assert.Equal(t, user.Username, post.Props["username"])
 	}
 }
+
+func TestAppUpdateChannelScheme(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	channel := th.BasicChannel
+	mockID := model.NewString("x")
+	channel.SchemeId = mockID
+
+	updatedChannel, err := th.App.UpdateChannelScheme(channel)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updatedChannel.SchemeId != mockID {
+		t.Fatal("Wrong Channel SchemeId")
+	}
+}

--- a/app/team.go
+++ b/app/team.go
@@ -114,6 +114,24 @@ func (a *App) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
 	return oldTeam, nil
 }
 
+func (a *App) UpdateTeamScheme(team *model.Team) (*model.Team, *model.AppError) {
+	var oldTeam *model.Team
+	var err *model.AppError
+	if oldTeam, err = a.GetTeam(team.Id); err != nil {
+		return nil, err
+	}
+
+	oldTeam.SchemeId = team.SchemeId
+
+	if result := <-a.Srv.Store.Team().Update(oldTeam); result.Err != nil {
+		return nil, result.Err
+	}
+
+	a.sendTeamEvent(oldTeam, model.WEBSOCKET_EVENT_UPDATE_TEAM)
+
+	return oldTeam, nil
+}
+
 func (a *App) PatchTeam(teamId string, patch *model.TeamPatch) (*model.Team, *model.AppError) {
 	team, err := a.GetTeam(teamId)
 	if err != nil {

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -559,3 +559,21 @@ func TestJoinUserToTeam(t *testing.T) {
 		}
 	})
 }
+
+func TestAppUpdateTeamScheme(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	team := th.BasicTeam
+	mockID := model.NewString("x")
+	team.SchemeId = mockID
+
+	updatedTeam, err := th.App.UpdateTeamScheme(th.BasicTeam)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updatedTeam.SchemeId != mockID {
+		t.Fatal("Wrong Team SchemeId")
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2507,6 +2507,14 @@
     "translation": "You do not have the appropriate permissions"
   },
   {
+    "id": "api.team.update_team_scheme.license.error",
+    "translation": "License does not support updating a team's scheme"
+  },
+  {
+    "id": "api.team.update_team_scheme.scheme_scope.error",
+    "translation": "Unable to set the scheme to the team because the supplied scheme is not a team scheme."
+  },
+  {
     "id": "api.templates.channel_name.group",
     "translation": "Group Message"
   },
@@ -6693,6 +6701,14 @@
   {
     "id": "api.channel.update_team_member_roles.scheme_role.app_error",
     "translation": "The provided role is managed by a Scheme and therefore cannot be applied directly to a Team Member"
+  },
+  {
+    "id": "api.channel.update_channel_scheme.license.error",
+    "translation": "License does not support updating a channel's scheme"
+  },
+  {
+    "id": "api.channel.update_channel_scheme.scheme_scope.error",
+    "translation": "Unable to set the scheme to the channel because the supplied scheme is not a channel scheme."
   },
   {
     "id": "store.sql_channel.get_by_scheme.app_error",

--- a/model/client4.go
+++ b/model/client4.go
@@ -327,11 +327,11 @@ func (c *Client4) GetTimezonesRoute() string {
 }
 
 func (c *Client4) GetChannelSchemeRoute(channelId string) string {
-	return fmt.Sprintf(c.GetChannelsRoute()+"/%v/schemes", channelId)
+	return fmt.Sprintf(c.GetChannelsRoute()+"/%v/scheme", channelId)
 }
 
 func (c *Client4) GetTeamSchemeRoute(teamId string) string {
-	return fmt.Sprintf(c.GetTeamsRoute()+"/%v/schemes", teamId)
+	return fmt.Sprintf(c.GetTeamsRoute()+"/%v/scheme", teamId)
 }
 
 func (c *Client4) DoApiGet(url string, etag string) (*http.Response, *AppError) {

--- a/model/client4.go
+++ b/model/client4.go
@@ -3514,59 +3514,6 @@ func (c *Client4) DeactivatePlugin(id string) (bool, *Response) {
 	}
 }
 
-// SetTeamIcon sets team icon of the team
-func (c *Client4) SetTeamIcon(teamId string, data []byte) (bool, *Response) {
-
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-
-	if part, err := writer.CreateFormFile("image", "teamIcon.png"); err != nil {
-		return false, &Response{Error: NewAppError("SetTeamIcon", "model.client.set_team_icon.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
-		return false, &Response{Error: NewAppError("SetTeamIcon", "model.client.set_team_icon.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	}
-
-	if err := writer.Close(); err != nil {
-		return false, &Response{Error: NewAppError("SetTeamIcon", "model.client.set_team_icon.writer.app_error", nil, err.Error(), http.StatusBadRequest)}
-	}
-
-	rq, _ := http.NewRequest("POST", c.ApiUrl+c.GetTeamRoute(teamId)+"/image", bytes.NewReader(body.Bytes()))
-	rq.Header.Set("Content-Type", writer.FormDataContentType())
-	rq.Close = true
-
-	if len(c.AuthToken) > 0 {
-		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
-	}
-
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
-		// set to http.StatusForbidden(403)
-		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetTeamRoute(teamId)+"/image", "model.client.connecting.app_error", nil, err.Error(), 403)}
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return CheckStatusOK(rp), BuildResponse(rp)
-		}
-	}
-}
-
-// GetTeamIcon gets the team icon of the team
-func (c *Client4) GetTeamIcon(teamId, etag string) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamRoute(teamId)+"/image", etag); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetTeamIcon", "model.client.get_team_icon.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
-	}
-}
-
 // UpdateChannelScheme will update a channel's scheme.
 func (c *Client4) UpdateChannelScheme(channelId, schemeId string) (bool, *Response) {
 	sip := &SchemeIDPatch{SchemeID: &schemeId}

--- a/model/scheme.go
+++ b/model/scheme.go
@@ -29,6 +29,10 @@ type Scheme struct {
 	DefaultChannelUserRole  string `json:"default_channel_user_role"`
 }
 
+type SchemeIDPatch struct {
+	SchemeID *string `json:"scheme_id"`
+}
+
 func (scheme *Scheme) ToJson() string {
 	b, _ := json.Marshal(scheme)
 	return string(b)
@@ -92,4 +96,15 @@ func (scheme *Scheme) IsValidForCreate() bool {
 	}
 
 	return true
+}
+
+func SchemeIDFromJson(data io.Reader) *string {
+	var p *SchemeIDPatch
+	json.NewDecoder(data).Decode(&p)
+	return p.SchemeID
+}
+
+func (p *SchemeIDPatch) ToJson() string {
+	b, _ := json.Marshal(p)
+	return string(b)
 }


### PR DESCRIPTION
#### Summary
Adds API endpoint to set a team's scheme and channel's scheme. 

This is awaiting https://github.com/mattermost/mattermost-server/pull/8615.

#### Ticket Link
[MM-10182](https://mattermost.atlassian.net/browse/MM-10182)
[MM-10183](https://mattermost.atlassian.net/browse/MM-10183)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation [here](https://github.com/mattermost/mattermost-api-reference/pull/360) and [here](https://github.com/mattermost/mattermost-api-reference/pull/361)
- [x] All new/modified APIs include changes to the drivers
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates