### PR TITLE
Avoid emails if user status is OOO or post is an auto response

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -216,7 +216,9 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 				}
 			}
 
-			if userAllowsEmails && status.Status != model.STATUS_ONLINE && profileMap[id].DeleteAt == 0 {
+			autoResponderRelated := status.Status == model.STATUS_OUT_OF_OFFICE || post.Type == model.POST_AUTO_RESPONDER
+
+			if userAllowsEmails && status.Status != model.STATUS_ONLINE && profileMap[id].DeleteAt == 0 && !autoResponderRelated {
 				a.sendNotificationEmail(post, profileMap[id], channel, team, senderName, sender)
 			}
 		}


### PR DESCRIPTION
#### Summary
Fixes email issues from MM-10638:
* Email notification from @System is sent to the user who DMed the OOO user
* Email notifications are sent to the OOO user


Hot fix for dot-release 4.10.1.
PR for master: https://github.com/mattermost/mattermost-server/pull/8842