### PR TITLE
MM-10495 Updated user agent detection to match output of previous library

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -6,7 +6,6 @@ package app
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/avct/uasurfer"
@@ -73,26 +72,10 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 
 	ua := uasurfer.Parse(r.UserAgent())
 
-	plat := ua.OS.Platform.String()
-	if plat == "" {
-		plat = "unknown"
-	}
-
-	os := ua.OS.Name.String()
-	if os == "" {
-		os = "unknown"
-	}
-
-	bname := ua.Browser.Name.String()
-	if bname == "" {
-		bname = "unknown"
-	}
-
-	if strings.Contains(r.UserAgent(), "Mattermost") {
-		bname = "Desktop App"
-	}
-
-	bversion := ua.Browser.Version
+	plat := getPlatformName(ua)
+	os := getOSName(ua)
+	bname := getBrowserName(ua, r.UserAgent())
+	bversion := getBrowserVersion(ua, r.UserAgent())
 
 	session.AddProp(model.SESSION_PROP_PLATFORM, plat)
 	session.AddProp(model.SESSION_PROP_OS, os)

--- a/app/user_agent.go
+++ b/app/user_agent.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package app
 
 import (

--- a/app/user_agent.go
+++ b/app/user_agent.go
@@ -1,0 +1,129 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/avct/uasurfer"
+)
+
+var platformNames = map[uasurfer.Platform]string{
+	uasurfer.PlatformUnknown:      "Windows",
+	uasurfer.PlatformWindows:      "Windows",
+	uasurfer.PlatformMac:          "Macintosh",
+	uasurfer.PlatformLinux:        "Linux",
+	uasurfer.PlatformiPad:         "iPad",
+	uasurfer.PlatformiPhone:       "iPhone",
+	uasurfer.PlatformiPod:         "iPod",
+	uasurfer.PlatformBlackberry:   "BlackBerry",
+	uasurfer.PlatformWindowsPhone: "Windows Phone",
+}
+
+func getPlatformName(ua *uasurfer.UserAgent) string {
+	platform := ua.OS.Platform
+
+	if name, ok := platformNames[platform]; !ok {
+		return platformNames[uasurfer.PlatformUnknown]
+	} else {
+		return name
+	}
+}
+
+var osNames = map[uasurfer.OSName]string{
+	uasurfer.OSUnknown:      "",
+	uasurfer.OSWindowsPhone: "Windows Phone",
+	uasurfer.OSWindows:      "Windows",
+	uasurfer.OSMacOSX:       "Mac OS",
+	uasurfer.OSiOS:          "iOS",
+	uasurfer.OSAndroid:      "Android",
+	uasurfer.OSBlackberry:   "BlackBerry",
+	uasurfer.OSChromeOS:     "Chrome OS",
+	uasurfer.OSKindle:       "Kindle",
+	uasurfer.OSWebOS:        "webOS",
+	uasurfer.OSLinux:        "Linux",
+}
+
+func getOSName(ua *uasurfer.UserAgent) string {
+	os := ua.OS
+
+	if os.Name == uasurfer.OSWindows {
+		major := os.Version.Major
+		minor := os.Version.Minor
+
+		name := "Windows"
+
+		// Adapted from https://github.com/mssola/user_agent/blob/master/operating_systems.go#L26
+		if major == 5 {
+			if minor == 0 {
+				name = "Windows 2000"
+			} else if minor == 1 {
+				name = "Windows XP"
+			} else if minor == 2 {
+				name = "Windows XP x64 Edition"
+			}
+		} else if major == 6 {
+			if minor == 0 {
+				name = "Windows Vista"
+			} else if minor == 1 {
+				name = "Windows 7"
+			} else if minor == 2 {
+				name = "Windows 8"
+			} else if minor == 3 {
+				name = "Windows 8.1"
+			}
+		} else if major == 10 {
+			name = "Windows 10"
+		}
+
+		return name
+	} else if name, ok := osNames[os.Name]; ok {
+		return name
+	} else {
+		return osNames[uasurfer.OSUnknown]
+	}
+}
+
+func getBrowserVersion(ua *uasurfer.UserAgent, userAgentString string) string {
+	if index := strings.Index(userAgentString, "Mattermost/"); index != -1 {
+		afterVersion := userAgentString[index+len("Mattermost/"):]
+		return strings.Fields(afterVersion)[0]
+	} else if index := strings.Index(userAgentString, "Franz/"); index != -1 {
+		afterVersion := userAgentString[index+len("Franz/"):]
+		return strings.Fields(afterVersion)[0]
+	} else {
+		return getUAVersion(ua.Browser.Version)
+	}
+}
+
+func getUAVersion(version uasurfer.Version) string {
+	if version.Patch == 0 {
+		return fmt.Sprintf("%v.%v", version.Major, version.Minor)
+	} else {
+		return fmt.Sprintf("%v.%v.%v", version.Major, version.Minor, version.Patch)
+	}
+}
+
+var browserNames = map[uasurfer.BrowserName]string{
+	uasurfer.BrowserUnknown:    "Unknown",
+	uasurfer.BrowserChrome:     "Chrome",
+	uasurfer.BrowserIE:         "Internet Explorer",
+	uasurfer.BrowserSafari:     "Safari",
+	uasurfer.BrowserFirefox:    "Firefox",
+	uasurfer.BrowserAndroid:    "Android",
+	uasurfer.BrowserOpera:      "Opera",
+	uasurfer.BrowserBlackberry: "BlackBerry",
+}
+
+func getBrowserName(ua *uasurfer.UserAgent, userAgentString string) string {
+	browser := ua.Browser.Name
+
+	if strings.Contains(userAgentString, "Mattermost") {
+		return "Desktop App"
+	} else if browser == uasurfer.BrowserIE && ua.Browser.Version.Major > 11 {
+		return "Edge"
+	} else if name, ok := browserNames[browser]; ok {
+		return name
+	} else {
+		return browserNames[uasurfer.BrowserUnknown]
+	}
+}

