### PR TITLE
Set a proper HTTP user-agent header

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -16,12 +16,14 @@ import (
 	"strings"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
+	"golang.org/x/net/html/charset"
+
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/mattermost/mattermost-server/services/httpservice"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
-	"golang.org/x/net/html/charset"
 )
 
 func (a *App) CreatePostAsUser(post *model.Post, clearPushNotifications bool) (*model.Post, *model.AppError) {
@@ -919,7 +921,7 @@ func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) *mod
 	req.Header.Set("Accept", "application/json")
 
 	// Allow access to plugin routes for action buttons
-	var httpClient *http.Client
+	var httpClient *httpservice.Client
 	url, _ := url.Parse(action.Integration.URL)
 	siteURL, _ := url.Parse(*a.Config().ServiceSettings.SiteURL)
 	subpath, _ := utils.GetSubpathFromConfig(a.Config())

--- a/services/httpservice/client_test.go
+++ b/services/httpservice/client_test.go
@@ -118,3 +118,24 @@ func TestDialContextFilter(t *testing.T) {
 		}
 	}
 }
+
+func TestUserAgentIsSet(t *testing.T) {
+	testUserAgent := "test-user-agent"
+	defaultUserAgent = testUserAgent
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ua := req.UserAgent()
+		if ua == "" {
+			t.Error("expected user-agent to be non-empty")
+		}
+		if ua != testUserAgent {
+			t.Errorf("expected user-agent to be %q but was %q", testUserAgent, ua)
+		}
+	}))
+	defer ts.Close()
+	client := NewHTTPClient(true, nil, nil)
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	if err != nil {
+		t.Fatal("NewRequest failed", err)
+	}
+	client.Do(req)
+}

--- a/services/httpservice/httpservice.go
+++ b/services/httpservice/httpservice.go
@@ -5,7 +5,6 @@ package httpservice
 
 import (
 	"net"
-	"net/http"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/services/configservice"
@@ -13,7 +12,7 @@ import (
 
 // Wraps the functionality for creating a new http.Client to encapsulate that and allow it to be mocked when testing
 type HTTPService interface {
-	MakeClient(trustURLs bool) *http.Client
+	MakeClient(trustURLs bool) *Client
 	Close()
 }
 
@@ -25,7 +24,7 @@ func MakeHTTPService(configService configservice.ConfigService) HTTPService {
 	return &HTTPServiceImpl{configService}
 }
 
-func (h *HTTPServiceImpl) MakeClient(trustURLs bool) *http.Client {
+func (h *HTTPServiceImpl) MakeClient(trustURLs bool) *Client {
 	insecure := h.configService.Config().ServiceSettings.EnableInsecureOutgoingConnections != nil && *h.configService.Config().ServiceSettings.EnableInsecureOutgoingConnections
 
 	if trustURLs {

--- a/utils/testutils/mocked_http_service.go
+++ b/utils/testutils/mocked_http_service.go
@@ -4,6 +4,7 @@
 package testutils
 
 import (
+	"github.com/mattermost/mattermost-server/services/httpservice"
 	"net/http"
 	"net/http/httptest"
 )
@@ -18,8 +19,8 @@ func MakeMockedHTTPService(handler http.Handler) *MockedHTTPService {
 	}
 }
 
-func (h *MockedHTTPService) MakeClient(trustURLs bool) *http.Client {
-	return h.Server.Client()
+func (h *MockedHTTPService) MakeClient(trustURLs bool) *httpservice.Client {
+	return &httpservice.Client{Client: h.Server.Client()}
 }
 
 func (h *MockedHTTPService) Close() {


### PR DESCRIPTION
Previously, mattermost-server would always request with the default
user-agent of Go's net/http package that is `Go-http-client/1.1` or
something similar.
This has several disadvantages, one is that the default user-agent
made it pretty hard to distinguish mattermost requests from other
service requests in a network log for example.

Now a user-agent of the form `mattermost-<current-version>` is set in
the client.

- [x] Added or updated unit tests (required for all new features)