### PR TITLE
Add siteURL to WS origin check

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -248,6 +248,7 @@ func (a *App) StopServer() {
 
 func (a *App) OriginChecker() func(*http.Request) bool {
 	if allowed := *a.Config().ServiceSettings.AllowCorsFrom; allowed != "" {
+		allowed += " " + *a.Config().ServiceSettings.SiteURL
 		return utils.OriginChecker(allowed)
 	}
 	return nil


### PR DESCRIPTION
#### Summary
When `ServiceSettings.AllowCorsFrom` is set, add the site URL to the allowed origins.