### PR TITLE
MM-11270: Forbid react/de-react in archived channels

### DIFF
--- a/app/reaction.go
+++ b/app/reaction.go
@@ -15,43 +15,46 @@ func (a *App) SaveReactionForPost(reaction *model.Reaction) (*model.Reaction, *m
 		return nil, err
 	}
 
-	if a.License() != nil && *a.Config().TeamSettings.ExperimentalTownSquareIsReadOnly {
-		var channel *model.Channel
-		if channel, err = a.GetChannel(post.ChannelId); err != nil {
+	channel, err := a.GetChannel(post.ChannelId)
+	if err != nil {
+		return nil, err
+	}
+
+	if channel.DeleteAt > 0 {
+		return nil, model.NewAppError("deleteReactionForPost", "api.reaction.save.archived_channel.app_error", nil, "", http.StatusForbidden)
+	}
+
+	if a.License() != nil && *a.Config().TeamSettings.ExperimentalTownSquareIsReadOnly && channel.Name == model.DEFAULT_CHANNEL {
+		user, err := a.GetUser(reaction.UserId)
+		if err != nil {
 			return nil, err
 		}
 
-		if channel.Name == model.DEFAULT_CHANNEL {
-			var user *model.User
-			if user, err = a.GetUser(reaction.UserId); err != nil {
-				return nil, err
-			}
-
-			if !a.RolesGrantPermission(user.GetRoles(), model.PERMISSION_MANAGE_SYSTEM.Id) {
-				return nil, model.NewAppError("saveReactionForPost", "api.reaction.town_square_read_only", nil, "", http.StatusForbidden)
-			}
+		if !a.RolesGrantPermission(user.GetRoles(), model.PERMISSION_MANAGE_SYSTEM.Id) {
+			return nil, model.NewAppError("saveReactionForPost", "api.reaction.town_square_read_only", nil, "", http.StatusForbidden)
 		}
 	}
 
-	if result := <-a.Srv.Store.Reaction().Save(reaction); result.Err != nil {
+	result := <-a.Srv.Store.Reaction().Save(reaction)
+	if result.Err != nil {
 		return nil, result.Err
-	} else {
-		reaction = result.Data.(*model.Reaction)
-
-		a.Go(func() {
-			a.sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_ADDED, reaction, post, true)
-		})
-
-		return reaction, nil
 	}
+
+	reaction = result.Data.(*model.Reaction)
+
+	a.Go(func() {
+		a.sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_ADDED, reaction, post, true)
+	})
+
+	return reaction, nil
 }
 
 func (a *App) GetReactionsForPost(postId string) ([]*model.Reaction, *model.AppError) {
-	if result := <-a.Srv.Store.Reaction().GetForPost(postId, true); result.Err != nil {
+	result := <-a.Srv.Store.Reaction().GetForPost(postId, true)
+	if result.Err != nil {
 		return nil, result.Err
-	} else {
-		return result.Data.([]*model.Reaction), nil
 	}
+	return result.Data.([]*model.Reaction), nil
 }
 
 func (a *App) DeleteReactionForPost(reaction *model.Reaction) *model.AppError {
@@ -60,21 +63,23 @@ func (a *App) DeleteReactionForPost(reaction *model.Reaction) *model.AppError {
 		return err
 	}
 
-	if a.License() != nil && *a.Config().TeamSettings.ExperimentalTownSquareIsReadOnly {
-		var channel *model.Channel
-		if channel, err = a.GetChannel(post.ChannelId); err != nil {
+	channel, err := a.GetChannel(post.ChannelId)
+	if err != nil {
+		return err
+	}
+
+	if channel.DeleteAt > 0 {
+		return model.NewAppError("deleteReactionForPost", "api.reaction.delete.archived_channel.app_error", nil, "", http.StatusForbidden)
+	}
+
+	if a.License() != nil && *a.Config().TeamSettings.ExperimentalTownSquareIsReadOnly && channel.Name == model.DEFAULT_CHANNEL {
+		user, err := a.GetUser(reaction.UserId)
+		if err != nil {
 			return err
 		}
 
-		if channel.Name == model.DEFAULT_CHANNEL {
-			var user *model.User
-			if user, err = a.GetUser(reaction.UserId); err != nil {
-				return err
-			}
-
-			if !a.RolesGrantPermission(user.GetRoles(), model.PERMISSION_MANAGE_SYSTEM.Id) {
-				return model.NewAppError("deleteReactionForPost", "api.reaction.town_square_read_only", nil, "", http.StatusForbidden)
-			}
+		if !a.RolesGrantPermission(user.GetRoles(), model.PERMISSION_MANAGE_SYSTEM.Id) {
+			return model.NewAppError("deleteReactionForPost", "api.reaction.town_square_read_only", nil, "", http.StatusForbidden)
 		}
 	}
 
@@ -85,11 +90,11 @@ func (a *App) DeleteReactionForPost(reaction *model.Reaction) *model.AppError {
 
 	if result := <-a.Srv.Store.Reaction().Delete(reaction); result.Err != nil {
 		return result.Err
-	} else {
-		a.Go(func() {
-			a.sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_REMOVED, reaction, post, hasReactions)
-		})
 	}
+
+	a.Go(func() {
+		a.sendReactionEvent(model.WEBSOCKET_EVENT_REACTION_REMOVED, reaction, post, hasReactions)
+	})
 
 	return nil
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1435,6 +1435,14 @@
     "translation": "Unable to set user preferences."
   },
   {
+    "id": "api.reaction.delete.archived_channel.app_error",
+    "translation": "You cannot remove a reaction in an archived channel."
+  },
+  {
+    "id": "api.reaction.save.archived_channel.app_error",
+    "translation": "You cannot react in an archived channel."
+  },
+  {
     "id": "api.reaction.save_reaction.invalid.app_error",
     "translation": "Reaction is not valid."
   },


### PR DESCRIPTION
#### Summary
Forbid to react and remove reactions in archived channels.

#### Ticket Link
[MM-11270](https://mattermost.atlassian.net/browse/11270)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates