### PR TITLE
Break HTML blocks to individual strings

### DIFF
--- a/app/email.go
+++ b/app/email.go
@@ -142,8 +142,9 @@ func (a *App) SendSignInChangeEmail(email, method, locale, siteURL string) *mode
 	bodyPage := a.NewEmailTemplate("signin_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.signin_change_email.body.title")
-	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.signin_change_email.body.info",
+	bodyPage.Props["Info"] = T("api.templates.signin_change_email.body.info",
 		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"], "Method": method})
+	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
 	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendSignInChangeEmail", "api.user.send_sign_in_change_email_and_forget.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -100,8 +100,10 @@ func (a *App) SendEmailChangeEmail(oldEmail, newEmail, locale, siteURL string) *
 	bodyPage := a.NewEmailTemplate("email_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.email_change_body.title")
-	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.email_change_body.info",
+	bodyPage.Props["Info"] = T("api.templates.email_change_body.info",
 		map[string]interface{}{"TeamDisplayName": a.Config().TeamSettings.SiteName, "NewEmail": newEmail})
+	
+	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
 	if err := a.SendMail(oldEmail, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendEmailChangeEmail", "api.user.send_email_change_email_and_forget.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -225,8 +225,9 @@ func (a *App) SendUserAccessTokenAddedEmail(email, locale, siteURL string) *mode
 	bodyPage := a.NewEmailTemplate("password_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.user_access_token_body.title")
-	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.user_access_token_body.info",
+	bodyPage.Props["Info"] = T("api.templates.user_access_token_body.info",
 		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"], "SiteURL": siteURL})
+	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
 	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendUserAccessTokenAddedEmail", "api.user.send_user_access_token.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -55,8 +55,9 @@ func (a *App) SendChangeUsernameEmail(oldUsername, newUsername, email, locale, s
 	bodyPage := a.NewEmailTemplate("email_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.username_change_body.title")
-	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.username_change_body.info",
+	bodyPage.Props["Info"] = T("api.templates.username_change_body.info",
 		map[string]interface{}{"TeamDisplayName": a.Config().TeamSettings.SiteName, "NewUsername": newUsername})
+	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
 	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendChangeUsernameEmail", "api.user.send_email_change_username_and_forget.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -242,7 +242,8 @@ func (a *App) SendPasswordResetEmail(email string, token *model.Token, locale, s
 	bodyPage := a.NewEmailTemplate("reset_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.reset_body.title")
-	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.reset_body.info", nil)
+	bodyPage.Props["Info1"] = utils.TranslateAsHtml(T, "api.templates.reset_body.info1", nil)
+	bodyPage.Props["Info2"] = T("api.templates.reset_body.info2")
 	bodyPage.Props["ResetUrl"] = link
 	bodyPage.Props["Button"] = T("api.templates.reset_body.button")
 

--- a/app/email.go
+++ b/app/email.go
@@ -216,17 +216,17 @@ func (a *App) SendPasswordChangeEmail(email, method, locale, siteURL string) *mo
 	return nil
 }
 
-func (a *App) SendUserAccessTokenAddedEmail(email, locale string) *model.AppError {
+func (a *App) SendUserAccessTokenAddedEmail(email, locale, siteURL string) *model.AppError {
 	T := utils.GetUserTranslations(locale)
 
 	subject := T("api.templates.user_access_token_subject",
 		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"]})
 
 	bodyPage := a.NewEmailTemplate("password_change_body", locale)
-	bodyPage.Props["SiteURL"] = a.GetSiteURL()
+	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.user_access_token_body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.user_access_token_body.info",
-		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"], "SiteURL": a.GetSiteURL()})
+		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"], "SiteURL": siteURL})
 
 	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendUserAccessTokenAddedEmail", "api.user.send_user_access_token.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -223,6 +223,7 @@ func (a *App) SendUserAccessTokenAddedEmail(email, locale string) *model.AppErro
 		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"]})
 
 	bodyPage := a.NewEmailTemplate("password_change_body", locale)
+	bodyPage.Props["SiteURL"] = a.GetSiteURL()
 	bodyPage.Props["Title"] = T("api.templates.user_access_token_body.title")
 	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.user_access_token_body.info",
 		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"], "SiteURL": a.GetSiteURL()})

--- a/app/email.go
+++ b/app/email.go
@@ -319,7 +319,8 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, senderUserId
 			bodyPage.Props["Info"] = map[string]interface{}{}
 			bodyPage.Props["Button"] = utils.T("api.templates.invite_body.button")
 			bodyPage.Html["ExtraInfo"] = utils.TranslateAsHtml(utils.T, "api.templates.invite_body.extra_info",
-				map[string]interface{}{"TeamDisplayName": team.DisplayName, "TeamURL": siteURL + "/" + team.Name})
+				map[string]interface{}{"TeamDisplayName": team.DisplayName})
+			bodyPage.Props["TeamURL"] = siteURL + "/" + team.Name
 
 			token := model.NewToken(
 				TOKEN_TYPE_TEAM_INVITATION,

--- a/app/email.go
+++ b/app/email.go
@@ -102,7 +102,6 @@ func (a *App) SendEmailChangeEmail(oldEmail, newEmail, locale, siteURL string) *
 	bodyPage.Props["Title"] = T("api.templates.email_change_body.title")
 	bodyPage.Props["Info"] = T("api.templates.email_change_body.info",
 		map[string]interface{}{"TeamDisplayName": a.Config().TeamSettings.SiteName, "NewEmail": newEmail})
-	
 	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
 	if err := a.SendMail(oldEmail, subject, bodyPage.Render()); err != nil {
@@ -373,7 +372,6 @@ func (a *App) NewEmailTemplate(name, locale string) *utils.HTMLTemplate {
 	t.Props["EmailInfo3"] = localT("api.templates.email_info3",
 		map[string]interface{}{"SiteName": a.Config().TeamSettings.SiteName})
 	t.Props["SupportEmail"] = *a.Config().SupportSettings.SupportEmail
-
 
 	return t
 }

--- a/app/email.go
+++ b/app/email.go
@@ -201,8 +201,9 @@ func (a *App) SendPasswordChangeEmail(email, method, locale, siteURL string) *mo
 	bodyPage := a.NewEmailTemplate("password_change_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.password_change_body.title")
-	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.password_change_body.info",
+	bodyPage.Props["Info"] = T("api.templates.password_change_body.info",
 		map[string]interface{}{"TeamDisplayName": a.Config().TeamSettings.SiteName, "TeamURL": siteURL, "Method": method})
+	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
 	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendPasswordChangeEmail", "api.user.send_password_change_email_and_forget.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -262,12 +262,13 @@ func (a *App) SendMfaChangeEmail(email string, activated bool, locale, siteURL s
 	bodyPage.Props["SiteURL"] = siteURL
 
 	if activated {
-		bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.mfa_activated_body.info", map[string]interface{}{"SiteURL": siteURL})
+		bodyPage.Props["Info"] = T("api.templates.mfa_activated_body.info", map[string]interface{}{"SiteURL": siteURL})
 		bodyPage.Props["Title"] = T("api.templates.mfa_activated_body.title")
 	} else {
-		bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.mfa_deactivated_body.info", map[string]interface{}{"SiteURL": siteURL})
+		bodyPage.Props["Info"] = T("api.templates.mfa_deactivated_body.info", map[string]interface{}{"SiteURL": siteURL})
 		bodyPage.Props["Title"] = T("api.templates.mfa_deactivated_body.title")
 	}
+	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
 	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendMfaChangeEmail", "api.user.send_mfa_change_email.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -390,8 +390,9 @@ func (a *App) SendDeactivateAccountEmail(email string, locale, siteURL string) *
 	bodyPage := a.NewEmailTemplate("deactivate_body", locale)
 	bodyPage.Props["SiteURL"] = siteURL
 	bodyPage.Props["Title"] = T("api.templates.deactivate_body.title", map[string]interface{}{"ServerURL": rawUrl.Host})
-	bodyPage.Html["Info"] = utils.TranslateAsHtml(T, "api.templates.deactivate_body.info",
+	bodyPage.Props["Info"] = T("api.templates.deactivate_body.info",
 		map[string]interface{}{"SiteURL": siteURL})
+	bodyPage.Props["Warning"] = T("api.templates.deactivate_body.warning")
 
 	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendDeactivateEmail", "api.user.send_deactivate_email_and_forget.failed.error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/email.go
+++ b/app/email.go
@@ -363,8 +363,12 @@ func (a *App) NewEmailTemplate(name, locale string) *utils.HTMLTemplate {
 		t.Props["Organization"] = ""
 	}
 
-	t.Html["EmailInfo"] = utils.TranslateAsHtml(localT, "api.templates.email_info",
-		map[string]interface{}{"SupportEmail": *a.Config().SupportSettings.SupportEmail, "SiteName": a.Config().TeamSettings.SiteName})
+	t.Props["EmailInfo1"] = localT("api.templates.email_info1")
+	t.Props["EmailInfo2"] = localT("api.templates.email_info2")
+	t.Props["EmailInfo3"] = localT("api.templates.email_info3",
+		map[string]interface{}{"SiteName": a.Config().TeamSettings.SiteName})
+	t.Props["SupportEmail"] = *a.Config().SupportSettings.SupportEmail
+
 
 	return t
 }

--- a/app/notification.go
+++ b/app/notification.go
@@ -6,7 +6,6 @@ package app
 import (
 	"fmt"
 	"html"
-	"html/template"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -550,12 +549,11 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 
 	t := getFormattedPostTime(recipient, post, useMilitaryTime, translateFunc)
 
-	var bodyText string
-	var info template.HTML
 	if channel.Type == model.CHANNEL_DIRECT {
 		if emailNotificationContentsType == model.EMAIL_NOTIFICATION_CONTENTS_FULL {
-			bodyText = translateFunc("app.notification.body.intro.direct.full")
-			info = utils.TranslateAsHtml(translateFunc, "app.notification.body.text.direct.full",
+			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.direct.full")
+			bodyPage.Props["Info1"] = ""
+			bodyPage.Props["Info2"] = translateFunc("app.notification.body.text.direct.full",
 				map[string]interface{}{
 					"SenderName": senderName,
 					"Hour":       t.Hour,
@@ -565,10 +563,10 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 					"Day":        t.Day,
 				})
 		} else {
-			bodyText = translateFunc("app.notification.body.intro.direct.generic", map[string]interface{}{
+			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.direct.generic", map[string]interface{}{
 				"SenderName": senderName,
 			})
-			info = utils.TranslateAsHtml(translateFunc, "app.notification.body.text.direct.generic",
+			bodyPage.Props["Info"] = translateFunc("app.notification.body.text.direct.generic",
 				map[string]interface{}{
 					"Hour":     t.Hour,
 					"Minute":   t.Minute,
@@ -579,10 +577,13 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 		}
 	} else if channel.Type == model.CHANNEL_GROUP {
 		if emailNotificationContentsType == model.EMAIL_NOTIFICATION_CONTENTS_FULL {
-			bodyText = translateFunc("app.notification.body.intro.group_message.full")
-			info = utils.TranslateAsHtml(translateFunc, "app.notification.body.text.group_message.full",
+			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.group_message.full")
+			bodyPage.Props["Info1"] = translateFunc("app.notification.body.text.group_message.full",
 				map[string]interface{}{
 					"ChannelName": channelName,
+				})
+			bodyPage.Props["Info2"] = translateFunc("app.notification.body.text.group_message.full2",
+				map[string]interface{}{
 					"SenderName":  senderName,
 					"Hour":        t.Hour,
 					"Minute":      t.Minute,
@@ -591,10 +592,10 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 					"Day":         t.Day,
 				})
 		} else {
-			bodyText = translateFunc("app.notification.body.intro.group_message.generic", map[string]interface{}{
+			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.group_message.generic", map[string]interface{}{
 				"SenderName": senderName,
 			})
-			info = utils.TranslateAsHtml(translateFunc, "app.notification.body.text.group_message.generic",
+			bodyPage.Props["Info"] = translateFunc("app.notification.body.text.group_message.generic",
 				map[string]interface{}{
 					"Hour":     t.Hour,
 					"Minute":   t.Minute,
@@ -605,10 +606,13 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 		}
 	} else {
 		if emailNotificationContentsType == model.EMAIL_NOTIFICATION_CONTENTS_FULL {
-			bodyText = translateFunc("app.notification.body.intro.notification.full")
-			info = utils.TranslateAsHtml(translateFunc, "app.notification.body.text.notification.full",
+			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.notification.full")
+			bodyPage.Props["Info1"] = translateFunc("app.notification.body.text.notification.full",
 				map[string]interface{}{
 					"ChannelName": channelName,
+				})
+			bodyPage.Props["Info2"] = translateFunc("app.notification.body.text.notification.full2",
+				map[string]interface{}{
 					"SenderName":  senderName,
 					"Hour":        t.Hour,
 					"Minute":      t.Minute,
@@ -617,10 +621,10 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 					"Day":         t.Day,
 				})
 		} else {
-			bodyText = translateFunc("app.notification.body.intro.notification.generic", map[string]interface{}{
+			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.notification.generic", map[string]interface{}{
 				"SenderName": senderName,
 			})
-			info = utils.TranslateAsHtml(translateFunc, "app.notification.body.text.notification.generic",
+			bodyPage.Props["Info"] = translateFunc("app.notification.body.text.notification.generic",
 				map[string]interface{}{
 					"Hour":     t.Hour,
 					"Minute":   t.Minute,
@@ -631,8 +635,6 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 		}
 	}
 
-	bodyPage.Props["BodyText"] = bodyText
-	bodyPage.Html["Info"] = info
 	bodyPage.Props["Button"] = translateFunc("api.templates.post_body.button")
 
 	return bodyPage.Render()

--- a/app/notification.go
+++ b/app/notification.go
@@ -584,12 +584,12 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 				})
 			bodyPage.Props["Info2"] = translateFunc("app.notification.body.text.group_message.full2",
 				map[string]interface{}{
-					"SenderName":  senderName,
-					"Hour":        t.Hour,
-					"Minute":      t.Minute,
-					"TimeZone":    t.TimeZone,
-					"Month":       t.Month,
-					"Day":         t.Day,
+					"SenderName": senderName,
+					"Hour":       t.Hour,
+					"Minute":     t.Minute,
+					"TimeZone":   t.TimeZone,
+					"Month":      t.Month,
+					"Day":        t.Day,
 				})
 		} else {
 			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.group_message.generic", map[string]interface{}{
@@ -613,12 +613,12 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 				})
 			bodyPage.Props["Info2"] = translateFunc("app.notification.body.text.notification.full2",
 				map[string]interface{}{
-					"SenderName":  senderName,
-					"Hour":        t.Hour,
-					"Minute":      t.Minute,
-					"TimeZone":    t.TimeZone,
-					"Month":       t.Month,
-					"Day":         t.Day,
+					"SenderName": senderName,
+					"Hour":       t.Hour,
+					"Minute":     t.Minute,
+					"TimeZone":   t.TimeZone,
+					"Month":      t.Month,
+					"Day":        t.Day,
 				})
 		} else {
 			bodyPage.Props["BodyText"] = translateFunc("app.notification.body.intro.notification.generic", map[string]interface{}{

--- a/app/session.go
+++ b/app/session.go
@@ -261,7 +261,7 @@ func (a *App) CreateUserAccessToken(token *model.UserAccessToken) (*model.UserAc
 		mlog.Error(result.Err.Error())
 	} else {
 		user := result.Data.(*model.User)
-		if err := a.SendUserAccessTokenAddedEmail(user.Email, user.Locale); err != nil {
+		if err := a.SendUserAccessTokenAddedEmail(user.Email, user.Locale, a.GetSiteURL()); err != nil {
 			mlog.Error(err.Error())
 		}
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1864,7 +1864,7 @@
   },
   {
     "id": "api.templates.signin_change_email.body.info",
-    "translation": "You updated your sign-in method on {{ .SiteName }} to {{.Method}}.<br>If this change wasn't initiated by you, please contact your system administrator."
+    "translation": "You updated your sign-in method on {{ .SiteName }} to {{.Method}}."
   },
   {
     "id": "api.templates.signin_change_email.body.method_email",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1779,8 +1779,16 @@
     "translation": "To change your notification preferences, log in to your team site and go to Account Settings > Notifications."
   },
   {
-    "id": "api.templates.email_info",
-    "translation": "Any questions at all, mail us any time: <a href='mailto:{{.SupportEmail}}' style='text-decoration: none; color:#2389D7;'>{{.SupportEmail}}</a>.<br>Best wishes,<br>The {{.SiteName}} Team<br>"
+    "id": "api.templates.email_info1",
+    "translation": "Any questions at all, mail us any time: "
+  },
+  {
+    "id": "api.templates.email_info2",
+    "translation": "Best wishes,"
+  },
+  {
+    "id": "api.templates.email_info3",
+    "translation": "The {{.SiteName}} Team"
   },
   {
     "id": "api.templates.email_organization",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1900,7 +1900,7 @@
   },
   {
     "id": "api.templates.username_change_body.info",
-    "translation": "Your username for {{.TeamDisplayName}} has been changed to {{.NewUsername}}.<br>If you did not make this change, please contact the system administrator."
+    "translation": "Your username for {{.TeamDisplayName}} has been changed to {{.NewUsername}}."
   },
   {
     "id": "api.templates.username_change_body.title",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1847,8 +1847,12 @@
     "translation": "Reset Password"
   },
   {
-    "id": "api.templates.reset_body.info",
-    "translation": "To change your password, click \"Reset Password\" below.<br>If you did not mean to reset your password, please ignore this email and your password will remain the same. The password reset link expires in 24 hours."
+    "id": "api.templates.reset_body.info1",
+    "translation": "To change your password, click \"Reset Password\" below."
+  },
+  {
+    "id": "api.templates.reset_body.info2",
+    "translation": "If you did not mean to reset your password, please ignore this email and your password will remain the same. The password reset link expires in 24 hours."
   },
   {
     "id": "api.templates.reset_body.title",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1799,6 +1799,10 @@
     "translation": "Sent by "
   },
   {
+    "id": "api.templates.email_warning",
+    "translation": "If you did not make this change, please contact the system administrator."
+  },
+  {
     "id": "api.templates.invite_body.button",
     "translation": "Join Team"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1804,11 +1804,11 @@
   },
   {
     "id": "api.templates.invite_body.extra_info",
-    "translation": "Mattermost lets you share messages and files from your PC or phone, with instant search and archiving. After you’ve joined <strong>{{.TeamDisplayName}}</strong>, you can sign-in to your new team and access these features anytime from the web address:<br/><br/><a href='{{.TeamURL}}'>{{.TeamURL}}</a>"
+    "translation": "Mattermost lets you share messages and files from your PC or phone, with instant search and archiving. After you’ve joined [[{{.TeamDisplayName}}]], you can sign-in to your new team and access these features anytime from the web address:"
   },
   {
     "id": "api.templates.invite_body.info",
-    "translation": "The team {{.SenderStatus}} <strong>{{.SenderName}}</strong>, has invited you to join <strong>{{.TeamDisplayName}}</strong>."
+    "translation": "The team {{.SenderStatus}} [[{{.SenderName}}]], has invited you to join [[{{.TeamDisplayName}}]]."
   },
   {
     "id": "api.templates.invite_body.title",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1827,10 +1827,6 @@
     "translation": "Multi-factor authentication was added"
   },
   {
-    "id": "api.templates.mfa_change_extra",
-    "translation": "If this change was not initiated by you, please contact your system administrator."
-  },
-  {
     "id": "api.templates.mfa_change_subject",
     "translation": "[{{ .SiteName }}] Your MFA has been updated"
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1828,7 +1828,7 @@
   },
   {
     "id": "api.templates.password_change_body.info",
-    "translation": "Your password has been updated for {{.TeamDisplayName}} on {{ .TeamURL }} by {{.Method}}.<br>If this change wasn't initiated by you, please contact your system administrator."
+    "translation": "Your password has been updated for {{.TeamDisplayName}} on {{ .TeamURL }} by {{.Method}}."
   },
   {
     "id": "api.templates.password_change_body.title",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1888,7 +1888,7 @@
   },
   {
     "id": "api.templates.user_access_token_body.info",
-    "translation": "A personal access token was added to your account on {{ .SiteURL }}. They can be used to access {{.SiteName}} with your account.<br>If this change wasn't initiated by you, please contact your system administrator."
+    "translation": "A personal access token was added to your account on {{ .SiteURL }}. They can be used to access {{.SiteName}} with your account."
   },
   {
     "id": "api.templates.user_access_token_body.title",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1736,7 +1736,11 @@
   },
   {
     "id": "api.templates.deactivate_body.info",
-    "translation": "You deactivated your account on {{ .SiteURL }}.<br>If this change wasn't initiated by you or you want to reactivate your account, contact your system administrator."
+    "translation": "You deactivated your account on {{ .SiteURL }}."
+  },
+  {
+    "id": "api.templates.deactivate_body.warning",
+    "translation": "If this change was not initiated by you or you want to reactivate your account, contact your system administrator."
   },
   {
     "id": "api.templates.deactivate_body.title",
@@ -1821,6 +1825,10 @@
   {
     "id": "api.templates.mfa_activated_body.title",
     "translation": "Multi-factor authentication was added"
+  },
+  {
+    "id": "api.templates.mfa_change_extra",
+    "translation": "If this change was not initiated by you, please contact your system administrator."
   },
   {
     "id": "api.templates.mfa_change_subject",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1748,7 +1748,7 @@
   },
   {
     "id": "api.templates.email_change_body.info",
-    "translation": "Your email address for {{.TeamDisplayName}} has been changed to {{.NewEmail}}.<br>If you did not make this change, please contact the system administrator."
+    "translation": "Your email address for {{.TeamDisplayName}} has been changed to {{.NewEmail}}."
   },
   {
     "id": "api.templates.email_change_body.title",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2956,7 +2956,11 @@
   },
   {
     "id": "app.notification.body.text.group_message.full",
-    "translation": "Channel: {{.ChannelName}}<br>@{{.SenderName}} - {{.Hour}}:{{.Minute}} {{.TimeZone}}, {{.Month}} {{.Day}}"
+    "translation": "Channel: {{.ChannelName}}"
+  },
+  {
+    "id": "app.notification.body.text.group_message.full2",
+    "translation": "@{{.SenderName}} - {{.Hour}}:{{.Minute}} {{.TimeZone}}, {{.Month}} {{.Day}}"
   },
   {
     "id": "app.notification.body.text.group_message.generic",
@@ -2964,7 +2968,11 @@
   },
   {
     "id": "app.notification.body.text.notification.full",
-    "translation": "Channel: {{.ChannelName}}<br>@{{.SenderName}} - {{.Hour}}:{{.Minute}} {{.TimeZone}}, {{.Month}} {{.Day}}"
+    "translation": "Channel: {{.ChannelName}}"
+  },
+  {
+    "id": "app.notification.body.text.notification.full2",
+    "translation": "@{{.SenderName}} - {{.Hour}}:{{.Minute}} {{.TimeZone}}, {{.Month}} {{.Day}}"
   },
   {
     "id": "app.notification.body.text.notification.generic",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -41,7 +41,7 @@
   },
   {
     "id": "api.admin.test_email.body",
-    "translation": "<br/><br/><br/>It appears your Mattermost email is setup correctly!"
+    "translation": "It appears your Mattermost email is setup correctly!"
   },
   {
     "id": "api.admin.test_email.missing_server",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1808,7 +1808,7 @@
   },
   {
     "id": "api.templates.mfa_activated_body.info",
-    "translation": "Multi-factor authentication has been added to your account on {{ .SiteURL }}.<br>If this change wasn't initiated by you, please contact your system administrator."
+    "translation": "Multi-factor authentication has been added to your account on {{ .SiteURL }}."
   },
   {
     "id": "api.templates.mfa_activated_body.title",
@@ -1820,7 +1820,7 @@
   },
   {
     "id": "api.templates.mfa_deactivated_body.info",
-    "translation": "Multi-factor authentication has been removed from your account on {{ .SiteURL }}.<br>If this change wasn't initiated by you, please contact your system administrator."
+    "translation": "Multi-factor authentication has been removed from your account on {{ .SiteURL }}."
   },
   {
     "id": "api.templates.mfa_deactivated_body.title",

--- a/templates/deactivate_body.html
+++ b/templates/deactivate_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.Title}}</h2>
-                                                <p>{{.Html.Info}}</p>
+                                                <p>{{.Props.Info}}<br>{{.Props.Warning}}</p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/templates/email_change_body.html
+++ b/templates/email_change_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.Title}}</h2>
-                                                <p>{{.Html.Info}}</p>
+                                                <p>{{.Props.Info}}<br>{{.Props.Warning}}</p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/templates/email_info.html
+++ b/templates/email_info.html
@@ -1,7 +1,7 @@
 {{define "email_info"}}
 
 <td style="color: #999; padding-top: 20px; line-height: 25px; font-size: 13px;">
-    {{.Html.EmailInfo}}
+    {{.Props.EmailInfo1}}<a href='mailto:{{.Props.SupportEmail}}' style='text-decoration: none; color:#2389D7;'>{{.Props.SupportEmail}}</a><br>{{.Props.EmailInfo2}}<br>{{.Props.EmailInfo3}}<br>
 </td>
 
 {{end}}

--- a/templates/invite_body.html
+++ b/templates/invite_body.html
@@ -23,7 +23,7 @@
                                                     <a href="{{.Props.Link}}" style="background: #2389D7; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 200px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none;text-decoration: none;">{{.Props.Button}}</a>
                                                 </p>
                                                 <br/>
-                                                <p>{{.Html.ExtraInfo}}</p>
+                                                <p>{{.Html.ExtraInfo}}<br/><br/><a href='{{.Props.TeamURL}}'>{{.Props.TeamURL}}</a></p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/templates/mfa_change_body.html
+++ b/templates/mfa_change_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.Title}}</h2>
-                                                <p>{{.Html.Info}}</p>
+                                                <p>{{.Props.Info}}<br>{{.Props.Warning}}</p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/templates/password_change_body.html
+++ b/templates/password_change_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.Title}}</h2>
-                                                <p>{{.Html.Info}}</p>
+                                                <p>{{.Props.Info}}<br>{{.Props.Warning}}</p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/templates/post_body_full.html
+++ b/templates/post_body_full.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.BodyText}}</h2>
-                                                <p>{{.Html.Info}}<br><pre style="text-align:left;font-family: 'Lato', sans-serif; white-space: pre-wrap; white-space: -moz-pre-wrap; white-space: -pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word;">{{.Props.PostMessage}}</pre></p>
+                                                <p>{{.Props.Info1}}<br>{{.Props.Info2}}<br><pre style="text-align:left;font-family: 'Lato', sans-serif; white-space: pre-wrap; white-space: -moz-pre-wrap; white-space: -pre-wrap; white-space: -o-pre-wrap; word-wrap: break-word;">{{.Props.PostMessage}}</pre></p>
                                                 <p style="margin: 20px 0 15px">
                                                     <a href="{{.Props.TeamLink}}" style="background: #2389D7; display: inline-block; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 170px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none;text-decoration: none;">{{.Props.Button}}</a>
                                                 </p>

--- a/templates/reset_body.html
+++ b/templates/reset_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.Title}}</h2>
-                                                <p>{{.Html.Info}}</p>
+                                                <p>{{.Props.Info1}}<br>{{.Props.Info2}}</p>
                                                 <p style="margin: 20px 0 15px">
                                                     <a href="{{.Props.ResetUrl}}" style="background: #2389D7; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 200px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none;text-decoration: none;">{{.Props.Button}}</a>
                                                 </p>

--- a/templates/signin_change_body.html
+++ b/templates/signin_change_body.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.Title}}</h2>
-                                                <p>{{.Html.Info}}</p>
+                                                <p>{{.Props.Info}}<br>{{.Props.Warning}}</p>
                                             </td>
                                         </tr>
                                         <tr>

--- a/utils/html.go
+++ b/utils/html.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync/atomic"
 
 	"github.com/fsnotify/fsnotify"
@@ -119,7 +120,10 @@ func (t *HTMLTemplate) RenderToWriter(w io.Writer) error {
 }
 
 func TranslateAsHtml(t i18n.TranslateFunc, translationID string, args map[string]interface{}) template.HTML {
-	return template.HTML(t(translationID, escapeForHtml(args)))
+	message := t(translationID, escapeForHtml(args))
+	message = strings.Replace(message, "[[", "<strong>", -1)
+	message = strings.Replace(message, "]]", "</strong>", -1)
+	return template.HTML(message)
 }
 
 func escapeForHtml(arg interface{}) interface{} {

--- a/utils/html_test.go
+++ b/utils/html_test.go
@@ -28,7 +28,7 @@ func init() {
 	htmlTestTranslationBundle = bundle.New()
 	fooBold, _ := translation.NewTranslation(map[string]interface{}{
 		"id":          "foo.bold",
-		"translation": "<b>{{ .Foo }}</b>",
+		"translation": "<p>[[{{ .Foo }}]]</p>",
 	})
 	htmlTestTranslationBundle.AddTranslation(&language.Language{Tag: "en"}, fooBold)
 }
@@ -103,7 +103,7 @@ func TestHTMLTemplate_RenderError(t *testing.T) {
 }
 
 func TestTranslateAsHtml(t *testing.T) {
-	assert.EqualValues(t, "<b>&lt;i&gt;foo&lt;/i&gt;</b>", TranslateAsHtml(i18n.TranslateFunc(htmlTestTranslationBundle.MustTfunc("en")), "foo.bold", map[string]interface{}{
+	assert.EqualValues(t, "<p><strong>&lt;i&gt;foo&lt;/i&gt;</strong></p>", TranslateAsHtml(i18n.TranslateFunc(htmlTestTranslationBundle.MustTfunc("en")), "foo.bold", map[string]interface{}{
 		"Foo": "<i>foo</i>",
 	}))
 }


### PR DESCRIPTION
#### Summary
(Some messages have not been fixed yet. See the bottom of Issue for details.)
Broke messages containing HTML tag to individual messages, and modifyed accordingly other resources such as e-mail templates etc.

#### Ticket Link
#6174
[JIRA](https://mattermost.atlassian.net/browse/MM-3736)

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates


---

## Status

UPDATED: 2018/06/27

| No | Status  | Message ID |
|:--:|:--------|:-----------|
| 1  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/298194723a8d8555bcb304e1a147d85f888a6c4f)       | api.admin.test_email.body |
| 2  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/6a014c90a304521a71f5e6f30ff0db07947dae79)    | api.templates.email_change_body.info |
| 3  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/4b510c95d1ce754b5e418a2b8594ba30dca06fcd)    | api.templates.email_info |
| 4  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/0038ed058cee4626a35b327f25269fa3bd51ae63), ([FIX](https://github.com/mattermost/mattermost-server/pull/8903/commits/15114b48df8d18a8304a60bcd6586f1d177bb611))   | api.templates.deactivate_body.info |
| 5  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/36c9ca7b881310abf2be8290b855bdaa1cafe9dc) | api.templates.invite_body.extra_info |
| 6  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/36c9ca7b881310abf2be8290b855bdaa1cafe9dc) | api.templates.invite_body.info |
| 7  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/50e038c1f6a5782f3465b1b1ece47e1a7f6b7031)    | api.templates.mfa_activated_body.info |
| 8  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/50e038c1f6a5782f3465b1b1ece47e1a7f6b7031)      | api.templates.mfa_deactivated_body.info |
| 9  | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/a7109f63edf8f61d1cbea9491d4560a75f4de0f9)    | api.templates.password_change_body.info |
| 10 | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/579b6fb62bdc2705f84105940c83a8ab97d3d4e1)    | api.templates.reset_body.info |
| 11 | [DONE](hhttps://github.com/mattermost/mattermost-server/pull/8903/commits/67f9236750d6f321d54ef6de29a835f2828e47e4)    | api.templates.signin_change_email.body.info |
| 12 | Removed by #8980 | api.templates.signup_team_body.info |
| 13 | Removed by #8980  | api.templates.upgrade_30_body.info |
| 14 | DONE [1](https://github.com/mattermost/mattermost-server/pull/8903/commits/c64b7be936174eb51e3332820d915b1cf0fe61fc),[2](https://github.com/mattermost/mattermost-server/pull/8903/commits/b58b31b05ba9c80268b60683154e9b2d020d7ca9),[3](https://github.com/mattermost/mattermost-server/pull/8903/commits/fd8be08aade2df60ba350e293379a38f3c904118)    | api.templates.user_access_token_body.info |
| 15 | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/9ce55d3c62b120ad8693af095f00990088e9325b)    | api.templates.username_change_body.info |
| 16 | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/5fe56efc8310a23b378780bac34440f2413bb2a1)    | app.notification.body.text.group_message.full |
| 17 | [DONE](https://github.com/mattermost/mattermost-server/pull/8903/commits/5fe56efc8310a23b378780bac34440f2413bb2a1)    | app.notification.body.text.notification.full |


## Questions
* ~~No.1~~
  * ~~This message is used in test email directly. Can I just remove 3 `<br/>` tags from the message?~~
* ~~No.5,6~~
  * ~~HTML tags appear in the middle of the message, so it seems necessary to change the whole message. But I have no idea how should we change these message.~~

## NOTE
* No.2, 16
  * This message has been fixed already. But the last sentence (`If you did not make this change,~`) is changed to `If this change wasn't initiated by you, please contact your system administrator.` to make it the same as other messages.
* No.14: The following changes include.
  * Add Props["siteURL"] (to fix bug)
  * Add argument `siteURL` to make it same as other methods in email.go
