### PR TITLE
MM-9547 Fixed invalid CustomUrlSchemes error message

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2368,7 +2368,7 @@ func (ds *DisplaySettings) isValid() *AppError {
 				return NewAppError(
 					"Config.IsValid",
 					"model.config.is_valid.display.custom_url_schemes.app_error",
-					map[string]interface{}{"Protocol": scheme},
+					map[string]interface{}{"Scheme": scheme},
 					"",
 					http.StatusBadRequest,
 				)


### PR DESCRIPTION
I missed changing this when I updated the wording of the setting from "protocol" to "scheme". The translation string reads `The custom URL scheme {{.Scheme}} is invalid...`