### PR TITLE
Skip notifications for expired sessions

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -752,6 +752,11 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 	msg.Message = a.getPushNotificationMessage(post.Message, explicitMention, channelWideMention, hasFiles, senderName, channelName, channel.Type, replyToThreadType, userLocale)
 
 	for _, session := range sessions {
+
+		if session.IsExpired() {
+			continue
+		}
+
 		tmpMessage := *model.PushNotificationFromJson(strings.NewReader(msg.ToJson()))
 		tmpMessage.SetDeviceIdAndPlatform(session.DeviceId)
 


### PR DESCRIPTION
#### Summary
The code change skips push notifications for expired sessions as reported in #8930. Currently the notifications test-suite does not have any tests covering session handling. Since this is a bug \w potential information disclosure I guess fixing it first and then enhancing the entire notification test suite to test `sendPushNotification` would be a solid approach, I would hope for your feedback though!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10836
https://github.com/mattermost/mattermost-server/issues/8930