### PR TITLE
Fix a really rare race condition in the migration scheduler.

### DIFF
--- a/migrations/scheduler.go
+++ b/migrations/scheduler.go
@@ -59,7 +59,7 @@ func (scheduler *Scheduler) ScheduleJob(cfg *model.Config, pendingJobs bool, las
 
 		if state == MIGRATION_STATE_IN_PROGRESS {
 			// Check the migration job isn't wedged.
-			if job != nil && job.LastActivityAt < model.GetMillis()-MIGRATION_JOB_WEDGED_TIMEOUT_MILLISECONDS {
+			if job != nil && job.LastActivityAt < model.GetMillis()-MIGRATION_JOB_WEDGED_TIMEOUT_MILLISECONDS && job.CreateAt < model.GetMillis()-MIGRATION_JOB_WEDGED_TIMEOUT_MILLISECONDS {
 				mlog.Warn("Job appears to be wedged. Rescheduling another instance.", mlog.String("scheduler", scheduler.Name()), mlog.String("wedged_job_id", job.Id), mlog.String("migration_key", key))
 				if err := scheduler.App.Jobs.SetJobError(job, nil); err != nil {
 					mlog.Error("Worker: Failed to set job error", mlog.String("scheduler", scheduler.Name()), mlog.String("job_id", job.Id), mlog.String("error", err.Error()))


### PR DESCRIPTION
#### Summary
This fixes a really rare edge case in the migrations scheduler where if a job hasn't started by the time the next scheduler run occurs, it assumes it has got stuck and reschedules it. If the timing is just right that this happens reliably on every run, the migration job will never run. This is extremely rare but just about possible if the HA setup is misconfigured in exactly the right way, so better to protect against it anyway.