### PR TITLE
[WIP] MM-11327: Restrict Teams by Email

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -96,15 +96,12 @@ func TestCreateTeamSanitization(t *testing.T) {
 			Name:           GenerateTestTeamName(),
 			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
-			AllowedDomains: "simulator.amazonses.com",
 		}
 
 		rteam, resp := th.Client.CreateTeam(team)
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -114,15 +111,12 @@ func TestCreateTeamSanitization(t *testing.T) {
 			Name:           GenerateTestTeamName(),
 			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
-			AllowedDomains: "simulator.amazonses.com",
 		}
 
 		rteam, resp := th.SystemAdminClient.CreateTeam(team)
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -183,7 +177,6 @@ func TestGetTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -197,8 +190,6 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email != "" {
 			t.Fatal("should've sanitized email")
-		} else if rteam.AllowedDomains != "" {
-			t.Fatal("should've sanitized allowed domains")
 		}
 	})
 
@@ -207,8 +198,6 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -217,8 +206,6 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -364,7 +351,6 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -375,8 +361,6 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -385,8 +369,6 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -463,7 +445,6 @@ func TestPatchTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -474,8 +455,6 @@ func TestPatchTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -484,8 +463,6 @@ func TestPatchTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -655,7 +632,6 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 		Name:            GenerateTestTeamName(),
 		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
 	})
 	CheckNoError(t, resp)
@@ -664,7 +640,6 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 		Name:            GenerateTestTeamName(),
 		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
 	})
 	CheckNoError(t, resp)
@@ -682,15 +657,11 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 				teamFound = true
 				if rteam.Email == "" {
 					t.Fatal("should not have sanitized email for team admin")
-				} else if rteam.AllowedDomains == "" {
-					t.Fatal("should not have sanitized allowed domains for team admin")
 				}
 			} else if rteam.Id == team2.Id {
 				team2Found = true
 				if rteam.Email != "" {
 					t.Fatal("should've sanitized email for non-admin")
-				} else if rteam.AllowedDomains != "" {
-					t.Fatal("should've sanitized allowed domains for non-admin")
 				}
 			}
 		}
@@ -710,8 +681,6 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -773,7 +742,6 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -787,8 +755,6 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email != "" {
 			t.Fatal("should've sanitized email")
-		} else if rteam.AllowedDomains != "" {
-			t.Fatal("should've sanitized allowed domains")
 		}
 	})
 
@@ -797,8 +763,6 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -807,8 +771,6 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -904,7 +866,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 	team2, resp := th.Client.CreateTeam(&model.Team{
@@ -912,7 +873,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -925,8 +885,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		for _, rteam := range rteams {
 			if rteam.Email != "" {
 				t.Fatal("should've sanitized email")
-			} else if rteam.AllowedDomains != "" {
-				t.Fatal("should've sanitized allowed domains")
 			}
 		}
 	})
@@ -942,8 +900,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		for _, rteam := range rteams {
 			if rteam.Email != "" {
 				t.Fatal("should've sanitized email")
-			} else if rteam.AllowedDomains != "" {
-				t.Fatal("should've sanitized allowed domains")
 			}
 		}
 	})
@@ -955,8 +911,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 			if rteam.Id == team.Id || rteam.Id == team2.Id || rteam.Id == th.BasicTeam.Id {
 				if rteam.Email == "" {
 					t.Fatal("should not have sanitized email")
-				} else if rteam.AllowedDomains == "" {
-					t.Fatal("should not have sanitized allowed domains")
 				}
 			}
 		}
@@ -968,8 +922,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		for _, rteam := range rteams {
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -1026,7 +978,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 	team2, resp := th.Client.CreateTeam(&model.Team{
@@ -1034,7 +985,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -1054,8 +1004,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email != "" {
 				t.Fatal("should've sanitized email")
-			} else if rteam.AllowedDomains != "" {
-				t.Fatal("should've sanitized allowed domains")
 			}
 		}
 	})
@@ -1070,8 +1018,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -1086,8 +1032,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -96,7 +96,7 @@ func TestCreateTeamSanitization(t *testing.T) {
 			Name:           GenerateTestTeamName(),
 			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
-			AllowedDomains: "simulator.amazonses.com",
+			AllowedDomains: "simulator.amazonses.com,dockerhost",
 		}
 
 		rteam, resp := th.Client.CreateTeam(team)
