### PR TITLE
Do not close the connection abruptly on too big file uploads

### DIFF
--- a/api4/brand.go
+++ b/api4/brand.go
@@ -4,6 +4,8 @@
 package api4
 
 import (
+	"io"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -27,6 +29,8 @@ func getBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
+	defer io.Copy(ioutil.Discard, r.Body)
+
 	if r.ContentLength > *c.App.Config().FileSettings.MaxFileSize {
 		c.Err = model.NewAppError("uploadBrandImage", "api.admin.upload_brand_image.too_large.app_error", nil, "", http.StatusRequestEntityTooLarge)
 		return

--- a/api4/file.go
+++ b/api4/file.go
@@ -5,6 +5,7 @@ package api4
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -56,6 +57,8 @@ func (api *API) InitFile() {
 }
 
 func uploadFile(c *Context, w http.ResponseWriter, r *http.Request) {
+	defer io.Copy(ioutil.Discard, r.Body)
+
 	if !*c.App.Config().FileSettings.EnableFileAttachments {
 		c.Err = model.NewAppError("uploadFile", "api.file.attachments.disabled.app_error", nil, "", http.StatusNotImplemented)
 		return

--- a/api4/team.go
+++ b/api4/team.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 
@@ -796,6 +798,8 @@ func getTeamIcon(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func setTeamIcon(c *Context, w http.ResponseWriter, r *http.Request) {
+	defer io.Copy(ioutil.Discard, r.Body)
+
 	c.RequireTeamId()
 	if c.Err != nil {
 		return

--- a/api4/user.go
+++ b/api4/user.go
@@ -5,6 +5,8 @@ package api4
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -234,6 +236,8 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func setProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
+	defer io.Copy(ioutil.Discard, r.Body)
+
 	c.RequireUserId()
 	if c.Err != nil {
 		return


### PR DESCRIPTION
#### Summary
This is a continuation of the MM-11189 bug fix already merged in
release-5.1 (#9083). The emoji upload was failing, the brand one is failing
until this PR is merged, and the other 2 cases are for API endpoints
that wasn't failing because the ui prevent the file upload.

#### Ticket Link
[MM-11189](https://mattermost.atlassian.net/browse/MM-11189)