### PR TITLE
MM-9739: deprecate the now unused Channels.ExtraUpdateAt

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5927,10 +5927,6 @@
     "translation": "We couldn't delete the channel"
   },
   {
-    "id": "store.sql_channel.extra_updated.app_error",
-    "translation": "Problem updating members last updated time"
-  },
-  {
     "id": "store.sql_channel.get.existing.app_error",
     "translation": "We couldn't find the existing channel"
   },

--- a/model/channel.go
+++ b/model/channel.go
@@ -44,7 +44,6 @@ type Channel struct {
 	Purpose       string `json:"purpose"`
 	LastPostAt    int64  `json:"last_post_at"`
 	TotalMsgCount int64  `json:"total_msg_count"`
-	ExtraUpdateAt int64  `json:"extra_update_at"`
 	CreatorId     string `json:"creator_id"`
 }
 
@@ -133,15 +132,10 @@ func (o *Channel) PreSave() {
 
 	o.CreateAt = GetMillis()
 	o.UpdateAt = o.CreateAt
-	o.ExtraUpdateAt = o.CreateAt
 }
 
 func (o *Channel) PreUpdate() {
 	o.UpdateAt = GetMillis()
-}
-
-func (o *Channel) ExtraUpdated() {
-	o.ExtraUpdateAt = GetMillis()
 }
 
 func (o *Channel) IsGroupOrDirect() bool {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -270,25 +270,6 @@ func (s SqlChannelStore) Update(channel *model.Channel) store.StoreChannel {
 	})
 }
 
-func (s SqlChannelStore) extraUpdated(channel *model.Channel) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		channel.ExtraUpdated()
-
-		_, err := s.GetMaster().Exec(
-			`UPDATE
-				Channels
-			SET
-				ExtraUpdateAt = :Time
-			WHERE
-				Id = :Id`,
-			map[string]interface{}{"Id": channel.Id, "Time": channel.ExtraUpdateAt})
-
-		if err != nil {
-			result.Err = model.NewAppError("SqlChannelStore.extraUpdated", "store.sql_channel.extra_updated.app_error", nil, "id="+channel.Id+", "+err.Error(), http.StatusInternalServerError)
-		}
-	})
-}
-
 func (s SqlChannelStore) GetChannelUnread(channelId, userId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var unreadChannel model.ChannelUnread
@@ -750,10 +731,6 @@ func (s SqlChannelStore) SaveMember(member *model.ChannelMember) store.StoreChan
 					if err := transaction.Commit(); err != nil {
 						result.Err = model.NewAppError("SqlChannelStore.SaveMember", "store.sql_channel.save_member.commit_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)
 					}
-					// If successfull record members have changed in channel
-					if mu := <-s.extraUpdated(channel); mu.Err != nil {
-						result.Err = mu.Err
-					}
 				}
 			}
 		}
@@ -1055,21 +1032,9 @@ func (s SqlChannelStore) GetMemberCount(channelId string, allowFromCache bool) s
 
 func (s SqlChannelStore) RemoveMember(channelId string, userId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		// Grab the channel we are saving this member to
-		if cr := <-s.Get(channelId, true); cr.Err != nil {
-			result.Err = cr.Err
-		} else {
-			channel := cr.Data.(*model.Channel)
-
-			_, err := s.GetMaster().Exec("DELETE FROM ChannelMembers WHERE ChannelId = :ChannelId AND UserId = :UserId", map[string]interface{}{"ChannelId": channelId, "UserId": userId})
-			if err != nil {
-				result.Err = model.NewAppError("SqlChannelStore.RemoveMember", "store.sql_channel.remove_member.app_error", nil, "channel_id="+channelId+", user_id="+userId+", "+err.Error(), http.StatusInternalServerError)
-			} else {
-				// If successfull record members have changed in channel
-				if mu := <-s.extraUpdated(channel); mu.Err != nil {
-					result.Err = mu.Err
-				}
-			}
+		_, err := s.GetMaster().Exec("DELETE FROM ChannelMembers WHERE ChannelId = :ChannelId AND UserId = :UserId", map[string]interface{}{"ChannelId": channelId, "UserId": userId})
+		if err != nil {
+			result.Err = model.NewAppError("SqlChannelStore.RemoveMember", "store.sql_channel.remove_member.app_error", nil, "channel_id="+channelId+", user_id="+userId+", "+err.Error(), http.StatusInternalServerError)
 		}
 	})
 }

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -713,9 +713,6 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	c1.Type = model.CHANNEL_OPEN
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
 
-	c1t1 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
-	t1 := c1t1.ExtraUpdateAt
-
 	u1 := model.User{}
 	u1.Email = model.NewId()
 	u1.Nickname = model.NewId()
@@ -739,13 +736,6 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	o2.UserId = u2.Id
 	o2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&o2))
-
-	c1t2 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
-	t2 := c1t2.ExtraUpdateAt
-
-	if t2 <= t1 {
-		t.Fatal("Member update time incorrect")
-	}
 
 	count := (<-ss.Channel().GetMemberCount(o1.ChannelId, true)).Data.(int64)
 	if count != 2 {
@@ -777,13 +767,6 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 		t.Fatal("should have removed 1 member")
 	}
 
-	c1t3 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
-	t3 := c1t3.ExtraUpdateAt
-
-	if t3 <= t2 || t3 <= t1 {
-		t.Fatal("Member update time incorrect on delete")
-	}
-
 	member := (<-ss.Channel().GetMember(o1.ChannelId, o1.UserId)).Data.(*model.ChannelMember)
 	if member.ChannelId != o1.ChannelId {
 		t.Fatal("should have go member")
@@ -791,12 +774,6 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 
 	if err := (<-ss.Channel().SaveMember(&o1)).Err; err == nil {
 		t.Fatal("Should have been a duplicate")
-	}
-
-	c1t4 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
-	t4 := c1t4.ExtraUpdateAt
-	if t4 != t3 {
-		t.Fatal("Should not update time upon failure")
 	}
 }
 
@@ -807,9 +784,6 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
-
-	c1t1 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
-	t1 := c1t1.ExtraUpdateAt
 
 	u1 := model.User{}
 	u1.Email = model.NewId()
@@ -834,13 +808,6 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	o2.UserId = u2.Id
 	o2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&o2))
-
-	c1t2 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
-	t2 := c1t2.ExtraUpdateAt
-
-	if t2 <= t1 {
-		t.Fatal("Member update time incorrect")
-	}
 
 	count := (<-ss.Channel().GetMemberCount(o1.ChannelId, false)).Data.(int64)
 	if count != 2 {


### PR DESCRIPTION
#### Summary
Deprecate the now unused Channels.ExtraUpdateAt. Not actually removing the database column from existing installs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-9739

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
