### PR TITLE
gob register AppError for plugins

### DIFF
--- a/plugin/client_rpc.go
+++ b/plugin/client_rpc.go
@@ -67,6 +67,7 @@ func init() {
 	gob.Register([]*model.SlackAttachment{})
 	gob.Register([]interface{}{})
 	gob.Register(map[string]interface{}{})
+	gob.Register(&model.AppError{})
 }
 
 // These enforce compile time checks to make sure types implement the interface


### PR DESCRIPTION
#### Summary
This allows plugin hooks to return the result of calling the API as an `error`.

#### Ticket Link
None.