### PR TITLE
[MM-10830] Clean Up FileInfo upon Permanent User Delete 

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -70,6 +70,14 @@ func (a *App) ReadFile(path string) ([]byte, *model.AppError) {
 	return backend.ReadFile(path)
 }
 
+func (a *App) FileExists(path string) (bool, *model.AppError) {
+	backend, err := a.FileBackend()
+	if err != nil {
+		return false, err
+	}
+	return backend.FileExists(path)
+}
+
 func (a *App) MoveFile(oldPath, newPath string) *model.AppError {
 	backend, err := a.FileBackend()
 	if err != nil {

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -480,3 +480,35 @@ func TestCreateUserWithToken(t *testing.T) {
 		}
 	})
 }
+
+func TestPermanentDeleteUser(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	b := []byte("testimage")
+
+	finfo, err := th.App.DoUploadFile(time.Now(), th.BasicTeam.Id, th.BasicChannel.Id, th.BasicUser.Id, "testfile.txt", b)
+
+	if err != nil {
+		t.Log(err)
+		t.Fatal("Unable to upload file")
+	}
+
+	err = th.App.PermanentDeleteUser(th.BasicUser)
+	if err != nil {
+		t.Log(err)
+		t.Fatal("Unable to delete user")
+	}
+
+	finfo, err = th.App.GetFileInfo(finfo.Id)
+
+	if finfo != nil {
+		t.Log(err)
+		t.Fatal("Unable to find finfo")
+	}
+
+	if err == nil {
+		t.Log(err)
+		t.Fatal("GetFileInfo after DeleteUser is nil")
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2827,6 +2827,10 @@
     "translation": "Blank email"
   },
   {
+    "id": "oauth.gitlab.tos.error",
+    "translation": "GitLab's Terms of Service have updated. Please go to gitlab.com to accept them and then try logging into Mattermost again."
+  },
+  {
     "id": "api.user.complete_switch_with_oauth.parse.app_error",
     "translation": "Could not parse auth data out of {{.Service}} user object"
   },

--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -177,6 +177,30 @@ func (fs SqlFileInfoStore) GetForPost(postId string, readFromMaster bool, allowF
 	})
 }
 
