### PR TITLE
[MM-11860]: Expose slack attachment parsing functions in the model package

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -38,7 +38,7 @@ func GetCommandProvider(name string) CommandProvider {
 }
 
 func (a *App) CreateCommandPost(post *model.Post, teamId string, response *model.CommandResponse) (*model.Post, *model.AppError) {
-	post.Message = parseSlackLinksToMarkdown(response.Text)
+	post.Message = model.ParseSlackLinksToMarkdown(response.Text)
 	post.CreateAt = model.GetMillis()
 
 	if strings.HasPrefix(post.Type, model.POST_SYSTEM_MESSAGE_PREFIX) {
@@ -47,7 +47,7 @@ func (a *App) CreateCommandPost(post *model.Post, teamId string, response *model
 	}
 
 	if response.Attachments != nil {
-		parseSlackAttachment(post, response.Attachments)
+		model.ParseSlackAttachment(post, response.Attachments)
 	}
 
 	if response.ResponseType == model.COMMAND_RESPONSE_TYPE_IN_CHANNEL {

--- a/app/post.go
+++ b/app/post.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
@@ -24,8 +23,6 @@ import (
 	"github.com/mattermost/mattermost-server/utils"
 	"golang.org/x/net/html/charset"
 )
-
-var linkWithTextRegex = regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
 
 func (a *App) CreatePostAsUser(post *model.Post) (*model.Post, *model.AppError) {
 	// Check that channel has not been deleted
@@ -306,28 +303,6 @@ func (a *App) handlePostEvents(post *model.Post, user *model.User, channel *mode
 	}
 
 	return nil
-}
-
-// This method only parses and processes the attachments,
-// all else should be set in the post which is passed
-func parseSlackAttachment(post *model.Post, attachments []*model.SlackAttachment) {
-	post.Type = model.POST_SLACK_ATTACHMENT
-
-	for _, attachment := range attachments {
-		attachment.Text = parseSlackLinksToMarkdown(attachment.Text)
-		attachment.Pretext = parseSlackLinksToMarkdown(attachment.Pretext)
-
-		for _, field := range attachment.Fields {
-			if value, ok := field.Value.(string); ok {
-				field.Value = parseSlackLinksToMarkdown(value)
-			}
-		}
-	}
-	post.AddProp("attachments", attachments)
-}
-
-func parseSlackLinksToMarkdown(text string) string {
-	return linkWithTextRegex.ReplaceAllString(text, "[${2}](${1})")
 }
 
 func (a *App) SendEphemeralPost(userId string, post *model.Post) *model.Post {
@@ -931,7 +906,7 @@ func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) *mod
 
 	if response.EphemeralText != "" {
 		ephemeralPost := &model.Post{}
-		ephemeralPost.Message = parseSlackLinksToMarkdown(response.EphemeralText)
+		ephemeralPost.Message = model.ParseSlackLinksToMarkdown(response.EphemeralText)
 		ephemeralPost.ChannelId = post.ChannelId
 		ephemeralPost.RootId = post.RootId
 		if ephemeralPost.RootId == "" {

--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -796,7 +796,7 @@ func (a *App) OldImportIncomingWebhookPost(post *model.Post, props model.StringI
 		for key, val := range props {
 			if key == "attachments" {
 				if attachments, success := val.([]*model.SlackAttachment); success {
-					parseSlackAttachment(post, attachments)
+					model.ParseSlackAttachment(post, attachments)
 				}
 			} else if key != "from_webhook" {
 				post.AddProp(key, val)

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -265,7 +265,7 @@ func (a *App) CreateWebhookPost(userId string, channel *model.Channel, text, ove
 		for key, val := range props {
 			if key == "attachments" {
 				if attachments, success := val.([]*model.SlackAttachment); success {
-					parseSlackAttachment(post, attachments)
+					model.ParseSlackAttachment(post, attachments)
 				}
 			} else if key != "override_icon_url" && key != "override_username" && key != "from_webhook" {
 				post.AddProp(key, val)


### PR DESCRIPTION
#### Summary
Refactored parseSlackAttachment functions from https://github.com/mattermost/mattermost-server/blob/master/app/post.go#L312
into model/slack_attachments.go so that plugins have access to them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11860

#### Checklist
Nothing in the checklist really applied, but I did write a plugin to test my changes located here:

https://github.com/cjbirk/mattermost-slackparse-plugin