### PR TITLE
MM-12067: Add SetDefaultProfileImage to reset the user profile image to a generated one

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2309,6 +2309,53 @@ func TestSetProfileImage(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestSetDefaultProfileImage(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+	Client := th.Client
+	user := th.BasicUser
+
+	ok, resp := Client.SetDefaultProfileImage(user.Id)
+	if !ok {
+		t.Fatal(resp.Error)
+	}
+	CheckNoError(t, resp)
+
+	ok, resp = Client.SetDefaultProfileImage(model.NewId())
+	if ok {
+		t.Fatal("Should return false, set profile image not allowed")
+	}
+	CheckForbiddenStatus(t, resp)
+
+	// status code returns either forbidden or unauthorized
+	// note: forbidden is set as default at Client4.SetDefaultProfileImage when request is terminated early by server
+	Client.Logout()
+	_, resp = Client.SetDefaultProfileImage(user.Id)
+	if resp.StatusCode == http.StatusForbidden {
+		CheckForbiddenStatus(t, resp)
+	} else if resp.StatusCode == http.StatusUnauthorized {
+		CheckUnauthorizedStatus(t, resp)
+	} else {
+		t.Fatal("Should have failed either forbidden or unauthorized")
+	}
+
+	buser, err := th.App.GetUser(user.Id)
+	require.Nil(t, err)
+
+	_, resp = th.SystemAdminClient.SetDefaultProfileImage(user.Id)
+	CheckNoError(t, resp)
+
+	ruser, err := th.App.GetUser(user.Id)
+	require.Nil(t, err)
+	assert.True(t, buser.LastPictureUpdate < ruser.LastPictureUpdate, "Picture should have updated for user")
+
+	info := &model.FileInfo{Path: "users/" + user.Id + "/profile.png"}
+	if err := th.cleanupTestFile(info); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCBALogin(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2340,15 +2340,12 @@ func TestSetDefaultProfileImage(t *testing.T) {
 		t.Fatal("Should have failed either forbidden or unauthorized")
 	}
 
-	buser, err := th.App.GetUser(user.Id)
-	require.Nil(t, err)
-
 	_, resp = th.SystemAdminClient.SetDefaultProfileImage(user.Id)
 	CheckNoError(t, resp)
 
 	ruser, err := th.App.GetUser(user.Id)
 	require.Nil(t, err)
-	assert.True(t, buser.LastPictureUpdate < ruser.LastPictureUpdate, "Picture should have updated for user")
+	assert.Equal(t, int64(0), ruser.LastPictureUpdate, "Picture should have resetted to default")
 
 	info := &model.FileInfo{Path: "users/" + user.Id + "/profile.png"}
 	if err := th.cleanupTestFile(info); err != nil {

--- a/app/user.go
+++ b/app/user.go
@@ -773,6 +773,14 @@ func (a *App) GetProfileImage(user *model.User) ([]byte, bool, *model.AppError) 
 	return data, false, nil
 }
 
+func (a *App) GetDefaultProfileImage(user *model.User) ([]byte, *model.AppError) {
+	img, appErr := CreateProfileImage(user.Username, user.Id, a.Config().FileSettings.InitialFont)
+	if appErr != nil {
+		return nil, appErr
+	}
+	return img, nil
+}
+
 func (a *App) SetDefaultProfileImage(user *model.User) *model.AppError {
 	img, appErr := CreateProfileImage(user.Username, user.Id, a.Config().FileSettings.InitialFont)
 	if appErr != nil {

--- a/app/user.go
+++ b/app/user.go
@@ -793,7 +793,7 @@ func (a *App) SetDefaultProfileImage(user *model.User) *model.AppError {
 		return err
 	}
 
-	<-a.Srv.Store.User().UpdateLastPictureUpdate(user.Id)
+	<-a.Srv.Store.User().ResetLastPictureUpdate(user.Id)
 
 	a.InvalidateCacheForUser(user.Id)
 

--- a/app/user.go
+++ b/app/user.go
@@ -745,36 +745,64 @@ func getFont(initialFont string) (*truetype.Font, error) {
 }
 
 func (a *App) GetProfileImage(user *model.User) ([]byte, bool, *model.AppError) {
-	var img []byte
-	readFailed := false
-
 	if len(*a.Config().FileSettings.DriverName) == 0 {
-		var err *model.AppError
-		if img, err = CreateProfileImage(user.Username, user.Id, a.Config().FileSettings.InitialFont); err != nil {
-			return nil, false, err
+		img, appErr := CreateProfileImage(user.Username, user.Id, a.Config().FileSettings.InitialFont)
+		if appErr != nil {
+			return nil, false, appErr
 		}
-	} else {
-		path := "users/" + user.Id + "/profile.png"
-
-		if data, err := a.ReadFile(path); err != nil {
-			readFailed = true
-
-			if img, err = CreateProfileImage(user.Username, user.Id, a.Config().FileSettings.InitialFont); err != nil {
-				return nil, false, err
-			}
-
-			if user.LastPictureUpdate == 0 {
-				if _, err := a.WriteFile(bytes.NewReader(img), path); err != nil {
-					return nil, false, err
-				}
-			}
-
-		} else {
-			img = data
-		}
+		return img, false, nil
 	}
 
-	return img, readFailed, nil
+	path := "users/" + user.Id + "/profile.png"
+
+	data, err := a.ReadFile(path)
+	if err != nil {
+		img, appErr := CreateProfileImage(user.Username, user.Id, a.Config().FileSettings.InitialFont)
+		if appErr != nil {
+			return nil, false, appErr
+		}
+
+		if user.LastPictureUpdate == 0 {
+			if _, err := a.WriteFile(bytes.NewReader(img), path); err != nil {
+				return nil, false, err
+			}
+		}
+		return img, true, nil
+	}
+
+	return data, false, nil
+}
+
+func (a *App) SetDefaultProfileImage(user *model.User) *model.AppError {
+	img, appErr := CreateProfileImage(user.Username, user.Id, a.Config().FileSettings.InitialFont)
+	if appErr != nil {
+		return appErr
+	}
+
+	path := "users/" + user.Id + "/profile.png"
+
+	if _, err := a.WriteFile(bytes.NewReader(img), path); err != nil {
+		return err
+	}
+
+	<-a.Srv.Store.User().UpdateLastPictureUpdate(user.Id)
+
+	a.InvalidateCacheForUser(user.Id)
+
+	updatedUser, appErr := a.GetUser(user.Id)
+	if appErr != nil {
+		mlog.Error(fmt.Sprintf("Error in getting users profile for id=%v forcing logout", user.Id), mlog.String("user_id", user.Id))
+		return nil
+	}
+
+	options := a.Config().GetSanitizeOptions()
+	updatedUser.SanitizeProfile(options)
+
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
+	message.Add("user", updatedUser)
+	a.Publish(message)
+
+	return nil
 }
 
 func (a *App) SetProfileImage(userId string, imageData *multipart.FileHeader) *model.AppError {

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -128,13 +128,11 @@ func TestSetDefaultProfileImage(t *testing.T) {
 
 	user := th.BasicUser
 
-	prevLastPictureUpdate := user.LastPictureUpdate
-
 	err = th.App.SetDefaultProfileImage(user)
 	require.Nil(t, err)
 
 	user = getUserFromDB(th.App, user.Id, t)
-	assert.True(t, prevLastPictureUpdate < user.LastPictureUpdate)
+	assert.Equal(t, int64(0), user.LastPictureUpdate)
 }
 
 func TestUpdateUserToRestrictedDomain(t *testing.T) {
@@ -552,10 +550,10 @@ func TestRecordUserServiceTermsAction(t *testing.T) {
 	defer th.TearDown()
 
 	user := &model.User{
-		Email: strings.ToLower(model.NewId()) + "success+test@example.com",
-		Nickname: "Luke Skywalker", // trying to bring balance to the "Force", one test user at a time
-		Username: "luke" + model.NewId(),
-		Password: "passwd1",
+		Email:       strings.ToLower(model.NewId()) + "success+test@example.com",
+		Nickname:    "Luke Skywalker", // trying to bring balance to the "Force", one test user at a time
+		Username:    "luke" + model.NewId(),
+		Password:    "passwd1",
 		AuthService: "",
 	}
 	user, err := th.App.CreateUser(user)

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
@@ -113,6 +114,27 @@ func TestCreateProfileImage(t *testing.T) {
 	if img.At(1, 1) != colorful {
 		t.Fatal("Failed to create correct color")
 	}
+}
+
+func TestSetDefaultProfileImage(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	err := th.App.SetDefaultProfileImage(&model.User{
+		Id:       model.NewId(),
+		Username: "notvaliduser",
+	})
+	require.Error(t, err)
+
+	user := th.BasicUser
+
+	prevLastPictureUpdate := user.LastPictureUpdate
+
+	err = th.App.SetDefaultProfileImage(user)
+	require.Nil(t, err)
+
+	user = getUserFromDB(th.App, user.Id, t)
+	assert.True(t, prevLastPictureUpdate < user.LastPictureUpdate)
 }
 
 func TestUpdateUserToRestrictedDomain(t *testing.T) {
@@ -249,12 +271,12 @@ func TestUpdateOAuthUserAttrs(t *testing.T) {
 }
 
 func getUserFromDB(a *App, id string, t *testing.T) *model.User {
-	if user, err := a.GetUser(id); err != nil {
+	user, err := a.GetUser(id)
+	if err != nil {
 		t.Fatal("user is not found", err)
 		return nil
-	} else {
-		return user
 	}
+	return user
 }
 
 func getGitlabUserPayload(gitlabUser oauthgitlab.GitLabUser, t *testing.T) []byte {

--- a/model/client4.go
+++ b/model/client4.go
@@ -723,7 +723,7 @@ func (c *Client4) AutocompleteUsers(username string, etag string) (*UserAutocomp
 	}
 }
 
-// GetDefaultProfileImage gets the default user's profile image. Must be logged in or be a system administrator.
+// GetDefaultProfileImage gets the default user's profile image. Must be logged in.
 func (c *Client4) GetDefaultProfileImage(userId string) ([]byte, *Response) {
 	r, appErr := c.DoApiGet(c.GetUserRoute(userId)+"/image/default", "")
 	if appErr != nil {
@@ -733,13 +733,13 @@ func (c *Client4) GetDefaultProfileImage(userId string) ([]byte, *Response) {
 
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return nil, BuildErrorResponse(r, NewAppError("GetProfileImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+		return nil, BuildErrorResponse(r, NewAppError("GetDefaultProfileImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
 	}
 
 	return data, BuildResponse(r)
 }
 
-// GetProfileImage gets user's profile image. Must be logged in or be a system administrator.
+// GetProfileImage gets user's profile image. Must be logged in.
 func (c *Client4) GetProfileImage(userId, etag string) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/image", etag); err != nil {
 		return nil, BuildErrorResponse(r, err)

--- a/model/client4.go
+++ b/model/client4.go
@@ -1105,6 +1105,15 @@ func (c *Client4) SendVerificationEmail(email string) (bool, *Response) {
 	}
 }
 
+// SetDefaultProfileImage resets the profile image to a default generated one
+func (c *Client4) SetDefaultProfileImage(userId string) (bool, *Response) {
+	r, err := c.DoApiDelete(c.GetUserRoute(userId) + "/image")
+	if err != nil {
+		return false, BuildErrorResponse(r, err)
+	}
+	return CheckStatusOK(r), BuildResponse(r)
+}
+
 // SetProfileImage sets profile image of the user
 func (c *Client4) SetProfileImage(userId string, data []byte) (bool, *Response) {
 	body := &bytes.Buffer{}

--- a/model/client4.go
+++ b/model/client4.go
@@ -723,6 +723,22 @@ func (c *Client4) AutocompleteUsers(username string, etag string) (*UserAutocomp
 	}
 }
 
+// GetDefaultProfileImage gets the default user's profile image. Must be logged in or be a system administrator.
+func (c *Client4) GetDefaultProfileImage(userId string) ([]byte, *Response) {
+	r, appErr := c.DoApiGet(c.GetUserRoute(userId)+"/image/default", "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
+	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetProfileImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+
+	return data, BuildResponse(r)
+}
+
 // GetProfileImage gets user's profile image. Must be logged in or be a system administrator.
 func (c *Client4) GetProfileImage(userId, etag string) ([]byte, *Response) {
 	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/image", etag); err != nil {

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -212,6 +212,16 @@ func (us SqlUserStore) UpdateLastPictureUpdate(userId string) store.StoreChannel
 	})
 }
 
+func (us SqlUserStore) ResetLastPictureUpdate(userId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		if _, err := us.GetMaster().Exec("UPDATE Users SET LastPictureUpdate = :Time, UpdateAt = :Time WHERE Id = :UserId", map[string]interface{}{"Time": 0, "UserId": userId}); err != nil {
+			result.Err = model.NewAppError("SqlUserStore.UpdateUpdateAt", "store.sql_user.update_last_picture_update.app_error", nil, "user_id="+userId, http.StatusInternalServerError)
+		} else {
+			result.Data = userId
+		}
+	})
+}
+
 func (us SqlUserStore) UpdateUpdateAt(userId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		curTime := model.GetMillis()

--- a/store/store.go
+++ b/store/store.go
@@ -230,6 +230,7 @@ type UserStore interface {
 	Save(user *model.User) StoreChannel
 	Update(user *model.User, allowRoleUpdate bool) StoreChannel
 	UpdateLastPictureUpdate(userId string) StoreChannel
+	ResetLastPictureUpdate(userId string) StoreChannel
 	UpdateUpdateAt(userId string) StoreChannel
 	UpdatePassword(userId, newPassword string) StoreChannel
 	UpdateAuthData(userId string, service string, authData *string, email string, resetMfa bool) StoreChannel

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -593,6 +593,22 @@ func (_m *UserStore) PermanentDelete(userId string) store.StoreChannel {
 	return r0
 }
 
+// ResetLastPictureUpdate provides a mock function with given fields: userId
+func (_m *UserStore) ResetLastPictureUpdate(userId string) store.StoreChannel {
+	ret := _m.Called(userId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+		r0 = rf(userId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Save provides a mock function with given fields: user
 func (_m *UserStore) Save(user *model.User) store.StoreChannel {
 	ret := _m.Called(user)


### PR DESCRIPTION
#### Summary
Add SetDefaultProfileImage to reset the user profile image to a generated one

#### Ticket Link
[MM-12067](https://mattermost.atlassian.net/browse/MM-12067)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers
