### PR TITLE
MM-11230: Make permissions checks in commands failsafe.

### DIFF
--- a/app/command_channel_header.go
+++ b/app/command_channel_header.go
@@ -4,9 +4,9 @@
 package app
 
 import (
-	"github.com/mattermost/mattermost-server/model"
-
 	goi18n "github.com/nicksnyder/go-i18n/i18n"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 type HeaderProvider struct {
@@ -37,33 +37,51 @@ func (me *HeaderProvider) GetCommand(a *App, T goi18n.TranslateFunc) *model.Comm
 func (me *HeaderProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	channel, err := a.GetChannel(args.ChannelId)
 	if err != nil {
-		return &model.CommandResponse{Text: args.T("api.command_channel_header.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_header.channel.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	switch channel.Type {
 	case model.CHANNEL_OPEN:
 		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
-			return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+			return &model.CommandResponse{
+				Text:         args.T("api.command_channel_header.permission.app_error"),
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
 		}
 
 	case model.CHANNEL_PRIVATE:
 		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
-			return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+			return &model.CommandResponse{
+				Text:         args.T("api.command_channel_header.permission.app_error"),
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
 		}
 
 	case model.CHANNEL_GROUP, model.CHANNEL_DIRECT:
 		// Modifying the header is not linked to any specific permission for group/dm channels, so just check for membership.
 		channelMember, err := a.GetChannelMember(args.ChannelId, args.Session.UserId)
 		if err != nil || channelMember == nil {
-			return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+			return &model.CommandResponse{
+				Text:         args.T("api.command_channel_header.permission.app_error"),
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
 		}
 
 	default:
-		return &model.CommandResponse{Text: args.T("api.command_channel_header.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_header.permission.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	if len(message) == 0 {
-		return &model.CommandResponse{Text: args.T("api.command_channel_header.message.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_header.message.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	patch := &model.ChannelPatch{
@@ -73,7 +91,10 @@ func (me *HeaderProvider) DoCommand(a *App, args *model.CommandArgs, message str
 
 	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
-		return &model.CommandResponse{Text: args.T("api.command_channel_header.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_header.update_channel.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	return &model.CommandResponse{}

--- a/app/command_channel_purpose.go
+++ b/app/command_channel_purpose.go
@@ -4,8 +4,9 @@
 package app
 
 import (
-	"github.com/mattermost/mattermost-server/model"
 	goi18n "github.com/nicksnyder/go-i18n/i18n"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 type PurposeProvider struct {
@@ -36,23 +37,39 @@ func (me *PurposeProvider) GetCommand(a *App, T goi18n.TranslateFunc) *model.Com
 func (me *PurposeProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	channel, err := a.GetChannel(args.ChannelId)
 	if err != nil {
-		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_purpose.channel.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
-		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	}
-
-	if channel.Type == model.CHANNEL_PRIVATE && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
-		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	}
-
-	if channel.Type == model.CHANNEL_GROUP || channel.Type == model.CHANNEL_DIRECT {
-		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.direct_group.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	switch channel.Type {
+	case model.CHANNEL_OPEN:
+		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+			return &model.CommandResponse{
+				Text:         args.T("api.command_channel_purpose.permission.app_error"),
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
+		}
+	case model.CHANNEL_PRIVATE:
+		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+			return &model.CommandResponse{
+				Text:         args.T("api.command_channel_purpose.permission.app_error"),
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
+		}
+	default:
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_purpose.direct_group.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	if len(message) == 0 {
-		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.message.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_purpose.message.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	patch := &model.ChannelPatch{
@@ -62,7 +79,10 @@ func (me *PurposeProvider) DoCommand(a *App, args *model.CommandArgs, message st
 
 	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
-		return &model.CommandResponse{Text: args.T("api.command_channel_purpose.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_purpose.update_channel.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	return &model.CommandResponse{}

--- a/app/command_channel_purpose_test.go
+++ b/app/command_channel_purpose_test.go
@@ -11,11 +11,11 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func TestHeaderProviderDoCommand(t *testing.T) {
+func TestPurposeProviderDoCommand(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
-	hp := HeaderProvider{}
+	pp := PurposeProvider{}
 
 	// Try a public channel *with* permission.
 	args := &model.CommandArgs{
@@ -25,10 +25,10 @@ func TestHeaderProviderDoCommand(t *testing.T) {
 	}
 
 	for msg, expected := range map[string]string{
-		"":      "api.command_channel_header.message.app_error",
+		"":      "api.command_channel_purpose.message.app_error",
 		"hello": "",
 	} {
-		actual := hp.DoCommand(th.App, args, msg).Text
+		actual := pp.DoCommand(th.App, args, msg).Text
 		assert.Equal(t, expected, actual)
 	}
 
@@ -39,8 +39,8 @@ func TestHeaderProviderDoCommand(t *testing.T) {
 		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
 	}
 
-	actual := hp.DoCommand(th.App, args, "hello").Text
-	assert.Equal(t, "api.command_channel_header.permission.app_error", actual)
+	actual := pp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_purpose.permission.app_error", actual)
 
 	// Try a private channel *with* permission.
 	privateChannel := th.CreatePrivateChannel(th.BasicTeam)
@@ -51,7 +51,7 @@ func TestHeaderProviderDoCommand(t *testing.T) {
 		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
 	}
 
-	actual = hp.DoCommand(th.App, args, "hello").Text
+	actual = pp.DoCommand(th.App, args, "hello").Text
 	assert.Equal(t, "", actual)
 
 	// Try a private channel *without* permission.
@@ -61,13 +61,12 @@ func TestHeaderProviderDoCommand(t *testing.T) {
 		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
 	}
 
-	actual = hp.DoCommand(th.App, args, "hello").Text
-	assert.Equal(t, "api.command_channel_header.permission.app_error", actual)
+	actual = pp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_purpose.permission.app_error", actual)
 
 	// Try a group channel *with* being a member.
 	user1 := th.CreateUser()
 	user2 := th.CreateUser()
-	user3 := th.CreateUser()
 
 	groupChannel := th.CreateGroupChannel(user1, user2)
 
@@ -77,18 +76,8 @@ func TestHeaderProviderDoCommand(t *testing.T) {
 		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
 	}
 
-	actual = hp.DoCommand(th.App, args, "hello").Text
-	assert.Equal(t, "", actual)
-
-	// Try a group channel *without* being a member.
-	args = &model.CommandArgs{
-		T:         func(s string, args ...interface{}) string { return s },
-		ChannelId: groupChannel.Id,
-		Session:   model.Session{UserId: user3.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
-	}
-
-	actual = hp.DoCommand(th.App, args, "hello").Text
-	assert.Equal(t, "api.command_channel_header.permission.app_error", actual)
+	actual = pp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_purpose.direct_group.app_error", actual)
 
 	// Try a direct channel *with* being a member.
 	directChannel := th.CreateDmChannel(user1)
@@ -99,16 +88,6 @@ func TestHeaderProviderDoCommand(t *testing.T) {
 		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
 	}
 
-	actual = hp.DoCommand(th.App, args, "hello").Text
-	assert.Equal(t, "", actual)
-
-	// Try a direct channel *without* being a member.
-	args = &model.CommandArgs{
-		T:         func(s string, args ...interface{}) string { return s },
-		ChannelId: directChannel.Id,
-		Session:   model.Session{UserId: user2.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
-	}
-
-	actual = hp.DoCommand(th.App, args, "hello").Text
-	assert.Equal(t, "api.command_channel_header.permission.app_error", actual)
+	actual = pp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_purpose.direct_group.app_error", actual)
 }

--- a/app/command_channel_rename.go
+++ b/app/command_channel_rename.go
@@ -4,8 +4,9 @@
 package app
 
 import (
-	"github.com/mattermost/mattermost-server/model"
 	goi18n "github.com/nicksnyder/go-i18n/i18n"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 type RenameProvider struct {
@@ -36,27 +37,50 @@ func (me *RenameProvider) GetCommand(a *App, T goi18n.TranslateFunc) *model.Comm
 func (me *RenameProvider) DoCommand(a *App, args *model.CommandArgs, message string) *model.CommandResponse {
 	channel, err := a.GetChannel(args.ChannelId)
 	if err != nil {
-		return &model.CommandResponse{Text: args.T("api.command_channel_rename.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_rename.channel.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
-		return &model.CommandResponse{Text: args.T("api.command_channel_rename.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	}
-
-	if channel.Type == model.CHANNEL_PRIVATE && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
-		return &model.CommandResponse{Text: args.T("api.command_channel_rename.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	}
-
-	if channel.Type == model.CHANNEL_GROUP || channel.Type == model.CHANNEL_DIRECT {
+	switch channel.Type {
+	case model.CHANNEL_OPEN:
+		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_PROPERTIES) {
+			return &model.CommandResponse{
+				Text:         args.T("api.command_channel_rename.permission.app_error"),
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
+		}
+	case model.CHANNEL_PRIVATE:
+		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
+			return &model.CommandResponse{
+				Text:         args.T("api.command_channel_rename.permission.app_error"),
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
+		}
+	default:
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.direct_group.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
 	if len(message) == 0 {
-		return &model.CommandResponse{Text: args.T("api.command_channel_rename.message.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_rename.message.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	} else if len(message) > model.CHANNEL_NAME_UI_MAX_LENGTH {
-		return &model.CommandResponse{Text: args.T("api.command_channel_rename.too_long.app_error", map[string]interface{}{"Length": model.CHANNEL_NAME_UI_MAX_LENGTH}), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text: args.T("api.command_channel_rename.too_long.app_error", map[string]interface{}{
+				"Length": model.CHANNEL_NAME_UI_MAX_LENGTH,
+			}),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	} else if len(message) < model.CHANNEL_NAME_MIN_LENGTH {
-		return &model.CommandResponse{Text: args.T("api.command_channel_rename.too_short.app_error", map[string]interface{}{"Length": model.CHANNEL_NAME_MIN_LENGTH}), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text: args.T("api.command_channel_rename.too_short.app_error", map[string]interface{}{
+				"Length": model.CHANNEL_NAME_MIN_LENGTH,
+			}),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	patch := &model.ChannelPatch{
@@ -66,7 +90,10 @@ func (me *RenameProvider) DoCommand(a *App, args *model.CommandArgs, message str
 
 	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
-		return &model.CommandResponse{Text: args.T("api.command_channel_rename.update_channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		return &model.CommandResponse{
+			Text:         args.T("api.command_channel_rename.update_channel.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	return &model.CommandResponse{}

--- a/app/command_channel_rename_test.go
+++ b/app/command_channel_rename_test.go
@@ -1,10 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
 package app
 
 import (
 	"testing"
 
-	"github.com/mattermost/mattermost-server/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 func TestRenameProviderDoCommand(t *testing.T) {
@@ -29,4 +33,63 @@ func TestRenameProviderDoCommand(t *testing.T) {
 		actual := rp.DoCommand(th.App, args, msg).Text
 		assert.Equal(t, expected, actual)
 	}
+
+	// Try a public channel *without* permission.
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: th.BasicChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual := rp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_rename.permission.app_error", actual)
+
+	// Try a private channel *with* permission.
+	privateChannel := th.CreatePrivateChannel(th.BasicTeam)
+
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: privateChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "", actual)
+
+	// Try a private channel *without* permission.
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: privateChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_rename.permission.app_error", actual)
+
+	// Try a group channel *with* being a member.
+	user1 := th.CreateUser()
+	user2 := th.CreateUser()
+
+	groupChannel := th.CreateGroupChannel(user1, user2)
+
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: groupChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_rename.direct_group.app_error", actual)
+
+	// Try a direct channel *with* being a member.
+	directChannel := th.CreateDmChannel(user1)
+
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: directChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, "hello").Text
+	assert.Equal(t, "api.command_channel_rename.direct_group.app_error", actual)
 }

--- a/app/command_invite_test.go
+++ b/app/command_invite_test.go
@@ -95,12 +95,7 @@ func TestInviteProvider(t *testing.T) {
 			msg:      basicUser4.Username,
 		},
 		{
-			desc:     "try to add a user to a direct channel",
-			expected: "api.command_invite.directchannel.app_error",
-			msg:      userAndDMChannel,
-		},
-		{
-			desc:     "try to add a user to a privante channel with no permission",
+			desc:     "try to add a user to a private channel with no permission",
 			expected: "api.command_invite.private_channel.app_error",
 			msg:      userAndInvalidPrivate,
 		},

--- a/app/command_join.go
+++ b/app/command_join.go
@@ -4,9 +4,11 @@
 package app
 
 import (
-	"github.com/mattermost/mattermost-server/model"
-	goi18n "github.com/nicksnyder/go-i18n/i18n"
 	"strings"
+
+	goi18n "github.com/nicksnyder/go-i18n/i18n"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 type JoinProvider struct {
@@ -41,33 +43,38 @@ func (me *JoinProvider) DoCommand(a *App, args *model.CommandArgs, message strin
 		channelName = message[1:]
 	}
 
-	if result := <-a.Srv.Store.Channel().GetByName(args.TeamId, channelName, true); result.Err != nil {
+	result := <-a.Srv.Store.Channel().GetByName(args.TeamId, channelName, true)
+	if result.Err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_join.list.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	} else {
-		channel := result.Data.(*model.Channel)
-
-		if channel.Name == channelName {
-			allowed := false
-			if (channel.Type == model.CHANNEL_PRIVATE && a.SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_READ_CHANNEL)) || channel.Type == model.CHANNEL_OPEN {
-				allowed = true
-			}
-
-			if !allowed {
-				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-			}
-
-			if err := a.JoinChannel(channel, args.UserId); err != nil {
-				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-			}
-
-			team, err := a.GetTeam(channel.TeamId)
-			if err != nil {
-				return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-			}
-
-			return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + channel.Name}
-		}
 	}
 
-	return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_join.missing.app_error")}
+	channel := result.Data.(*model.Channel)
+
+	if channel.Name != channelName {
+		return &model.CommandResponse{ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL, Text: args.T("api.command_join.missing.app_error")}
+	}
+
+	switch channel.Type {
+	case model.CHANNEL_OPEN:
+		if !a.SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_JOIN_PUBLIC_CHANNELS) {
+			return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		}
+	case model.CHANNEL_PRIVATE:
+		if !a.SessionHasPermissionToChannel(args.Session, channel.Id, model.PERMISSION_READ_CHANNEL) {
+			return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		}
+	default:
+		return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	}
+
+	if err := a.JoinChannel(channel, args.UserId); err != nil {
+		return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	}
+
+	team, err := a.GetTeam(channel.TeamId)
+	if err != nil {
+		return &model.CommandResponse{Text: args.T("api.command_join.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	}
+
+	return &model.CommandResponse{GotoLocation: args.SiteURL + "/" + team.Name + "/channels/" + channel.Name}
 }

--- a/app/command_join_test.go
+++ b/app/command_join_test.go
@@ -5,9 +5,11 @@ package app
 
 import (
 	"testing"
-	"github.com/mattermost/mattermost-server/model"
+
 	"github.com/nicksnyder/go-i18n/i18n"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 func TestJoinCommandNoChannel(t *testing.T) {
@@ -20,10 +22,11 @@ func TestJoinCommandNoChannel(t *testing.T) {
 
 	cmd := &JoinProvider{}
 	resp := cmd.DoCommand(th.App, &model.CommandArgs{
-		T:      i18n.IdentityTfunc(),
-		UserId: th.BasicUser2.Id,
+		T:       i18n.IdentityTfunc(),
+		UserId:  th.BasicUser2.Id,
 		SiteURL: "http://test.url",
-		TeamId:      th.BasicTeam.Id,
+		TeamId:  th.BasicTeam.Id,
+		Session: model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
 	}, "asdsad")
 
 	assert.Equal(t, "api.command_join.list.app_error", resp.Text)
@@ -38,20 +41,20 @@ func TestJoinCommandForExistingChannel(t *testing.T) {
 	}
 
 	channel2, _ := th.App.CreateChannel(&model.Channel{
-	  DisplayName: "AA",
-	  Name:        "aa" + model.NewId() + "a",
-	  Type:        model.CHANNEL_OPEN,
-	  TeamId:      th.BasicTeam.Id,
-	  CreatorId:   th.BasicUser.Id,
+		DisplayName: "AA",
+		Name:        "aa" + model.NewId() + "a",
+		Type:        model.CHANNEL_OPEN,
+		TeamId:      th.BasicTeam.Id,
+		CreatorId:   th.BasicUser.Id,
 	}, false)
-
 
 	cmd := &JoinProvider{}
 	resp := cmd.DoCommand(th.App, &model.CommandArgs{
-		T:      i18n.IdentityTfunc(),
-		UserId: th.BasicUser2.Id,
+		T:       i18n.IdentityTfunc(),
+		UserId:  th.BasicUser2.Id,
 		SiteURL: "http://test.url",
-		TeamId:      th.BasicTeam.Id,
+		TeamId:  th.BasicTeam.Id,
+		Session: model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
 	}, channel2.Name)
 
 	assert.Equal(t, "", resp.Text)
@@ -67,22 +70,81 @@ func TestJoinCommandWithTilde(t *testing.T) {
 	}
 
 	channel2, _ := th.App.CreateChannel(&model.Channel{
-	  DisplayName: "AA",
-	  Name:        "aa" + model.NewId() + "a",
-	  Type:        model.CHANNEL_OPEN,
-	  TeamId:      th.BasicTeam.Id,
-	  CreatorId:   th.BasicUser.Id,
+		DisplayName: "AA",
+		Name:        "aa" + model.NewId() + "a",
+		Type:        model.CHANNEL_OPEN,
+		TeamId:      th.BasicTeam.Id,
+		CreatorId:   th.BasicUser.Id,
 	}, false)
-
 
 	cmd := &JoinProvider{}
 	resp := cmd.DoCommand(th.App, &model.CommandArgs{
-		T:      i18n.IdentityTfunc(),
-		UserId: th.BasicUser2.Id,
+		T:       i18n.IdentityTfunc(),
+		UserId:  th.BasicUser2.Id,
 		SiteURL: "http://test.url",
-		TeamId:      th.BasicTeam.Id,
+		TeamId:  th.BasicTeam.Id,
+		Session: model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
 	}, "~"+channel2.Name)
 
 	assert.Equal(t, "", resp.Text)
 	assert.Equal(t, "http://test.url/"+th.BasicTeam.Name+"/channels/"+channel2.Name, resp.GotoLocation)
+}
+
+func TestJoinCommandPermissions(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	channel2, _ := th.App.CreateChannel(&model.Channel{
+		DisplayName: "AA",
+		Name:        "aa" + model.NewId() + "a",
+		Type:        model.CHANNEL_OPEN,
+		TeamId:      th.BasicTeam.Id,
+		CreatorId:   th.BasicUser.Id,
+	}, false)
+
+	cmd := &JoinProvider{}
+
+	// Try a public channel *without* permission.
+	args := &model.CommandArgs{
+		T:       i18n.IdentityTfunc(),
+		UserId:  th.BasicUser2.Id,
+		SiteURL: "http://test.url",
+		TeamId:  th.BasicTeam.Id,
+		Session: model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual := cmd.DoCommand(th.App, args, "~"+channel2.Name).Text
+	assert.Equal(t, "api.command_join.fail.app_error", actual)
+
+	// Try a public channel with permission.
+	args = &model.CommandArgs{
+		T:       i18n.IdentityTfunc(),
+		UserId:  th.BasicUser2.Id,
+		SiteURL: "http://test.url",
+		TeamId:  th.BasicTeam.Id,
+		Session: model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
+	}
+
+	actual = cmd.DoCommand(th.App, args, "~"+channel2.Name).Text
+	assert.Equal(t, "", actual)
+
+	// Try a private channel *without* permission.
+	channel3, _ := th.App.CreateChannel(&model.Channel{
+		DisplayName: "BB",
+		Name:        "aa" + model.NewId() + "a",
+		Type:        model.CHANNEL_PRIVATE,
+		TeamId:      th.BasicTeam.Id,
+		CreatorId:   th.BasicUser.Id,
+	}, false)
+
+	args = &model.CommandArgs{
+		T:       i18n.IdentityTfunc(),
+		UserId:  th.BasicUser2.Id,
+		SiteURL: "http://test.url",
+		TeamId:  th.BasicTeam.Id,
+		Session: model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: model.TEAM_USER_ROLE_ID}}},
+	}
+
+	actual = cmd.DoCommand(th.App, args, "~"+channel3.Name).Text
+	assert.Equal(t, "api.command_join.fail.app_error", actual)
 }

--- a/app/command_remove.go
+++ b/app/command_remove.go
@@ -70,15 +70,16 @@ func doCommand(a *App, args *model.CommandArgs, message string) *model.CommandRe
 		return &model.CommandResponse{Text: args.T("api.command_channel_rename.channel.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	if channel.Type == model.CHANNEL_OPEN && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
-		return &model.CommandResponse{Text: args.T("api.command_remove.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	}
-
-	if channel.Type == model.CHANNEL_PRIVATE && !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
-		return &model.CommandResponse{Text: args.T("api.command_remove.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-	}
-
-	if channel.Type == model.CHANNEL_GROUP || channel.Type == model.CHANNEL_DIRECT {
+	switch channel.Type {
+	case model.CHANNEL_OPEN:
+		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
+			return &model.CommandResponse{Text: args.T("api.command_remove.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		}
+	case model.CHANNEL_PRIVATE:
+		if !a.SessionHasPermissionToChannel(args.Session, args.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
+			return &model.CommandResponse{Text: args.T("api.command_remove.permission.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		}
+	default:
 		return &model.CommandResponse{Text: args.T("api.command_remove.direct_group.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 

--- a/app/command_remove_test.go
+++ b/app/command_remove_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func TestRemoveProviderDoCommand(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	rp := RemoveProvider{}
+
+	publicChannel, _ := th.App.CreateChannel(&model.Channel{
+		DisplayName: "AA",
+		Name:        "aa" + model.NewId() + "a",
+		Type:        model.CHANNEL_OPEN,
+		TeamId:      th.BasicTeam.Id,
+		CreatorId:   th.BasicUser.Id,
+	}, false)
+
+	privateChannel, _ := th.App.CreateChannel(&model.Channel{
+		DisplayName: "BB",
+		Name:        "aa" + model.NewId() + "a",
+		Type:        model.CHANNEL_OPEN,
+		TeamId:      th.BasicTeam.Id,
+		CreatorId:   th.BasicUser.Id,
+	}, false)
+
+	targetUser := th.CreateUser()
+	th.App.AddUserToTeam(th.BasicTeam.Id, targetUser.Id, targetUser.Id)
+	th.App.AddUserToChannel(targetUser, publicChannel)
+	th.App.AddUserToChannel(targetUser, privateChannel)
+
+	// Try a public channel *without* permission.
+	args := &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: publicChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual := rp.DoCommand(th.App, args, targetUser.Username).Text
+	assert.Equal(t, "api.command_remove.permission.app_error", actual)
+
+	// Try a public channel *with* permission.
+	th.App.AddUserToChannel(th.BasicUser, publicChannel)
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: publicChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, targetUser.Username).Text
+	assert.Equal(t, "", actual)
+
+	// Try a private channel *without* permission.
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: privateChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, targetUser.Username).Text
+	assert.Equal(t, "api.command_remove.permission.app_error", actual)
+
+	// Try a private channel *with* permission.
+	th.App.AddUserToChannel(th.BasicUser, privateChannel)
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: privateChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, targetUser.Username).Text
+	assert.Equal(t, "", actual)
+
+	// Try a group channel
+	user1 := th.CreateUser()
+	user2 := th.CreateUser()
+
+	groupChannel := th.CreateGroupChannel(user1, user2)
+
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: groupChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, user1.Username).Text
+	assert.Equal(t, "api.command_remove.direct_group.app_error", actual)
+
+	// Try a direct channel *with* being a member.
+	directChannel := th.CreateDmChannel(user1)
+
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: directChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, user1.Username).Text
+	assert.Equal(t, "api.command_remove.direct_group.app_error", actual)
+}


### PR DESCRIPTION
#### Summary
Where necessary, rewrite permissions checks in built-in slash command handlers to be fail-safe and more robust against future code changes. Also add unit tests where the modified code is not properly unit tested.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11230

#### Checklist
- [x] Added or updated unit tests (required for all new features)