### PR TITLE
MM-9747: Small fixes for attachments import

### DIFF
--- a/api4/file.go
+++ b/api4/file.go
@@ -285,6 +285,7 @@ func getFilePreview(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.Err = err
 		c.Err.StatusCode = http.StatusNotFound
+		return
 	}
 	defer fileReader.Close()
 

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -763,7 +763,7 @@ func (a *App) ImportReply(data *ReplyImportData, post *model.Post, teamId string
 
 	var reply *model.Post
 	for _, r := range replies {
-		if r.Message == *data.Message {
+		if r.Message == *data.Message && r.RootId == post.Id {
 			reply = r
 			break
 		}
@@ -784,7 +784,7 @@ func (a *App) ImportReply(data *ReplyImportData, post *model.Post, teamId string
 		if err != nil {
 			return err
 		}
-		reply.FileIds = fileIds
+		reply.FileIds = append(reply.FileIds, fileIds...)
 	}
 
 	if reply.Id == "" {
@@ -819,6 +819,8 @@ func (a *App) ImportAttachment(data *AttachmentImportData, post *model.Post, tea
 			fmt.Print(err)
 			return nil, fileUploadError
 		}
+
+		a.HandleImages([]string{fileInfo.PreviewPath}, []string{fileInfo.ThumbnailPath}, [][]byte{buf.Bytes()})
 
 		mlog.Info(fmt.Sprintf("uploading file with name %s", file.Name()))
 		return fileInfo, nil
@@ -889,7 +891,7 @@ func (a *App) ImportPost(data *PostImportData, dryRun bool) *model.AppError {
 		if err != nil {
 			return err
 		}
-		post.FileIds = fileIds
+		post.FileIds = append(post.FileIds, fileIds...)
 	}
 
 	if post.Id == "" {

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -1700,6 +1700,60 @@ func TestImportImportPost(t *testing.T) {
 			}
 		}
 	}
+
+	// Update post with replies.
+	data = &PostImportData{
+		Team:     &teamName,
+		Channel:  &channelName,
+		User:     &user2.Username,
+		Message:  ptrStr("Message with reply"),
+		CreateAt: &replyPostTime,
+		Replies: &[]ReplyImportData{{
+			User:     &username,
+			Message:  ptrStr("Message reply"),
+			CreateAt: &replyTime,
+		}},
+	}
+	if err := th.App.ImportPost(data, false); err != nil {
+		t.Fatalf("Expected success.")
+	}
+	AssertAllPostsCount(t, th.App, initialPostCount, 8, team.Id)
+
+	// Create new post with replies based on the previous one.
+	data = &PostImportData{
+		Team:     &teamName,
+		Channel:  &channelName,
+		User:     &user2.Username,
+		Message:  ptrStr("Message with reply 2"),
+		CreateAt: &replyPostTime,
+		Replies: &[]ReplyImportData{{
+			User:     &username,
+			Message:  ptrStr("Message reply"),
+			CreateAt: &replyTime,
+		}},
+	}
+	if err := th.App.ImportPost(data, false); err != nil {
+		t.Fatalf("Expected success.")
+	}
+	AssertAllPostsCount(t, th.App, initialPostCount, 10, team.Id)
+
+	// Create new reply for existing post with replies.
+	data = &PostImportData{
+		Team:     &teamName,
+		Channel:  &channelName,
+		User:     &user2.Username,
+		Message:  ptrStr("Message with reply"),
+		CreateAt: &replyPostTime,
+		Replies: &[]ReplyImportData{{
+			User:     &username,
+			Message:  ptrStr("Message reply 2"),
+			CreateAt: &replyTime,
+		}},
+	}
+	if err := th.App.ImportPost(data, false); err != nil {
+		t.Fatalf("Expected success.")
+	}
+	AssertAllPostsCount(t, th.App, initialPostCount, 11, team.Id)
 }
 
 func TestImportImportDirectChannel(t *testing.T) {


### PR DESCRIPTION
#### Summary
Small fixes for attachments import. Force the thumbnail/preview
generation and follow the "not-destroy" policy appending attachments at
the end of the current existing post/reply. Besides I improved how it
checks for reply posts to update.

#### Ticket Link
[MM-9747](https://mattermost.atlassian.net/browse/MM-9747)