### PR TITLE
[MM-10346] CSRF Token Implementation for Plugins

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -126,7 +126,7 @@ func (a *App) GetUserForLogin(id, loginId string) (*model.User, *model.AppError)
 
 func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId string) (*model.Session, *model.AppError) {
 	session := &model.Session{UserId: user.Id, Roles: user.GetRawRoles(), DeviceId: deviceId, IsOAuth: false}
-
+	session.GenerateCSRF()
 	maxAge := *a.Config().ServiceSettings.SessionLengthWebInDays * 60 * 60 * 24
 
 	if len(deviceId) > 0 {

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -327,6 +327,7 @@ func (a *App) GetOAuthAccessTokenForCodeFlow(clientId, grantType, redirectUri, c
 func (a *App) newSession(appName string, user *model.User) (*model.Session, *model.AppError) {
 	// set new token an session
 	session := &model.Session{UserId: user.Id, Roles: user.Roles, IsOAuth: true}
+	session.GenerateCSRF()
 	session.SetExpireInDays(*a.Config().ServiceSettings.SessionLengthSSOInDays)
 	session.AddProp(model.SESSION_PROP_PLATFORM, appName)
 	session.AddProp(model.SESSION_PROP_OS, "OAuth2")

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -65,6 +65,16 @@ func (api *PluginAPI) UnregisterCommand(teamId, trigger string) error {
 	return nil
 }
 
+func (api *PluginAPI) GetSession(sessionId string) (*model.Session, *model.AppError) {
+	session, err := api.app.GetSessionById(sessionId)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return session, nil
+}
+
 func (api *PluginAPI) GetConfig() *model.Config {
 	return api.app.GetConfig()
 }

--- a/model/session.go
+++ b/model/session.go
@@ -135,6 +135,20 @@ func (me *Session) GetUserRoles() []string {
 	return strings.Fields(me.Roles)
 }
 
+func (me *Session) GenerateCSRF() string {
+	token := NewId()
+	me.AddProp("csrf", token)
+	return token
+}
+
+func (me *Session) GetCSRF() string {
+	if me.Props == nil {
+		return ""
+	}
+
+	return me.Props["csrf"]
+}
+
 func SessionsToJson(o []*Session) string {
 	if b, err := json.Marshal(o); err != nil {
 		return "[]"

--- a/model/session_test.go
+++ b/model/session_test.go
@@ -63,3 +63,18 @@ func TestSessionJson(t *testing.T) {
 
 	session.SetExpireInDays(10)
 }
+
+func TestSessionCSRF(t *testing.T) {
+	s := Session{}
+	token := s.GetCSRF()
+	assert.Empty(t, token)
+
+	token = s.GenerateCSRF()
+	assert.NotEmpty(t, token)
+
+	token2 := s.GetCSRF()
+	assert.NotEmpty(t, token2)
+	assert.Equal(t, token, token2)
+}
+
+

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -25,6 +25,9 @@ type API interface {
 	// UnregisterCommand unregisters a command previously registered via RegisterCommand.
 	UnregisterCommand(teamId, trigger string) error
 
+	// GetSession returns the session object for the Session ID
+	GetSession(sessionId string) (*model.Session, *model.AppError)
+
 	// GetConfig fetches the currently persisted config
 	GetConfig() *model.Config
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -558,6 +558,35 @@ func (s *apiRPCServer) UnregisterCommand(args *Z_UnregisterCommandArgs, returns 
 	return nil
 }
 
+type Z_GetSessionArgs struct {
+	A string
+}
+
+type Z_GetSessionReturns struct {
+	A *model.Session
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetSession(sessionId string) (*model.Session, *model.AppError) {
+	_args := &Z_GetSessionArgs{sessionId}
+	_returns := &Z_GetSessionReturns{}
+	if err := g.client.Call("Plugin.GetSession", _args, _returns); err != nil {
+		log.Printf("RPC call to GetSession API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetSession(args *Z_GetSessionArgs, returns *Z_GetSessionReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetSession(sessionId string) (*model.Session, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetSession(args.A)
+	} else {
+		return fmt.Errorf("API GetSession called but not implemented.")
+	}
+	return nil
+}
+
 type Z_GetConfigArgs struct {
 }
 

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -7,4 +7,5 @@ package plugin
 //
 // It is currently a placeholder while the implementation details are sorted out.
 type Context struct {
+	SessionId string
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -499,6 +499,31 @@ func (_m *API) GetPublicChannelsForTeam(teamId string, offset int, limit int) (*
 	return r0, r1
 }
 
+// GetSession provides a mock function with given fields: sessionId
+func (_m *API) GetSession(sessionId string) (*model.Session, *model.AppError) {
+	ret := _m.Called(sessionId)
+
+	var r0 *model.Session
+	if rf, ok := ret.Get(0).(func(string) *model.Session); ok {
+		r0 = rf(sessionId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Session)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(sessionId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetTeam provides a mock function with given fields: teamId
 func (_m *API) GetTeam(teamId string) (*model.Team, *model.AppError) {
 	ret := _m.Called(teamId)


### PR DESCRIPTION
#### Summary
This PR implements CSRF token which are being attached to users sessions. The CSRF tokens are rolled out and can be enforced as alternative to XHR checks in the plugin request system. The plugin API was extended to allow a simple implementation in the plugins code base.

The PR lays the foundation for the further roll out in the MM core.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10346

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
