### PR TITLE
MM-11521/MM-11522 Fix being able to create users with invalid emails through API

### DIFF
--- a/app/team_test.go
+++ b/app/team_test.go
@@ -45,34 +45,11 @@ func TestCreateTeamWithUser(t *testing.T) {
 	}
 
 	if _, err := th.App.CreateTeamWithUser(team, th.BasicUser.Id); err != nil {
-		t.Log(err)
-		t.Fatal("Should create a new team with existing user")
+		t.Fatal("Should create a new team with existing user", err)
 	}
 
 	if _, err := th.App.CreateTeamWithUser(team, model.NewId()); err == nil {
 		t.Fatal("Should not create a new team - user does not exist")
-	}
-
-	user := model.User{Email: strings.ToLower(model.NewId()) + "success+test", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
-	ruser, _ := th.App.CreateUser(&user)
-
-	id = model.NewId()
-	team2 := &model.Team{
-		DisplayName: "dn_" + id,
-		Name:        "name" + id,
-		Email:       "success2+" + id + "@simulator.amazonses.com",
-		Type:        model.TEAM_OPEN,
-	}
-
-	//Fail to create a team with user when user has set email without domain
-	if _, err := th.App.CreateTeamWithUser(team2, ruser.Id); err == nil {
-		t.Log(err.Message)
-		t.Fatal("Should not create a team with user when user has set email without domain")
-	} else {
-		if err.Id != "model.team.is_valid.email.app_error" {
-			t.Log(err)
-			t.Fatal("Invalid error message")
-		}
 	}
 }
 

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -250,7 +250,7 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 
 func getUserFromDB(a *App, id string, t *testing.T) *model.User {
 	if user, err := a.GetUser(id); err != nil {
-		t.Fatal("user is not found")
+		t.Fatal("user is not found", err)
 		return nil
 	} else {
 		return user
@@ -261,13 +261,13 @@ func getGitlabUserPayload(gitlabUser oauthgitlab.GitLabUser, t *testing.T) []byt
 	var payload []byte
 	var err error
 	if payload, err = json.Marshal(gitlabUser); err != nil {
-		t.Fatal("Serialization of gitlab user to json failed")
+		t.Fatal("Serialization of gitlab user to json failed", err)
 	}
 
 	return payload
 }
 
-func createGitlabUser(t *testing.T, a *App, email string, username string) (*model.User, oauthgitlab.GitLabUser) {
+func createGitlabUser(t *testing.T, a *App, username string, email string) (*model.User, oauthgitlab.GitLabUser) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	gitlabUserObj := oauthgitlab.GitLabUser{Id: int64(r.Intn(1000)) + 1, Username: username, Login: "user1", Email: email, Name: "Test User"}
 	gitlabUser := getGitlabUserPayload(gitlabUserObj, t)
@@ -276,7 +276,7 @@ func createGitlabUser(t *testing.T, a *App, email string, username string) (*mod
 	var err *model.AppError
 
 	if user, err = a.CreateOAuthUser("gitlab", bytes.NewReader(gitlabUser), ""); err != nil {
-		t.Fatal("unable to create the user")
+		t.Fatal("unable to create the user", err)
 	}
 
 	return user, gitlabUserObj

--- a/model/user.go
+++ b/model/user.go
@@ -132,7 +132,7 @@ func (u *User) IsValid() *AppError {
 		return InvalidUserError("username", u.Id)
 	}
 
-	if len(u.Email) > USER_EMAIL_MAX_LENGTH || len(u.Email) == 0 {
+	if len(u.Email) > USER_EMAIL_MAX_LENGTH || len(u.Email) == 0 || !IsValidEmail(u.Email) {
 		return InvalidUserError("email", u.Id)
 	}
 

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -118,34 +118,39 @@ func TestUserIsValid(t *testing.T) {
 
 	user.Id = NewId()
 	if err := user.IsValid(); !HasExpectedUserIsValidError(err, "create_at", user.Id) {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	user.CreateAt = GetMillis()
 	if err := user.IsValid(); !HasExpectedUserIsValidError(err, "update_at", user.Id) {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	user.UpdateAt = GetMillis()
 	if err := user.IsValid(); !HasExpectedUserIsValidError(err, "username", user.Id) {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	user.Username = NewId() + "^hello#"
 	if err := user.IsValid(); !HasExpectedUserIsValidError(err, "username", user.Id) {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	user.Username = NewId()
-	user.Email = strings.Repeat("01234567890", 20)
-	if err := user.IsValid(); err == nil {
-		t.Fatal()
+	if err := user.IsValid(); !HasExpectedUserIsValidError(err, "email", user.Id) {
+		t.Fatal(err)
 	}
 
-	user.Email = strings.Repeat("a", 128)
+	user.Email = strings.Repeat("01234567890", 20)
+	if err := user.IsValid(); !HasExpectedUserIsValidError(err, "email", user.Id) {
+		t.Fatal(err)
+	}
+
+	user.Email = "user@example.com"
+
 	user.Nickname = strings.Repeat("a", 65)
 	if err := user.IsValid(); !HasExpectedUserIsValidError(err, "nickname", user.Id) {
-		t.Fatal()
+		t.Fatal(err)
 	}
 
 	user.Nickname = strings.Repeat("a", 64)

--- a/model/utils.go
+++ b/model/utils.go
@@ -279,16 +279,18 @@ func IsLower(s string) bool {
 }
 
 func IsValidEmail(email string) bool {
-
 	if !IsLower(email) {
 		return false
 	}
 
-	if _, err := mail.ParseAddress(email); err == nil {
-		return true
+	if addr, err := mail.ParseAddress(email); err != nil {
+		return false
+	} else if addr.Name != "" {
+		// mail.ParseAddress accepts input of the form "Billy Bob <billy@example.com>" which we don't allow
+		return false
 	}
 
-	return false
+	return true
 }
 
 var reservedName = []string{

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -77,13 +77,87 @@ func TestMapJson(t *testing.T) {
 	}
 }
 
-func TestValidEmail(t *testing.T) {
-	if !IsValidEmail("corey+test@hulen.com") {
-		t.Error("email should be valid")
-	}
-
-	if IsValidEmail("@corey+test@hulen.com") {
-		t.Error("should be invalid")
+func TestIsValidEmail(t *testing.T) {
+	for _, testCase := range []struct {
+		Input    string
+		Expected bool
+	}{
+		{
+			Input:    "corey",
+			Expected: false,
+		},
+		{
+			Input:    "corey@example.com",
+			Expected: true,
+		},
+		{
+			Input:    "corey+test@example.com",
+			Expected: true,
+		},
+		{
+			Input:    "@corey+test@example.com",
+			Expected: false,
+		},
+		{
+			Input:    "firstname.lastname@example.com",
+			Expected: true,
+		},
+		{
+			Input:    "firstname.lastname@subdomain.example.com",
+			Expected: true,
+		},
+		{
+			Input:    "123454567@domain.com",
+			Expected: true,
+		},
+		{
+			Input:    "email@domain-one.com",
+			Expected: true,
+		},
+		{
+			Input:    "email@domain.co.jp",
+			Expected: true,
+		},
+		{
+			Input:    "firstname-lastname@domain.com",
+			Expected: true,
+		},
+		{
+			Input:    "@domain.com",
+			Expected: false,
+		},
+		{
+			Input:    "Billy Bob <billy@example.com>",
+			Expected: false,
+		},
+		{
+			Input:    "email.domain.com",
+			Expected: false,
+		},
+		{
+			Input:    "email.@domain.com",
+			Expected: false,
+		},
+		{
+			Input:    "email@domain@domain.com",
+			Expected: false,
+		},
+		{
+			Input:    "(email@domain.com)",
+			Expected: false,
+		},
+		{
+			Input:    "email@汤.中国",
+			Expected: true,
+		},
+		{
+			Input:    "email1@domain.com, email2@domain.com",
+			Expected: false,
+		},
+	} {
+		t.Run(testCase.Input, func(t *testing.T) {
+			assert.Equal(t, testCase.Expected, IsValidEmail(testCase.Input))
+		})
 	}
 }
 

--- a/store/storetest/channel_member_history_store.go
+++ b/store/storetest/channel_member_history_store.go
@@ -33,7 +33,7 @@ func testLogJoinEvent(t *testing.T, ss store.Store) {
 
 	// and a test user
 	user := model.User{
-		Email:    model.NewId() + "@mattermost.com",
+		Email:    MakeEmail(),
 		Nickname: model.NewId(),
 		Username: model.NewId(),
 	}
@@ -56,7 +56,7 @@ func testLogLeaveEvent(t *testing.T, ss store.Store) {
 
 	// and a test user
 	user := model.User{
-		Email:    model.NewId() + "@mattermost.com",
+		Email:    MakeEmail(),
 		Nickname: model.NewId(),
 		Username: model.NewId(),
 	}
@@ -82,7 +82,7 @@ func testGetUsersInChannelAtChannelMemberHistory(t *testing.T, ss store.Store) {
 
 	// and a test user
 	user := model.User{
-		Email:    model.NewId() + "@mattermost.com",
+		Email:    MakeEmail(),
 		Nickname: model.NewId(),
 		Username: model.NewId(),
 	}
@@ -165,7 +165,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, ss store.Store) {
 
 	// and a test user
 	user := model.User{
-		Email:    model.NewId() + "@mattermost.com",
+		Email:    MakeEmail(),
 		Nickname: model.NewId(),
 		Username: model.NewId(),
 	}
@@ -267,14 +267,14 @@ func testPermanentDeleteBatch(t *testing.T, ss store.Store) {
 
 	// and two test users
 	user := model.User{
-		Email:    model.NewId() + "@mattermost.com",
+		Email:    MakeEmail(),
 		Nickname: model.NewId(),
 		Username: model.NewId(),
 	}
 	user = *store.Must(ss.User().Save(&user)).(*model.User)
 
 	user2 := model.User{
-		Email:    model.NewId() + "@mattermost.com",
+		Email:    MakeEmail(),
 		Nickname: model.NewId(),
 		Username: model.NewId(),
 	}

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -99,13 +99,13 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_DIRECT
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Nickname = model.NewId()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Nickname = model.NewId()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1))
@@ -175,13 +175,13 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store) {
 
 func testChannelStoreCreateDirectChannel(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Nickname = model.NewId()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Nickname = model.NewId()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1))
@@ -329,13 +329,13 @@ func testChannelStoreGet(t *testing.T, ss store.Store) {
 	}
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Nickname = model.NewId()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
 	u2 := model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Nickname = model.NewId()
 	store.Must(ss.User().Save(&u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1))
@@ -728,13 +728,13 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	assert.EqualValues(t, 0, c1t1.ExtraUpdateAt, "ExtraUpdateAt should be 0")
 
 	u1 := model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Nickname = model.NewId()
 	store.Must(ss.User().Save(&u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
 	u2 := model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Nickname = model.NewId()
 	store.Must(ss.User().Save(&u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1))
@@ -812,13 +812,13 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	assert.EqualValues(t, 0, c1t1.ExtraUpdateAt, "ExtraUpdateAt should be 0")
 
 	u1 := model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Nickname = model.NewId()
 	store.Must(ss.User().Save(&u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
 	u2 := model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Nickname = model.NewId()
 	store.Must(ss.User().Save(&u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1))
@@ -1263,7 +1263,7 @@ func testChannelStoreGetMembersForUser(t *testing.T, ss store.Store) {
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
 	t1.Name = model.NewId()
-	t1.Email = model.NewId() + "@nowhere.com"
+	t1.Email = MakeEmail()
 	t1.Type = model.TEAM_OPEN
 	store.Must(ss.Team().Save(&t1))
 
@@ -1554,7 +1554,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&c2, -1))
 
 	u1 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		DeleteAt: 0,
 	}
 	store.Must(ss.User().Save(u1))
@@ -1574,7 +1574,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 	}
 
 	u2 := model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		DeleteAt: 0,
 	}
 	store.Must(ss.User().Save(&u2))
@@ -1595,7 +1595,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 
 	// make sure members of other channels aren't counted
 	u3 := model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		DeleteAt: 0,
 	}
 	store.Must(ss.User().Save(&u3))
@@ -1616,7 +1616,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 
 	// make sure inactive users aren't counted
 	u4 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		DeleteAt: 10000,
 	}
 	store.Must(ss.User().Save(u4))
@@ -2114,12 +2114,12 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&p3, -1))
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Nickname = model.NewId()
 	store.Must(ss.User().Save(u1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Nickname = model.NewId()
 	store.Must(ss.User().Save(u2))
 

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -78,18 +78,18 @@ func testComplianceExport(t *testing.T, ss store.Store) {
 	t1 := &model.Team{}
 	t1.DisplayName = "DisplayName"
 	t1.Name = "zz" + model.NewId() + "b"
-	t1.Email = model.NewId() + "@nowhere.com"
+	t1.Email = MakeEmail()
 	t1.Type = model.TEAM_OPEN
 	t1 = store.Must(ss.Team().Save(t1)).(*model.Team)
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = model.NewId()
 	u1 = store.Must(ss.User().Save(u1)).(*model.User)
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: t1.Id, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Username = model.NewId()
 	u2 = store.Must(ss.User().Save(u2)).(*model.User)
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: t1.Id, UserId: u2.Id}, -1))
@@ -240,18 +240,18 @@ func testComplianceExportDirectMessages(t *testing.T, ss store.Store) {
 	t1 := &model.Team{}
 	t1.DisplayName = "DisplayName"
 	t1.Name = "zz" + model.NewId() + "b"
-	t1.Email = model.NewId() + "@nowhere.com"
+	t1.Email = MakeEmail()
 	t1.Type = model.TEAM_OPEN
 	t1 = store.Must(ss.Team().Save(t1)).(*model.Team)
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = model.NewId()
 	u1 = store.Must(ss.User().Save(u1)).(*model.User)
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: t1.Id, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Username = model.NewId()
 	u2 = store.Must(ss.User().Save(u2)).(*model.User)
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: t1.Id, UserId: u2.Id}, -1))
@@ -337,14 +337,14 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 	team := &model.Team{
 		DisplayName: "DisplayName",
 		Name:        "zz" + model.NewId() + "b",
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 	}
 	team = store.Must(ss.Team().Save(team)).(*model.Team)
 
 	// and two users that are a part of that team
 	user1 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user1 = store.Must(ss.User().Save(user1)).(*model.User)
@@ -354,7 +354,7 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 	}, -1))
 
 	user2 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user2 = store.Must(ss.User().Save(user2)).(*model.User)
@@ -438,14 +438,14 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 	team := &model.Team{
 		DisplayName: "DisplayName",
 		Name:        "zz" + model.NewId() + "b",
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 	}
 	team = store.Must(ss.Team().Save(team)).(*model.Team)
 
 	// and two users that are a part of that team
 	user1 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user1 = store.Must(ss.User().Save(user1)).(*model.User)
@@ -455,7 +455,7 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 	}, -1))
 
 	user2 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user2 = store.Must(ss.User().Save(user2)).(*model.User)
@@ -541,14 +541,14 @@ func testMessageExportDirectMessageChannel(t *testing.T, ss store.Store) {
 	team := &model.Team{
 		DisplayName: "DisplayName",
 		Name:        "zz" + model.NewId() + "b",
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 	}
 	team = store.Must(ss.Team().Save(team)).(*model.Team)
 
 	// and two users that are a part of that team
 	user1 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user1 = store.Must(ss.User().Save(user1)).(*model.User)
@@ -558,7 +558,7 @@ func testMessageExportDirectMessageChannel(t *testing.T, ss store.Store) {
 	}, -1))
 
 	user2 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user2 = store.Must(ss.User().Save(user2)).(*model.User)
@@ -619,14 +619,14 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 	team := &model.Team{
 		DisplayName: "DisplayName",
 		Name:        "zz" + model.NewId() + "b",
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 	}
 	team = store.Must(ss.Team().Save(team)).(*model.Team)
 
 	// and three users that are a part of that team
 	user1 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user1 = store.Must(ss.User().Save(user1)).(*model.User)
@@ -636,7 +636,7 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 	}, -1))
 
 	user2 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user2 = store.Must(ss.User().Save(user2)).(*model.User)
