### PR TITLE
MM-6992 Added highlighting to elasticsearch results

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -341,7 +341,7 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	startTime := time.Now()
 
-	posts, err := c.App.SearchPostsInTeam(terms, c.Session.UserId, c.Params.TeamId, isOrSearch)
+	results, err := c.App.SearchPostsInTeam(terms, c.Session.UserId, c.Params.TeamId, isOrSearch)
 
 	elapsedTime := float64(time.Since(startTime)) / float64(time.Second)
 	metrics := c.App.Metrics
@@ -356,7 +356,7 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Write([]byte(c.App.PostListWithProxyAddedToImageURLs(posts).ToJson()))
+	w.Write([]byte(c.App.PostListWithProxyAddedToImageURLs(results.PostList).ToJson()))
 }
 
 func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/post.go
+++ b/api4/post.go
@@ -355,8 +355,10 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	results = model.MakePostSearchResults(c.App.PostListWithProxyAddedToImageURLs(results.PostList), results.Matches)
+
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	w.Write([]byte(c.App.PostListWithProxyAddedToImageURLs(results.PostList).ToJson()))
+	w.Write([]byte(results.ToJson()))
 }
 
 func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -12,7 +12,7 @@ import (
 type ElasticsearchInterface interface {
 	Start() *model.AppError
 	IndexPost(post *model.Post, teamId string) *model.AppError
-	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, *model.AppError)
+	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, map[string][]string, *model.AppError)
 	DeletePost(post *model.Post) *model.AppError
 	TestConfig(cfg *model.Config) *model.AppError
 	PurgeIndexes() *model.AppError

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -12,7 +12,7 @@ import (
 type ElasticsearchInterface interface {
 	Start() *model.AppError
 	IndexPost(post *model.Post, teamId string) *model.AppError
-	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, map[string][]string, *model.AppError)
+	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, model.PostSearchMatches, *model.AppError)
 	DeletePost(post *model.Post) *model.AppError
 	TestConfig(cfg *model.Config) *model.AppError
 	PurgeIndexes() *model.AppError

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4279,6 +4279,10 @@
     "translation": "Search failed to complete"
   },
   {
+    "id": "ent.elasticsearch.search_posts.parse_matches_failed",
+    "translation": "Failed to parse search result matches"
+  },
+  {
     "id": "ent.elasticsearch.search_posts.unmarshall_post_failed",
     "translation": "Failed to decode search results"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -2127,6 +2127,17 @@ func (c *Client4) SearchPosts(teamId string, terms string, isOrSearch bool) (*Po
 	}
 }
 
+// SearchPosts returns any posts with matching terms string, including .
+func (c *Client4) SearchPostsWithMatches(teamId string, terms string, isOrSearch bool) (*PostSearchResults, *Response) {
+	requestBody := map[string]interface{}{"terms": terms, "is_or_search": isOrSearch}
+	if r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/posts/search", StringInterfaceToJson(requestBody)); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return PostSearchResultsFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // DoPostAction performs a post action.
 func (c *Client4) DoPostAction(postId, actionId string) (bool, *Response) {
 	if r, err := c.DoApiPost(c.GetPostRoute(postId)+"/actions/"+actionId, ""); err != nil {

--- a/model/post_search_results.go
+++ b/model/post_search_results.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type PostSearchResults struct {
+	*PostList
+	Matches map[string][]string `json:"matches"`
+}
+
+func MakePostSearchResults(posts *PostList, matches map[string][]string) *PostSearchResults {
+	return &PostSearchResults{
+		posts,
+		matches,
+	}
+}
+
+func (o *PostSearchResults) ToJson() string {
+	copy := *o
+	copy.PostList.StripActionIntegrations()
+	b, err := json.Marshal(&copy)
+	if err != nil {
+		return ""
+	} else {
+		return string(b)
+	}
+}
+
+func PostSearchResultsFromJson(data io.Reader) *PostSearchResults {
+	var o *PostSearchResults
+	json.NewDecoder(data).Decode(&o)
+	return o
+}

--- a/model/post_search_results.go
+++ b/model/post_search_results.go
@@ -8,12 +8,14 @@ import (
 	"io"
 )
 
+type PostSearchMatches map[string][]string
+
 type PostSearchResults struct {
 	*PostList
-	Matches map[string][]string `json:"matches"`
+	Matches PostSearchMatches `json:"matches"`
 }
 
-func MakePostSearchResults(posts *PostList, matches map[string][]string) *PostSearchResults {
+func MakePostSearchResults(posts *PostList, matches PostSearchMatches) *PostSearchResults {
 	return &PostSearchResults{
 		posts,
 		matches,


### PR DESCRIPTION
As discussed with George, this adds a `matches` field to search results done with Elasticsearch containing a list of all words in the post that will be highlighted
```
// Searching for appl*
{
    "posts": ...,
    "order": ...,
    "matches": {
        "postid1": ["apple", "apples"],
        "postid2": ["apply", "#apple"],
    }
}
```

Searches done without Elasticsearch will not contain this field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-6992

#### Checklist
- Added or updated unit tests (required for all new features)
- Added API documentation (https://github.com/mattermost/mattermost-api-reference/pull/374)
required for all new APIs)
- All new/modified APIs include changes to the drivers
- Has enterprise changes (https://github.com/mattermost/enterprise/pull/300)
