### PR TITLE
Fix invalid markdown text ranges

### DIFF
--- a/utils/markdown/inlines.go
+++ b/utils/markdown/inlines.go
@@ -427,7 +427,7 @@ func (p *inlineParser) parseCharacterReference() {
 	if semicolon := strings.IndexByte(p.raw[p.position:], ';'); semicolon == -1 {
 		p.inlines = append(p.inlines, &Text{
 			Text:  "&",
-			Range: Range{absPos, 1},
+			Range: Range{absPos, absPos + 1},
 		})
 	} else if s := CharacterReference(p.raw[p.position : p.position+semicolon]); s != "" {
 		p.position += semicolon + 1
@@ -438,7 +438,7 @@ func (p *inlineParser) parseCharacterReference() {
 	} else {
 		p.inlines = append(p.inlines, &Text{
 			Text:  "&",
-			Range: Range{absPos, 1},
+			Range: Range{absPos, absPos + 1},
 		})
 	}
 }

--- a/utils/markdown/text_range_test.go
+++ b/utils/markdown/text_range_test.go
@@ -86,9 +86,14 @@ func TestTextRanges(t *testing.T) {
 			ExpectedValues: []string{"&amp test"},
 		},
 		"notcharref2": {
-			Markdown:       "&mattermost;",
-			ExpectedRanges: []Range{{0, 12}},
-			ExpectedValues: []string{"&mattermost;"},
+			Markdown:       "this is &mattermost;",
+			ExpectedRanges: []Range{{0, 20}},
+			ExpectedValues: []string{"this is &mattermost;"},
+		},
+		"standalone-ampersand": {
+			Markdown:       "Hello & World",
+			ExpectedRanges: []Range{{0, 13}},
+			ExpectedValues: []string{"Hello & World"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### Summary
Fixes a bug in the Range generation for markdown Text nodes, which caused e.g. the autolink plugin to fail/crash (depending on the message containing `&`).

#### Checklist
- [x] Added or updated unit tests (required for all new features)
