### PR TITLE
MM-10425 Include active_channel in cluster update user status messages

### DIFF
--- a/app/cluster_handlers.go
+++ b/app/cluster_handlers.go
@@ -29,8 +29,8 @@ func (a *App) ClusterPublishHandler(msg *model.ClusterMessage) {
 }
 
 func (a *App) ClusterUpdateStatusHandler(msg *model.ClusterMessage) {
-	clusterStatus := model.UserStatusClusterMessageFromJson(strings.NewReader(msg.Data))
-	a.AddStatusCacheSkipClusterSend(clusterStatus.ToStatus())
+	status := model.StatusFromJson(strings.NewReader(msg.Data))
+	a.AddStatusCacheSkipClusterSend(status)
 }
 
 func (a *App) ClusterInvalidateAllCachesHandler(msg *model.ClusterMessage) {

--- a/app/cluster_handlers.go
+++ b/app/cluster_handlers.go
@@ -29,8 +29,8 @@ func (a *App) ClusterPublishHandler(msg *model.ClusterMessage) {
 }
 
 func (a *App) ClusterUpdateStatusHandler(msg *model.ClusterMessage) {
-	status := model.StatusFromJson(strings.NewReader(msg.Data))
-	a.AddStatusCacheSkipClusterSend(status)
+	clusterStatus := model.UserStatusClusterMessageFromJson(strings.NewReader(msg.Data))
+	a.AddStatusCacheSkipClusterSend(clusterStatus.ToStatus())
 }
 
 func (a *App) ClusterInvalidateAllCachesHandler(msg *model.ClusterMessage) {

--- a/app/status.go
+++ b/app/status.go
@@ -26,11 +26,10 @@ func (a *App) AddStatusCache(status *model.Status) {
 	a.AddStatusCacheSkipClusterSend(status)
 
 	if a.Cluster != nil {
-		clusterStatus := model.NewUserStatusClusterMessage(status)
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_UPDATE_STATUS,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
-			Data:     clusterStatus.ToJson(),
+			Data:     status.ToClusterJson(),
 		}
 		a.Cluster.SendClusterMessage(msg)
 	}

--- a/app/status.go
+++ b/app/status.go
@@ -26,10 +26,11 @@ func (a *App) AddStatusCache(status *model.Status) {
 	a.AddStatusCacheSkipClusterSend(status)
 
 	if a.Cluster != nil {
+		clusterStatus := model.NewUserStatusClusterMessage(status)
 		msg := &model.ClusterMessage{
 			Event:    model.CLUSTER_EVENT_UPDATE_STATUS,
 			SendType: model.CLUSTER_SEND_BEST_EFFORT,
-			Data:     status.ToJson(),
+			Data:     clusterStatus.ToJson(),
 		}
 		a.Cluster.SendClusterMessage(msg)
 	}

--- a/model/status.go
+++ b/model/status.go
@@ -24,35 +24,18 @@ type Status struct {
 	Status         string `json:"status"`
 	Manual         bool   `json:"manual"`
 	LastActivityAt int64  `json:"last_activity_at"`
-	ActiveChannel  string `json:"-" db:"-"`
-}
-
-type UserStatusClusterMessage struct {
-	*Status
-	ActiveChannel string `json:"active_channel"`
-}
-
-func NewUserStatusClusterMessage(status *Status) *UserStatusClusterMessage {
-	return &UserStatusClusterMessage{Status: status, ActiveChannel: status.ActiveChannel}
-}
-
-func (s *UserStatusClusterMessage) ToJson() string {
-	b, _ := json.Marshal(s)
-	return string(b)
-}
-
-func UserStatusClusterMessageFromJson(data io.Reader) *UserStatusClusterMessage {
-	var s *UserStatusClusterMessage
-	json.NewDecoder(data).Decode(&s)
-	return s
-}
-
-func (s *UserStatusClusterMessage) ToStatus() *Status {
-	s.Status.ActiveChannel = s.ActiveChannel
-	return s.Status
+	ActiveChannel  string `json:"active_channel,omitempty" db:"-"`
 }
 
 func (o *Status) ToJson() string {
+	tempChannelId := o.ActiveChannel
+	o.ActiveChannel = ""
+	b, _ := json.Marshal(o)
+	o.ActiveChannel = tempChannelId
+	return string(b)
+}
+
+func (o *Status) ToClusterJson() string {
 	b, _ := json.Marshal(o)
 	return string(b)
 }
@@ -64,7 +47,18 @@ func StatusFromJson(data io.Reader) *Status {
 }
 
 func StatusListToJson(u []*Status) string {
+	activeChannels := make([]string, len(u))
+	for index, s := range u {
+		activeChannels[index] = s.ActiveChannel
+		s.ActiveChannel = ""
+	}
+
 	b, _ := json.Marshal(u)
+
+	for index, s := range u {
+		s.ActiveChannel = activeChannels[index]
+	}
+
 	return string(b)
 }
 

--- a/model/status.go
+++ b/model/status.go
@@ -27,6 +27,31 @@ type Status struct {
 	ActiveChannel  string `json:"-" db:"-"`
 }
 
+type UserStatusClusterMessage struct {
+	*Status
+	ActiveChannel string `json:"active_channel"`
+}
+
+func NewUserStatusClusterMessage(status *Status) *UserStatusClusterMessage {
+	return &UserStatusClusterMessage{Status: status, ActiveChannel: status.ActiveChannel}
+}
+
+func (s *UserStatusClusterMessage) ToJson() string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+func UserStatusClusterMessageFromJson(data io.Reader) *UserStatusClusterMessage {
+	var s *UserStatusClusterMessage
+	json.NewDecoder(data).Decode(&s)
+	return s
+}
+
+func (s *UserStatusClusterMessage) ToStatus() *Status {
+	s.Status.ActiveChannel = s.ActiveChannel
+	return s.Status
+}
+
 func (o *Status) ToJson() string {
 	b, _ := json.Marshal(o)
 	return string(b)

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -7,10 +7,12 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStatus(t *testing.T) {
-	status := Status{NewId(), STATUS_ONLINE, true, 0, ""}
+	status := Status{NewId(), STATUS_ONLINE, true, 0, "123"}
 	json := status.ToJson()
 	status2 := StatusFromJson(strings.NewReader(json))
 
@@ -29,10 +31,17 @@ func TestStatus(t *testing.T) {
 	if status.Manual != status2.Manual {
 		t.Fatal("Manual should have matched")
 	}
+
+	assert.Equal(t, "", status2.ActiveChannel)
+
+	json = status.ToClusterJson()
+	status2 = StatusFromJson(strings.NewReader(json))
+
+	assert.Equal(t, status.ActiveChannel, status2.ActiveChannel)
 }
 
 func TestStatusListToJson(t *testing.T) {
-	statuses := []*Status{{NewId(), STATUS_ONLINE, true, 0, ""}, {NewId(), STATUS_OFFLINE, true, 0, ""}}
+	statuses := []*Status{{NewId(), STATUS_ONLINE, true, 0, "123"}, {NewId(), STATUS_OFFLINE, true, 0, ""}}
 	jsonStatuses := StatusListToJson(statuses)
 
 	var dat []map[string]interface{}
@@ -40,15 +49,12 @@ func TestStatusListToJson(t *testing.T) {
 		panic(err)
 	}
 
-	if len(dat) != 2 {
-		t.Fatal("Status array should contain 2 elements")
-	}
-	if statuses[0].UserId != dat[0]["user_id"] {
-		t.Fatal("UserId should be equal")
-	}
-	if statuses[1].UserId != dat[1]["user_id"] {
-		t.Fatal("UserId should be equal")
-	}
+	assert.Equal(t, len(dat), 2)
+
+	_, ok := dat[0]["active_channel"]
+	assert.False(t, ok)
+	assert.Equal(t, statuses[0].UserId, dat[0]["user_id"])
+	assert.Equal(t, statuses[1].UserId, dat[1]["user_id"])
 }
 
 func TestStatusListFromJson(t *testing.T) {

--- a/model/status_test.go
+++ b/model/status_test.go
@@ -53,6 +53,7 @@ func TestStatusListToJson(t *testing.T) {
 
 	_, ok := dat[0]["active_channel"]
 	assert.False(t, ok)
+	assert.Equal(t, statuses[0].ActiveChannel, "123")
 	assert.Equal(t, statuses[0].UserId, dat[0]["user_id"])
 	assert.Equal(t, statuses[1].UserId, dat[1]["user_id"])
 }


### PR DESCRIPTION
#### Summary
I'm pretty sure this will fix getting push (and other) notifications for plugins/integrations triggered by you (e.g. starting a zoom meeting in a DM) while you're viewing the channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10425

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has enterprise changes (https://github.com/mattermost/enterprise/pull/315)