### PR TITLE
MM-12192: autocompleteUsers: if a teamId is provided, require it to match the channel's team id

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -533,6 +533,20 @@ func autocompleteUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// If a teamId is provided, require it to match the channel's team id.
+		if teamId != "" {
+			channel, err := c.App.GetChannel(channelId)
+			if err != nil {
+				c.Err = err
+				return
+			}
+
+			if channel.TeamId != teamId {
+				c.Err = model.NewAppError("autocompleteUsers", "api.user.autocomplete_users.invalid_team_id", nil, "", http.StatusUnauthorized)
+				return
+			}
+		}
+
 		result, err := c.App.AutocompleteUsersInChannel(teamId, channelId, name, searchOptions, c.IsSystemAdmin())
 		if err != nil {
 			c.Err = err

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -872,6 +872,11 @@ func TestAutocompleteUsers(t *testing.T) {
 	if rusers.Users[0].FirstName != "" || rusers.Users[0].LastName != "" {
 		t.Fatal("should not show first/last name")
 	}
+
+	t.Run("team id, if provided, must match channel's team id", func(t *testing.T) {
+		rusers, resp = Client.AutocompleteUsersInChannel("otherTeamId", channelId, username, "")
+		CheckErrorMessage(t, resp, "api.user.autocomplete_users.invalid_team_id")
+	})
 }
 
 func TestGetProfileImage(t *testing.T) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2019,6 +2019,10 @@
     "translation": "Unsupported OAuth service provider"
   },
   {
+    "id": "api.user.autocomplete_users.invalid_team_id",
+    "translation": "Invalid team id"
+  },
+  {
     "id": "api.user.check_user_login_attempts.too_many.app_error",
     "translation": "Your account is locked because of too many failed password attempts. Please reset your password."
   },


### PR DESCRIPTION
#### Summary
If a teamId is provided, require it to match the channel's team id.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12192

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates