### PR TITLE
MM-10910 fix join and open channel commands to work with tilde

### DIFF
--- a/app/command_join.go
+++ b/app/command_join.go
@@ -4,9 +4,9 @@
 package app
 
 import (
-	"strings"
 	"github.com/mattermost/mattermost-server/model"
 	goi18n "github.com/nicksnyder/go-i18n/i18n"
+	"strings"
 )
 
 type JoinProvider struct {

--- a/app/command_join.go
+++ b/app/command_join.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"strings"
 	"github.com/mattermost/mattermost-server/model"
 	goi18n "github.com/nicksnyder/go-i18n/i18n"
 )
@@ -34,12 +35,18 @@ func (me *JoinProvider) GetCommand(a *App, T goi18n.TranslateFunc) *model.Comman
 }
 
 func (me *JoinProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
-	if result := <-a.Srv.Store.Channel().GetByName(args.TeamId, message, true); result.Err != nil {
+	channelName := message
+
+	if strings.HasPrefix(message, "~") {
+		channelName = message[1:]
+	}
+
+	if result := <-a.Srv.Store.Channel().GetByName(args.TeamId, channelName, true); result.Err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_join.list.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	} else {
 		channel := result.Data.(*model.Channel)
 
-		if channel.Name == message {
+		if channel.Name == channelName {
 			allowed := false
 			if (channel.Type == model.CHANNEL_PRIVATE && a.SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_READ_CHANNEL)) || channel.Type == model.CHANNEL_OPEN {
 				allowed = true

--- a/app/command_join_test.go
+++ b/app/command_join_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"testing"
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/nicksnyder/go-i18n/i18n"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinCommandNoChannel(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	cmd := &JoinProvider{}
+	resp := cmd.DoCommand(th.App, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser2.Id,
+		SiteURL: "http://test.url",
+		TeamId:      th.BasicTeam.Id,
+	}, "asdsad")
+
+	assert.Equal(t, "api.command_join.list.app_error", resp.Text)
+}
+
+func TestJoinCommandForExistingChannel(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	channel2, _ := th.App.CreateChannel(&model.Channel{
+	  DisplayName: "AA",
+	  Name:        "aa" + model.NewId() + "a",
+	  Type:        model.CHANNEL_OPEN,
+	  TeamId:      th.BasicTeam.Id,
+	  CreatorId:   th.BasicUser.Id,
+	}, false)
+
+
+	cmd := &JoinProvider{}
+	resp := cmd.DoCommand(th.App, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser2.Id,
+		SiteURL: "http://test.url",
+		TeamId:      th.BasicTeam.Id,
+	}, channel2.Name)
+
+	assert.Equal(t, "", resp.Text)
+	assert.Equal(t, "http://test.url/"+th.BasicTeam.Name+"/channels/"+channel2.Name, resp.GotoLocation)
+}
+
+func TestJoinCommandWithTilde(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	if testing.Short() {
+		t.SkipNow()
+	}
+
+	channel2, _ := th.App.CreateChannel(&model.Channel{
+	  DisplayName: "AA",
+	  Name:        "aa" + model.NewId() + "a",
+	  Type:        model.CHANNEL_OPEN,
+	  TeamId:      th.BasicTeam.Id,
+	  CreatorId:   th.BasicUser.Id,
+	}, false)
+
+
+	cmd := &JoinProvider{}
+	resp := cmd.DoCommand(th.App, &model.CommandArgs{
+		T:      i18n.IdentityTfunc(),
+		UserId: th.BasicUser2.Id,
+		SiteURL: "http://test.url",
+		TeamId:      th.BasicTeam.Id,
+	}, "~"+channel2.Name)
+
+	assert.Equal(t, "", resp.Text)
+	assert.Equal(t, "http://test.url/"+th.BasicTeam.Name+"/channels/"+channel2.Name, resp.GotoLocation)
+}


### PR DESCRIPTION
#### Summary
fix join and open channel commands to work with a tilde

#### Ticket Link
[MM-10910](https://mattermost.atlassian.net/browse/MM-10910)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [X] Has UI changes
