### PR TITLE
MM-11572: Force correct order on messages generated in the bulk

### DIFF
--- a/cmd/mattermost/commands/sampledata.go
+++ b/cmd/mattermost/commands/sampledata.go
@@ -59,6 +59,15 @@ func randomPastTime(seconds int) int64 {
 	return (today.Unix() * 1000) - int64(rand.Intn(seconds*1000))
 }
 
+func sortedRandomDates(size int) []int64 {
+	dates := make([]int64, size)
+	for i := 0; i < size; i++ {
+		dates[i] = randomPastTime(50000)
+	}
+	sort.Slice(dates, func(a, b int) bool { return dates[a] < dates[b] })
+	return dates
+}
+
 func randomEmoji() string {
 	emojis := []string{"+1", "-1", "heart", "blush"}
 	return emojis[rand.Intn(len(emojis))]
@@ -274,8 +283,10 @@ func sampleDataCmdF(command *cobra.Command, args []string) error {
 
 	for team, channels := range teamsAndChannels {
 		for _, channel := range channels {
+			dates := sortedRandomDates(postsPerChannel)
+
 			for i := 0; i < postsPerChannel; i++ {
-				postLine := createPost(team, channel, allUsers)
+				postLine := createPost(team, channel, allUsers, dates[i])
 				encoder.Encode(postLine)
 			}
 		}
@@ -286,8 +297,10 @@ func sampleDataCmdF(command *cobra.Command, args []string) error {
 		user2 := allUsers[rand.Intn(len(allUsers))]
 		channelLine := createDirectChannel([]string{user1, user2})
 		encoder.Encode(channelLine)
+
+		dates := sortedRandomDates(postsPerDirectChannel)
 		for j := 0; j < postsPerDirectChannel; j++ {
-			postLine := createDirectPost([]string{user1, user2})
+			postLine := createDirectPost([]string{user1, user2}, dates[j])
 			encoder.Encode(postLine)
 		}
 	}
@@ -303,8 +316,10 @@ func sampleDataCmdF(command *cobra.Command, args []string) error {
 		}
 		channelLine := createDirectChannel(users)
 		encoder.Encode(channelLine)
+
+		dates := sortedRandomDates(postsPerGroupChannel)
 		for j := 0; j < postsPerGroupChannel; j++ {
-			postLine := createDirectPost(users)
+			postLine := createDirectPost(users, dates[j])
 			encoder.Encode(postLine)
 		}
 	}
@@ -529,9 +544,9 @@ func createChannel(idx int, teamName string) app.LineImportData {
 	}
 }
 
-func createPost(team string, channel string, allUsers []string) app.LineImportData {
+func createPost(team string, channel string, allUsers []string, createAt int64) app.LineImportData {
 	message := randomMessage(allUsers)
-	create_at := randomPastTime(50000)
+	create_at := createAt
 	user := allUsers[rand.Intn(len(allUsers))]
 
 	// Some messages are flagged by an user
@@ -589,9 +604,9 @@ func createDirectChannel(members []string) app.LineImportData {
 	}
 }
 
-func createDirectPost(members []string) app.LineImportData {
+func createDirectPost(members []string, createAt int64) app.LineImportData {
 	message := randomMessage(members)
-	create_at := randomPastTime(50000)
+	create_at := createAt
 	user := members[rand.Intn(len(members))]
 
 	// Some messages are flagged by an user

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4911,6 +4911,10 @@
     "translation": "We could not reset the channel schemes"
   },
   {
+    "id": "store.sql_channel.reset_last_post_at.app_error",
+    "translation": "We could not reset the channel last post at date"
+  },
+  {
     "id": "store.sql_channel.save.archived_channel.app_error",
     "translation": "You can not modify an archived channel"
   },

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1921,3 +1921,11 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() store.StoreChannel {
 		}
 	})
 }
+
+func (s SqlChannelStore) ResetLastPostAt() store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = (SELECT UpdateAt FROM Posts WHERE ChannelId = Channels.Id ORDER BY UpdateAt DESC LIMIT 1);"); err != nil {
+			result.Err = model.NewAppError("SqlChannelStore.ResetLastPostAt", "store.sql_channel.reset_last_post_at.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+	})
+}

--- a/store/store.go
+++ b/store/store.go
@@ -172,6 +172,7 @@ type ChannelStore interface {
 	MigrateChannelMembers(fromChannelId string, fromUserId string) StoreChannel
 	ResetAllChannelSchemes() StoreChannel
 	ClearAllCustomRoleAssignments() StoreChannel
+	ResetLastPostAt() StoreChannel
 }
 
 type ChannelMemberHistoryStore interface {

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -711,6 +711,22 @@ func (_m *ChannelStore) ResetAllChannelSchemes() store.StoreChannel {
 	return r0
 }
 
+// ResetLastPostAt provides a mock function with given fields:
+func (_m *ChannelStore) ResetLastPostAt() store.StoreChannel {
+	ret := _m.Called()
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Restore provides a mock function with given fields: channelId, time
 func (_m *ChannelStore) Restore(channelId string, time int64) store.StoreChannel {
 	ret := _m.Called(channelId, time)


### PR DESCRIPTION
#### Summary
Force correct order on messages generated in the bulk, and at the end of
the import, update the LastPostAt (this is needed because we import replies as part of the original message, so a reply can be anywhere in the time, but the import will be at the same time of the "parent post").

#### Ticket Link
[MM-11572](https://mattermost.atlassian.net/browse/11572)