### PR TITLE
send channel wide push notification type when at-here is used

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -312,7 +312,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 					sender,
 					senderName,
 					mentionedUserIds[id],
-					(channelNotification || allNotification),
+					(channelNotification || hereNotification || allNotification),
 					replyToThreadType,
 				)
 			}


### PR DESCRIPTION
#### Summary
Push notification is sent as a channel wide mention when using `at-here`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11545