### PR TITLE
MM-11520: Make entity ID checks consistent across api4.

### DIFF
--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -91,6 +91,12 @@ func updateOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The app being updated in the payload must be the same one as indicated in the URL.
+	if oauthApp.Id != c.Params.AppId {
+		c.SetInvalidParam("app_id")
+		return
+	}
+
 	c.LogAudit("attempt")
 
 	oldOauthApp, err := c.App.GetOAuthApp(c.Params.AppId)

--- a/api4/post.go
+++ b/api4/post.go
@@ -382,6 +382,12 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The post being updated in the payload must be the same one as indicated in the URL.
+	if post.Id != c.Params.PostId {
+		c.SetInvalidParam("post_id")
+		return
+	}
+
 	if !c.App.SessionHasPermissionToChannelByPost(c.Session, c.Params.PostId, model.PERMISSION_EDIT_POST) {
 		c.SetPermissionError(model.PERMISSION_EDIT_POST)
 		return

--- a/api4/status.go
+++ b/api4/status.go
@@ -68,6 +68,12 @@ func updateUserStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The user being updated in the payload must be the same one as indicated in the URL.
+	if status.UserId != c.Params.UserId {
+		c.SetInvalidParam("user_id")
+		return
+	}
+
 	if !c.App.SessionHasPermissionToUser(c.Session, c.Params.UserId) {
 		c.SetPermissionError(model.PERMISSION_EDIT_OTHER_USERS)
 		return

--- a/api4/team.go
+++ b/api4/team.go
@@ -137,7 +137,11 @@ func updateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	team.Id = c.Params.TeamId
+	// The team being updated in the payload must be the same one as indicated in the URL.
+	if team.Id != c.Params.TeamId {
+		c.SetInvalidParam("team_id")
+		return
+	}
 
 	if !c.App.SessionHasPermissionToTeam(c.Session, c.Params.TeamId, model.PERMISSION_MANAGE_TEAM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_TEAM)

--- a/api4/user.go
+++ b/api4/user.go
@@ -583,6 +583,12 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The user being updated in the payload must be the same one as indicated in the URL.
+	if user.Id != c.Params.UserId {
+		c.SetInvalidParam("user_id")
+		return
+	}
+
 	if !c.App.SessionHasPermissionToUser(c.Session, user.Id) {
 		c.SetPermissionError(model.PERMISSION_EDIT_OTHER_USERS)
 		return


### PR DESCRIPTION
#### Summary
This PR adds some checks to ensure that where the payload and URL both contain an entity ID, we error if they are not identical. It also refactors the `updateOutgoingWebhook` API handler a little to be more consistent with the equivalent one for incoming webhooks.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11520