### PR TITLE
Adding RootId information to MessageExport

### DIFF
--- a/model/message_export.go
+++ b/model/message_export.go
@@ -21,6 +21,7 @@ type MessageExport struct {
 	PostCreateAt   *int64
 	PostMessage    *string
 	PostType       *string
+	PostRootId     *string
 	PostOriginalId *string
 	PostFileIds    StringArray
 }

--- a/store/sqlstore/compliance_store.go
+++ b/store/sqlstore/compliance_store.go
@@ -224,6 +224,7 @@ func (s SqlComplianceStore) MessageExport(after int64, limit int) store.StoreCha
 				Posts.Message AS PostMessage,
 				Posts.Type AS PostType,
 				Posts.OriginalId AS PostOriginalId,
+				Posts.RootId AS PostRootId,
 				Posts.FileIds AS PostFileIds,
 				Teams.Id AS TeamId,
 				Teams.Name AS TeamName,


### PR DESCRIPTION
#### Summary
Adding RootId information to MessageExport. The idea is to include
"conversation" concept in to the compliance exports (for now only for CSV, but
in the future for Actiance and Global Relay)

#### Checklist
- [x] Has enterprise changes (mattermost/enterprise#319)