### PR TITLE
Do not force downloading of shared public files

### DIFF
--- a/api4/file.go
+++ b/api4/file.go
@@ -356,7 +356,7 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	defer fileReader.Close()
 
-	err = writeFileResponse(info.Name, info.MimeType, info.Size, fileReader, true, w, r)
+	err = writeFileResponse(info.Name, info.MimeType, info.Size, fileReader, false, w, r)
 	if err != nil {
 		c.Err = err
 		return


### PR DESCRIPTION
I believe we don't need to force downloading of shared public files, because `writeFileResponse` method will compare its MIME type with `MEDIA_CONTENT_TYPES` and output it inline or as attachment automatically.

Usually we share images and it is much more convenient to see them without downloading.