@@ -114,7 +114,7 @@ func TestCreateTeamSanitization(t *testing.T) {
 			Name:           GenerateTestTeamName(),
 			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
-			AllowedDomains: "simulator.amazonses.com",
+			AllowedDomains: "simulator.amazonses.com,dockerhost",
 		}
 
 		rteam, resp := th.SystemAdminClient.CreateTeam(team)
@@ -183,7 +183,7 @@ func TestGetTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 
@@ -364,7 +364,7 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 
@@ -463,7 +463,7 @@ func TestPatchTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 
@@ -655,7 +655,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 		Name:            GenerateTestTeamName(),
 		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
+		AllowedDomains:  "simulator.amazonses.com,dockerhost",
 		AllowOpenInvite: true,
 	})
 	CheckNoError(t, resp)
@@ -664,7 +664,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 		Name:            GenerateTestTeamName(),
 		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
-		AllowedDomains:  "simulator.amazonses.com",
+		AllowedDomains:  "simulator.amazonses.com,dockerhost",
 		AllowOpenInvite: true,
 	})
 	CheckNoError(t, resp)
@@ -773,7 +773,7 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 
@@ -904,7 +904,7 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 	team2, resp := th.Client.CreateTeam(&model.Team{
@@ -912,7 +912,7 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 
@@ -1026,7 +1026,7 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 	team2, resp := th.Client.CreateTeam(&model.Team{
@@ -1034,7 +1034,7 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
-		AllowedDomains: "simulator.amazonses.com",
+		AllowedDomains: "simulator.amazonses.com,dockerhost",
 	})
 	CheckNoError(t, resp)
 

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -96,12 +96,15 @@ func TestCreateTeamSanitization(t *testing.T) {
 			Name:           GenerateTestTeamName(),
 			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
+			AllowedDomains: "simulator.amazonses.com",
 		}
 
 		rteam, resp := th.Client.CreateTeam(team)
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -111,12 +114,15 @@ func TestCreateTeamSanitization(t *testing.T) {
 			Name:           GenerateTestTeamName(),
 			Email:          th.GenerateTestEmail(),
 			Type:           model.TEAM_OPEN,
+			AllowedDomains: "simulator.amazonses.com",
 		}
 
 		rteam, resp := th.SystemAdminClient.CreateTeam(team)
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -177,6 +183,7 @@ func TestGetTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -190,6 +197,8 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email != "" {
 			t.Fatal("should've sanitized email")
+		} else if rteam.AllowedDomains != "" {
+			t.Fatal("should've sanitized allowed domains")
 		}
 	})
 
@@ -198,6 +207,8 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -206,6 +217,8 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -351,6 +364,7 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -361,6 +375,8 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -369,6 +385,8 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -445,6 +463,7 @@ func TestPatchTeamSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -455,6 +474,8 @@ func TestPatchTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -463,6 +484,8 @@ func TestPatchTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -632,6 +655,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 		Name:            GenerateTestTeamName(),
 		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
+		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
 	})
 	CheckNoError(t, resp)
@@ -640,6 +664,7 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 		Name:            GenerateTestTeamName(),
 		Email:           th.GenerateTestEmail(),
 		Type:            model.TEAM_OPEN,
+		AllowedDomains:  "simulator.amazonses.com",
 		AllowOpenInvite: true,
 	})
 	CheckNoError(t, resp)
@@ -657,11 +682,15 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 				teamFound = true
 				if rteam.Email == "" {
 					t.Fatal("should not have sanitized email for team admin")
+				} else if rteam.AllowedDomains == "" {
+					t.Fatal("should not have sanitized allowed domains for team admin")
 				}
 			} else if rteam.Id == team2.Id {
 				team2Found = true
 				if rteam.Email != "" {
 					t.Fatal("should've sanitized email for non-admin")
+				} else if rteam.AllowedDomains != "" {
+					t.Fatal("should've sanitized allowed domains for non-admin")
 				}
 			}
 		}
