### PR TITLE
MM-10767: Adding ordering to the system-admin list all teams

### DIFF
--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -342,7 +342,7 @@ func (s SqlTeamStore) GetAll() store.StoreChannel {
 func (s SqlTeamStore) GetAllPage(offset int, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var data []*model.Team
-		if _, err := s.GetReplica().Select(&data, "SELECT * FROM Teams LIMIT :Limit OFFSET :Offset", map[string]interface{}{"Offset": offset, "Limit": limit}); err != nil {
+		if _, err := s.GetReplica().Select(&data, "SELECT * FROM Teams ORDER BY DisplayName LIMIT :Limit OFFSET :Offset", map[string]interface{}{"Offset": offset, "Limit": limit}); err != nil {
 			result.Err = model.NewAppError("SqlTeamStore.GetAllTeams", "store.sql_team.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 


### PR DESCRIPTION
#### Summary
Added ordering to the list of all teams. This force a full scan of the team
table. 

I'm not concerned about the performance here because:

1. this call is done only from 2 places. One the list for select join
to a new team (Only call this one if you are system admin, if not, the query is
other for only open teams). And the other place is in the edit scheme screen,
when you add a new team to the scheme.

2. We can handle instances with 30K or 40K teams without too much problem.

#### Ticket Link
[MM-10767](https://mattermost.atlassian.net/browse/MM-10767)