### PR TITLE
MM-12110: Don't /invite or /kick deactivated users.

### DIFF
--- a/app/command_invite.go
+++ b/app/command_invite.go
@@ -49,15 +49,21 @@ func (me *InviteProvider) DoCommand(a *App, args *model.CommandArgs, message str
 	targetUsername := splitMessage[0]
 	targetUsername = strings.TrimPrefix(targetUsername, "@")
 
-	var userProfile *model.User
-	if result := <-a.Srv.Store.User().GetByUsername(targetUsername); result.Err != nil {
+	result := <-a.Srv.Store.User().GetByUsername(targetUsername)
+	if result.Err != nil {
 		mlog.Error(result.Err.Error())
 		return &model.CommandResponse{
 			Text:         args.T("api.command_invite.missing_user.app_error"),
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 		}
-	} else {
-		userProfile = result.Data.(*model.User)
+	}
+
+	userProfile := result.Data.(*model.User)
+	if userProfile.DeleteAt != 0 {
+		return &model.CommandResponse{
+			Text:         args.T("api.command_invite.missing_user.app_error"),
+			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+		}
 	}
 
 	var channelToJoin *model.Channel

--- a/app/command_invite_test.go
+++ b/app/command_invite_test.go
@@ -23,6 +23,8 @@ func TestInviteProvider(t *testing.T) {
 	basicUser3 := th.CreateUser()
 	th.LinkUserToTeam(basicUser3, th.BasicTeam)
 	basicUser4 := th.CreateUser()
+	deactivatedUser := th.CreateUser()
+	th.App.UpdateActive(deactivatedUser, false)
 
 	InviteP := InviteProvider{}
 	args := &model.CommandArgs{
@@ -38,6 +40,7 @@ func TestInviteProvider(t *testing.T) {
 	userAndPrivateChannel := "@" + th.BasicUser2.Username + " ~" + privateChannel.Name
 	userAndDMChannel := "@" + basicUser3.Username + " ~" + dmChannel.Name
 	userAndInvalidPrivate := "@" + basicUser3.Username + " ~" + privateChannel2.Name
+	deactivatedUserPublicChannel := "@" + deactivatedUser.Username + " ~" + channel.Name
 
 	tests := []struct {
 		desc     string
@@ -98,6 +101,11 @@ func TestInviteProvider(t *testing.T) {
 			desc:     "try to add a user to a private channel with no permission",
 			expected: "api.command_invite.private_channel.app_error",
 			msg:      userAndInvalidPrivate,
+		},
+		{
+			desc:     "try to add a deleted user to a public channel",
+			expected: "api.command_invite.missing_user.app_error",
+			msg:      deactivatedUserPublicChannel,
 		},
 	}
 

--- a/app/command_remove_test.go
+++ b/app/command_remove_test.go
@@ -106,4 +106,19 @@ func TestRemoveProviderDoCommand(t *testing.T) {
 
 	actual = rp.DoCommand(th.App, args, user1.Username).Text
 	assert.Equal(t, "api.command_remove.direct_group.app_error", actual)
+
+	// Try a public channel with a deactivated user.
+	deactivatedUser := th.CreateUser()
+	th.App.AddUserToTeam(th.BasicTeam.Id, deactivatedUser.Id, deactivatedUser.Id)
+	th.App.AddUserToChannel(deactivatedUser, publicChannel)
+	th.App.UpdateActive(deactivatedUser, false)
+
+	args = &model.CommandArgs{
+		T:         func(s string, args ...interface{}) string { return s },
+		ChannelId: publicChannel.Id,
+		Session:   model.Session{UserId: th.BasicUser.Id, TeamMembers: []*model.TeamMember{{TeamId: th.BasicTeam.Id, Roles: ""}}},
+	}
+
+	actual = rp.DoCommand(th.App, args, deactivatedUser.Username).Text
+	assert.Equal(t, "api.command_remove.missing.app_error", actual)
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -412,6 +412,10 @@
     "translation": "Error to update the current channel."
   },
   {
+    "id": "api.command_channel_remove.channel.app_error",
+    "translation": "Error retrieving the current channel."
+  },
+  {
     "id": "api.command_channel_rename.channel.app_error",
     "translation": "Error to retrieve the current channel."
   },
@@ -616,7 +620,7 @@
   },
   {
     "id": "api.command_invite.missing_user.app_error",
-    "translation": "Unable to find the user."
+    "translation": "We couldn't find the user. They may have been deactivated by the System Administrator."
   },
   {
     "id": "api.command_invite.name",
@@ -824,7 +828,7 @@
   },
   {
     "id": "api.command_remove.missing.app_error",
-    "translation": "Unable to find the user"
+    "translation": "We couldn't find the user. They may have been deactivated by the System Administrator."
   },
   {
     "id": "api.command_remove.name",


### PR DESCRIPTION
#### Summary
Fix /invite /kick and /remove to not work on deactivated users.

Also take the opportunity to tidy up the functions that have been touched to be a little more readable.

Finally, update the UI strings as requested.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12110

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file updates
