### PR TITLE
Adding IdAttribute setting for SAML

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -458,6 +458,7 @@ func (a *App) trackConfig() {
 		"encrypt":                             *cfg.SamlSettings.Encrypt,
 		"isdefault_scoping_idp_provider_id":   isDefault(*cfg.SamlSettings.ScopingIDPProviderId, ""),
 		"isdefault_scoping_idp_name":          isDefault(*cfg.SamlSettings.ScopingIDPName, ""),
+		"isdefault_id_attribute":              isDefault(*cfg.SamlSettings.IdAttribute, model.SAML_SETTINGS_DEFAULT_ID_ATTRIBUTE),
 		"isdefault_first_name_attribute":      isDefault(*cfg.SamlSettings.FirstNameAttribute, model.SAML_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE),
 		"isdefault_last_name_attribute":       isDefault(*cfg.SamlSettings.LastNameAttribute, model.SAML_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE),
 		"isdefault_email_attribute":           isDefault(*cfg.SamlSettings.EmailAttribute, model.SAML_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE),

--- a/config/default.json
+++ b/config/default.json
@@ -318,6 +318,7 @@
         "IdpCertificateFile": "",
         "PublicCertificateFile": "",
         "PrivateKeyFile": "",
+        "IdAttribute": "",
         "FirstNameAttribute": "",
         "LastNameAttribute": "",
         "EmailAttribute": "",

--- a/model/config.go
+++ b/model/config.go
@@ -120,6 +120,7 @@ const (
 	LDAP_SETTINGS_DEFAULT_POSITION_ATTRIBUTE   = ""
 	LDAP_SETTINGS_DEFAULT_LOGIN_FIELD_NAME     = ""
 
+	SAML_SETTINGS_DEFAULT_ID_ATTRIBUTE         = ""
 	SAML_SETTINGS_DEFAULT_FIRST_NAME_ATTRIBUTE = ""
 	SAML_SETTINGS_DEFAULT_LAST_NAME_ATTRIBUTE  = ""
 	SAML_SETTINGS_DEFAULT_EMAIL_ATTRIBUTE      = ""
@@ -1474,6 +1475,7 @@ type SamlSettings struct {
 	PrivateKeyFile        *string
 
 	// User Mapping
+	IdAttribute        *string
 	FirstNameAttribute *string
 	LastNameAttribute  *string
 	EmailAttribute     *string
@@ -1540,6 +1542,10 @@ func (s *SamlSettings) SetDefaults() {
 
 	if s.LoginButtonText == nil || *s.LoginButtonText == "" {
 		s.LoginButtonText = NewString(USER_AUTH_SERVICE_SAML_TEXT)
+	}
+
+	if s.IdAttribute == nil {
+		s.IdAttribute = NewString(SAML_SETTINGS_DEFAULT_ID_ATTRIBUTE)
 	}
 
 	if s.FirstNameAttribute == nil {


### PR DESCRIPTION
#### Summary
Adding IdAttribute setting for SAML for allow more robust treatment of
deactivated accounts

#### Ticket Link
[MM-10532](https://mattermost.atlassian.net/browse/10532)

#### Checklist
- [x] Has enterprise changes (mattermost/enterprise#341)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)