### PR TITLE
allow tuning *IdleConn* for intra-cluster messages

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -325,7 +325,7 @@
         "GossipPort": 8074,
         "StreamingPort": 8075,
         "MaxIdleConns": 100,
-        "MaxIdleConnsPerHost": 2,
+        "MaxIdleConnsPerHost": 128,
         "IdleConnTimeoutMilliseconds": 90000
     },
     "MetricsSettings": {

--- a/config/default.json
+++ b/config/default.json
@@ -323,7 +323,10 @@
         "UseExperimentalGossip": false,
         "ReadOnlyConfig": true,
         "GossipPort": 8074,
-        "StreamingPort": 8075
+        "StreamingPort": 8075,
+        "MaxIdleConns": 100,
+        "MaxIdleConnsPerHost": 2,
+        "IdleConnTimeoutMilliseconds": 90000
     },
     "MetricsSettings": {
         "Enable": false,

--- a/model/config.go
+++ b/model/config.go
@@ -460,14 +460,17 @@ func (s *ServiceSettings) SetDefaults() {
 }
 
 type ClusterSettings struct {
-	Enable                *bool
-	ClusterName           *string
-	OverrideHostname      *string
-	UseIpAddress          *bool
-	UseExperimentalGossip *bool
-	ReadOnlyConfig        *bool
-	GossipPort            *int
-	StreamingPort         *int
+	Enable                      *bool
+	ClusterName                 *string
+	OverrideHostname            *string
+	UseIpAddress                *bool
+	UseExperimentalGossip       *bool
+	ReadOnlyConfig              *bool
+	GossipPort                  *int
+	StreamingPort               *int
+	MaxIdleConns                *int
+	MaxIdleConnsPerHost         *int
+	IdleConnTimeoutMilliseconds *int
 }
 
 func (s *ClusterSettings) SetDefaults() {
@@ -501,6 +504,18 @@ func (s *ClusterSettings) SetDefaults() {
 
 	if s.StreamingPort == nil {
 		s.StreamingPort = NewInt(8075)
+	}
+
+	if s.MaxIdleConns == nil {
+		s.MaxIdleConns = NewInt(100)
+	}
+
+	if s.MaxIdleConnsPerHost == nil {
+		s.MaxIdleConnsPerHost = NewInt(2)
+	}
+
+	if s.IdleConnTimeoutMilliseconds == nil {
+		s.IdleConnTimeoutMilliseconds = NewInt(90000)
 	}
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -511,7 +511,7 @@ func (s *ClusterSettings) SetDefaults() {
 	}
 
 	if s.MaxIdleConnsPerHost == nil {
-		s.MaxIdleConnsPerHost = NewInt(2)
+		s.MaxIdleConnsPerHost = NewInt(128)
 	}
 
 	if s.IdleConnTimeoutMilliseconds == nil {


### PR DESCRIPTION
#### Summary
This change allows tuning the various *IdleConn* parameters for the `http.Client` used for intra-cluster messages.

I haven't tested this with an actual cluster yet, but want to get a build going for easy deployment/loadtesting.

#### Ticket Link
None.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes: https://github.com/mattermost/enterprise/pull/293