@@ -646,7 +646,7 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 	}, -1))
 
 	user3 := &model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 	}
 	user3 = store.Must(ss.User().Save(user3)).(*model.User)

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -1022,7 +1022,7 @@ func testUserCountsWithPostsByDay(t *testing.T, ss store.Store) {
 	t1 := &model.Team{}
 	t1.DisplayName = "DisplayName"
 	t1.Name = "zz" + model.NewId() + "b"
-	t1.Email = model.NewId() + "@nowhere.com"
+	t1.Email = MakeEmail()
 	t1.Type = model.TEAM_OPEN
 	t1 = store.Must(ss.Team().Save(t1)).(*model.Team)
 
@@ -1080,7 +1080,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	t1 := &model.Team{}
 	t1.DisplayName = "DisplayName"
 	t1.Name = "zz" + model.NewId() + "b"
-	t1.Email = model.NewId() + "@nowhere.com"
+	t1.Email = MakeEmail()
 	t1.Type = model.TEAM_OPEN
 	t1 = store.Must(ss.Team().Save(t1)).(*model.Team)
 

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -381,7 +381,7 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	t4 := &model.Team{
 		Name:        model.NewId(),
 		DisplayName: model.NewId(),
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 		SchemeId:    &d4.Id,
 	}

--- a/store/storetest/status_store.go
+++ b/store/storetest/status_store.go
@@ -125,7 +125,7 @@ func testGetAllFromTeam(t *testing.T, ss store.Store) {
 	team1 := model.Team{}
 	team1.DisplayName = model.NewId()
 	team1.Name = model.NewId()
-	team1.Email = model.NewId() + "@example.com"
+	team1.Email = MakeEmail()
 	team1.Type = model.TEAM_OPEN
 
 	if err := (<-ss.Team().Save(&team1)).Err; err != nil {
@@ -135,7 +135,7 @@ func testGetAllFromTeam(t *testing.T, ss store.Store) {
 	team2 := model.Team{}
 	team2.DisplayName = model.NewId()
 	team2.Name = model.NewId()
-	team2.Email = model.NewId() + "@example.com"
+	team2.Email = MakeEmail()
 	team2.Type = model.TEAM_OPEN
 
 	if err := (<-ss.Team().Save(&team2)).Err; err != nil {

--- a/store/storetest/storetestlib.go
+++ b/store/storetest/storetestlib.go
@@ -1,0 +1,9 @@
+package storetest
+
+import (
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func MakeEmail() string {
+	return "success_" + model.NewId() + "@simulator.amazonses.com"
+}

--- a/store/storetest/storetestlib.go
+++ b/store/storetest/storetestlib.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package storetest
 
 import (

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -50,7 +50,7 @@ func testTeamStoreSave(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 
 	if err := (<-ss.Team().Save(&o1)).Err; err != nil {
@@ -71,7 +71,7 @@ func testTeamStoreUpdate(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	if err := (<-ss.Team().Save(&o1)).Err; err != nil {
 		t.Fatal(err)
@@ -98,7 +98,7 @@ func testTeamStoreUpdateDisplayName(t *testing.T, ss store.Store) {
 	o1 := &model.Team{}
 	o1.DisplayName = "Display Name"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1 = (<-ss.Team().Save(o1)).Data.(*model.Team)
 
@@ -118,7 +118,7 @@ func testTeamStoreGet(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	store.Must(ss.Team().Save(&o1))
 
@@ -139,7 +139,7 @@ func testTeamStoreGetByName(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 
 	if err := (<-ss.Team().Save(&o1)).Err; err != nil {
@@ -164,7 +164,7 @@ func testTeamStoreSearchByName(t *testing.T, ss store.Store) {
 	o1.DisplayName = "DisplayName"
 	var name = "zzz" + model.NewId()
 	o1.Name = name + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 
 	if err := (<-ss.Team().Save(&o1)).Err; err != nil {
@@ -184,7 +184,7 @@ func testTeamStoreSearchAll(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "ADisplayName" + model.NewId()
 	o1.Name = "zz" + model.NewId() + "a"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 
 	if err := (<-ss.Team().Save(&o1)).Err; err != nil {
@@ -194,7 +194,7 @@ func testTeamStoreSearchAll(t *testing.T, ss store.Store) {
 	p2 := model.Team{}
 	p2.DisplayName = "BDisplayName" + model.NewId()
 	p2.Name = "b" + model.NewId() + "b"
-	p2.Email = model.NewId() + "@nowhere.com"
+	p2.Email = MakeEmail()
 	p2.Type = model.TEAM_INVITE
 
 	if err := (<-ss.Team().Save(&p2)).Err; err != nil {
@@ -236,7 +236,7 @@ func testTeamStoreSearchOpen(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "ADisplayName" + model.NewId()
 	o1.Name = "zz" + model.NewId() + "a"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.AllowOpenInvite = true
 
@@ -247,7 +247,7 @@ func testTeamStoreSearchOpen(t *testing.T, ss store.Store) {
 	o2 := model.Team{}
 	o2.DisplayName = "ADisplayName" + model.NewId()
 	o2.Name = "zz" + model.NewId() + "a"
-	o2.Email = model.NewId() + "@nowhere.com"
+	o2.Email = MakeEmail()
 	o2.Type = model.TEAM_OPEN
 	o2.AllowOpenInvite = false
 
@@ -258,7 +258,7 @@ func testTeamStoreSearchOpen(t *testing.T, ss store.Store) {
 	p2 := model.Team{}
 	p2.DisplayName = "BDisplayName" + model.NewId()
 	p2.Name = "b" + model.NewId() + "b"
-	p2.Email = model.NewId() + "@nowhere.com"
+	p2.Email = MakeEmail()
 	p2.Type = model.TEAM_INVITE
 	p2.AllowOpenInvite = true
 
@@ -325,7 +325,7 @@ func testTeamStoreGetByIniviteId(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.InviteId = model.NewId()
 
@@ -336,7 +336,7 @@ func testTeamStoreGetByIniviteId(t *testing.T, ss store.Store) {
 	o2 := model.Team{}
 	o2.DisplayName = "DisplayName"
 	o2.Name = "zz" + model.NewId() + "b"
-	o2.Email = model.NewId() + "@nowhere.com"
+	o2.Email = MakeEmail()
 	o2.Type = model.TEAM_OPEN
 
 	if err := (<-ss.Team().Save(&o2)).Err; err != nil {
@@ -371,7 +371,7 @@ func testTeamStoreByUserId(t *testing.T, ss store.Store) {
 	o1 := &model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.InviteId = model.NewId()
 	o1 = store.Must(ss.Team().Save(o1)).(*model.Team)
@@ -398,7 +398,7 @@ func testGetAllTeamListing(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.AllowOpenInvite = true
 	store.Must(ss.Team().Save(&o1))
@@ -406,14 +406,14 @@ func testGetAllTeamListing(t *testing.T, ss store.Store) {
 	o2 := model.Team{}
 	o2.DisplayName = "DisplayName"
 	o2.Name = "zz" + model.NewId() + "b"
-	o2.Email = model.NewId() + "@nowhere.com"
+	o2.Email = MakeEmail()
 	o2.Type = model.TEAM_OPEN
 	store.Must(ss.Team().Save(&o2))
 
 	o3 := model.Team{}
 	o3.DisplayName = "DisplayName"
 	o3.Name = "z-z-z" + model.NewId() + "b"
-	o3.Email = model.NewId() + "@nowhere.com"
+	o3.Email = MakeEmail()
 	o3.Type = model.TEAM_INVITE
 	o3.AllowOpenInvite = true
 	store.Must(ss.Team().Save(&o3))
@@ -421,7 +421,7 @@ func testGetAllTeamListing(t *testing.T, ss store.Store) {
 	o4 := model.Team{}
 	o4.DisplayName = "DisplayName"
 	o4.Name = "zz" + model.NewId() + "b"
-	o4.Email = model.NewId() + "@nowhere.com"
+	o4.Email = MakeEmail()
 	o4.Type = model.TEAM_INVITE
 	store.Must(ss.Team().Save(&o4))
 
@@ -446,7 +446,7 @@ func testGetAllTeamPageListing(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.AllowOpenInvite = true
 	store.Must(ss.Team().Save(&o1))
@@ -454,7 +454,7 @@ func testGetAllTeamPageListing(t *testing.T, ss store.Store) {
 	o2 := model.Team{}
 	o2.DisplayName = "DisplayName"
 	o2.Name = "zz" + model.NewId() + "b"
-	o2.Email = model.NewId() + "@nowhere.com"
+	o2.Email = MakeEmail()
 	o2.Type = model.TEAM_OPEN
 	o2.AllowOpenInvite = false
 	store.Must(ss.Team().Save(&o2))
@@ -462,7 +462,7 @@ func testGetAllTeamPageListing(t *testing.T, ss store.Store) {
 	o3 := model.Team{}
 	o3.DisplayName = "DisplayName"
 	o3.Name = "z-z-z" + model.NewId() + "b"
-	o3.Email = model.NewId() + "@nowhere.com"
+	o3.Email = MakeEmail()
 	o3.Type = model.TEAM_INVITE
 	o3.AllowOpenInvite = true
 	store.Must(ss.Team().Save(&o3))
@@ -470,7 +470,7 @@ func testGetAllTeamPageListing(t *testing.T, ss store.Store) {
 	o4 := model.Team{}
 	o4.DisplayName = "DisplayName"
 	o4.Name = "zz" + model.NewId() + "b"
-	o4.Email = model.NewId() + "@nowhere.com"
+	o4.Email = MakeEmail()
 	o4.Type = model.TEAM_INVITE
 	o4.AllowOpenInvite = false
 	store.Must(ss.Team().Save(&o4))
@@ -494,7 +494,7 @@ func testGetAllTeamPageListing(t *testing.T, ss store.Store) {
 	o5 := model.Team{}
 	o5.DisplayName = "DisplayName"
 	o5.Name = "z-z-z" + model.NewId() + "b"
-	o5.Email = model.NewId() + "@nowhere.com"
+	o5.Email = MakeEmail()
 	o5.Type = model.TEAM_OPEN
 	o5.AllowOpenInvite = true
 	store.Must(ss.Team().Save(&o5))
@@ -536,7 +536,7 @@ func testDelete(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.AllowOpenInvite = true
 	store.Must(ss.Team().Save(&o1))
@@ -544,7 +544,7 @@ func testDelete(t *testing.T, ss store.Store) {
 	o2 := model.Team{}
 	o2.DisplayName = "DisplayName"
 	o2.Name = "zz" + model.NewId() + "b"
-	o2.Email = model.NewId() + "@nowhere.com"
+	o2.Email = MakeEmail()
 	o2.Type = model.TEAM_OPEN
 	store.Must(ss.Team().Save(&o2))
 
@@ -557,7 +557,7 @@ func testTeamCount(t *testing.T, ss store.Store) {
 	o1 := model.Team{}
 	o1.DisplayName = "DisplayName"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.AllowOpenInvite = true
 	store.Must(ss.Team().Save(&o1))
@@ -709,7 +709,7 @@ func testSaveTeamMemberMaxMembers(t *testing.T, ss store.Store) {
 	for i := 0; i < maxUsersPerTeam; i++ {
 		userIds[i] = store.Must(ss.User().Save(&model.User{
 			Username: model.NewId(),
-			Email:    model.NewId(),
+			Email:    MakeEmail(),
 		})).(*model.User).Id
 
 		defer func(userId string) {
@@ -734,7 +734,7 @@ func testSaveTeamMemberMaxMembers(t *testing.T, ss store.Store) {
 
 	newUserId := store.Must(ss.User().Save(&model.User{
 		Username: model.NewId(),
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 	})).(*model.User).Id
 	defer func() {
 		<-ss.User().PermanentDelete(newUserId)
@@ -787,7 +787,7 @@ func testSaveTeamMemberMaxMembers(t *testing.T, ss store.Store) {
 
 	newUserId2 := store.Must(ss.User().Save(&model.User{
 		Username: model.NewId(),
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 	})).(*model.User).Id
 	if result := <-ss.Team().SaveMember(&model.TeamMember{TeamId: team.Id, UserId: newUserId2}, maxUsersPerTeam); result.Err != nil {
 		t.Fatal("should've been able to save new member after deleting one", result.Err)
@@ -898,11 +898,11 @@ func testGetTeamMembersByIds(t *testing.T, ss store.Store) {
 
 func testTeamStoreMemberCount(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.DeleteAt = 1
 	store.Must(ss.User().Save(u2))
 
@@ -1054,7 +1054,7 @@ func testUpdateLastTeamIconUpdate(t *testing.T, ss store.Store) {
 	o1 := &model.Team{}
 	o1.DisplayName = "Display Name"
 	o1.Name = "z-z-z" + model.NewId() + "b"
-	o1.Email = model.NewId() + "@nowhere.com"
+	o1.Email = MakeEmail()
 	o1.Type = model.TEAM_OPEN
 	o1.LastTeamIconUpdate = lastTeamIconUpdateInitial
 	o1 = (<-ss.Team().Save(o1)).Data.(*model.Team)
@@ -1094,7 +1094,7 @@ func testGetTeamsByScheme(t *testing.T, ss store.Store) {
 	t1 := &model.Team{
 		Name:        model.NewId(),
 		DisplayName: model.NewId(),
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 		SchemeId:    &s1.Id,
 	}
@@ -1102,7 +1102,7 @@ func testGetTeamsByScheme(t *testing.T, ss store.Store) {
 	t2 := &model.Team{
 		Name:        model.NewId(),
 		DisplayName: model.NewId(),
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 		SchemeId:    &s1.Id,
 	}
@@ -1110,7 +1110,7 @@ func testGetTeamsByScheme(t *testing.T, ss store.Store) {
 	t3 := &model.Team{
 		Name:        model.NewId(),
 		DisplayName: model.NewId(),
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 	}
 
@@ -1142,7 +1142,7 @@ func testTeamStoreMigrateTeamMembers(t *testing.T, ss store.Store) {
 	t1 := &model.Team{
 		DisplayName: "Name",
 		Name:        "z-z-z" + model.NewId() + "b",
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 		InviteId:    model.NewId(),
 		SchemeId:    &s1,
@@ -1218,7 +1218,7 @@ func testResetAllTeamSchemes(t *testing.T, ss store.Store) {
 	t1 := &model.Team{
 		Name:        model.NewId(),
 		DisplayName: model.NewId(),
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 		SchemeId:    &s1.Id,
 	}
@@ -1226,7 +1226,7 @@ func testResetAllTeamSchemes(t *testing.T, ss store.Store) {
 	t2 := &model.Team{
 		Name:        model.NewId(),
 		DisplayName: model.NewId(),
-		Email:       model.NewId() + "@nowhere.com",
+		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 		SchemeId:    &s1.Id,
 	}

--- a/store/storetest/user_access_token_store.go
+++ b/store/storetest/user_access_token_store.go
@@ -134,7 +134,7 @@ func testUserAccessTokenDisableEnable(t *testing.T, ss store.Store) {
 
 func testUserAccessTokenSearch(t *testing.T, ss store.Store) {
 	u1 := model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = model.NewId()
 
 	store.Must(ss.User().Save(&u1))

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -58,7 +58,7 @@ func testUserStoreSave(t *testing.T, ss store.Store) {
 	maxUsersPerTeam := 50
 
 	u1 := model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = model.NewId()
 
 	if err := (<-ss.User().Save(&u1)).Err; err != nil {
@@ -89,7 +89,7 @@ func testUserStoreSave(t *testing.T, ss store.Store) {
 
 	for i := 0; i < 49; i++ {
 		u1.Id = ""
-		u1.Email = model.NewId()
+		u1.Email = MakeEmail()
 		u1.Username = model.NewId()
 		if err := (<-ss.User().Save(&u1)).Err; err != nil {
 			t.Fatal("couldn't save item", err)
@@ -99,7 +99,7 @@ func testUserStoreSave(t *testing.T, ss store.Store) {
 	}
 
 	u1.Id = ""
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = model.NewId()
 	if err := (<-ss.User().Save(&u1)).Err; err != nil {
 		t.Fatal("couldn't save item", err)
@@ -112,12 +112,12 @@ func testUserStoreSave(t *testing.T, ss store.Store) {
 
 func testUserStoreUpdate(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.AuthService = "ldap"
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1))
@@ -138,19 +138,19 @@ func testUserStoreUpdate(t *testing.T, ss store.Store) {
 		t.Fatal("Update should have faile because id change")
 	}
 
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	if err := (<-ss.User().Update(u2, false)).Err; err == nil {
 		t.Fatal("Update should have failed because you can't modify AD/LDAP fields")
 	}
 
 	u3 := &model.User{}
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	oldEmail := u3.Email
 	u3.AuthService = "gitlab"
 	store.Must(ss.User().Save(u3))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u3.Id}, -1))
 
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	if result := <-ss.User().Update(u3, false); result.Err != nil {
 		t.Fatal("Update should not have failed")
 	} else {
@@ -160,7 +160,7 @@ func testUserStoreUpdate(t *testing.T, ss store.Store) {
 		}
 	}
 
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	if result := <-ss.User().Update(u3, true); result.Err != nil {
 		t.Fatal("Update should not have failed")
 	} else {
@@ -177,7 +177,7 @@ func testUserStoreUpdate(t *testing.T, ss store.Store) {
 
 func testUserStoreUpdateUpdateAt(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
@@ -199,7 +199,7 @@ func testUserStoreUpdateUpdateAt(t *testing.T, ss store.Store) {
 
 func testUserStoreUpdateFailedPasswordAttempts(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
@@ -219,7 +219,7 @@ func testUserStoreUpdateFailedPasswordAttempts(t *testing.T, ss store.Store) {
 
 func testUserStoreGet(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
@@ -238,7 +238,7 @@ func testUserStoreGet(t *testing.T, ss store.Store) {
 
 func testUserCount(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
@@ -254,12 +254,12 @@ func testUserCount(t *testing.T, ss store.Store) {
 
 func testGetAllUsingAuthService(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.AuthService = "someservice"
 	store.Must(ss.User().Save(u1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.AuthService = "someservice"
 	store.Must(ss.User().Save(u2))
 
@@ -275,11 +275,11 @@ func testGetAllUsingAuthService(t *testing.T, ss store.Store) {
 
 func testUserStoreGetAllProfiles(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 
 	if r1 := <-ss.User().GetAllProfiles(0, 100); r1.Err != nil {
@@ -317,7 +317,7 @@ func testUserStoreGetAllProfiles(t *testing.T, ss store.Store) {
 	}
 
 	u3 := &model.User{}
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	store.Must(ss.User().Save(u3))
 
 	if r2 := <-ss.User().GetEtagForAllProfiles(); r2.Err != nil {
@@ -333,12 +333,12 @@ func testUserStoreGetProfiles(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
@@ -378,7 +378,7 @@ func testUserStoreGetProfiles(t *testing.T, ss store.Store) {
 	}
 
 	u3 := &model.User{}
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	store.Must(ss.User().Save(u3))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
@@ -395,12 +395,12 @@ func testUserStoreGetProfilesInChannel(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
@@ -471,12 +471,12 @@ func testUserStoreGetProfilesInChannelByStatus(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
@@ -550,14 +550,14 @@ func testUserStoreGetProfilesWithoutTeam(t *testing.T, ss store.Store) {
 
 	u1 := &model.User{}
 	u1.Username = "a000000000" + model.NewId()
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 	defer ss.User().PermanentDelete(u1.Id)
 
 	u2 := &model.User{}
 	u2.Username = "a000000001" + model.NewId()
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	defer ss.User().PermanentDelete(u2.Id)
 
@@ -588,12 +588,12 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
@@ -676,12 +676,12 @@ func testUserStoreGetProfilesNotInChannel(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
@@ -769,12 +769,12 @@ func testUserStoreGetProfilesByIds(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
@@ -911,13 +911,13 @@ func testUserStoreGetProfilesByUsernames(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = "username1" + model.NewId()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Username = "username2" + model.NewId()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
@@ -955,7 +955,7 @@ func testUserStoreGetProfilesByUsernames(t *testing.T, ss store.Store) {
 	team2Id := model.NewId()
 
 	u3 := &model.User{}
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	u3.Username = "username3" + model.NewId()
 	store.Must(ss.User().Save(u3))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: team2Id, UserId: u3.Id}, -1))
@@ -995,13 +995,13 @@ func testUserStoreGetSystemAdminProfiles(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Roles = model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
@@ -1019,7 +1019,7 @@ func testUserStoreGetByEmail(t *testing.T, ss store.Store) {
 	teamid := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamid, UserId: u1.Id}, -1))
 
@@ -1038,7 +1038,7 @@ func testUserStoreGetByAuthData(t *testing.T, ss store.Store) {
 	auth := "123" + model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.AuthData = &auth
 	u1.AuthService = "service"
 	store.Must(ss.User().Save(u1))
@@ -1058,7 +1058,7 @@ func testUserStoreGetByUsername(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = model.NewId()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
@@ -1076,7 +1076,7 @@ func testUserStoreGetForLogin(t *testing.T, ss store.Store) {
 	auth := model.NewId()
 
 	u1 := &model.User{
-		Email:       model.NewId(),
+		Email:       MakeEmail(),
 		Username:    model.NewId(),
 		AuthService: model.USER_AUTH_SERVICE_GITLAB,
 		AuthData:    &auth,
@@ -1086,7 +1086,7 @@ func testUserStoreGetForLogin(t *testing.T, ss store.Store) {
 	auth2 := model.NewId()
 
 	u2 := &model.User{
-		Email:       model.NewId(),
+		Email:       MakeEmail(),
 		Username:    model.NewId(),
 		AuthService: model.USER_AUTH_SERVICE_LDAP,
 		AuthData:    &auth2,
@@ -1119,7 +1119,7 @@ func testUserStoreUpdatePassword(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
@@ -1141,7 +1141,7 @@ func testUserStoreUpdatePassword(t *testing.T, ss store.Store) {
 
 func testUserStoreDelete(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
@@ -1154,7 +1154,7 @@ func testUserStoreUpdateAuthData(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
@@ -1198,12 +1198,12 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 
 	u1 := &model.User{}
 	u1.Username = "user1" + model.NewId()
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Username = "user2" + model.NewId()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
@@ -1274,7 +1274,7 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 
 func testUserStoreUpdateMfaSecret(t *testing.T, ss store.Store) {
 	u1 := model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(&u1))
 
 	time.Sleep(100 * time.Millisecond)
@@ -1291,7 +1291,7 @@ func testUserStoreUpdateMfaSecret(t *testing.T, ss store.Store) {
 
 func testUserStoreUpdateMfaActive(t *testing.T, ss store.Store) {
 	u1 := model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(&u1))
 
 	time.Sleep(100 * time.Millisecond)
@@ -1312,7 +1312,7 @@ func testUserStoreUpdateMfaActive(t *testing.T, ss store.Store) {
 
 func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Status().SaveOrUpdate(&model.Status{UserId: u1.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}))
 	tid := model.NewId()
@@ -1325,7 +1325,7 @@ func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, ss store.Store) {
 
 func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Status().SaveOrUpdate(&model.Status{UserId: u1.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}))
 	tid := model.NewId()
@@ -1347,12 +1347,12 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 
 	u2 := &model.User{}
 	u2.Username = "jim-bobby" + model.NewId()
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 
 	u3 := &model.User{}
 	u3.Username = "jimbo" + model.NewId()
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	u3.DeleteAt = 1
 	store.Must(ss.User().Save(u3))
 
@@ -1361,7 +1361,7 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 	u5.FirstName = "En"
 	u5.LastName = "Yu"
 	u5.Nickname = "enyu"
-	u5.Email = model.NewId() + "@simulator.amazonses.com"
+	u5.Email = MakeEmail()
 	store.Must(ss.User().Save(u5))
 
 	u6 := &model.User{}
@@ -1369,7 +1369,7 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 	u6.FirstName = "Du_"
 	u6.LastName = "_DE"
 	u6.Nickname = "lodash"
-	u6.Email = model.NewId() + "@simulator.amazonses.com"
+	u6.Email = MakeEmail()
 	store.Must(ss.User().Save(u6))
 
 	tid := model.NewId()
@@ -1786,7 +1786,7 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 	// Search Users not in Team.
 	u4 := &model.User{}
 	u4.Username = "simon" + model.NewId()
-	u4.Email = model.NewId()
+	u4.Email = MakeEmail()
 	u4.DeleteAt = 0
 	store.Must(ss.User().Save(u4))
 
@@ -1878,12 +1878,12 @@ func testUserStoreSearchWithoutTeam(t *testing.T, ss store.Store) {
 
 	u2 := &model.User{}
 	u2.Username = "jim-bobby" + model.NewId()
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 
 	u3 := &model.User{}
 	u3.Username = "jimbo" + model.NewId()
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	u3.DeleteAt = 1
 	store.Must(ss.User().Save(u3))
 
@@ -1928,7 +1928,7 @@ func testUserStoreSearchWithoutTeam(t *testing.T, ss store.Store) {
 
 func testUserStoreAnalyticsGetInactiveUsersCount(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 
 	var count int64
@@ -1940,7 +1940,7 @@ func testUserStoreAnalyticsGetInactiveUsersCount(t *testing.T, ss store.Store) {
 	}
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.DeleteAt = model.GetMillis()
 	store.Must(ss.User().Save(u2))
 
@@ -1963,12 +1963,12 @@ func testUserStoreAnalyticsGetSystemAdminCount(t *testing.T, ss store.Store) {
 	}
 
 	u1 := model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	u1.Username = model.NewId()
 	u1.Roles = "system_user system_admin"
 
 	u2 := model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	u2.Username = model.NewId()
 
 	if err := (<-ss.User().Save(&u1)).Err; err != nil {
@@ -1993,13 +1993,13 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
 	u1 := &model.User{}
-	u1.Email = model.NewId()
+	u1.Email = MakeEmail()
 	store.Must(ss.User().Save(u1))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 	store.Must(ss.User().UpdateUpdateAt(u1.Id))
 
 	u2 := &model.User{}
-	u2.Email = model.NewId()
+	u2.Email = MakeEmail()
 	store.Must(ss.User().Save(u2))
 	store.Must(ss.User().UpdateUpdateAt(u2.Id))
 
@@ -2105,7 +2105,7 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, ss store.Store) {
 
 	time.Sleep(time.Millisecond * 10)
 	u3 := &model.User{}
-	u3.Email = model.NewId()
+	u3.Email = MakeEmail()
 	store.Must(ss.User().Save(u3))
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 	store.Must(ss.User().UpdateUpdateAt(u3.Id))
@@ -2123,22 +2123,22 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, ss store.Store) {
 
 func testUserStoreClearAllCustomRoleAssignments(t *testing.T, ss store.Store) {
 	u1 := model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 		Roles:    "system_user system_admin system_post_all",
 	}
 	u2 := model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 		Roles:    "system_user custom_role system_admin another_custom_role",
 	}
 	u3 := model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 		Roles:    "system_user",
 	}
 	u4 := model.User{
-		Email:    model.NewId(),
+		Email:    MakeEmail(),
 		Username: model.NewId(),
 		Roles:    "custom_only",
 	}


### PR DESCRIPTION
Actually use the existing validation to test if a user's email field is valid

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11521
https://mattermost.atlassian.net/browse/MM-11522

#### Checklist
- Added or updated unit tests (required for all new features)
