### PR TITLE
MM-10570: Make permissions reset command clear custom role assignments.

### DIFF
--- a/app/permissions.go
+++ b/app/permissions.go
@@ -27,6 +27,21 @@ func (a *App) ResetPermissionsSystem() *model.AppError {
 		return result.Err
 	}
 
+	// Reset all Custom Role assignments to Users.
+	if result := <-a.Srv.Store.User().ClearAllCustomRoleAssignments(); result.Err != nil {
+		return result.Err
+	}
+
+	// Reset all Custom Role assignments to TeamMembers.
+	if result := <-a.Srv.Store.Team().ClearAllCustomRoleAssignments(); result.Err != nil {
+		return result.Err
+	}
+
+	// Reset all Custom Role assignments to ChannelMembers.
+	if result := <-a.Srv.Store.Channel().ClearAllCustomRoleAssignments(); result.Err != nil {
+		return result.Err
+	}
+
 	// Purge all schemes from the database.
 	if result := <-a.Srv.Store.Scheme().PermanentDeleteAll(); result.Err != nil {
 		return result.Err

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1535,6 +1535,66 @@
     "translation": "Unable to open the Slack export zip file.\r\n"
   },
   {
+    "id": "store.sql_user.clear_all_custom_role_assignments.open_transaction.app_error",
+    "translation": "Failed to begin the database transaction"
+  },
+  {
+    "id": "store.sql_user.clear_all_custom_role_assignments.rollback_transaction.app_error",
+    "translation": "Failed to rollback the database transaction"
+  },
+  {
+    "id": "store.sql_user.clear_all_custom_role_assignments.select.app_error",
+    "translation": "Failed to retrieve the users"
+  },
+  {
+    "id": "store.sql_user.clear_all_custom_role_assignments.update.app_error",
+    "translation": "Failed to update the user"
+  },
+  {
+    "id": "store.sql_user.clear_all_custom_role_assignments.commit_transaction.app_error",
+    "translation": "Failed to commit the database transaction"
+  },
+  {
+    "id": "store.sql_team.clear_all_custom_role_assignments.open_transaction.app_error",
+    "translation": "Failed to begin the database transaction"
+  },
+  {
+    "id": "store.sql_team.clear_all_custom_role_assignments.rollback_transaction.app_error",
+    "translation": "Failed to rollback the database transaction"
+  },
+  {
+    "id": "store.sql_team.clear_all_custom_role_assignments.select.app_error",
+    "translation": "Failed to retrieve the team members"
+  },
+  {
+    "id": "store.sql_team.clear_all_custom_role_assignments.update.app_error",
+    "translation": "Failed to update the team member"
+  },
+  {
+    "id": "store.sql_team.clear_all_custom_role_assignments.commit_transaction.app_error",
+    "translation": "Failed to commit the database transaction"
+  },
+  {
+    "id": "store.sql_channel.clear_all_custom_role_assignments.open_transaction.app_error",
+    "translation": "Failed to begin the database transaction"
+  },
+  {
+    "id": "store.sql_channel.clear_all_custom_role_assignments.rollback_transaction.app_error",
+    "translation": "Failed to rollback the database transaction"
+  },
+  {
+    "id": "store.sql_channel.clear_all_custom_role_assignments.select.app_error",
+    "translation": "Failed to retrieve the channel members"
+  },
+  {
+    "id": "store.sql_channel.clear_all_custom_role_assignments.update.app_error",
+    "translation": "Failed to update the channel member"
+  },
+  {
+    "id": "store.sql_channel.clear_all_custom_role_assignments.commit_transaction.app_error",
+    "translation": "Failed to commit the database transaction"
+  },
+  {
     "id": "api.status.user_not_found.app_error",
     "translation": "User not found"
   },

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -806,3 +806,72 @@ func (s SqlTeamStore) ResetAllTeamSchemes() store.StoreChannel {
 		}
 	})
 }
+
+func (s SqlTeamStore) ClearAllCustomRoleAssignments() store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		builtInRoles := model.MakeDefaultRoles()
+		lastUserId := strings.Repeat("0", 26)
+		lastTeamId := strings.Repeat("0", 26)
+
+		for true {
+			var transaction *gorp.Transaction
+			var err error
+
+			if transaction, err = s.GetMaster().Begin(); err != nil {
+				result.Err = model.NewAppError("SqlTeamStore.ClearAllCustomRoleAssignments", "store.sql_team.clear_all_custom_role_assignments.open_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			var teamMembers []*teamMember
+			if _, err := transaction.Select(&teamMembers, "SELECT * from TeamMembers WHERE (TeamId, UserId) > (:TeamId, :UserId) ORDER BY TeamId, UserId LIMIT 1000", map[string]interface{}{"TeamId": lastTeamId, "UserId": lastUserId}); err != nil {
+				if err2 := transaction.Rollback(); err2 != nil {
+					result.Err = model.NewAppError("SqlTeamStore.ClearAllCustomRoleAssignments", "store.sql_team.clear_all_custom_role_assignments.rollback_transaction.app_error", nil, err2.Error(), http.StatusInternalServerError)
+					return
+				}
+				result.Err = model.NewAppError("SqlTeamStore.ClearAllCustomRoleAssignments", "store.sql_team.clear_all_custom_role_assignments.select.app_error", nil, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			if len(teamMembers) == 0 {
+				break
+			}
+
+			for _, member := range teamMembers {
+				lastUserId = member.UserId
+				lastTeamId = member.TeamId
+
+				var newRoles []string
+
+				for _, role := range strings.Fields(member.Roles) {
+					for name := range builtInRoles {
+						if name == role {
+							newRoles = append(newRoles, role)
+							break
+						}
+					}
+				}
+
+				newRolesString := strings.Join(newRoles, " ")
+				if newRolesString != member.Roles {
+					if _, err := transaction.Exec("UPDATE TeamMembers SET Roles = :Roles WHERE UserId = :UserId AND TeamId = :TeamId", map[string]interface{}{"Roles": newRolesString, "TeamId": member.TeamId, "UserId": member.UserId}); err != nil {
+						if err2 := transaction.Rollback(); err2 != nil {
+							result.Err = model.NewAppError("SqlTeamStore.ClearAllCustomRoleAssignments", "store.sql_team.clear_all_custom_role_assignments.rollback_transaction.app_error", nil, err2.Error(), http.StatusInternalServerError)
+							return
+						}
+						result.Err = model.NewAppError("SqlTeamStore.ClearAllCustomRoleAssignments", "store.sql_team.clear_all_custom_role_assignments.update.app_error", nil, err.Error(), http.StatusInternalServerError)
+						return
+					}
+				}
+			}
+
+			if err := transaction.Commit(); err != nil {
+				if err2 := transaction.Rollback(); err2 != nil {
+					result.Err = model.NewAppError("SqlTeamStore.ClearAllCustomRoleAssignments", "store.sql_team.clear_all_custom_role_assignments.rollback_transaction.app_error", nil, err2.Error(), http.StatusInternalServerError)
+					return
+				}
+				result.Err = model.NewAppError("SqlTeamStore.ClearAllCustomRoleAssignments", "store.sql_team.clear_all_custom_role_assignments.commit_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	})
+}

--- a/store/store.go
+++ b/store/store.go
@@ -107,6 +107,7 @@ type TeamStore interface {
 	GetTeamsByScheme(schemeId string, offset int, limit int) StoreChannel
 	MigrateTeamMembers(fromTeamId string, fromUserId string) StoreChannel
 	ResetAllTeamSchemes() StoreChannel
+	ClearAllCustomRoleAssignments() StoreChannel
 }
 
 type ChannelStore interface {
@@ -167,6 +168,7 @@ type ChannelStore interface {
 	GetChannelsByScheme(schemeId string, offset int, limit int) StoreChannel
 	MigrateChannelMembers(fromChannelId string, fromUserId string) StoreChannel
 	ResetAllChannelSchemes() StoreChannel
+	ClearAllCustomRoleAssignments() StoreChannel
 }
 
 type ChannelMemberHistoryStore interface {
@@ -258,6 +260,7 @@ type UserStore interface {
 	AnalyticsGetSystemAdminCount() StoreChannel
 	GetProfilesNotInTeam(teamId string, offset int, limit int) StoreChannel
 	GetEtagForProfilesNotInTeam(teamId string) StoreChannel
+	ClearAllCustomRoleAssignments() StoreChannel
 }
 
 type SessionStore interface {

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -61,6 +61,22 @@ func (_m *ChannelStore) AutocompleteInTeam(teamId string, term string) store.Sto
 	return r0
 }
 
+// ClearAllCustomRoleAssignments provides a mock function with given fields:
+func (_m *ChannelStore) ClearAllCustomRoleAssignments() store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // ClearCaches provides a mock function with given fields:
 func (_m *ChannelStore) ClearCaches() {
 	_m.Called()

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -29,6 +29,22 @@ func (_m *TeamStore) AnalyticsTeamCount() store.StoreChannel {
 	return r0
 }
 
+// ClearAllCustomRoleAssignments provides a mock function with given fields:
+func (_m *TeamStore) ClearAllCustomRoleAssignments() store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Get provides a mock function with given fields: id
 func (_m *TeamStore) Get(id string) store.StoreChannel {
 	ret := _m.Called(id)

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -77,6 +77,22 @@ func (_m *UserStore) AnalyticsUniqueUserCount(teamId string) store.StoreChannel 
 	return r0
 }
 
+// ClearAllCustomRoleAssignments provides a mock function with given fields:
+func (_m *UserStore) ClearAllCustomRoleAssignments() store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // ClearCaches provides a mock function with given fields:
 func (_m *UserStore) ClearCaches() {
 	_m.Called()


### PR DESCRIPTION
#### Summary
Make the `permissions reset` CLI command clear any custom role assignments.

This means the command will now work to clear up after full-custom (phase 3 advanced permissions style) roles.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10570

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
