### PR TITLE
MM-11172: Don't allow reacting in read-only town square.

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -164,6 +164,10 @@
     "translation": "The channel has been archived or deleted"
   },
   {
+    "id": "api.reaction.town_square_read_only",
+    "translation": "Reacting to posts is not possible in read-only channels."
+  },
+  {
     "id": "api.channel.delete_channel.type.invalid",
     "translation": "Cannot delete direct or group message channels"
   },


### PR DESCRIPTION
#### Summary
Apply the same rule to town square when it's read only for reactions as we do for posts. Web client and RN changes to follow in separate PRs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11172

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
