### PR TITLE
MM-10597 Improved handling of punctuation around notifications

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -1004,23 +1004,24 @@ func GetExplicitMentions(message string, keywords map[string][]string) *Explicit
 				continue
 			}
 
+			word = strings.TrimLeft(word, ":.-_")
+
 			if checkForMention(word) {
 				continue
 			}
 
-			// remove trailing '.', as that is the end of a sentence
-			foundWithSuffix := false
-			for _, suffixPunctuation := range []string{".", ":"} {
-				for strings.HasSuffix(word, suffixPunctuation) {
-					word = strings.TrimSuffix(word, suffixPunctuation)
-					if checkForMention(word) {
-						foundWithSuffix = true
-						break
-					}
+			foundWithoutSuffix := false
+			wordWithoutSuffix := word
+			for strings.LastIndexAny(wordWithoutSuffix, ".-:_") != -1 {
+				wordWithoutSuffix = wordWithoutSuffix[0 : len(wordWithoutSuffix)-1]
+
+				if checkForMention(wordWithoutSuffix) {
+					foundWithoutSuffix = true
+					break
 				}
 			}
 
-			if foundWithSuffix {
+			if foundWithoutSuffix {
 				continue
 			}
 

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -148,14 +148,58 @@ func TestGetExplicitMentions(t *testing.T) {
 				OtherPotentialMentions: []string{"user"},
 			},
 		},
-		"OnePersonWithColonAtEnd": {
-			Message:  "this is a message for @user:",
-			Keywords: map[string][]string{"this": {id1}},
+		"OnePersonWithPeriodAfter": {
+			Message:  "this is a message for @user.",
+			Keywords: map[string][]string{"@user": {id1}},
 			Expected: &ExplicitMentions{
 				MentionedUserIds: map[string]bool{
 					id1: true,
 				},
-				OtherPotentialMentions: []string{"user"},
+			},
+		},
+		"OnePersonWithPeriodBefore": {
+			Message:  "this is a message for .@user",
+			Keywords: map[string][]string{"@user": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"OnePersonWithColonAfter": {
+			Message:  "this is a message for @user:",
+			Keywords: map[string][]string{"@user": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"OnePersonWithColonBefore": {
+			Message:  "this is a message for :@user",
+			Keywords: map[string][]string{"@user": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"OnePersonWithHyphenAfter": {
+			Message:  "this is a message for @user.",
+			Keywords: map[string][]string{"@user": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"OnePersonWithHyphenBefore": {
+			Message:  "this is a message for -@user",
+			Keywords: map[string][]string{"@user": {id1}},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
 			},
 		},
 		"MultiplePeopleWithOneWord": {
@@ -493,7 +537,7 @@ func TestGetExplicitMentionsAtHere(t *testing.T) {
 		"(@here(":   true,
 		")@here)":   true,
 		"-@here-":   true,
-		"_@here_":   false, // This case shouldn't mention since it would be mentioning "@here_"
+		"_@here_":   true,
 		"=@here=":   true,
 		"+@here+":   true,
 		"[@here[":   true,


### PR DESCRIPTION
The main fix here is to do a left trim to remove the punctuation preceding the word. I looked at improving the splitting logic to not be so clunky, but because we're matching arbitrary words and not just at mentions, it broke some existing behaviour, so I left that as it was.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10597

#### Checklist
- Added or updated unit tests (required for all new features)
- Touches critical sections of the codebase (notifications)
