### PR TITLE
[MM-10200] Respect image orientation before saving height and width of FileInfo

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -361,6 +361,14 @@ func (a *App) DoUploadFile(now time.Time, rawTeamId string, rawChannelId string,
 		return nil, err
 	}
 
+	if orientation, err := getImageOrientation(bytes.NewReader(data)); err == nil &&
+		(orientation == RotatedCWMirrored ||
+			orientation == RotatedCCW ||
+			orientation == RotatedCCWMirrored ||
+			orientation == RotatedCW) {
+		info.Width, info.Height = info.Height, info.Width
+	}
+
 	info.Id = model.NewId()
 	info.CreatorId = userId
 


### PR DESCRIPTION
#### Summary
Respect image orientation before saving height and width of FileInfo during file upload of image.

The issue on high-resolution image attached to that ticket was that it has exif orientation of rotate CW. Currently, the server respects orientation before writing/saving the file but not when saving the FileInfo - where the webapp depends on during single image view calculation.
 
#### Ticket Link
Jira ticket: [MM-10200](https://mattermost.atlassian.net/browse/MM-10200)