@@ -681,6 +710,8 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
+			} else if rteam.AllowedDomains == "" {
+				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -742,6 +773,7 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -755,6 +787,8 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email != "" {
 			t.Fatal("should've sanitized email")
+		} else if rteam.AllowedDomains != "" {
+			t.Fatal("should've sanitized allowed domains")
 		}
 	})
 
@@ -763,6 +797,8 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -771,6 +807,8 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
+		} else if rteam.AllowedDomains == "" {
+			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -866,6 +904,7 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 	team2, resp := th.Client.CreateTeam(&model.Team{
@@ -873,6 +912,7 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -885,6 +925,8 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		for _, rteam := range rteams {
 			if rteam.Email != "" {
 				t.Fatal("should've sanitized email")
+			} else if rteam.AllowedDomains != "" {
+				t.Fatal("should've sanitized allowed domains")
 			}
 		}
 	})
@@ -900,6 +942,8 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		for _, rteam := range rteams {
 			if rteam.Email != "" {
 				t.Fatal("should've sanitized email")
+			} else if rteam.AllowedDomains != "" {
+				t.Fatal("should've sanitized allowed domains")
 			}
 		}
 	})
@@ -911,6 +955,8 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 			if rteam.Id == team.Id || rteam.Id == team2.Id || rteam.Id == th.BasicTeam.Id {
 				if rteam.Email == "" {
 					t.Fatal("should not have sanitized email")
+				} else if rteam.AllowedDomains == "" {
+					t.Fatal("should not have sanitized allowed domains")
 				}
 			}
 		}
@@ -922,6 +968,8 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		for _, rteam := range rteams {
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
+			} else if rteam.AllowedDomains == "" {
+				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -978,6 +1026,7 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 	team2, resp := th.Client.CreateTeam(&model.Team{
@@ -985,6 +1034,7 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 		Name:           GenerateTestTeamName(),
 		Email:          th.GenerateTestEmail(),
 		Type:           model.TEAM_OPEN,
+		AllowedDomains: "simulator.amazonses.com",
 	})
 	CheckNoError(t, resp)
 
@@ -1004,6 +1054,8 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email != "" {
 				t.Fatal("should've sanitized email")
+			} else if rteam.AllowedDomains != "" {
+				t.Fatal("should've sanitized allowed domains")
 			}
 		}
 	})
@@ -1018,6 +1070,8 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
+			} else if rteam.AllowedDomains == "" {
+				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -1032,6 +1086,8 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
+			} else if rteam.AllowedDomains == "" {
+				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -103,8 +103,6 @@ func TestCreateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -121,8 +119,6 @@ func TestCreateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -197,8 +193,6 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email != "" {
 			t.Fatal("should've sanitized email")
-		} else if rteam.AllowedDomains != "" {
-			t.Fatal("should've sanitized allowed domains")
 		}
 	})
 
@@ -207,8 +201,6 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -217,8 +209,6 @@ func TestGetTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -375,8 +365,6 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -385,8 +373,6 @@ func TestUpdateTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -474,8 +460,6 @@ func TestPatchTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -484,8 +468,6 @@ func TestPatchTeamSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email for admin")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -682,15 +664,11 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 				teamFound = true
 				if rteam.Email == "" {
 					t.Fatal("should not have sanitized email for team admin")
-				} else if rteam.AllowedDomains == "" {
-					t.Fatal("should not have sanitized allowed domains for team admin")
 				}
 			} else if rteam.Id == team2.Id {
 				team2Found = true
 				if rteam.Email != "" {
 					t.Fatal("should've sanitized email for non-admin")
-				} else if rteam.AllowedDomains != "" {
-					t.Fatal("should've sanitized allowed domains for non-admin")
 				}
 			}
 		}
@@ -710,8 +688,6 @@ func TestGetAllTeamsSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -787,8 +763,6 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email != "" {
 			t.Fatal("should've sanitized email")
-		} else if rteam.AllowedDomains != "" {
-			t.Fatal("should've sanitized allowed domains")
 		}
 	})
 
@@ -797,8 +771,6 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 
@@ -807,8 +779,6 @@ func TestGetTeamByNameSanitization(t *testing.T) {
 		CheckNoError(t, resp)
 		if rteam.Email == "" {
 			t.Fatal("should not have sanitized email")
-		} else if rteam.AllowedDomains == "" {
-			t.Fatal("should not have sanitized allowed domains")
 		}
 	})
 }
