### PR TITLE
MM-10498 Skip cluster send when getting non-cached statuses

### DIFF
--- a/app/status.go
+++ b/app/status.go
@@ -87,7 +87,7 @@ func (a *App) GetStatusesByIds(userIds []string) (map[string]interface{}, *model
 			statuses := result.Data.([]*model.Status)
 
 			for _, s := range statuses {
-				a.AddStatusCache(s)
+				a.AddStatusCacheSkipClusterSend(s)
 				statusMap[s.UserId] = s.Status
 			}
 		}
@@ -134,7 +134,7 @@ func (a *App) GetUserStatusesByIds(userIds []string) ([]*model.Status, *model.Ap
 			statuses := result.Data.([]*model.Status)
 
 			for _, s := range statuses {
-				a.AddStatusCache(s)
+				a.AddStatusCacheSkipClusterSend(s)
 			}
 
 			statusMap = append(statusMap, statuses...)


### PR DESCRIPTION
#### Summary
Skip cluster send when getting non-cached statuses. Not sure if this will completely fix the issue, but it should reduce cluster messages either way. I'll look at pre-release metrics after this goes in to see if the spikes still occur.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10498