### PR TITLE
MM-10606: License feature flag for custom schemes.

### DIFF
--- a/api4/scheme.go
+++ b/api4/scheme.go
@@ -26,7 +26,7 @@ func createScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if c.App.License() == nil {
+	if c.App.License() == nil || !*c.App.License().Features.CustomPermissionsSchemes {
 		c.Err = model.NewAppError("Api4.CreateScheme", "api.scheme.create_scheme.license.error", nil, "", http.StatusNotImplemented)
 		return
 	}
@@ -161,7 +161,7 @@ func patchScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if c.App.License() == nil {
+	if c.App.License() == nil || !*c.App.License().Features.CustomPermissionsSchemes {
 		c.Err = model.NewAppError("Api4.PatchScheme", "api.scheme.patch_scheme.license.error", nil, "", http.StatusNotImplemented)
 		return
 	}
@@ -192,7 +192,7 @@ func deleteScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if c.App.License() == nil {
+	if c.App.License() == nil || !*c.App.License().Features.CustomPermissionsSchemes {
 		c.Err = model.NewAppError("Api4.DeleteScheme", "api.scheme.delete_scheme.license.error", nil, "", http.StatusNotImplemented)
 		return
 	}

--- a/api4/scheme_test.go
+++ b/api4/scheme_test.go
@@ -16,7 +16,7 @@ func TestCreateScheme(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	// Mark the migration as done.
 	<-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
@@ -124,7 +124,7 @@ func TestCreateScheme(t *testing.T) {
 	assert.Nil(t, res.Err)
 
 	th.LoginSystemAdmin()
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	scheme7 := &model.Scheme{
 		Name:        model.NewId(),
@@ -139,7 +139,7 @@ func TestGetScheme(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	// Basic test of creating a team scheme.
 	scheme1 := &model.Scheme{
@@ -198,7 +198,7 @@ func TestGetSchemes(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	scheme1 := &model.Scheme{
 		Name:        model.NewId(),
@@ -260,7 +260,7 @@ func TestGetTeamsForScheme(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	// Mark the migration as done while we create the scheme.
 	<-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
@@ -361,7 +361,7 @@ func TestGetChannelsForScheme(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	// Mark the migration as done while we create the scheme.
 	<-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
@@ -464,7 +464,7 @@ func TestPatchScheme(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
 
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	// Mark the migration as done.
 	<-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
@@ -557,7 +557,7 @@ func TestPatchScheme(t *testing.T) {
 	assert.Nil(t, res.Err)
 
 	th.LoginSystemAdmin()
-	th.App.SetLicense(model.NewTestLicense(""))
+	th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 	_, r12 := th.SystemAdminClient.PatchScheme(s6.Id, schemePatch)
 	CheckInternalErrorStatus(t, r12)
@@ -568,7 +568,7 @@ func TestDeleteScheme(t *testing.T) {
 	defer th.TearDown()
 
 	t.Run("ValidTeamScheme", func(t *testing.T) {
-		th.App.SetLicense(model.NewTestLicense(""))
+		th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 		// Mark the migration as done.
 		<-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
@@ -661,7 +661,7 @@ func TestDeleteScheme(t *testing.T) {
 	})
 
 	t.Run("ValidChannelScheme", func(t *testing.T) {
-		th.App.SetLicense(model.NewTestLicense(""))
+		th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 		// Mark the migration as done.
 		<-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
@@ -736,7 +736,7 @@ func TestDeleteScheme(t *testing.T) {
 	})
 
 	t.Run("FailureCases", func(t *testing.T) {
-		th.App.SetLicense(model.NewTestLicense(""))
+		th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 		// Mark the migration as done.
 		<-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
@@ -773,7 +773,7 @@ func TestDeleteScheme(t *testing.T) {
 		res = <-th.App.Srv.Store.System().PermanentDeleteByName(model.MIGRATION_KEY_ADVANCED_PERMISSIONS_PHASE_2)
 		assert.Nil(t, res.Err)
 
-		th.App.SetLicense(model.NewTestLicense(""))
+		th.App.SetLicense(model.NewTestLicense("custom_permissions_schemes"))
 
 		_, r6 := th.SystemAdminClient.DeleteScheme(s1.Id)
 		CheckInternalErrorStatus(t, r6)

--- a/model/license.go
+++ b/model/license.go
@@ -56,6 +56,7 @@ type Features struct {
 	EmailNotificationContents *bool `json:"email_notification_contents"`
 	DataRetention             *bool `json:"data_retention"`
 	MessageExport             *bool `json:"message_export"`
+	CustomPermissionsSchemes  *bool `json:"custom_permissions_schemes"`
 
 	// after we enabled more features for webrtc we'll need to control them with this
 	FutureFeatures *bool `json:"future_features"`
@@ -78,6 +79,7 @@ func (f *Features) ToMap() map[string]interface{} {
 		"email_notification_contents": *f.EmailNotificationContents,
 		"data_retention":              *f.DataRetention,
 		"message_export":              *f.MessageExport,
+		"custom_permissions_schemes":  *f.CustomPermissionsSchemes,
 		"future":                      *f.FutureFeatures,
 	}
 }
@@ -157,6 +159,10 @@ func (f *Features) SetDefaults() {
 
 	if f.MessageExport == nil {
 		f.MessageExport = NewBool(*f.FutureFeatures)
+	}
+
+	if f.CustomPermissionsSchemes == nil {
+		f.CustomPermissionsSchemes = NewBool(*f.FutureFeatures)
 	}
 }
 

--- a/model/license_test.go
+++ b/model/license_test.go
@@ -28,6 +28,8 @@ func TestLicenseFeaturesToMap(t *testing.T) {
 	CheckTrue(t, m["elastic_search"].(bool))
 	CheckTrue(t, m["email_notification_contents"].(bool))
 	CheckTrue(t, m["data_retention"].(bool))
+	CheckTrue(t, m["message_export"].(bool))
+	CheckTrue(t, m["custom_permissions_schemes"].(bool))
 	CheckTrue(t, m["future"].(bool))
 }
 
@@ -50,6 +52,8 @@ func TestLicenseFeaturesSetDefaults(t *testing.T) {
 	CheckTrue(t, *f.Elasticsearch)
 	CheckTrue(t, *f.EmailNotificationContents)
 	CheckTrue(t, *f.DataRetention)
+	CheckTrue(t, *f.MessageExport)
+	CheckTrue(t, *f.CustomPermissionsSchemes)
 	CheckTrue(t, *f.FutureFeatures)
 
 	f = Features{}
@@ -70,6 +74,8 @@ func TestLicenseFeaturesSetDefaults(t *testing.T) {
 	*f.PasswordRequirements = true
 	*f.Elasticsearch = true
 	*f.DataRetention = true
+	*f.MessageExport = true
+	*f.CustomPermissionsSchemes = true
 	*f.EmailNotificationContents = true
 
 	f.SetDefaults()
@@ -89,6 +95,8 @@ func TestLicenseFeaturesSetDefaults(t *testing.T) {
 	CheckTrue(t, *f.Elasticsearch)
 	CheckTrue(t, *f.EmailNotificationContents)
 	CheckTrue(t, *f.DataRetention)
+	CheckTrue(t, *f.MessageExport)
+	CheckTrue(t, *f.CustomPermissionsSchemes)
 	CheckFalse(t, *f.FutureFeatures)
 }
 
@@ -171,6 +179,8 @@ func TestLicenseToFromJson(t *testing.T) {
 	CheckBool(t, *f1.PasswordRequirements, *f.PasswordRequirements)
 	CheckBool(t, *f1.Elasticsearch, *f.Elasticsearch)
 	CheckBool(t, *f1.DataRetention, *f.DataRetention)
+	CheckBool(t, *f1.MessageExport, *f.MessageExport)
+	CheckBool(t, *f1.CustomPermissionsSchemes, *f.CustomPermissionsSchemes)
 	CheckBool(t, *f1.FutureFeatures, *f.FutureFeatures)
 
 	invalid := `{"asdf`

--- a/utils/license.go
+++ b/utils/license.go
@@ -152,6 +152,7 @@ func GetClientLicense(l *model.License) map[string]string {
 		props["PhoneNumber"] = l.Customer.PhoneNumber
 		props["EmailNotificationContents"] = strconv.FormatBool(*l.Features.EmailNotificationContents)
 		props["MessageExport"] = strconv.FormatBool(*l.Features.MessageExport)
+		props["CustomPermissionsSchemes"] = strconv.FormatBool(*l.Features.CustomPermissionsSchemes)
 	}
 
 	return props


### PR DESCRIPTION
#### Summary
Adds a license feature flag for custom schemes and checks it in the relevant API endpoints.

I've named it `CustomPermissionsSchemes` on the assumption that `CustomRoles` will be behind a different license feature when we implement them. However, I can modify this to just be `AdvancedPermissions` or something if we only want 1 license feature flag for the whole feature.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10606

#### Checklist
- [x] Added or updated unit tests (required for all new features)
