### PR TITLE
MM-11649: Fix caching issue in channel API endpoints.

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -97,10 +97,11 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	var oldChannel *model.Channel
-	var err *model.AppError
-	if oldChannel, err = c.App.GetChannel(channel.Id); err != nil {
+	if originalOldChannel, err := c.App.GetChannel(channel.Id); err != nil {
 		c.Err = err
 		return
+	} else {
+		oldChannel = originalOldChannel.DeepCopy()
 	}
 
 	switch oldChannel.Type {
@@ -229,10 +230,12 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oldChannel, err := c.App.GetChannel(c.Params.ChannelId)
-	if err != nil {
+	var oldChannel *model.Channel
+	if originalOldChannel, err := c.App.GetChannel(c.Params.ChannelId); err != nil {
 		c.Err = err
 		return
+	} else {
+		oldChannel = originalOldChannel.DeepCopy()
 	}
 
 	switch oldChannel.Type {

--- a/model/channel.go
+++ b/model/channel.go
@@ -59,6 +59,9 @@ type ChannelPatch struct {
 
 func (o *Channel) DeepCopy() *Channel {
 	copy := *o
+	if copy.SchemeId != nil {
+		copy.SchemeId = NewString(*o.SchemeId)
+	}
 	return &copy
 }
 


### PR DESCRIPTION
#### Summary
Fixes the Channel Update & Patch endpoints to work on a *copy* of the cached object so as not to pollute the cache if the update fails.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11649