### PR TITLE
MM-12080: Added some extra logging to cluster leader changed.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -244,6 +244,7 @@ func New(options ...Option) (outApp *App, outErr error) {
 	})
 
 	app.clusterLeaderListenerId = app.AddClusterLeaderChangedListener(func() {
+		mlog.Info("Cluster leader changed. Determining if job schedulers should be running:", mlog.Bool("isLeader", app.IsLeader()))
 		app.Jobs.Schedulers.HandleClusterLeaderChange(app.IsLeader())
 	})
 

--- a/app/cluster.go
+++ b/app/cluster.go
@@ -3,7 +3,10 @@
 
 package app
 
-import "github.com/mattermost/mattermost-server/model"
+import (
+	"github.com/mattermost/mattermost-server/mlog"
+	"github.com/mattermost/mattermost-server/model"
+)
 
 // Registers a given function to be called when the cluster leader may have changed. Returns a unique ID for the
 // listener which can later be used to remove it. If clustering is not enabled in this build, the callback will never
@@ -20,6 +23,7 @@ func (a *App) RemoveClusterLeaderChangedListener(id string) {
 }
 
 func (a *App) InvokeClusterLeaderChangedListeners() {
+	mlog.Info("Cluster leader changed. Invoking ClusterLeaderChanged listeners.")
 	a.Go(func() {
 		a.clusterLeaderListeners.Range(func(_, listener interface{}) bool {
 			listener.(func())()


### PR DESCRIPTION
#### Summary
Added some extra logging to cluster leader changed.

Purpose of this is to make in-field debugging of cluster leader issues
(particularly around duplicate job scheduling) easier to debug from
production server logs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12080