### PR TITLE
Add ExperimentalSidebarPreference in the config

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -44,6 +44,7 @@ const (
 	TRACK_CONFIG_DATA_RETENTION = "config_data_retention"
 	TRACK_CONFIG_MESSAGE_EXPORT = "config_message_export"
 	TRACK_CONFIG_DISPLAY        = "config_display"
+	TRACK_CONFIG_SIDEBAR        = "config_sidebar"
 	TRACK_CONFIG_TIMEZONE       = "config_timezone"
 
 	TRACK_ACTIVITY = "activity"
@@ -540,6 +541,10 @@ func (a *App) trackConfig() {
 	a.SendDiagnostic(TRACK_CONFIG_DISPLAY, map[string]interface{}{
 		"experimental_timezone":        *cfg.DisplaySettings.ExperimentalTimezone,
 		"isdefault_custom_url_schemes": len(*cfg.DisplaySettings.CustomUrlSchemes) != 0,
+	})
+
+	a.SendDiagnostic(TRACK_CONFIG_SIDEBAR, map[string]interface{}{
+		"experimental_channel_organization": *cfg.ServiceSettings.ExperimentalChannelOrganization,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TIMEZONE, map[string]interface{}{

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -44,7 +44,6 @@ const (
 	TRACK_CONFIG_DATA_RETENTION = "config_data_retention"
 	TRACK_CONFIG_MESSAGE_EXPORT = "config_message_export"
 	TRACK_CONFIG_DISPLAY        = "config_display"
-	TRACK_CONFIG_SIDEBAR        = "config_sidebar"
 	TRACK_CONFIG_TIMEZONE       = "config_timezone"
 
 	TRACK_ACTIVITY = "activity"
@@ -253,6 +252,7 @@ func (a *App) trackConfig() {
 		"experimental_enable_hardened_mode":                       *cfg.ServiceSettings.ExperimentalEnableHardenedMode,
 		"experimental_limit_client_config":                        *cfg.ServiceSettings.ExperimentalLimitClientConfig,
 		"enable_email_invitations":                                *cfg.ServiceSettings.EnableEmailInvitations,
+		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{
@@ -541,10 +541,6 @@ func (a *App) trackConfig() {
 	a.SendDiagnostic(TRACK_CONFIG_DISPLAY, map[string]interface{}{
 		"experimental_timezone":        *cfg.DisplaySettings.ExperimentalTimezone,
 		"isdefault_custom_url_schemes": len(*cfg.DisplaySettings.CustomUrlSchemes) != 0,
-	})
-
-	a.SendDiagnostic(TRACK_CONFIG_SIDEBAR, map[string]interface{}{
-		"experimental_channel_organization": *cfg.ServiceSettings.ExperimentalChannelOrganization,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TIMEZONE, map[string]interface{}{

--- a/config/default.json
+++ b/config/default.json
@@ -63,7 +63,7 @@
         "EnableTutorial": true,
         "ExperimentalEnableDefaultChannelLeaveJoinMessages": true,
         "ExperimentalGroupUnreadChannels": "disabled",
-        "ExperimentalSidebarPreference": true,
+        "ExperimentalSidebarPreference": false,
         "ImageProxyType": "",
         "ImageProxyOptions": "",
         "ImageProxyURL": "",

--- a/config/default.json
+++ b/config/default.json
@@ -63,6 +63,7 @@
         "EnableTutorial": true,
         "ExperimentalEnableDefaultChannelLeaveJoinMessages": true,
         "ExperimentalGroupUnreadChannels": "disabled",
+        "ExperimentalSidebarPreference": true,
         "ImageProxyType": "",
         "ImageProxyOptions": "",
         "ImageProxyURL": "",

--- a/config/default.json
+++ b/config/default.json
@@ -63,7 +63,7 @@
         "EnableTutorial": true,
         "ExperimentalEnableDefaultChannelLeaveJoinMessages": true,
         "ExperimentalGroupUnreadChannels": "disabled",
-        "ExperimentalSidebarPreference": false,
+        "ExperimentalChannelOrganization": false,
         "ImageProxyType": "",
         "ImageProxyOptions": "",
         "ImageProxyURL": "",

--- a/model/config.go
+++ b/model/config.go
@@ -480,7 +480,8 @@ func (s *ServiceSettings) SetDefaults() {
 	}
 
 	if s.ExperimentalSidebarPreference == nil {
-		s.ExperimentalSidebarPreference = NewBool(true)
+		experimentalUnreadEnabled := *s.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED
+		s.ExperimentalSidebarPreference = NewBool(experimentalUnreadEnabled)
 	}
 
 	if s.ImageProxyType == nil {

--- a/model/config.go
+++ b/model/config.go
@@ -233,7 +233,7 @@ type ServiceSettings struct {
 	EnableTutorial                                    *bool
 	ExperimentalEnableDefaultChannelLeaveJoinMessages *bool
 	ExperimentalGroupUnreadChannels                   *string
-	ExperimentalSidebarPreference                     *bool
+	ExperimentalChannelOrganization                   *bool
 	ImageProxyType                                    *string
 	ImageProxyURL                                     *string
 	ImageProxyOptions                                 *string
@@ -479,9 +479,9 @@ func (s *ServiceSettings) SetDefaults() {
 		s.ExperimentalGroupUnreadChannels = NewString(GROUP_UNREAD_CHANNELS_DEFAULT_ON)
 	}
 
-	if s.ExperimentalSidebarPreference == nil {
+	if s.ExperimentalChannelOrganization == nil {
 		experimentalUnreadEnabled := *s.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED
-		s.ExperimentalSidebarPreference = NewBool(experimentalUnreadEnabled)
+		s.ExperimentalChannelOrganization = NewBool(experimentalUnreadEnabled)
 	}
 
 	if s.ImageProxyType == nil {

--- a/model/config.go
+++ b/model/config.go
@@ -233,6 +233,7 @@ type ServiceSettings struct {
 	EnableTutorial                                    *bool
 	ExperimentalEnableDefaultChannelLeaveJoinMessages *bool
 	ExperimentalGroupUnreadChannels                   *string
+	ExperimentalSidebarPreference                     *bool
 	ImageProxyType                                    *string
 	ImageProxyURL                                     *string
 	ImageProxyOptions                                 *string
@@ -476,6 +477,10 @@ func (s *ServiceSettings) SetDefaults() {
 		s.ExperimentalGroupUnreadChannels = NewString(GROUP_UNREAD_CHANNELS_DISABLED)
 	} else if *s.ExperimentalGroupUnreadChannels == "1" {
 		s.ExperimentalGroupUnreadChannels = NewString(GROUP_UNREAD_CHANNELS_DEFAULT_ON)
+	}
+
+	if s.ExperimentalSidebarPreference == nil {
+		s.ExperimentalSidebarPreference = NewBool(true)
 	}
 
 	if s.ImageProxyType == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -534,10 +534,10 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["ExperimentalEnableDefaultChannelLeaveJoinMessages"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages)
 	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
 
-	if *c.ServiceSettings.ExperimentalSidebarPreference || *c.ServiceSettings.ExperimentalGroupUnreadChannels != model.GROUP_UNREAD_CHANNELS_DISABLED {
-		props["ExperimentalSidebarPreference"] = strconv.FormatBool(true)
+	if *c.ServiceSettings.ExperimentalChannelOrganization || *c.ServiceSettings.ExperimentalGroupUnreadChannels != model.GROUP_UNREAD_CHANNELS_DISABLED {
+		props["ExperimentalChannelOrganization"] = strconv.FormatBool(true)
 	} else {
-		props["ExperimentalSidebarPreference"] = strconv.FormatBool(false)
+		props["ExperimentalChannelOrganization"] = strconv.FormatBool(false)
 	}
 
 	props["ExperimentalEnableAutomaticReplies"] = strconv.FormatBool(*c.TeamSettings.ExperimentalEnableAutomaticReplies)

--- a/utils/config.go
+++ b/utils/config.go
@@ -533,7 +533,13 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
 	props["ExperimentalEnableDefaultChannelLeaveJoinMessages"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages)
 	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
-	props["ExperimentalSidebarPreference"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalSidebarPreference)
+
+	if *c.ServiceSettings.ExperimentalSidebarPreference || *c.ServiceSettings.ExperimentalGroupUnreadChannels != model.GROUP_UNREAD_CHANNELS_DISABLED {
+		props["ExperimentalSidebarPreference"] = strconv.FormatBool(true)
+	} else {
+		props["ExperimentalSidebarPreference"] = strconv.FormatBool(false)
+	}
+
 	props["ExperimentalEnableAutomaticReplies"] = strconv.FormatBool(*c.TeamSettings.ExperimentalEnableAutomaticReplies)
 	props["ExperimentalTimezone"] = strconv.FormatBool(*c.DisplaySettings.ExperimentalTimezone)
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -533,6 +533,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
 	props["ExperimentalEnableDefaultChannelLeaveJoinMessages"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages)
 	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
+	props["ExperimentalSidebarPreference"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalSidebarPreference)
 	props["ExperimentalEnableAutomaticReplies"] = strconv.FormatBool(*c.TeamSettings.ExperimentalEnableAutomaticReplies)
 	props["ExperimentalTimezone"] = strconv.FormatBool(*c.DisplaySettings.ExperimentalTimezone)
 


### PR DESCRIPTION
#### Summary
Exposes `ExperimentalSidebarPreference` in config, to be used in the new sidebar channel ordering feature.

Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/1374
Redux PR: https://github.com/mattermost/mattermost-redux/pull/549