### PR TITLE
MM-10412: Adds deleteBy prop to posts.

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -264,7 +264,7 @@ func deletePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if _, err := c.App.DeletePost(c.Params.PostId); err != nil {
+	if _, err := c.App.DeletePost(c.Params.PostId, c.Session.UserId); err != nil {
 		c.Err = err
 		return
 	}

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -158,7 +158,7 @@ func (api *PluginAPI) CreatePost(post *model.Post) (*model.Post, *model.AppError
 }
 
 func (api *PluginAPI) DeletePost(postId string) *model.AppError {
-	_, err := api.app.DeletePost(postId)
+	_, err := api.app.DeletePost(postId, api.id)
 	return err
 }
 

--- a/app/post.go
+++ b/app/post.go
@@ -569,14 +569,14 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 	}
 }
 
-func (a *App) DeletePost(postId string) (*model.Post, *model.AppError) {
+func (a *App) DeletePost(postId, deleteByID string) (*model.Post, *model.AppError) {
 	if result := <-a.Srv.Store.Post().GetSingle(postId); result.Err != nil {
 		result.Err.StatusCode = http.StatusBadRequest
 		return nil, result.Err
 	} else {
 		post := result.Data.(*model.Post)
 
-		if result := <-a.Srv.Store.Post().Delete(postId, model.GetMillis()); result.Err != nil {
+		if result := <-a.Srv.Store.Post().Delete(postId, model.GetMillis(), deleteByID); result.Err != nil {
 			return nil, result.Err
 		}
 

--- a/model/post.go
+++ b/model/post.go
@@ -50,6 +50,7 @@ const (
 	POST_CUSTOM_TYPE_PREFIX     = "custom_"
 	PROPS_ADD_CHANNEL_MEMBER    = "add_channel_member"
 	POST_PROPS_ADDED_USER_ID    = "addedUserId"
+	POST_PROPS_DELETE_BY        = "deleteBy"
 )
 
 type Post struct {

--- a/store/store.go
+++ b/store/store.go
@@ -181,7 +181,7 @@ type PostStore interface {
 	Update(newPost *model.Post, oldPost *model.Post) StoreChannel
 	Get(id string) StoreChannel
 	GetSingle(id string) StoreChannel
-	Delete(postId string, time int64) StoreChannel
+	Delete(postId string, time int64, deleteByID string) StoreChannel
 	PermanentDeleteByUser(userId string) StoreChannel
 	PermanentDeleteByChannel(channelId string) StoreChannel
 	GetPosts(channelId string, offset int, limit int, allowFromCache bool) StoreChannel

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -67,12 +67,12 @@ func (_m *PostStore) ClearCaches() {
 }
 
 // Delete provides a mock function with given fields: postId, time
-func (_m *PostStore) Delete(postId string, time int64) store.StoreChannel {
+func (_m *PostStore) Delete(postId string, time int64, deleteByID string) store.StoreChannel {
 	ret := _m.Called(postId, time)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
-		r0 = rf(postId, time)
+	if rf, ok := ret.Get(0).(func(string, int64, string) store.StoreChannel); ok {
+		r0 = rf(postId, time, deleteByID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)


### PR DESCRIPTION
#### Summary
Adds `deleteBy` to the `Props` json of deleted posts. Normally the value is set to the user id of the current user except for deletion by a plugin in which case the value is set to the plugin id (but that may be changed in the future if the plugin API is changed to allow the plugin to set an arbitrary value).

#### Ticket Link
[MM-10412](https://mattermost.atlassian.net/browse/MM-10412)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)