### PR TITLE
MM-10201: querystring for get slash commands

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -23,8 +23,8 @@ func (api *API) InitCommand() {
 	api.BaseRoutes.Team.Handle("/commands/autocomplete", api.ApiSessionRequired(listAutocompleteCommands)).Methods("GET")
 	api.BaseRoutes.Command.Handle("/regen_token", api.ApiSessionRequired(regenCommandToken)).Methods("PUT")
 
-	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testPostCommand)).Methods("POST")
 	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testGetCommand)).Methods("GET")
+	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testPostCommand)).Methods("POST")
 }
 
 func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/command.go
+++ b/api4/command.go
@@ -4,8 +4,8 @@
 package api4
 
 import (
-	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -23,8 +23,8 @@ func (api *API) InitCommand() {
 	api.BaseRoutes.Team.Handle("/commands/autocomplete", api.ApiSessionRequired(listAutocompleteCommands)).Methods("GET")
 	api.BaseRoutes.Command.Handle("/regen_token", api.ApiSessionRequired(regenCommandToken)).Methods("PUT")
 
-	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testCommand)).Methods("POST")
-	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testCommand)).Methods("GET")
+	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testPostCommand)).Methods("POST")
+	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testGetCommand)).Methods("GET")
 }
 
 func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -292,20 +292,46 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(model.MapToJson(resp)))
 }
 
