### PR TITLE
Remove global-relay export command from the cli

### DIFF
--- a/cmd/mattermost/commands/message_export.go
+++ b/cmd/mattermost/commands/message_export.go
@@ -44,25 +44,15 @@ var ActianceExportCmd = &cobra.Command{
 	RunE:    buildExportCmdF("actiance"),
 }
 
-var GlobalRelayExportCmd = &cobra.Command{
-	Use:     "global-relay",
-	Short:   "Export data from Mattermost in Global Relay format",
-	Long:    "Export data from Mattermost in Global Relay format",
-	Example: "export global-relay --exportFrom=12345",
-	RunE:    buildExportCmdF("globalrelay"),
-}
-
 func init() {
 	ScheduleExportCmd.Flags().String("format", "actiance", "The format to export data")
 	ScheduleExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
 	ScheduleExportCmd.Flags().Int("timeoutSeconds", -1, "The maximum number of seconds to wait for the job to complete before timing out.")
 	CsvExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
 	ActianceExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
-	GlobalRelayExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
 	MessageExportCmd.AddCommand(ScheduleExportCmd)
 	MessageExportCmd.AddCommand(CsvExportCmd)
 	MessageExportCmd.AddCommand(ActianceExportCmd)
-	MessageExportCmd.AddCommand(GlobalRelayExportCmd)
 	RootCmd.AddCommand(MessageExportCmd)
 }
 


### PR DESCRIPTION
#### Summary
We decide to remove the global relay export command because the behavior
defer from the other commands (csv and actiance export). The expectation
of similar behavior can generate problems to some users, so we prefer to
disable it for now.

#### Ticket Link
[MM-11003](https://mattermost.atlassian.net/browse/MM-11003)