### PR TITLE
[MM-10830] Enhance Log Output from Permanent Delete

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1309,16 +1309,28 @@ func (a *App) PermanentDeleteUser(user *model.User) *model.AppError {
 			res, err := a.FileExists(info.Path)
 
 			if err != nil {
-				mlog.Warn(fmt.Sprintf("Error checking existence of file '%s': %s", info.Path, err))
+				mlog.Warn(
+					"Error checking existence of file",
+					mlog.String("path", info.Path),
+					mlog.Err(err),
+				)
 				continue
 			}
 
-			if res {
-				a.RemoveFile(info.Path)
-			} else {
-				mlog.Warn(fmt.Sprintf("Unable to remove file '%s': %s", info.Path, err))
+			if !res {
+				mlog.Warn("File not found", mlog.String("path", info.Path))
+				continue
 			}
 
+			err = a.RemoveFile(info.Path)
+
+			if err != nil {
+				mlog.Warn(
+					"Unable to remove file",
+					mlog.String("path", info.Path),
+					mlog.Err(err),
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
#### Summary
This PR enhances the log output from MM-10830 to print a warning when a file was not found or the delete failed for various reasons. Previously, deletion errors were ignored and the file not found warning was opaque.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10830
