### PR TITLE
Revert "disable EnablePublicChannelsMaterialization by default (#9418)"

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -131,7 +131,7 @@
         "Trace": false,
         "AtRestEncryptKey": "",
         "QueryTimeout": 30,
-        "EnablePublicChannelsMaterialization": false
+        "EnablePublicChannelsMaterialization": true
     },
     "LogSettings": {
         "EnableConsole": true,

--- a/model/config.go
+++ b/model/config.go
@@ -687,7 +687,7 @@ func (s *SqlSettings) SetDefaults() {
 	}
 
 	if s.EnablePublicChannelsMaterialization == nil {
-		s.EnablePublicChannelsMaterialization = NewBool(false)
+		s.EnablePublicChannelsMaterialization = NewBool(true)
 	}
 }
 


### PR DESCRIPTION
#### Summary
This reverts commit 5786b0d6d57b90bbb0c262235dd9d19b497b5fae, now that
the feature is safe to enable by default.

#### Ticket Link
None.