### PR TITLE
MM-11575: change plugin nil semantics

### DIFF
--- a/app/plugin_deadlock_test.go
+++ b/app/plugin_deadlock_test.go
@@ -45,7 +45,7 @@ func TestPluginDeadlock(t *testing.T) {
 
 			func (p *MyPlugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*model.Post, string) {
 				if _, from_plugin := post.Props["from_plugin"]; from_plugin {
-					return post, ""
+					return nil, ""
 				}
 
 				p.API.CreatePost(&model.Post{
@@ -57,7 +57,7 @@ func TestPluginDeadlock(t *testing.T) {
 					},
 				})
 
-				return post, ""
+				return nil, ""
 			}
 
 			func main() {
@@ -120,7 +120,7 @@ func TestPluginDeadlock(t *testing.T) {
 
 			func (p *MyPlugin) MessageWillBePosted(c *plugin.Context, post *model.Post) (*model.Post, string) {
 				if _, from_plugin := post.Props["from_plugin"]; from_plugin {
-					return post, ""
+					return nil, ""
 				}
 
 				p.API.CreatePost(&model.Post{
@@ -132,7 +132,7 @@ func TestPluginDeadlock(t *testing.T) {
 					},
 				})
 
-				return post, ""
+				return nil, ""
 			}
 
 			func main() {

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -296,7 +296,7 @@ func TestHookMessageHasBeenPosted(t *testing.T) {
 
 	var mockAPI plugintest.API
 	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
-	mockAPI.On("DeleteUser", "message").Return(nil)
+	mockAPI.On("LogDebug", "message").Return(nil)
 
 	SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -313,7 +313,7 @@ func TestHookMessageHasBeenPosted(t *testing.T) {
 		}
 
 		func (p *MyPlugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
-			p.API.DeleteUser(post.Message)
+			p.API.LogDebug(post.Message)
 		}
 
 		func main() {
@@ -386,8 +386,8 @@ func TestHookMessageHasBeenUpdated(t *testing.T) {
 
 	var mockAPI plugintest.API
 	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
-	mockAPI.On("DeleteUser", "message_edited").Return(nil)
-	mockAPI.On("DeleteTeam", "message_").Return(nil)
+	mockAPI.On("LogDebug", "message_edited").Return(nil)
+	mockAPI.On("LogDebug", "message_").Return(nil)
 	SetAppEnvironmentWithPlugins(t,
 		[]string{
 			`
@@ -403,8 +403,8 @@ func TestHookMessageHasBeenUpdated(t *testing.T) {
 		}
 
 		func (p *MyPlugin) MessageHasBeenUpdated(c *plugin.Context, newPost, oldPost *model.Post) {
-			p.API.DeleteUser(newPost.Message)
-			p.API.DeleteTeam(oldPost.Message)
+			p.API.LogDebug(newPost.Message)
+			p.API.LogDebug(oldPost.Message)
 		}
 
 		func main() {
@@ -437,8 +437,8 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 
 		var mockAPI plugintest.API
 		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
-		mockAPI.On("DeleteUser", "testhook.txt").Return(nil)
-		mockAPI.On("DeleteTeam", "inputfile").Return(nil)
+		mockAPI.On("LogDebug", "testhook.txt").Return(nil)
+		mockAPI.On("LogDebug", "inputfile").Return(nil)
 		SetAppEnvironmentWithPlugins(t, []string{
 			`
 			package main
@@ -483,8 +483,8 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 
 		var mockAPI plugintest.API
 		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
-		mockAPI.On("DeleteUser", "testhook.txt").Return(nil)
-		mockAPI.On("DeleteTeam", "inputfile").Return(nil)
+		mockAPI.On("LogDebug", "testhook.txt").Return(nil)
+		mockAPI.On("LogDebug", "inputfile").Return(nil)
 		SetAppEnvironmentWithPlugins(t, []string{
 			`
 			package main
@@ -531,8 +531,8 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 
 		var mockAPI plugintest.API
 		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
-		mockAPI.On("DeleteUser", "testhook.txt").Return(nil)
-		mockAPI.On("DeleteTeam", "inputfile").Return(nil)
+		mockAPI.On("LogDebug", "testhook.txt").Return(nil)
+		mockAPI.On("LogDebug", "inputfile").Return(nil)
 		SetAppEnvironmentWithPlugins(t, []string{
 			`
 			package main
@@ -589,8 +589,8 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 
 		var mockAPI plugintest.API
 		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
-		mockAPI.On("DeleteUser", "testhook.txt").Return(nil)
-		mockAPI.On("DeleteTeam", "inputfile").Return(nil)
+		mockAPI.On("LogDebug", "testhook.txt").Return(nil)
+		mockAPI.On("LogDebug", "inputfile").Return(nil)
 		SetAppEnvironmentWithPlugins(t, []string{
 			`
 			package main
@@ -607,10 +607,10 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 			}
 
 			func (p *MyPlugin) FileWillBeUploaded(c *plugin.Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string) {
-				p.API.DeleteUser(info.Name)
+				p.API.LogDebug(info.Name)
 				var buf bytes.Buffer
 				buf.ReadFrom(file)
-				p.API.DeleteTeam(buf.String())
+				p.API.LogDebug(buf.String())
 
 				outbuf := bytes.NewBufferString("changedtext")
 				io.Copy(output, outbuf)

--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -74,7 +74,7 @@ type Hooks interface {
 	//
 	// To reject a post, return an non-empty string describing why the post was rejected.
 	// To modify the post, return the replacement, non-nil *model.Post and an empty string.
-	// To allow the post, return a nil *model.Post and an empty string.
+	// To allow the post without modification, return a nil *model.Post and an empty string.
 	//
 	// If you don't need to modify or reject posts, use MessageHasBeenPosted instead.
 	//
@@ -132,8 +132,12 @@ type Hooks interface {
 	UserHasLoggedIn(c *Context, user *model.User)
 
 	// FileWillBeUploaded is invoked when a file is uploaded, but before it is committed to backing store.
-	// Read from file to retrieve the body of the uploaded file. You may modify the body of the file by writing to output.
-	// Returned FileInfo will be used instead of input FileInfo. Return nil to reject the file upload and include a text reason as the second argument.
+	// Read from file to retrieve the body of the uploaded file.
+	//
+	// To reject a file upload, return an non-empty string describing why the file was rejected.
+	// To modify the file, write to the output and/or return a non-nil *model.FileInfo, as well as an empty string.
+	// To allow the file without modification, do not write to the output and return a nil *model.FileInfo and an empty string.
+	//
 	// Note that this method will be called for files uploaded by plugins, including the plugin that uploaded the post.
 	// FileInfo.Size will be automatically set properly if you modify the file.
 	FileWillBeUploaded(c *Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string)

--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -71,7 +71,10 @@ type Hooks interface {
 
 	// MessageWillBePosted is invoked when a message is posted by a user before it is committed
 	// to the database. If you also want to act on edited posts, see MessageWillBeUpdated.
-	// Return values should be the modified post or nil if rejected and an explanation for the user.
+	//
+	// To reject a post, return an non-empty string describing why the post was rejected.
+	// To modify the post, return the replacement, non-nil *model.Post and an empty string.
+	// To allow the post, return a nil *model.Post and an empty string.
 	//
 	// If you don't need to modify or reject posts, use MessageHasBeenPosted instead.
 	//


### PR DESCRIPTION
#### Summary
As discussed, this changes the interpretation of the nil return values for `MessageWillBePosted` and `FileWillBeUploaded` to no-op. This has the nice performance improvement of not requiring the plugin to return the data back over net/rpc in the common case of no-oping, and avoids the previous "shoot yourself in the foot" semantics of implementing what appears to be a no-op hook function only to block all posts and/or file uploads.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11575

#### Checklist
- [x] Added or updated unit tests (required for all new features)