### PR TITLE
MM-11272 Add OpenGraph and image dimension metadata to posts

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -4,7 +4,6 @@
 package api4
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -726,22 +725,6 @@ func CheckInternalErrorStatus(t *testing.T, resp *model.Response) {
 		t.Log("actual: " + strconv.Itoa(resp.StatusCode))
 		t.Log("expected: " + strconv.Itoa(http.StatusInternalServerError))
 		t.Fatal("wrong status code")
-	}
-}
-
-func readTestFile(name string) ([]byte, error) {
-	path, _ := utils.FindDir("tests")
-	file, err := os.Open(filepath.Join(path, name))
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	data := &bytes.Buffer{}
-	if _, err := io.Copy(data, file); err != nil {
-		return nil, err
-	} else {
-		return data.Bytes(), nil
 	}
 }
 

--- a/api4/brand_test.go
+++ b/api4/brand_test.go
@@ -6,6 +6,8 @@ package api4
 import (
 	"net/http"
 	"testing"
+
+	"github.com/mattermost/mattermost-server/utils/testutils"
 )
 
 func TestGetBrandImage(t *testing.T) {
@@ -29,7 +31,7 @@ func TestUploadBrandImage(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	data, err := readTestFile("test.png")
+	data, err := testutils.ReadTestFile("test.png")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
+	"github.com/mattermost/mattermost-server/utils/testutils"
 )
 
 func TestUploadFileAsMultipart(t *testing.T) {
@@ -25,7 +26,7 @@ func TestUploadFileAsMultipart(t *testing.T) {
 	var uploadInfo *model.FileInfo
 	var data []byte
 	var err error
-	if data, err = readTestFile("test.png"); err != nil {
+	if data, err = testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else if fileResp, resp := Client.UploadFile(data, channel.Id, "test.png"); resp.Error != nil {
 		t.Fatal(resp.Error)
@@ -138,7 +139,7 @@ func TestUploadFileAsRequestBody(t *testing.T) {
 	var uploadInfo *model.FileInfo
 	var data []byte
 	var err error
-	if data, err = readTestFile("test.png"); err != nil {
+	if data, err = testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else if fileResp, resp := Client.UploadFileAsRequestBody(data, channel.Id, "test.png"); resp.Error != nil {
 		t.Fatal(resp.Error)
@@ -263,7 +264,7 @@ func TestGetFile(t *testing.T) {
 	fileId := ""
 	var sent []byte
 	var err error
-	if sent, err = readTestFile("test.png"); err != nil {
+	if sent, err = testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
 		fileResp, resp := Client.UploadFile(sent, channel.Id, "test.png")
@@ -378,7 +379,7 @@ func TestGetFileThumbnail(t *testing.T) {
 	fileId := ""
 	var sent []byte
 	var err error
-	if sent, err = readTestFile("test.png"); err != nil {
+	if sent, err = testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
 		fileResp, resp := Client.UploadFile(sent, channel.Id, "test.png")
@@ -437,7 +438,7 @@ func TestGetFileLink(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.PublicLinkSalt = model.NewId() })
 
 	fileId := ""
-	if data, err := readTestFile("test.png"); err != nil {
+	if data, err := testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
 		fileResp, resp := Client.UploadFile(data, channel.Id, "test.png")
@@ -505,7 +506,7 @@ func TestGetFilePreview(t *testing.T) {
 	fileId := ""
 	var sent []byte
 	var err error
-	if sent, err = readTestFile("test.png"); err != nil {
+	if sent, err = testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
 		fileResp, resp := Client.UploadFile(sent, channel.Id, "test.png")
@@ -558,7 +559,7 @@ func TestGetFileInfo(t *testing.T) {
 	fileId := ""
 	var sent []byte
 	var err error
-	if sent, err = readTestFile("test.png"); err != nil {
+	if sent, err = testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
 		fileResp, resp := Client.UploadFile(sent, channel.Id, "test.png")
@@ -631,7 +632,7 @@ func TestGetPublicFile(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.PublicLinkSalt = GenerateTestId() })
 
 	fileId := ""
-	if data, err := readTestFile("test.png"); err != nil {
+	if data, err := testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
 		fileResp, resp := Client.UploadFile(data, channel.Id, "test.png")

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
+	"github.com/mattermost/mattermost-server/utils/testutils"
 )
 
 func TestCreatePost(t *testing.T) {
@@ -1767,7 +1768,7 @@ func TestGetFileInfosForPost(t *testing.T) {
 	Client := th.Client
 
 	fileIds := make([]string, 3)
-	if data, err := readTestFile("test.png"); err != nil {
+	if data, err := testutils.ReadTestFile("test.png"); err != nil {
 		t.Fatal(err)
 	} else {
 		for i := 0; i < 3; i++ {

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
+	"github.com/mattermost/mattermost-server/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1815,7 +1816,7 @@ func TestImportTeam(t *testing.T) {
 	t.Run("ImportTeam", func(t *testing.T) {
 		var data []byte
 		var err error
-		data, err = readTestFile("Fake_Team_Import.zip")
+		data, err = testutils.ReadTestFile("Fake_Team_Import.zip")
 		if err != nil && len(data) == 0 {
 			t.Fatal("Error while reading the test file.")
 		}
@@ -1876,7 +1877,7 @@ func TestImportTeam(t *testing.T) {
 	t.Run("WrongPermission", func(t *testing.T) {
 		var data []byte
 		var err error
-		data, err = readTestFile("Fake_Team_Import.zip")
+		data, err = testutils.ReadTestFile("Fake_Team_Import.zip")
 		if err != nil && len(data) == 0 {
 			t.Fatal("Error while reading the test file.")
 		}
@@ -2031,7 +2032,7 @@ func TestSetTeamIcon(t *testing.T) {
 	Client := th.Client
 	team := th.BasicTeam
 
-	data, err := readTestFile("test.png")
+	data, err := testutils.ReadTestFile("test.png")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2111,7 +2112,7 @@ func TestRemoveTeamIcon(t *testing.T) {
 	team := th.BasicTeam
 
 	th.LoginTeamAdmin()
-	data, _ := readTestFile("test.png")
+	data, _ := testutils.ReadTestFile("test.png")
 	Client.SetTeamIcon(team.Id, data)
 
 	_, resp := Client.RemoveTeamIcon(team.Id)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
+	"github.com/mattermost/mattermost-server/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2255,7 +2256,7 @@ func TestSetProfileImage(t *testing.T) {
 	Client := th.Client
 	user := th.BasicUser
 
-	data, err := readTestFile("test.png")
+	data, err := testutils.ReadTestFile("test.png")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -251,6 +251,8 @@ func New(options ...Option) (outApp *App, outErr error) {
 		handlers: make(map[string]webSocketHandler),
 	}
 
+	app.InitPostMetadata()
+
 	return app, nil
 }
 

--- a/app/opengraph.go
+++ b/app/opengraph.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/dyatlov/go-opengraph/opengraph"
+	"github.com/mattermost/mattermost-server/mlog"
+	"golang.org/x/net/html/charset"
+)
+
+func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
+	og := opengraph.NewOpenGraph()
+
+	res, err := a.HTTPClient(false).Get(requestURL)
+	if err != nil {
+		mlog.Error(fmt.Sprintf("GetOpenGraphMetadata request failed for url=%v with err=%v", requestURL, err.Error()))
+		return og
+	}
+	defer consumeAndClose(res)
+
+	contentType := res.Header.Get("Content-Type")
+	body := forceHTMLEncodingToUTF8(res.Body, contentType)
+
+	if err := og.ProcessHTML(body); err != nil {
+		mlog.Error(fmt.Sprintf("GetOpenGraphMetadata processing failed for url=%v with err=%v", requestURL, err.Error()))
+	}
+
+	makeOpenGraphURLsAbsolute(og, requestURL)
+
+	// The URL should be the link the user provided in their message, not a redirected one.
+	if og.URL != "" {
+		og.URL = requestURL
+	}
+
+	return og
+}
+
+func forceHTMLEncodingToUTF8(body io.Reader, contentType string) io.Reader {
+	r, err := charset.NewReader(body, contentType)
+	if err != nil {
+		mlog.Error(fmt.Sprintf("forceHTMLEncodingToUTF8 failed to convert for contentType=%v with err=%v", contentType, err.Error()))
+		return body
+	}
+	return r
+}
+
+func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) {
+	parsedRequestURL, err := url.Parse(requestURL)
+	if err != nil {
+		mlog.Warn(fmt.Sprintf("makeOpenGraphURLsAbsolute failed to parse url=%v", requestURL))
+		return
+	}
+
+	makeURLAbsolute := func(resultURL string) string {
+		if resultURL == "" {
+			return resultURL
+		}
+
+		parsedResultURL, err := url.Parse(resultURL)
+		if err != nil {
+			mlog.Warn(fmt.Sprintf("makeOpenGraphURLsAbsolute failed to parse result url=%v", resultURL))
+			return resultURL
+		}
+
+		if parsedResultURL.IsAbs() {
+			return resultURL
+		}
+
+		return parsedRequestURL.ResolveReference(parsedResultURL).String()
+	}
+
+	og.URL = makeURLAbsolute(og.URL)
+
+	for _, image := range og.Images {
+		image.URL = makeURLAbsolute(image.URL)
+		image.SecureURL = makeURLAbsolute(image.SecureURL)
+	}
+
+	for _, audio := range og.Audios {
+		audio.URL = makeURLAbsolute(audio.URL)
+		audio.SecureURL = makeURLAbsolute(audio.SecureURL)
+	}
+
+	for _, video := range og.Videos {
+		video.URL = makeURLAbsolute(video.URL)
+		video.SecureURL = makeURLAbsolute(video.SecureURL)
+	}
+}

--- a/app/opengraph_test.go
+++ b/app/opengraph_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dyatlov/go-opengraph/opengraph"
+)
+
+func BenchmarkForceHTMLEncodingToUTF8(b *testing.B) {
+	HTML := `
+		<html>
+			<head>
+				<meta property="og:url" content="https://example.com/apps/mattermost">
+				<meta property="og:image" content="https://images.example.com/image.png">
+			</head>
+		</html>
+	`
+	ContentType := "text/html; utf-8"
+
+	b.Run("with converting", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			r := forceHTMLEncodingToUTF8(strings.NewReader(HTML), ContentType)
+
+			og := opengraph.NewOpenGraph()
+			og.ProcessHTML(r)
+		}
+	})
+
+	b.Run("without converting", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			og := opengraph.NewOpenGraph()
+			og.ProcessHTML(strings.NewReader(HTML))
+		}
+	})
+}
+
+func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
+	for name, tc := range map[string]struct {
+		HTML       string
+		RequestURL string
+		URL        string
+		ImageURL   string
+	}{
+		"absolute URLs": {
+			HTML: `
+				<html>
+					<head>
+						<meta property="og:url" content="https://example.com/apps/mattermost">
+						<meta property="og:image" content="https://images.example.com/image.png">
+					</head>
+				</html>`,
+			RequestURL: "https://example.com",
+			URL:        "https://example.com/apps/mattermost",
+			ImageURL:   "https://images.example.com/image.png",
+		},
+		"URLs starting with /": {
+			HTML: `
+				<html>
+					<head>
+						<meta property="og:url" content="/apps/mattermost">
+						<meta property="og:image" content="/image.png">
+					</head>
+				</html>`,
+			RequestURL: "http://example.com",
+			URL:        "http://example.com/apps/mattermost",
+			ImageURL:   "http://example.com/image.png",
+		},
+		"HTTPS URLs starting with /": {
+			HTML: `
+				<html>
+					<head>
+						<meta property="og:url" content="/apps/mattermost">
+						<meta property="og:image" content="/image.png">
+					</head>
+				</html>`,
+			RequestURL: "https://example.com",
+			URL:        "https://example.com/apps/mattermost",
+			ImageURL:   "https://example.com/image.png",
+		},
+		"missing image URL": {
+			HTML: `
+				<html>
+					<head>
+						<meta property="og:url" content="/apps/mattermost">
+					</head>
+				</html>`,
+			RequestURL: "http://example.com",
+			URL:        "http://example.com/apps/mattermost",
+			ImageURL:   "",
+		},
+		"relative URLs": {
+			HTML: `
+				<html>
+					<head>
+						<meta property="og:url" content="index.html">
+						<meta property="og:image" content="../resources/image.png">
+					</head>
+				</html>`,
+			RequestURL: "http://example.com/content/index.html",
+			URL:        "http://example.com/content/index.html",
+			ImageURL:   "http://example.com/resources/image.png",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			og := opengraph.NewOpenGraph()
+			if err := og.ProcessHTML(strings.NewReader(tc.HTML)); err != nil {
+				t.Fatal(err)
+			}
+
+			makeOpenGraphURLsAbsolute(og, tc.RequestURL)
+
+			if og.URL != tc.URL {
+				t.Fatalf("incorrect url, expected %v, got %v", tc.URL, og.URL)
+			}
+
+			if len(og.Images) > 0 {
+				if og.Images[0].URL != tc.ImageURL {
+					t.Fatalf("incorrect image url, expected %v, got %v", tc.ImageURL, og.Images[0].URL)
+				}
+			} else if tc.ImageURL != "" {
+				t.Fatalf("missing image url, expected %v, got nothing", tc.ImageURL)
+			}
+		})
+	}
+}

--- a/app/post.go
+++ b/app/post.go
@@ -11,17 +11,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"regexp"
 	"strings"
 
-	"github.com/dyatlov/go-opengraph/opengraph"
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
-	"golang.org/x/net/html/charset"
 )
 
 const (
@@ -823,85 +820,6 @@ func (a *App) GetFileInfosForPost(postId string, readFromMaster bool) ([]*model.
 	}
 
 	return infos, nil
-}
-
-func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
-	og := opengraph.NewOpenGraph()
-
-	res, err := a.HTTPClient(false).Get(requestURL)
-	if err != nil {
-		mlog.Error(fmt.Sprintf("GetOpenGraphMetadata request failed for url=%v with err=%v", requestURL, err.Error()))
-		return og
-	}
-	defer consumeAndClose(res)
-
-	contentType := res.Header.Get("Content-Type")
-	body := forceHTMLEncodingToUTF8(res.Body, contentType)
-
-	if err := og.ProcessHTML(body); err != nil {
-		mlog.Error(fmt.Sprintf("GetOpenGraphMetadata processing failed for url=%v with err=%v", requestURL, err.Error()))
-	}
-
-	makeOpenGraphURLsAbsolute(og, requestURL)
-
-	// The URL should be the link the user provided in their message, not a redirected one.
-	if og.URL != "" {
-		og.URL = requestURL
-	}
-
-	return og
-}
-
-func forceHTMLEncodingToUTF8(body io.Reader, contentType string) io.Reader {
-	r, err := charset.NewReader(body, contentType)
-	if err != nil {
-		mlog.Error(fmt.Sprintf("forceHTMLEncodingToUTF8 failed to convert for contentType=%v with err=%v", contentType, err.Error()))
-		return body
-	}
-	return r
-}
-
-func makeOpenGraphURLsAbsolute(og *opengraph.OpenGraph, requestURL string) {
-	parsedRequestURL, err := url.Parse(requestURL)
-	if err != nil {
-		mlog.Warn(fmt.Sprintf("makeOpenGraphURLsAbsolute failed to parse url=%v", requestURL))
-		return
-	}
-
-	makeURLAbsolute := func(resultURL string) string {
-		if resultURL == "" {
-			return resultURL
-		}
-
-		parsedResultURL, err := url.Parse(resultURL)
-		if err != nil {
-			mlog.Warn(fmt.Sprintf("makeOpenGraphURLsAbsolute failed to parse result url=%v", resultURL))
-			return resultURL
-		}
-
-		if parsedResultURL.IsAbs() {
-			return resultURL
-		}
-
-		return parsedRequestURL.ResolveReference(parsedResultURL).String()
-	}
-
-	og.URL = makeURLAbsolute(og.URL)
-
-	for _, image := range og.Images {
-		image.URL = makeURLAbsolute(image.URL)
-		image.SecureURL = makeURLAbsolute(image.SecureURL)
-	}
-
-	for _, audio := range og.Audios {
-		audio.URL = makeURLAbsolute(audio.URL)
-		audio.SecureURL = makeURLAbsolute(audio.SecureURL)
-	}
-
-	for _, video := range og.Videos {
-		video.URL = makeURLAbsolute(video.URL)
-		video.SecureURL = makeURLAbsolute(video.SecureURL)
-	}
 }
 
 func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) *model.AppError {

--- a/app/post.go
+++ b/app/post.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -4,11 +4,31 @@
 package app
 
 import (
+	"image"
+	"io"
+	"net/http"
 	"strings"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/utils"
+	"github.com/mattermost/mattermost-server/utils/markdown"
 )
+
+const LINK_CACHE_SIZE = 10000
+const LINK_CACHE_DURATION = 3600
+
+var linkCache = utils.NewLru(LINK_CACHE_SIZE)
+
+func (a *App) InitPostMetadata() {
+	// Dump any cached links if the proxy settings have changed so image URLs can be updated
+	a.AddConfigListener(func(before, after *model.Config) {
+		if (before.ServiceSettings.ImageProxyType != after.ServiceSettings.ImageProxyType) ||
+			(before.ServiceSettings.ImageProxyURL != after.ServiceSettings.ImageProxyType) {
+			linkCache.Purge()
+		}
+	})
+}
 
 func (a *App) PreparePostListForClient(originalList *model.PostList) (*model.PostList, *model.AppError) {
 	list := &model.PostList{
@@ -31,15 +51,15 @@ func (a *App) PreparePostListForClient(originalList *model.PostList) (*model.Pos
 func (a *App) PreparePostForClient(originalPost *model.Post) (*model.Post, *model.AppError) {
 	post := originalPost.Clone()
 
-	var err *model.AppError
-
 	needReactionCounts := post.ReactionCounts == nil
 	needEmojis := post.Emojis == nil
-	needImageDimensions := post.ImageDimensions == nil
 	needOpenGraphData := post.OpenGraphData == nil
+	needImageDimensions := post.ImageDimensions == nil
 
+	// Get reactions to post
 	var reactions []*model.Reaction
 	if needReactionCounts || needEmojis {
+		var err *model.AppError
 		reactions, err = a.GetReactionsForPost(post.Id)
 		if err != nil {
 			return post, err
@@ -50,15 +70,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post) (*model.Post, *mode
 		post.ReactionCounts = model.CountReactions(reactions)
 	}
 
-	if post.FileInfos == nil {
-		fileInfos, err := a.GetFileInfosForPost(post.Id, false)
-		if err != nil {
-			return post, err
-		}
-
-		post.FileInfos = fileInfos
-	}
-
+	// Get emojis for post
 	if needEmojis {
 		emojis, err := a.getCustomEmojisForPost(post.Message, reactions)
 		if err != nil {
@@ -68,21 +80,77 @@ func (a *App) PreparePostForClient(originalPost *model.Post) (*model.Post, *mode
 		post.Emojis = emojis
 	}
 
+	// Get files for post
+	if post.FileInfos == nil {
+		fileInfos, err := a.GetFileInfosForPost(post.Id, false)
+		if err != nil {
+			return post, err
+		}
+
+		post.FileInfos = fileInfos
+	}
+
+	// Proxy image links in post
 	post = a.PostWithProxyAddedToImageURLs(post)
 
-	if needImageDimensions || needOpenGraphData {
-		if needImageDimensions {
-			post.ImageDimensions = []*model.PostImageDimensions{}
+	// Get OpenGraph and image metadata
+	if needOpenGraphData || needImageDimensions {
+		err := a.preparePostWithOpenGraphAndImageMetadata(post, needOpenGraphData, needImageDimensions)
+		if err != nil {
+			return post, err
 		}
-
-		if needOpenGraphData {
-			post.OpenGraphData = []*opengraph.OpenGraph{}
-		}
-
-		// TODO
 	}
 
 	return post, nil
+}
+
+func (a *App) preparePostWithOpenGraphAndImageMetadata(post *model.Post, needOpenGraphData, needImageDimensions bool) *model.AppError {
+	var appError *model.AppError
+
+	if needOpenGraphData {
+		post.OpenGraphData = []*opengraph.OpenGraph{}
+	}
+
+	if needImageDimensions {
+		post.ImageDimensions = []*model.PostImageDimensions{}
+	}
+
+	firstLink, images := getFirstLinkAndImages(post.Message)
+
+	// Look at the first link to see if it's a web page or an image
+	if firstLink != "" {
+		og, dimensions, err := a.getLinkMetadata(firstLink, true)
+		if err != nil {
+			// Keep going so that one bad link doesn't prevent other image dimensions from being sent to the client
+			appError = model.NewAppError("PreparePostForClient", "app.post.metadata.link.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		if needOpenGraphData {
+			post.OpenGraphData = append(post.OpenGraphData, og)
+		}
+
+		if needImageDimensions {
+			post.ImageDimensions = append(post.ImageDimensions, dimensions)
+		}
+	}
+
+	if needImageDimensions {
+		// And dimensions for other images
+		for _, image := range images {
+			_, dimensions, err := a.getLinkMetadata(image, true)
+			if err != nil {
+				// Keep going so that one bad link doesn't prevent other image dimensions from being sent to the client
+				appError = model.NewAppError("PreparePostForClient", "app.post.metadata.link.app_error", nil, err.Error(), http.StatusInternalServerError)
+				continue
+			}
+
+			if dimensions != nil {
+				post.ImageDimensions = append(post.ImageDimensions, dimensions)
+			}
+		}
+	}
+
+	return appError
 }
 
 func (a *App) getCustomEmojisForPost(message string, reactions []*model.Reaction) ([]*model.Emoji, *model.AppError) {
@@ -108,4 +176,130 @@ func (a *App) getCustomEmojisForPost(message string, reactions []*model.Reaction
 	}
 
 	return a.GetMultipleEmojiByName(names)
+}
+
+// Given a string, returns the first autolinked URL in the string as well as an array of all Markdown
+// images of the form ![alt text](image url). Note that this does not return Markdown links of the
+// form [text](url).
+func getFirstLinkAndImages(str string) (string, []string) {
+	firstLink := ""
+	images := []string{}
+
+	markdown.Inspect(str, func(blockOrInline interface{}) bool {
+		switch v := blockOrInline.(type) {
+		case *markdown.Autolink:
+			if firstLink == "" {
+				firstLink = v.Destination()
+			}
+		case *markdown.InlineImage:
+			images = append(images, v.Destination())
+		case *markdown.ReferenceImage:
+			images = append(images, v.ReferenceDefinition.Destination())
+		}
+
+		return true
+	})
+
+	if len(images) > 1 {
+		images = model.RemoveDuplicateStrings(images)
+	}
+
+	return firstLink, images
+}
+
+func (a *App) getLinkMetadata(requestURL string, useCache bool) (*opengraph.OpenGraph, *model.PostImageDimensions, error) {
+	// Check cache
+	if useCache {
+		og, dimensions, ok := getLinkMetadataFromCache(requestURL)
+
+		if ok {
+			return og, dimensions, nil
+		}
+	}
+
+	// Make request for a web page or an image
+	request, err := http.NewRequest("GET", requestURL, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	request.Header.Add("Accept", "text/html, image/*")
+
+	res, err := a.HTTPClient(false).Do(request) // TODO figure out a way to mock out the client for testing
+	if err != nil {
+		return nil, nil, err
+	}
+	defer consumeAndClose(res)
+
+	// Parse the data
+	og, dimensions, err := a.parseLinkMetadata(requestURL, res.Body, res.Header.Get("Content-Type"))
+
+	// Write back to cache
+	if useCache {
+		cacheLinkMetadata(requestURL, og, dimensions)
+	}
+
+	return og, dimensions, err
+}
+
+func getLinkMetadataFromCache(requestURL string) (*opengraph.OpenGraph, *model.PostImageDimensions, bool) {
+	cached, ok := linkCache.Get(requestURL)
+	if !ok {
+		return nil, nil, false
+	}
+
+	switch v := cached.(type) {
+	case *opengraph.OpenGraph:
+		return v, nil, true
+	case *model.PostImageDimensions:
+		return nil, v, true
+	default:
+		return nil, nil, true
+	}
+}
+
+func cacheLinkMetadata(requestURL string, og *opengraph.OpenGraph, dimensions *model.PostImageDimensions) {
+	var val interface{}
+	if og != nil {
+		val = og
+	} else if dimensions != nil {
+		val = dimensions
+	}
+
+	linkCache.AddWithExpiresInSecs(requestURL, val, LINK_CACHE_DURATION)
+}
+
+func (a *App) parseLinkMetadata(requestURL string, body io.Reader, contentType string) (*opengraph.OpenGraph, *model.PostImageDimensions, error) {
+	if strings.HasPrefix(contentType, "image") {
+		dimensions, err := parseImageDimensions(requestURL, body)
+		return nil, dimensions, err
+	} else if strings.HasPrefix(contentType, "text/html") {
+		og := a.ParseOpenGraphMetadata(requestURL, body, contentType)
+
+		// The OpenGraph library and Go HTML library don't error for malformed input, so check that at least
+		// one of these required fields exists before returning the OpenGraph data
+		if og.Title != "" || og.Type != "" || og.URL != "" {
+			return og, nil, nil
+		} else {
+			return nil, nil, nil
+		}
+	} else {
+		// Not an image or web page with OpenGraph information
+		return nil, nil, nil
+	}
+}
+
+func parseImageDimensions(requestURL string, body io.Reader) (*model.PostImageDimensions, error) {
+	config, _, err := image.DecodeConfig(body)
+	if err != nil {
+		return nil, err
+	}
+
+	dimensions := &model.PostImageDimensions{
+		URL:    requestURL,
+		Width:  config.Width,
+		Height: config.Height,
+	}
+
+	return dimensions, nil
 }

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -8,12 +8,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/dyatlov/go-opengraph/opengraph"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -349,124 +347,6 @@ func TestImageProxy(t *testing.T) {
 				assert.Equal(t, "![foo]("+tc.ImageURL+" =500x200)", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
 				post.Message = "![foo](" + tc.ProxiedImageURL + " =500x200)"
 				assert.Equal(t, "![foo]("+tc.ImageURL+" =500x200)", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
-			}
-		})
-	}
-}
-
-func BenchmarkForceHTMLEncodingToUTF8(b *testing.B) {
-	HTML := `
-		<html>
-			<head>
-				<meta property="og:url" content="https://example.com/apps/mattermost">
-				<meta property="og:image" content="https://images.example.com/image.png">
-			</head>
-		</html>
-	`
-	ContentType := "text/html; utf-8"
-
-	b.Run("with converting", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			r := forceHTMLEncodingToUTF8(strings.NewReader(HTML), ContentType)
-
-			og := opengraph.NewOpenGraph()
-			og.ProcessHTML(r)
-		}
-	})
-
-	b.Run("without converting", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			og := opengraph.NewOpenGraph()
-			og.ProcessHTML(strings.NewReader(HTML))
-		}
-	})
-}
-
-func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
-	for name, tc := range map[string]struct {
-		HTML       string
-		RequestURL string
-		URL        string
-		ImageURL   string
-	}{
-		"absolute URLs": {
-			HTML: `
-				<html>
-					<head>
-						<meta property="og:url" content="https://example.com/apps/mattermost">
-						<meta property="og:image" content="https://images.example.com/image.png">
-					</head>
-				</html>`,
-			RequestURL: "https://example.com",
-			URL:        "https://example.com/apps/mattermost",
-			ImageURL:   "https://images.example.com/image.png",
-		},
-		"URLs starting with /": {
-			HTML: `
-				<html>
-					<head>
-						<meta property="og:url" content="/apps/mattermost">
-						<meta property="og:image" content="/image.png">
-					</head>
-				</html>`,
-			RequestURL: "http://example.com",
-			URL:        "http://example.com/apps/mattermost",
-			ImageURL:   "http://example.com/image.png",
-		},
-		"HTTPS URLs starting with /": {
-			HTML: `
-				<html>
-					<head>
-						<meta property="og:url" content="/apps/mattermost">
-						<meta property="og:image" content="/image.png">
-					</head>
-				</html>`,
-			RequestURL: "https://example.com",
-			URL:        "https://example.com/apps/mattermost",
-			ImageURL:   "https://example.com/image.png",
-		},
-		"missing image URL": {
-			HTML: `
-				<html>
-					<head>
-						<meta property="og:url" content="/apps/mattermost">
-					</head>
-				</html>`,
-			RequestURL: "http://example.com",
-			URL:        "http://example.com/apps/mattermost",
-			ImageURL:   "",
-		},
-		"relative URLs": {
-			HTML: `
-				<html>
-					<head>
-						<meta property="og:url" content="index.html">
-						<meta property="og:image" content="../resources/image.png">
-					</head>
-				</html>`,
-			RequestURL: "http://example.com/content/index.html",
-			URL:        "http://example.com/content/index.html",
-			ImageURL:   "http://example.com/resources/image.png",
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			og := opengraph.NewOpenGraph()
-			if err := og.ProcessHTML(strings.NewReader(tc.HTML)); err != nil {
-				t.Fatal(err)
-			}
-
-			makeOpenGraphURLsAbsolute(og, tc.RequestURL)
-
-			if og.URL != tc.URL {
-				t.Fatalf("incorrect url, expected %v, got %v", tc.URL, og.URL)
-			}
-
-			if len(og.Images) > 0 {
-				if og.Images[0].URL != tc.ImageURL {
-					t.Fatalf("incorrect image url, expected %v, got %v", tc.ImageURL, og.Images[0].URL)
-				}
-			} else if tc.ImageURL != "" {
-				t.Fatalf("missing image url, expected %v, got nothing", tc.ImageURL)
 			}
 		})
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3119,6 +3119,10 @@
     "translation": "Plugins and/or plugin uploads have been disabled."
   },
   {
+    "id": "app.post.metadata.link.app_error",
+    "translation": "Failed to get metadata for a link in a post."
+  },
+  {
     "id": "app.role.check_roles_exist.role_not_found",
     "translation": "The provided role does not exist"
   },

--- a/model/post.go
+++ b/model/post.go
@@ -93,8 +93,8 @@ type Post struct {
 
 type PostImageDimensions struct {
 	URL    string `json:"url"`
-	Width  int64  `json:"width"`
-	Height int64  `json:"height"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
 }
 
 type PostEphemeral struct {

--- a/utils/testutils/testutils.go
+++ b/utils/testutils/testutils.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package testutils
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/mattermost/mattermost-server/utils"
+)
+
+func ReadTestFile(name string) ([]byte, error) {
+	path, _ := utils.FindDir("tests")
+	file, err := os.Open(filepath.Join(path, name))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	data := &bytes.Buffer{}
+	if _, err := io.Copy(data, file); err != nil {
+		return nil, err
+	} else {
+		return data.Bytes(), nil
+	}
+}


### PR DESCRIPTION
Here's the rest of the metadata stuff. It's more expensive than the earlier stuff, but I did add at least some basic caching for the new stuff. There's a lot that we could do to further improve performance as well like paralleling network requests or adding additional caching, even perhaps on-disk caching.

The only thing potentially missing from this is that OpenGraph images don't have dimensions. I'm not 100% sure if we need this, so I left it out for the time being since that would require an additional network request.

I'm also going to make a follow up ticket to improve the tests for this. We have no way to mock the http.Client calls here so these tests need an internet connection to pass. I've pointed them at files in https://github.com/hmhealey/test-files so that we have full control over them to ensure they don't break randomly, but I would like to add mocking for them eventually.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11272

#### Checklist
- Added or updated unit tests (required for all new features)
- Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- Touches critical sections of the codebase (auth, upgrade, etc.)
