### PR TITLE
MM-10684: Show logs on Slack Import CLI.

### DIFF
--- a/cmd/mattermost/commands/import.go
+++ b/cmd/mattermost/commands/import.go
@@ -74,9 +74,18 @@ func slackImportCmdF(command *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("Running Slack Import. This may take a long time for large teams or teams with many messages.")
 
-	a.SlackImport(fileReader, fileInfo.Size(), team.Id)
+	importErr, log := a.SlackImport(fileReader, fileInfo.Size(), team.Id)
+
+	if importErr != nil {
+		return err
+	}
+
+	CommandPrettyPrintln("")
+	CommandPrintln(log.String())
+	CommandPrettyPrintln("")
 
 	CommandPrettyPrintln("Finished Slack Import.")
+	CommandPrettyPrintln("")
 
 	return nil
 }


### PR DESCRIPTION
#### Summary
Show importer logs at the end of CLI SLack import, to make it the same as the web based import.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10684