### PR TITLE
Add PostId to PostActionIntegrationRequest

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -869,6 +869,7 @@ func (a *App) DoPostAction(postId string, actionId string, userId string) *model
 
 	request := &model.PostActionIntegrationRequest{
 		UserId:  userId,
+		PostId:  postId,
 		Context: action.Integration.Context,
 	}
 

--- a/model/post.go
+++ b/model/post.go
@@ -121,6 +121,7 @@ type PostActionIntegration struct {
 
 type PostActionIntegrationRequest struct {
 	UserId  string          `json:"user_id"`
+	PostId  string          `json:"post_id"`
 	Context StringInterface `json:"context,omitempty"`
 }
 


### PR DESCRIPTION
#### Summary
This PR adds a `PostId` field to `model.PostActionIntegrationRequest`. This plugins to e.g. delete the post, when a action button is pressed.

#### Ticket Link
See [discussion on pre-release](https://pre-release.mattermost.com/core/pl/j5nauysw9fn4mp8ce6gmdfyi1e)
