### PR TITLE
MM-10863: Handle non-API errors with redirect to webapp

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -157,8 +157,12 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			c.Err.IsOAuth = false
 		}
 
-		w.WriteHeader(c.Err.StatusCode)
-		w.Write([]byte(c.Err.ToJson()))
+		if IsApiCall(r) || len(r.Header.Get("X-Mobile-App")) > 0 {
+			w.WriteHeader(c.Err.StatusCode)
+			w.Write([]byte(c.Err.ToJson()))
+		} else {
+			utils.RenderWebAppError(w, r, c.Err, c.App.AsymmetricSigningKey())
+		}
 
 		if c.App.Metrics != nil {
 			c.App.Metrics.IncrementHttpError()

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/app"
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func handlerForTest(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.Err = model.NewAppError("loginWithSaml", "api.user.saml.not_available.app_error", nil, "", http.StatusFound)
+}
+
+func TestHandlerServeHTTPErrors(t *testing.T) {
+	a, err := app.New(app.StoreOverride(testStore), app.DisableConfigWatch)
+	web := NewWeb(a, a.Srv.Router)
+	if err != nil {
+		panic(err)
+	}
+	handler := web.NewHandler(handlerForTest)
+
+	var flagtests = []struct {
+		name     string
+		url      string
+		mobile   bool
+		redirect bool
+	}{
+		{"redirect on destkop non-api endpoint", "/login/sso/saml", false, true},
+		{"not redirect on destkop api endpoint", "/api/v4/test", false, false},
+		{"not redirect on mobile non-api endpoint", "/login/sso/saml", true, false},
+		{"not redirect on mobile api endpoint", "/api/v4/test", true, false},
+	}
+
+	for _, tt := range flagtests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := httptest.NewRequest("GET", tt.url, nil)
+			if tt.mobile {
+				request.Header.Add("X-Mobile-App", "mattermost")
+			}
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+
+			if tt.redirect {
+				assert.Contains(t, response.Body.String(), "/error?message=")
+			} else {
+				assert.NotContains(t, response.Body.String(), "/error?message=")
+			}
+		})
+	}
+}

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -19,6 +19,8 @@ func handlerForTest(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func TestHandlerServeHTTPErrors(t *testing.T) {
 	a, err := app.New(app.StoreOverride(testStore), app.DisableConfigWatch)
+	defer a.Shutdown()
+
 	web := NewWeb(a, a.Srv.Router)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
#### Summary
The /login/sso/saml was returning to the browser json errors. Now redirect to an error page in the webapp.

#### Ticket Link
[MM-10863](https://mattermost.atlassian.net/browse/MM-10863)