### PR TITLE
MM-10532: Add EnableSyncWithLdapIncludeAuth config

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -452,8 +452,9 @@ func (a *App) trackConfig() {
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_SAML, map[string]interface{}{
-		"enable":                              *cfg.SamlSettings.Enable,
-		"enable_sync_with_ldap":               *cfg.SamlSettings.EnableSyncWithLdap,
+		"enable":                             *cfg.SamlSettings.Enable,
+		"enable_sync_with_ldap":              *cfg.SamlSettings.EnableSyncWithLdap,
+		"enable_sync_with_ldap_include_auth": *cfg.SamlSettings.EnableSyncWithLdapIncludeAuth,
 		"verify":                              *cfg.SamlSettings.Verify,
 		"encrypt":                             *cfg.SamlSettings.Encrypt,
 		"isdefault_scoping_idp_provider_id":   isDefault(*cfg.SamlSettings.ScopingIDPProviderId, ""),

--- a/config/default.json
+++ b/config/default.json
@@ -308,6 +308,7 @@
     "SamlSettings": {
         "Enable": false,
         "EnableSyncWithLdap": false,
+        "EnableSyncWithLdapIncludeAuth": false,
         "Verify": true,
         "Encrypt": true,
         "IdpUrl": "",

--- a/model/config.go
+++ b/model/config.go
@@ -1457,8 +1457,9 @@ func (s *LocalizationSettings) SetDefaults() {
 
 type SamlSettings struct {
 	// Basic
-	Enable             *bool
-	EnableSyncWithLdap *bool
+	Enable                        *bool
+	EnableSyncWithLdap            *bool
+	EnableSyncWithLdapIncludeAuth *bool
 
 	Verify  *bool
 	Encrypt *bool
@@ -1498,6 +1499,10 @@ func (s *SamlSettings) SetDefaults() {
 
 	if s.EnableSyncWithLdap == nil {
 		s.EnableSyncWithLdap = NewBool(false)
+	}
+
+	if s.EnableSyncWithLdapIncludeAuth == nil {
+		s.EnableSyncWithLdapIncludeAuth = NewBool(false)
 	}
 
 	if s.Verify == nil {


### PR DESCRIPTION
#### Summary
Add EnableSyncWithLdapIncludeAuth config to allow to include the
AuthData in the synchronization process or not.

#### Ticket Link
[MM-10532](https://mattermost.atlassian.net/browse/10532)

#### Checklist
- [x] Has enterprise changes (mattermost/enterprise#342)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)