+func (fs SqlFileInfoStore) GetForUser(userId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var infos []*model.FileInfo
+
+		dbmap := fs.GetReplica()
+
+		if _, err := dbmap.Select(&infos,
+			`SELECT
+				*
+			FROM
+				FileInfo
+			WHERE
+				CreatorId = :CreatorId
+				AND DeleteAt = 0
+			ORDER BY
+				CreateAt`, map[string]interface{}{"CreatorId": userId}); err != nil {
+			result.Err = model.NewAppError("SqlFileInfoStore.GetForPost",
+				"store.sql_file_info.get_for_user_id.app_error", nil, "creator_id="+userId+", "+err.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = infos
+		}
+	})
+}
+
 func (fs SqlFileInfoStore) AttachToPost(fileId, postId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if _, err := fs.GetMaster().Exec(
@@ -239,6 +263,25 @@ func (s SqlFileInfoStore) PermanentDeleteBatch(endTime int64, limit int64) store
 			rowsAffected, err1 := sqlResult.RowsAffected()
 			if err1 != nil {
 				result.Err = model.NewAppError("SqlFileInfoStore.PermanentDeleteBatch", "store.sql_file_info.permanent_delete_batch.app_error", nil, ""+err.Error(), http.StatusInternalServerError)
+				result.Data = int64(0)
+			} else {
+				result.Data = rowsAffected
+			}
+		}
+	})
+}
+
+func (s SqlFileInfoStore) PermanentDeleteByUser(userId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		query := "DELETE from FileInfo WHERE CreatorId = :CreatorId"
+
+		sqlResult, err := s.GetMaster().Exec(query, map[string]interface{}{"CreatorId": userId})
+		if err != nil {
+			result.Err = model.NewAppError("SqlFileInfoStore.PermanentDeleteByUser", "store.sql_file_info.PermanentDeleteByUser.app_error", nil, ""+err.Error(), http.StatusInternalServerError)
+		} else {
+			rowsAffected, err1 := sqlResult.RowsAffected()
+			if err1 != nil {
+				result.Err = model.NewAppError("SqlFileInfoStore.PermanentDeleteByUser", "store.sql_file_info.PermanentDeleteByUser.app_error", nil, ""+err.Error(), http.StatusInternalServerError)
 				result.Data = int64(0)
 			} else {
 				result.Data = rowsAffected

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -342,7 +342,7 @@ func (s SqlTeamStore) GetAll() store.StoreChannel {
 func (s SqlTeamStore) GetAllPage(offset int, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var data []*model.Team
-		if _, err := s.GetReplica().Select(&data, "SELECT * FROM Teams LIMIT :Limit OFFSET :Offset", map[string]interface{}{"Offset": offset, "Limit": limit}); err != nil {
+		if _, err := s.GetReplica().Select(&data, "SELECT * FROM Teams ORDER BY DisplayName LIMIT :Limit OFFSET :Offset", map[string]interface{}{"Offset": offset, "Limit": limit}); err != nil {
 			result.Err = model.NewAppError("SqlTeamStore.GetAllTeams", "store.sql_team.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 

--- a/store/store.go
+++ b/store/store.go
@@ -427,11 +427,13 @@ type FileInfoStore interface {
 	Get(id string) StoreChannel
 	GetByPath(path string) StoreChannel
 	GetForPost(postId string, readFromMaster bool, allowFromCache bool) StoreChannel
+	GetForUser(userId string) StoreChannel
 	InvalidateFileInfosForPostCache(postId string)
 	AttachToPost(fileId string, postId string) StoreChannel
 	DeleteForPost(postId string) StoreChannel
 	PermanentDelete(fileId string) StoreChannel
 	PermanentDeleteBatch(endTime int64, limit int64) StoreChannel
+	PermanentDeleteByUser(userId string) StoreChannel
 	ClearCaches()
 }
 

--- a/store/storetest/mocks/FileInfoStore.go
+++ b/store/storetest/mocks/FileInfoStore.go
@@ -98,6 +98,22 @@ func (_m *FileInfoStore) GetForPost(postId string, readFromMaster bool, allowFro
 	return r0
 }
 
+// GetForUser provides a mock function with given fields: userId
+func (_m *FileInfoStore) GetForUser(userId string) store.StoreChannel {
+	ret := _m.Called(userId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+		r0 = rf(userId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // InvalidateFileInfosForPostCache provides a mock function with given fields: postId
 func (_m *FileInfoStore) InvalidateFileInfosForPostCache(postId string) {
 	_m.Called(postId)
@@ -126,6 +142,22 @@ func (_m *FileInfoStore) PermanentDeleteBatch(endTime int64, limit int64) store.
 	var r0 store.StoreChannel
 	if rf, ok := ret.Get(0).(func(int64, int64) store.StoreChannel); ok {
 		r0 = rf(endTime, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+// PermanentDeleteByUser provides a mock function with given fields: userId
+func (_m *FileInfoStore) PermanentDeleteByUser(userId string) store.StoreChannel {
+	ret := _m.Called(userId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+		r0 = rf(userId)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/utils/file_backend.go
+++ b/utils/file_backend.go
@@ -14,6 +14,7 @@ type FileBackend interface {
 	TestConnection() *model.AppError
 
 	ReadFile(path string) ([]byte, *model.AppError)
+	FileExists(path string) (bool, *model.AppError)
 	CopyFile(oldPath, newPath string) *model.AppError
 	MoveFile(oldPath, newPath string) *model.AppError
 	WriteFile(fr io.Reader, path string) (int64, *model.AppError)

--- a/utils/file_backend_local.go
+++ b/utils/file_backend_local.go
@@ -41,6 +41,18 @@ func (b *LocalFileBackend) ReadFile(path string) ([]byte, *model.AppError) {
 	}
 }
 
+func (b *LocalFileBackend) FileExists(path string) (bool, *model.AppError) {
+	_, err := os.Stat(filepath.Join(b.directory, path))
+
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err == nil {
+		return true, nil
+	}
+
+	return false, model.NewAppError("ReadFile", "api.file.file_exists.exists_local.app_error", nil, err.Error(), http.StatusInternalServerError)
+}
+
 func (b *LocalFileBackend) CopyFile(oldPath, newPath string) *model.AppError {
 	if err := CopyFile(filepath.Join(b.directory, oldPath), filepath.Join(b.directory, newPath)); err != nil {
 		return model.NewAppError("copyFile", "api.file.move_file.rename.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/utils/file_backend_s3.go
+++ b/utils/file_backend_s3.go
@@ -99,6 +99,25 @@ func (b *S3FileBackend) ReadFile(path string) ([]byte, *model.AppError) {
 	}
 }
 
+func (b *S3FileBackend) FileExists(path string) (bool, *model.AppError) {
+	s3Clnt, err := b.s3New()
+
+	if err != nil {
+		return false, model.NewAppError("FileExists", "api.file.file_exists.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	_, err = s3Clnt.StatObject(b.bucket, path, s3.StatObjectOptions{})
+
+	if err == nil {
+		return true, nil
+	}
+
+	if err.(s3.ErrorResponse).Code == "NoSuchKey" {
+		return false, nil
+	}
+
+	return false, model.NewAppError("FileExists", "api.file.file_exists.s3.app_error", nil, err.Error(), http.StatusInternalServerError)
+}
+
 func (b *S3FileBackend) CopyFile(oldPath, newPath string) *model.AppError {
 	s3Clnt, err := b.s3New()
 	if err != nil {

--- a/utils/file_backend_test.go
+++ b/utils/file_backend_test.go
@@ -124,6 +124,23 @@ func (s *FileBackendTestSuite) TestReadWriteFileImage() {
 	s.EqualValues(readString, "testimage")
 }
 
+func (s *FileBackendTestSuite) TestFileExists() {
+	b := []byte("testimage")
+	path := "tests/" + model.NewId() + ".png"
+
+	_, err := s.backend.WriteFile(bytes.NewReader(b), path)
+	s.Nil(err)
+	defer s.backend.RemoveFile(path)
+
+	res, err := s.backend.FileExists(path)
+	s.Nil(err)
+	s.True(res)
+
+	res, err = s.backend.FileExists("tests/idontexist.png")
+	s.Nil(err)
+	s.False(res)
+}
+
 func (s *FileBackendTestSuite) TestCopyFile() {
 	b := []byte("test")
 	path1 := "tests/" + model.NewId()


### PR DESCRIPTION
#### Summary
This pull requests implements the following functionality:

- Clean Up FileInfo from user upon permanent user delete
- Delete files remaining files from users `FileStore`
- Implement `FileExists` function
- Related unit tests

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10830

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
(Unsure about the critical, since it's user deletion I would define that as critical.)
