### PR TITLE
MM-11189: Do not close the connection abruptly on too big emojis

### DIFF
--- a/api4/emoji.go
+++ b/api4/emoji.go
@@ -4,6 +4,8 @@
 package api4
 
 import (
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -28,6 +30,8 @@ func (api *API) InitEmoji() {
 }
 
 func createEmoji(c *Context, w http.ResponseWriter, r *http.Request) {
+	defer io.Copy(ioutil.Discard, r.Body)
+
 	if !*c.App.Config().ServiceSettings.EnableCustomEmoji {
 		c.Err = model.NewAppError("createEmoji", "api.emoji.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return


### PR DESCRIPTION
#### Summary
Firefox Fetch implementation consider a cut in the connection when is
too soon a "Network error". If we manage the post data before close the
connection it behaves correctly.

#### Ticket Link
[MM-11189](https://mattermost.atlassian.net/browse/MM-11189)