### PR TITLE
Disable Gfycat by default during Beta

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -208,6 +208,7 @@ func (a *App) trackConfig() {
 		"enable_user_access_tokens":                               *cfg.ServiceSettings.EnableUserAccessTokens,
 		"enable_custom_emoji":                                     *cfg.ServiceSettings.EnableCustomEmoji,
 		"enable_emoji_picker":                                     *cfg.ServiceSettings.EnableEmojiPicker,
+		"enable_gif_picker":                                       *cfg.ServiceSettings.EnableGifPicker,
 		"experimental_enable_authentication_transfer":             *cfg.ServiceSettings.ExperimentalEnableAuthenticationTransfer,
 		"restrict_custom_emoji_creation":                          *cfg.ServiceSettings.RestrictCustomEmojiCreation,
 		"enable_testing":                                          cfg.ServiceSettings.EnableTesting,

--- a/config/default.json
+++ b/config/default.json
@@ -44,7 +44,7 @@
         "WebserverMode": "gzip",
         "EnableCustomEmoji": false,
         "EnableEmojiPicker": true,
-        "EnableGifPicker": true,
+        "EnableGifPicker": false,
         "GfycatApiKey": "",
         "GfycatApiSecret": "",
         "RestrictCustomEmojiCreation": "all",


### PR DESCRIPTION
I missed this during initial review. Beta features should be turned off by default.