### PR TITLE
MM-8477 Support for interactive menus in message attachments

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -513,7 +513,12 @@ func doPostAction(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := c.App.DoPostAction(c.Params.PostId, c.Params.ActionId, c.Session.UserId); err != nil {
+	actionRequest := model.DoPostActionRequestFromJson(r.Body)
+	if actionRequest == nil {
+		actionRequest = &model.DoPostActionRequest{}
+	}
+
+	if err := c.App.DoPostAction(c.Params.PostId, c.Params.ActionId, c.Session.UserId, actionRequest.SelectedOption); err != nil {
 		c.Err = err
 		return
 	}

--- a/app/post.go
+++ b/app/post.go
@@ -852,7 +852,7 @@ func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) {
 	}
 }
 
-func (a *App) DoPostAction(postId string, actionId string, userId string) *model.AppError {
+func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) *model.AppError {
 	pchan := a.Srv.Store.Post().GetSingle(postId)
 
 	var post *model.Post
@@ -870,7 +870,13 @@ func (a *App) DoPostAction(postId string, actionId string, userId string) *model
 	request := &model.PostActionIntegrationRequest{
 		UserId:  userId,
 		PostId:  postId,
+		Type:    action.Type,
 		Context: action.Integration.Context,
+	}
+
+	if action.Type == model.POST_ACTION_TYPE_SELECT {
+		request.DataSource = action.DataSource
+		request.Context["selected_option"] = selectedOption
 	}
 
 	req, _ := http.NewRequest("POST", action.Integration.URL, strings.NewReader(request.ToJson()))

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -134,6 +134,12 @@ func TestPostAction(t *testing.T) {
 		err := json.NewDecoder(r.Body).Decode(&request)
 		assert.NoError(t, err)
 		assert.Equal(t, request.UserId, th.BasicUser.Id)
+		if request.Type == model.POST_ACTION_TYPE_SELECT {
+			assert.Equal(t, request.DataSource, "some_source")
+			assert.Equal(t, request.Context["selected_option"], "selected")
+		} else {
+			assert.Equal(t, request.DataSource, "")
+		}
 		assert.Equal(t, "foo", request.Context["s"])
 		assert.EqualValues(t, 3, request.Context["n"])
 		fmt.Fprintf(w, `{"update": {"message": "updated"}, "ephemeral_text": "foo"}`)
@@ -158,7 +164,9 @@ func TestPostAction(t *testing.T) {
 								},
 								URL: ts.URL,
 							},
-							Name: "action",
+							Name:       "action",
+							Type:       "some_type",
+							DataSource: "some_source",
 						},
 					},
 				},
@@ -175,11 +183,51 @@ func TestPostAction(t *testing.T) {
 	require.NotEmpty(t, attachments[0].Actions)
 	require.NotEmpty(t, attachments[0].Actions[0].Id)
 
-	err = th.App.DoPostAction(post.Id, "notavalidid", th.BasicUser.Id)
+	menuPost := model.Post{
+		Message:       "Interactive post",
+		ChannelId:     th.BasicChannel.Id,
+		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		UserId:        th.BasicUser.Id,
+		Props: model.StringInterface{
+			"attachments": []*model.SlackAttachment{
+				{
+					Text: "hello",
+					Actions: []*model.PostAction{
+						{
+							Integration: &model.PostActionIntegration{
+								Context: model.StringInterface{
+									"s": "foo",
+									"n": 3,
+								},
+								URL: ts.URL,
+							},
+							Name:       "action",
+							Type:       model.POST_ACTION_TYPE_SELECT,
+							DataSource: "some_source",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	post2, err := th.App.CreatePostAsUser(&menuPost)
+	require.Nil(t, err)
+
+	attachments2, ok := post2.Props["attachments"].([]*model.SlackAttachment)
+	require.True(t, ok)
+
+	require.NotEmpty(t, attachments2[0].Actions)
+	require.NotEmpty(t, attachments2[0].Actions[0].Id)
+
+	err = th.App.DoPostAction(post.Id, "notavalidid", th.BasicUser.Id, "")
 	require.NotNil(t, err)
 	assert.Equal(t, http.StatusNotFound, err.StatusCode)
 
-	err = th.App.DoPostAction(post.Id, attachments[0].Actions[0].Id, th.BasicUser.Id)
+	err = th.App.DoPostAction(post.Id, attachments[0].Actions[0].Id, th.BasicUser.Id, "")
+	require.Nil(t, err)
+
+	err = th.App.DoPostAction(post2.Id, attachments2[0].Actions[0].Id, th.BasicUser.Id, "selected")
 	require.Nil(t, err)
 }
 

--- a/model/post.go
+++ b/model/post.go
@@ -50,6 +50,8 @@ const (
 	PROPS_ADD_CHANNEL_MEMBER    = "add_channel_member"
 	POST_PROPS_ADDED_USER_ID    = "addedUserId"
 	POST_PROPS_DELETE_BY        = "deleteBy"
+	POST_ACTION_TYPE_BUTTON     = "button"
+	POST_ACTION_TYPE_SELECT     = "select"
 )
 
 type Post struct {
@@ -108,10 +110,22 @@ type PostForIndexing struct {
 	ParentCreateAt *int64 `json:"parent_create_at"`
 }
 
+type DoPostActionRequest struct {
+	SelectedOption string `json:"selected_option"`
+}
+
 type PostAction struct {
 	Id          string                 `json:"id"`
 	Name        string                 `json:"name"`
+	Type        string                 `json:"type"`
+	DataSource  string                 `json:"data_source"`
+	Options     []*PostActionOptions   `json:"options"`
 	Integration *PostActionIntegration `json:"integration,omitempty"`
+}
+
+type PostActionOptions struct {
+	Text  string `json:"text"`
+	Value string `json:"value"`
 }
 
 type PostActionIntegration struct {
@@ -120,9 +134,11 @@ type PostActionIntegration struct {
 }
 
 type PostActionIntegrationRequest struct {
-	UserId  string          `json:"user_id"`
-	PostId  string          `json:"post_id"`
-	Context StringInterface `json:"context,omitempty"`
+	UserId     string          `json:"user_id"`
+	PostId     string          `json:"post_id"`
+	Type       string          `json:"type"`
+	DataSource string          `json:"data_source"`
+	Context    StringInterface `json:"context,omitempty"`
 }
 
 type PostActionIntegrationResponse struct {
@@ -453,6 +469,12 @@ func (o *Post) WithRewrittenImageURLs(f func(string) string) *Post {
 func (o *PostEphemeral) ToUnsanitizedJson() string {
 	b, _ := json.Marshal(o)
 	return string(b)
+}
+
+func DoPostActionRequestFromJson(data io.Reader) *DoPostActionRequest {
+	var o *DoPostActionRequest
+	json.NewDecoder(data).Decode(&o)
+	return o
 }
 
 // RewriteImageURLs takes a message and returns a copy that has all of the image URLs replaced


### PR DESCRIPTION
#### Summary
Adds more fields for post actions to support the "select" type in message attachments.

Now a post with this attachment:
```
"attachments": [
    {
      "pretext": "This is the attachment pretext.",
      "text": "Action options",
      "actions": [
        {
          "name": "Select an option...,
          "integration": {
            "url": "http://127.0.0.1:5000/action_users",
            "context": {
              "action": "do_something"
            }
          },
          "type": "select",
          "options": [
          	{
          		"text": "Option1",
          		"value": "opt1"
          	},
          	{
          		"text": "Option2",
          		"value": "opt2"
          	},
          	{
          		"text": "Option3",
          		"value": "opt3"
          	}
          ]
        }
      ]
    }
  ]
```

Will get a POST with the following payload, when a user selects an option:

```
{
	"user_id": "bn5yzq7jmpgz8rszcgxa1dxokh",
	"post_id": "89wkk3u9npbbmrdfowd1wz6pcy",
	"type": "select",
	"data_source": "",
	"context": {
		"action": "do_something",
		"selected_option": "opt3"
	}
}
```

Optionally, a `data_source` field can be supplied as "users" or "channels" instead of supplying manual options.

#### Ticket Link
Server part of https://mattermost.atlassian.net/browse/MM-8477

#### Checklist
- [x] Added or updated unit tests (required for all new features)