### PR TITLE
[MM-11210] Add API GET 'api/v4/channels/{channel_id:[A-Za-z0-9]+}/posts/unread' for scrolling overhaul

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	PAGE_DEFAULT     = 0
-	PER_PAGE_DEFAULT = 60
+	MAX_LIMIT_POSTS_SINCE = 1000
+	PAGE_DEFAULT          = 0
+	PER_PAGE_DEFAULT      = 60
 )
 
 func (api *API) InitPost() {
@@ -136,7 +137,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	etag := ""
 
 	if since > 0 {
-		list, err = c.App.GetPostsSince(c.Params.ChannelId, since)
+		list, err = c.App.GetPostsSince(c.Params.ChannelId, since, MAX_LIMIT_POSTS_SINCE)
 	} else if len(afterPost) > 0 {
 		etag = c.App.GetPostsEtag(c.Params.ChannelId)
 

--- a/api4/post.go
+++ b/api4/post.go
@@ -9,13 +9,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
-)
-
-const (
-	MAX_LIMIT_POSTS_SINCE = 1000
-	PAGE_DEFAULT          = 0
-	PER_PAGE_DEFAULT      = 60
 )
 
 func (api *API) InitPost() {
@@ -137,7 +132,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	etag := ""
 
 	if since > 0 {
-		list, err = c.App.GetPostsSince(c.Params.ChannelId, since, MAX_LIMIT_POSTS_SINCE)
+		list, err = c.App.GetPostsSince(c.Params.ChannelId, since, app.MAX_LIMIT_POSTS_SINCE)
 	} else if len(afterPost) > 0 {
 		etag = c.App.GetPostsEtag(c.Params.ChannelId)
 
@@ -201,7 +196,7 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 			return
 		}
 
-		postList, err = c.App.GetPostsPage(channelId, PAGE_DEFAULT, PER_PAGE_DEFAULT)
+		postList, err = c.App.GetPostsPage(channelId, app.PAGE_DEFAULT, app.PER_PAGE_DEFAULT)
 	}
 
 	if len(etag) > 0 {

--- a/api4/post.go
+++ b/api4/post.go
@@ -12,6 +12,11 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
+const (
+	PAGE_DEFAULT     = 0
+	PER_PAGE_DEFAULT = 60
+)
+
 func (api *API) InitPost() {
 	api.BaseRoutes.Posts.Handle("", api.ApiSessionRequired(createPost)).Methods("POST")
 	api.BaseRoutes.Post.Handle("", api.ApiSessionRequired(getPost)).Methods("GET")
@@ -195,7 +200,7 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 			return
 		}
 
-		postList, err = c.App.GetPostsPage(channelId, 0, 60)
+		postList, err = c.App.GetPostsPage(channelId, PAGE_DEFAULT, PER_PAGE_DEFAULT)
 	}
 
 	if len(etag) > 0 {

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/store"
 )
 
 func TestCreatePost(t *testing.T) {
@@ -1113,6 +1114,117 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 
 	if len(posts.Posts) != 0 {
 		t.Fatal("should have no posts")
+	}
+}
+
+func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	Client := th.Client
+
+	var lastBeforePost *model.Post
+	for i := 0; i < 100; i++ {
+		if i == 40 {
+			lastBeforePost = th.CreatePost()
+		} else {
+			th.CreatePost()
+		}
+	}
+
+	posts, resp := Client.GetPostsAroundLastUnread(th.BasicChannel.Id)
+	CheckNoError(t, resp)
+
+	if len(posts.Order) != 60 {
+		t.Fatal("Should return 60 posts only since there's no unread post")
+	}
+
+	var lastUnreadPost *model.Post
+	var post *model.Post
+	for i := 0; i < 10; i++ {
+		if i == 0 {
+			lastUnreadPost = th.CreatePost()
+		} else {
+			post = th.CreatePost()
+		}
+	}
+
+	since := lastUnreadPost.CreateAt - 1
+	channelMember := store.Must(th.App.Srv.Store.Channel().GetMember(th.BasicChannel.Id, th.BasicUser.Id)).(*model.ChannelMember)
+	channelMember.LastViewedAt = since
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+
+	posts, resp = Client.GetPostsAroundLastUnread(th.BasicChannel.Id)
+	CheckNoError(t, resp)
+
+	if len(posts.Order) != 70 {
+		t.Fatal("Should return 70 posts")
+	}
+
+	for i, postId := range posts.Order {
+		post = posts.Posts[postId]
+		if i < 10 {
+			if post.CreateAt < channelMember.LastViewedAt {
+				t.Fatal("Should be unread post")
+			}
+		}
+
+		if i == 9 {
+			if post.Id != lastUnreadPost.Id {
+				t.Fatal("Should match the last unread post")
+			}
+		}
+
+		if i == 69 {
+			if post.Id != lastBeforePost.Id {
+				t.Fatal("Should match the last unread post")
+			}
+		}
+	}
+
+	var recentUnreadPost *model.Post
+	for i := 0; i < 100; i++ {
+		if i == 49 {
+			recentUnreadPost = th.CreatePost()
+		} else {
+			th.CreatePost()
+		}
+	}
+
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+
+	posts, resp = Client.GetPostsAroundLastUnread(th.BasicChannel.Id)
+	CheckNoError(t, resp)
+
+	if len(posts.Order) != 120 {
+		t.Fatal("Should return 120 posts")
+	}
+
+	for i, postId := range posts.Order {
+		post = posts.Posts[postId]
+
+		if i == 0 {
+			if post.Id != recentUnreadPost.Id {
+				t.Fatal("Should match recent unread post")
+			}
+		}
+
+		if i < 60 {
+			if post.CreateAt < channelMember.LastViewedAt {
+				t.Fatal("Should be unread post")
+			}
+		}
+
+		if i == 59 {
+			if post.Id != lastUnreadPost.Id {
+				t.Fatal("Should match the last unread post")
+			}
+		}
+
+		if i == 119 {
+			if post.Id != lastBeforePost.Id {
+				t.Fatal("Should match the last before post")
+			}
+		}
 	}
 }
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1135,7 +1135,7 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	posts, resp := Client.GetPostsAroundLastUnread(th.BasicChannel.Id)
 	CheckNoError(t, resp)
 
