### PR TITLE
MM-12045: Fix MFA for ldap accounts

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -116,8 +116,11 @@ func (a *App) GetUserForLogin(id, loginId string) (*model.User, *model.AppError)
 
 	// Try to get the user with LDAP if enabled
 	if *a.Config().LdapSettings.Enable && a.Ldap != nil {
-		if user, err := a.Ldap.GetUser(loginId); err == nil {
-			return user, nil
+		if ldapUser, err := a.Ldap.GetUser(loginId); err == nil {
+			if user, err := a.GetUserByAuth(ldapUser.AuthData, model.USER_AUTH_SERVICE_LDAP); err == nil {
+				return user, nil
+			}
+			return ldapUser, nil
 		}
 	}
 


### PR DESCRIPTION
#### Summary
On LDAP login it was getting the user from the LDAP, not from
mattermost. It makes sense because the login can be done without
existing mattermost user. But for be sure the MFA is activated we need
to check the real user when it exists.

#### Ticket Link
[MM-12045](https://mattermost.atlassian.net/browse/MM-12045)