### PR TITLE
MM-12013: Fix post-permission checks to cascade for DM/GM channels.

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -455,6 +455,20 @@ func (me *TestHelper) CreateMessagePostNoClient(channel *model.Channel, message 
 	return post
 }
 
+func (me *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
+	utils.DisableDebugLogForTest()
+	var err *model.AppError
+	var channel *model.Channel
+	if channel, err = me.App.CreateDirectChannel(me.BasicUser.Id, user.Id); err != nil {
+		mlog.Error(err.Error())
+
+		time.Sleep(time.Second)
+		panic(err)
+	}
+	utils.EnableDebugLogForTest()
+	return channel
+}
+
 func (me *TestHelper) LoginBasic() {
 	me.LoginBasicWithClient(me.Client)
 }

--- a/app/authorization.go
+++ b/app/authorization.go
@@ -74,7 +74,9 @@ func (a *App) SessionHasPermissionToChannelByPost(session model.Session, postId 
 
 	if result := <-a.Srv.Store.Channel().GetForPost(postId); result.Err == nil {
 		channel := result.Data.(*model.Channel)
-		return a.SessionHasPermissionToTeam(session, channel.TeamId, permission)
+		if channel.TeamId != "" {
+			return a.SessionHasPermissionToTeam(session, channel.TeamId, permission)
+		}
 	}
 
 	return a.SessionHasPermissionTo(session, permission)


### PR DESCRIPTION
#### Summary
Fixes post-derived permission checks to cascade properly to System level when there isn't a team (i.e. the post is in a DM or GM channel).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12013

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase: authorization.
