### PR TITLE
Feature/fileinfo create copy

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -608,7 +608,7 @@ func (a *App) GetFileInfo(fileId string) (*model.FileInfo, *model.AppError) {
 func (a *App) CopyFileInfos(userId string, fileIds []string) ([]string, *model.AppError) {
 	newFileIds := []string{}
 
-	now := time.Now()
+	now := model.GetMillis()
 
 	for _, fileId := range fileIds {
 		fileInfo := &model.FileInfo{}
@@ -621,11 +621,12 @@ func (a *App) CopyFileInfos(userId string, fileIds []string) ([]string, *model.A
 
 		fileInfo.Id = model.NewId()
 		fileInfo.CreatorId = userId
-		fileInfo.CreateAt = now.UnixNano() / int64(time.Millisecond)
+		fileInfo.CreateAt = now
+		fileInfo.UpdateAt = now
 		fileInfo.PostId = ""
 
 		if result := <-a.Srv.Store.FileInfo().Save(fileInfo); result.Err != nil {
-			return nil, result.Err
+			return newFileIds, result.Err
 		}
 
 		newFileIds = append(newFileIds, fileInfo.Id)

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -265,6 +265,10 @@ func (api *PluginAPI) UpdatePost(post *model.Post) (*model.Post, *model.AppError
 	return api.app.UpdatePost(post, false)
 }
 
+func (api *PluginAPI) CopyFileInfos(userId string, fileIds []string) ([]string, *model.AppError) {
+	return api.app.CopyFileInfos(userId, fileIds)
+}
+
 func (api *PluginAPI) KVSet(key string, value []byte) *model.AppError {
 	return api.app.SetPluginKey(api.id, key, value)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -152,6 +152,13 @@ type API interface {
 	// UpdatePost updates a post.
 	UpdatePost(post *model.Post) (*model.Post, *model.AppError)
 
+	// CopyFileInfos creates a copy of FileInfo objects provided in the list of FileIds
+	// these new FileInfo objects will not be linked to any post and will
+	// be ready to provide to a new CreatePost call
+	// this should be used when you want to create a copy of a post including
+	// file attachments without duplicating the file uploads
+	CopyFileInfos(userId string, fileIds []string) ([]string, *model.AppError)
+
 	// KVSet will store a key-value pair, unique per plugin.
 	KVSet(key string, value []byte) *model.AppError
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1791,6 +1791,36 @@ func (s *apiRPCServer) UpdatePost(args *Z_UpdatePostArgs, returns *Z_UpdatePostR
 	return nil
 }
 
+type Z_CopyFileInfosArgs struct {
+	A string
+	B []string
+}
+
+type Z_CopyFileInfosReturns struct {
+	A []string
+	B *model.AppError
+}
+
+func (g *apiRPCClient) CopyFileInfos(userId string, fileIds []string) ([]string, *model.AppError) {
+	_args := &Z_CopyFileInfosArgs{userId, fileIds}
+	_returns := &Z_CopyFileInfosReturns{}
+	if err := g.client.Call("Plugin.CopyFileInfos", _args, _returns); err != nil {
+		log.Printf("RPC call to CopyFileInfos API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) CopyFileInfos(args *Z_CopyFileInfosArgs, returns *Z_CopyFileInfosReturns) error {
+	if hook, ok := s.impl.(interface {
+		CopyFileInfos(userId string, fileIds []string) ([]string, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.CopyFileInfos(args.A, args.B)
+	} else {
+		return fmt.Errorf("API CopyFileInfos called but not implemented.")
+	}
+	return nil
+}
+
 type Z_KVSetArgs struct {
 	A string
 	B []byte

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -37,6 +37,31 @@ func (_m *API) AddChannelMember(channelId string, userId string) (*model.Channel
 	return r0, r1
 }
 
+// CopyFileInfos provides a mock function with given fields: userId, fileIds
+func (_m *API) CopyFileInfos(userId string, fileIds []string) ([]string, *model.AppError) {
+	ret := _m.Called(userId, fileIds)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(string, []string) []string); ok {
+		r0 = rf(userId, fileIds)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, []string) *model.AppError); ok {
+		r1 = rf(userId, fileIds)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // CreateChannel provides a mock function with given fields: channel
 func (_m *API) CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 	ret := _m.Called(channel)


### PR DESCRIPTION
#### Summary
This change adds a way to create a copy of the FileInfo object(s) from a list of IDs of existing FileInfo objects. This is useful if you want to create a post that you want to reuse an attachment that already exists in another post without needing to re-upload the attachment file and duplicating the file. This change also adds this function to the plugin APIs. 

**Use Case:** a plugin that monitors all posts for keywords and re-posts them to a designated channel for review/compliance reasons, this process needs to capture the entire post including the attachments

#### Ticket Link
N/A

#### Checklist
- [ ] Added or updated unit tests (required for all new features)

Some unit tests in progress