### PR TITLE
Support attachments in post and replies - Bulk import

### DIFF
--- a/app/import.go
+++ b/app/import.go
@@ -133,8 +133,8 @@ type ReplyImportData struct {
 	Message  *string `json:"message"`
 	CreateAt *int64  `json:"create_at"`
 
-	FlaggedBy *[]string             `json:"flagged_by"`
-	Reactions *[]ReactionImportData `json:"reactions"`
+	FlaggedBy   *[]string               `json:"flagged_by"`
+	Reactions   *[]ReactionImportData   `json:"reactions"`
 	Attachments *[]AttachmentImportData `json:"attachments"`
 }
 

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -3792,7 +3792,7 @@ func TestImportBulkImport(t *testing.T) {
 {"type": "user", "user": {"username": "` + username + `", "email": "` + username + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}]}]}}
-{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachements":[{"path": "` + testImage + `"}]}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachments":[{"path": "` + testImage + `"}]}}
 {"type": "direct_channel", "direct_channel": {"members": ["` + username + `", "` + username2 + `"]}}
 {"type": "direct_channel", "direct_channel": {"members": ["` + username + `", "` + username2 + `", "` + username3 + `"]}}
 {"type": "direct_post", "direct_post": {"channel_members": ["` + username + `", "` + username2 + `"], "user": "` + username + `", "message": "Hello Direct Channel", "create_at": 123456789013}}
@@ -3985,7 +3985,6 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 		t.Fatalf("Failed to get user3 from database.")
 	}
 
-
 	// Post with attachments.
 	time := model.GetMillis()
 	attachmentsPostTime := time
@@ -3994,16 +3993,16 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	testImage := filepath.Join(testsDir, "test.png")
 	testMarkDown := filepath.Join(testsDir, "test-attachments.md")
 	data := &PostImportData{
-		Team:     &teamName,
-		Channel:  &channelName,
-		User:     &username,
-		Message:  ptrStr("Message with reply"),
-		CreateAt: &attachmentsPostTime,
+		Team:        &teamName,
+		Channel:     &channelName,
+		User:        &username,
+		Message:     ptrStr("Message with reply"),
+		CreateAt:    &attachmentsPostTime,
 		Attachments: &[]AttachmentImportData{{Path: &testImage}, {Path: &testMarkDown}},
 		Replies: &[]ReplyImportData{{
-			User:     &user4.Username,
-			Message:  ptrStr("Message reply"),
-			CreateAt: &attachmentsReplyTime,
+			User:        &user4.Username,
+			Message:     ptrStr("Message reply"),
+			CreateAt:    &attachmentsReplyTime,
 			Attachments: &[]AttachmentImportData{{Path: &testImage}},
 		}},
 	}
@@ -4056,10 +4055,10 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 		User:     &user3.Username,
 		Message:  ptrStr("Message with Replies"),
 		CreateAt: ptrInt64(model.GetMillis()),
-		Replies:  &[]ReplyImportData{{
-			User:     &user4.Username,
-			Message:  ptrStr("Message reply with attachment"),
-			CreateAt: ptrInt64(model.GetMillis()),
+		Replies: &[]ReplyImportData{{
+			User:        &user4.Username,
+			Message:     ptrStr("Message reply with attachment"),
+			CreateAt:    ptrInt64(model.GetMillis()),
 			Attachments: &[]AttachmentImportData{{Path: &testImage}},
 		}},
 	}
@@ -4074,7 +4073,6 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	AssertFileIdsInPost(attachments, th, t)
 
 }
-
 
 func GetAttachments(userId string, th *TestHelper, t *testing.T) []*model.FileInfo {
 	if result := <-th.App.Srv.Store.FileInfo().GetForUser(userId); result.Err != nil {

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -3792,7 +3792,7 @@ func TestImportBulkImport(t *testing.T) {
 {"type": "user", "user": {"username": "` + username + `", "email": "` + username + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username2 + `", "email": "` + username2 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}]}]}}
 {"type": "user", "user": {"username": "` + username3 + `", "email": "` + username3 + `@example.com", "teams": [{"name": "` + teamName + `", "channels": [{"name": "` + channelName + `"}]}]}}
-{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012}}
+{"type": "post", "post": {"team": "` + teamName + `", "channel": "` + channelName + `", "user": "` + username + `", "message": "Hello World", "create_at": 123456789012, "attachements":[{"path": "` + testImage + `"}]}}
 {"type": "direct_channel", "direct_channel": {"members": ["` + username + `", "` + username2 + `"]}}
 {"type": "direct_channel", "direct_channel": {"members": ["` + username + `", "` + username2 + `", "` + username3 + `"]}}
 {"type": "direct_post", "direct_post": {"channel_members": ["` + username + `", "` + username2 + `"], "user": "` + username + `", "message": "Hello Direct Channel", "create_at": 123456789013}}
@@ -3910,4 +3910,22 @@ func TestImportImportEmoji(t *testing.T) {
 
 	err = th.App.ImportEmoji(&data, false)
 	assert.Nil(t, err, "Second run should have succeeded apply mode")
+}
+
+func TestImportAttachment(t *testing.T) {
+	th := Setup()
+	defer th.TearDown()
+
+	testsDir, _ := utils.FindDir("tests")
+	testImage := filepath.Join(testsDir, "test.png")
+	invalidPath := "some-invalid-path"
+
+	data := AttachmentImportData{Path: &testImage}
+	_, err := th.App.ImportAttachment(&data, &model.Post{UserId: model.NewId(), ChannelId: "some-channel"}, "some-team", true)
+	assert.Nil(t, err, "sample run without errors")
+
+	data = AttachmentImportData{Path: &invalidPath}
+	_, err = th.App.ImportAttachment(&data, &model.Post{UserId: model.NewId(), ChannelId: "some-channel"}, "some-team", true)
+	assert.NotNil(t, err, "should have failed when opening the file")
+	assert.Equal(t, err.Id, "app.import.attachment.bad_file.error")
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2927,6 +2927,14 @@
     "translation": "Team name missing from User's Team Membership."
   },
   {
+    "id": "app.import.attachment.bad_file.error",
+    "translation": "Error reading the file at: \"{{.FilePath}}\""
+  },
+  {
+    "id": "app.import.attachment.file_upload.error",
+    "translation": "Error uploading the file: \"{{.FilePath}}\""
+  },
+  {
     "id": "app.notification.body.intro.direct.full",
     "translation": "You have a new Direct Message."
   },


### PR DESCRIPTION
#### Summary
Currently the bulk import tool doesn't support file attachments. Added the support for the same

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9006

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
