### PR TITLE
MM-8622: improved plugin error handling

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -112,7 +112,7 @@ func (a *App) activatePlugin(manifest *model.Manifest) *model.AppError {
 
 func (a *App) deactivatePlugin(manifest *model.Manifest) *model.AppError {
 	if err := a.PluginEnv.DeactivatePlugin(manifest.Id); err != nil {
-		return model.NewAppError("removePlugin", "app.plugin.deactivate.app_error", nil, err.Error(), http.StatusBadRequest)
+		return model.NewAppError("deactivatePlugin", "app.plugin.deactivate.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
 	a.UnregisterPluginCommands(manifest.Id)
@@ -251,9 +251,11 @@ func (a *App) removePlugin(id string, allowPrepackaged bool) *model.AppError {
 	}
 
 	var manifest *model.Manifest
+	var pluginPath string
 	for _, p := range plugins {
 		if p.Manifest.Id == id {
 			manifest = p.Manifest
+			pluginPath = filepath.Dir(p.ManifestPath)
 			break
 		}
 	}
@@ -269,7 +271,7 @@ func (a *App) removePlugin(id string, allowPrepackaged bool) *model.AppError {
 		}
 	}
 
-	err = os.RemoveAll(filepath.Join(a.PluginEnv.SearchPath(), id))
+	err = os.RemoveAll(pluginPath)
 	if err != nil {
 		return model.NewAppError("removePlugin", "app.plugin.remove.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost-server/mlog"
@@ -31,10 +30,6 @@ import (
 	"github.com/mattermost/mattermost-server/plugin/pluginenv"
 	"github.com/mattermost/mattermost-server/plugin/rpcplugin"
 	"github.com/mattermost/mattermost-server/plugin/rpcplugin/sandbox"
-)
-
-const (
-	PLUGIN_MAX_ID_LENGTH = 190
 )
 
 var prepackagedPlugins map[string]func(string) ([]byte, error) = map[string]func(string) ([]byte, error){
@@ -171,8 +166,8 @@ func (a *App) installPlugin(pluginFile io.Reader, allowPrepackaged bool) (*model
 		return nil, model.NewAppError("installPlugin", "app.plugin.prepackaged.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	if utf8.RuneCountInString(manifest.Id) > PLUGIN_MAX_ID_LENGTH {
-		return nil, model.NewAppError("installPlugin", "app.plugin.id_length.app_error", map[string]interface{}{"Max": PLUGIN_MAX_ID_LENGTH}, err.Error(), http.StatusBadRequest)
+	if !plugin.IsValidId(manifest.Id) {
+		return nil, model.NewAppError("installPlugin", "app.plugin.invalid_id.app_error", map[string]interface{}{"Min": plugin.MinIdLength, "Max": plugin.MaxIdLength, "Regex": plugin.ValidId.String()}, "", http.StatusBadRequest)
 	}
 
 	bundles, err := a.PluginEnv.Plugins()

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -62,13 +62,13 @@ func (a *App) initBuiltInPlugins() {
 
 func (a *App) setPluginsActive(activate bool) {
 	if a.PluginEnv == nil {
-		mlog.Error(fmt.Sprintf("Cannot setPluginsActive(%b): plugin env not initialized", activate))
+		mlog.Error(fmt.Sprintf("Cannot setPluginsActive(%t): plugin env not initialized", activate))
 		return
 	}
 
 	plugins, err := a.PluginEnv.Plugins()
 	if err != nil {
-		mlog.Error(fmt.Sprintf("Cannot setPluginsActive(%b)", activate), mlog.Err(err))
+		mlog.Error(fmt.Sprintf("Cannot setPluginsActive(%t)", activate), mlog.Err(err))
 		return
 	}
 
@@ -88,12 +88,12 @@ func (a *App) setPluginsActive(activate bool) {
 
 		if activate && pluginState.Enable && !active {
 			if err := a.activatePlugin(plugin.Manifest); err != nil {
-				mlog.Error(fmt.Sprintf("Plugin failed to activate", mlog.String("plugin_id", plugin.Manifest.Id), mlog.String("err", err.DetailedError)))
+				mlog.Error("Plugin failed to activate", mlog.String("plugin_id", plugin.Manifest.Id), mlog.String("err", err.DetailedError))
 			}
 
 		} else if (!activate || !pluginState.Enable) && active {
 			if err := a.deactivatePlugin(plugin.Manifest); err != nil {
-				mlog.Error(fmt.Sprintf("Plugin failed to deactivate", mlog.String("plugin_id", plugin.Manifest.Id), mlog.String("err", err.DetailedError)))
+				mlog.Error("Plugin failed to deactivate", mlog.String("plugin_id", plugin.Manifest.Id), mlog.String("err", err.DetailedError))
 			}
 		}
 	}

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -73,6 +73,10 @@ func (a *App) setPluginsActive(activate bool) {
 	}
 
 	for _, plugin := range plugins {
+		if plugin.Manifest == nil {
+			continue
+		}
+
 		id := plugin.Manifest.Id
 
 		pluginState := &model.PluginState{Enable: false}
@@ -176,7 +180,7 @@ func (a *App) installPlugin(pluginFile io.Reader, allowPrepackaged bool) (*model
 	}
 
 	for _, bundle := range bundles {
-		if bundle.Manifest.Id == manifest.Id {
+		if bundle.Manifest != nil && bundle.Manifest.Id == manifest.Id {
 			return nil, model.NewAppError("installPlugin", "app.plugin.install_id.app_error", nil, "", http.StatusBadRequest)
 		}
 	}
@@ -203,6 +207,10 @@ func (a *App) GetPlugins() (*model.PluginsResponse, *model.AppError) {
 
 	resp := &model.PluginsResponse{Active: []*model.PluginInfo{}, Inactive: []*model.PluginInfo{}}
 	for _, plugin := range plugins {
+		if plugin.Manifest == nil {
+			continue
+		}
+
 		info := &model.PluginInfo{
 			Manifest: *plugin.Manifest,
 		}
@@ -253,7 +261,7 @@ func (a *App) removePlugin(id string, allowPrepackaged bool) *model.AppError {
 	var manifest *model.Manifest
 	var pluginPath string
 	for _, p := range plugins {
-		if p.Manifest.Id == id {
+		if p.Manifest != nil && p.Manifest.Id == id {
 			manifest = p.Manifest
 			pluginPath = filepath.Dir(p.ManifestPath)
 			break

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3812,7 +3812,7 @@
   },
   {
     "id": "app.plugin.activate.app_error",
-    "translation": "Unable to activate extracted plugin. Plugin may already exist and be activated."
+    "translation": "Unable to activate extracted plugin."
   },
   {
     "id": "app.plugin.cluster.save_config.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3847,8 +3847,8 @@
     "translation": "Unable to get active plugins"
   },
   {
-    "id": "app.plugin.id_length.app_error",
-    "translation": "Plugin Id must be less than {{.Max}} characters."
+    "id": "app.plugin.invalid_id.app_error",
+    "translation": "Plugin Id must be at least {{.Min}} characters, at most {{.Max}} characters and match {{.Regex}}."
   },
   {
     "id": "app.plugin.install.app_error",

--- a/mlog/log.go
+++ b/mlog/log.go
@@ -29,6 +29,7 @@ type Field = zapcore.Field
 var Int64 = zap.Int64
 var Int = zap.Int
 var String = zap.String
+var Err = zap.Error
 
 type LoggerConfiguration struct {
 	EnableConsole bool

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -93,9 +93,9 @@ type PluginSettingsSchema struct {
 //               help_text: When true, an extra thing will be enabled!
 //               default: false
 type Manifest struct {
-	// The id is a globally unique identifier that represents your plugin. Ids are limited
-	// to 190 characters. Reverse-DNS notation using a name you control is a good option.
-	// For example, "com.mycompany.myplugin".
+	// The id is a globally unique identifier that represents your plugin. Ids must be at least
+	// 3 characters, at most 190 characters and must match ^[a-zA-Z0-9-_\.]+$.
+	// Reverse-DNS notation using a name you control is a good option, e.g. "com.mycompany.myplugin".
 	Id string `json:"id" yaml:"id"`
 
 	// The name to be displayed for the plugin.

--- a/plugin/pluginenv/environment.go
+++ b/plugin/pluginenv/environment.go
@@ -112,6 +112,10 @@ func (env *Environment) ActivatePlugin(id string) error {
 	env.mutex.Lock()
 	defer env.mutex.Unlock()
 
+	if !plugin.IsValidId(id) {
+		return fmt.Errorf("invalid plugin id: %s", id)
+	}
+
 	if _, ok := env.activePlugins[id]; ok {
 		return nil
 	}

--- a/plugin/pluginenv/environment.go
+++ b/plugin/pluginenv/environment.go
@@ -113,7 +113,7 @@ func (env *Environment) ActivatePlugin(id string) error {
 	defer env.mutex.Unlock()
 
 	if _, ok := env.activePlugins[id]; ok {
-		return fmt.Errorf("plugin already active: %v", id)
+		return nil
 	}
 	plugins, err := ScanSearchPath(env.searchPath)
 	if err != nil {

--- a/plugin/pluginenv/environment_test.go
+++ b/plugin/pluginenv/environment_test.go
@@ -149,7 +149,7 @@ func TestEnvironment(t *testing.T) {
 	assert.Equal(t, env.ActivePluginIds(), []string{"foo"})
 	activePlugins = env.ActivePlugins()
 	assert.Len(t, activePlugins, 1)
-	assert.Error(t, env.ActivatePlugin("foo"))
+	assert.NoError(t, env.ActivatePlugin("foo"))
 	assert.True(t, env.IsPluginActive("foo"))
 
 	hooks.On("OnDeactivate").Return(nil)

--- a/plugin/rpcplugin/hooks.go
+++ b/plugin/rpcplugin/hooks.go
@@ -5,7 +5,6 @@ package rpcplugin
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -240,7 +239,7 @@ func (h *RemoteHooks) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Request:              forwardedRequest,
 		RequestBodyStream:    requestBodyStream,
 	}, nil); err != nil {
-		mlog.Error(fmt.Sprintf("Plugin `%s` failed to ServeHTTP: %s", h.pluginId, err.Error()))
+		mlog.Error("Plugin failed to ServeHTTP", mlog.String("plugin_id", h.pluginId), mlog.Err(err))
 		http.Error(w, "500 internal server error", http.StatusInternalServerError)
 	}
 }

--- a/plugin/rpcplugin/hooks_test.go
+++ b/plugin/rpcplugin/hooks_test.go
@@ -31,7 +31,7 @@ func testHooksRPC(hooks interface{}, f func(*RemoteHooks)) error {
 	id, server := c1.Serve()
 	go ServeHooks(hooks, server, c1)
 
-	remote, err := ConnectHooks(c2.Connect(id), c2)
+	remote, err := ConnectHooks(c2.Connect(id), c2, "plugin_id")
 	if err != nil {
 		return err
 	}

--- a/plugin/rpcplugin/main.go
+++ b/plugin/rpcplugin/main.go
@@ -30,7 +30,7 @@ func Main(hooks interface{}) {
 }
 
 // Returns the hooks being served by a call to Main.
-func ConnectMain(muxer *Muxer) (*RemoteHooks, error) {
+func ConnectMain(muxer *Muxer, pluginId string) (*RemoteHooks, error) {
 	buf := make([]byte, 1)
 	if _, err := muxer.Read(buf); err != nil {
 		return nil, err
@@ -43,5 +43,5 @@ func ConnectMain(muxer *Muxer) (*RemoteHooks, error) {
 		return nil, err
 	}
 
-	return ConnectHooks(muxer.Connect(id), muxer)
+	return ConnectHooks(muxer.Connect(id), muxer, pluginId)
 }

--- a/plugin/rpcplugin/main_test.go
+++ b/plugin/rpcplugin/main_test.go
@@ -10,11 +10,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/plugin/plugintest"
 	"github.com/mattermost/mattermost-server/plugin/rpcplugin/rpcplugintest"
 )
 
 func TestMain(t *testing.T) {
+	// Setup a global logger to catch tests logging outside of app context
+	// The global logger will be stomped by apps initalizing but that's fine for testing. Ideally this won't happen.
+	mlog.InitGlobalLogger(mlog.NewLogger(&mlog.LoggerConfiguration{
+		EnableConsole: true,
+		ConsoleJson:   true,
+		ConsoleLevel:  "error",
+		EnableFile:    false,
+	}))
+
 	dir, err := ioutil.TempDir("", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -46,7 +56,7 @@ func TestMain(t *testing.T) {
 
 	var api plugintest.API
 
-	hooks, err := ConnectMain(muxer)
+	hooks, err := ConnectMain(muxer, "plugin_id")
 	require.NoError(t, err)
 	assert.NoError(t, hooks.OnActivate(&api))
 	assert.NoError(t, hooks.OnDeactivate())

--- a/plugin/rpcplugin/sandbox/main_test.go
+++ b/plugin/rpcplugin/sandbox/main_test.go
@@ -1,0 +1,18 @@
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/mlog"
+)
+
+func TestMain(t *testing.T) {
+	// Setup a global logger to catch tests logging outside of app context
+	// The global logger will be stomped by apps initalizing but that's fine for testing. Ideally this won't happen.
+	mlog.InitGlobalLogger(mlog.NewLogger(&mlog.LoggerConfiguration{
+		EnableConsole: true,
+		ConsoleJson:   true,
+		ConsoleLevel:  "error",
+		EnableFile:    false,
+	}))
+}

--- a/plugin/rpcplugin/supervisor.go
+++ b/plugin/rpcplugin/supervisor.go
@@ -12,19 +12,26 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
+)
+
+const (
+	MaxProcessRestarts = 3
 )
 
 // Supervisor implements a plugin.Supervisor that launches the plugin in a separate process and
 // communicates via RPC.
 //
-// If the plugin unexpectedly exists, the supervisor will relaunch it after a short delay.
+// If the plugin unexpectedly exits, the supervisor will relaunch it after a short delay, but will
+// only restart a plugin at most three times.
 type Supervisor struct {
 	hooks      atomic.Value
 	done       chan bool
 	cancel     context.CancelFunc
 	newProcess func(context.Context) (Process, io.ReadWriteCloser, error)
+	pluginId   string
 }
 
 var _ plugin.Supervisor = (*Supervisor)(nil)
@@ -66,19 +73,28 @@ func (s *Supervisor) run(ctx context.Context, start chan<- error, api plugin.API
 		s.done <- true
 	}()
 	done := ctx.Done()
-	for {
+	for i := 0; i <= MaxProcessRestarts; i++ {
 		s.runPlugin(ctx, start, api)
 		select {
 		case <-done:
 			return
 		default:
 			start = nil
-			time.Sleep(time.Second)
+			if i < MaxProcessRestarts {
+				mlog.Debug(fmt.Sprintf("Plugin `%s` terminated unexpectedly", s.pluginId))
+				time.Sleep(time.Duration((1 + i*i)) * time.Second)
+			} else {
+				mlog.Debug(fmt.Sprintf("Plugin `%s` terminated unexpectedly too many times", s.pluginId))
+			}
 		}
 	}
 }
 
 func (s *Supervisor) runPlugin(ctx context.Context, start chan<- error, api plugin.API) error {
+	if start == nil {
+		mlog.Debug(fmt.Sprintf("Restarting plugin `%s`", s.pluginId))
+	}
+
 	p, ipc, err := s.newProcess(ctx)
 	if err != nil {
 		if start != nil {
@@ -100,7 +116,7 @@ func (s *Supervisor) runPlugin(ctx context.Context, start chan<- error, api plug
 		muxerClosed <- muxer.Close()
 	}()
 
-	hooks, err := ConnectMain(muxer)
+	hooks, err := ConnectMain(muxer, s.pluginId)
 	if err == nil {
 		err = hooks.OnActivate(api)
 	}
@@ -147,5 +163,5 @@ func SupervisorWithNewProcessFunc(bundle *model.BundleInfo, newProcess func(cont
 	if strings.HasPrefix(executable, "..") {
 		return nil, fmt.Errorf("invalid backend executable")
 	}
-	return &Supervisor{newProcess: newProcess}, nil
+	return &Supervisor{pluginId: bundle.Manifest.Id, newProcess: newProcess}, nil
 }

--- a/plugin/rpcplugin/supervisor.go
+++ b/plugin/rpcplugin/supervisor.go
@@ -81,10 +81,10 @@ func (s *Supervisor) run(ctx context.Context, start chan<- error, api plugin.API
 		default:
 			start = nil
 			if i < MaxProcessRestarts {
-				mlog.Debug(fmt.Sprintf("Plugin `%s` terminated unexpectedly", s.pluginId))
+				mlog.Debug("Plugin terminated unexpectedly", mlog.String("plugin_id", s.pluginId))
 				time.Sleep(time.Duration((1 + i*i)) * time.Second)
 			} else {
-				mlog.Debug(fmt.Sprintf("Plugin `%s` terminated unexpectedly too many times", s.pluginId))
+				mlog.Debug("Plugin terminated unexpectedly too many times", mlog.String("plugin_id", s.pluginId), mlog.Int("max_process_restarts", MaxProcessRestarts))
 			}
 		}
 	}
@@ -92,7 +92,7 @@ func (s *Supervisor) run(ctx context.Context, start chan<- error, api plugin.API
 
 func (s *Supervisor) runPlugin(ctx context.Context, start chan<- error, api plugin.API) error {
 	if start == nil {
-		mlog.Debug(fmt.Sprintf("Restarting plugin `%s`", s.pluginId))
+		mlog.Debug("Restarting plugin", mlog.String("plugin_id", s.pluginId))
 	}
 
 	p, ipc, err := s.newProcess(ctx)

--- a/plugin/valid.go
+++ b/plugin/valid.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package plugin
+
+import (
+	"regexp"
+	"unicode/utf8"
+)
+
+const (
+	MinIdLength = 3
+	MaxIdLength = 190
+)
+
+var ValidId *regexp.Regexp
+
+func init() {
+	ValidId = regexp.MustCompile(`^[a-zA-Z0-9-_\.]+$`)
+}
+
+func IsValidId(id string) bool {
+	if utf8.RuneCountInString(id) < MinIdLength {
+		return false
+	}
+
+	if utf8.RuneCountInString(id) > MaxIdLength {
+		return false
+	}
+
+	return ValidId.MatchString(id)
+}

--- a/plugin/valid_test.go
+++ b/plugin/valid_test.go
@@ -1,0 +1,32 @@
+package plugin_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/plugin"
+)
+
+func TestIsValid(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]bool{
+		"":    false,
+		"a":   false,
+		"ab":  false,
+		"abc": true,
+		"abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij":  true,
+		"abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghij1": false,
+		"../path":                                 false,
+		"/etc/passwd":                             false,
+		"com.mattermost.plugin_with_features-0.9": true,
+		"PLUGINS-THAT-YELL-ARE-OK-2":              true,
+	}
+
+	for id, valid := range testCases {
+		t.Run(id, func(t *testing.T) {
+			assert.Equal(t, valid, plugin.IsValidId(id))
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
This PR contains a series of commits -- each self-documenting -- proposing a set of improvements around plugin error handling and logging. This came about as I was researching https://mattermost.atlassian.net/browse/MM-8622 in a bid to determine how to present plugin errors to the system administrator more effectively.

A quick summary:
* leverage mlog, `plugin_id`
* improved logging of various events, including sideloaded plugins with malformed manifest files 
* allow deleting of plugins whose manifests are corrupted (e.g. `id` doesn't match installation path)
* if a plugin exits three times, don't keep restarting it (and we'll eventually surface this error)
* further constrain plugin ids, preventing a plugin id akin to `../../path/to/evil` and successfully installing files to arbitrary paths

Note that the new `id` constraints above are backwards incompatible: but I think in a necessary way.

This will be followed by a PR to capture these error states in a new database table for display on the System Console.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8622

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates