### PR TITLE
[MM-11876] Add cursor to posts list such as next_post_id and previous_post_id

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -126,6 +126,9 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	var since int64
 	var parseError error
 
+	var nextPostId string
+	var previousPostId string
+
 	if len(sinceString) > 0 {
 		since, parseError = strconv.ParseInt(sinceString, 10, 64)
 		if parseError != nil {
@@ -153,6 +156,9 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		list, err = c.App.GetPostsAfterPost(c.Params.ChannelId, afterPost, c.Params.Page, c.Params.PerPage)
+		if len(list.Order) > 0 {
+			previousPostId = afterPost
+		}
 	} else if len(beforePost) > 0 {
 		etag = c.App.GetPostsEtag(c.Params.ChannelId)
 
@@ -161,6 +167,9 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		list, err = c.App.GetPostsBeforePost(c.Params.ChannelId, beforePost, c.Params.Page, c.Params.PerPage)
+		if len(list.Order) > 0 {
+			nextPostId = beforePost
+		}
 	} else {
 		etag = c.App.GetPostsEtag(c.Params.ChannelId)
 
@@ -184,6 +193,17 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		mlog.Error("Failed to prepare posts for getPostsForChannel response", mlog.Any("err", err))
 	}
+
+	if nextPostId == "" {
+		nextPostId = c.App.GetNextPostFromPostList(clientPostList)
+	}
+
+	if previousPostId == "" {
+		previousPostId = c.App.GetPreviousPostFromPostList(clientPostList)
+	}
+
+	clientPostList.NextPostId = nextPostId
+	clientPostList.PreviousPostId = previousPostId
 
 	w.Write([]byte(clientPostList.ToJson()))
 }
@@ -227,6 +247,9 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 	if err != nil {
 		mlog.Error("Failed to prepare posts for getPostsForChannelAroundLastUnread response", mlog.Any("err", err))
 	}
+
+	clientPostList.NextPostId = c.App.GetNextPostFromPostList(clientPostList)
+	clientPostList.PreviousPostId = c.App.GetPreviousPostFromPostList(clientPostList)
 
 	if len(etag) > 0 {
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1077,11 +1077,27 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 		}
 	}
 
-	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post3.Id, 1, 1, "")
+	if posts.NextPostId != post3.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PreviousPostId != "" {
+		t.Fatal("should match empty PreviousPostId")
+	}
+
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post4.Id, 1, 1, "")
 	CheckNoError(t, resp)
 
 	if len(posts.Posts) != 1 {
 		t.Fatal("too many posts returned")
+	}
+	if posts.Order[0] != post2.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post4.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PreviousPostId != post1.Id {
+		t.Fatal("should match PreviousPostId")
 	}
 
 	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, "junk", 1, 1, "")
@@ -1089,6 +1105,9 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 
 	if len(posts.Posts) != 0 {
 		t.Fatal("should have no posts")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should match empty NextPostId")
 	}
 
 	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post3.Id, 0, 100, "")
@@ -1113,11 +1132,27 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 		}
 	}
 
-	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post3.Id, 1, 1, "")
+	if posts.NextPostId != "" {
+		t.Fatal("should match empty NextPostId")
+	}
+	if posts.PreviousPostId != post3.Id {
+		t.Fatal("should match PreviousPostId")
+	}
+
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post2.Id, 1, 1, "")
 	CheckNoError(t, resp)
 
 	if len(posts.Posts) != 1 {
 		t.Fatal("too many posts returned")
+	}
+	if posts.Order[0] != post4.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post5.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PreviousPostId != post2.Id {
+		t.Fatal("should match PreviousPostId")
 	}
 
 	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, "junk", 1, 1, "")
@@ -1125,6 +1160,9 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 
 	if len(posts.Posts) != 0 {
 		t.Fatal("should have no posts")
+	}
+	if posts.PreviousPostId != "" {
+		t.Fatal("should match empty PreviousPostId")
 	}
 }
 

--- a/app/opengraph.go
+++ b/app/opengraph.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
-	res, err := a.HTTPClient(false).Get(requestURL)
+	res, err := a.HTTPService.MakeClient(false).Get(requestURL)
 	if err != nil {
 		mlog.Error("GetOpenGraphMetadata request failed", mlog.String("requestURL", requestURL), mlog.Any("err", err))
 		return nil

--- a/app/post.go
+++ b/app/post.go
@@ -607,6 +607,58 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 	}
 }
 
