### PR TITLE
MM-11707: Removes edit_others_posts permission from the team_admin ro…

### DIFF
--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -587,7 +587,7 @@ func TestUpdatePost(t *testing.T) {
 	Client.Logout()
 
 	_, resp = th.SystemAdminClient.UpdatePost(rpost.Id, rpost)
-	CheckNoError(t, resp)
+	CheckForbiddenStatus(t, resp)
 }
 
 func TestPatchPost(t *testing.T) {
@@ -672,7 +672,7 @@ func TestPatchPost(t *testing.T) {
 
 	th.LoginTeamAdmin()
 	_, resp = Client.PatchPost(post.Id, patch)
-	CheckNoError(t, resp)
+	CheckForbiddenStatus(t, resp)
 
 	_, resp = th.SystemAdminClient.PatchPost(post.Id, patch)
 	CheckNoError(t, resp)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -314,7 +314,6 @@ func TestDoAdvancedPermissionsMigration(t *testing.T) {
 			model.PERMISSION_CREATE_POST_PUBLIC.Id,
 		},
 		"team_admin": []string{
-			model.PERMISSION_EDIT_OTHERS_POSTS.Id,
 			model.PERMISSION_REMOVE_USER_FROM_TEAM.Id,
 			model.PERMISSION_MANAGE_TEAM.Id,
 			model.PERMISSION_IMPORT_TEAM.Id,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -152,7 +152,6 @@ func TestDoAdvancedPermissionsMigration(t *testing.T) {
 			model.PERMISSION_CREATE_POST_PUBLIC.Id,
 		},
 		"team_admin": []string{
-			model.PERMISSION_EDIT_OTHERS_POSTS.Id,
 			model.PERMISSION_REMOVE_USER_FROM_TEAM.Id,
 			model.PERMISSION_MANAGE_TEAM.Id,
 			model.PERMISSION_IMPORT_TEAM.Id,
@@ -549,7 +548,6 @@ func TestDoEmojisPermissionsMigration(t *testing.T) {
 	role2, err2 := th.App.GetRoleByName(model.TEAM_ADMIN_ROLE_ID)
 	assert.Nil(t, err2)
 	expected2 := []string{
-		model.PERMISSION_EDIT_OTHERS_POSTS.Id,
 		model.PERMISSION_REMOVE_USER_FROM_TEAM.Id,
 		model.PERMISSION_MANAGE_TEAM.Id,
 		model.PERMISSION_IMPORT_TEAM.Id,

--- a/model/role.go
+++ b/model/role.go
@@ -243,7 +243,6 @@ func MakeDefaultRoles() map[string]*Role {
 		DisplayName: "authentication.roles.team_admin.name",
 		Description: "authentication.roles.team_admin.description",
 		Permissions: []string{
-			PERMISSION_EDIT_OTHERS_POSTS.Id,
 			PERMISSION_REMOVE_USER_FROM_TEAM.Id,
 			PERMISSION_MANAGE_TEAM.Id,
 			PERMISSION_IMPORT_TEAM.Id,

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -27,7 +27,6 @@ func createDefaultRoles(t *testing.T, ss store.Store) {
 		Name:        model.TEAM_ADMIN_ROLE_ID,
 		DisplayName: model.TEAM_ADMIN_ROLE_ID,
 		Permissions: []string{
-			model.PERMISSION_EDIT_OTHERS_POSTS.Id,
 			model.PERMISSION_DELETE_OTHERS_POSTS.Id,
 		},
 	})


### PR DESCRIPTION
…le in MakeDefaultRoles().

#### Summary
Removes `edit_others_posts` permissions from the default permissions of new installs.

#### Ticket Link
Part of [MM-11707](https://mattermost.atlassian.net/browse/MM-11707) (minus the migration).

#### Checklist

- [ ] Added or updated unit tests (required for all new features)