### PR TITLE
ensure subpath redirect preserves query string correctly

### DIFF
--- a/web/static.go
+++ b/web/static.go
@@ -45,7 +45,8 @@ func (w *Web) InitStatic() {
 		// trailing slash. We don't want to use StrictSlash on the w.MainRouter and affect
 		// all routes, just /subpath -> /subpath/.
 		w.MainRouter.HandleFunc("", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, r.URL.String()+"/", http.StatusFound)
+			r.URL.Path += "/"
+			http.Redirect(w, r, r.URL.String(), http.StatusFound)
 		}))
 	}
 }


### PR DESCRIPTION
#### Summary
The previous code appended a `/` to the end of the URL, breaking if a query string was present. I encountered this as part of implementing https://mattermost.atlassian.net/browse/MM-12205 when I tried to redirect to the root without a trailing slash but with a non-empty query string. Since I always run with subpath enabled, this exposed the bug.

#### Ticket Link
None.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)