### PR TITLE
MM-10189 Fixed inconsistency when using environment variables for MessageExportSettings

### DIFF
--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -396,3 +396,25 @@ func sToP(s string) *string {
 func bToP(b bool) *bool {
 	return &b
 }
+
+func TestGetDefaultsFromStruct(t *testing.T) {
+	s := struct {
+		TestSettings struct {
+			IntValue    int
+			BoolValue   bool
+			StringValue string
+		}
+		PointerToTestSettings *struct {
+			Value int
+		}
+	}{}
+
+	defaults := getDefaultsFromStruct(s)
+
+	assert.Equal(t, defaults["TestSettings.IntValue"], 0)
+	assert.Equal(t, defaults["TestSettings.BoolValue"], false)
+	assert.Equal(t, defaults["TestSettings.StringValue"], "")
+	assert.Equal(t, defaults["PointerToTestSettings.Value"], 0)
+	assert.NotContains(t, defaults, "PointerToTestSettings")
+	assert.Len(t, defaults, 4)
+}


### PR DESCRIPTION
The problem was that we were telling it to default MessageExportSettings.GlobalRelaySettings to nil since it's a pointer unlike every other Settings type. That appears to have been intentional, but it was causing it to sometimes set it based on the environment variables but then blank out the entire struct with the default value before applying the values from the config so it would sometimes work like
1. Set MessageExportSettings.GlobalRelaySettings to nil from the default
2. Set MessageExportSettings.GlobalRelaySettings.CustomerType to "test" from an environment variable
3. Set MessageExportSettings.GlobalRelaySettings.SmtpUsername to "user" from an environment variable

which works fine but other times, it may look like

1. Set MessageExportSettings.GlobalRelaySettings.SmtpUsername to "user" from an environment variable
2. Set MessageExportSettings.GlobalRelaySettings to nil from the default (clearing the SmtpUsername)
3. Set MessageExportSettings.GlobalRelaySettings.CustomerType to "test" from an environment variable
4. Because SmtpUsername is unset, set MessageExportSettings.GlobalRelaySettings.SmtpUsername to "" from the config.json

Since we're now setting defaults for the individual keys instead, it will never overwrite the whole MessageExportSettings.GlobalRelaySettings as in the second example above. 

Fun.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10189