### PR TITLE
[MM-10754] Remove unnecessary command_test route

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -4,7 +4,6 @@
 package api4
 
 import (
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -22,9 +21,6 @@ func (api *API) InitCommand() {
 
 	api.BaseRoutes.Team.Handle("/commands/autocomplete", api.ApiSessionRequired(listAutocompleteCommands)).Methods("GET")
 	api.BaseRoutes.Command.Handle("/regen_token", api.ApiSessionRequired(regenCommandToken)).Methods("PUT")
-
-	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testCommand)).Methods("POST")
-	api.BaseRoutes.Teams.Handle("/command_test", api.ApiHandler(testCommand)).Methods("GET")
 }
 
 func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -290,26 +286,4 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	resp["token"] = rcmd.Token
 
 	w.Write([]byte(model.MapToJson(resp)))
-}
-
-func testCommand(c *Context, w http.ResponseWriter, r *http.Request) {
-	r.ParseForm()
-
-	msg := ""
-	if r.Method == "POST" {
-		msg = msg + "\ntoken=" + r.FormValue("token")
-		msg = msg + "\nteam_domain=" + r.FormValue("team_domain")
-	} else {
-		body, _ := ioutil.ReadAll(r.Body)
-		msg = string(body)
-	}
-
-	rc := &model.CommandResponse{
-		Text:         "test command response " + msg,
-		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
-		Type:         "custom_test",
-		Props:        map[string]interface{}{"someprop": "somevalue"},
-	}
-
-	w.Write([]byte(rc.ToJson()))
 }

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -591,14 +591,29 @@ func TestExecuteCommandAgainstChannelOnAnotherTeam(t *testing.T) {
 		})
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCommands = true })
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost" })
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
+	})
+
+	expectedCommandResponse := &model.CommandResponse{
+		Text:         "test post command response",
+		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
+		Type:         "custom_test",
+		Props:        map[string]interface{}{"someprop": "somevalue"},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(expectedCommandResponse.ToJson()))
+	}))
+	defer ts.Close()
 
 	// create a slash command on some other team where we have permission to do so
 	team2 := th.CreateTeam()
 	postCmd := &model.Command{
 		CreatorId: th.BasicUser.Id,
 		TeamId:    team2.Id,
-		URL:       "http://localhost",
+		URL:       ts.URL,
 		Method:    model.COMMAND_METHOD_POST,
 		Trigger:   "postcommand",
 	}
@@ -626,14 +641,29 @@ func TestExecuteCommandAgainstChannelUserIsNotIn(t *testing.T) {
 		})
 	}()
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCommands = true })
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost" })
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
+	})
+
+	expectedCommandResponse := &model.CommandResponse{
+		Text:         "test post command response",
+		ResponseType: model.COMMAND_RESPONSE_TYPE_IN_CHANNEL,
+		Type:         "custom_test",
+		Props:        map[string]interface{}{"someprop": "somevalue"},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(expectedCommandResponse.ToJson()))
+	}))
+	defer ts.Close()
 
 	// create a slash command on some other team where we have permission to do so
 	team2 := th.CreateTeam()
 	postCmd := &model.Command{
 		CreatorId: th.BasicUser.Id,
 		TeamId:    team2.Id,
-		URL:       "http://localhost",
+		URL:       ts.URL,
 		Method:    model.COMMAND_METHOD_POST,
 		Trigger:   "postcommand",
 	}


### PR DESCRIPTION
#### Summary
Remove unnecessary command_test route.  Test functionality is replaced with `httptest` whenever needed.

#### Ticket Link
Jira ticket: [MM-10754](https://mattermost.atlassian.net/browse/MM-10754)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (nothing to update)
