### PR TITLE
Stop re-wrapping password reset email error in another error

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1176,11 +1176,7 @@ func (a *App) SendPasswordReset(email string, siteURL string) (bool, *model.AppE
 		return false, err
 	}
 
-	if _, err := a.SendPasswordResetEmail(user.Email, token, user.Locale, siteURL); err != nil {
-		return false, model.NewAppError("SendPasswordReset", "api.user.send_password_reset.send.app_error", nil, "err="+err.Message, http.StatusInternalServerError)
-	}
-
-	return true, nil
+	return a.SendPasswordResetEmail(user.Email, token, user.Locale, siteURL)
 }
 
 func (a *App) CreatePasswordRecoveryToken(userId string) (*model.Token, *model.AppError) {


### PR DESCRIPTION
App.SendPasswordResetEmail already returns a properly formatted AppError, so App.SendPasswordReset was just re-wrapping it except with the details replaced with a generic error message