### PR TITLE
[MM-11180] Experimental Custom Default Channels (closes #9058)

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -163,6 +163,36 @@ func TestJoinDefaultChannelsCreatesChannelMemberHistoryRecordOffTopic(t *testing
 	assert.True(t, found)
 }
 
+func TestJoinDefaultChannelsExperimentalDefaultChannels(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	basicChannel2 := th.CreateChannel(th.BasicTeam)
+	defaultChannelList := []string{th.BasicChannel.Name, basicChannel2.Name, basicChannel2.Name}
+	th.App.Config().TeamSettings.ExperimentalDefaultChannels = defaultChannelList
+
+	user := th.CreateUser()
+	th.App.JoinDefaultChannels(th.BasicTeam.Id, user, false, "")
+
+	for _, channelName := range defaultChannelList {
+		channel, err := th.App.GetChannelByName(channelName, th.BasicTeam.Id)
+
+		if err != nil {
+			t.Errorf("Expected nil, got %s", err)
+		}
+
+		member, err := th.App.GetChannelMember(channel.Id, user.Id)
+
+		if member == nil {
+			t.Errorf("Expected member object, got nil")
+		}
+
+		if err != nil {
+			t.Errorf("Expected nil object, got %s", err)
+		}
+	}
+}
+
 func TestCreateChannelPublicCreatesChannelMemberHistoryRecord(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -283,6 +283,7 @@ func (a *App) trackConfig() {
 		"experimental_town_square_is_hidden_in_lhs": *cfg.TeamSettings.ExperimentalHideTownSquareinLHS,
 		"experimental_town_square_is_read_only":     *cfg.TeamSettings.ExperimentalTownSquareIsReadOnly,
 		"experimental_primary_team":                 isDefault(*cfg.TeamSettings.ExperimentalPrimaryTeam, ""),
+		"experimental_default_channels":             len(cfg.TeamSettings.ExperimentalDefaultChannels),
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_CLIENT_REQ, map[string]interface{}{

--- a/model/config.go
+++ b/model/config.go
@@ -1105,6 +1105,7 @@ type TeamSettings struct {
 	ExperimentalHideTownSquareinLHS     *bool
 	ExperimentalTownSquareIsReadOnly    *bool
 	ExperimentalPrimaryTeam             *string
+	ExperimentalDefaultChannels         []string
 }
 
 func (s *TeamSettings) SetDefaults() {
@@ -1215,6 +1216,10 @@ func (s *TeamSettings) SetDefaults() {
 
 	if s.ExperimentalPrimaryTeam == nil {
 		s.ExperimentalPrimaryTeam = NewString("")
+	}
+
+	if s.ExperimentalDefaultChannels == nil {
+		s.ExperimentalDefaultChannels = []string{}
 	}
 
 	if s.EnableTeamCreation == nil {


### PR DESCRIPTION
#### Summary
Implementation of custom default channel functionality using an experimental config entry. Config entry has to be a string array containing channel names of default channels. 

Change is non breaking since previous behavior is kept if experimental flag is not set. Code duplication was removed and consistency for `ExperimentalEnableDefaultChannelLeaveJoinMessages` implemented, since previously all other default channels but `town-square` still sent `Join/Leave` messages. In this PR all default channels don't post a join message.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9058
https://mattermost.atlassian.net/browse/MM-11180

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
