### PR TITLE
MM-10791: Don't try and generate thumbnails for non-images/svgs.

### DIFF
--- a/app/import.go
+++ b/app/import.go
@@ -1699,10 +1699,12 @@ func (a *App) OldImportFile(timestamp time.Time, file io.Reader, teamId string, 
 		return nil, err
 	}
 
-	img, width, height := prepareImage(data)
-	if img != nil {
-		a.generateThumbnailImage(*img, fileInfo.ThumbnailPath, width, height)
-		a.generatePreviewImage(*img, fileInfo.PreviewPath, width)
+	if fileInfo.IsImage() && fileInfo.MimeType != "image/svg+xml" {
+		img, width, height := prepareImage(data)
+		if img != nil {
+			a.generateThumbnailImage(*img, fileInfo.ThumbnailPath, width, height)
+			a.generatePreviewImage(*img, fileInfo.PreviewPath, width)
+		}
 	}
 
 	return fileInfo, nil


### PR DESCRIPTION
#### Summary
In Slack importer, don't try and generate thumbnails for non-image files and SVGs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10791