### PR TITLE
Fix idempotency of scheme migrations.

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1733,8 +1733,12 @@ func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId 
 		for _, member := range channelMembers {
 			roles := strings.Fields(member.Roles)
 			var newRoles []string
-			member.SchemeAdmin = sql.NullBool{Bool: false, Valid: true}
-			member.SchemeUser = sql.NullBool{Bool: false, Valid: true}
+			if !member.SchemeAdmin.Valid {
+				member.SchemeAdmin = sql.NullBool{Bool: false, Valid: true}
+			}
+			if !member.SchemeUser.Valid {
+				member.SchemeUser = sql.NullBool{Bool: false, Valid: true}
+			}
 			for _, role := range roles {
 				if role == model.CHANNEL_ADMIN_ROLE_ID {
 					member.SchemeAdmin = sql.NullBool{Bool: true, Valid: true}

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -755,8 +755,12 @@ func (s SqlTeamStore) MigrateTeamMembers(fromTeamId string, fromUserId string) s
 		for _, member := range teamMembers {
 			roles := strings.Fields(member.Roles)
 			var newRoles []string
-			member.SchemeAdmin = sql.NullBool{Bool: false, Valid: true}
-			member.SchemeUser = sql.NullBool{Bool: false, Valid: true}
+			if !member.SchemeAdmin.Valid {
+				member.SchemeAdmin = sql.NullBool{Bool: false, Valid: true}
+			}
+			if !member.SchemeUser.Valid {
+				member.SchemeUser = sql.NullBool{Bool: false, Valid: true}
+			}
 			for _, role := range roles {
 				if role == model.TEAM_ADMIN_ROLE_ID {
 					member.SchemeAdmin = sql.NullBool{Bool: true, Valid: true}


### PR DESCRIPTION
#### Summary
This fixes the issue where if the migration tries to migrate an already
scheme-aware member object it would end up removing it's scheme-derived
roles.

Instead, only if the member object is unmigrated do we default to
setting the scheme-derived role booleans to false. We tell if it is an
unmigrated member object by checking if the booleans are set to null.

#### Ticket Link
???