### PR TITLE
MM-11895: Don't crush user-provided GET parameters on slash command URLs

### DIFF
--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -491,6 +491,7 @@ func TestExecuteGetCommand(t *testing.T) {
 
 		require.Equal(t, token, values.Get("token"))
 		require.Equal(t, th.BasicTeam.Name, values.Get("team_domain"))
+		require.Equal(t, "ourCommand", values.Get("cmd"))
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(expectedCommandResponse.ToJson()))
@@ -500,7 +501,7 @@ func TestExecuteGetCommand(t *testing.T) {
 	getCmd := &model.Command{
 		CreatorId: th.BasicUser.Id,
 		TeamId:    th.BasicTeam.Id,
-		URL:       ts.URL,
+		URL:       ts.URL + "/?cmd=ourCommand",
 		Method:    model.COMMAND_METHOD_GET,
 		Trigger:   "getcommand",
 		Token:     token,

--- a/app/command.go
+++ b/app/command.go
@@ -233,7 +233,11 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 				var req *http.Request
 				if cmd.Method == model.COMMAND_METHOD_GET {
 					req, _ = http.NewRequest(http.MethodGet, cmd.URL, nil)
-					req.URL.RawQuery = p.Encode()
+
+					if req.URL.RawQuery != "" {
+						req.URL.RawQuery += "&"
+					}
+					req.URL.RawQuery += p.Encode()
 				} else {
 					req, _ = http.NewRequest(http.MethodPost, cmd.URL, strings.NewReader(p.Encode()))
 				}


### PR DESCRIPTION
#### Summary
This fix for https://github.com/mattermost/mattermost-server/issues/9356 naively concatenates the GET query parameters on the provided endpoint URL with Mattermost's ones.

Parameters specified by both the user and Mattermost will be duplicated (see https://github.com/mattermost/mattermost-server/issues/9279#issuecomment-416783023). Currently, no warning is shown for this, either in the webapp/documentation, or on the server logs.

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-11895
Github: https://github.com/mattermost/mattermost-server/issues/9356

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
