### PR TITLE
MM-10649: soften Channels.ExtraUpdateAt deprecation

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -44,6 +44,7 @@ type Channel struct {
 	Purpose       string `json:"purpose"`
 	LastPostAt    int64  `json:"last_post_at"`
 	TotalMsgCount int64  `json:"total_msg_count"`
+	ExtraUpdateAt int64  `json:"extra_update_at"`
 	CreatorId     string `json:"creator_id"`
 }
 
@@ -132,6 +133,7 @@ func (o *Channel) PreSave() {
 
 	o.CreateAt = GetMillis()
 	o.UpdateAt = o.CreateAt
+	o.ExtraUpdateAt = 0
 }
 
 func (o *Channel) PreUpdate() {

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -713,6 +713,9 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	c1.Type = model.CHANNEL_OPEN
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
 
+	c1t1 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
+	assert.EqualValues(t, 0, c1t1.ExtraUpdateAt, "ExtraUpdateAt should be 0")
+
 	u1 := model.User{}
 	u1.Email = model.NewId()
 	u1.Nickname = model.NewId()
@@ -736,6 +739,9 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	o2.UserId = u2.Id
 	o2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&o2))
+
+	c1t2 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
+	assert.EqualValues(t, 0, c1t2.ExtraUpdateAt, "ExtraUpdateAt should be 0")
 
 	count := (<-ss.Channel().GetMemberCount(o1.ChannelId, true)).Data.(int64)
 	if count != 2 {
@@ -767,6 +773,9 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 		t.Fatal("should have removed 1 member")
 	}
 
+	c1t3 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
+	assert.EqualValues(t, 0, c1t3.ExtraUpdateAt, "ExtraUpdateAt should be 0")
+
 	member := (<-ss.Channel().GetMember(o1.ChannelId, o1.UserId)).Data.(*model.ChannelMember)
 	if member.ChannelId != o1.ChannelId {
 		t.Fatal("should have go member")
@@ -775,6 +784,9 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	if err := (<-ss.Channel().SaveMember(&o1)).Err; err == nil {
 		t.Fatal("Should have been a duplicate")
 	}
+
+	c1t4 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
+	assert.EqualValues(t, 0, c1t4.ExtraUpdateAt, "ExtraUpdateAt should be 0")
 }
 
 func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
@@ -784,6 +796,9 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	c1.Name = "zz" + model.NewId() + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
+
+	c1t1 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
+	assert.EqualValues(t, 0, c1t1.ExtraUpdateAt, "ExtraUpdateAt should be 0")
 
 	u1 := model.User{}
 	u1.Email = model.NewId()
@@ -808,6 +823,9 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	o2.UserId = u2.Id
 	o2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&o2))
+
+	c1t2 := (<-ss.Channel().Get(c1.Id, false)).Data.(*model.Channel)
+	assert.EqualValues(t, 0, c1t2.ExtraUpdateAt, "ExtraUpdateAt should be 0")
 
 	count := (<-ss.Channel().GetMemberCount(o1.ChannelId, false)).Data.(int64)
 	if count != 2 {


### PR DESCRIPTION
#### Summary
The previous complete removal of this field resulted in an incompatibility with 4.x servers that could not handle the now null column field.

Instead, ensure this field is at least always set to 0, with a plan to remove it altogether in a future release.

To test this, I created a fresh database with the 5.0 schema, added a few channels, then switched back to 4.10 without issues. Doing so without this branch resulted in the query failures observed in MM-10649.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10649

#### Checklist
- [x] Added or updated unit tests (required for all new features)