### PR TITLE
Fix TestSendNotifications test

### DIFF
--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -37,7 +37,7 @@ func TestSendNotifications(t *testing.T) {
 	} else if mentions == nil {
 		t.Log(mentions)
 		t.Fatal("user should have been mentioned")
-	} else if mentions[0] != th.BasicUser2.Id {
+	} else if !utils.StringInSlice(th.BasicUser2.Id, mentions) {
 		t.Log(mentions)
 		t.Fatal("user should have been mentioned")
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -13,6 +13,15 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
+func StringInSlice(a string, slice []string) bool {
+	for _, b := range slice {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 func StringArrayIntersection(arr1, arr2 []string) []string {
 	arrMap := map[string]bool{}
 	result := []string{}


### PR DESCRIPTION
#### Summary
TestSendNotifications was randonly failing because the order of mentions
depends on the order of profiles, and wasn't specified an order by in the
query. So, we have to check all the possible notifications.

#### Checklist
- [x] Added or updated unit tests (required for all new features)