### PR TITLE
Update custom url schemes error message to reflect what we actually support

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3784,7 +3784,7 @@
   },
   {
     "id": "model.config.is_valid.display.custom_url_schemes.app_error",
-    "translation": "The custom URL scheme {{.Scheme}} is invalid. Custom URL schemes must start with a letter and contain only letters, numbers, plus (+), period (.), and hyphen (-)."
+    "translation": "The custom URL scheme {{.Scheme}} is invalid. Custom URL schemes must start with a letter and contain only letters, numbers and hyphen (-)."
   },
   {
     "id": "model.config.is_valid.elastic_search.aggregate_posts_after_days.app_error",

--- a/model/config.go
+++ b/model/config.go
@@ -2418,7 +2418,7 @@ func (mes *MessageExportSettings) isValid(fs FileSettings) *AppError {
 
 func (ds *DisplaySettings) isValid() *AppError {
 	if len(*ds.CustomUrlSchemes) != 0 {
-		validProtocolPattern := regexp.MustCompile(`(?i)^\s*[a-z][a-z0-9+.-]*\s*$`)
+		validProtocolPattern := regexp.MustCompile(`(?i)^\s*[a-z][a-z0-9-]*\s*$`)
 
 		for _, scheme := range *ds.CustomUrlSchemes {
 			if !validProtocolPattern.MatchString(scheme) {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -466,7 +466,7 @@ func TestDisplaySettingsIsValidCustomUrlSchemes(t *testing.T) {
 		{
 			name:  "containing period",
 			value: []string{"iris.beep"},
-			valid: true,
+			valid: false, // should technically be true, but client doesn't support it
 		},
 		{
 			name:  "containing hyphen",
@@ -476,7 +476,7 @@ func TestDisplaySettingsIsValidCustomUrlSchemes(t *testing.T) {
 		{
 			name:  "containing plus",
 			value: []string{"coap+tcp", "coap+ws"},
-			valid: true,
+			valid: false, // should technically be true, but client doesn't support it
 		},
 		{
 			name:  "starting with number",


### PR DESCRIPTION
The markdown renderer on the client doesn't support protocols containing a plus or period, so update the validation on the server to match that

#### Checklist
- Added or updated unit tests (required for all new features)
- Has UI changes
- Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates