### PR TITLE
MM-10757: Default roles from scheme should be keyed by name not ID.

### DIFF
--- a/api4/scheme_test.go
+++ b/api4/scheme_test.go
@@ -44,13 +44,13 @@ func TestCreateScheme(t *testing.T) {
 	assert.NotZero(t, len(s1.DefaultChannelUserRole))
 
 	// Check the default roles have been created.
-	_, roleRes1 := th.SystemAdminClient.GetRole(s1.DefaultTeamAdminRole)
+	_, roleRes1 := th.SystemAdminClient.GetRoleByName(s1.DefaultTeamAdminRole)
 	CheckNoError(t, roleRes1)
-	_, roleRes2 := th.SystemAdminClient.GetRole(s1.DefaultTeamUserRole)
+	_, roleRes2 := th.SystemAdminClient.GetRoleByName(s1.DefaultTeamUserRole)
 	CheckNoError(t, roleRes2)
-	_, roleRes3 := th.SystemAdminClient.GetRole(s1.DefaultChannelAdminRole)
+	_, roleRes3 := th.SystemAdminClient.GetRoleByName(s1.DefaultChannelAdminRole)
 	CheckNoError(t, roleRes3)
-	_, roleRes4 := th.SystemAdminClient.GetRole(s1.DefaultChannelUserRole)
+	_, roleRes4 := th.SystemAdminClient.GetRoleByName(s1.DefaultChannelUserRole)
 	CheckNoError(t, roleRes4)
 
 	// Basic Test of a Channel scheme.
@@ -77,9 +77,9 @@ func TestCreateScheme(t *testing.T) {
 	assert.NotZero(t, len(s2.DefaultChannelUserRole))
 
 	// Check the default roles have been created.
-	_, roleRes5 := th.SystemAdminClient.GetRole(s2.DefaultChannelAdminRole)
+	_, roleRes5 := th.SystemAdminClient.GetRoleByName(s2.DefaultChannelAdminRole)
 	CheckNoError(t, roleRes5)
-	_, roleRes6 := th.SystemAdminClient.GetRole(s2.DefaultChannelUserRole)
+	_, roleRes6 := th.SystemAdminClient.GetRoleByName(s2.DefaultChannelUserRole)
 	CheckNoError(t, roleRes6)
 
 	// Try and create a scheme with an invalid scope.
@@ -590,13 +590,13 @@ func TestDeleteScheme(t *testing.T) {
 		CheckNoError(t, r1)
 
 		// Retrieve the roles and check they are not deleted.
-		role1, roleRes1 := th.SystemAdminClient.GetRole(s1.DefaultTeamAdminRole)
+		role1, roleRes1 := th.SystemAdminClient.GetRoleByName(s1.DefaultTeamAdminRole)
 		CheckNoError(t, roleRes1)
-		role2, roleRes2 := th.SystemAdminClient.GetRole(s1.DefaultTeamUserRole)
+		role2, roleRes2 := th.SystemAdminClient.GetRoleByName(s1.DefaultTeamUserRole)
 		CheckNoError(t, roleRes2)
-		role3, roleRes3 := th.SystemAdminClient.GetRole(s1.DefaultChannelAdminRole)
+		role3, roleRes3 := th.SystemAdminClient.GetRoleByName(s1.DefaultChannelAdminRole)
 		CheckNoError(t, roleRes3)
-		role4, roleRes4 := th.SystemAdminClient.GetRole(s1.DefaultChannelUserRole)
+		role4, roleRes4 := th.SystemAdminClient.GetRoleByName(s1.DefaultChannelUserRole)
 		CheckNoError(t, roleRes4)
 
 		assert.Zero(t, role1.DeleteAt)
@@ -620,13 +620,13 @@ func TestDeleteScheme(t *testing.T) {
 		CheckNoError(t, r3)
 
 		// Check the roles were deleted.
-		role1, roleRes1 = th.SystemAdminClient.GetRole(s1.DefaultTeamAdminRole)
+		role1, roleRes1 = th.SystemAdminClient.GetRoleByName(s1.DefaultTeamAdminRole)
 		CheckNoError(t, roleRes1)
-		role2, roleRes2 = th.SystemAdminClient.GetRole(s1.DefaultTeamUserRole)
+		role2, roleRes2 = th.SystemAdminClient.GetRoleByName(s1.DefaultTeamUserRole)
 		CheckNoError(t, roleRes2)
-		role3, roleRes3 = th.SystemAdminClient.GetRole(s1.DefaultChannelAdminRole)
+		role3, roleRes3 = th.SystemAdminClient.GetRoleByName(s1.DefaultChannelAdminRole)
 		CheckNoError(t, roleRes3)
-		role4, roleRes4 = th.SystemAdminClient.GetRole(s1.DefaultChannelUserRole)
+		role4, roleRes4 = th.SystemAdminClient.GetRoleByName(s1.DefaultChannelUserRole)
 		CheckNoError(t, roleRes4)
 
 		assert.NotZero(t, role1.DeleteAt)
@@ -657,9 +657,9 @@ func TestDeleteScheme(t *testing.T) {
 		CheckNoError(t, r1)
 
 		// Retrieve the roles and check they are not deleted.
-		role3, roleRes3 := th.SystemAdminClient.GetRole(s1.DefaultChannelAdminRole)
+		role3, roleRes3 := th.SystemAdminClient.GetRoleByName(s1.DefaultChannelAdminRole)
 		CheckNoError(t, roleRes3)
-		role4, roleRes4 := th.SystemAdminClient.GetRole(s1.DefaultChannelUserRole)
+		role4, roleRes4 := th.SystemAdminClient.GetRoleByName(s1.DefaultChannelUserRole)
 		CheckNoError(t, roleRes4)
 
 		assert.Zero(t, role3.DeleteAt)
@@ -681,9 +681,9 @@ func TestDeleteScheme(t *testing.T) {
 		CheckNoError(t, r3)
 
 		// Check the roles were deleted.
-		role3, roleRes3 = th.SystemAdminClient.GetRole(s1.DefaultChannelAdminRole)
+		role3, roleRes3 = th.SystemAdminClient.GetRoleByName(s1.DefaultChannelAdminRole)
 		CheckNoError(t, roleRes3)
-		role4, roleRes4 = th.SystemAdminClient.GetRole(s1.DefaultChannelUserRole)
+		role4, roleRes4 = th.SystemAdminClient.GetRoleByName(s1.DefaultChannelUserRole)
 		CheckNoError(t, roleRes4)
 
 		assert.NotZero(t, role3.DeleteAt)

--- a/app/apptestlib.go
+++ b/app/apptestlib.go
@@ -330,7 +330,7 @@ func (me *TestHelper) CreateScheme() (*model.Scheme, []*model.Role) {
 		panic(err)
 	}
 
-	roleIDs := []string{
+	roleNames := []string{
 		scheme.DefaultTeamAdminRole,
 		scheme.DefaultTeamUserRole,
 		scheme.DefaultChannelAdminRole,
@@ -338,8 +338,8 @@ func (me *TestHelper) CreateScheme() (*model.Scheme, []*model.Role) {
 	}
 
 	var roles []*model.Role
-	for _, roleID := range roleIDs {
-		role, err := me.App.GetRole(roleID)
+	for _, roleName := range roleNames {
+		role, err := me.App.GetRoleByName(roleName)
 		if err != nil {
 			panic(err)
 		}

--- a/store/sqlstore/scheme_supplier.go
+++ b/store/sqlstore/scheme_supplier.go
@@ -109,7 +109,7 @@ func (s *SqlSupplier) createScheme(ctx context.Context, scheme *model.Scheme, tr
 			result.Err = saveRoleResult.Err
 			return result
 		} else {
-			scheme.DefaultTeamAdminRole = saveRoleResult.Data.(*model.Role).Id
+			scheme.DefaultTeamAdminRole = saveRoleResult.Data.(*model.Role).Name
 		}
 
 		// Team User Role
@@ -124,7 +124,7 @@ func (s *SqlSupplier) createScheme(ctx context.Context, scheme *model.Scheme, tr
 			result.Err = saveRoleResult.Err
 			return result
 		} else {
-			scheme.DefaultTeamUserRole = saveRoleResult.Data.(*model.Role).Id
+			scheme.DefaultTeamUserRole = saveRoleResult.Data.(*model.Role).Name
 		}
 	}
 	if scheme.Scope == model.SCHEME_SCOPE_TEAM || scheme.Scope == model.SCHEME_SCOPE_CHANNEL {
@@ -140,7 +140,7 @@ func (s *SqlSupplier) createScheme(ctx context.Context, scheme *model.Scheme, tr
 			result.Err = saveRoleResult.Err
 			return result
 		} else {
-			scheme.DefaultChannelAdminRole = saveRoleResult.Data.(*model.Role).Id
+			scheme.DefaultChannelAdminRole = saveRoleResult.Data.(*model.Role).Name
 		}
 
 		// Channel User Role
@@ -155,7 +155,7 @@ func (s *SqlSupplier) createScheme(ctx context.Context, scheme *model.Scheme, tr
 			result.Err = saveRoleResult.Err
 			return result
 		} else {
-			scheme.DefaultChannelUserRole = saveRoleResult.Data.(*model.Role).Id
+			scheme.DefaultChannelUserRole = saveRoleResult.Data.(*model.Role).Name
 		}
 	}
 
@@ -231,16 +231,16 @@ func (s *SqlSupplier) SchemeDelete(ctx context.Context, schemeId string, hints .
 	}
 
 	// Delete the roles belonging to the scheme.
-	roleIds := []string{scheme.DefaultChannelUserRole, scheme.DefaultChannelAdminRole}
+	roleNames := []string{scheme.DefaultChannelUserRole, scheme.DefaultChannelAdminRole}
 	if scheme.Scope == model.SCHEME_SCOPE_TEAM {
-		roleIds = append(roleIds, scheme.DefaultTeamUserRole, scheme.DefaultTeamAdminRole)
+		roleNames = append(roleNames, scheme.DefaultTeamUserRole, scheme.DefaultTeamAdminRole)
 	}
 
 	var inQueryList []string
 	queryArgs := make(map[string]interface{})
-	for i, roleId := range roleIds {
-		inQueryList = append(inQueryList, fmt.Sprintf(":RoleId%v", i))
-		queryArgs[fmt.Sprintf("RoleId%v", i)] = roleId
+	for i, roleId := range roleNames {
+		inQueryList = append(inQueryList, fmt.Sprintf(":RoleName%v", i))
+		queryArgs[fmt.Sprintf("RoleName%v", i)] = roleId
 	}
 	inQuery := strings.Join(inQueryList, ", ")
 
@@ -248,7 +248,7 @@ func (s *SqlSupplier) SchemeDelete(ctx context.Context, schemeId string, hints .
 	queryArgs["UpdateAt"] = time
 	queryArgs["DeleteAt"] = time
 
-	if _, err := s.GetMaster().Exec("UPDATE Roles SET UpdateAt = :UpdateAt, DeleteAt = :DeleteAt WHERE Id IN ("+inQuery+")", queryArgs); err != nil {
+	if _, err := s.GetMaster().Exec("UPDATE Roles SET UpdateAt = :UpdateAt, DeleteAt = :DeleteAt WHERE Name IN ("+inQuery+")", queryArgs); err != nil {
 		result.Err = model.NewAppError("SqlSchemeStore.Delete", "store.sql_scheme.delete.role_update.app_error", nil, "Id="+schemeId+", "+err.Error(), http.StatusInternalServerError)
 		return result
 	}

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -440,8 +440,8 @@ func (s SqlTeamStore) AnalyticsTeamCount() store.StoreChannel {
 var TEAM_MEMBERS_WITH_SCHEME_SELECT_QUERY = `
 	SELECT
 		TeamMembers.*,
-		TeamScheme.DefaultChannelUserRole TeamSchemeDefaultUserRole,
-		TeamScheme.DefaultChannelAdminRole TeamSchemeDefaultAdminRole
+		TeamScheme.DefaultTeamUserRole TeamSchemeDefaultUserRole,
+		TeamScheme.DefaultTeamAdminRole TeamSchemeDefaultAdminRole
 	FROM 
 		TeamMembers
 	LEFT JOIN

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -87,25 +87,25 @@ func testSchemeStoreSave(t *testing.T, ss store.Store) {
 	assert.Len(t, d1.DefaultChannelUserRole, 26)
 
 	// Check the default roles were created correctly.
-	roleRes1 := <-ss.Role().Get(d1.DefaultTeamAdminRole)
+	roleRes1 := <-ss.Role().GetByName(d1.DefaultTeamAdminRole)
 	assert.Nil(t, roleRes1.Err)
 	role1 := roleRes1.Data.(*model.Role)
 	assert.Equal(t, role1.Permissions, []string{"edit_others_posts", "delete_others_posts"})
 	assert.True(t, role1.SchemeManaged)
 
-	roleRes2 := <-ss.Role().Get(d1.DefaultTeamUserRole)
+	roleRes2 := <-ss.Role().GetByName(d1.DefaultTeamUserRole)
 	assert.Nil(t, roleRes2.Err)
 	role2 := roleRes2.Data.(*model.Role)
 	assert.Equal(t, role2.Permissions, []string{"view_team", "add_user_to_team"})
 	assert.True(t, role2.SchemeManaged)
 
-	roleRes3 := <-ss.Role().Get(d1.DefaultChannelAdminRole)
+	roleRes3 := <-ss.Role().GetByName(d1.DefaultChannelAdminRole)
 	assert.Nil(t, roleRes3.Err)
 	role3 := roleRes3.Data.(*model.Role)
 	assert.Equal(t, role3.Permissions, []string{"manage_public_channel_members", "manage_private_channel_members"})
 	assert.True(t, role3.SchemeManaged)
 
-	roleRes4 := <-ss.Role().Get(d1.DefaultChannelUserRole)
+	roleRes4 := <-ss.Role().GetByName(d1.DefaultChannelUserRole)
 	assert.Nil(t, roleRes4.Err)
 	role4 := roleRes4.Data.(*model.Role)
 	assert.Equal(t, role4.Permissions, []string{"read_channel", "create_post"})
@@ -274,25 +274,25 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	assert.Len(t, d1.DefaultChannelUserRole, 26)
 
 	// Check the default roles were created correctly.
-	roleRes1 := <-ss.Role().Get(d1.DefaultTeamAdminRole)
+	roleRes1 := <-ss.Role().GetByName(d1.DefaultTeamAdminRole)
 	assert.Nil(t, roleRes1.Err)
 	role1 := roleRes1.Data.(*model.Role)
 	assert.Equal(t, role1.Permissions, []string{"edit_others_posts", "delete_others_posts"})
 	assert.True(t, role1.SchemeManaged)
 
-	roleRes2 := <-ss.Role().Get(d1.DefaultTeamUserRole)
+	roleRes2 := <-ss.Role().GetByName(d1.DefaultTeamUserRole)
 	assert.Nil(t, roleRes2.Err)
 	role2 := roleRes2.Data.(*model.Role)
 	assert.Equal(t, role2.Permissions, []string{"view_team", "add_user_to_team"})
 	assert.True(t, role2.SchemeManaged)
 
-	roleRes3 := <-ss.Role().Get(d1.DefaultChannelAdminRole)
+	roleRes3 := <-ss.Role().GetByName(d1.DefaultChannelAdminRole)
 	assert.Nil(t, roleRes3.Err)
 	role3 := roleRes3.Data.(*model.Role)
 	assert.Equal(t, role3.Permissions, []string{"manage_public_channel_members", "manage_private_channel_members"})
 	assert.True(t, role3.SchemeManaged)
 
-	roleRes4 := <-ss.Role().Get(d1.DefaultChannelUserRole)
+	roleRes4 := <-ss.Role().GetByName(d1.DefaultChannelUserRole)
 	assert.Nil(t, roleRes4.Err)
 	role4 := roleRes4.Data.(*model.Role)
 	assert.Equal(t, role4.Permissions, []string{"read_channel", "create_post"})
@@ -307,22 +307,22 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	assert.NotZero(t, d2.DeleteAt)
 
 	// Check that the roles are deleted too.
-	roleRes5 := <-ss.Role().Get(d1.DefaultTeamAdminRole)
+	roleRes5 := <-ss.Role().GetByName(d1.DefaultTeamAdminRole)
 	assert.Nil(t, roleRes5.Err)
 	role5 := roleRes5.Data.(*model.Role)
 	assert.NotZero(t, role5.DeleteAt)
 
-	roleRes6 := <-ss.Role().Get(d1.DefaultTeamUserRole)
+	roleRes6 := <-ss.Role().GetByName(d1.DefaultTeamUserRole)
 	assert.Nil(t, roleRes6.Err)
 	role6 := roleRes6.Data.(*model.Role)
 	assert.NotZero(t, role6.DeleteAt)
 
-	roleRes7 := <-ss.Role().Get(d1.DefaultChannelAdminRole)
+	roleRes7 := <-ss.Role().GetByName(d1.DefaultChannelAdminRole)
 	assert.Nil(t, roleRes7.Err)
 	role7 := roleRes7.Data.(*model.Role)
 	assert.NotZero(t, role7.DeleteAt)
 
-	roleRes8 := <-ss.Role().Get(d1.DefaultChannelUserRole)
+	roleRes8 := <-ss.Role().GetByName(d1.DefaultChannelUserRole)
 	assert.Nil(t, roleRes8.Err)
 	role8 := roleRes8.Data.(*model.Role)
 	assert.NotZero(t, role8.DeleteAt)


### PR DESCRIPTION
#### Summary
Roles are keyed by `name` rather than ID when assigned to member objects, but custom schemes were keying them by ID instead, meaning that permissions checks in custom schemes were looking up invalid roles.

Thanks to @mkraft for investigating the cause of this bug.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10757

#### Checklist
- [x] Added or updated unit tests (required for all new features)
