### PR TITLE
MM-11529: Allow to Leave an archived channel from the API

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -1064,11 +1064,6 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Params.UserId != c.Session.UserId {
-		if channel.DeleteAt > 0 {
-			c.Err = model.NewAppError("RemoveUserFromChannel", "api.channel.remove_user_from_channel.deleted.app_error", nil, "", http.StatusBadRequest)
-			return
-		}
-
 		if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS)
 			return

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -1064,6 +1064,11 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Params.UserId != c.Session.UserId {
+		if channel.DeleteAt > 0 {
+			c.Err = model.NewAppError("RemoveUserFromChannel", "api.channel.remove_user_from_channel.deleted.app_error", nil, "", http.StatusBadRequest)
+			return
+		}
+
 		if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(c.Session, channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS)
 			return

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1983,9 +1983,6 @@ func TestRemoveChannelMember(t *testing.T) {
 	deletedChannel.DeleteAt = 1
 	th.App.UpdateChannel(deletedChannel)
 
-	_, resp = Client.RemoveUserFromChannel(deletedChannel.Id, th.BasicUser2.Id)
-	CheckBadRequestStatus(t, resp)
-
 	_, resp = Client.RemoveUserFromChannel(deletedChannel.Id, th.BasicUser.Id)
 	CheckNoError(t, resp)
 

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1974,6 +1974,21 @@ func TestRemoveChannelMember(t *testing.T) {
 	_, resp = th.SystemAdminClient.RemoveUserFromChannel(th.BasicChannel.Id, th.BasicUser.Id)
 	CheckNoError(t, resp)
 
+	// Leave deleted channel
+	th.LoginBasic()
+	deletedChannel := th.CreatePublicChannel()
+	th.App.AddUserToChannel(th.BasicUser, deletedChannel)
+	th.App.AddUserToChannel(th.BasicUser2, deletedChannel)
+
+	deletedChannel.DeleteAt = 1
+	th.App.UpdateChannel(deletedChannel)
+
+	_, resp = Client.RemoveUserFromChannel(deletedChannel.Id, th.BasicUser2.Id)
+	CheckBadRequestStatus(t, resp)
+
+	_, resp = Client.RemoveUserFromChannel(deletedChannel.Id, th.BasicUser.Id)
+	CheckNoError(t, resp)
+
 	th.LoginBasic()
 	private := th.CreatePrivateChannel()
 	th.App.AddUserToChannel(th.BasicUser2, private)

--- a/app/channel.go
+++ b/app/channel.go
@@ -1380,11 +1380,6 @@ func (a *App) postRemoveFromChannelMessage(removerUserId string, removedUser *mo
 }
 
 func (a *App) removeUserFromChannel(userIdToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
-	if channel.DeleteAt > 0 {
-		err := model.NewAppError("RemoveUserFromChannel", "api.channel.remove_user_from_channel.deleted.app_error", nil, "", http.StatusBadRequest)
-		return err
-	}
-
 	if channel.Name == model.DEFAULT_CHANNEL {
 		return model.NewAppError("RemoveUserFromChannel", "api.channel.remove.default.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}, "", http.StatusBadRequest)
 	}
@@ -1449,11 +1444,6 @@ func (a *App) RemoveUserFromChannel(userIdToRemove string, removerUserId string,
 	if userIdToRemove == removerUserId {
 		a.postLeaveChannelMessage(user, channel)
 	} else {
-
-		if err != nil {
-			return err
-		}
-
 		a.Go(func() {
 			a.postRemoveFromChannelMessage(removerUserId, user, channel)
 		})

--- a/app/notification.go
+++ b/app/notification.go
@@ -22,6 +22,11 @@ const (
 )
 
 func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *model.Channel, sender *model.User, parentPostList *model.PostList) ([]string, *model.AppError) {
+	// Do not send notifications in archived channels
+	if channel.DeleteAt > 0 {
+		return []string{}, nil
+	}
+
 	pchan := a.Srv.Store.User().GetAllProfilesInChannel(channel.Id, true)
 	cmnchan := a.Srv.Store.Channel().GetAllChannelMembersNotifyPropsForChannel(channel.Id, true)
 	var fchan store.StoreChannel

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -78,6 +78,11 @@ func TestSendNotifications(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	th.BasicChannel.DeleteAt = 1
+	mentions, err = th.App.SendNotifications(post1, th.BasicTeam, th.BasicChannel, th.BasicUser, nil)
+	assert.Nil(t, err)
+	assert.Len(t, mentions, 0)
 }
 
 func TestGetExplicitMentions(t *testing.T) {


### PR DESCRIPTION
#### Summary
Allow to Leave an archived channel from the API when you are the channel
member. Also avoid any notification outgoing from archive channels
interaction.

#### Ticket Link
[MM-11529](https://mattermost.atlassian.net/browse/MM-11529)

#### Checklist
- [x] Added or updated unit tests (required for all new features)