### PR TITLE
MM-11637: avoid stopping unstarted jobs

### DIFF
--- a/cmd/mattermost/commands/jobserver.go
+++ b/cmd/mattermost/commands/jobserver.go
@@ -41,11 +41,15 @@ func jobserverCmdF(command *cobra.Command, args []string) {
 
 	// Run jobs
 	mlog.Info("Starting Mattermost job server")
+	defer mlog.Info("Stopped Mattermost job server")
+
 	if !noJobs {
 		a.Jobs.StartWorkers()
+		defer a.Jobs.StopWorkers()
 	}
 	if !noSchedule {
 		a.Jobs.StartSchedulers()
+		defer a.Jobs.StopSchedulers()
 	}
 
 	signalChan := make(chan os.Signal, 1)
@@ -54,9 +58,4 @@ func jobserverCmdF(command *cobra.Command, args []string) {
 
 	// Cleanup anything that isn't handled by a defer statement
 	mlog.Info("Stopping Mattermost job server")
-
-	a.Jobs.StopSchedulers()
-	a.Jobs.StopWorkers()
-
-	mlog.Info("Stopped Mattermost job server")
 }

--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -181,9 +181,11 @@ func runServer(configFileLocation string, disableConfigWatch bool, usedPlatform 
 
 	if *a.Config().JobSettings.RunJobs {
 		a.Jobs.StartWorkers()
+		defer a.Jobs.StopWorkers()
 	}
 	if *a.Config().JobSettings.RunScheduler {
 		a.Jobs.StartSchedulers()
+		defer a.Jobs.StopSchedulers()
 	}
 
 	notifyReady()
@@ -200,9 +202,6 @@ func runServer(configFileLocation string, disableConfigWatch bool, usedPlatform 
 	if a.Metrics != nil {
 		a.Metrics.StopServer()
 	}
-
-	a.Jobs.StopSchedulers()
-	a.Jobs.StopWorkers()
 
 	return nil
 }


### PR DESCRIPTION
#### Summary
The new locking primitives in 5.2 around jobs assume the worker/scheduler was actually started, so don't try to stop if not started.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11637

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
