### PR TITLE
Bump AuthorizeRequest State max length to 1024

### DIFF
--- a/model/authorize.go
+++ b/model/authorize.go
@@ -90,7 +90,7 @@ func (ar *AuthorizeRequest) IsValid() *AppError {
 		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.redirect_uri.app_error", nil, "client_id="+ar.ClientId, http.StatusBadRequest)
 	}
 
-	if len(ar.State) > 128 {
+	if len(ar.State) > 1024 {
 		return NewAppError("AuthData.IsValid", "model.authorize.is_valid.state.app_error", nil, "client_id="+ar.ClientId, http.StatusBadRequest)
 	}
 


### PR DESCRIPTION
#### Summary
See #9462 and linked issues. Bumps OAuth state value max length from 128 to 1024 in last place where
given small limit is enforced.

#### Ticket Link
#9462

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
