### PR TITLE
MM-7088 Reset status to away after web conn disconnect if necessary

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -227,6 +227,9 @@ func (a *App) AttachDeviceId(sessionId string, deviceId string, expiresAt int64)
 
 func (a *App) UpdateLastActivityAtIfNeeded(session model.Session) {
 	now := model.GetMillis()
+
+	a.UpdateWebConnUserActivity(session, now)
+
 	if now-session.LastActivityAt < model.SESSION_ACTIVITY_TIMEOUT {
 		return
 	}

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -33,6 +33,7 @@ type WebConn struct {
 	Send                      chan model.WebSocketMessage
 	sessionToken              atomic.Value
 	session                   atomic.Value
+	LastUserActivityAt        int64
 	UserId                    string
 	T                         goi18n.TranslateFunc
 	Locale                    string
@@ -52,14 +53,15 @@ func (a *App) NewWebConn(ws *websocket.Conn, session model.Session, t goi18n.Tra
 	}
 
 	wc := &WebConn{
-		App:          a,
-		Send:         make(chan model.WebSocketMessage, SEND_QUEUE_SIZE),
-		WebSocket:    ws,
-		UserId:       session.UserId,
-		T:            t,
-		Locale:       locale,
-		endWritePump: make(chan struct{}, 2),
-		pumpFinished: make(chan struct{}, 1),
+		App:                a,
+		Send:               make(chan model.WebSocketMessage, SEND_QUEUE_SIZE),
+		WebSocket:          ws,
+		LastUserActivityAt: model.GetMillis(),
+		UserId:             session.UserId,
+		T:                  t,
+		Locale:             locale,
+		endWritePump:       make(chan struct{}, 2),
+		pumpFinished:       make(chan struct{}, 1),
 	}
 
 	wc.SetSession(&session)


### PR DESCRIPTION
#### Summary
Fixes the case described in the ticket where a user is away on one or more devices, then briefly connects with a new device and then disconnects, causing their status to stay as online for 5 minutes (away timeout) before they start receiving notifications again. This tracks the last activity at for each websocket connection separately. If one disconnects, it checks the last activity time of the other web conns to set the status appropriately.

@esethna not sure if you or QA want to try this out on the spinmint first

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-7088
