### PR TITLE
MM-12211 Add setting to let everyone create user access tokens

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1322,7 +1322,7 @@ func createUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("")
 
-	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_CREATE_USER_ACCESS_TOKEN) {
+	if !*c.App.Config().ServiceSettings.AllowUserAccessTokensForAllUsers && !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_CREATE_USER_ACCESS_TOKEN) {
 		c.SetPermissionError(model.PERMISSION_CREATE_USER_ACCESS_TOKEN)
 		return
 	}
@@ -1391,7 +1391,7 @@ func getUserAccessTokensForUser(c *Context, w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_READ_USER_ACCESS_TOKEN) {
+	if !*c.App.Config().ServiceSettings.AllowUserAccessTokensForAllUsers && !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_READ_USER_ACCESS_TOKEN) {
 		c.SetPermissionError(model.PERMISSION_READ_USER_ACCESS_TOKEN)
 		return
 	}
@@ -1416,7 +1416,7 @@ func getUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_READ_USER_ACCESS_TOKEN) {
+	if !*c.App.Config().ServiceSettings.AllowUserAccessTokensForAllUsers && !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_READ_USER_ACCESS_TOKEN) {
 		c.SetPermissionError(model.PERMISSION_READ_USER_ACCESS_TOKEN)
 		return
 	}
@@ -1445,7 +1445,7 @@ func revokeUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAudit("")
 
-	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_REVOKE_USER_ACCESS_TOKEN) {
+	if !*c.App.Config().ServiceSettings.AllowUserAccessTokensForAllUsers && !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_REVOKE_USER_ACCESS_TOKEN) {
 		c.SetPermissionError(model.PERMISSION_REVOKE_USER_ACCESS_TOKEN)
 		return
 	}
@@ -1482,7 +1482,7 @@ func disableUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) 
 	c.LogAudit("")
 
 	// No separate permission for this action for now
-	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_REVOKE_USER_ACCESS_TOKEN) {
+	if !*c.App.Config().ServiceSettings.AllowUserAccessTokensForAllUsers && !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_REVOKE_USER_ACCESS_TOKEN) {
 		c.SetPermissionError(model.PERMISSION_REVOKE_USER_ACCESS_TOKEN)
 		return
 	}
@@ -1519,7 +1519,7 @@ func enableUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.LogAudit("")
 
 	// No separate permission for this action for now
-	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_CREATE_USER_ACCESS_TOKEN) {
+	if !*c.App.Config().ServiceSettings.AllowUserAccessTokensForAllUsers && !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_CREATE_USER_ACCESS_TOKEN) {
 		c.SetPermissionError(model.PERMISSION_CREATE_USER_ACCESS_TOKEN)
 		return
 	}

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -207,6 +207,7 @@ func (a *App) trackConfig() {
 		"enable_post_username_override":               cfg.ServiceSettings.EnablePostUsernameOverride,
 		"enable_post_icon_override":                   cfg.ServiceSettings.EnablePostIconOverride,
 		"enable_user_access_tokens":                   *cfg.ServiceSettings.EnableUserAccessTokens,
+		"allow_user_access_tokens_for_all_users":      *cfg.ServiceSettings.AllowUserAccessTokensForAllUsers,
 		"enable_custom_emoji":                         *cfg.ServiceSettings.EnableCustomEmoji,
 		"enable_emoji_picker":                         *cfg.ServiceSettings.EnableEmojiPicker,
 		"enable_gif_picker":                           *cfg.ServiceSettings.EnableGifPicker,

--- a/config/default.json
+++ b/config/default.json
@@ -32,6 +32,7 @@
         "EnableMultifactorAuthentication": false,
         "EnforceMultifactorAuthentication": false,
         "EnableUserAccessTokens": false,
+        "AllowUserAccessTokensForAllUsers": false,
         "AllowCorsFrom": "",
         "CorsExposedHeaders": "",
         "CorsAllowCredentials": false,

--- a/model/config.go
+++ b/model/config.go
@@ -206,6 +206,7 @@ type ServiceSettings struct {
 	EnableMultifactorAuthentication                   *bool
 	EnforceMultifactorAuthentication                  *bool
 	EnableUserAccessTokens                            *bool
+	AllowUserAccessTokensForAllUsers                  *bool
 	AllowCorsFrom                                     *string
 	CorsExposedHeaders                                *string
 	CorsAllowCredentials                              *bool
@@ -306,6 +307,10 @@ func (s *ServiceSettings) SetDefaults() {
 
 	if s.EnableUserAccessTokens == nil {
 		s.EnableUserAccessTokens = NewBool(false)
+	}
+
+	if s.AllowUserAccessTokensForAllUsers == nil {
+		s.AllowUserAccessTokensForAllUsers = NewBool(false)
 	}
 
 	if s.GoroutineHealthThreshold == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -529,6 +529,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["EnablePostUsernameOverride"] = strconv.FormatBool(c.ServiceSettings.EnablePostUsernameOverride)
 	props["EnablePostIconOverride"] = strconv.FormatBool(c.ServiceSettings.EnablePostIconOverride)
 	props["EnableUserAccessTokens"] = strconv.FormatBool(*c.ServiceSettings.EnableUserAccessTokens)
+	props["AllowUserAccessTokensForAllUsers"] = strconv.FormatBool(*c.ServiceSettings.AllowUserAccessTokensForAllUsers)
 	props["EnableLinkPreviews"] = strconv.FormatBool(*c.ServiceSettings.EnableLinkPreviews)
 	props["EnableTesting"] = strconv.FormatBool(c.ServiceSettings.EnableTesting)
 	props["EnableDeveloper"] = strconv.FormatBool(*c.ServiceSettings.EnableDeveloper)


### PR DESCRIPTION
#### Summary
Enabling this lets all users create user access tokens, without requiring an admin to enable tokens for them first.

#### Ticket Link
https://pre-release.mattermost.com/core/pl/jkerpgtu63ywxej84aqhhmw6ie

#### Checklist
- [ ] Added or updated unit tests [TODO]