### PR TITLE
MM-10603: Ignore Redirects and Other Changes when Displaying Link Previews

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -765,6 +765,9 @@ func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
 
 	makeOpenGraphURLsAbsolute(og, requestURL)
 
+	// The URL should be the link the user provided in their message, not a redirected one.
+	og.URL = requestURL
+
 	return og
 }
 

--- a/app/post.go
+++ b/app/post.go
@@ -766,7 +766,9 @@ func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
 	makeOpenGraphURLsAbsolute(og, requestURL)
 
 	// The URL should be the link the user provided in their message, not a redirected one.
-	og.URL = requestURL
+	if og.URL != "" {
+		og.URL = requestURL
+	}
 
 	return og
 }


### PR DESCRIPTION
#### Summary
This PR is a small behavior change with link previews. When a user posts a message with a URL, we get the contents of that URL and check for `<meta>` annotations that conform to the [Open Graph protocol](http://ogp.me/). If these annotations are present, we show a link preview in Mattermost (if that setting is enabled.) We also follow redirects when performing this action, which means that sometimes we follow a redirect, and our final landing page provides a `og:url` different from the URL the user put in their message. This behavior is intended, but confusing. **This PR ignores the `og:url` property, and always uses the link the user originally provided instead.** We still follow redirects for displaying other link preview information.

#### Ticket Link
Closes: Github #9008, JIRA [MM-10603](https://mattermost.atlassian.net/browse/MM-10603)

#### Checklist
Nothing applicable here.