-func testCommand(c *Context, w http.ResponseWriter, r *http.Request) {
+func testGetCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 
-	msg := ""
-	if r.Method == "POST" {
-		msg = msg + "\ntoken=" + r.FormValue("token")
-		msg = msg + "\nteam_domain=" + r.FormValue("team_domain")
-	} else {
-		body, _ := ioutil.ReadAll(r.Body)
-		msg = string(body)
+	if r.Method != http.MethodGet {
+		c.Err = model.NewAppError("testGetCommand", "api.command.invalid_method.app_error", nil, "", http.StatusBadRequest)
+		return
 	}
 
+	values, err := url.ParseQuery(r.URL.RawQuery)
+	if err != nil {
+		c.Err = model.NewAppError("testGetCommand", "api.command.invalid_query_string.app_error", nil, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	msg := "\ntoken=" + values.Get("token")
+	msg = msg + "\nteam_domain=" + values.Get("team_domain")
+
 	rc := &model.CommandResponse{
-		Text:         "test command response " + msg,
+		Text:         "test get command response: " + msg,
+		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
+		Type:         "custom_test",
+		Props:        map[string]interface{}{"someprop": "somevalue"},
+	}
+
+	w.Write([]byte(rc.ToJson()))
+}
+
+func testPostCommand(c *Context, w http.ResponseWriter, r *http.Request) {
+	r.ParseForm()
+
+	if r.Method != http.MethodPost {
+		c.Err = model.NewAppError("testPostCommand", "api.command.invalid_method.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
+	msg := "\ntoken=" + r.FormValue("token")
+	msg = msg + "\nteam_domain=" + r.FormValue("team_domain")
+
+	rc := &model.CommandResponse{
+		Text:         "test post command response: " + msg,
 		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
 		Type:         "custom_test",
 		Props:        map[string]interface{}{"someprop": "somevalue"},

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -392,7 +391,7 @@ func TestRegenToken(t *testing.T) {
 	}
 }
 
-func TestExecuteCommand(t *testing.T) {
+func TestExecutePostCommand(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 	Client := th.Client
@@ -435,7 +434,7 @@ func TestExecuteCommand(t *testing.T) {
 
 	cmdPosted := false
 	for _, post := range posts.Posts {
-		if strings.Contains(post.Message, "test command response") {
+		if post.Message == fmt.Sprintf("test post command response: \ntoken=%s\nteam_domain=%s", postCmd.Token, th.BasicTeam.Name) {
 			if post.Type != "custom_test" {
 				t.Fatal("wrong type set in slash command post")
 			}
@@ -452,6 +451,24 @@ func TestExecuteCommand(t *testing.T) {
 	if !cmdPosted {
 		t.Fatal("Test command response failed to post")
 	}
+}
+
+func TestExecuteGetCommand(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+	channel := th.BasicChannel
+
+	enableCommands := *th.App.Config().ServiceSettings.EnableCommands
+	allowedInternalConnections := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableCommands = &enableCommands })
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
+		})
+	}()
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCommands = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost" })
 
 	getCmd := &model.Command{
 		CreatorId: th.BasicUser.Id,
@@ -465,19 +482,69 @@ func TestExecuteCommand(t *testing.T) {
 		t.Fatal("failed to create get command")
 	}
 
-	commandResponse, resp = Client.ExecuteCommand(channel.Id, "/getcommand")
+	commandResponse, resp := Client.ExecuteCommand(channel.Id, "/getcommand")
 	CheckNoError(t, resp)
 
 	if commandResponse == nil {
 		t.Fatal("command response should have returned")
 	}
 
-	posts, err = th.App.GetPostsPage(channel.Id, 0, 10)
-	if err != nil || posts == nil || len(posts.Order) != 4 {
+	posts, err := th.App.GetPostsPage(channel.Id, 0, 10)
+	if err != nil || posts == nil || len(posts.Order) != 3 {
 		t.Fatal("Test command failed to send")
 	}
 
-	_, resp = Client.ExecuteCommand(channel.Id, "")
+	cmdReceived := false
+	for _, post := range posts.Posts {
+		if post.Message == fmt.Sprintf("test get command response: \ntoken=%s\nteam_domain=%s", getCmd.Token, th.BasicTeam.Name) {
+			if post.Type != "custom_test" {
+				t.Fatal("wrong type set in slash command post")
+			}
+
+			if post.Props["someprop"] != "somevalue" {
+				t.Fatal("wrong prop set in slash command post")
+			}
+
+			cmdReceived = true
+			break
+		}
+	}
+
+	if !cmdReceived {
+		t.Fatal("Test command response failed to be received")
+	}
+}
+
+func TestExecuteInvalidCommand(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+	channel := th.BasicChannel
+
+	enableCommands := *th.App.Config().ServiceSettings.EnableCommands
+	allowedInternalConnections := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableCommands = &enableCommands })
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
+		})
+	}()
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCommands = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost" })
+
+	getCmd := &model.Command{
+		CreatorId: th.BasicUser.Id,
+		TeamId:    th.BasicTeam.Id,
+		URL:       fmt.Sprintf("http://localhost:%v", th.App.Srv.ListenAddr.Port) + model.API_URL_SUFFIX_V4 + "/teams/command_test",
+		Method:    model.COMMAND_METHOD_GET,
+		Trigger:   "getcommand",
+	}
+
+	if _, err := th.App.CreateCommand(getCmd); err != nil {
+		t.Fatal("failed to create get command")
+	}
+
+	_, resp := Client.ExecuteCommand(channel.Id, "")
 	CheckBadRequestStatus(t, resp)
 
 	_, resp = Client.ExecuteCommand(channel.Id, "/")

--- a/app/command.go
+++ b/app/command.go
@@ -230,12 +230,14 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 					p.Set("response_url", args.SiteURL+"/hooks/commands/"+hook.Id)
 				}
 
-				method := "POST"
+				var req *http.Request
 				if cmd.Method == model.COMMAND_METHOD_GET {
-					method = "GET"
+					req, _ = http.NewRequest(http.MethodGet, cmd.URL, nil)
+					req.URL.RawQuery = p.Encode()
+				} else {
+					req, _ = http.NewRequest(http.MethodPost, cmd.URL, strings.NewReader(p.Encode()))
 				}
 
-				req, _ := http.NewRequest(method, cmd.URL, strings.NewReader(p.Encode()))
 				req.Header.Set("Accept", "application/json")
 				req.Header.Set("Authorization", "Token "+cmd.Token)
 				if cmd.Method == model.COMMAND_METHOD_POST {


### PR DESCRIPTION
#### Summary
Slash commands configured to receive GET payloads incorrectly received HTTP requests with bodies.

I'll be updating developer documentation to complement this PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10201

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)