### PR TITLE
[MM-12264] if EnableLinkPreviews not enabled, do not execute function

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -451,6 +451,13 @@ func testS3(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getRedirectLocation(c *Context, w http.ResponseWriter, r *http.Request) {
+	m := make(map[string]string)
+	m["location"] = ""
+	cfg := c.App.GetConfig()
+	if !*cfg.ServiceSettings.EnableLinkPreviews {
+		w.Write([]byte(model.MapToJson(m)))
+		return
+	}
 	url := r.URL.Query().Get("url")
 	if len(url) == 0 {
 		c.SetInvalidParam("url")
@@ -462,9 +469,6 @@ func getRedirectLocation(c *Context, w http.ResponseWriter, r *http.Request) {
 			return http.ErrUseLastResponse
 		},
 	}
-
-	m := make(map[string]string)
-	m["location"] = ""
 
 	res, err := client.Head(url)
 	if err != nil {


### PR DESCRIPTION
#### Summary
if enablelinkpreview is disabled this function should not be executed

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-12264
mattermost/mattermost-server#9457
mattermost/mattermost-server#9437


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Has UI changes

ui changes https://github.com/mattermost/mattermost-webapp/pull/1772