### PR TITLE
Add ChannelId and TeamId to PostActionIntegrationRequest

### DIFF
--- a/app/post_test.go
+++ b/app/post_test.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -130,10 +129,12 @@ func TestPostAction(t *testing.T) {
 	})
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var request model.PostActionIntegrationRequest
-		err := json.NewDecoder(r.Body).Decode(&request)
-		assert.NoError(t, err)
+		request := model.PostActionIntegrationRequesteFromJson(r.Body)
+		assert.NotNil(t, request)
+
 		assert.Equal(t, request.UserId, th.BasicUser.Id)
+		assert.Equal(t, request.ChannelId, th.BasicChannel.Id)
+		assert.Equal(t, request.TeamId, th.BasicTeam.Id)
 		if request.Type == model.POST_ACTION_TYPE_SELECT {
 			assert.Equal(t, request.DataSource, "some_source")
 			assert.Equal(t, request.Context["selected_option"], "selected")

--- a/model/post.go
+++ b/model/post.go
@@ -154,6 +154,8 @@ type PostActionIntegration struct {
 
 type PostActionIntegrationRequest struct {
 	UserId     string          `json:"user_id"`
+	ChannelId  string          `json:"channel_id"`
+	TeamId     string          `json:"team_id"`
 	PostId     string          `json:"post_id"`
 	Type       string          `json:"type"`
 	DataSource string          `json:"data_source"`


### PR DESCRIPTION
#### Summary
This PR adds a `ChannelId` and `TeamId` field to `model.PostActionIntegrationRequest`.

### Ticket Link
See https://pre-release.mattermost.com/core/pl/se1g1wck47raxp9ui91fwtuc4w


