### PR TITLE
disable the config watcher before shutting the world down

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -224,6 +224,7 @@ func (a *App) Shutdown() {
 
 	mlog.Info("Stopping Server...")
 
+	a.DisableConfigWatch()
 	a.StopServer()
 	a.HubStop()
 
@@ -243,8 +244,6 @@ func (a *App) Shutdown() {
 	a.RemoveLicenseListener(a.licenseListenerId)
 	a.RemoveConfigListener(a.logListenerId)
 	mlog.Info("Server stopped")
-
-	a.DisableConfigWatch()
 }
 
 var accountMigrationInterface func(*App) einterfaces.AccountMigrationInterface


### PR DESCRIPTION
#### Summary
Seeing lots of build failures due to the config watcher being triggered after the SqlStore had been shutdown.

#### Ticket Link
None.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)