### PR TITLE
MM-10348 Adding experimental hardened mode.

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -63,7 +63,8 @@
         "ImageProxyType": "",
         "ImageProxyOptions": "",
         "ImageProxyURL": "",
-        "EnableAPITeamDeletion": false
+        "EnableAPITeamDeletion": false,
+        "ExperimentalEnableHardenedMode": false
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/model/config.go
+++ b/model/config.go
@@ -225,6 +225,7 @@ type ServiceSettings struct {
 	ImageProxyURL                                     *string
 	ImageProxyOptions                                 *string
 	EnableAPITeamDeletion                             *bool
+	ExperimentalEnableHardenedMode                    *bool
 }
 
 func (s *ServiceSettings) SetDefaults() {
@@ -456,6 +457,10 @@ func (s *ServiceSettings) SetDefaults() {
 
 	if s.EnableAPITeamDeletion == nil {
 		s.EnableAPITeamDeletion = NewBool(false)
+	}
+
+	if s.ExperimentalEnableHardenedMode == nil {
+		s.ExperimentalEnableHardenedMode = NewBool(false)
 	}
 }
 

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -139,6 +139,16 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			c.Err.DetailedError = ""
 		}
 
+		// Sanitize all 5xx error messages in hardened mode
+		if *c.App.Config().ServiceSettings.ExperimentalEnableHardenedMode && c.Err.StatusCode >= 500 {
+			c.Err.Id = ""
+			c.Err.Message = "Internal Server Error"
+			c.Err.DetailedError = ""
+			c.Err.StatusCode = 500
+			c.Err.Where = ""
+			c.Err.IsOAuth = false
+		}
+
 		w.WriteHeader(c.Err.StatusCode)
 		w.Write([]byte(c.Err.ToJson()))
 


### PR DESCRIPTION
Changes made when this mode is enabled:
- Login will return a generic error message instead of a specific messages for username and password.
- If MFA is enabled, the route to check if a user has MFA enabled will always return true. This will cause the MFA input screen to show even if the user does not have MFA enabled. The user may enter any value to pass the screen. Note that you can enable the setting to enforce MFA and there will be no user experience cost.
- Password reset will not inform the user that they can not reset their SSO account through Mattermost and claim to have sent the password reset email.
- All 500 errors are sanitized before being returned to the client. Use the supplied `request_id` to match user facing errors with the server logs.