--- a/app/user_agent_test.go
+++ b/app/user_agent_test.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/avct/uasurfer"
+)
+
+type testUserAgent struct {
+	Name      string
+	UserAgent string
+}
+
+var testUserAgents = []testUserAgent{
+	{"Mozilla 40.1", "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.1"},
+	{"Chrome 60", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36"},
+	{"Chrome Mobile", "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Mobile Safari/537.36"},
+	{"MM Classic App", "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.81 Mobile Safari/537.36 Web-Atoms-Mobile-WebView"},
+	{"MM App 3.7.1", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.7.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36"},
+	{"Franz 4.0.4", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Franz/4.0.4 Chrome/52.0.2743.82 Electron/1.3.1 Safari/537.36"},
+	{"Edge 14", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393"},
+	{"Internet Explorer 9", "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0"},
+	{"Internet Explorer 11", "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko"},
+	{"Internet Explorer 11 2", "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Zoom 3.6.0; rv:11.0) like Gecko"},
+	{"Internet Explorer 11 (Compatibility Mode) 1", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; .NET CLR 1.1.4322; InfoPath.3; Zoom 3.6.0)"},
+	{"Internet Explorer 11 (Compatibility Mode) 2", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Zoom 3.6.0)"},
+	{"Safari 9", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Safari/604.1.38"},
+	{"Safari 8", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12"},
+	{"Safari Mobile", "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1"},
+}
+
+func TestGetPlatformName(t *testing.T) {
+	expected := []string{
+		"Windows",
+		"Macintosh",
+		"Linux",
+		"Linux",
+		"Macintosh",
+		"Macintosh",
+		"Windows",
+		"Windows",
+		"Windows",
+		"Windows",
+		"Windows",
+		"Windows",
+		"Macintosh",
+		"Macintosh",
+		"iPhone",
+	}
+
+	for i, userAgent := range testUserAgents {
+		t.Run(fmt.Sprintf("GetPlatformName_%v", i), func(t *testing.T) {
+			ua := uasurfer.Parse(userAgent.UserAgent)
+
+			if actual := getPlatformName(ua); actual != expected[i] {
+				t.Fatalf("%v Got %v, expected %v", userAgent.Name, actual, expected[i])
+			}
+		})
+	}
+}
+
+func TestGetOSName(t *testing.T) {
+	expected := []string{
+		"Windows 7",
+		"Mac OS",
+		"Android",
+		"Android",
+		"Mac OS",
+		"Mac OS",
+		"Windows 10",
+		"Windows",
+		"Windows 10",
+		"Windows 10",
+		"Windows 10",
+		"Windows 10",
+		"Mac OS",
+		"Mac OS",
+		"iOS",
+	}
+
+	for i, userAgent := range testUserAgents {
+		t.Run(fmt.Sprintf("GetOSName_%v", i), func(t *testing.T) {
+			ua := uasurfer.Parse(userAgent.UserAgent)
+
+			if actual := getOSName(ua); actual != expected[i] {
+				t.Fatalf("Got %v, expected %v", actual, expected[i])
+			}
+		})
+	}
+}
+
+func TestGetBrowserName(t *testing.T) {
+	expected := []string{
+		"Firefox",
+		"Chrome",
+		"Chrome",
+		"Chrome",
+		"Desktop App",
+		"Chrome",
+		"Edge",
+		"Internet Explorer",
+		"Internet Explorer",
+		"Internet Explorer",
+		"Internet Explorer",
+		"Internet Explorer",
+		"Safari",
+		"Safari",
+		"Safari",
+	}
+
+	for i, userAgent := range testUserAgents {
+		t.Run(fmt.Sprintf("GetBrowserName_%v", i), func(t *testing.T) {
+			ua := uasurfer.Parse(userAgent.UserAgent)
+
+			if actual := getBrowserName(ua, userAgent.UserAgent); actual != expected[i] {
+				t.Fatalf("Got %v, expected %v", actual, expected[i])
+			}
+		})
+	}
+}
+
+func TestGetBrowserVersion(t *testing.T) {
+	expected := []string{
+		"40.1",
+		"60.0.3112", // Doesn't report the fourth part of the version
+		"60.0.3112", // Doesn't report the fourth part of the version
+		"61.0.3163",
+		"3.7.1",
+		"4.0.4",
+		"14.14393",
+		"9.0",
+		"11.0",
+		"11.0",
+		"7.0",
+		"7.0",
+		"11.0",
+		"8.0.7",
+		"9.0",
+	}
+
+	for i, userAgent := range testUserAgents {
+		t.Run(fmt.Sprintf("GetBrowserVersion_%v", i), func(t *testing.T) {
+			ua := uasurfer.Parse(userAgent.UserAgent)
+
+			if actual := getBrowserVersion(ua, userAgent.UserAgent); actual != expected[i] {
+				t.Fatalf("Got %v, expected %v", actual, expected[i])
+			}
+		})
+	}
+}


### PR DESCRIPTION
When removing the old library, I missed that the enums that the new library used did not follow the same naming as the previous library, so I've added code to emulate that along with unit tests for different types of sessions. This should also fix the sessions modal since it was displaying based on those props.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10495

#### Checklist
- Added or updated unit tests (required for all new features)