### PR TITLE
MM-10319: Use normalized email for Saml (migration)

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -419,5 +419,6 @@ func UpgradeDatabaseToVersion410(sqlStore SqlStore) {
 	sqlStore.RemoveIndexIfExists("ClientId_2", "OAuthAccessData")
 
 	//	saveSchemaVersion(sqlStore, VERSION_4_10_0)
+	sqlStore.GetMaster().Exec("UPDATE Users SET AuthData=LOWER(AuthData) WHERE AuthService = 'saml'")
 	//}
 }


### PR DESCRIPTION
#### Summary
I normalized all the emails stored in the AuthData of the users in the saml
authentication and migration. This migration normalize the AuthData for the
existing saml accounts.

My unique concern here is that now can exists 2 accounts with the same AuthData
(email) with different case, and if this happens for 2 different accounts with
saml authentication, the migration will fail.

#### Ticket Link
[MM-10319](https://mattermost.atlassian.net/browse/MM-10319)

#### Checklist
- [x] Has enterprise changes (https://github.com/mattermost/enterprise/pull/284)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)