### PR TITLE
GH-9408: Add plugin API methode to return the current server version

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -83,6 +83,10 @@ func (api *PluginAPI) SaveConfig(config *model.Config) *model.AppError {
 	return api.app.SaveConfig(config, true)
 }
 
+func (api *PluginAPI) GetServerVersion() string {
+	return model.CurrentVersion
+}
+
 func (api *PluginAPI) CreateTeam(team *model.Team) (*model.Team, *model.AppError) {
 	return api.app.CreateTeam(team)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -34,6 +34,9 @@ type API interface {
 	// SaveConfig sets the given config and persists the changes
 	SaveConfig(config *model.Config) *model.AppError
 
+	// GetServerVersion return the current Mattermost server version
+	GetServerVersion() string
+
 	// CreateUser creates a user.
 	CreateUser(user *model.User) (*model.User, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -656,6 +656,33 @@ func (s *apiRPCServer) SaveConfig(args *Z_SaveConfigArgs, returns *Z_SaveConfigR
 	return nil
 }
 
+type Z_GetServerVersionArgs struct {
+}
+
+type Z_GetServerVersionReturns struct {
+	A string
+}
+
+func (g *apiRPCClient) GetServerVersion() string {
+	_args := &Z_GetServerVersionArgs{}
+	_returns := &Z_GetServerVersionReturns{}
+	if err := g.client.Call("Plugin.GetServerVersion", _args, _returns); err != nil {
+		log.Printf("RPC call to GetServerVersion API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) GetServerVersion(args *Z_GetServerVersionArgs, returns *Z_GetServerVersionReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetServerVersion() string
+	}); ok {
+		returns.A = hook.GetServerVersion()
+	} else {
+		return encodableError(fmt.Errorf("API GetServerVersion called but not implemented."))
+	}
+	return nil
+}
+
 type Z_CreateUserArgs struct {
 	A *model.User
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -624,6 +624,20 @@ func (_m *API) GetReactions(postId string) ([]*model.Reaction, *model.AppError) 
 	return r0, r1
 }
 
+// GetServerVersion provides a mock function with given fields:
+func (_m *API) GetServerVersion() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetSession provides a mock function with given fields: sessionId
 func (_m *API) GetSession(sessionId string) (*model.Session, *model.AppError) {
 	ret := _m.Called(sessionId)


### PR DESCRIPTION
#### Summary
This PR adds a `GetServerVersion() string` methode to the plugin API.

#### Ticket Link
Fixes #9408