### PR TITLE
MM-11678: Split the cache for includeDeleted and not includeDeleted memberships requests

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1093,6 +1093,7 @@ func (s SqlChannelStore) GetMember(channelId string, userId string) store.StoreC
 
 func (s SqlChannelStore) InvalidateAllChannelMembersForUser(userId string) {
 	allChannelMembersForUserCache.Remove(userId)
+	allChannelMembersForUserCache.Remove(userId + "_deleted")
 	if s.metrics != nil {
 		s.metrics.IncrementMemCacheInvalidationCounter("All Channel Members for User - Remove by UserId")
 	}
@@ -1164,7 +1165,11 @@ func (s SqlChannelStore) GetMemberForPost(postId string, userId string) store.St
 func (s SqlChannelStore) GetAllChannelMembersForUser(userId string, allowFromCache bool, includeDeleted bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if allowFromCache {
-			if cacheItem, ok := allChannelMembersForUserCache.Get(userId); ok {
+			cache_key := userId
+			if includeDeleted {
+				cache_key += "_deleted"
+			}
+			if cacheItem, ok := allChannelMembersForUserCache.Get(cache_key); ok {
 				if s.metrics != nil {
 					s.metrics.IncrementMemCacheHitCounter("All Channel Members for User")
 				}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1164,11 +1164,11 @@ func (s SqlChannelStore) GetMemberForPost(postId string, userId string) store.St
 
 func (s SqlChannelStore) GetAllChannelMembersForUser(userId string, allowFromCache bool, includeDeleted bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		cache_key := userId
+		if includeDeleted {
+			cache_key += "_deleted"
+		}
 		if allowFromCache {
-			cache_key := userId
-			if includeDeleted {
-				cache_key += "_deleted"
-			}
 			if cacheItem, ok := allChannelMembersForUserCache.Get(cache_key); ok {
 				if s.metrics != nil {
 					s.metrics.IncrementMemCacheHitCounter("All Channel Members for User")
@@ -1218,7 +1218,7 @@ func (s SqlChannelStore) GetAllChannelMembersForUser(userId string, allowFromCac
 		result.Data = ids
 
 		if allowFromCache {
-			allChannelMembersForUserCache.AddWithExpiresInSecs(userId, ids, ALL_CHANNEL_MEMBERS_FOR_USER_CACHE_SEC)
+			allChannelMembersForUserCache.AddWithExpiresInSecs(cache_key, ids, ALL_CHANNEL_MEMBERS_FOR_USER_CACHE_SEC)
 		}
 	})
 }


### PR DESCRIPTION
#### Summary
The problem was that the method was caching without taking care that
some times may be asked for the memberships with the deleted channels
and sometimes not. If we share the cache there, there will be
inconsistencies.

#### Ticket Link
[MM-11678](https://mattermost.atlassian.net/browse/11678)