### PR TITLE
Add back the ability to reply to push notifications in iOS

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -722,6 +722,7 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 		msg.Badge = int(badge.Data.(int64))
 	}
 
+	msg.Category = model.CATEGORY_CAN_REPLY
 	msg.Version = model.PUSH_MESSAGE_V2
 	msg.Type = model.PUSH_TYPE_MESSAGE
 	msg.TeamId = channel.TeamId


### PR DESCRIPTION
#### Summary
This PR fixes a regression where the option to reply to a push notification on iOS was not available cause of the Category not being set.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10991
