### PR TITLE
Update serverside markdown parser to respect unicode and capitalized links

### DIFF
--- a/utils/markdown/commonmark_test.go
+++ b/utils/markdown/commonmark_test.go
@@ -1000,7 +1000,7 @@ func TestCommonMarkReferenceStrings(t *testing.T) {
 	}
 }
 
-func TestCommonMarkRefernceAutolinks(t *testing.T) {
+func TestCommonMarkReferenceAutolinks(t *testing.T) {
 	// These tests are adapted from the GitHub-flavoured CommonMark extension tests located at
 	// https://github.com/github/cmark/blob/master/test/extensions.txt
 	for name, tc := range map[string]struct {

--- a/utils/markdown/html.go
+++ b/utils/markdown/html.go
@@ -157,7 +157,7 @@ func RenderInlineHTML(inline Inline) (result string) {
 		}
 		result += "</a>"
 	case *Autolink:
-		result += `<a href="` + htmlEscaper.Replace(escapeURL(v.Link)) + `">`
+		result += `<a href="` + htmlEscaper.Replace(escapeURL(v.Destination())) + `">`
 		for _, inline := range v.Children {
 			result += RenderInlineHTML(inline)
 		}


### PR DESCRIPTION
A followup to the previous autolinking PR since there were a few issues with that code and links containing unicode.

@coreyhulen If your autolinking plugin is updated to use the autolinking provided by utils/markdown, this will improve that behaviour

#### Checklist
- Added or updated unit tests (required for all new features)