### PR TITLE
MM-11782: Make archived channels experimental and off-by-default.

### DIFF
--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1273,6 +1273,16 @@ func TestGetPostThread(t *testing.T) {
 func TestSearchPosts(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
+	experimentalViewArchivedChannels := *th.App.Config().TeamSettings.ExperimentalViewArchivedChannels
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.TeamSettings.ExperimentalViewArchivedChannels = &experimentalViewArchivedChannels
+		})
+	}()
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.TeamSettings.ExperimentalViewArchivedChannels = true
+	})
+
 	th.LoginBasic()
 	Client := th.Client
 
@@ -1313,6 +1323,16 @@ func TestSearchPosts(t *testing.T) {
 	posts, resp = Client.SearchPostsIncludeDeletedChannels(th.BasicTeam.Id, "#hashtag", false)
 	CheckNoError(t, resp)
 	if len(posts.Order) != 2 {
+		t.Fatal("wrong search")
+	}
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.TeamSettings.ExperimentalViewArchivedChannels = false
+	})
+	
+	posts, resp = Client.SearchPostsIncludeDeletedChannels(th.BasicTeam.Id, "#hashtag", false)
+	CheckNoError(t, resp)
+	if len(posts.Order) != 1 {
 		t.Fatal("wrong search")
 	}
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -1498,7 +1498,7 @@ func (a *App) UpdateChannelLastViewedAt(channelIds []string, userId string) *mod
 }
 
 func (a *App) AutocompleteChannels(teamId string, term string) (*model.ChannelList, *model.AppError) {
-	includeDeleted := *a.Config().TeamSettings.ViewArchivedChannels
+	includeDeleted := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
 	if result := <-a.Srv.Store.Channel().AutocompleteInTeam(teamId, term, includeDeleted); result.Err != nil {
 		return nil, result.Err
@@ -1508,7 +1508,7 @@ func (a *App) AutocompleteChannels(teamId string, term string) (*model.ChannelLi
 }
 
 func (a *App) SearchChannels(teamId string, term string) (*model.ChannelList, *model.AppError) {
-	includeDeleted := *a.Config().TeamSettings.ViewArchivedChannels
+	includeDeleted := *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
 	if result := <-a.Srv.Store.Channel().SearchInTeam(teamId, term, includeDeleted); result.Err != nil {
 		return nil, result.Err

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -278,7 +278,7 @@ func (a *App) trackConfig() {
 		"max_users_per_team":                        *cfg.TeamSettings.MaxUsersPerTeam,
 		"max_channels_per_team":                     *cfg.TeamSettings.MaxChannelsPerTeam,
 		"teammate_name_display":                     *cfg.TeamSettings.TeammateNameDisplay,
-		"view_archived_channels":                    *cfg.TeamSettings.ViewArchivedChannels,
+		"experimental_view_archived_channels":       *cfg.TeamSettings.ExperimentalViewArchivedChannels,
 		"isdefault_site_name":                       isDefault(cfg.TeamSettings.SiteName, "Mattermost"),
 		"isdefault_custom_brand_text":               isDefault(*cfg.TeamSettings.CustomBrandText, model.TEAM_SETTINGS_DEFAULT_CUSTOM_BRAND_TEXT),
 		"isdefault_custom_description_text":         isDefault(*cfg.TeamSettings.CustomDescriptionText, model.TEAM_SETTINGS_DEFAULT_CUSTOM_DESCRIPTION_TEXT),

--- a/app/post.go
+++ b/app/post.go
@@ -648,7 +648,7 @@ func (a *App) DeletePostFiles(post *model.Post) {
 
 func (a *App) SearchPostsInTeam(terms string, userId string, teamId string, isOrSearch bool, includeDeletedChannels bool) (*model.PostSearchResults, *model.AppError) {
 	paramsList := model.ParseSearchParams(terms)
-	includeDeleted := includeDeletedChannels && *a.Config().TeamSettings.ViewArchivedChannels
+	includeDeleted := includeDeletedChannels && *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
 	esInterface := a.Elasticsearch
 	if license := a.License(); esInterface != nil && *a.Config().ElasticsearchSettings.EnableSearching && license != nil && *license.Features.Elasticsearch {

--- a/config/default.json
+++ b/config/default.json
@@ -101,7 +101,7 @@
         "MaxNotificationsPerChannel": 1000,
         "EnableConfirmNotificationsToChannel": true,
         "TeammateNameDisplay": "username",
-        "ViewArchivedChannels": true,
+        "ExperimentalViewArchivedChannels": false,
         "ExperimentalEnableAutomaticReplies": false,
         "ExperimentalHideTownSquareinLHS": false,
         "ExperimentalTownSquareIsReadOnly": false,

--- a/model/config.go
+++ b/model/config.go
@@ -1125,7 +1125,7 @@ type TeamSettings struct {
 	MaxNotificationsPerChannel          *int64
 	EnableConfirmNotificationsToChannel *bool
 	TeammateNameDisplay                 *string
-	ViewArchivedChannels                *bool
+	ExperimentalViewArchivedChannels    *bool
 	ExperimentalEnableAutomaticReplies  *bool
 	ExperimentalHideTownSquareinLHS     *bool
 	ExperimentalTownSquareIsReadOnly    *bool
@@ -1255,8 +1255,8 @@ func (s *TeamSettings) SetDefaults() {
 		s.EnableUserCreation = NewBool(true)
 	}
 
-	if s.ViewArchivedChannels == nil {
-		s.ViewArchivedChannels = NewBool(true)
+	if s.ExperimentalViewArchivedChannels == nil {
+		s.ExperimentalViewArchivedChannels = NewBool(false)
 	}
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -506,7 +506,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["EnableXToLeaveChannelsFromLHS"] = strconv.FormatBool(*c.TeamSettings.EnableXToLeaveChannelsFromLHS)
 	props["TeammateNameDisplay"] = *c.TeamSettings.TeammateNameDisplay
 	props["ExperimentalPrimaryTeam"] = *c.TeamSettings.ExperimentalPrimaryTeam
-	props["ViewArchivedChannels"] = strconv.FormatBool(*c.TeamSettings.ViewArchivedChannels)
+	props["ExperimentalViewArchivedChannels"] = strconv.FormatBool(*c.TeamSettings.ExperimentalViewArchivedChannels)
 
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(c.ServiceSettings.EnableOAuthServiceProvider)
 	props["GoogleDeveloperKey"] = c.ServiceSettings.GoogleDeveloperKey


### PR DESCRIPTION
#### Summary
Change View Archive Channels to a new config setting that's off by default.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11782

Webapp Changes: https://github.com/mattermost/mattermost-webapp/pull/1598