### PR TITLE
MM-11118: disallow deleting direct or group channels

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -638,6 +638,11 @@ func deleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if channel.Type == model.CHANNEL_DIRECT || channel.Type == model.CHANNEL_GROUP {
+		c.Err = model.NewAppError("deleteChannel", "api.channel.delete_channel.type.invalid", nil, "", http.StatusBadRequest)
+		return
+	}
+
 	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_DELETE_PUBLIC_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_DELETE_PUBLIC_CHANNEL)
 		return

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateChannel(t *testing.T) {
@@ -320,6 +321,23 @@ func TestCreateDirectChannel(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
+func TestDeleteDirectChannel(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+	user := th.BasicUser
+	user2 := th.BasicUser2
+
+	rgc, resp := Client.CreateDirectChannel(user.Id, user2.Id)
+	CheckNoError(t, resp)
+	CheckCreatedStatus(t, resp)
+	require.NotNil(t, rgc, "should have created a direct channel")
+
+	deleted, resp := Client.DeleteChannel(rgc.Id)
+	CheckErrorMessage(t, resp, "api.channel.delete_channel.type.invalid")
+	require.False(t, deleted, "should not have been able to delete direct channel.")
+}
+
 func TestCreateGroupChannel(t *testing.T) {
 	th := Setup().InitBasic().InitSystemAdmin()
 	defer th.TearDown()
@@ -390,6 +408,26 @@ func TestCreateGroupChannel(t *testing.T) {
 
 	_, resp = th.SystemAdminClient.CreateGroupChannel(userIds)
 	CheckNoError(t, resp)
+}
+
+func TestDeleteGroupChannel(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+	user := th.BasicUser
+	user2 := th.BasicUser2
+	user3 := th.CreateUser()
+
+	userIds := []string{user.Id, user2.Id, user3.Id}
+
+	rgc, resp := Client.CreateGroupChannel(userIds)
+	CheckNoError(t, resp)
+	CheckCreatedStatus(t, resp)
+	require.NotNil(t, rgc, "should have created a group channel")
+
+	deleted, resp := Client.DeleteChannel(rgc.Id)
+	CheckErrorMessage(t, resp, "api.channel.delete_channel.type.invalid")
+	require.False(t, deleted, "should not have been able to delete group channel.")
 }
 
 func TestGetChannel(t *testing.T) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -160,6 +160,10 @@
     "translation": "The channel has been archived or deleted"
   },
   {
+    "id": "api.channel.delete_channel.type.invalid",
+    "translation": "Cannot delete direct or group message channels"
+  },
+  {
     "id": "api.channel.join_channel.already_deleted.app_error",
     "translation": "Channel is already deleted"
   },


### PR DESCRIPTION
#### Summary
Originally reported as an issue restoring a channel, the root problem here is that we shouldn't allow a direct or group channel to be marked as deleted in the first place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11118
https://github.com/mattermost/mattermost-server/issues/9001#issue-335775057

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation: https://github.com/mattermost/mattermost-api-reference/pull/380
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
