### PR TITLE
 Skip cluster send when getting non-cached statuses

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -524,7 +524,7 @@ func TestS3TestConnection(t *testing.T) {
 	config.FileSettings.AmazonS3Bucket = "Wrong_bucket"
 	_, resp = th.SystemAdminClient.TestS3Connection(&config)
 	CheckInternalErrorStatus(t, resp)
-	require.Equal(t, "Error checking if bucket exists.", resp.Error.Message)
+	require.Equal(t, "Unable to create bucket", resp.Error.Message)
 }
 
 func TestSupportedTimezones(t *testing.T) {

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -10,6 +10,7 @@ import (
 	l4g "github.com/alecthomas/log4go"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetPing(t *testing.T) {
@@ -523,9 +524,7 @@ func TestS3TestConnection(t *testing.T) {
 	config.FileSettings.AmazonS3Bucket = "Wrong_bucket"
 	_, resp = th.SystemAdminClient.TestS3Connection(&config)
 	CheckInternalErrorStatus(t, resp)
-	if resp.Error.Message != "Error checking if bucket exists." {
-		t.Fatal("should return error ")
-	}
+	require.Equal(t, "Error checking if bucket exists.", resp.Error.Message)
 }
 
 func TestSupportedTimezones(t *testing.T) {

--- a/app/status.go
+++ b/app/status.go
@@ -86,7 +86,7 @@ func (a *App) GetStatusesByIds(userIds []string) (map[string]interface{}, *model
 			statuses := result.Data.([]*model.Status)
 
 			for _, s := range statuses {
-				a.AddStatusCache(s)
+				a.AddStatusCacheSkipClusterSend(s)
 				statusMap[s.UserId] = s.Status
 			}
 		}
@@ -133,7 +133,7 @@ func (a *App) GetUserStatusesByIds(userIds []string) ([]*model.Status, *model.Ap
 			statuses := result.Data.([]*model.Status)
 
 			for _, s := range statuses {
-				a.AddStatusCache(s)
+				a.AddStatusCacheSkipClusterSend(s)
 			}
 
 			statusMap = append(statusMap, statuses...)

--- a/config/default.json
+++ b/config/default.json
@@ -318,7 +318,10 @@
         "UseExperimentalGossip": false,
         "ReadOnlyConfig": true,
         "GossipPort": 8074,
-        "StreamingPort": 8075
+        "StreamingPort": 8075,
+        "MaxIdleConns": 100,
+        "MaxIdleConnsPerHost": 2,
+        "IdleConnTimeoutMilliseconds": 90000
     },
     "MetricsSettings": {
         "Enable": false,

--- a/config/default.json
+++ b/config/default.json
@@ -320,7 +320,7 @@
         "GossipPort": 8074,
         "StreamingPort": 8075,
         "MaxIdleConns": 100,
-        "MaxIdleConnsPerHost": 2,
+        "MaxIdleConnsPerHost": 16,
         "IdleConnTimeoutMilliseconds": 90000
     },
     "MetricsSettings": {

--- a/model/config.go
+++ b/model/config.go
@@ -459,14 +459,17 @@ func (s *ServiceSettings) SetDefaults() {
 }
 
 type ClusterSettings struct {
-	Enable                *bool
-	ClusterName           *string
-	OverrideHostname      *string
-	UseIpAddress          *bool
-	UseExperimentalGossip *bool
-	ReadOnlyConfig        *bool
-	GossipPort            *int
-	StreamingPort         *int
+	Enable                      *bool
+	ClusterName                 *string
+	OverrideHostname            *string
+	UseIpAddress                *bool
+	UseExperimentalGossip       *bool
+	ReadOnlyConfig              *bool
+	GossipPort                  *int
+	StreamingPort               *int
+	MaxIdleConns                *int
+	MaxIdleConnsPerHost         *int
+	IdleConnTimeoutMilliseconds *int
 }
 
 func (s *ClusterSettings) SetDefaults() {
@@ -500,6 +503,18 @@ func (s *ClusterSettings) SetDefaults() {
 
 	if s.StreamingPort == nil {
 		s.StreamingPort = NewInt(8075)
+	}
+
+	if s.MaxIdleConns == nil {
+		s.MaxIdleConns = NewInt(100)
+	}
+
+	if s.MaxIdleConnsPerHost == nil {
+		s.MaxIdleConnsPerHost = NewInt(2)
+	}
+
+	if s.IdleConnTimeoutMilliseconds == nil {
+		s.IdleConnTimeoutMilliseconds = NewInt(90000)
 	}
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -510,7 +510,7 @@ func (s *ClusterSettings) SetDefaults() {
 	}
 
 	if s.MaxIdleConnsPerHost == nil {
-		s.MaxIdleConnsPerHost = NewInt(2)
+		s.MaxIdleConnsPerHost = NewInt(16)
 	}
 
 	if s.IdleConnTimeoutMilliseconds == nil {


### PR DESCRIPTION
#### Summary
Based on #8799. Skip cluster send when getting non-cached statuses.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10498