### PR TITLE
MM-10352: Add locking incoming webhooks to a single channel.

### DIFF
--- a/app/webhook.go
+++ b/app/webhook.go
@@ -633,6 +633,10 @@ func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookReq
 		}
 	}
 
+	if hook.ChannelLocked && hook.ChannelId != channel.Id {
+		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel_locked.app_error", nil, "", http.StatusForbidden)
+	}
+
 	if a.License() != nil && *a.Config().TeamSettings.ExperimentalTownSquareIsReadOnly &&
 		channel.Name == model.DEFAULT_CHANNEL {
 		return model.NewAppError("HandleIncomingWebhook", "api.post.create_post.town_square_read_only", nil, "", http.StatusForbidden)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6719,6 +6719,10 @@
     "translation": "Unable to get roles"
   },
   {
+    "id": "web.incoming_webhook.channel_locked.app_error",
+    "translation": "This webhook is not permitted to post to the requested channel"
+  },
+  {
     "id": "store.sql_role.permanent_delete_all.app_error",
     "translation": "We could not permanently delete all the roles"
   },

--- a/model/incoming_webhook.go
+++ b/model/incoming_webhook.go
@@ -16,17 +16,18 @@ const (
 )
 
 type IncomingWebhook struct {
-	Id          string `json:"id"`
-	CreateAt    int64  `json:"create_at"`
-	UpdateAt    int64  `json:"update_at"`
-	DeleteAt    int64  `json:"delete_at"`
-	UserId      string `json:"user_id"`
-	ChannelId   string `json:"channel_id"`
-	TeamId      string `json:"team_id"`
-	DisplayName string `json:"display_name"`
-	Description string `json:"description"`
-	Username    string `json:"username"`
-	IconURL     string `json:"icon_url"`
+	Id            string `json:"id"`
+	CreateAt      int64  `json:"create_at"`
+	UpdateAt      int64  `json:"update_at"`
+	DeleteAt      int64  `json:"delete_at"`
+	UserId        string `json:"user_id"`
+	ChannelId     string `json:"channel_id"`
+	TeamId        string `json:"team_id"`
+	DisplayName   string `json:"display_name"`
+	Description   string `json:"description"`
+	Username      string `json:"username"`
+	IconURL       string `json:"icon_url"`
+	ChannelLocked bool   `json:"channel_locked"`
 }
 
 type IncomingWebhookRequest struct {

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -427,6 +427,8 @@ func UpgradeDatabaseToVersion410(sqlStore SqlStore) {
 func UpgradeDatabaseToVersion50(sqlStore SqlStore) {
 	// TODO: Uncomment following condition when version 3.10.0 is released
 	//if shouldPerformUpgrade(sqlStore, VERSION_4_10_0, VERSION_5_0_0) {
+	sqlStore.CreateColumnIfNotExists("IncomingWebhooks", "ChannelLocked", "boolean", "boolean", "0")
+
 	//	saveSchemaVersion(sqlStore, VERSION_5_0_0)
 	//}
 }


### PR DESCRIPTION
#### Summary
Adds the ability to lock an incoming webhook to a single channel.

Webapp changes: https://github.com/mattermost/mattermost-webapp/pull/1237

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10352

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
