### PR TITLE
MM-11710 Add a check to webhook messages to populate username from DM channel for email subject

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -163,7 +163,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 	if post.IsSystemMessage() {
 		senderName = utils.T("system.message.name")
 	} else {
-		if value, ok := post.Props["override_username"]; ok && post.Props["from_webhook"] == "true" {
+		if value, ok := post.Props["override_username"]; ok && post.Props["from_webhook"] == "true" && channel.Type != model.CHANNEL_DIRECT {
 			senderName = value.(string)
 			senderUsername = value.(string)
 		} else {


### PR DESCRIPTION
#### Summary
Change subject line for email when in a DM with webhooks to use other username instead of webhook override.

#### Ticket Link
[MM-11710](https://mattermost.atlassian.net/browse/MM-11710)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes
