### PR TITLE
MM-10234: Make CLI roles command advanced-permissions aware.

### DIFF
--- a/cmd/commands/roles.go
+++ b/cmd/commands/roles.go
@@ -71,7 +71,7 @@ func makeSystemAdminCmdF(command *cobra.Command, args []string) error {
 				systemUser = true
 			}
 		}
-		
+
 		if !systemUser {
 			roles = append(roles, model.SYSTEM_USER_ROLE_ID)
 		}

--- a/cmd/commands/roles.go
+++ b/cmd/commands/roles.go
@@ -70,13 +70,13 @@ func makeSystemAdminCmdF(command *cobra.Command, args []string) error {
 			case model.SYSTEM_USER_ROLE_ID:
 				systemUser = true
 			}
-
-			if !systemUser {
-				roles = append(roles, model.SYSTEM_USER_ROLE_ID)
-			}
-			if !systemAdmin {
-				roles = append(roles, model.SYSTEM_ADMIN_ROLE_ID)
-			}
+		}
+		
+		if !systemUser {
+			roles = append(roles, model.SYSTEM_USER_ROLE_ID)
+		}
+		if !systemAdmin {
+			roles = append(roles, model.SYSTEM_ADMIN_ROLE_ID)
 		}
 
 		if _, err := a.UpdateUserRoles(user.Id, strings.Join(roles, " "), true); err != nil {
@@ -117,10 +117,10 @@ func makeMemberCmdF(command *cobra.Command, args []string) error {
 				}
 				newRoles = append(newRoles, role)
 			}
+		}
 
-			if !systemUser {
-				newRoles = append(roles, model.SYSTEM_USER_ROLE_ID)
-			}
+		if !systemUser {
+			newRoles = append(roles, model.SYSTEM_USER_ROLE_ID)
 		}
 
 		if _, err := a.UpdateUserRoles(user.Id, strings.Join(newRoles, " "), true); err != nil {

--- a/cmd/commands/roles.go
+++ b/cmd/commands/roles.go
@@ -5,9 +5,12 @@ package commands
 
 import (
 	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mattermost-server/cmd"
-	"github.com/spf13/cobra"
+	"github.com/mattermost/mattermost-server/model"
 )
 
 var RolesCmd = &cobra.Command{
@@ -56,7 +59,27 @@ func makeSystemAdminCmdF(command *cobra.Command, args []string) error {
 			return errors.New("Unable to find user '" + args[i] + "'")
 		}
 
-		if _, err := a.UpdateUserRoles(user.Id, "system_admin system_user", true); err != nil {
+		systemAdmin := false
+		systemUser := false
+
+		roles := strings.Fields(user.Roles)
+		for _, role := range roles {
+			switch role {
+			case model.SYSTEM_ADMIN_ROLE_ID:
+				systemAdmin = true
+			case model.SYSTEM_USER_ROLE_ID:
+				systemUser = true
+			}
+
+			if !systemUser {
+				roles = append(roles, model.SYSTEM_USER_ROLE_ID)
+			}
+			if !systemAdmin {
+				roles = append(roles, model.SYSTEM_ADMIN_ROLE_ID)
+			}
+		}
+
+		if _, err := a.UpdateUserRoles(user.Id, strings.Join(roles, " "), true); err != nil {
 			return err
 		}
 	}
@@ -81,7 +104,26 @@ func makeMemberCmdF(command *cobra.Command, args []string) error {
 			return errors.New("Unable to find user '" + args[i] + "'")
 		}
 
-		if _, err := a.UpdateUserRoles(user.Id, "system_user", true); err != nil {
+		systemUser := false
+		var newRoles []string
+
+		roles := strings.Fields(user.Roles)
+		for _, role := range roles {
+			switch role {
+			case model.SYSTEM_ADMIN_ROLE_ID:
+			default:
+				if role == model.SYSTEM_USER_ROLE_ID {
+					systemUser = true
+				}
+				newRoles = append(newRoles, role)
+			}
+
+			if !systemUser {
+				newRoles = append(roles, model.SYSTEM_USER_ROLE_ID)
+			}
+		}
+
+		if _, err := a.UpdateUserRoles(user.Id, strings.Join(newRoles, " "), true); err != nil {
 			return err
 		}
 	}

--- a/cmd/commands/roles_test.go
+++ b/cmd/commands/roles_test.go
@@ -21,8 +21,19 @@ func TestAssignRole(t *testing.T) {
 		t.Fatal()
 	} else {
 		user := result.Data.(*model.User)
-		if user.Roles != "system_admin system_user" {
-			t.Fatal()
+		if user.Roles != "system_user system_admin" {
+			t.Fatal("Got wrong roles:", user.Roles)
+		}
+	}
+
+	cmd.CheckCommand(t, "roles", "member", th.BasicUser.Email)
+
+	if result := <-th.App.Srv.Store.User().GetByEmail(th.BasicUser.Email); result.Err != nil {
+		t.Fatal()
+	} else {
+		user := result.Data.(*model.User)
+		if user.Roles != "system_user" {
+			t.Fatal("Got wrong roles:", user.Roles, user.Id)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
This makes the `roles` CLI commands advanced-permissions aware. It doesn't make any backwards incompatible changes to the commands, or any changes to their functionality, so they won't be particularly useful as advanced permissions progresses, but we'll be adding new CLI commands for the new functionality in due course, so the objective here is mostly not to break things for existing users who use or script the CLI.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10234

#### Checklist
- [x] Added or updated unit tests (required for all new features)