### PR TITLE
push notifications follow teammate name display user or server setting

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -694,24 +694,13 @@ func (a *App) GetMessageForNotification(post *model.Post, translateFunc i18n.Tra
 
 func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *model.Channel, channelName string, sender *model.User, senderName string,
 	explicitMention, channelWideMention bool, replyToThreadType string) *model.AppError {
-	contentsConfig := *a.Config().EmailSettings.PushNotificationContents
+	cfg := a.Config()
+	contentsConfig := *cfg.EmailSettings.PushNotificationContents
+	teammateNameConfig := *cfg.TeamSettings.TeammateNameDisplay
 	sessions, err := a.getMobileAppSessions(user.Id)
+	sentBySystem := senderName == utils.T("system.message.name")
 	if err != nil {
 		return err
-	}
-
-	if channel.Type == model.CHANNEL_DIRECT {
-		if senderName == utils.T("system.message.name") {
-			channelName = senderName
-		} else {
-			preference, prefError := a.GetPreferenceByCategoryAndNameForUser(user.Id, model.PREFERENCE_CATEGORY_DISPLAY_SETTINGS, "name_format")
-			if prefError != nil {
-				channelName = fmt.Sprintf("@%v", senderName)
-			} else {
-				channelName = fmt.Sprintf("@%v", sender.GetDisplayName(preference.Value))
-				senderName = channelName
-			}
-		}
 	}
 
 	msg := model.PushNotification{}
@@ -731,12 +720,25 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 	msg.RootId = post.RootId
 	msg.SenderId = post.UserId
 
+	if !sentBySystem {
+		senderName = sender.GetDisplayName(teammateNameConfig)
+		preference, prefError := a.GetPreferenceByCategoryAndNameForUser(user.Id, model.PREFERENCE_CATEGORY_DISPLAY_SETTINGS, "name_format")
+		if prefError == nil && preference.Value != teammateNameConfig {
+			senderName = sender.GetDisplayName(preference.Value)
+		}
+	}
+
+	if channel.Type == model.CHANNEL_DIRECT {
+		channelName = fmt.Sprintf("@%v", senderName)
+	}
+
 	if contentsConfig != model.GENERIC_NO_CHANNEL_NOTIFICATION || channel.Type == model.CHANNEL_DIRECT {
 		msg.ChannelName = channelName
 	}
 
 	if ou, ok := post.Props["override_username"].(string); ok {
 		msg.OverrideUsername = ou
+		senderName = ou
 	}
 
 	if oi, ok := post.Props["override_icon_url"].(string); ok {

--- a/app/notification.go
+++ b/app/notification.go
@@ -736,12 +736,12 @@ func (a *App) sendPushNotification(post *model.Post, user *model.User, channel *
 		msg.ChannelName = channelName
 	}
 
-	if ou, ok := post.Props["override_username"].(string); ok {
+	if ou, ok := post.Props["override_username"].(string); ok && cfg.ServiceSettings.EnablePostUsernameOverride {
 		msg.OverrideUsername = ou
 		senderName = ou
 	}
 
-	if oi, ok := post.Props["override_icon_url"].(string); ok {
+	if oi, ok := post.Props["override_icon_url"].(string); ok && cfg.ServiceSettings.EnablePostIconOverride {
 		msg.OverrideIconUrl = oi
 	}
 

--- a/model/user.go
+++ b/model/user.go
@@ -406,11 +406,11 @@ func (u *User) AddNotifyProp(key string, value string) {
 }
 
 func (u *User) GetFullName() string {
-	if u.FirstName != "" && u.LastName != "" {
+	if len(u.FirstName) > 0 && len(u.LastName) > 0 {
 		return u.FirstName + " " + u.LastName
-	} else if u.FirstName != "" {
+	} else if len(u.FirstName) > 0 {
 		return u.FirstName
-	} else if u.LastName != "" {
+	} else if len(u.LastName) > 0 {
 		return u.LastName
 	} else {
 		return ""
@@ -421,13 +421,13 @@ func (u *User) GetDisplayName(nameFormat string) string {
 	displayName := u.Username
 
 	if nameFormat == SHOW_NICKNAME_FULLNAME {
-		if u.Nickname != "" {
+		if len(u.Nickname) > 0 {
 			displayName = u.Nickname
-		} else if fullName := u.GetFullName(); fullName != "" {
+		} else if fullName := u.GetFullName(); len(fullName) > 0 {
 			displayName = fullName
 		}
 	} else if nameFormat == SHOW_FULLNAME {
-		if fullName := u.GetFullName(); fullName != "" {
+		if fullName := u.GetFullName(); len(fullName) > 0 {
 			displayName = fullName
 		}
 	}


### PR DESCRIPTION
#### Summary
This PR addresses the teammate display name not being shown when a push notification was sent.

It should be tested and loadtested in order to ensure it does not creates performance issues, if that is the case we can always remove the user preference and always use the server one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11105
