### PR TITLE
MM-11863 Add KVList method

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -331,8 +331,8 @@ func (api *PluginAPI) KVDelete(key string) *model.AppError {
 	return api.app.DeletePluginKey(api.id, key)
 }
 
-func (api *PluginAPI) KVList() ([]string, *model.AppError) {
-	return api.app.ListPluginKeys(api.id)
+func (api *PluginAPI) KVList(offset int, limit int) ([]string, *model.AppError) {
+	return api.app.ListPluginKeys(api.id, offset, limit)
 }
 
 func (api *PluginAPI) PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *model.WebsocketBroadcast) {

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -331,8 +331,8 @@ func (api *PluginAPI) KVDelete(key string) *model.AppError {
 	return api.app.DeletePluginKey(api.id, key)
 }
 
-func (api *PluginAPI) KVList(offset int, limit int) ([]string, *model.AppError) {
-	return api.app.ListPluginKeys(api.id, offset, limit)
+func (api *PluginAPI) KVList(page, perPage int) ([]string, *model.AppError) {
+	return api.app.ListPluginKeys(api.id, page, perPage)
 }
 
 func (api *PluginAPI) PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *model.WebsocketBroadcast) {

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -331,6 +331,10 @@ func (api *PluginAPI) KVDelete(key string) *model.AppError {
 	return api.app.DeletePluginKey(api.id, key)
 }
 
+func (api *PluginAPI) KVList() ([]string, *model.AppError) {
+	return api.app.ListPluginKeys(api.id)
+}
+
 func (api *PluginAPI) PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *model.WebsocketBroadcast) {
 	api.app.Publish(&model.WebSocketEvent{
 		Event:     fmt.Sprintf("custom_%v_%v", api.id, event),

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -67,5 +67,10 @@ func (a *App) ListPluginKeys(pluginId string) ([]string, *model.AppError) {
 		mlog.Error(result.Err.Error())
 	}
 
+	if result.Data != nil {
+		list := result.Data.([]string)
+		return list, nil
+	}
+
 	return nil, result.Err
 }

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -60,8 +60,8 @@ func (a *App) DeletePluginKey(pluginId string, key string) *model.AppError {
 	return result.Err
 }
 
-func (a *App) ListPluginKeys(pluginId string) ([]string, *model.AppError) {
-	result := <-a.Srv.Store.Plugin().List(pluginId)
+func (a *App) ListPluginKeys(pluginId string, offset int, limit int) ([]string, *model.AppError) {
+	result := <-a.Srv.Store.Plugin().List(pluginId, offset, limit)
 
 	if result.Err != nil {
 		mlog.Error(result.Err.Error())

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -59,3 +59,13 @@ func (a *App) DeletePluginKey(pluginId string, key string) *model.AppError {
 
 	return result.Err
 }
+
+func (a *App) ListPluginKeys(pluginId string) ([]string, *model.AppError) {
+	result := <-a.Srv.Store.Plugin().List(pluginId)
+
+	if result.Err != nil {
+		mlog.Error(result.Err.Error())
+	}
+
+	return nil, result.Err
+}

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -60,17 +60,13 @@ func (a *App) DeletePluginKey(pluginId string, key string) *model.AppError {
 	return result.Err
 }
 
-func (a *App) ListPluginKeys(pluginId string, offset int, limit int) ([]string, *model.AppError) {
-	result := <-a.Srv.Store.Plugin().List(pluginId, offset, limit)
+func (a *App) ListPluginKeys(pluginId string, page, perPage int) ([]string, *model.AppError) {
+	result := <-a.Srv.Store.Plugin().List(pluginId, page, perPage)
 
 	if result.Err != nil {
 		mlog.Error(result.Err.Error())
+		return nil, result.Err
 	}
 
-	if result.Data != nil {
-		list := result.Data.([]string)
-		return list, nil
-	}
-
-	return nil, result.Err
+	return result.Data.([]string), nil
 }

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -52,10 +52,36 @@ func TestPluginKeyValueStore(t *testing.T) {
 	assert.Nil(t, th.App.SetPluginKey(pluginId, "key2", []byte("test")))
 	hashedKey := getHashedKey("key")
 	hashedKey2 := getHashedKey("key2")
-	list, err := th.App.ListPluginKeys(pluginId)
-	assert.Equal(t, 2, len(list))
+	list, err := th.App.ListPluginKeys(pluginId, 0, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(list))
 	assert.Equal(t, hashedKey, list[0])
-	assert.Equal(t, hashedKey2, list[1])
+
+	list, err = th.App.ListPluginKeys(pluginId, 1, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, hashedKey2, list[0])
+
+	//List Keys bad input
+	list, err = th.App.ListPluginKeys(pluginId, 0, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(list))
+
+	list, err = th.App.ListPluginKeys(pluginId, 0, -1)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(list))
+
+	list, err = th.App.ListPluginKeys(pluginId, -1, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(list))
+
+	list, err = th.App.ListPluginKeys(pluginId, -1, 0)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(list))
+
+	list, err = th.App.ListPluginKeys(pluginId, 2, 2)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(list))
 }
 
 func TestServePluginRequest(t *testing.T) {

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -197,7 +197,7 @@ type API interface {
 	KVDelete(key string) *model.AppError
 
 	// KVList will list all keys for a plugin.
-	KVList(offset int, limit int) ([]string, *model.AppError)
+	KVList(page, perPage int) ([]string, *model.AppError)
 
 	// PublishWebSocketEvent sends an event to WebSocket connections.
 	// event is the type and will be prepended with "custom_<pluginid>_"

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -196,6 +196,9 @@ type API interface {
 	// KVDelete will remove a key-value pair. Returns nil for non-existent keys.
 	KVDelete(key string) *model.AppError
 
+	// KVList will list all keys for a plugin. Returns nil for non-existent keys.
+	KVList() ([]string, *model.AppError)
+
 	// PublishWebSocketEvent sends an event to WebSocket connections.
 	// event is the type and will be prepended with "custom_<pluginid>_"
 	// payload is the data sent with the event. Interface values must be primitive Go types or mattermost-server/model types

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -197,7 +197,7 @@ type API interface {
 	KVDelete(key string) *model.AppError
 
 	// KVList will list all keys for a plugin.
-	KVList() ([]string, *model.AppError)
+	KVList(offset int, limit int) ([]string, *model.AppError)
 
 	// PublishWebSocketEvent sends an event to WebSocket connections.
 	// event is the type and will be prepended with "custom_<pluginid>_"

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -196,7 +196,7 @@ type API interface {
 	// KVDelete will remove a key-value pair. Returns nil for non-existent keys.
 	KVDelete(key string) *model.AppError
 
-	// KVList will list all keys for a plugin. Returns nil for non-existent keys.
+	// KVList will list all keys for a plugin.
 	KVList() ([]string, *model.AppError)
 
 	// PublishWebSocketEvent sends an event to WebSocket connections.

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2152,6 +2152,8 @@ func (s *apiRPCServer) KVDelete(args *Z_KVDeleteArgs, returns *Z_KVDeleteReturns
 }
 
 type Z_KVListArgs struct {
+	A int
+	B int
 }
 
 type Z_KVListReturns struct {
@@ -2159,8 +2161,8 @@ type Z_KVListReturns struct {
 	B *model.AppError
 }
 
-func (g *apiRPCClient) KVList() ([]string, *model.AppError) {
-	_args := &Z_KVListArgs{}
+func (g *apiRPCClient) KVList(offset int, limit int) ([]string, *model.AppError) {
+	_args := &Z_KVListArgs{offset, limit}
 	_returns := &Z_KVListReturns{}
 	if err := g.client.Call("Plugin.KVList", _args, _returns); err != nil {
 		log.Printf("RPC call to KVList API failed: %s", err.Error())
@@ -2170,9 +2172,9 @@ func (g *apiRPCClient) KVList() ([]string, *model.AppError) {
 
 func (s *apiRPCServer) KVList(args *Z_KVListArgs, returns *Z_KVListReturns) error {
 	if hook, ok := s.impl.(interface {
-		KVList() ([]string, *model.AppError)
+		KVList(offset int, limit int) ([]string, *model.AppError)
 	}); ok {
-		returns.A, returns.B = hook.KVList()
+		returns.A, returns.B = hook.KVList(args.A, args.B)
 	} else {
 		return encodableError(fmt.Errorf("API KVList called but not implemented."))
 	}

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2151,6 +2151,34 @@ func (s *apiRPCServer) KVDelete(args *Z_KVDeleteArgs, returns *Z_KVDeleteReturns
 	return nil
 }
 
+type Z_KVListArgs struct {
+}
+
+type Z_KVListReturns struct {
+	A []string
+	B *model.AppError
+}
+
+func (g *apiRPCClient) KVList() ([]string, *model.AppError) {
+	_args := &Z_KVListArgs{}
+	_returns := &Z_KVListReturns{}
+	if err := g.client.Call("Plugin.KVList", _args, _returns); err != nil {
+		log.Printf("RPC call to KVList API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) KVList(args *Z_KVListArgs, returns *Z_KVListReturns) error {
+	if hook, ok := s.impl.(interface {
+		KVList() ([]string, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.KVList()
+	} else {
+		return encodableError(fmt.Errorf("API KVList called but not implemented."))
+	}
+	return nil
+}
+
 type Z_PublishWebSocketEventArgs struct {
 	A string
 	B map[string]interface{}

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2161,8 +2161,8 @@ type Z_KVListReturns struct {
 	B *model.AppError
 }
 
-func (g *apiRPCClient) KVList(offset int, limit int) ([]string, *model.AppError) {
-	_args := &Z_KVListArgs{offset, limit}
+func (g *apiRPCClient) KVList(page, perPage int) ([]string, *model.AppError) {
+	_args := &Z_KVListArgs{page, perPage}
 	_returns := &Z_KVListReturns{}
 	if err := g.client.Call("Plugin.KVList", _args, _returns); err != nil {
 		log.Printf("RPC call to KVList API failed: %s", err.Error())
@@ -2172,7 +2172,7 @@ func (g *apiRPCClient) KVList(offset int, limit int) ([]string, *model.AppError)
 
 func (s *apiRPCServer) KVList(args *Z_KVListArgs, returns *Z_KVListReturns) error {
 	if hook, ok := s.impl.(interface {
-		KVList(offset int, limit int) ([]string, *model.AppError)
+		KVList(page, perPage int) ([]string, *model.AppError)
 	}); ok {
 		returns.A, returns.B = hook.KVList(args.A, args.B)
 	} else {

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -996,6 +996,31 @@ func (_m *API) KVGet(key string) ([]byte, *model.AppError) {
 	return r0, r1
 }
 
+// KVList provides a mock function with given fields:
+func (_m *API) KVList() ([]string, *model.AppError) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // KVSet provides a mock function with given fields: key, value
 func (_m *API) KVSet(key string, value []byte) *model.AppError {
 	ret := _m.Called(key, value)

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -996,13 +996,13 @@ func (_m *API) KVGet(key string) ([]byte, *model.AppError) {
 	return r0, r1
 }
 
-// KVList provides a mock function with given fields: offset, limit
-func (_m *API) KVList(offset int, limit int) ([]string, *model.AppError) {
-	ret := _m.Called(offset, limit)
+// KVList provides a mock function with given fields: page, perPage
+func (_m *API) KVList(page int, perPage int) ([]string, *model.AppError) {
+	ret := _m.Called(page, perPage)
 
 	var r0 []string
 	if rf, ok := ret.Get(0).(func(int, int) []string); ok {
-		r0 = rf(offset, limit)
+		r0 = rf(page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -1011,7 +1011,7 @@ func (_m *API) KVList(offset int, limit int) ([]string, *model.AppError) {
 
 	var r1 *model.AppError
 	if rf, ok := ret.Get(1).(func(int, int) *model.AppError); ok {
-		r1 = rf(offset, limit)
+		r1 = rf(page, perPage)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -996,13 +996,13 @@ func (_m *API) KVGet(key string) ([]byte, *model.AppError) {
 	return r0, r1
 }
 
-// KVList provides a mock function with given fields:
-func (_m *API) KVList() ([]string, *model.AppError) {
-	ret := _m.Called()
+// KVList provides a mock function with given fields: offset, limit
+func (_m *API) KVList(offset int, limit int) ([]string, *model.AppError) {
+	ret := _m.Called(offset, limit)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func() []string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(int, int) []string); ok {
+		r0 = rf(offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -1010,8 +1010,8 @@ func (_m *API) KVList() ([]string, *model.AppError) {
 	}
 
 	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(int, int) *model.AppError); ok {
+		r1 = rf(offset, limit)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/store/sqlstore/plugin_store.go
+++ b/store/sqlstore/plugin_store.go
@@ -12,6 +12,10 @@ import (
 	"github.com/mattermost/mattermost-server/store"
 )
 
+const (
+	DEFAULT_KEY_FETCH_LIMIT = 10
+)
+
 type SqlPluginStore struct {
 	SqlStore
 }
@@ -93,10 +97,18 @@ func (ps SqlPluginStore) Delete(pluginId, key string) store.StoreChannel {
 	})
 }
 
-func (ps SqlPluginStore) List(pluginId string) store.StoreChannel {
+func (ps SqlPluginStore) List(pluginId string, offset int, limit int) store.StoreChannel {
+	if limit <= 0 {
+		limit = DEFAULT_KEY_FETCH_LIMIT
+	}
+
+	if offset <= 0 {
+		offset = 0
+	}
+
 	return store.Do(func(result *store.StoreResult) {
 		var keys []string
-		_, err := ps.GetReplica().Select(&keys, "SELECT PKey FROM PluginKeyValueStore WHERE PluginId = :PluginId", map[string]interface{}{"PluginId": pluginId})
+		_, err := ps.GetReplica().Select(&keys, "SELECT PKey FROM PluginKeyValueStore WHERE PluginId = :PluginId order by PKey limit :Limit offset :Offset", map[string]interface{}{"PluginId": pluginId, "Limit": limit, "Offset": offset})
 		if err != nil {
 			result.Err = model.NewAppError("SqlPluginStore.List", "store.sql_plugin_store.list.app_error", nil, fmt.Sprintf("plugin_id=%v, err=%v", pluginId, err.Error()), http.StatusInternalServerError)
 		} else {

--- a/store/sqlstore/plugin_store.go
+++ b/store/sqlstore/plugin_store.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DEFAULT_KEY_FETCH_LIMIT = 10
+	DEFAULT_PLUGIN_KEY_FETCH_LIMIT = 10
 )
 
 type SqlPluginStore struct {
@@ -99,7 +99,7 @@ func (ps SqlPluginStore) Delete(pluginId, key string) store.StoreChannel {
 
 func (ps SqlPluginStore) List(pluginId string, offset int, limit int) store.StoreChannel {
 	if limit <= 0 {
-		limit = DEFAULT_KEY_FETCH_LIMIT
+		limit = DEFAULT_PLUGIN_KEY_FETCH_LIMIT
 	}
 
 	if offset <= 0 {

--- a/store/sqlstore/plugin_store.go
+++ b/store/sqlstore/plugin_store.go
@@ -92,3 +92,14 @@ func (ps SqlPluginStore) Delete(pluginId, key string) store.StoreChannel {
 		}
 	})
 }
+
+func (ps SqlPluginStore) List(pluginId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var keys []string
+		if _, err := ps.GetReplica().Select(&keys, "SELECT PKey FROM PluginKeyValueStore WHERE PluginId = :PluginId", map[string]interface{}{"PluginId": pluginId}); err != nil {
+			result.Err = model.NewAppError("SqlPluginStore.List", "store.sql_plugin_store.list.app_error", nil, fmt.Sprintf("plugin_id=%v, err=%v", pluginId, err.Error()), http.StatusInternalServerError)
+		} else {
+			result.Data = keys
+		}
+	})
+}

--- a/store/sqlstore/plugin_store.go
+++ b/store/sqlstore/plugin_store.go
@@ -96,7 +96,8 @@ func (ps SqlPluginStore) Delete(pluginId, key string) store.StoreChannel {
 func (ps SqlPluginStore) List(pluginId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var keys []string
-		if _, err := ps.GetReplica().Select(&keys, "SELECT PKey FROM PluginKeyValueStore WHERE PluginId = :PluginId", map[string]interface{}{"PluginId": pluginId}); err != nil {
+		_, err := ps.GetReplica().Select(&keys, "SELECT PKey FROM PluginKeyValueStore WHERE PluginId = :PluginId", map[string]interface{}{"PluginId": pluginId})
+		if err != nil {
 			result.Err = model.NewAppError("SqlPluginStore.List", "store.sql_plugin_store.list.app_error", nil, fmt.Sprintf("plugin_id=%v, err=%v", pluginId, err.Error()), http.StatusInternalServerError)
 		} else {
 			result.Data = keys

--- a/store/store.go
+++ b/store/store.go
@@ -501,7 +501,7 @@ type PluginStore interface {
 	SaveOrUpdate(keyVal *model.PluginKeyValue) StoreChannel
 	Get(pluginId, key string) StoreChannel
 	Delete(pluginId, key string) StoreChannel
-	List(pluginId string, offset int, limit int) StoreChannel
+	List(pluginId string, page, perPage int) StoreChannel
 }
 
 type RoleStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -501,7 +501,7 @@ type PluginStore interface {
 	SaveOrUpdate(keyVal *model.PluginKeyValue) StoreChannel
 	Get(pluginId, key string) StoreChannel
 	Delete(pluginId, key string) StoreChannel
-	List(pluginId string) StoreChannel
+	List(pluginId string, offset int, limit int) StoreChannel
 }
 
 type RoleStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -501,6 +501,7 @@ type PluginStore interface {
 	SaveOrUpdate(keyVal *model.PluginKeyValue) StoreChannel
 	Get(pluginId, key string) StoreChannel
 	Delete(pluginId, key string) StoreChannel
+	List(pluginId string) StoreChannel
 }
 
 type RoleStore interface {

--- a/store/storetest/mocks/PluginStore.go
+++ b/store/storetest/mocks/PluginStore.go
@@ -45,13 +45,13 @@ func (_m *PluginStore) Get(pluginId string, key string) store.StoreChannel {
 	return r0
 }
 
-// List provides a mock function with given fields: pluginId
-func (_m *PluginStore) List(pluginId string) store.StoreChannel {
-	ret := _m.Called(pluginId)
+// List provides a mock function with given fields: pluginId, offset, limit
+func (_m *PluginStore) List(pluginId string, offset int, limit int) store.StoreChannel {
+	ret := _m.Called(pluginId, offset, limit)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
-		r0 = rf(pluginId)
+	if rf, ok := ret.Get(0).(func(string, int, int) store.StoreChannel); ok {
+		r0 = rf(pluginId, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/mocks/PluginStore.go
+++ b/store/storetest/mocks/PluginStore.go
@@ -45,6 +45,22 @@ func (_m *PluginStore) Get(pluginId string, key string) store.StoreChannel {
 	return r0
 }
 
+// List provides a mock function with given fields: pluginId
+func (_m *PluginStore) List(pluginId string) store.StoreChannel {
+	ret := _m.Called(pluginId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+		r0 = rf(pluginId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // SaveOrUpdate provides a mock function with given fields: keyVal
 func (_m *PluginStore) SaveOrUpdate(keyVal *model.PluginKeyValue) store.StoreChannel {
 	ret := _m.Called(keyVal)

--- a/store/storetest/mocks/PluginStore.go
+++ b/store/storetest/mocks/PluginStore.go
@@ -45,13 +45,13 @@ func (_m *PluginStore) Get(pluginId string, key string) store.StoreChannel {
 	return r0
 }
 
-// List provides a mock function with given fields: pluginId, offset, limit
-func (_m *PluginStore) List(pluginId string, offset int, limit int) store.StoreChannel {
-	ret := _m.Called(pluginId, offset, limit)
+// List provides a mock function with given fields: pluginId, page, perPage
+func (_m *PluginStore) List(pluginId string, page int, perPage int) store.StoreChannel {
+	ret := _m.Called(pluginId, page, perPage)
 
 	var r0 store.StoreChannel
 	if rf, ok := ret.Get(0).(func(string, int, int) store.StoreChannel); ok {
-		r0 = rf(pluginId, offset, limit)
+		r0 = rf(pluginId, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)


### PR DESCRIPTION
The pull request adds a method to the plugin API called KVList() that returns a list of all the keys stored by the plugin.

#### Summary
[A brief description of what this pull request does.]

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9377

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] Added or updated unit tests (required for all new features)
