### PR TITLE
Blacklist System as Username

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -565,6 +565,7 @@ var restrictedUsernames = []string{
 	"all",
 	"channel",
 	"matterbot",
+	"system",
 }
 
 func IsValidUsername(s string) bool {

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -272,6 +272,7 @@ var usernames = []struct {
 	{"spin'punch", false},
 	{"spin*punch", false},
 	{"all", false},
+	{"system", false},
 }
 
 func TestValidUsername(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR blacklists System as a username. The justification is that system notifications, e.g. user join messages are sent with that nickname, allowing an attacker to act as a system user for social engineering, an example would be:

![Example of Abuse](https://i.imgur.com/29gHryL.png)

Implementation was discussed with @crspeller, there is no ticket or issue right now for it.

#### Checklist
- [x] Added or updated unit tests (required for all new features)