### PR TITLE
Use regex to find mentions

### DIFF
--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -469,7 +469,41 @@ func TestGetExplicitMentions(t *testing.T) {
 				ChannelMentioned: true,
 			},
 		},
-
+		"ChineseKeywordMatchFully": {
+			Message: "番茄",
+			Keywords: map[string][]string{
+				"番茄": {id1},
+			},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"ChineseKeywordInTheMiddle": {
+			Message: "我爱吃番茄炒饭",
+			Keywords: map[string][]string{
+				"番茄": {id1},
+			},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+				},
+			},
+		},
+		"MixedLanguageKeywordsInTheMiddle": {
+			Message: "我爱吃番茄carrot炒饭",
+			Keywords: map[string][]string{
+				"番茄":     {id1},
+				"carrot": {id2},
+			},
+			Expected: &ExplicitMentions{
+				MentionedUserIds: map[string]bool{
+					id1: true,
+					id2: true,
+				},
+			},
+		},
 		// The following tests cover cases where the message mentions @user.name, so we shouldn't assume that
 		// the user might be intending to mention some @user that isn't in the channel.
 		"Don't include potential mention that's part of an actual mention (without trailing period)": {


### PR DESCRIPTION
#### Summary
Add non-English keyword mention support. 

The original code breaks a sentence into words by whitespace and matched them against keywords setup by the user. Language such as Chinese does not use whitespace to separate words.

This commit uses regex to scan for mentions. Should work for any language (tested with English, Chinese and mix of both).

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/8642

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Added or updated unit tests (required for all new features)
