### PR TITLE
MM-11762 Add GetLDAPUserAttributes method to the plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -184,6 +184,22 @@ func (api *PluginAPI) UpdateUserStatus(userId, status string) (*model.Status, *m
 
 	return api.app.GetStatus(userId)
 }
+func (api *PluginAPI) GetLDAPUserAttributes(userId string, attributes []string) (map[string]string, *model.AppError) {
+	if api.app.Ldap == nil {
+		return nil, model.NewAppError("GetLdapUserAttributes", "ent.ldap.disabled.app_error", nil, "", http.StatusNotImplemented)
+	}
+
+	user, err := api.app.GetUser(userId)
+	if err != nil {
+		return nil, err
+	}
+
+	if user.AuthService != model.USER_AUTH_SERVICE_LDAP || user.AuthData == nil {
+		return map[string]string{}, nil
+	}
+
+	return api.app.Ldap.GetUserAttributes(*user.AuthData, attributes)
+}
 
 func (api *PluginAPI) CreateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 	return api.app.CreateChannel(channel, false)

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -62,6 +62,12 @@ type API interface {
 	// The status parameter can be: "online", "away", "dnd", or "offline".
 	UpdateUserStatus(userId, status string) (*model.Status, *model.AppError)
 
+	// GetLDAPUserAttributes will return LDAP attributes for a user.
+	// The attributes parameter should be a list of attributes to pull.
+	// Returns a map with attribute names as keys and the user's attributes as values.
+	// Requires an enterprise license, LDAP to be configured and for the user to use LDAP as an authentication method.
+	GetLDAPUserAttributes(userId string, attributes []string) (map[string]string, *model.AppError)
+
 	// CreateTeam creates a team.
 	CreateTeam(team *model.Team) (*model.Team, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -903,6 +903,36 @@ func (s *apiRPCServer) UpdateUserStatus(args *Z_UpdateUserStatusArgs, returns *Z
 	return nil
 }
 
+type Z_GetLDAPUserAttributesArgs struct {
+	A string
+	B []string
+}
+
+type Z_GetLDAPUserAttributesReturns struct {
+	A map[string]string
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetLDAPUserAttributes(userId string, attributes []string) (map[string]string, *model.AppError) {
+	_args := &Z_GetLDAPUserAttributesArgs{userId, attributes}
+	_returns := &Z_GetLDAPUserAttributesReturns{}
+	if err := g.client.Call("Plugin.GetLDAPUserAttributes", _args, _returns); err != nil {
+		log.Printf("RPC call to GetLDAPUserAttributes API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetLDAPUserAttributes(args *Z_GetLDAPUserAttributesArgs, returns *Z_GetLDAPUserAttributesReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetLDAPUserAttributes(userId string, attributes []string) (map[string]string, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetLDAPUserAttributes(args.A, args.B)
+	} else {
+		return fmt.Errorf("API GetLDAPUserAttributes called but not implemented.")
+	}
+	return nil
+}
+
 type Z_CreateTeamArgs struct {
 	A *model.Team
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -524,6 +524,31 @@ func (_m *API) GetGroupChannel(userIds []string) (*model.Channel, *model.AppErro
 	return r0, r1
 }
 
+// GetLDAPUserAttributes provides a mock function with given fields: userId, attributes
+func (_m *API) GetLDAPUserAttributes(userId string, attributes []string) (map[string]string, *model.AppError) {
+	ret := _m.Called(userId, attributes)
+
+	var r0 map[string]string
+	if rf, ok := ret.Get(0).(func(string, []string) map[string]string); ok {
+		r0 = rf(userId, attributes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, []string) *model.AppError); ok {
+		r1 = rf(userId, attributes)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPost provides a mock function with given fields: postId
 func (_m *API) GetPost(postId string) (*model.Post, *model.AppError) {
 	ret := _m.Called(postId)


### PR DESCRIPTION
#### Summary
Add GetLDAPUserAttributes method to the plugin API to add back functionality that the `ldapextras` built-in plugin had.

Example usage:
```go
attributesMap, err := p.API.GetLDAPUserAttributes(userID, []string{"sAMAccountName", "description"})
if err != nil {
	return err
}
// do something with attributesMap
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11762