### PR TITLE
fix `make run-server`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ GO_LINKER_FLAGS ?= -ldflags \
 # GOOS/GOARCH of the build host, used to determine whether we're cross-compiling or not
 BUILDER_GOOS_GOARCH="$(shell $(GO) env GOOS)_$(shell $(GO) env GOARCH)"
 
-PLATFORM_FILES="./cmd/mattermost/"
+PLATFORM_FILES="./cmd/mattermost/main.go"
 
 # Output paths
 DIST_ROOT=dist


### PR DESCRIPTION
#### Summary
The `PLATFORM_FILES` environment variable no longer gives `go run` the
necessary context to run the mattermost binary.

#### Ticket Link
None.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