+func (a *App) GetPostAfter(channelId, postId string) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostAfter(channelId, postId)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.(*model.Post), nil
+}
+
+func (a *App) GetPostBefore(channelId, postId string) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostBefore(channelId, postId)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.(*model.Post), nil
+}
+
+func (a *App) GetNextPostFromPostList(postList *model.PostList) string {
+	if len(postList.Order) > 0 {
+		firstPostId := postList.Order[0]
+		firstPost := postList.Posts[firstPostId]
+		nextPost, err := a.GetPostAfter(firstPost.ChannelId, firstPost.Id)
+		if err != nil {
+			mlog.Error("GetNextPostFromPostList: failed in getting next post", mlog.Any("err", err))
+		}
+
+		if nextPost != nil {
+			return nextPost.Id
+		}
+	}
+
+	return ""
+}
+
+func (a *App) GetPreviousPostFromPostList(postList *model.PostList) string {
+	if len(postList.Order) > 0 {
+		lastPostId := postList.Order[len(postList.Order)-1]
+		lastPost := postList.Posts[lastPostId]
+		previousPost, err := a.GetPostBefore(lastPost.ChannelId, lastPost.Id)
+		if err != nil {
+			mlog.Error("GetPreviousPostFromPostList: failed in getting previous post", mlog.Any("err", err))
+		}
+
+		if previousPost != nil {
+			return previousPost.Id
+		}
+	}
+
+	return ""
+}
+
 func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string, limitBefore, limitAfter int) (*model.PostList, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -225,7 +225,7 @@ func (a *App) getLinkMetadata(requestURL string, useCache bool) (*opengraph.Open
 
 	request.Header.Add("Accept", "text/html, image/*")
 
-	res, err := a.HTTPClient(false).Do(request) // TODO figure out a way to mock out the client for testing
+	res, err := a.HTTPService.MakeClient(false).Do(request)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
+	"strings"
 	"testing"
 	"time"
 

--- a/model/post_list.go
+++ b/model/post_list.go
@@ -10,8 +10,10 @@ import (
 )
 
 type PostList struct {
-	Order []string         `json:"order"`
-	Posts map[string]*Post `json:"posts"`
+	Order          []string         `json:"order"`
+	Posts          map[string]*Post `json:"posts"`
+	NextPostId     string           `json:"next_post_id,omitempty"`
+	PreviousPostId string           `json:"previous_post_id,omitempty"`
 }
 
 func NewPostList() *PostList {

--- a/store/store.go
+++ b/store/store.go
@@ -197,6 +197,8 @@ type PostStore interface {
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) StoreChannel
+	GetPostAfter(channelId, postId string) StoreChannel
+	GetPostBefore(channelId, postId string) StoreChannel
 	GetEtag(channelId string, allowFromCache bool) StoreChannel
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -194,6 +194,38 @@ func (_m *PostStore) GetOldest() store.StoreChannel {
 	return r0
 }
 
+// GetPostAfter provides a mock function with given fields: channelId, postId
+func (_m *PostStore) GetPostAfter(channelId string, postId string) store.StoreChannel {
+	ret := _m.Called(channelId, postId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+		r0 = rf(channelId, postId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+// GetPostBefore provides a mock function with given fields: channelId, postId
+func (_m *PostStore) GetPostBefore(channelId string, postId string) store.StoreChannel {
+	ret := _m.Called(channelId, postId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+		r0 = rf(channelId, postId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetPosts provides a mock function with given fields: channelId, offset, limit, allowFromCache
 func (_m *PostStore) GetPosts(channelId string, offset int, limit int, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(channelId, offset, limit, allowFromCache)


### PR DESCRIPTION
#### Summary
Add cursor to posts list such as next_post_id and previous_post_id with the shape like:
```json
{
    "next_post_id": "post_id_3",
    "order": ["post_id_1", "post_id_2"],
    "posts": {
        "post_id_1": {...}, 
        "post_id_2": {...}, 
    },
    "previous_post_id": "post_id_0",
}
```

This adds cursor to posts list returned by the following:
- getPostsForChannel `GET api/v4/channels/{channel_id:[A-Za-z0-9]+}/posts`
  - [UPDATE] On query `?before={post_id}`, said before post ID is automatically set as `next_post_id`.  Only `previous_post_id` will be queried from the database after getting the post list.
  - [UPDATE] On query `?after={post_id}`, said after post ID is automatically set as `previous_post_id`.  Only `next_post_id` will be queried from the database after getting the post list.
  - [UPDATE] On query `?since={time}`, both `next_post_id` and `previous_post_id` will be queried separately from the database after getting the post list.
- getPostsForChannelAroundLastUnread `GET api/v4/users/{user_id:[A-Za-z0-9]+}/channels/{channel_id:[A-Za-z0-9]+}/posts/unread`
  - [UPDATE] both `next_post_id` and `previous_post_id` will be queried separately from the database after getting the post list.
  - ~~websocket event `WEBSOCKET_EVENT_POSTED = "posted"` will include `previous_post_id` on its published message~~ [UPDATE] will submit this separately

Note that cursor is NOT applied to the following:
- [UPDATE] getPost `GET api/v4/posts/{post_id}`
- getPinnedPosts `GET api/v4/channels/{channel_id:[A-Za-z0-9]+}/pinned`
- getFlaggedPostsForUser `GET api/v4/users/{user_id:[A-Za-z0-9]+}/posts/flagged`
- getPostThread `GET api/v4/channels/{channel_id:[A-Za-z0-9]+}/thread`
- searchPosts `GET api/v4/teams/{team_id:[A-Za-z0-9]+}/posts/search`

#### Ticket Link
Jira ticket: [MM-11876](https://mattermost.atlassian.net/browse/MM-11876)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (to follow)
- [x] All new/modified APIs include changes to the drivers
