### PR TITLE
MM-10972 Ignore | characters in postgres channel search

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1617,6 +1617,8 @@ func (s SqlChannelStore) buildFulltextClause(term string) (fulltextClause, fullt
 
 	// Prepare the FULLTEXT portion of the query.
 	if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+		fulltextTerm = strings.Replace(fulltextTerm, "|", "", -1)
+
 		splitTerm := strings.Fields(fulltextTerm)
 		for i, t := range strings.Fields(fulltextTerm) {
 			if i == len(splitTerm)-1 {

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -2028,6 +2028,19 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 					t.Fatal("wrong channel returned")
 				}
 			}
+
+			if result := <-search(o1.TeamId, "town square |"); result.Err != nil {
+				t.Fatal(result.Err)
+			} else {
+				channels := result.Data.(*model.ChannelList)
+				if len(*channels) != 1 {
+					t.Fatal("should return 1 channel")
+				}
+
+				if (*channels)[0].Name != o9.Name {
+					t.Fatal("wrong channel returned")
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### Summary
It was causing a syntax error in the full text search clause for Postgres.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10972

#### Checklist
- [x] Added or updated unit tests (required for all new features)