### PR TITLE
MM-10502: Only cluster master should run job schedulers.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -439,6 +439,8 @@ func (a *App) initJobs() {
 	if jobsMigrationsInterface != nil {
 		a.Jobs.Migrations = jobsMigrationsInterface(a)
 	}
+	a.Jobs.Workers = a.Jobs.InitWorkers()
+	a.Jobs.Schedulers = a.Jobs.InitSchedulers()
 }
 
 func (a *App) DiagnosticId() string {

--- a/app/cluster.go
+++ b/app/cluster.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2018-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import "github.com/mattermost/mattermost-server/model"
+
+// Registers a given function to be called when the cluster leader may have changed. Returns a unique ID for the
+// listener which can later be used to remove it. If clustering is not enabled in this build, the callback will never
+// be called.
+func (a *App) AddClusterLeaderChangedListener(listener func()) string {
+	id := model.NewId()
+	a.clusterLeaderListeners[id] = listener
+	return id
+}
+
+// Removes a listener function by the unique ID returned when AddConfigListener was called
+func (a *App) RemoveClusterLeaderChangedListener(id string) {
+	delete(a.clusterLeaderListeners, id)
+}
+
+func (a *App) InvokeClusterLeaderChangedListeners() {
+	a.Go(func() {
+		for _, listener := range a.clusterLeaderListeners {
+			listener()
+		}
+	})
+}

--- a/jobs/server.go
+++ b/jobs/server.go
@@ -50,11 +50,11 @@ func (srv *JobServer) Config() *model.Config {
 }
 
 func (srv *JobServer) StartWorkers() {
-	srv.Workers = srv.InitWorkers().Start()
+	srv.Workers = srv.Workers.Start()
 }
 
 func (srv *JobServer) StartSchedulers() {
-	srv.Schedulers = srv.InitSchedulers().Start()
+	srv.Schedulers = srv.Schedulers.Start()
 }
 
 func (srv *JobServer) StopWorkers() {


### PR DESCRIPTION
#### Summary
At present, in a HA cluster, every app node will run all the job schedulers, resulting in time-based scheduled jobs being scheduled `n` times where `n` is the number of app servers in the cluster, rather than just once. This changes the schedulers subsystem to only schedule jobs on the cluster master when operating in HA mode. Outside of HA mode, or where HA app servers have `RunSchedulers: false` in the config, this change has no effect.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10502

#### Checklist
- [x] Has enterprise changes https://github.com/mattermost/enterprise/pull/331
