### PR TITLE
Adding paging to elasticsearch API

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -622,7 +622,7 @@ func (a *App) DeletePostFiles(post *model.Post) {
 	}
 }
 
-func (a *App) SearchPostsInTeam(terms string, userId string, teamId string, isOrSearch bool, includeDeletedChannels bool, timeZoneOffset int) (*model.PostSearchResults, *model.AppError) {
+func (a *App) SearchPostsInTeam(terms string, userId string, teamId string, isOrSearch bool, includeDeletedChannels bool, timeZoneOffset int, page, perPage int) (*model.PostSearchResults, *model.AppError) {
 	paramsList := model.ParseSearchParams(terms, timeZoneOffset)
 	includeDeleted := includeDeletedChannels && *a.Config().TeamSettings.ExperimentalViewArchivedChannels
 
@@ -668,7 +668,7 @@ func (a *App) SearchPostsInTeam(terms string, userId string, teamId string, isOr
 			return nil, err
 		}
 
-		postIds, matches, err := a.Elasticsearch.SearchPosts(userChannels, finalParamsList)
+		postIds, matches, err := a.Elasticsearch.SearchPosts(userChannels, finalParamsList, page, perPage)
 		if err != nil {
 			return nil, err
 		}

--- a/einterfaces/elasticsearch.go
+++ b/einterfaces/elasticsearch.go
@@ -13,7 +13,7 @@ type ElasticsearchInterface interface {
 	Start() *model.AppError
 	Stop() *model.AppError
 	IndexPost(post *model.Post, teamId string) *model.AppError
-	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams) ([]string, model.PostSearchMatches, *model.AppError)
+	SearchPosts(channels *model.ChannelList, searchParams []*model.SearchParams, page, perPage int) ([]string, model.PostSearchMatches, *model.AppError)
 	DeletePost(post *model.Post) *model.AppError
 	TestConfig(cfg *model.Config) *model.AppError
 	PurgeIndexes() *model.AppError

--- a/model/client4.go
+++ b/model/client4.go
@@ -2168,17 +2168,6 @@ func (c *Client4) SearchPostsWithParams(teamId string, params *SearchParameter) 
 	}
 }
 
-// SearchPosts returns any posts with matching terms string including deleted channels.
-func (c *Client4) SearchPostsIncludeDeletedChannels(teamId string, terms string, isOrSearch bool) (*PostList, *Response) {
-	requestBody := map[string]interface{}{"terms": terms, "is_or_search": isOrSearch}
-	if r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/posts/search?include_deleted_channels=true", StringInterfaceToJson(requestBody)); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
-	}
-}
-
 // SearchPosts returns any posts with matching terms string, including .
 func (c *Client4) SearchPostsWithMatches(teamId string, terms string, isOrSearch bool) (*PostSearchResults, *Response) {
 	requestBody := map[string]interface{}{"terms": terms, "is_or_search": isOrSearch}

--- a/model/post.go
+++ b/model/post.go
@@ -97,9 +97,12 @@ type PostPatch struct {
 }
 
 type SearchParameter struct {
-	Terms          *string `json:"terms"`
-	IsOrSearch     *bool   `json:"is_or_search"`
-	TimeZoneOffset *int    `json:"time_zone_offset"`
+	Terms                  *string `json:"terms"`
+	IsOrSearch             *bool   `json:"is_or_search"`
+	TimeZoneOffset         *int    `json:"time_zone_offset"`
+	Page                   *int    `json:"page"`
+	PerPage                *int    `json:"per_page"`
+	IncludeDeletedChannels *bool   `json:"include_deleted_channels"`
 }
 
 func (o *PostPatch) WithRewrittenImageURLs(f func(string) string) *PostPatch {


### PR DESCRIPTION
#### Summary
- Adds paging to Elasticsearch API
- Note that paging is not supported with DB search.
- Modifies the location of include_deleted_channels parameter to the POST body rather than the query string
- Client support PR in progress. 

API PR: https://github.com/mattermost/mattermost-api-reference/pull/392
Enterprise PR: https://github.com/mattermost/enterprise/pull/357