-	if len(posts.Order) != PER_PAGE_DEFAULT {
+	if len(posts.Order) != app.PER_PAGE_DEFAULT {
 		t.Fatal("Should return 60 posts only since there's no unread post")
 	}
 
@@ -1148,7 +1148,7 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	posts, resp = Client.GetPostsAroundLastUnread(th.BasicChannel.Id)
 	CheckNoError(t, resp)
 
-	if len(posts.Order) != PER_PAGE_DEFAULT {
+	if len(posts.Order) != app.PER_PAGE_DEFAULT {
 		t.Fatal("Should return 60 posts only since there's no unread post")
 	}
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1134,7 +1134,7 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	posts, resp := Client.GetPostsAroundLastUnread(th.BasicChannel.Id)
 	CheckNoError(t, resp)
 
-	if len(posts.Order) != 60 {
+	if len(posts.Order) != PER_PAGE_DEFAULT {
 		t.Fatal("Should return 60 posts only since there's no unread post")
 	}
 

--- a/app/post.go
+++ b/app/post.go
@@ -24,6 +24,8 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
+const MAX_POSTS_SINCE = 1000
+
 var linkWithTextRegex = regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
 
 func (a *App) CreatePostAsUser(post *model.Post) (*model.Post, *model.AppError) {
@@ -483,7 +485,7 @@ func (a *App) GetPostsEtag(channelId string) string {
 }
 
 func (a *App) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
-	if result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, 1000, true); result.Err != nil {
+	if result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, MAX_POSTS_SINCE, true); result.Err != nil {
 		return nil, result.Err
 	} else {
 		return result.Data.(*model.PostList), nil

--- a/app/post.go
+++ b/app/post.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	DEFAULT_LIMIT_POSTS_SINCE = 60
-	PAGE_DEFAULT              = 0
-	PER_PAGE_DEFAULT          = 60
+	MAX_LIMIT_POSTS_SINCE = 1000
+	PAGE_DEFAULT          = 0
+	PER_PAGE_DEFAULT      = 60
 )
 
 var linkWithTextRegex = regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
@@ -602,7 +602,7 @@ func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string) (*mod
 	}
 
 	var postListSince *model.PostList
-	if postListSince, err = a.GetPostsSince(channelId, member.LastViewedAt, DEFAULT_LIMIT_POSTS_SINCE); err != nil {
+	if postListSince, err = a.GetPostsSince(channelId, member.LastViewedAt, PER_PAGE_DEFAULT); err != nil {
 		return nil, err
 	} else if len(postListSince.Order) == 0 {
 		return model.NewPostList(), nil

--- a/app/post.go
+++ b/app/post.go
@@ -24,7 +24,11 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
-const MAX_POSTS_SINCE = 1000
+const (
+	DEFAULT_LIMIT_POSTS_SINCE = 60
+	PAGE_DEFAULT              = 0
+	PER_PAGE_DEFAULT          = 60
+)
 
 var linkWithTextRegex = regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
 
@@ -484,15 +488,7 @@ func (a *App) GetPostsEtag(channelId string) string {
 	return (<-a.Srv.Store.Post().GetEtag(channelId, true)).Data.(string)
 }
 
-func (a *App) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
-	if result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, MAX_POSTS_SINCE, true); result.Err != nil {
-		return nil, result.Err
-	} else {
-		return result.Data.(*model.PostList), nil
-	}
-}
-
-func (a *App) GetPostsSinceWithLimit(channelId string, time int64, limit int) (*model.PostList, *model.AppError) {
+func (a *App) GetPostsSince(channelId string, time int64, limit int) (*model.PostList, *model.AppError) {
 	if result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, limit, true); result.Err != nil {
 		return nil, result.Err
 	} else {
@@ -601,38 +597,31 @@ func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string) (*mod
 	var err *model.AppError
 	if member, err = a.GetChannelMember(channelId, userId); err != nil {
 		return nil, err
+	} else if member.LastViewedAt == 0 {
+		return model.NewPostList(), nil
 	}
 
 	var postListSince *model.PostList
-	if member.LastViewedAt > 0 {
-		if postListSince, err = a.GetPostsSinceWithLimit(channelId, member.LastViewedAt, 60); err != nil {
-			return nil, err
-		}
+	if postListSince, err = a.GetPostsSince(channelId, member.LastViewedAt, DEFAULT_LIMIT_POSTS_SINCE); err != nil {
+		return nil, err
+	} else if len(postListSince.Order) == 0 {
+		return model.NewPostList(), nil
 	}
 
-	var lastUnreadPostId string
-	if len(postListSince.Order) > 0 {
-		lastUnreadPostId = postListSince.Order[len(postListSince.Order)-1]
-	}
-
+	var lastUnreadPostId = postListSince.Order[len(postListSince.Order)-1]
 	var postListBefore *model.PostList
 	if lastUnreadPostId != "" {
-		if postListBefore, err = a.GetPostsBeforePost(channelId, lastUnreadPostId, 0, 60); err != nil {
+		if postListBefore, err = a.GetPostsBeforePost(channelId, lastUnreadPostId, PAGE_DEFAULT, PER_PAGE_DEFAULT); err != nil {
 			return nil, err
 		}
-	}
-
-	var postList *model.PostList
-	if postListSince != nil {
-		postList = postListSince
 	}
 
 	if postListBefore != nil {
-		postList.Extend(postListBefore)
+		postListSince.Extend(postListBefore)
 	}
 
-	postList.SortByCreateAt()
-	return postList, nil
+	postListSince.SortByCreateAt()
+	return postListSince, nil
 }
 
 func (a *App) DeletePost(postId, deleteByID string) (*model.Post, *model.AppError) {

--- a/model/client4.go
+++ b/model/client4.go
@@ -2116,6 +2116,16 @@ func (c *Client4) GetPostsBefore(channelId, postId string, page, perPage int, et
 	}
 }
 
+// GetPostsAroundLastUnread gets a list of posts around last unread post by a user in a channel.
+func (c *Client4) GetPostsAroundLastUnread(channelId string) (*PostList, *Response) {
+	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts/unread", ""); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return PostListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // SearchPosts returns any posts with matching terms string.
 func (c *Client4) SearchPosts(teamId string, terms string, isOrSearch bool) (*PostList, *Response) {
 	requestBody := map[string]interface{}{"terms": terms, "is_or_search": isOrSearch}

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -547,7 +547,7 @@ func (s *SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFr
 	})
 }
 
-func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
+func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if allowFromCache {
 			// If the last post in the channel's time is less than or equal to the time we are getting posts since,
@@ -579,7 +579,7 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 			WHERE
 			    (UpdateAt > :Time
 			        AND ChannelId = :ChannelId)
-			LIMIT 1000)
+			LIMIT :Limit)
 			UNION
 			(SELECT
 			    *
@@ -595,9 +595,9 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 			    WHERE
 			        UpdateAt > :Time
 			            AND ChannelId = :ChannelId
-			    LIMIT 1000) temp_tab))
+			    LIMIT :Limit) temp_tab))
 			ORDER BY CreateAt DESC`,
-			map[string]interface{}{"ChannelId": channelId, "Time": time})
+			map[string]interface{}{"ChannelId": channelId, "Time": time, "Limit": limit})
 
 		if err != nil {
 			result.Err = model.NewAppError("SqlPostStore.GetPostsSince", "store.sql_post.get_posts_since.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)

--- a/store/store.go
+++ b/store/store.go
@@ -194,7 +194,7 @@ type PostStore interface {
 	GetFlaggedPostsForChannel(userId, channelId string, offset int, limit int) StoreChannel
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
-	GetPostsSince(channelId string, time int64, allowFromCache bool) StoreChannel
+	GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) StoreChannel
 	GetEtag(channelId string, allowFromCache bool) StoreChannel
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -290,13 +290,13 @@ func (_m *PostStore) GetPostsCreatedAt(channelId string, time int64) store.Store
 	return r0
 }
 
-// GetPostsSince provides a mock function with given fields: channelId, time, allowFromCache
-func (_m *PostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
+// GetPostsSince provides a mock function with given fields: channelId, time, limit, allowFromCache
+func (_m *PostStore) GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(channelId, time, allowFromCache)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64, bool) store.StoreChannel); ok {
-		r0 = rf(channelId, time, allowFromCache)
+	if rf, ok := ret.Get(0).(func(string, int64, int, bool) store.StoreChannel); ok {
+		r0 = rf(channelId, time, limit, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -782,7 +782,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o5.RootId = o4.Id
 	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, false)).Data.(*model.PostList)
+	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, 1000, false)).Data.(*model.PostList)
 
 	if r1.Order[0] != o5.Id {
 		t.Fatal("invalid order")
@@ -808,7 +808,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 		t.Fatal("Missing parent")
 	}
 
-	r2 := (<-ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, true)).Data.(*model.PostList)
+	r2 := (<-ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, 1000, true)).Data.(*model.PostList)
 
 	if len(r2.Order) != 0 {
 		t.Fatal("wrong size ", len(r2.Posts))


### PR DESCRIPTION
#### Summary
Add API `GET 'api/v4/channels/{channel_id:[A-Za-z0-9]+}/posts/unread'`.

The idea is to jump into the last unread post and return a list of posts around it.  This API prevents having multiple requests of loading more posts when there are too many unread post.

#### Ticket Link
Jira ticket: [MM-11210](https://mattermost.atlassian.net/browse/MM-11210)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (to follow)
- [x] All new/modified APIs include changes to the drivers
- [ ] Touches critical sections of the codebase (changed GetPostSince in store package which makes the hard limit part of the parameters)
