### PR TITLE
Make sure diagnostic ID is loaded before client config.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -184,7 +184,6 @@ func New(options ...Option) (outApp *App, outErr error) {
 		})
 
 	})
-	app.regenerateClientConfig()
 
 	mlog.Info("Server is initializing...")
 
@@ -206,6 +205,9 @@ func New(options ...Option) (outApp *App, outErr error) {
 	if err := app.ensureAsymmetricSigningKey(); err != nil {
 		return nil, errors.Wrapf(err, "unable to ensure asymmetric signing key")
 	}
+
+	app.EnsureDiagnosticId()
+	app.regenerateClientConfig()
 
 	app.initJobs()
 	app.AddLicenseListener(func() {

--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -146,8 +146,6 @@ func runServer(configFileLocation string, disableConfigWatch bool, usedPlatform 
 		manualtesting.Init(api)
 	}
 
-	a.EnsureDiagnosticId()
-
 	a.Go(func() {
 		runSecurityJob(a)
 	})


### PR DESCRIPTION
#### Summary
Make sure diagnostic ID is loaded before client config.

https://mattermost.atlassian.net/browse/MM-10999