### PR TITLE
Add missing dots (fixing compilation error on go 1.11)

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -60,7 +60,7 @@ type RecoveryLogger struct {
 
 func (rl *RecoveryLogger) Println(i ...interface{}) {
 	mlog.Error("Please check the std error output for the stack trace")
-	mlog.Error(fmt.Sprint(i))
+	mlog.Error(fmt.Sprint(i...))
 }
 
 const TIME_TO_WAIT_FOR_CONNECTIONS_TO_CLOSE_ON_SERVER_SHUTDOWN = time.Second


### PR DESCRIPTION
#### Summary
On go 1.11, I can't run the tests because it generates a compilation
error. This commit fixes the problem.

It only happens in the compilation process for the tests, not for the normal binary.