### PR TITLE
disable EnablePublicChannelsMaterialization by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -131,7 +131,7 @@
         "Trace": false,
         "AtRestEncryptKey": "",
         "QueryTimeout": 30,
-        "EnablePublicChannelsMaterialization": true
+        "EnablePublicChannelsMaterialization": false
     },
     "LogSettings": {
         "EnableConsole": true,

--- a/model/config.go
+++ b/model/config.go
@@ -687,7 +687,7 @@ func (s *SqlSettings) SetDefaults() {
 	}
 
 	if s.EnablePublicChannelsMaterialization == nil {
-		s.EnablePublicChannelsMaterialization = NewBool(true)
+		s.EnablePublicChannelsMaterialization = NewBool(false)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Creating triggers on Amazon RDS seems to reqiure extra privileges. More
investigation is required. See https://pre-release.mattermost.com/core/pl/ddmtpshtyp843y1sk46smeo8jo for discussion.

#### Ticket Link
N/A.