### PR TITLE
MM-10235: Make permissions reset CLI shcemes-aware.

### DIFF
--- a/app/permissions.go
+++ b/app/permissions.go
@@ -8,6 +8,21 @@ import (
 )
 
 func (a *App) ResetPermissionsSystem() *model.AppError {
+	// Reset all Teams to not have a scheme.
+	if result := <-a.Srv.Store.Team().ResetAllTeamSchemes(); result.Err != nil {
+		return result.Err
+	}
+
+	// Reset all Channels to not have a scheme.
+	if result := <-a.Srv.Store.Channel().ResetAllChannelSchemes(); result.Err != nil {
+		return result.Err
+	}
+
+	// Purge all schemes from the database.
+	if result := <-a.Srv.Store.Scheme().PermanentDeleteAll(); result.Err != nil {
+		return result.Err
+	}
+
 	// Purge all roles from the database.
 	if result := <-a.Srv.Store.Role().PermanentDeleteAll(); result.Err != nil {
 		return result.Err

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -272,6 +272,18 @@
     "translation": "The channel requested to convert is already a private channel."
   },
   {
+    "id": "store.sql_channel.reset_all_channel_schemes.app_error",
+    "translation": "We could not reset the channel schemes"
+  },
+  {
+    "id": "store.sql_scheme.permanent_delete_all.app_error",
+    "translation": "We could not permanently delete the schemes"
+  },
+  {
+    "id": "store.sql_team.reset_all_team_schemes.app_error",
+    "translation": "We could not reset the team schemes"
+  },
+  {
     "id": "api.channel.create_channel.direct_channel.app_error",
     "translation": "Must use createDirectChannel API service for direct message channel creation"
   },

--- a/store/layered_store.go
+++ b/store/layered_store.go
@@ -298,3 +298,9 @@ func (s *LayeredSchemeStore) GetAllPage(scope string, offset int, limit int) Sto
 		return supplier.SchemeGetAllPage(s.TmpContext, scope, offset, limit)
 	})
 }
+
+func (s *LayeredSchemeStore) PermanentDeleteAll() StoreChannel {
+	return s.RunQuery(func(supplier LayeredStoreSupplier) *LayeredStoreSupplierResult {
+		return supplier.SchemePermanentDeleteAll(s.TmpContext)
+	})
+}

