### PR TITLE
disable console logging by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -125,7 +125,7 @@
         "QueryTimeout": 30
     },
     "LogSettings": {
-        "EnableConsole": true,
+        "EnableConsole": false,
         "ConsoleLevel": "DEBUG",
         "ConsoleJson": true,
         "EnableFile": true,


### PR DESCRIPTION
#### Summary
This PR is meant to facilitate loadtesting of same. There are other
concerns overall with disabling console logging in the first place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10527