### PR TITLE
MM-11349 Lock go-hclog and go-plugin dependencies to a revision

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -174,7 +174,6 @@
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/go-hclog"
   packages = ["."]
   revision = "69ff559dc25f3b435631604f573a5fa1efdb6433"
@@ -198,7 +197,6 @@
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
-  branch = "master"
   name = "github.com/hashicorp/go-plugin"
   packages = ["."]
   revision = "e8d22c780116115ae5624720c9af0c97afe4f551"
@@ -245,7 +243,7 @@
   branch = "master"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
-  revision = "2658be15c5f05e76244154714161f17e3e77de2e"
+  revision = "3520598351bb3500a49ae9563f5539666ae0a27c"
 
 [[projects]]
   branch = "master"
@@ -774,6 +772,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2147cb986b5e1ba46b0c4479601fd9829cc46ccbc1bf4e8b9e59dfe0cccad77e"
+  inputs-digest = "70c0a23e6c8edc03d3c11a5227b2a43caea33f6170bfde2cf7698dcddf529036"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,6 +55,15 @@
   name = "github.com/segmentio/analytics-go"
   version = "2.1.1"
 
+# Lock to control when plugins use new versions
+[[constraint]]
+  name = "github.com/hashicorp/go-hclog"
+  revision = "69ff559dc25f3b435631604f573a5fa1efdb6433"
+
+[[constraint]]
+  name = "github.com/hashicorp/go-plugin"
+  revision = "e8d22c780116115ae5624720c9af0c97afe4f551"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -309,8 +309,10 @@ func (s *Session) keepalive() {
 		case <-time.After(s.config.KeepAliveInterval):
 			_, err := s.Ping()
 			if err != nil {
-				s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
-				s.exitErr(ErrKeepAliveTimeout)
+				if err != ErrSessionShutdown {
+					s.logger.Printf("[ERR] yamux: keepalive failed: %v", err)
+					s.exitErr(ErrKeepAliveTimeout)
+				}
 				return
 			}
 		case <-s.shutdownCh:


### PR DESCRIPTION
#### Summary
I only locked `go-plugin` and `go-hclog` as those were the only packages we're using in our `plugin` package. Not super familiar with dep so let me know if there's anything else I need to do here.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11349