### PR TITLE
Lock bulk importing to master database node

### DIFF
--- a/app/import.go
+++ b/app/import.go
@@ -209,6 +209,9 @@ func (a *App) BulkImport(fileReader io.Reader, dryRun bool, workers int) (*model
 	scanner := bufio.NewScanner(fileReader)
 	lineNumber := 0
 
+	a.Srv.Store.LockToMaster()
+	defer a.Srv.Store.UnlockFromMaster()
+
 	errorsChan := make(chan LineImportWorkerError, (2*workers)+1) // size chosen to ensure it never gets filled up completely.
 	var wg sync.WaitGroup
 	var linesChan chan LineImportWorkerData

--- a/store/layered_store.go
+++ b/store/layered_store.go
@@ -181,6 +181,14 @@ func (s *LayeredStore) Close() {
 	s.DatabaseLayer.Close()
 }
 
+func (s *LayeredStore) LockToMaster() {
+	s.DatabaseLayer.LockToMaster()
+}
+
+func (s *LayeredStore) UnlockFromMaster() {
+	s.DatabaseLayer.UnlockFromMaster()
+}
+
 func (s *LayeredStore) DropAllTables() {
 	s.DatabaseLayer.DropAllTables()
 }

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -65,6 +65,8 @@ type SqlStore interface {
 	RemoveIndexIfExists(indexName string, tableName string) bool
 	GetAllConns() []*gorp.DbMap
 	Close()
+	LockToMaster()
+	UnlockFromMaster()
 	Team() store.TeamStore
 	Channel() store.ChannelStore
 	Post() store.PostStore

--- a/store/store.go
+++ b/store/store.go
@@ -67,6 +67,8 @@ type Store interface {
 	Plugin() PluginStore
 	MarkSystemRanUnitTests()
 	Close()
+	LockToMaster()
+	UnlockFromMaster()
 	DropAllTables()
 	TotalMasterDbConnections() int
 	TotalReadDbConnections() int

--- a/store/storetest/mocks/LayeredStoreDatabaseLayer.go
+++ b/store/storetest/mocks/LayeredStoreDatabaseLayer.go
@@ -200,6 +200,11 @@ func (_m *LayeredStoreDatabaseLayer) License() store.LicenseStore {
 	return r0
 }
 
+// LockToMaster provides a mock function with given fields:
+func (_m *LayeredStoreDatabaseLayer) LockToMaster() {
+	_m.Called()
+}
+
 // MarkSystemRanUnitTests provides a mock function with given fields:
 func (_m *LayeredStoreDatabaseLayer) MarkSystemRanUnitTests() {
 	_m.Called()
@@ -849,6 +854,11 @@ func (_m *LayeredStoreDatabaseLayer) TotalSearchDbConnections() int {
 	}
 
 	return r0
+}
+
+// UnlockFromMaster provides a mock function with given fields:
+func (_m *LayeredStoreDatabaseLayer) UnlockFromMaster() {
+	_m.Called()
 }
 
 // User provides a mock function with given fields:

--- a/store/storetest/mocks/SqlStore.go
+++ b/store/storetest/mocks/SqlStore.go
@@ -411,6 +411,11 @@ func (_m *SqlStore) License() store.LicenseStore {
 	return r0
 }
 
+// LockToMaster provides a mock function with given fields:
+func (_m *SqlStore) LockToMaster() {
+	_m.Called()
+}
+
 // MarkSystemRanUnitTests provides a mock function with given fields:
 func (_m *SqlStore) MarkSystemRanUnitTests() {
 	_m.Called()
@@ -704,6 +709,11 @@ func (_m *SqlStore) TotalSearchDbConnections() int {
 	}
 
 	return r0
+}
+
+// UnlockFromMaster provides a mock function with given fields:
+func (_m *SqlStore) UnlockFromMaster() {
+	_m.Called()
 }
 
 // User provides a mock function with given fields:

--- a/store/storetest/mocks/Store.go
+++ b/store/storetest/mocks/Store.go
@@ -198,6 +198,11 @@ func (_m *Store) License() store.LicenseStore {
 	return r0
 }
 
+// LockToMaster provides a mock function with given fields:
+func (_m *Store) LockToMaster() {
+	_m.Called()
+}
+
 // MarkSystemRanUnitTests provides a mock function with given fields:
 func (_m *Store) MarkSystemRanUnitTests() {
 	_m.Called()
@@ -435,6 +440,11 @@ func (_m *Store) TotalSearchDbConnections() int {
 	}
 
 	return r0
+}
+
+// UnlockFromMaster provides a mock function with given fields:
+func (_m *Store) UnlockFromMaster() {
+	_m.Called()
 }
 
 // User provides a mock function with given fields:

--- a/store/storetest/store.go
+++ b/store/storetest/store.go
@@ -77,6 +77,8 @@ func (s *Store) ChannelMemberHistory() store.ChannelMemberHistoryStore {
 }
 func (s *Store) MarkSystemRanUnitTests()       { /* do nothing */ }
 func (s *Store) Close()                        { /* do nothing */ }
+func (s *Store) LockToMaster()                 { /* do nothing */ }
+func (s *Store) UnlockFromMaster()             { /* do nothing */ }
 func (s *Store) DropAllTables()                { /* do nothing */ }
 func (s *Store) TotalMasterDbConnections() int { return 1 }
 func (s *Store) TotalReadDbConnections() int   { return 1 }


### PR DESCRIPTION
#### Summary
This is to prevent races between replication and reads against the replicas during bulk import.

#### Ticket Link
Based on https://pre-release.mattermost.com/core/pl/m1wwgtakttnnfquh6pxo79rr1h