@@ -955,8 +925,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 			if rteam.Id == team.Id || rteam.Id == team2.Id || rteam.Id == th.BasicTeam.Id {
 				if rteam.Email == "" {
 					t.Fatal("should not have sanitized email")
-				} else if rteam.AllowedDomains == "" {
-					t.Fatal("should not have sanitized allowed domains")
 				}
 			}
 		}
@@ -968,8 +936,6 @@ func TestSearchAllTeamsSanitization(t *testing.T) {
 		for _, rteam := range rteams {
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -1054,8 +1020,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email != "" {
 				t.Fatal("should've sanitized email")
-			} else if rteam.AllowedDomains != "" {
-				t.Fatal("should've sanitized allowed domains")
 			}
 		}
 	})
@@ -1070,8 +1034,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})
@@ -1086,8 +1048,6 @@ func TestGetTeamsForUserSanitization(t *testing.T) {
 
 			if rteam.Email == "" {
 				t.Fatal("should not have sanitized email")
-			} else if rteam.AllowedDomains == "" {
-				t.Fatal("should not have sanitized allowed domains")
 			}
 		}
 	})

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2008,20 +2008,20 @@ func TestInviteUsersToTeam(t *testing.T) {
 	})
 
 	t.Run("override restricted domains", func(t *testing.T) {
-		th.BasicTeam.AllowedDomains = "team.com,common.com"
+		th.BasicTeam.AllowedDomains = "invalid.com,common.com"
+		if _, err := th.App.UpdateTeam(th.BasicTeam); err == nil {
+			t.Fatal("Should not update the team")
+		}
+
+		th.BasicTeam.AllowedDomains = "common.com"
 		if _, err := th.App.UpdateTeam(th.BasicTeam); err != nil {
 			t.Log(err)
 			t.Fatal("Should update the team")
 		}
 
-		if err := th.App.InviteNewUsersToTeam([]string{"test@team.com"}, th.BasicTeam.Id, th.BasicUser.Id); err == nil || err.Where != "InviteNewUsersToTeam" {
-			t.Log(err)
-			t.Fatal("Global team restriction should not override per team restriction")
-		}
-
 		if err := th.App.InviteNewUsersToTeam([]string{"test@global.com"}, th.BasicTeam.Id, th.BasicUser.Id); err == nil || err.Where != "InviteNewUsersToTeam" {
 			t.Log(err)
-			t.Fatal("Per team restriction should not override global team restriction")
+			t.Fatal("Per team restriction should take precedence over the global restriction")
 		}
 
 		if err := th.App.InviteNewUsersToTeam([]string{"test@common.com"}, th.BasicTeam.Id, th.BasicUser.Id); err != nil {
@@ -2035,7 +2035,6 @@ func TestInviteUsersToTeam(t *testing.T) {
 		}
 
 	})
-
 }
 
 func TestGetTeamInviteInfo(t *testing.T) {

--- a/app/team.go
+++ b/app/team.go
@@ -456,7 +456,7 @@ func (a *App) joinUserToTeam(team *model.Team, user *model.User) (*model.TeamMem
 
 func (a *App) JoinUserToTeam(team *model.Team, user *model.User, userRequestorId string) *model.AppError {
 	if !a.isTeamEmailAllowed(user, team) {
-		return model.NewAppError("JoinUserToTeam", "api.team.is_team_creation_allowed.domain.app_error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("JoinUserToTeam", "api.team.join_user_to_team.allowed_domains.app_error", nil, "", http.StatusBadRequest)
 	}
 	tm, alreadyAdded, err := a.joinUserToTeam(team, user)
 	if err != nil {

--- a/app/team.go
+++ b/app/team.go
@@ -60,10 +60,10 @@ func (a *App) CreateTeamWithUser(team *model.Team, userId string) (*model.Team, 
 	return rteam, nil
 }
 
-func (a *App) isTeamEmailAddressAllowed(email string, RestrictCreationToDomains string) bool {
+func (a *App) isTeamEmailAddressAllowed(email string, allowedDomains string) bool {
 	email = strings.ToLower(email)
-	// First check per team RestrictCreationToDomains, then app wide restrictions
-	for _, restriction := range []string{RestrictCreationToDomains, a.Config().TeamSettings.RestrictCreationToDomains} {
+	// First check per team allowedDomains, then app wide restrictions
+	for _, restriction := range []string{allowedDomains, a.Config().TeamSettings.RestrictCreationToDomains} {
 		// commas and @ signs are optional
 		// can be in the form of "@corp.mattermost.com, mattermost.com mattermost.org" -> corp.mattermost.com mattermost.com mattermost.org
 		domains := strings.Fields(strings.TrimSpace(strings.ToLower(strings.Replace(strings.Replace(restriction, "@", " ", -1), ",", " ", -1))))

--- a/app/team.go
+++ b/app/team.go
@@ -435,7 +435,7 @@ func (a *App) joinUserToTeam(team *model.Team, user *model.User) (*model.TeamMem
 
 func (a *App) JoinUserToTeam(team *model.Team, user *model.User, userRequestorId string) *model.AppError {
 	if !a.isTeamEmailAllowed(user, team) {
-		return model.NewAppError("isTeamEmailAllowed", "api.team.is_team_creation_allowed.domain.app_error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("JoinUserToTeam", "api.team.is_team_creation_allowed.domain.app_error", nil, "", http.StatusBadRequest)
 	}
 	tm, alreadyAdded, err := a.joinUserToTeam(team, user)
 	if err != nil {

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -94,7 +94,7 @@ func TestAddUserToTeam(t *testing.T) {
 		ruser, _ := th.App.CreateUser(&user)
 		defer th.App.PermanentDeleteUser(&user)
 
-		if _, err := th.App.AddUserToTeam(th.BasicTeam.Id, ruser.Id, ""); err == nil || err.Where != "isTeamEmailAllowed" {
+		if _, err := th.App.AddUserToTeam(th.BasicTeam.Id, ruser.Id, ""); err == nil || err.Where != "JoinUserToTeam" {
 			t.Log(err)
 			t.Fatal("Should not add restricted user")
 		}
@@ -196,7 +196,7 @@ func TestAddUserToTeamByToken(t *testing.T) {
 		)
 		<-th.App.Srv.Store.Token().Save(token)
 
-		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token); err == nil || err.Where != "isTeamEmailAllowed" {
+		if _, err := th.App.AddUserToTeamByToken(ruser.Id, token.Token); err == nil || err.Where != "JoinUserToTeam" {
 			t.Log(err)
 			t.Fatal("Should not add restricted user")
 		}
@@ -228,7 +228,7 @@ func TestAddUserToTeamByTeamId(t *testing.T) {
 		ruser, _ := th.App.CreateUser(&user)
 		defer th.App.PermanentDeleteUser(&user)
 
-		if err := th.App.AddUserToTeamByTeamId(th.BasicTeam.Id, ruser); err == nil || err.Where != "isTeamEmailAllowed" {
+		if err := th.App.AddUserToTeamByTeamId(th.BasicTeam.Id, ruser); err == nil || err.Where != "JoinUserToTeam" {
 			t.Log(err)
 			t.Fatal("Should not add restricted user")
 		}

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -305,7 +305,6 @@ func TestSanitizeTeam(t *testing.T) {
 	team := &model.Team{
 		Id:             model.NewId(),
 		Email:          th.MakeEmail(),
-		AllowedDomains: "example.com",
 	}
 	copyTeam := func() *model.Team {
 		copy := &model.Team{}
@@ -327,7 +326,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
+		if sanitized.Email != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -346,7 +345,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
+		if sanitized.Email != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -365,7 +364,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
+		if sanitized.Email == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -384,7 +383,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
+		if sanitized.Email != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -403,7 +402,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
+		if sanitized.Email == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -422,7 +421,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
+		if sanitized.Email == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -437,12 +436,10 @@ func TestSanitizeTeams(t *testing.T) {
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
-				AllowedDomains: "example.com",
 			},
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
-				AllowedDomains: "example.com",
 			},
 		}
 
@@ -465,11 +462,11 @@ func TestSanitizeTeams(t *testing.T) {
 
 		sanitized := th.App.SanitizeTeams(session, teams)
 
-		if sanitized[0].Email != "" && sanitized[0].AllowedDomains != "" {
+		if sanitized[0].Email != "" {
 			t.Fatal("should've sanitized first team")
 		}
 
-		if sanitized[1].Email == "" && sanitized[1].AllowedDomains == "" {
+		if sanitized[1].Email == "" {
 			t.Fatal("shouldn't have sanitized second team")
 		}
 	})
@@ -479,12 +476,10 @@ func TestSanitizeTeams(t *testing.T) {
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
-				AllowedDomains: "example.com",
 			},
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
-				AllowedDomains: "example.com",
 			},
 		}
 
@@ -502,11 +497,11 @@ func TestSanitizeTeams(t *testing.T) {
 
 		sanitized := th.App.SanitizeTeams(session, teams)
 
-		if sanitized[0].Email == "" && sanitized[0].AllowedDomains == "" {
+		if sanitized[0].Email == "" {
 			t.Fatal("shouldn't have sanitized first team")
 		}
 
-		if sanitized[1].Email == "" && sanitized[1].AllowedDomains == "" {
+		if sanitized[1].Email == "" {
 			t.Fatal("shouldn't have sanitized second team")
 		}
 	})

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -371,6 +371,7 @@ func TestSanitizeTeam(t *testing.T) {
 	team := &model.Team{
 		Id:             model.NewId(),
 		Email:          th.MakeEmail(),
+		AllowedDomains: "example.com",
 	}
 	copyTeam := func() *model.Team {
 		copy := &model.Team{}
@@ -392,7 +393,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" {
+		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -411,7 +412,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" {
+		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -430,7 +431,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" {
+		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -449,7 +450,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" {
+		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -468,7 +469,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" {
+		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -487,7 +488,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" {
+		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -502,10 +503,12 @@ func TestSanitizeTeams(t *testing.T) {
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
+				AllowedDomains: "example.com",
 			},
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
+				AllowedDomains: "example.com",
 			},
 		}
 
@@ -528,11 +531,11 @@ func TestSanitizeTeams(t *testing.T) {
 
 		sanitized := th.App.SanitizeTeams(session, teams)
 
-		if sanitized[0].Email != "" {
+		if sanitized[0].Email != "" && sanitized[0].AllowedDomains != "" {
 			t.Fatal("should've sanitized first team")
 		}
 
-		if sanitized[1].Email == "" {
+		if sanitized[1].Email == "" && sanitized[1].AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized second team")
 		}
 	})
@@ -542,10 +545,12 @@ func TestSanitizeTeams(t *testing.T) {
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
+				AllowedDomains: "example.com",
 			},
 			{
 				Id:             model.NewId(),
 				Email:          th.MakeEmail(),
+				AllowedDomains: "example.com",
 			},
 		}
 
@@ -563,11 +568,11 @@ func TestSanitizeTeams(t *testing.T) {
 
 		sanitized := th.App.SanitizeTeams(session, teams)
 
-		if sanitized[0].Email == "" {
+		if sanitized[0].Email == "" && sanitized[0].AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized first team")
 		}
 
-		if sanitized[1].Email == "" {
+		if sanitized[1].Email == "" && sanitized[1].AllowedDomains == "" {
 			t.Fatal("shouldn't have sanitized second team")
 		}
 	})

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -393,7 +393,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
+		if sanitized.Email != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -412,7 +412,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
+		if sanitized.Email != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -431,7 +431,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
+		if sanitized.Email == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -450,7 +450,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email != "" && sanitized.AllowedDomains != "" {
+		if sanitized.Email != "" {
 			t.Fatal("should've sanitized team")
 		}
 	})
@@ -469,7 +469,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
+		if sanitized.Email == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -488,7 +488,7 @@ func TestSanitizeTeam(t *testing.T) {
 		}
 
 		sanitized := th.App.SanitizeTeam(session, copyTeam())
-		if sanitized.Email == "" && sanitized.AllowedDomains == "" {
+		if sanitized.Email == "" {
 			t.Fatal("shouldn't have sanitized team")
 		}
 	})
@@ -531,11 +531,11 @@ func TestSanitizeTeams(t *testing.T) {
 
 		sanitized := th.App.SanitizeTeams(session, teams)
 
-		if sanitized[0].Email != "" && sanitized[0].AllowedDomains != "" {
+		if sanitized[0].Email != "" {
 			t.Fatal("should've sanitized first team")
 		}
 
-		if sanitized[1].Email == "" && sanitized[1].AllowedDomains == "" {
+		if sanitized[1].Email == "" {
 			t.Fatal("shouldn't have sanitized second team")
 		}
 	})
@@ -568,11 +568,11 @@ func TestSanitizeTeams(t *testing.T) {
 
 		sanitized := th.App.SanitizeTeams(session, teams)
 
-		if sanitized[0].Email == "" && sanitized[0].AllowedDomains == "" {
+		if sanitized[0].Email == "" {
 			t.Fatal("shouldn't have sanitized first team")
 		}
 
-		if sanitized[1].Email == "" && sanitized[1].AllowedDomains == "" {
+		if sanitized[1].Email == "" {
 			t.Fatal("shouldn't have sanitized second team")
 		}
 	})

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1655,6 +1655,10 @@
     "translation": "%v joined the team."
   },
   {
+    "id": "api.team.join_user_to_team.allowed_domains.app_error",
+    "translation": "Email must be from a specific domain (e.g. @example.com). Please ask your team or system administrator for details."
+  },
+  {
     "id": "api.team.leave.left",
     "translation": "%v left the team."
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1731,6 +1731,10 @@
     "translation": "Specified user is not a member of specified team."
   },
   {
+    "id": "api.team.update_restricted_domains.mismatch.app_error",
+    "translation": "Restricting team to {{ .Domain }} is not allowed by the system config. Please contact your system administrator."
+  },
+  {
     "id": "api.team.update_team_scheme.license.error",
     "translation": "Your license does not support updating a team's scheme"
   },

--- a/model/team.go
+++ b/model/team.go
@@ -47,6 +47,7 @@ type TeamPatch struct {
 	DisplayName     *string `json:"display_name"`
 	Description     *string `json:"description"`
 	CompanyName     *string `json:"company_name"`
+	AllowedDomains  *string `json:"allowed_domains"`
 	InviteId        *string `json:"invite_id"`
 	AllowOpenInvite *bool   `json:"allow_open_invite"`
 }
@@ -255,6 +256,10 @@ func (t *Team) Patch(patch *TeamPatch) {
 
 	if patch.CompanyName != nil {
 		t.CompanyName = *patch.CompanyName
+	}
+
+	if patch.AllowedDomains != nil {
+		t.AllowedDomains = *patch.AllowedDomains
 	}
 
 	if patch.InviteId != nil {

--- a/model/team.go
+++ b/model/team.go
@@ -242,6 +242,7 @@ func CleanTeamName(s string) string {
 
 func (o *Team) Sanitize() {
 	o.Email = ""
+	o.AllowedDomains = ""
 }
 
 func (t *Team) Patch(patch *TeamPatch) {

--- a/model/team.go
+++ b/model/team.go
@@ -242,7 +242,6 @@ func CleanTeamName(s string) string {
 
 func (o *Team) Sanitize() {
 	o.Email = ""
-	o.AllowedDomains = ""
 }
 
 func (t *Team) Patch(patch *TeamPatch) {


### PR DESCRIPTION
#### Summary
This allows individual teams to be restricted to an email domain whitelist. The per team setting overrides the server-wide whitelist, but teams which do not set the option will still fallback to the server-wide setting.

The change leverages the preexisting team.allowedDomains model property. For now, it must be modified via REST API, as UI has not been implemented.

I started modifying the SanitizeTeam code to permit updates to allowedDomains, but wasn't sure if that should be included in this PR or later when UI is added. I left it out for now, but can update the PR, if appropriate?

Tests have been added for the AddUserToTeam* methods to make sure bad email domains get blocked when the whitelist is enabled. I'm unsure if there are other code paths which may need testing. Open vs invite only teams, or enterprise LDAP accounts, for example.

#### Ticket Link
- Help Wanted: #9111
- Uservoice: [restrict-team-by-email](https://mattermost.uservoice.com/forums/306457-general/suggestions/33014368-restrict-team-by-email)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
