### PR TITLE
MM-10269: Make jobserver work without restart.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -208,6 +208,9 @@ func New(options ...Option) (outApp *App, outErr error) {
 	}
 
 	app.initJobs()
+	app.AddLicenseListener(func() {
+		app.initJobs()
+	})
 
 	subpath, err := utils.GetSubpathFromConfig(app.Config())
 	if err != nil {

--- a/jobs/workers.go
+++ b/jobs/workers.go
@@ -95,6 +95,8 @@ func (workers *Workers) Start() *Workers {
 }
 
 func (workers *Workers) handleConfigChange(oldConfig *model.Config, newConfig *model.Config) {
+	mlog.Debug("Workers received config change.")
+
 	if workers.DataRetention != nil {
 		if (!*oldConfig.DataRetentionSettings.EnableMessageDeletion && !*oldConfig.DataRetentionSettings.EnableFileDeletion) && (*newConfig.DataRetentionSettings.EnableMessageDeletion || *newConfig.DataRetentionSettings.EnableFileDeletion) {
 			go workers.DataRetention.Run()


### PR DESCRIPTION
#### Summary
Make job server work properly when license is uploaded and/or jobs are configured on/off without a server restart. There were duplicate config checks in the wrong place which caused the problem with some job types before. See enterprise changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10269

Enterprise changes: https://github.com/mattermost/enterprise/pull/316