### PR TITLE
try to fix the flaky test - TestHubStopWithMultipleConnections

### DIFF
--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -53,8 +53,10 @@ func TestHubStopWithMultipleConnections(t *testing.T) {
 	defer s.Close()
 
 	th.App.HubStart()
-	registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
-	registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
-	registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
-	th.App.HubStop()
+	wc1 := registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
+	wc2 := registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
+	wc3 := registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
+	defer wc1.Close()
+	defer wc2.Close()
+	defer wc3.Close()
 }


### PR DESCRIPTION
#### Summary
Remove the `th.App.HubStop()` because when the server is shut down it calls the hubstop and adds the close for the WS connections.

with that, I was able to run in my local machine all the time, before most of the test execution failed.
and in the CI it starts passing without the issue we saw in other build/releases (timeout)

Opening this against release-5.2, I opened one for master to test and I ran around 10 builds and the issue did not happen anymore before we saw that very often 

#### Ticket Link
jira: https://mattermost.atlassian.net/browse/MM-11317
