### PR TITLE
Support for Embeded chat

### DIFF
--- a/app/extension.go
+++ b/app/extension.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/mattermost-server/model"
+	"html/template"
+	"net/http"
+)
+
+func (a *App) ExtensionSupportEnabled() bool {
+	return *a.Config().ExtensionSettings.EnableExperimentalExtensions
+}
+
+func (a *App) ValidateExtension(extensionID string) bool {
+	extensionIsValid := false
+	extensionIDs := a.Config().ExtensionSettings.AllowedExtensionsIDs
+
+	for _, id := range extensionIDs {
+		if extensionID == id {
+			extensionIsValid = true
+		}
+	}
+
+	if !extensionIsValid {
+		return false
+	}
+
+	return true
+}
+
+func (a *App) SendMessageToExtension(w http.ResponseWriter, extensionId string, token string) *model.AppError {
+	var t *template.Template
+	var err error
+	if len(extensionId) == 0 {
+		return model.NewAppError("completeSaml", "api.user.saml.extension_id.app_error", nil, "", http.StatusInternalServerError)
+	}
+
+	t = template.New("complete_saml_extension_body")
+	t, err = t.ParseFiles("templates/complete_saml_extension_body.html")
+
+	if err != nil {
+		return model.NewAppError("completeSaml", "api.user.saml.app_error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+
+	var errMessage string
+	if len(token) == 0 {
+		loginError := model.NewAppError("completeSaml", "api.user.saml.app_error", nil, "", http.StatusInternalServerError)
+		errMessage = loginError.Message
+	}
+
+	data := struct {
+		ExtensionId string
+		Token       string
+		Error       string
+	}{
+		extensionId,
+		token,
+		errMessage,
+	}
+
+	if err := t.Execute(w, data); err != nil {
+		return model.NewAppError("completeSaml", "api.user.saml.app_error", nil, "err="+err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
+}

--- a/app/extension.go
+++ b/app/extension.go
@@ -23,16 +23,12 @@ func (a *App) ValidateExtension(extensionID string) bool {
 		}
 	}
 
-	if !extensionIsValid {
-		return false
-	}
-
-	return true
+	return extensionIsValid
 }
 
 func (a *App) SendMessageToExtension(w http.ResponseWriter, extensionId string, token string) *model.AppError {
-	var t *template.Template
 	var err error
+	var t *template.Template
 	if len(extensionId) == 0 {
 		return model.NewAppError("completeSaml", "api.user.saml.extension_id.app_error", nil, "", http.StatusInternalServerError)
 	}

--- a/config/default.json
+++ b/config/default.json
@@ -194,6 +194,10 @@
         "LoginButtonBorderColor": "",
         "LoginButtonTextColor": ""
     },
+    "ExtensionSettings": {
+        "EnableExperimentalExtensions": false,
+        "AllowedExtensionsIDs": []
+    },
     "RateLimitSettings": {
         "Enable": false,
         "PerSec": 10,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2167,6 +2167,22 @@
     "translation": "Failed to send the deactivate account email successfully"
   },
   {
+    "id": "api.user.saml.app_error",
+    "translation": "Unable to process SAML login request."
+  },
+  {
+    "id": "api.user.saml.extension_unsupported",
+    "translation": "Extensions are not supported."
+  },
+  {
+    "id": "api.user.saml.extension_id.app_error",
+    "translation": "Invalid extension id"
+  },
+  {
+    "id": "api.user.saml.invalid_extension",
+    "translation": "Extension with extension_id={{.ExtensionId}} is not supported."
+  },
+  {
     "id": "api.user.send_email_change_email_and_forget.error",
     "translation": "Failed to send email change notification email successfully"
   },

--- a/model/config.go
+++ b/model/config.go
@@ -907,6 +907,21 @@ func (s *EmailSettings) SetDefaults() {
 	}
 }
 
+type ExtensionSettings struct {
+	EnableExperimentalExtensions *bool
+	AllowedExtensionsIDs         []string
+}
+
+func (s *ExtensionSettings) SetDefaults() {
+	if s.EnableExperimentalExtensions == nil {
+		s.EnableExperimentalExtensions = NewBool(false)
+	}
+
+	if s.AllowedExtensionsIDs == nil {
+		s.AllowedExtensionsIDs = []string{}
+	}
+}
+
 type RateLimitSettings struct {
 	Enable           *bool
 	PerSec           *int
@@ -1870,6 +1885,7 @@ type Config struct {
 	PasswordSettings      PasswordSettings
 	FileSettings          FileSettings
 	EmailSettings         EmailSettings
+	ExtensionSettings     ExtensionSettings
 	RateLimitSettings     RateLimitSettings
 	PrivacySettings       PrivacySettings
 	SupportSettings       SupportSettings
@@ -1967,6 +1983,7 @@ func (o *Config) SetDefaults() {
 	o.MessageExportSettings.SetDefaults()
 	o.TimezoneSettings.SetDefaults()
 	o.DisplaySettings.SetDefaults()
+	o.ExtensionSettings.SetDefaults()
 }
 
 func (o *Config) IsValid() *AppError {

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -17,6 +17,7 @@ const (
 	OAUTH_ACTION_EMAIL_TO_SSO = "email_to_sso"
 	OAUTH_ACTION_SSO_TO_EMAIL = "sso_to_email"
 	OAUTH_ACTION_MOBILE       = "mobile"
+	OAUTH_ACTION_CLIENT       = "client"
 )
 
 type OAuthApp struct {

--- a/templates/complete_saml_extension_body.html
+++ b/templates/complete_saml_extension_body.html
@@ -1,0 +1,30 @@
+{{define "complete_saml_extension_body"}}
+
+<html>
+    <head>
+        <script>
+            document.addEventListener("DOMContentLoaded", function(event) {
+                var extensionId = {{.ExtensionId}};
+
+                if (!extensionId) {
+                    return;
+                }
+
+                chrome.runtime.sendMessage(
+                    extensionId,
+                    {
+                        value: {{.Token}},
+                        error: {{.Error}}
+                    },
+                    function(response) {
+                    }
+                );
+            });
+        </script>
+    </head>
+    <body>
+        Login Successful
+    </body>
+</html>
+
+{{end}}

--- a/web/saml.go
+++ b/web/saml.go
@@ -50,16 +50,9 @@ func loginWithSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if len(extensionId) != 0 {
 		relayProps["extension_id"] = extensionId
-		enabled := c.App.ExtensionSupportEnabled()
-		if !enabled {
-			c.Err = model.NewAppError("completeSaml", "api.user.saml.extension_unsupported", nil, "", http.StatusInternalServerError)
-			return
-		}
-
-		valid := c.App.ValidateExtension(extensionId)
-		if !valid {
-			params := map[string]interface{}{"extensionId": extensionId}
-			c.Err = model.NewAppError("completeSaml", "api.user.saml.invalid_extension", params, "", http.StatusInternalServerError)
+		err := c.App.ValidateExtension(extensionId)
+		if err != nil {
+			c.Err = err
 			return
 		}
 	}

--- a/web/saml.go
+++ b/web/saml.go
@@ -32,6 +32,7 @@ func loginWithSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	action := r.URL.Query().Get("action")
 	redirectTo := r.URL.Query().Get("redirect_to")
+	extensionId := r.URL.Query().Get("extension_id")
 	relayProps := map[string]string{}
 	relayState := ""
 
@@ -45,6 +46,22 @@ func loginWithSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if len(redirectTo) != 0 {
 		relayProps["redirect_to"] = redirectTo
+	}
+
+	if len(extensionId) != 0 {
+		relayProps["extension_id"] = extensionId
+		enabled := c.App.ExtensionSupportEnabled()
+		if !enabled {
+			c.Err = model.NewAppError("completeSaml", "api.user.saml.extension_unsupported", nil, "", http.StatusInternalServerError)
+			return
+		}
+
+		valid := c.App.ValidateExtension(extensionId)
+		if !valid {
+			params := map[string]interface{}{"extensionId": extensionId}
+			c.Err = model.NewAppError("completeSaml", "api.user.saml.invalid_extension", params, "", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	if len(relayProps) > 0 {
@@ -141,6 +158,13 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		if action == model.OAUTH_ACTION_MOBILE {
 			ReturnStatusOK(w)
+		} else if action == model.OAUTH_ACTION_CLIENT {
+			err = c.App.SendMessageToExtension(w, relayProps["extension_id"], c.Session.Token)
+
+			if err != nil {
+				c.Err = err
+				return
+			}
 		} else {
 			http.Redirect(w, r, c.GetSiteURLHeader(), http.StatusFound)
 		}


### PR DESCRIPTION
#### Summary
Add authentication support for extensions.
This supports multiple extensions via the `ExtensionSettings.AllowedExtensionsIDs` config property.
The key in this change is the communication layer between the api and the extension.

We are relying on the chrome api to send data safely between the api and the extension that made the request.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11151

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)