### PR TITLE
[MM-11293] Fix Issues detected by Megacheck + New Make Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,14 @@ gofmt: ## Runs gofmt against all packages.
 	done
 	@echo "gofmt success"; \
 
+megacheck: ## Run megacheck on codebasis
+	go get honnef.co/go/tools/cmd/megacheck
+	$(GOPATH)/bin/megacheck $(TE_PACKAGES)
+
+ifeq ($(BUILD_ENTERPRISE_READY),true)
+	$(GOPATH)/bin/megacheck $(EE_PACKAGES) || exit 1
+endif
+
 store-mocks: ## Creates mock files.
 	go get -u github.com/vektra/mockery/...
 	$(GOPATH)/bin/mockery -dir store -all -output store/storetest/mocks -note 'Regenerate this file using `make store-mocks`.'

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -150,8 +150,8 @@ func TestUpdateChannel(t *testing.T) {
 	channel := &model.Channel{DisplayName: "Test API Name", Name: GenerateTestChannelName(), Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	private := &model.Channel{DisplayName: "Test API Name", Name: GenerateTestChannelName(), Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 
-	channel, resp := Client.CreateChannel(channel)
-	private, resp = Client.CreateChannel(private)
+	channel, _ = Client.CreateChannel(channel)
+	private, _ = Client.CreateChannel(private)
 
 	//Update a open channel
 	channel.DisplayName = "My new display name"
@@ -434,7 +434,7 @@ func TestCreateGroupChannel(t *testing.T) {
 		t.Fatal("should be equal")
 	}
 
-	rgc, resp = Client.CreateGroupChannel([]string{user2.Id})
+	_, resp = Client.CreateGroupChannel([]string{user2.Id})
 	CheckBadRequestStatus(t, resp)
 
 	user4 := th.CreateUser()
@@ -541,12 +541,12 @@ func TestGetDeletedChannelsForTeam(t *testing.T) {
 	Client := th.Client
 	team := th.BasicTeam
 
-	channels, resp := Client.GetDeletedChannelsForTeam(team.Id, 0, 100, "")
+	_, resp := Client.GetDeletedChannelsForTeam(team.Id, 0, 100, "")
 	CheckForbiddenStatus(t, resp)
 
 	th.LoginTeamAdmin()
 
-	channels, resp = Client.GetDeletedChannelsForTeam(team.Id, 0, 100, "")
+	channels, resp := Client.GetDeletedChannelsForTeam(team.Id, 0, 100, "")
 	CheckNoError(t, resp)
 	numInitialChannelsForTeam := len(channels)
 
@@ -860,6 +860,7 @@ func TestDeleteChannel(t *testing.T) {
 
 	// successful delete of channel with multiple members
 	publicChannel3 := th.CreatePublicChannel()
+	th.App.AddUserToChannel(user, publicChannel3)
 	th.App.AddUserToChannel(user2, publicChannel3)
 	_, resp = Client.DeleteChannel(publicChannel3.Id)
 	CheckNoError(t, resp)
@@ -901,7 +902,7 @@ func TestDeleteChannel(t *testing.T) {
 	publicChannel5 := th.CreatePublicChannel()
 	Client.Logout()
 
-	Client.Login(user2.Id, user2.Password)
+	Client.Login(user.Id, user.Password)
 	_, resp = Client.DeleteChannel(publicChannel5.Id)
 	CheckUnauthorizedStatus(t, resp)
 
@@ -927,16 +928,14 @@ func TestDeleteChannel(t *testing.T) {
 	th.AddPermissionToRole(model.PERMISSION_DELETE_PRIVATE_CHANNEL.Id, model.TEAM_USER_ROLE_ID)
 
 	Client = th.Client
-	team = th.BasicTeam
 	user = th.BasicUser
-	user2 = th.BasicUser2
 
 	// channels created by SystemAdmin
 	publicChannel6 := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_OPEN)
 	privateChannel7 := th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	th.App.AddUserToChannel(user, publicChannel6)
 	th.App.AddUserToChannel(user, privateChannel7)
-	th.App.AddUserToChannel(user2, privateChannel7)
+	th.App.AddUserToChannel(user, privateChannel7)
 
 	// successful delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -956,7 +955,7 @@ func TestDeleteChannel(t *testing.T) {
 	privateChannel7 = th.CreateChannelWithClient(th.SystemAdminClient, model.CHANNEL_PRIVATE)
 	th.App.AddUserToChannel(user, publicChannel6)
 	th.App.AddUserToChannel(user, privateChannel7)
-	th.App.AddUserToChannel(user2, privateChannel7)
+	th.App.AddUserToChannel(user, privateChannel7)
 
 	// cannot delete by user
 	_, resp = Client.DeleteChannel(publicChannel6.Id)
@@ -1629,7 +1628,7 @@ func TestUpdateChannelRoles(t *testing.T) {
 	CheckNoError(t, resp)
 
 	// System Admin promotes User 1
-	pass, resp = th.SystemAdminClient.UpdateChannelRoles(channel.Id, th.BasicUser.Id, CHANNEL_ADMIN)
+	_, resp = th.SystemAdminClient.UpdateChannelRoles(channel.Id, th.BasicUser.Id, CHANNEL_ADMIN)
 	CheckNoError(t, resp)
 
 	th.LoginBasic()

--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -329,12 +329,16 @@ func TestDeleteEmoji(t *testing.T) {
 
 	th.RemovePermissionFromRole(model.PERMISSION_MANAGE_EMOJIS.Id, model.SYSTEM_USER_ROLE_ID)
 	th.AddPermissionToRole(model.PERMISSION_MANAGE_OTHERS_EMOJIS.Id, model.SYSTEM_USER_ROLE_ID)
+
 	Client.Logout()
 	th.LoginBasic2()
-	ok, resp = Client.DeleteEmoji(newEmoji.Id)
+
+	_, resp = Client.DeleteEmoji(newEmoji.Id)
 	CheckForbiddenStatus(t, resp)
+
 	th.RemovePermissionFromRole(model.PERMISSION_MANAGE_OTHERS_EMOJIS.Id, model.SYSTEM_USER_ROLE_ID)
 	th.AddPermissionToRole(model.PERMISSION_MANAGE_EMOJIS.Id, model.SYSTEM_USER_ROLE_ID)
+
 	Client.Logout()
 	th.LoginBasic()
 
@@ -349,8 +353,10 @@ func TestDeleteEmoji(t *testing.T) {
 
 	Client.Logout()
 	th.LoginBasic2()
-	ok, resp = Client.DeleteEmoji(newEmoji.Id)
+
+	_, resp = Client.DeleteEmoji(newEmoji.Id)
 	CheckForbiddenStatus(t, resp)
+
 	Client.Logout()
 	th.LoginBasic()
 
@@ -365,9 +371,11 @@ func TestDeleteEmoji(t *testing.T) {
 
 	th.AddPermissionToRole(model.PERMISSION_MANAGE_EMOJIS.Id, model.SYSTEM_USER_ROLE_ID)
 	th.AddPermissionToRole(model.PERMISSION_MANAGE_OTHERS_EMOJIS.Id, model.SYSTEM_USER_ROLE_ID)
+
 	Client.Logout()
 	th.LoginBasic2()
-	ok, resp = Client.DeleteEmoji(newEmoji.Id)
+
+	_, resp = Client.DeleteEmoji(newEmoji.Id)
 	CheckNoError(t, resp)
 
 	Client.Logout()
@@ -401,7 +409,8 @@ func TestDeleteEmoji(t *testing.T) {
 
 	Client.Logout()
 	th.LoginBasic2()
-	ok, resp = Client.DeleteEmoji(newEmoji.Id)
+
+	_, resp = Client.DeleteEmoji(newEmoji.Id)
 	CheckNoError(t, resp)
 }
 

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -446,7 +446,7 @@ func TestGetFileLink(t *testing.T) {
 		fileId = fileResp.FileInfos[0].Id
 	}
 
-	link, resp := Client.GetFileLink(fileId)
+	_, resp := Client.GetFileLink(fileId)
 	CheckBadRequestStatus(t, resp)
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
@@ -460,8 +460,9 @@ func TestGetFileLink(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FileSettings.EnablePublicLink = true })
-	link, resp = Client.GetFileLink(fileId)
+	link, resp := Client.GetFileLink(fileId)
 	CheckNoError(t, resp)
+
 	if link == "" {
 		t.Fatal("should've received public link")
 	}

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -65,7 +65,7 @@ func TestCreatePost(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	post2 := &model.Post{ChannelId: th.BasicChannel2.Id, Message: "zz" + model.NewId() + "a", CreateAt: 123}
-	rpost2, resp := Client.CreatePost(post2)
+	rpost2, _ := Client.CreatePost(post2)
 
 	if rpost2.CreateAt == post2.CreateAt {
 		t.Fatal("create at should not match")
@@ -154,7 +154,7 @@ func TestCreatePostEphemeral(t *testing.T) {
 	CheckUnauthorizedStatus(t, resp)
 
 	Client = th.Client
-	rpost, resp = Client.CreatePostEphemeral(ephemeralPost)
+	_, resp = Client.CreatePostEphemeral(ephemeralPost)
 	CheckForbiddenStatus(t, resp)
 }
 
@@ -1023,22 +1023,22 @@ func TestGetFlaggedPostsForUser(t *testing.T) {
 
 	Client.Logout()
 
-	rpl, resp = Client.GetFlaggedPostsForUserInChannel(user.Id, channel1.Id, 0, 10)
+	_, resp = Client.GetFlaggedPostsForUserInChannel(user.Id, channel1.Id, 0, 10)
 	CheckUnauthorizedStatus(t, resp)
 
-	rpl, resp = Client.GetFlaggedPostsForUserInTeam(user.Id, team1.Id, 0, 10)
+	_, resp = Client.GetFlaggedPostsForUserInTeam(user.Id, team1.Id, 0, 10)
 	CheckUnauthorizedStatus(t, resp)
 
-	rpl, resp = Client.GetFlaggedPostsForUser(user.Id, 0, 10)
+	_, resp = Client.GetFlaggedPostsForUser(user.Id, 0, 10)
 	CheckUnauthorizedStatus(t, resp)
 
-	rpl, resp = th.SystemAdminClient.GetFlaggedPostsForUserInChannel(user.Id, channel1.Id, 0, 10)
+	_, resp = th.SystemAdminClient.GetFlaggedPostsForUserInChannel(user.Id, channel1.Id, 0, 10)
 	CheckNoError(t, resp)
 
-	rpl, resp = th.SystemAdminClient.GetFlaggedPostsForUserInTeam(user.Id, team1.Id, 0, 10)
+	_, resp = th.SystemAdminClient.GetFlaggedPostsForUserInTeam(user.Id, team1.Id, 0, 10)
 	CheckNoError(t, resp)
 
-	rpl, resp = th.SystemAdminClient.GetFlaggedPostsForUser(user.Id, 0, 10)
+	_, resp = th.SystemAdminClient.GetFlaggedPostsForUser(user.Id, 0, 10)
 	CheckNoError(t, resp)
 }
 
@@ -1153,25 +1153,25 @@ func TestGetPost(t *testing.T) {
 	Client.RemoveUserFromChannel(th.BasicChannel.Id, th.BasicUser.Id)
 
 	// Channel is public, should be able to read post
-	post, resp = Client.GetPost(th.BasicPost.Id, "")
+	_, resp = Client.GetPost(th.BasicPost.Id, "")
 	CheckNoError(t, resp)
 
 	privatePost := th.CreatePostWithClient(Client, th.BasicPrivateChannel)
 
-	post, resp = Client.GetPost(privatePost.Id, "")
+	_, resp = Client.GetPost(privatePost.Id, "")
 	CheckNoError(t, resp)
 
 	Client.RemoveUserFromChannel(th.BasicPrivateChannel.Id, th.BasicUser.Id)
 
 	// Channel is private, should not be able to read post
-	post, resp = Client.GetPost(privatePost.Id, "")
+	_, resp = Client.GetPost(privatePost.Id, "")
 	CheckForbiddenStatus(t, resp)
 
 	Client.Logout()
 	_, resp = Client.GetPost(model.NewId(), "")
 	CheckUnauthorizedStatus(t, resp)
 
-	post, resp = th.SystemAdminClient.GetPost(th.BasicPost.Id, "")
+	_, resp = th.SystemAdminClient.GetPost(th.BasicPost.Id, "")
 	CheckNoError(t, resp)
 }
 
@@ -1267,7 +1267,7 @@ func TestGetPostThread(t *testing.T) {
 	_, resp = Client.GetPostThread(model.NewId(), "")
 	CheckUnauthorizedStatus(t, resp)
 
-	list, resp = th.SystemAdminClient.GetPostThread(th.BasicPost.Id, "")
+	_, resp = th.SystemAdminClient.GetPostThread(th.BasicPost.Id, "")
 	CheckNoError(t, resp)
 }
 
@@ -1351,12 +1351,13 @@ func TestSearchPosts(t *testing.T) {
 		t.Fatal("wrong search")
 	}
 
-	if posts, resp = Client.SearchPosts(th.BasicTeam.Id, "*", false); len(posts.Order) != 0 {
+	if posts, _ = Client.SearchPosts(th.BasicTeam.Id, "*", false); len(posts.Order) != 0 {
 		t.Fatal("searching for just * shouldn't return any results")
 	}
 
 	posts, resp = Client.SearchPosts(th.BasicTeam.Id, "post1 post2", true)
 	CheckNoError(t, resp)
+
 	if len(posts.Order) != 2 {
 		t.Fatal("wrong search results")
 	}

--- a/api4/preference_test.go
+++ b/api4/preference_test.go
@@ -105,15 +105,15 @@ func TestGetPreferencesByCategory(t *testing.T) {
 		t.Fatalf("received the wrong number of preferences %v:%v", len(prefs), 2)
 	}
 
-	prefs, resp = Client.GetPreferencesByCategory(user1.Id, "junk")
+	_, resp = Client.GetPreferencesByCategory(user1.Id, "junk")
 	CheckNotFoundStatus(t, resp)
 
 	th.LoginBasic2()
 
-	prefs, resp = Client.GetPreferencesByCategory(th.BasicUser2.Id, category)
+	_, resp = Client.GetPreferencesByCategory(th.BasicUser2.Id, category)
 	CheckNotFoundStatus(t, resp)
 
-	prefs, resp = Client.GetPreferencesByCategory(user1.Id, category)
+	_, resp = Client.GetPreferencesByCategory(user1.Id, category)
 	CheckForbiddenStatus(t, resp)
 
 	prefs, resp = Client.GetPreferencesByCategory(th.BasicUser2.Id, "junk")
@@ -309,7 +309,7 @@ func TestDeletePreferences(t *testing.T) {
 
 	th.LoginBasic()
 
-	prefs, resp := Client.GetPreferences(th.BasicUser.Id)
+	prefs, _ := Client.GetPreferences(th.BasicUser.Id)
 	originalCount := len(prefs)
 
 	// save 10 preferences
@@ -328,7 +328,7 @@ func TestDeletePreferences(t *testing.T) {
 	// delete 10 preferences
 	th.LoginBasic2()
 
-	_, resp = Client.DeletePreferences(th.BasicUser2.Id, &preferences)
+	_, resp := Client.DeletePreferences(th.BasicUser2.Id, &preferences)
 	CheckForbiddenStatus(t, resp)
 
 	th.LoginBasic()
@@ -339,7 +339,7 @@ func TestDeletePreferences(t *testing.T) {
 	_, resp = Client.DeletePreferences(th.BasicUser2.Id, &preferences)
 	CheckForbiddenStatus(t, resp)
 
-	prefs, resp = Client.GetPreferences(th.BasicUser.Id)
+	prefs, _ = Client.GetPreferences(th.BasicUser.Id)
 	if len(prefs) != originalCount {
 		t.Fatal("should've deleted preferences")
 	}

--- a/api4/role_test.go
+++ b/api4/role_test.go
@@ -130,7 +130,7 @@ func TestGetRolesByNames(t *testing.T) {
 	assert.Contains(t, received, role3)
 
 	// Check a list of non-existent roles.
-	received, resp = th.Client.GetRolesByNames([]string{model.NewId(), model.NewId()})
+	_, resp = th.Client.GetRolesByNames([]string{model.NewId(), model.NewId()})
 	CheckNoError(t, resp)
 
 	// Empty list should error.
@@ -138,11 +138,11 @@ func TestGetRolesByNames(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	// Invalid role name should error.
-	received, resp = th.Client.GetRolesByNames([]string{model.NewId(), model.NewId(), "!!!!!!"})
+	_, resp = th.Client.GetRolesByNames([]string{model.NewId(), model.NewId(), "!!!!!!"})
 	CheckBadRequestStatus(t, resp)
 
 	// Empty/whitespace rolenames should be ignored.
-	received, resp = th.Client.GetRolesByNames([]string{model.NewId(), model.NewId(), "", "    "})
+	_, resp = th.Client.GetRolesByNames([]string{model.NewId(), model.NewId(), "", "    "})
 	CheckNoError(t, resp)
 }
 
@@ -178,16 +178,16 @@ func TestPatchRole(t *testing.T) {
 	assert.Equal(t, received.SchemeManaged, role.SchemeManaged)
 
 	// Check a no-op patch succeeds.
-	received, resp = th.SystemAdminClient.PatchRole(role.Id, patch)
+	_, resp = th.SystemAdminClient.PatchRole(role.Id, patch)
 	CheckNoError(t, resp)
 
-	received, resp = th.SystemAdminClient.PatchRole("junk", patch)
+	_, resp = th.SystemAdminClient.PatchRole("junk", patch)
 	CheckBadRequestStatus(t, resp)
 
-	received, resp = th.Client.PatchRole(model.NewId(), patch)
+	_, resp = th.Client.PatchRole(model.NewId(), patch)
 	CheckNotFoundStatus(t, resp)
 
-	received, resp = th.Client.PatchRole(role.Id, patch)
+	_, resp = th.Client.PatchRole(role.Id, patch)
 	CheckForbiddenStatus(t, resp)
 
 	// Check a change that the license would not allow.
@@ -195,7 +195,7 @@ func TestPatchRole(t *testing.T) {
 		Permissions: &[]string{"manage_system", "manage_webhooks"},
 	}
 
-	received, resp = th.SystemAdminClient.PatchRole(role.Id, patch)
+	_, resp = th.SystemAdminClient.PatchRole(role.Id, patch)
 	CheckNotImplementedStatus(t, resp)
 
 	// Add a license.

--- a/api4/status_test.go
+++ b/api4/status_test.go
@@ -150,11 +150,11 @@ func TestUpdateUserStatus(t *testing.T) {
 	}
 
 	toUpdateUserStatus.Status = "online"
-	updateUserStatus, resp = Client.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
+	_, resp = Client.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
 	CheckForbiddenStatus(t, resp)
 
 	toUpdateUserStatus.Status = "online"
-	updateUserStatus, resp = th.SystemAdminClient.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
+	updateUserStatus, _ = th.SystemAdminClient.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
 	if updateUserStatus.Status != "online" {
 		t.Fatal("Should return online status")
 	}

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -858,10 +858,10 @@ func TestSearchAllTeams(t *testing.T) {
 
 	Client.Logout()
 
-	rteams, resp = Client.SearchTeams(&model.TeamSearch{Term: pTeam.Name})
+	_, resp = Client.SearchTeams(&model.TeamSearch{Term: pTeam.Name})
 	CheckUnauthorizedStatus(t, resp)
 
-	rteams, resp = Client.SearchTeams(&model.TeamSearch{Term: pTeam.DisplayName})
+	_, resp = Client.SearchTeams(&model.TeamSearch{Term: pTeam.DisplayName})
 	CheckUnauthorizedStatus(t, resp)
 }
 
@@ -1148,10 +1148,10 @@ func TestGetTeamMembers(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	Client.Logout()
-	rmembers, resp = Client.GetTeamMembers(team.Id, 0, 1, "")
+	_, resp = Client.GetTeamMembers(team.Id, 0, 1, "")
 	CheckUnauthorizedStatus(t, resp)
 
-	rmembers, resp = th.SystemAdminClient.GetTeamMembers(team.Id, 0, 100, "")
+	_, resp = th.SystemAdminClient.GetTeamMembers(team.Id, 0, 100, "")
 	CheckNoError(t, resp)
 }
 
@@ -1220,10 +1220,10 @@ func TestGetTeamMembersByIds(t *testing.T) {
 		t.Fatal("1 user should be returned")
 	}
 
-	tm1, resp = Client.GetTeamMembersByIds("junk", []string{th.BasicUser.Id})
+	_, resp = Client.GetTeamMembersByIds("junk", []string{th.BasicUser.Id})
 	CheckBadRequestStatus(t, resp)
 
-	tm1, resp = Client.GetTeamMembersByIds(model.NewId(), []string{th.BasicUser.Id})
+	_, resp = Client.GetTeamMembersByIds(model.NewId(), []string{th.BasicUser.Id})
 	CheckForbiddenStatus(t, resp)
 
 	Client.Logout()
@@ -1244,7 +1244,7 @@ func TestAddTeamMember(t *testing.T) {
 
 	// Regular user can't add a member to a team they don't belong to.
 	th.LoginBasic2()
-	tm, resp := Client.AddTeamMember(team.Id, otherUser.Id)
+	_, resp := Client.AddTeamMember(team.Id, otherUser.Id)
 	CheckForbiddenStatus(t, resp)
 	if resp.Error == nil {
 		t.Fatalf("Error is nil")
@@ -1253,7 +1253,7 @@ func TestAddTeamMember(t *testing.T) {
 
 	// Regular user can add a member to a team they belong to.
 	th.LoginBasic()
-	tm, resp = Client.AddTeamMember(team.Id, otherUser.Id)
+	tm, resp := Client.AddTeamMember(team.Id, otherUser.Id)
 	CheckNoError(t, resp)
 	CheckCreatedStatus(t, resp)
 
@@ -1370,7 +1370,7 @@ func TestAddTeamMember(t *testing.T) {
 	token.CreateAt = model.GetMillis() - 1000*60*60*50
 	<-th.App.Srv.Store.Token().Save(token)
 
-	tm, resp = Client.AddTeamMemberFromInvite(token.Token, "")
+	_, resp = Client.AddTeamMemberFromInvite(token.Token, "")
 	CheckBadRequestStatus(t, resp)
 	th.App.DeleteToken(token)
 
@@ -1382,7 +1382,7 @@ func TestAddTeamMember(t *testing.T) {
 	)
 	<-th.App.Srv.Store.Token().Save(token)
 
-	tm, resp = Client.AddTeamMemberFromInvite(token.Token, "")
+	_, resp = Client.AddTeamMemberFromInvite(token.Token, "")
 	CheckNotFoundStatus(t, resp)
 	th.App.DeleteToken(token)
 
@@ -1428,13 +1428,13 @@ func TestAddTeamMembers(t *testing.T) {
 
 	// Regular user can't add a member to a team they don't belong to.
 	th.LoginBasic2()
-	tm, resp := Client.AddTeamMembers(team.Id, userList)
+	_, resp := Client.AddTeamMembers(team.Id, userList)
 	CheckForbiddenStatus(t, resp)
 	Client.Logout()
 
 	// Regular user can add a member to a team they belong to.
 	th.LoginBasic()
-	tm, resp = Client.AddTeamMembers(team.Id, userList)
+	tm, resp := Client.AddTeamMembers(team.Id, userList)
 	CheckNoError(t, resp)
 	CheckCreatedStatus(t, resp)
 
@@ -2018,7 +2018,7 @@ func TestGetTeamInviteInfo(t *testing.T) {
 	team, resp = th.SystemAdminClient.UpdateTeam(team)
 	CheckNoError(t, resp)
 
-	team, resp = Client.GetTeamInviteInfo(team.InviteId)
+	_, resp = Client.GetTeamInviteInfo(team.InviteId)
 	CheckNoError(t, resp)
 
 	_, resp = Client.GetTeamInviteInfo("junk")

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -406,7 +406,7 @@ func TestGetUser(t *testing.T) {
 	CheckUnauthorizedStatus(t, resp)
 
 	// System admins should ignore privacy settings
-	ruser, resp = th.SystemAdminClient.GetUser(user.Id, resp.Etag)
+	ruser, _ = th.SystemAdminClient.GetUser(user.Id, resp.Etag)
 	if ruser.Email == "" {
 		t.Fatal("email should not be blank")
 	}
@@ -474,7 +474,7 @@ func TestGetUserByUsername(t *testing.T) {
 	CheckUnauthorizedStatus(t, resp)
 
 	// System admins should ignore privacy settings
-	ruser, resp = th.SystemAdminClient.GetUserByUsername(user.Username, resp.Etag)
+	ruser, _ = th.SystemAdminClient.GetUserByUsername(user.Username, resp.Etag)
 	if ruser.Email == "" {
 		t.Fatal("email should not be blank")
 	}
@@ -539,7 +539,7 @@ func TestGetUserByEmail(t *testing.T) {
 	CheckUnauthorizedStatus(t, resp)
 
 	// System admins should ignore privacy settings
-	ruser, resp = th.SystemAdminClient.GetUserByEmail(user.Email, resp.Etag)
+	ruser, _ = th.SystemAdminClient.GetUserByEmail(user.Email, resp.Etag)
 	if ruser.Email == "" {
 		t.Fatal("email should not be blank")
 	}
@@ -2208,14 +2208,14 @@ func TestVerifyUserEmail(t *testing.T) {
 
 	user := model.User{Email: th.GenerateTestEmail(), Nickname: "Darth Vader", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID}
 
-	ruser, resp := Client.CreateUser(&user)
+	ruser, _ := Client.CreateUser(&user)
 
 	token, err := th.App.CreateVerifyEmailToken(ruser.Id)
 	if err != nil {
 		t.Fatal("Unable to create email verify token")
 	}
 
-	_, resp = Client.VerifyUserEmail(token.Token)
+	_, resp := Client.VerifyUserEmail(token.Token)
 	CheckNoError(t, resp)
 
 	_, resp = Client.VerifyUserEmail(GenerateTestId())
@@ -2329,7 +2329,7 @@ func TestCBALogin(t *testing.T) {
 	}
 
 	Client.HttpHeader["X-SSL-Client-Cert-Subject-DN"] = "C=US, ST=Maryland, L=Pasadena, O=Brent Baccala, OU=FreeSoft, CN=www.freesoft.org/emailAddress=" + th.BasicUser.Email
-	user, resp = Client.Login(th.BasicUser.Email, "")
+	user, _ = Client.Login(th.BasicUser.Email, "")
 	if !(user != nil && user.Email == th.BasicUser.Email) {
 		t.Fatal("Should have been able to login")
 	}
@@ -2340,13 +2340,13 @@ func TestCBALogin(t *testing.T) {
 	})
 
 	Client.HttpHeader["X-SSL-Client-Cert-Subject-DN"] = "C=US, ST=Maryland, L=Pasadena, O=Brent Baccala, OU=FreeSoft, CN=www.freesoft.org/emailAddress=" + th.BasicUser.Email
-	user, resp = Client.Login(th.BasicUser.Email, "")
+	user, _ = Client.Login(th.BasicUser.Email, "")
 	if resp.Error.StatusCode != 400 && user == nil {
 		t.Fatal("Should have failed because password is required")
 	}
 
 	Client.HttpHeader["X-SSL-Client-Cert-Subject-DN"] = "C=US, ST=Maryland, L=Pasadena, O=Brent Baccala, OU=FreeSoft, CN=www.freesoft.org/emailAddress=" + th.BasicUser.Email
-	user, resp = Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+	user, _ = Client.Login(th.BasicUser.Email, th.BasicUser.Password)
 	if !(user != nil && user.Email == th.BasicUser.Email) {
 		t.Fatal("Should have been able to login")
 	}
@@ -2597,7 +2597,7 @@ func TestGetUserAccessToken(t *testing.T) {
 	_, resp = AdminClient.GetUserAccessToken(token.Id)
 	CheckNoError(t, resp)
 
-	token, resp = Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
+	_, resp = Client.CreateUserAccessToken(th.BasicUser.Id, testDescription)
 	CheckNoError(t, resp)
 
 	rtokens, resp := Client.GetUserAccessTokensForUser(th.BasicUser.Id, 0, 100)

--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -365,7 +365,7 @@ func TestGetOutgoingWebhooks(t *testing.T) {
 		t.Fatal("missing hook")
 	}
 
-	hooks, resp = th.SystemAdminClient.GetOutgoingWebhooksForChannel(model.NewId(), 0, 1000, "")
+	_, resp = th.SystemAdminClient.GetOutgoingWebhooksForChannel(model.NewId(), 0, 1000, "")
 	CheckForbiddenStatus(t, resp)
 
 	_, resp = Client.GetOutgoingWebhooks(0, 1000, "")

--- a/app/app.go
+++ b/app/app.go
@@ -642,7 +642,6 @@ func (a *App) DoEmojisPermissionsMigration() {
 			mlog.Critical(err.Error())
 			return
 		}
-		break
 	case model.RESTRICT_EMOJI_CREATION_ADMIN:
 		role, err = a.GetRoleByName(model.TEAM_ADMIN_ROLE_ID)
 		if err != nil {
@@ -650,10 +649,8 @@ func (a *App) DoEmojisPermissionsMigration() {
 			mlog.Critical(err.Error())
 			return
 		}
-		break
 	case model.RESTRICT_EMOJI_CREATION_SYSTEM_ADMIN:
 		role = nil
-		break
 	default:
 		mlog.Critical("Failed to migrate emojis creation permissions from mattermost config.")
 		mlog.Critical("Invalid restrict emoji creation setting")
@@ -703,13 +700,13 @@ func (a *App) StartElasticsearch() {
 	})
 
 	a.AddConfigListener(func(oldConfig *model.Config, newConfig *model.Config) {
-		if *oldConfig.ElasticsearchSettings.EnableIndexing == false && *newConfig.ElasticsearchSettings.EnableIndexing == true {
+		if !*oldConfig.ElasticsearchSettings.EnableIndexing && *newConfig.ElasticsearchSettings.EnableIndexing {
 			a.Go(func() {
 				if err := a.Elasticsearch.Start(); err != nil {
 					mlog.Error(err.Error())
 				}
 			})
-		} else if *oldConfig.ElasticsearchSettings.EnableIndexing == true && *newConfig.ElasticsearchSettings.EnableIndexing == false {
+		} else if *oldConfig.ElasticsearchSettings.EnableIndexing && !*newConfig.ElasticsearchSettings.EnableIndexing {
 			a.Go(func() {
 				if err := a.Elasticsearch.Stop(); err != nil {
 					mlog.Error(err.Error())
@@ -717,7 +714,7 @@ func (a *App) StartElasticsearch() {
 			})
 		} else if *oldConfig.ElasticsearchSettings.Password != *newConfig.ElasticsearchSettings.Password || *oldConfig.ElasticsearchSettings.Username != *newConfig.ElasticsearchSettings.Username || *oldConfig.ElasticsearchSettings.ConnectionUrl != *newConfig.ElasticsearchSettings.ConnectionUrl || *oldConfig.ElasticsearchSettings.Sniff != *newConfig.ElasticsearchSettings.Sniff {
 			a.Go(func() {
-				if *oldConfig.ElasticsearchSettings.EnableIndexing == true {
+				if *oldConfig.ElasticsearchSettings.EnableIndexing {
 					if err := a.Elasticsearch.Stop(); err != nil {
 						mlog.Error(err.Error())
 					}

--- a/app/auto_responder_test.go
+++ b/app/auto_responder_test.go
@@ -94,7 +94,7 @@ func TestSendAutoResponseSuccess(t *testing.T) {
 	userUpdated1, err := th.App.PatchUser(user.Id, patch, true)
 	require.Nil(t, err)
 
-	firstPost, err := th.App.CreatePost(&model.Post{
+	firstPost, _ := th.App.CreatePost(&model.Post{
 		ChannelId: th.BasicChannel.Id,
 		Message:   "zz" + model.NewId() + "a",
 		UserId:    th.BasicUser.Id},
@@ -134,7 +134,7 @@ func TestSendAutoResponseFailure(t *testing.T) {
 	userUpdated1, err := th.App.PatchUser(user.Id, patch, true)
 	require.Nil(t, err)
 
-	firstPost, err := th.App.CreatePost(&model.Post{
+	firstPost, _ := th.App.CreatePost(&model.Post{
 		ChannelId: th.BasicChannel.Id,
 		Message:   "zz" + model.NewId() + "a",
 		UserId:    th.BasicUser.Id},

--- a/app/brand.go
+++ b/app/brand.go
@@ -27,10 +27,10 @@ func (a *App) SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 	}
 
 	file, err := imageData.Open()
-	defer file.Close()
 	if err != nil {
 		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.open.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
+	defer file.Close()
 
 	// Decode image config first to check dimensions before loading the whole thing into memory later on
 	config, _, err := image.DecodeConfig(file)

--- a/app/channel.go
+++ b/app/channel.go
@@ -52,7 +52,7 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 	} else {
 		seenChannels := map[string]bool{}
 		for _, channelName := range a.Config().TeamSettings.ExperimentalDefaultChannels {
-			if seenChannels[channelName] != true {
+			if !seenChannels[channelName] {
 				defaultChannelList = append(defaultChannelList, channelName)
 				seenChannels[channelName] = true
 			}
@@ -1398,7 +1398,7 @@ func (a *App) removeUserFromChannel(userIdToRemove string, removerUserId string,
 
 		var actorUser *model.User
 		if removerUserId != "" {
-			actorUser, err = a.GetUser(removerUserId)
+			actorUser, _ = a.GetUser(removerUserId)
 		}
 
 		a.Go(func() {

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -122,12 +122,10 @@ func TestEnsureInstallationDate(t *testing.T) {
 			sqlStore := th.App.Srv.Store.User().(*sqlstore.SqlUserStore)
 			sqlStore.GetMaster().Exec("DELETE FROM Users")
 
-			var users []*model.User
 			for _, createAt := range tc.UsersCreationDates {
 				user := th.CreateUser()
 				user.CreateAt = createAt
 				sqlStore.GetMaster().Exec("UPDATE Users SET CreateAt = :CreateAt WHERE Id = :UserId", map[string]interface{}{"CreateAt": createAt, "UserId": user.Id})
-				users = append(users, user)
 			}
 
 			if tc.PrevInstallationDate == nil {

--- a/app/diagnostics_test.go
+++ b/app/diagnostics_test.go
@@ -103,19 +103,13 @@ func TestDiagnostics(t *testing.T) {
 
 		info := ""
 		// Collect the info sent.
+		Loop:
 		for {
-			done := false
 			select {
 			case result := <-data:
 				info += result
 			case <-time.After(time.Second * 1):
-				// Done recieving
-				done = true
-				break
-			}
-
-			if done {
-				break
+				break Loop
 			}
 		}
 

--- a/app/file.go
+++ b/app/file.go
@@ -613,19 +613,18 @@ func (a *App) GetFileInfo(fileId string) (*model.FileInfo, *model.AppError) {
 }
 
 func (a *App) CopyFileInfos(userId string, fileIds []string) ([]string, *model.AppError) {
-	newFileIds := []string{}
+	var newFileIds []string
 
 	now := model.GetMillis()
 
 	for _, fileId := range fileIds {
-		fileInfo := &model.FileInfo{}
+		result := <-a.Srv.Store.FileInfo().Get(fileId)
 
-		if result := <-a.Srv.Store.FileInfo().Get(fileId); result.Err != nil {
+		if result.Err != nil {
 			return nil, result.Err
-		} else {
-			fileInfo = result.Data.(*model.FileInfo)
 		}
 
+		fileInfo := result.Data.(*model.FileInfo)
 		fileInfo.Id = model.NewId()
 		fileInfo.CreatorId = userId
 		fileInfo.CreateAt = now

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -123,9 +123,9 @@ func (a *App) ImportRole(data *RoleImportData, dryRun bool, isSchemeRole bool) *
 	}
 
 	if len(role.Id) == 0 {
-		role, err = a.CreateRole(role)
+		_, err = a.CreateRole(role)
 	} else {
-		role, err = a.UpdateRole(role)
+		_, err = a.UpdateRole(role)
 	}
 
 	return err

--- a/app/notification_email.go
+++ b/app/notification_email.go
@@ -306,7 +306,7 @@ func getFormattedPostTime(user *model.User, post *model.Post, useMilitaryTime bo
 		Year:     fmt.Sprintf("%d", localTime.Year()),
 		Month:    translateFunc(localTime.Month().String()),
 		Day:      fmt.Sprintf("%d", localTime.Day()),
-		Hour:     fmt.Sprintf("%s", hour),
+		Hour:     hour,
 		Minute:   fmt.Sprintf("%02d"+period, localTime.Minute()),
 		TimeZone: zone,
 	}

--- a/app/permissions.go
+++ b/app/permissions.go
@@ -138,11 +138,7 @@ func (a *App) ExportPermissions(w io.Writer) error {
 	schemeExport = append(schemeExport, []byte("\n")...)
 
 	_, err = w.Write(schemeExport)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (a *App) ImportPermissions(jsonl io.Reader) error {

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -89,7 +89,7 @@ func TestHookMessageWillBePosted(t *testing.T) {
 			Message:   "message_",
 			CreateAt:  model.GetMillis() - 10000,
 		}
-		post, err := th.App.CreatePost(post, th.BasicChannel, false)
+		_, err := th.App.CreatePost(post, th.BasicChannel, false)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "Post rejected by plugin. rejected", err.Message)
 		}
@@ -129,7 +129,7 @@ func TestHookMessageWillBePosted(t *testing.T) {
 			Message:   "message_",
 			CreateAt:  model.GetMillis() - 10000,
 		}
-		post, err := th.App.CreatePost(post, th.BasicChannel, false)
+		_, err := th.App.CreatePost(post, th.BasicChannel, false)
 		if assert.NotNil(t, err) {
 			assert.Equal(t, "Post rejected by plugin. rejected", err.Message)
 		}
@@ -327,7 +327,7 @@ func TestHookMessageHasBeenPosted(t *testing.T) {
 		Message:   "message",
 		CreateAt:  model.GetMillis() - 10000,
 	}
-	post, err := th.App.CreatePost(post, th.BasicChannel, false)
+	_, err := th.App.CreatePost(post, th.BasicChannel, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -424,7 +424,7 @@ func TestHookMessageHasBeenUpdated(t *testing.T) {
 	}
 	assert.Equal(t, "message_", post.Message)
 	post.Message = post.Message + "edited"
-	post, err = th.App.UpdatePost(post, true)
+	_, err = th.App.UpdatePost(post, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -785,7 +785,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	user, err = th.App.GetUser(th.BasicUser.Id)
+	user, _ = th.App.GetUser(th.BasicUser.Id)
 
 	if user.FirstName != "plugin-callback-success" {
 		t.Errorf("Expected firstname overwrite, got default")

--- a/app/session_test.go
+++ b/app/session_test.go
@@ -54,8 +54,6 @@ func TestGetSessionIdleTimeoutInMinutes(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, rsession.Id, session.Id)
 
-	rsession, err = th.App.GetSession(session.Token)
-
 	// Test regular session, should timeout
 	time := session.LastActivityAt - (1000 * 60 * 6)
 	<-th.App.Srv.Store.Session().UpdateLastActivityAt(session.Id, time)

--- a/app/team.go
+++ b/app/team.go
@@ -468,7 +468,7 @@ func (a *App) JoinUserToTeam(team *model.Team, user *model.User, userRequestorId
 	if a.PluginsReady() {
 		var actor *model.User
 		if userRequestorId != "" {
-			actor, err = a.GetUser(userRequestorId)
+			actor, _ = a.GetUser(userRequestorId)
 		}
 
 		a.Go(func() {
@@ -798,7 +798,7 @@ func (a *App) LeaveTeam(team *model.Team, user *model.User, requestorId string) 
 	if a.PluginsReady() {
 		var actor *model.User
 		if requestorId != "" {
-			actor, err = a.GetUser(requestorId)
+			actor, _ = a.GetUser(requestorId)
 		}
 
 		a.Go(func() {

--- a/cmd/mattermost/commands/permissions.go
+++ b/cmd/mattermost/commands/permissions.go
@@ -124,9 +124,5 @@ func importPermissionsCmdF(command *cobra.Command, args []string) error {
 	}
 	defer file.Close()
 
-	if err := a.ImportPermissions(file); err != nil {
-		return err
-	}
-
-	return nil
+	return a.ImportPermissions(file)
 }

--- a/cmd/mattermost/commands/permissions_test.go
+++ b/cmd/mattermost/commands/permissions_test.go
@@ -30,7 +30,7 @@ func permissionsLicenseRequiredTest(t *testing.T, subcommand string) {
 		t.Fail()
 	}
 	args := []string{"-test.run", "ExecCommand", "--", "--disableconfigwatch", "permissions", subcommand}
-	output, err := exec.Command(path, args...).CombinedOutput()
+	output, _ := exec.Command(path, args...).CombinedOutput()
 
 	actual := string(output)
 	expected := utils.T("cli.license.critical")

--- a/model/config.go
+++ b/model/config.go
@@ -2370,7 +2370,7 @@ func (ss *ServiceSettings) isValid() *AppError {
 		}
 	}
 
-	host, port, err := net.SplitHostPort(*ss.ListenAddress)
+	host, port, _ := net.SplitHostPort(*ss.ListenAddress)
 	var isValidHost bool
 	if host == "" {
 		isValidHost = true

--- a/model/session_test.go
+++ b/model/session_test.go
@@ -31,7 +31,7 @@ func TestSessionDeepCopy(t *testing.T) {
 	session = &Session{Id: sessionId}
 	copySession = session.DeepCopy()
 
-	assert.Equal(t, sessionId, session.Id)
+	assert.Equal(t, sessionId, copySession.Id)
 
 	session = &Session{TeamMembers: []*TeamMember{}}
 	copySession = session.DeepCopy()

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -52,7 +52,7 @@ func TestUserDeepCopy(t *testing.T) {
 	user = &User{Id: id}
 	copyUser = user.DeepCopy()
 
-	assert.Equal(t, id, user.Id)
+	assert.Equal(t, id, copyUser.Id)
 }
 
 func TestUserJson(t *testing.T) {

--- a/plugin/client_rpc.go
+++ b/plugin/client_rpc.go
@@ -295,7 +295,6 @@ func (g *hooksRPCClient) ServeHTTP(c *Context, w http.ResponseWriter, r *http.Re
 		g.log.Error("Plugin failed to ServeHTTP, RPC call failed", mlog.Err(err))
 		http.Error(w, "500 internal server error", http.StatusInternalServerError)
 	}
-	return
 }
 
 func (s *hooksRPCServer) ServeHTTP(args *Z_ServeHTTPArgs, returns *struct{}) error {

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -209,7 +209,7 @@ func (g *hooksRPCClient) MessageHasBeenPosted(c *Context, post *model.Post) {
 			g.log.Error("RPC call MessageHasBeenPosted to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) MessageHasBeenPosted(args *Z_MessageHasBeenPostedArgs, returns *Z_MessageHasBeenPostedReturns) error {
@@ -244,7 +244,7 @@ func (g *hooksRPCClient) MessageHasBeenUpdated(c *Context, newPost, oldPost *mod
 			g.log.Error("RPC call MessageHasBeenUpdated to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) MessageHasBeenUpdated(args *Z_MessageHasBeenUpdatedArgs, returns *Z_MessageHasBeenUpdatedReturns) error {
@@ -278,7 +278,7 @@ func (g *hooksRPCClient) ChannelHasBeenCreated(c *Context, channel *model.Channe
 			g.log.Error("RPC call ChannelHasBeenCreated to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) ChannelHasBeenCreated(args *Z_ChannelHasBeenCreatedArgs, returns *Z_ChannelHasBeenCreatedReturns) error {
@@ -313,7 +313,7 @@ func (g *hooksRPCClient) UserHasJoinedChannel(c *Context, channelMember *model.C
 			g.log.Error("RPC call UserHasJoinedChannel to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) UserHasJoinedChannel(args *Z_UserHasJoinedChannelArgs, returns *Z_UserHasJoinedChannelReturns) error {
@@ -348,7 +348,7 @@ func (g *hooksRPCClient) UserHasLeftChannel(c *Context, channelMember *model.Cha
 			g.log.Error("RPC call UserHasLeftChannel to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) UserHasLeftChannel(args *Z_UserHasLeftChannelArgs, returns *Z_UserHasLeftChannelReturns) error {
@@ -383,7 +383,7 @@ func (g *hooksRPCClient) UserHasJoinedTeam(c *Context, teamMember *model.TeamMem
 			g.log.Error("RPC call UserHasJoinedTeam to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) UserHasJoinedTeam(args *Z_UserHasJoinedTeamArgs, returns *Z_UserHasJoinedTeamReturns) error {
@@ -418,7 +418,7 @@ func (g *hooksRPCClient) UserHasLeftTeam(c *Context, teamMember *model.TeamMembe
 			g.log.Error("RPC call UserHasLeftTeam to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) UserHasLeftTeam(args *Z_UserHasLeftTeamArgs, returns *Z_UserHasLeftTeamReturns) error {
@@ -487,7 +487,7 @@ func (g *hooksRPCClient) UserHasLoggedIn(c *Context, user *model.User) {
 			g.log.Error("RPC call UserHasLoggedIn to plugin failed.", mlog.Err(err))
 		}
 	}
-	return
+
 }
 
 func (s *hooksRPCServer) UserHasLoggedIn(args *Z_UserHasLoggedInArgs, returns *Z_UserHasLoggedInReturns) error {
@@ -2095,7 +2095,7 @@ func (g *apiRPCClient) PublishWebSocketEvent(event string, payload map[string]in
 	if err := g.client.Call("Plugin.PublishWebSocketEvent", _args, _returns); err != nil {
 		log.Printf("RPC call to PublishWebSocketEvent API failed: %s", err.Error())
 	}
-	return
+
 }
 
 func (s *apiRPCServer) PublishWebSocketEvent(args *Z_PublishWebSocketEventArgs, returns *Z_PublishWebSocketEventReturns) error {
@@ -2212,7 +2212,7 @@ func (g *apiRPCClient) LogDebug(msg string, keyValuePairs ...interface{}) {
 	if err := g.client.Call("Plugin.LogDebug", _args, _returns); err != nil {
 		log.Printf("RPC call to LogDebug API failed: %s", err.Error())
 	}
-	return
+
 }
 
 func (s *apiRPCServer) LogDebug(args *Z_LogDebugArgs, returns *Z_LogDebugReturns) error {
@@ -2240,7 +2240,7 @@ func (g *apiRPCClient) LogInfo(msg string, keyValuePairs ...interface{}) {
 	if err := g.client.Call("Plugin.LogInfo", _args, _returns); err != nil {
 		log.Printf("RPC call to LogInfo API failed: %s", err.Error())
 	}
-	return
+
 }
 
 func (s *apiRPCServer) LogInfo(args *Z_LogInfoArgs, returns *Z_LogInfoReturns) error {
@@ -2268,7 +2268,7 @@ func (g *apiRPCClient) LogError(msg string, keyValuePairs ...interface{}) {
 	if err := g.client.Call("Plugin.LogError", _args, _returns); err != nil {
 		log.Printf("RPC call to LogError API failed: %s", err.Error())
 	}
-	return
+
 }
 
 func (s *apiRPCServer) LogError(args *Z_LogErrorArgs, returns *Z_LogErrorReturns) error {
@@ -2296,7 +2296,7 @@ func (g *apiRPCClient) LogWarn(msg string, keyValuePairs ...interface{}) {
 	if err := g.client.Call("Plugin.LogWarn", _args, _returns); err != nil {
 		log.Printf("RPC call to LogWarn API failed: %s", err.Error())
 	}
-	return
+
 }
 
 func (s *apiRPCServer) LogWarn(args *Z_LogWarnArgs, returns *Z_LogWarnReturns) error {

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -18,7 +18,6 @@ import (
 )
 
 type apiImplCreatorFunc func(*model.Manifest) API
-type supervisorCreatorFunc func(*model.BundleInfo, *mlog.Logger, API) (*supervisor, error)
 
 // multiPluginHookRunnerFunc is a callback function to invoke as part of RunMultiPluginHook.
 //

--- a/plugin/interface_generator/main.go
+++ b/plugin/interface_generator/main.go
@@ -229,7 +229,7 @@ func (g *hooksRPCClient) {{.Name}}{{funcStyle .Params}} {{funcStyle .Return}} {
 			g.log.Error("RPC call {{.Name}} to plugin failed.", mlog.Err(err))
 		}
 	}
-	return {{destruct "_returns." .Return}}
+	{{ if .Return }} return {{destruct "_returns." .Return}} {{ end }}
 }
 
 func (s *hooksRPCServer) {{.Name}}(args *{{.Name | obscure}}Args, returns *{{.Name | obscure}}Returns) error {
@@ -260,7 +260,7 @@ func (g *apiRPCClient) {{.Name}}{{funcStyle .Params}} {{funcStyle .Return}} {
 	if err := g.client.Call("Plugin.{{.Name}}", _args, _returns); err != nil {
 		log.Printf("RPC call to {{.Name}} API failed: %s", err.Error())
 	}
-	return {{destruct "_returns." .Return}}
+	{{ if .Return }} return {{destruct "_returns." .Return}} {{ end }}
 }
 
 func (s *apiRPCServer) {{.Name}}(args *{{.Name | obscure}}Args, returns *{{.Name | obscure}}Returns) error {

--- a/plugin/io_rpc.go
+++ b/plugin/io_rpc.go
@@ -9,19 +9,6 @@ import (
 	"io"
 )
 
-type rwc struct {
-	io.ReadCloser
-	io.WriteCloser
-}
-
-func (rwc *rwc) Close() (err error) {
-	err = rwc.WriteCloser.Close()
-	if rerr := rwc.ReadCloser.Close(); err == nil {
-		err = rerr
-	}
-	return
-}
-
 type remoteIOReader struct {
 	conn io.ReadWriteCloser
 }

--- a/plugin/supervisor.go
+++ b/plugin/supervisor.go
@@ -17,7 +17,6 @@ import (
 )
 
 type supervisor struct {
-	pluginId    string
 	client      *plugin.Client
 	hooks       Hooks
 	implemented [TotalHooksId]bool

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1859,7 +1859,7 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() store.StoreChannel {
 		lastUserId := strings.Repeat("0", 26)
 		lastChannelId := strings.Repeat("0", 26)
 
-		for true {
+		for {
 			var transaction *gorp.Transaction
 			var err error
 

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -851,7 +851,7 @@ func (s SqlTeamStore) ClearAllCustomRoleAssignments() store.StoreChannel {
 		lastUserId := strings.Repeat("0", 26)
 		lastTeamId := strings.Repeat("0", 26)
 
-		for true {
+		for {
 			var transaction *gorp.Transaction
 			var err error
 

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1255,7 +1255,7 @@ func (us SqlUserStore) ClearAllCustomRoleAssignments() store.StoreChannel {
 		builtInRoles := model.MakeDefaultRoles()
 		lastUserId := strings.Repeat("0", 26)
 
-		for true {
+		for {
 			var transaction *gorp.Transaction
 			var err error
 

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -2281,9 +2281,9 @@ func testChannelStoreGetChannelsByScheme(t *testing.T, ss store.Store) {
 		Type:        model.CHANNEL_OPEN,
 	}
 
-	c1 = (<-ss.Channel().Save(c1, 100)).Data.(*model.Channel)
-	c2 = (<-ss.Channel().Save(c2, 100)).Data.(*model.Channel)
-	c3 = (<-ss.Channel().Save(c3, 100)).Data.(*model.Channel)
+	_ = (<-ss.Channel().Save(c1, 100)).Data.(*model.Channel)
+	_ = (<-ss.Channel().Save(c2, 100)).Data.(*model.Channel)
+	_ = (<-ss.Channel().Save(c3, 100)).Data.(*model.Channel)
 
 	// Get the channels by a valid Scheme ID.
 	res1 := <-ss.Channel().GetChannelsByScheme(s1.Id, 0, 100)

--- a/store/storetest/command_store.go
+++ b/store/storetest/command_store.go
@@ -105,7 +105,7 @@ func testCommandStoreGetByTrigger(t *testing.T, ss store.Store) {
 	o2.Trigger = "trigger1"
 
 	o1 = (<-ss.Command().Save(o1)).Data.(*model.Command)
-	o2 = (<-ss.Command().Save(o2)).Data.(*model.Command)
+	_ = (<-ss.Command().Save(o2)).Data.(*model.Command)
 
 	if r1 := <-ss.Command().GetByTrigger(o1.TeamId, o1.Trigger); r1.Err != nil {
 		t.Fatal(r1.Err)

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -108,14 +108,14 @@ func testComplianceExport(t *testing.T, ss store.Store) {
 	o1a.UserId = u1.Id
 	o1a.CreateAt = o1.CreateAt + 10
 	o1a.Message = "zz" + model.NewId() + "b"
-	o1a = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u1.Id
 	o2.CreateAt = o1.CreateAt + 20
 	o2.Message = "zz" + model.NewId() + "b"
-	o2 = store.Must(ss.Post().Save(o2)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o2)).(*model.Post)
 
 	o2a := &model.Post{}
 	o2a.ChannelId = c1.Id
@@ -272,21 +272,21 @@ func testComplianceExportDirectMessages(t *testing.T, ss store.Store) {
 	o1a.UserId = u1.Id
 	o1a.CreateAt = o1.CreateAt + 10
 	o1a.Message = "zz" + model.NewId() + "b"
-	o1a = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u1.Id
 	o2.CreateAt = o1.CreateAt + 20
 	o2.Message = "zz" + model.NewId() + "b"
-	o2 = store.Must(ss.Post().Save(o2)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o2)).(*model.Post)
 
 	o2a := &model.Post{}
 	o2a.ChannelId = c1.Id
 	o2a.UserId = u2.Id
 	o2a.CreateAt = o1.CreateAt + 30
 	o2a.Message = "zz" + model.NewId() + "b"
-	o2a = store.Must(ss.Post().Save(o2a)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o2a)).(*model.Post)
 
 	o3 := &model.Post{}
 	o3.ChannelId = cDM.Id

--- a/store/storetest/job_store.go
+++ b/store/storetest/job_store.go
@@ -492,7 +492,6 @@ func testJobUpdateStatusUpdateStatusOptimistically(t *testing.T, ss store.Store)
 		if received.LastActivityAt <= lastUpdateAt {
 			t.Fatal("lastActivityAt wasn't updated")
 		}
-		lastUpdateAt = received.LastActivityAt
 	}
 }
 

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -514,7 +514,7 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o2)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
 	o2a := &model.Post{}
@@ -609,7 +609,7 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	o6.ChannelId = o1.ChannelId
 	o6.UserId = model.NewId()
 	o6.Message = "zz" + model.NewId() + "b"
-	o6 = (<-ss.Post().Save(o6)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o6)).Data.(*model.Post)
 
 	// Should only be 6 since we hit the cache
 	r3 := (<-ss.Post().GetPosts(o1.ChannelId, 0, 30, true)).Data.(*model.PostList)
@@ -627,7 +627,7 @@ func testPostStoreGetPostsBeforeAfter(t *testing.T, ss store.Store) {
 	o0.ChannelId = model.NewId()
 	o0.UserId = model.NewId()
 	o0.Message = "zz" + model.NewId() + "b"
-	o0 = (<-ss.Post().Save(o0)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o0)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
 	o1 := &model.Post{}
@@ -677,7 +677,7 @@ func testPostStoreGetPostsBeforeAfter(t *testing.T, ss store.Store) {
 	o5.Message = "zz" + model.NewId() + "b"
 	o5.ParentId = o4.Id
 	o5.RootId = o4.Id
-	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o5)).Data.(*model.Post)
 
 	r1 := (<-ss.Post().GetPostsBefore(o1.ChannelId, o1.Id, 4, 0)).Data.(*model.PostList)
 
@@ -731,7 +731,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o0.ChannelId = model.NewId()
 	o0.UserId = model.NewId()
 	o0.Message = "zz" + model.NewId() + "b"
-	o0 = (<-ss.Post().Save(o0)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o0)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
 	o1 := &model.Post{}
@@ -747,7 +747,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o2)).Data.(*model.Post)
 	time.Sleep(2 * time.Millisecond)
 
 	o2a := &model.Post{}
@@ -865,7 +865,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	o1a.UserId = model.NewId()
 	o1a.Message = "corey mattermost new york"
 	o1a.Type = model.POST_JOIN_CHANNEL
-	o1a = (<-ss.Post().Save(o1a)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o1a)).Data.(*model.Post)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
@@ -877,7 +877,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	o3.ChannelId = c2.Id
 	o3.UserId = model.NewId()
 	o3.Message = "New Jersey is where John is from corey new york"
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o3)).Data.(*model.Post)
 
 	o4 := &model.Post{}
 	o4.ChannelId = c1.Id
@@ -1045,7 +1045,7 @@ func testUserCountsWithPostsByDay(t *testing.T, ss store.Store) {
 	o1a.UserId = model.NewId()
 	o1a.CreateAt = o1.CreateAt
 	o1a.Message = "zz" + model.NewId() + "b"
-	o1a = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
@@ -1059,7 +1059,7 @@ func testUserCountsWithPostsByDay(t *testing.T, ss store.Store) {
 	o2a.UserId = o2.UserId
 	o2a.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24)
 	o2a.Message = "zz" + model.NewId() + "b"
-	o2a = store.Must(ss.Post().Save(o2a)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o2a)).(*model.Post)
 
 	if r1 := <-ss.Post().AnalyticsUserCountsWithPostsByDay(t1.Id); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -1103,7 +1103,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	o1a.UserId = model.NewId()
 	o1a.CreateAt = o1.CreateAt
 	o1a.Message = "zz" + model.NewId() + "b"
-	o1a = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
@@ -1117,7 +1117,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	o2a.UserId = o2.UserId
 	o2a.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24 * 2)
 	o2a.Message = "zz" + model.NewId() + "b"
-	o2a = store.Must(ss.Post().Save(o2a)).(*model.Post)
+	_ = store.Must(ss.Post().Save(o2a)).(*model.Post)
 
 	time.Sleep(1 * time.Second)
 
@@ -1534,14 +1534,14 @@ func testPostStoreGetPostsCreatedAt(t *testing.T, ss store.Store) {
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
 	o2.CreateAt = createTime + 1
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o2)).Data.(*model.Post)
 
 	o3 := &model.Post{}
 	o3.ChannelId = model.NewId()
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.CreateAt = createTime
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	_ = (<-ss.Post().Save(o3)).Data.(*model.Post)
 
 	r1 := (<-ss.Post().GetPostsCreatedAt(o1.ChannelId, createTime)).Data.([]*model.Post)
 	assert.Equal(t, 2, len(r1))

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -20,6 +20,7 @@ func TestSchemeStore(t *testing.T, ss store.Store) {
 	t.Run("GetAllPage", func(t *testing.T) { testSchemeStoreGetAllPage(t, ss) })
 	t.Run("Delete", func(t *testing.T) { testSchemeStoreDelete(t, ss) })
 	t.Run("PermanentDeleteAll", func(t *testing.T) { testSchemeStorePermanentDeleteAll(t, ss) })
+	t.Run("GetByName", func(t *testing.T) { testSchemeStoreGetByName(t, ss) })
 }
 
 func createDefaultRoles(t *testing.T, ss store.Store) {

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -1088,9 +1088,9 @@ func testGetTeamsByScheme(t *testing.T, ss store.Store) {
 		Type:        model.TEAM_OPEN,
 	}
 
-	t1 = (<-ss.Team().Save(t1)).Data.(*model.Team)
-	t2 = (<-ss.Team().Save(t2)).Data.(*model.Team)
-	t3 = (<-ss.Team().Save(t3)).Data.(*model.Team)
+	_ = (<-ss.Team().Save(t1)).Data.(*model.Team)
+	_ = (<-ss.Team().Save(t2)).Data.(*model.Team)
+	_ = (<-ss.Team().Save(t3)).Data.(*model.Team)
 
 	// Get the teams by a valid Scheme ID.
 	res1 := <-ss.Team().GetTeamsByScheme(s1.Id, 0, 100)
@@ -1286,7 +1286,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 		Type:        model.TEAM_OPEN,
 		SchemeId:    &s1.Id,
 	}
-	t1 = (<-ss.Team().Save(t1)).Data.(*model.Team)
+	_ = (<-ss.Team().Save(t1)).Data.(*model.Team)
 
 	count2 := (<-ss.Team().AnalyticsGetTeamCountForScheme(s1.Id)).Data.(int64)
 	assert.Equal(t, int64(1), count2)
@@ -1298,7 +1298,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 		Type:        model.TEAM_OPEN,
 		SchemeId:    &s1.Id,
 	}
-	t2 = (<-ss.Team().Save(t2)).Data.(*model.Team)
+	_ = (<-ss.Team().Save(t2)).Data.(*model.Team)
 
 	count3 := (<-ss.Team().AnalyticsGetTeamCountForScheme(s1.Id)).Data.(int64)
 	assert.Equal(t, int64(2), count3)
@@ -1309,7 +1309,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
 	}
-	t3 = (<-ss.Team().Save(t3)).Data.(*model.Team)
+	_ = (<-ss.Team().Save(t3)).Data.(*model.Team)
 
 	count4 := (<-ss.Team().AnalyticsGetTeamCountForScheme(s1.Id)).Data.(int64)
 	assert.Equal(t, int64(2), count4)
@@ -1322,7 +1322,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 		SchemeId:    &s1.Id,
 		DeleteAt:    model.GetMillis(),
 	}
-	t4 = (<-ss.Team().Save(t4)).Data.(*model.Team)
+	_ = (<-ss.Team().Save(t4)).Data.(*model.Team)
 
 	count5 := (<-ss.Team().AnalyticsGetTeamCountForScheme(s1.Id)).Data.(int64)
 	assert.Equal(t, int64(2), count5)

--- a/store/storetest/webhook_store.go
+++ b/store/storetest/webhook_store.go
@@ -484,7 +484,7 @@ func testWebhookStoreCountIncoming(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.TeamId = model.NewId()
 
-	o1 = (<-ss.Webhook().SaveIncoming(o1)).Data.(*model.IncomingWebhook)
+	_ = (<-ss.Webhook().SaveIncoming(o1)).Data.(*model.IncomingWebhook)
 
 	if r := <-ss.Webhook().AnalyticsIncomingCount(""); r.Err != nil {
 		t.Fatal(r.Err)
@@ -502,7 +502,7 @@ func testWebhookStoreCountOutgoing(t *testing.T, ss store.Store) {
 	o1.TeamId = model.NewId()
 	o1.CallbackURLs = []string{"http://nowhere.com/"}
 
-	o1 = (<-ss.Webhook().SaveOutgoing(o1)).Data.(*model.OutgoingWebhook)
+	_ = (<-ss.Webhook().SaveOutgoing(o1)).Data.(*model.OutgoingWebhook)
 
 	if r := <-ss.Webhook().AnalyticsOutgoingCount(""); r.Err != nil {
 		t.Fatal(r.Err)

--- a/utils/config.go
+++ b/utils/config.go
@@ -51,9 +51,7 @@ func FindPath(path string, baseSearchPaths []string, filter func(os.FileInfo) bo
 	}
 
 	searchPaths := []string{}
-	for _, baseSearchPath := range baseSearchPaths {
-		searchPaths = append(searchPaths, baseSearchPath)
-	}
+	searchPaths = append(searchPaths, baseSearchPaths...)
 
 	// Additionally attempt to search relative to the location of the running binary.
 	var binaryDir string

--- a/utils/i18n.go
+++ b/utils/i18n.go
@@ -27,12 +27,7 @@ func TranslationsPreInit() error {
 	// segfault trying to handle the error, and the untranslated IDs are strictly better.
 	T = TfuncWithFallback("en")
 	TDefault = TfuncWithFallback("en")
-
-	if err := InitTranslationsWithDir("i18n"); err != nil {
-		return err
-	}
-
-	return nil
+	return InitTranslationsWithDir("i18n")
 }
 
 func InitTranslations(localizationSettings model.LocalizationSettings) error {

--- a/utils/jsonutils/json_test.go
+++ b/utils/jsonutils/json_test.go
@@ -76,8 +76,6 @@ func TestHumanizeJsonError(t *testing.T) {
 func TestNewHumanizedJsonError(t *testing.T) {
 	t.Parallel()
 
-	type testType struct{}
-
 	testCases := []struct {
 		Description string
 		Data        []byte

--- a/utils/mail.go
+++ b/utils/mail.go
@@ -257,20 +257,18 @@ func SendMail(c *smtp.Client, mimeTo, smtpTo string, from mail.Address, subject,
 	m.SetBody("text/plain", txtBody)
 	m.AddAlternative("text/html", htmlMessage)
 
-	if attachments != nil {
-		for _, fileInfo := range attachments {
-			bytes, err := fileBackend.ReadFile(fileInfo.Path)
-			if err != nil {
-				return err
-			}
-
-			m.Attach(fileInfo.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-				if _, err := writer.Write(bytes); err != nil {
-					return model.NewAppError("SendMail", "utils.mail.sendMail.attachments.write_error", nil, err.Error(), http.StatusInternalServerError)
-				}
-				return nil
-			}))
+	for _, fileInfo := range attachments {
+		bytes, err := fileBackend.ReadFile(fileInfo.Path)
+		if err != nil {
+			return err
 		}
+
+		m.Attach(fileInfo.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
+			if _, err := writer.Write(bytes); err != nil {
+				return model.NewAppError("SendMail", "utils.mail.sendMail.attachments.write_error", nil, err.Error(), http.StatusInternalServerError)
+			}
+			return nil
+		}))
 	}
 
 	if err := c.Mail(from.Address); err != nil {


### PR DESCRIPTION
#### Summary

The following issues were detected by executing the static analysis tool [megacheck](https://github.com/dominikh/go-tools/tree/master/cmd/megacheck) and solved as part of this PR:

- [x] api4/channel_test.go:931:2: this value of team is never used (SA4006)
- [x] api4/channel_test.go:932:2: this value of user is never used (SA4006)
- [x] api4/channel_test.go:1633:2: this value of pass is never used (SA4006)
- [x] api4/emoji_test.go:334:2: this value of ok is never used (SA4006)
- [x] api4/emoji_test.go:352:2: this value of ok is never used (SA4006)
- [x] api4/emoji_test.go:370:2: this value of ok is never used (SA4006)
- [x] api4/emoji_test.go:404:2: this value of ok is never used (SA4006)
- [x] api4/file_test.go:449:2: this value of link is never used (SA4006)
- [x] api4/post_test.go:67:10: this value of resp is never used (SA4006)
- [x] api4/post_test.go:156:2: this value of rpost is never used (SA4006)
- [x] api4/post_test.go:1025:2: this value of rpl is never used (SA4006)
- [x] api4/post_test.go:1028:2: this value of rpl is never used (SA4006)
- [x] api4/post_test.go:1031:2: this value of rpl is never used (SA4006)
- [x] api4/post_test.go:1034:2: this value of rpl is never used (SA4006)
- [x] api4/post_test.go:1037:2: this value of rpl is never used (SA4006)
- [x] api4/post_test.go:1040:2: this value of rpl is never used (SA4006)
- [x] api4/post_test.go:1155:2: this value of post is never used (SA4006)
- [x] api4/post_test.go:1160:2: this value of post is never used (SA4006)
- [x] api4/post_test.go:1166:2: this value of post is never used (SA4006)
- [x] api4/post_test.go:1173:2: this value of post is never used (SA4006)
- [x] api4/post_test.go:1269:2: this value of list is never used (SA4006)
- [x] api4/post_test.go:1319:12: this value of resp is never used (SA4006)
- [x] api4/preference_test.go:108:2: this value of prefs is never used (SA4006)
- [x] api4/preference_test.go:113:2: this value of prefs is never used (SA4006)
- [x] api4/preference_test.go:116:2: this value of prefs is never used (SA4006)
- [x] api4/preference_test.go:312:9: this value of resp is never used (SA4006)
- [x] api4/preference_test.go:342:9: this value of resp is never used (SA4006)
- [x] api4/role_test.go:133:2: this value of received is never used (SA4006)
- [x] api4/role_test.go:141:2: this value of received is never used (SA4006)
- [x] api4/role_test.go:145:2: this value of received is never used (SA4006)
- [x] api4/role_test.go:181:2: this value of received is never used (SA4006)
- [x] api4/role_test.go:184:2: this value of received is never used (SA4006)
- [x] api4/role_test.go:187:2: this value of received is never used (SA4006)
- [x] api4/role_test.go:190:2: this value of received is never used (SA4006)
- [x] api4/role_test.go:198:2: this value of received is never used (SA4006)
- [x] api4/status_test.go:153:2: this value of updateUserStatus is never used (SA4006)
- [x] api4/status_test.go:157:20: this value of resp is never used (SA4006)
- [x] api4/team_test.go:891:2: this value of rteams is never used (SA4006)
- [x] api4/team_test.go:894:2: this value of rteams is never used (SA4006)
- [x] api4/team_test.go:1191:2: this value of rmembers is never used (SA4006)
- [x] api4/team_test.go:1194:2: this value of rmembers is never used (SA4006)
- [x] api4/team_test.go:1263:2: this value of tm1 is never used (SA4006)
- [x] api4/team_test.go:1266:2: this value of tm1 is never used (SA4006)
- [x] api4/team_test.go:1287:2: this value of tm is never used (SA4006)
- [x] api4/team_test.go:1413:2: this value of tm is never used (SA4006)
- [x] api4/team_test.go:1425:2: this value of tm is never used (SA4006)
- [x] api4/team_test.go:1471:2: this value of tm is never used (SA4006)
- [x] api4/team_test.go:2030:2: this value of team is never used (SA4006)
- [x] api4/user_test.go:409:9: this value of resp is never used (SA4006)
- [x] api4/user_test.go:477:9: this value of resp is never used (SA4006)
- [x] api4/user_test.go:542:9: this value of resp is never used (SA4006)
- [x] api4/user_test.go:2211:9: this value of resp is never used (SA4006)
- [x] api4/user_test.go:2332:8: this value of resp is never used (SA4006)
- [x] api4/user_test.go:2349:8: this value of resp is never used (SA4006)
- [x] api4/user_test.go:2600:2: this value of token is never used (SA4006)
- [x] api4/webhook_test.go:368:2: this value of hooks is never used (SA4006)
- [x] app/auto_responder_test.go:97:13: this value of err is never used (SA4006)
- [x] app/auto_responder_test.go:137:13: this value of err is never used (SA4006)
- [x] app/brand.go:30:2: should check returned error before deferring file.Close() (SA5001)
- [x] app/channel.go:1401:15: this value of err is never used (SA4006)
- [x] app/config_test.go:130:19: this result of append is never used, except maybe in other appends (SA4010)
- [x] app/diagnostics_test.go:114:5: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
- [x] app/file.go:621:3: this value of fileInfo is never used (SA4006)
- [x] app/import_functions.go:126:3: this value of role is never used (SA4006)
- [x] app/import_functions.go:128:3: this value of role is never used (SA4006)
- [x] app/plugin_hooks_test.go:92:3: this value of post is never used (SA4006)
- [x] app/plugin_hooks_test.go:132:3: this value of post is never used (SA4006)
- [x] app/plugin_hooks_test.go:330:2: this value of post is never used (SA4006)
- [x] app/plugin_hooks_test.go:427:2: this value of post is never used (SA4006)
- [x] app/plugin_hooks_test.go:788:8: this value of err is never used (SA4006)
- [x] app/session_test.go:57:2: this value of rsession is never used (SA4006)
- [x] app/session_test.go:57:12: this value of err is never used (SA4006)
- [x] app/team.go:443:11: this value of err is never used (SA4006)
- [x] app/team.go:773:11: this value of err is never used (SA4006)
- [x] cmd/mattermost/commands/permissions_test.go:33:10: this value of err is never used (SA4006)
- [x] model/config.go:2362:14: this value of err is never used (SA4006)
- [x] model/session_test.go:32:2: this value of copySession is never used (SA4006)
- [x] model/user_test.go:53:2: this value of copyUser is never used (SA4006)
- [x] store/storetest/channel_store.go:2284:2: this value of c1 is never used (SA4006)
- [x] store/storetest/channel_store.go:2285:2: this value of c2 is never used (SA4006)
- [x] store/storetest/channel_store.go:2286:2: this value of c3 is never used (SA4006)
- [x] store/storetest/command_store.go:108:2: this value of o2 is never used (SA4006)
- [x] store/storetest/compliance_store.go:111:2: this value of o1a is never used (SA4006)
- [x] store/storetest/compliance_store.go:118:2: this value of o2 is never used (SA4006)
- [x] store/storetest/compliance_store.go:275:2: this value of o1a is never used (SA4006)
- [x] store/storetest/compliance_store.go:282:2: this value of o2 is never used (SA4006)
- [x] store/storetest/compliance_store.go:289:2: this value of o2a is never used (SA4006)
- [x] store/storetest/job_store.go:495:3: this value of lastUpdateAt is never used (SA4006)
- [x] store/storetest/post_store.go:517:2: this value of o2 is never used (SA4006)
- [x] store/storetest/post_store.go:612:2: this value of o6 is never used (SA4006)
- [x] store/storetest/post_store.go:630:2: this value of o0 is never used (SA4006)
- [x] store/storetest/post_store.go:680:2: this value of o5 is never used (SA4006)
- [x] store/storetest/post_store.go:734:2: this value of o0 is never used (SA4006)
- [x] store/storetest/post_store.go:750:2: this value of o2 is never used (SA4006)
- [x] store/storetest/post_store.go:868:2: this value of o1a is never used (SA4006)
- [x] store/storetest/post_store.go:880:2: this value of o3 is never used (SA4006)
- [x] store/storetest/post_store.go:1048:2: this value of o1a is never used (SA4006)
- [x] store/storetest/post_store.go:1062:2: this value of o2a is never used (SA4006)
- [x] store/storetest/post_store.go:1106:2: this value of o1a is never used (SA4006)
- [x] store/storetest/post_store.go:1120:2: this value of o2a is never used (SA4006)
- [x] store/storetest/post_store.go:1537:2: this value of o2 is never used (SA4006)
- [x] store/storetest/post_store.go:1544:2: this value of o3 is never used (SA4006)
- [x] store/storetest/team_store.go:1091:2: this value of t1 is never used (SA4006)
- [x] store/storetest/team_store.go:1092:2: this value of t2 is never used (SA4006)
- [x] store/storetest/team_store.go:1093:2: this value of t3 is never used (SA4006)
- [x] store/storetest/team_store.go:1289:2: this value of t1 is never used (SA4006)
- [x] store/storetest/team_store.go:1301:2: this value of t2 is never used (SA4006)
- [x] store/storetest/team_store.go:1312:2: this value of t3 is never used (SA4006)
- [x] store/storetest/team_store.go:1325:2: this value of t4 is never used (SA4006)
- [x] store/storetest/webhook_store.go:487:2: this value of o1 is never used (SA4006)
- [x] store/storetest/webhook_store.go:505:2: this value of o1 is never used (SA4006)
- [x] app/app.go:645:3: redundant break statement (S1023)
- [x] app/app.go:653:3: redundant break statement (S1023)
- [x] app/app.go:656:3: redundant break statement (S1023)
- [x] app/app.go:706:6: should omit comparison to bool constant, can be simplified to !*oldConfig.ElasticsearchSettings.EnableIndexing (S1002)
- [x] app/app.go:706:66: should omit comparison to bool constant, can be simplified to *newConfig.ElasticsearchSettings.EnableIndexing (S1002)
- [x] app/app.go:712:13: should omit comparison to bool constant, can be simplified to *oldConfig.ElasticsearchSettings.EnableIndexing (S1002)
- [x] app/app.go:712:72: should omit comparison to bool constant, can be simplified to !*newConfig.ElasticsearchSettings.EnableIndexing (S1002)
- [x] app/app.go:720:8: should omit comparison to bool constant, can be simplified to *oldConfig.ElasticsearchSettings.EnableIndexing (S1002)
- [x] app/channel.go:55:7: should omit comparison to bool constant, can be simplified to !seenChannels[channelName] (S1002)
- [x] app/notification_email.go:309:13: the argument is already a string, there's no need to use fmt.Sprintf (S1025)
- [x] app/permissions.go:141:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
- [x] cmd/mattermost/commands/permissions.go:127:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
- [x] plugin/client_rpc.go:298:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:212:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:247:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:281:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:316:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:351:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:386:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:421:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:490:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:2098:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:2215:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:2243:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:2271:2: redundant return statement (S1023)
- [x] plugin/client_rpc_generated.go:2299:2: redundant return statement (S1023)
- [x] store/sqlstore/channel_store.go:1862:3: should use for {} instead of for true {} (S1006)
- [x] store/sqlstore/team_store.go:854:3: should use for {} instead of for true {} (S1006)
- [x] store/sqlstore/user_store.go:1258:3: should use for {} instead of for true {} (S1006)
- [x] utils/config.go:54:2: should replace loop with searchPaths = append(searchPaths, baseSearchPaths...) (S1011)
- [x] utils/i18n.go:31:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
- [x] utils/mail.go:260:2: unnecessary nil check around range (S1031)
- [x] plugin/environment.go:21:6: type supervisorCreatorFunc is unused (U1000)
- [x] plugin/io_rpc.go:12:6: type rwc is unused (U1000)
- [x] plugin/supervisor.go:20:2: field pluginId is unused (U1000)
- [x] store/local_cache_supplier_schemes.go:12:30: func (*LocalCacheSupplier).handleClusterInvalidateScheme is unused (U1000)
- [x] store/storetest/scheme_store.go:182:6: func testSchemeStoreGetByName is unused (U1000)
- [x] utils/jsonutils/json_test.go:79:7: type testType is unused (U1000)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11293
https://github.com/mattermost/mattermost-server/issues/9100

#### Checklist
- [x] Added or updated unit tests (required for all new features)