### PR TITLE
MM-10628 Add inactive user count to analytics and fix client analytics function

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -512,15 +512,18 @@ func TestGetAnalyticsOld(t *testing.T) {
 	CheckNoError(t, resp)
 
 	found := false
+	found2 := false
 	for _, row := range rows {
 		if row.Name == "unique_user_count" {
 			found = true
+		} else if row.Name == "inactive_user_count" {
+			found2 = true
+			assert.True(t, row.Value >= 0)
 		}
 	}
 
-	if !found {
-		t.Fatal("should return unique user count")
-	}
+	assert.True(t, found, "should return unique user count")
+	assert.True(t, found2, "should return inactive user count")
 
 	_, resp = th.SystemAdminClient.GetAnalyticsOld("post_counts_day", "")
 	CheckNoError(t, resp)
@@ -531,8 +534,14 @@ func TestGetAnalyticsOld(t *testing.T) {
 	_, resp = th.SystemAdminClient.GetAnalyticsOld("extra_counts", "")
 	CheckNoError(t, resp)
 
-	_, resp = th.SystemAdminClient.GetAnalyticsOld("", th.BasicTeam.Id)
+	rows, resp = th.SystemAdminClient.GetAnalyticsOld("", th.BasicTeam.Id)
 	CheckNoError(t, resp)
+
+	for _, row := range rows {
+		if row.Name == "inactive_user_count" {
+			assert.Equal(t, float64(-1), row.Value, "inactive user count should be -1 when team specified")
+		}
+	}
 
 	rows2, resp2 := th.SystemAdminClient.GetAnalyticsOld("standard", "")
 	CheckNoError(t, resp2)

--- a/app/analytics.go
+++ b/app/analytics.go
@@ -30,7 +30,7 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 	}
 
 	if name == "standard" {
-		var rows model.AnalyticsRows = make([]*model.AnalyticsRow, 10)
+		var rows model.AnalyticsRows = make([]*model.AnalyticsRow, 11)
 		rows[0] = &model.AnalyticsRow{Name: "channel_open_count", Value: 0}
 		rows[1] = &model.AnalyticsRow{Name: "channel_private_count", Value: 0}
 		rows[2] = &model.AnalyticsRow{Name: "post_count", Value: 0}
@@ -41,13 +41,17 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 		rows[7] = &model.AnalyticsRow{Name: "total_read_db_connections", Value: 0}
 		rows[8] = &model.AnalyticsRow{Name: "daily_active_users", Value: 0}
 		rows[9] = &model.AnalyticsRow{Name: "monthly_active_users", Value: 0}
+		rows[10] = &model.AnalyticsRow{Name: "inactive_user_count", Value: 0}
 
 		openChan := a.Srv.Store.Channel().AnalyticsTypeCount(teamId, model.CHANNEL_OPEN)
 		privateChan := a.Srv.Store.Channel().AnalyticsTypeCount(teamId, model.CHANNEL_PRIVATE)
 		teamChan := a.Srv.Store.Team().AnalyticsTeamCount()
 
 		var userChan store.StoreChannel
-		if teamId != "" {
+		var userInactiveChan store.StoreChannel
+		if teamId == "" {
+			userInactiveChan = a.Srv.Store.User().AnalyticsGetInactiveUsersCount()
+		} else {
 			userChan = a.Srv.Store.User().AnalyticsUniqueUserCount(teamId)
 		}
 
@@ -88,6 +92,16 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 				return nil, r.Err
 			} else {
 				rows[3].Value = float64(r.Data.(int64))
+			}
+		}
+
+		if userInactiveChan == nil {
+			rows[10].Value = -1
+		} else {
+			if r := <-userInactiveChan; r.Err != nil {
+				return nil, r.Err
+			} else {
+				rows[10].Value = float64(r.Data.(int64))
 			}
 		}
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -2359,7 +2359,7 @@ func (c *Client4) RemoveLicenseFile() (bool, *Response) {
 // and defaults to "standard". The "teamId" argument is optional and will limit results
 // to a specific team.
 func (c *Client4) GetAnalyticsOld(name, teamId string) (AnalyticsRows, *Response) {
-	query := fmt.Sprintf("?name=%v&teamId=%v", name, teamId)
+	query := fmt.Sprintf("?name=%v&team_id=%v", name, teamId)
 	if r, err := c.DoApiGet(c.GetAnalyticsRoute()+"/old"+query, ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {


### PR DESCRIPTION
#### Summary
Add inactive user count so I can use that on the client in an upcoming PR. Also fixed a bad query parameter in the `GetAnalyticsOld` client function.

#### Ticket Link
Server part of https://mattermost.atlassian.net/browse/MM-10268

#### Checklist
- [x] Added or updated unit tests (required for all new features)