### PR TITLE
Ignore link-local addresses in cluster advertisement

### DIFF
--- a/model/utils.go
+++ b/model/utils.go
@@ -263,7 +263,7 @@ func GetServerIpAddress() string {
 	} else {
 		for _, addr := range addrs {
 
-			if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() {
+			if ip, ok := addr.(*net.IPNet); ok && !ip.IP.IsLoopback() && !ip.IP.IsLinkLocalUnicast() && !ip.IP.IsLinkLocalMulticast() {
 				if ip.IP.To4() != nil {
 					return ip.IP.String()
 				}


### PR DESCRIPTION
#### Summary
Ignore link-local class addresses when selecting the IP address to advertise to the cluster.

#### Ticket Link
Requested by Jason Blais via e-mail

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [x] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)