### PR TITLE
MM-11243: Make Elasticsearch work after enabling without restart.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -701,6 +701,17 @@ func (a *App) StartElasticsearch() {
 					mlog.Error(err.Error())
 				}
 			})
+		} else if *oldConfig.ElasticsearchSettings.Password != *newConfig.ElasticsearchSettings.Password || *oldConfig.ElasticsearchSettings.Username != *newConfig.ElasticsearchSettings.Username || *oldConfig.ElasticsearchSettings.ConnectionUrl != *newConfig.ElasticsearchSettings.ConnectionUrl || *oldConfig.ElasticsearchSettings.Sniff != *newConfig.ElasticsearchSettings.Sniff {
+			a.Go(func() {
+				if *oldConfig.ElasticsearchSettings.EnableIndexing == true {
+					if err := a.Elasticsearch.Stop(); err != nil {
+						mlog.Error(err.Error())
+					}
+					if err := a.Elasticsearch.Start(); err != nil {
+						mlog.Error(err.Error())
+					}
+				}
+			})
 		}
 	})
 

--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -176,11 +176,7 @@ func runServer(configFileLocation string, disableConfigWatch bool, usedPlatform 
 	}
 
 	if a.Elasticsearch != nil {
-		a.Go(func() {
-			if err := a.Elasticsearch.Start(); err != nil {
-				mlog.Error(err.Error())
-			}
-		})
+		a.StartElasticsearch()
 	}
 
 	if *a.Config().JobSettings.RunJobs {

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -11,6 +11,7 @@ import (
 
 type ElasticsearchInterface interface {
 	Start() *model.AppError
+	Stop() *model.AppError
 	IndexPost(post *model.Post, teamId string) *model.AppError
 	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, model.PostSearchMatches, *model.AppError)
 	DeletePost(post *model.Post) *model.AppError

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -168,6 +168,14 @@
     "translation": "Channel is already deleted"
   },
   {
+    "id": "ent.elasticsearch.start.already_started.app_error",
+    "translation": "Elasticsearch is already started"
+  },
+  {
+    "id": "ent.elasticsearch.stop.already_stopped.app_error",
+    "translation": "Elasticsearch is already stopped"
+  },
+  {
     "id": "api.channel.join_channel.permissions.app_error",
     "translation": "You do not have the appropriate permissions"
   },


### PR DESCRIPTION
#### Summary
Make Elasticsearch work after config/license change without restart.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11243

#### Checklist

- [x] Has enterprise changes (please link)
- [x] Has UI changes
- [x] Includes text changes and localization file updates
