### PR TITLE
MM-10615: Reset teams/channels to default scheme on delete scheme.

### DIFF
--- a/api4/scheme_test.go
+++ b/api4/scheme_test.go
@@ -617,29 +617,6 @@ func TestDeleteScheme(t *testing.T) {
 		assert.Nil(t, res.Err)
 		team := res.Data.(*model.Team)
 
-		// Try and fail to delete the scheme.
-		_, r2 := th.SystemAdminClient.DeleteScheme(s1.Id)
-		CheckInternalErrorStatus(t, r2)
-
-		role1, roleRes1 = th.SystemAdminClient.GetRole(s1.DefaultTeamAdminRole)
-		CheckNoError(t, roleRes1)
-		role2, roleRes2 = th.SystemAdminClient.GetRole(s1.DefaultTeamUserRole)
-		CheckNoError(t, roleRes2)
-		role3, roleRes3 = th.SystemAdminClient.GetRole(s1.DefaultChannelAdminRole)
-		CheckNoError(t, roleRes3)
-		role4, roleRes4 = th.SystemAdminClient.GetRole(s1.DefaultChannelUserRole)
-		CheckNoError(t, roleRes4)
-
-		assert.Zero(t, role1.DeleteAt)
-		assert.Zero(t, role2.DeleteAt)
-		assert.Zero(t, role3.DeleteAt)
-		assert.Zero(t, role4.DeleteAt)
-
-		// Change the team using it to a different scheme.
-		emptyString := ""
-		team.SchemeId = &emptyString
-		res = <-th.App.Srv.Store.Team().Update(team)
-
 		// Delete the Scheme.
 		_, r3 := th.SystemAdminClient.DeleteScheme(s1.Id)
 		CheckNoError(t, r3)
@@ -658,6 +635,11 @@ func TestDeleteScheme(t *testing.T) {
 		assert.NotZero(t, role2.DeleteAt)
 		assert.NotZero(t, role3.DeleteAt)
 		assert.NotZero(t, role4.DeleteAt)
+
+		// Check the team now uses the default scheme
+		c2, resp := th.SystemAdminClient.GetTeam(team.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "", *c2.SchemeId)
 	})
 
 	t.Run("ValidChannelScheme", func(t *testing.T) {
@@ -704,23 +686,6 @@ func TestDeleteScheme(t *testing.T) {
 		assert.Nil(t, res.Err)
 		channel := res.Data.(*model.Channel)
 
-		// Try and fail to delete the scheme.
-		_, r2 := th.SystemAdminClient.DeleteScheme(s1.Id)
-		CheckInternalErrorStatus(t, r2)
-
-		role3, roleRes3 = th.SystemAdminClient.GetRole(s1.DefaultChannelAdminRole)
-		CheckNoError(t, roleRes3)
-		role4, roleRes4 = th.SystemAdminClient.GetRole(s1.DefaultChannelUserRole)
-		CheckNoError(t, roleRes4)
-
-		assert.Zero(t, role3.DeleteAt)
-		assert.Zero(t, role4.DeleteAt)
-
-		// Change the team using it to a different scheme.
-		emptyString := ""
-		channel.SchemeId = &emptyString
-		res = <-th.App.Srv.Store.Channel().Update(channel)
-
 		// Delete the Scheme.
 		_, r3 := th.SystemAdminClient.DeleteScheme(s1.Id)
 		CheckNoError(t, r3)
@@ -733,6 +698,11 @@ func TestDeleteScheme(t *testing.T) {
 
 		assert.NotZero(t, role3.DeleteAt)
 		assert.NotZero(t, role4.DeleteAt)
+
+		// Check the channel now uses the default scheme
+		c2, resp := th.SystemAdminClient.GetChannelByName(channel.Name, channel.TeamId, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "", *c2.SchemeId)
 	})
 
 	t.Run("FailureCases", func(t *testing.T) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6847,16 +6847,16 @@
     "translation": "Unable to get the scheme"
   },
   {
-    "id": "store.sql_scheme.team_count.app_error",
-    "translation": "Unable to count the number of teams using this scheme"
+    "id": "store.sql_scheme.reset_teams.app_error",
+    "translation": "Unable to reset all teams using this scheme to the default scheme"
   },
   {
     "id": "store.sql_scheme.delete.scheme_in_use.app_error",
     "translation": "Unable to delete the scheme as it in use by 1 or more teams or channels"
   },
   {
-    "id": "store.sql_scheme.channel_count.app_error",
-    "translation": "Unable to count the number of channels using this scheme"
+    "id": "store.sql_scheme.reset_channels.app_error",
+    "translation": "Unable to reset all channels using this scheme to the default scheme"
   },
   {
     "id": "store.sql_scheme.delete.role_update.app_error",

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -336,7 +336,12 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	t4 = tres4.Data.(*model.Team)
 
 	sres4 := <-ss.Scheme().Delete(d4.Id)
-	assert.NotNil(t, sres4.Err)
+	assert.Nil(t, sres4.Err)
+
+	tres5 := <-ss.Team().Get(t4.Id)
+	assert.Nil(t, tres5.Err)
+	t5 := tres5.Data.(*model.Team)
+	assert.Equal(t, "", *t5.SchemeId)
 
 	// Try deleting a channel scheme that's in use.
 	s5 := &model.Scheme{
@@ -360,5 +365,10 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	c5 = cres5.Data.(*model.Channel)
 
 	sres5 := <-ss.Scheme().Delete(d5.Id)
-	assert.NotNil(t, sres5.Err)
+	assert.Nil(t, sres5.Err)
+
+	cres6 := <-ss.Channel().Get(c5.Id, true)
+	assert.Nil(t, cres6.Err)
+	c6 := cres6.Data.(*model.Channel)
+	assert.Equal(t, "", *c6.SchemeId)
 }


### PR DESCRIPTION
#### Summary
Instead of blocking deletion of a scheme that's in use, reset all teams/channels using it to the default scheme.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10615

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
