### PR TITLE
emit CustomTermsOfService in license

### DIFF
--- a/utils/license.go
+++ b/utils/license.go
@@ -151,6 +151,7 @@ func GetClientLicense(l *model.License) map[string]string {
 		props["EmailNotificationContents"] = strconv.FormatBool(*l.Features.EmailNotificationContents)
 		props["MessageExport"] = strconv.FormatBool(*l.Features.MessageExport)
 		props["CustomPermissionsSchemes"] = strconv.FormatBool(*l.Features.CustomPermissionsSchemes)
+		props["CustomTermsOfService"] = strconv.FormatBool(*l.Features.CustomTermsOfService)
 	}
 
 	return props


### PR DESCRIPTION
#### Summary
This is a patch to https://github.com/mattermost/mattermost-server/pull/9450 to send down the `CustomTermsOfService` bit in the license for use client-side.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12130

#### Checklist
- [ ] Added or updated unit tests (required for all new features)