### PR TITLE
MM-11241: fix context site url header

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -68,7 +68,9 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	c.SetSiteURLHeader(app.GetProtocol(r) + "://" + r.Host)
+	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
+	siteURLHeader := app.GetProtocol(r) + "://" + r.Host + subpath
+	c.SetSiteURLHeader(siteURLHeader)
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.RequestId)
 	w.Header().Set(model.HEADER_VERSION_ID, fmt.Sprintf("%v.%v.%v.%v", model.CurrentVersion, model.BuildNumber, c.App.ClientConfigHash(), c.App.License() != nil))

--- a/web/saml.go
+++ b/web/saml.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 )
@@ -143,7 +142,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		if action == model.OAUTH_ACTION_MOBILE {
 			ReturnStatusOK(w)
 		} else {
-			http.Redirect(w, r, app.GetProtocol(r)+"://"+r.Host, http.StatusFound)
+			http.Redirect(w, r, c.GetSiteURLHeader(), http.StatusFound)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
I missed the context's SiteURLHeader when testing, in part because I had implemented the root redirect and wasn't testing using a proxy server that redirected `/` elsewhere. Hurrah for the spinmint testing!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11241
https://mattermost.atlassian.net/browse/MM-11246

#### Checklist
- [ ] Added or updated unit tests (required for all new features)