--- a/store/layered_store_supplier.go
+++ b/store/layered_store_supplier.go
@@ -43,4 +43,5 @@ type LayeredStoreSupplier interface {
 	SchemeGet(ctx context.Context, schemeId string, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
 	SchemeDelete(ctx context.Context, schemeId string, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
 	SchemeGetAllPage(ctx context.Context, scope string, offset int, limit int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
+	SchemePermanentDeleteAll(ctx context.Context, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
 }

--- a/store/local_cache_supplier_schemes.go
+++ b/store/local_cache_supplier_schemes.go
@@ -46,3 +46,9 @@ func (s *LocalCacheSupplier) SchemeDelete(ctx context.Context, schemeId string, 
 func (s *LocalCacheSupplier) SchemeGetAllPage(ctx context.Context, scope string, offset int, limit int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
 	return s.Next().SchemeGetAllPage(ctx, scope, offset, limit, hints...)
 }
+
+func (s *LocalCacheSupplier) SchemePermanentDeleteAll(ctx context.Context, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
+	defer s.doClearCacheCluster(s.schemeCache)
+
+	return s.Next().SchemePermanentDeleteAll(ctx, hints...)
+}

--- a/store/redis_supplier_schemes.go
+++ b/store/redis_supplier_schemes.go
@@ -28,3 +28,8 @@ func (s *RedisSupplier) SchemeGetAllPage(ctx context.Context, scope string, offs
 	// TODO: Redis caching.
 	return s.Next().SchemeGetAllPage(ctx, scope, offset, limit, hints...)
 }
+
+func (s *RedisSupplier) SchemePermanentDeleteAll(ctx context.Context, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
+	// TODO: Redis caching.
+	return s.Next().SchemePermanentDeleteAll(ctx, hints...)
+}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1772,3 +1772,11 @@ func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId 
 		result.Data = data
 	})
 }
+
+func (s SqlChannelStore) ResetAllChannelSchemes() store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if _, err := s.GetMaster().Exec("UPDATE Channels SET SchemeId=''"); err != nil {
+			result.Err = model.NewAppError("SqlChannelStore.ResetAllChannelSchemes", "store.sql_channel.reset_all_channel_schemes.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+	})
+}

--- a/store/sqlstore/scheme_supplier.go
+++ b/store/sqlstore/scheme_supplier.go
@@ -289,3 +289,13 @@ func (s *SqlSupplier) SchemeGetAllPage(ctx context.Context, scope string, offset
 
 	return result
 }
+
+func (s *SqlSupplier) SchemePermanentDeleteAll(ctx context.Context, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
+	result := store.NewSupplierResult()
+
+	if _, err := s.GetMaster().Exec("DELETE from Schemes"); err != nil {
+		result.Err = model.NewAppError("SqlSchemeStore.PermanentDeleteAll", "store.sql_scheme.permanent_delete_all.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return result
+}

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -794,3 +794,11 @@ func (s SqlTeamStore) MigrateTeamMembers(fromTeamId string, fromUserId string) s
 		result.Data = data
 	})
 }
+
+func (s SqlTeamStore) ResetAllTeamSchemes() store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if _, err := s.GetMaster().Exec("UPDATE Teams SET SchemeId=''"); err != nil {
+			result.Err = model.NewAppError("SqlTeamStore.ResetAllTeamSchemes", "store.sql_team.reset_all_team_schemes.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+	})
+}

--- a/store/store.go
+++ b/store/store.go
@@ -106,6 +106,7 @@ type TeamStore interface {
 	UpdateLastTeamIconUpdate(teamId string, curTime int64) StoreChannel
 	GetTeamsByScheme(schemeId string, offset int, limit int) StoreChannel
 	MigrateTeamMembers(fromTeamId string, fromUserId string) StoreChannel
+	ResetAllTeamSchemes() StoreChannel
 }
 
 type ChannelStore interface {
@@ -165,6 +166,7 @@ type ChannelStore interface {
 	ClearCaches()
 	GetChannelsByScheme(schemeId string, offset int, limit int) StoreChannel
 	MigrateChannelMembers(fromChannelId string, fromUserId string) StoreChannel
+	ResetAllChannelSchemes() StoreChannel
 }
 
 type ChannelMemberHistoryStore interface {
@@ -489,4 +491,5 @@ type SchemeStore interface {
 	Get(schemeId string) StoreChannel
 	GetAllPage(scope string, offset int, limit int) StoreChannel
 	Delete(schemeId string) StoreChannel
+	PermanentDeleteAll() StoreChannel
 }

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -679,6 +679,22 @@ func (_m *ChannelStore) RemoveMember(channelId string, userId string) store.Stor
 	return r0
 }
 
+// ResetAllChannelSchemes provides a mock function with given fields:
+func (_m *ChannelStore) ResetAllChannelSchemes() store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Restore provides a mock function with given fields: channelId, time
 func (_m *ChannelStore) Restore(channelId string, time int64) store.StoreChannel {
 	ret := _m.Called(channelId, time)

--- a/store/storetest/mocks/LayeredStoreDatabaseLayer.go
+++ b/store/storetest/mocks/LayeredStoreDatabaseLayer.go
@@ -655,6 +655,29 @@ func (_m *LayeredStoreDatabaseLayer) SchemeGetAllPage(ctx context.Context, scope
 	return r0
 }
 
+// SchemePermanentDeleteAll provides a mock function with given fields: ctx, hints
+func (_m *LayeredStoreDatabaseLayer) SchemePermanentDeleteAll(ctx context.Context, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
+	_va := make([]interface{}, len(hints))
+	for _i := range hints {
+		_va[_i] = hints[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *store.LayeredStoreSupplierResult
+	if rf, ok := ret.Get(0).(func(context.Context, ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult); ok {
+		r0 = rf(ctx, hints...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*store.LayeredStoreSupplierResult)
+		}
+	}
+
+	return r0
+}
+
 // SchemeSave provides a mock function with given fields: ctx, scheme, hints
 func (_m *LayeredStoreDatabaseLayer) SchemeSave(ctx context.Context, scheme *model.Scheme, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
 	_va := make([]interface{}, len(hints))

--- a/store/storetest/mocks/LayeredStoreSupplier.go
+++ b/store/storetest/mocks/LayeredStoreSupplier.go
@@ -352,6 +352,29 @@ func (_m *LayeredStoreSupplier) SchemeGetAllPage(ctx context.Context, scope stri
 	return r0
 }
 
+// SchemePermanentDeleteAll provides a mock function with given fields: ctx, hints
+func (_m *LayeredStoreSupplier) SchemePermanentDeleteAll(ctx context.Context, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
+	_va := make([]interface{}, len(hints))
+	for _i := range hints {
+		_va[_i] = hints[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *store.LayeredStoreSupplierResult
+	if rf, ok := ret.Get(0).(func(context.Context, ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult); ok {
+		r0 = rf(ctx, hints...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*store.LayeredStoreSupplierResult)
+		}
+	}
+
+	return r0
+}
+
 // SchemeSave provides a mock function with given fields: ctx, scheme, hints
 func (_m *LayeredStoreSupplier) SchemeSave(ctx context.Context, scheme *model.Scheme, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
 	_va := make([]interface{}, len(hints))

--- a/store/storetest/mocks/SchemeStore.go
+++ b/store/storetest/mocks/SchemeStore.go
@@ -61,6 +61,22 @@ func (_m *SchemeStore) GetAllPage(scope string, offset int, limit int) store.Sto
 	return r0
 }
 
+// PermanentDeleteAll provides a mock function with given fields:
+func (_m *SchemeStore) PermanentDeleteAll() store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Save provides a mock function with given fields: scheme
 func (_m *SchemeStore) Save(scheme *model.Scheme) store.StoreChannel {
 	ret := _m.Called(scheme)

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -381,6 +381,22 @@ func (_m *TeamStore) RemoveMember(teamId string, userId string) store.StoreChann
 	return r0
 }
 
+// ResetAllTeamSchemes provides a mock function with given fields:
+func (_m *TeamStore) ResetAllTeamSchemes() store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Save provides a mock function with given fields: team
 func (_m *TeamStore) Save(team *model.Team) store.StoreChannel {
 	ret := _m.Called(team)

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -19,6 +19,7 @@ func TestSchemeStore(t *testing.T, ss store.Store) {
 	t.Run("Get", func(t *testing.T) { testSchemeStoreGet(t, ss) })
 	t.Run("GetAllPage", func(t *testing.T) { testSchemeStoreGetAllPage(t, ss) })
 	t.Run("Delete", func(t *testing.T) { testSchemeStoreDelete(t, ss) })
+	t.Run("PermanentDeleteAll", func(t *testing.T) { testSchemeStorePermanentDeleteAll(t, ss) })
 }
 
 func createDefaultRoles(t *testing.T, ss store.Store) {
@@ -361,4 +362,34 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 
 	sres5 := <-ss.Scheme().Delete(d5.Id)
 	assert.NotNil(t, sres5.Err)
+}
+
+func testSchemeStorePermanentDeleteAll(t *testing.T, ss store.Store) {
+	s1 := &model.Scheme{
+		Name:        model.NewId(),
+		Description: model.NewId(),
+		Scope:       model.SCHEME_SCOPE_TEAM,
+	}
+
+	s2 := &model.Scheme{
+		Name:        model.NewId(),
+		Description: model.NewId(),
+		Scope:       model.SCHEME_SCOPE_CHANNEL,
+	}
+
+	s1 = (<-ss.Scheme().Save(s1)).Data.(*model.Scheme)
+	s2 = (<-ss.Scheme().Save(s2)).Data.(*model.Scheme)
+
+	res := <-ss.Scheme().PermanentDeleteAll()
+	assert.Nil(t, res.Err)
+
+	res1 := <-ss.Scheme().Get(s1.Id)
+	assert.NotNil(t, res1.Err)
+
+	res2 := <-ss.Scheme().Get(s2.Id)
+	assert.NotNil(t, res2.Err)
+
+	res3 := <-ss.Scheme().GetAllPage("", 0, 100000)
+	assert.Nil(t, res3.Err)
+	assert.Len(t, res3.Data.([]*model.Scheme), 0)
 }


### PR DESCRIPTION
#### Summary
This PR makes the `permissions reset` CLI command schemes aware (i.e. it can reset the Phase 2 permissions stuff).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10235

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates