### PR TITLE
MM-11506 If no origin header is set for WebSocket, do not fail upgrade when AllowFromCORS is set

### DIFF
--- a/utils/api.go
+++ b/utils/api.go
@@ -19,6 +19,10 @@ import (
 
 func CheckOrigin(r *http.Request, allowedOrigins string) bool {
 	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
 	if allowedOrigins == "*" {
 		return true
 	}


### PR DESCRIPTION
#### Summary
For non-browser clients trying to connect to the WebSocket that don't provide an Origin header, don't fail the WebSocket upgrade when `ServiceSettings.AllowCorsFrom` is non-blank.

Cause: Introduced over a year ago with a security fix to WebSockets for CORS.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11506