### PR TITLE
bug fix: after and before search flags should not be inclusive of the selected date

### DIFF
--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1581,19 +1581,24 @@ func TestSearchPostsWithDateFlags(t *testing.T) {
 			resultCount = resultCount + 1
 		}
 	}
-	if resultCount != 3 {
+	if resultCount != 2 {
 		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	posts, _ = Client.SearchPosts(th.BasicTeam.Id, "before:2018-08-02", false)
-	if len(posts.Order) != 2 {
+	if len(posts.Order) != 1 {
 		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
 
 	posts, _ = Client.SearchPosts(th.BasicTeam.Id, "before:2018-08-03 after:2018-08-02", false)
-	if len(posts.Order) != 2 {
+	if len(posts.Order) != 0 {
 		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
 	}
+
+	posts, _ = Client.SearchPosts(th.BasicTeam.Id, "before:2018-08-03 after:2018-08-01", false)
+	if len(posts.Order) != 1 {
+		t.Fatalf("wrong number of posts returned %v", len(posts.Order))
+	}	
 }
 
 func TestGetFileInfosForPost(t *testing.T) {

--- a/model/search_params.go
+++ b/model/search_params.go
@@ -6,6 +6,7 @@ package model
 import (
 	"regexp"
 	"strings"
+	"time"
 )
 
 var searchTermPuncStart = regexp.MustCompile(`^[^\pL\d\s#"]+`)
@@ -27,13 +28,19 @@ type SearchParams struct {
 // Returns the epoch timestamp of the start of the day specified by SearchParams.AfterDate
 func (p *SearchParams) GetAfterDateMillis() int64 {
 	date := ParseDateFilterToTime(p.AfterDate)
-	return GetStartOfDayMillis(date, p.TimeZoneOffset)
+	// travel forward 1 day
+	oneDay := time.Hour * 24
+	afterDate := date.Add(oneDay)
+	return GetStartOfDayMillis(afterDate, p.TimeZoneOffset)
 }
 
 // Returns the epoch timestamp of the end of the day specified by SearchParams.BeforeDate
 func (p *SearchParams) GetBeforeDateMillis() int64 {
 	date := ParseDateFilterToTime(p.BeforeDate)
-	return GetEndOfDayMillis(date, p.TimeZoneOffset)
+	// travel back 1 day
+	oneDay := time.Hour * -24
+	beforeDate := date.Add(oneDay)
+	return GetEndOfDayMillis(beforeDate, p.TimeZoneOffset)
 }
 
 // Returns the epoch timestamps of the start and end of the day specified by SearchParams.OnDate


### PR DESCRIPTION
#### Summary
bug fix: after and before search flags should not be inclusive of the selected date

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)