### PR TITLE
MM-10699: Disallow renaming direct and group message channels

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -163,6 +163,14 @@ func (a *App) CreateChannelWithUser(channel *model.Channel, userId string) (*mod
 
 // RenameChannel is used to rename the channel Name and the DisplayName fields
 func (a *App) RenameChannel(channel *model.Channel, newChannelName string, newDisplayName string) (*model.Channel, *model.AppError) {
+	if channel.Type == model.CHANNEL_DIRECT {
+		return nil, model.NewAppError("RenameChannel", "api.channel.rename_channel.cant_rename_direct_messages.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if channel.Type == model.CHANNEL_GROUP {
+		return nil, model.NewAppError("RenameChannel", "api.channel.rename_channel.cant_rename_group_messages.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	channel.Name = newChannelName
 	if newDisplayName != "" {
 		channel.DisplayName = newDisplayName

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -640,12 +640,45 @@ func TestRenameChannel(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
-	channel := th.createChannel(th.BasicTeam, model.CHANNEL_OPEN)
-
-	channel, err := th.App.RenameChannel(channel, "newchannelname", "New Display Name")
-	if err != nil {
-		t.Fatal("Failed to update channel name. Error: " + err.Error())
+	testCases := []struct {
+		Name                string
+		Channel             *model.Channel
+		ExpectError         bool
+		ExpectedName        string
+		ExpectedDisplayName string
+	}{
+		{
+			"Rename open channel",
+			th.createChannel(th.BasicTeam, model.CHANNEL_OPEN),
+			false,
+			"newchannelname",
+			"New Display Name",
+		},
+		{
+			"Fail on rename direct message channel",
+			th.CreateDmChannel(th.BasicUser2),
+			true,
+			"",
+			"",
+		},
+		{
+			"Fail on rename direct message channel",
+			th.CreateGroupChannel(th.BasicUser2, th.CreateUser()),
+			true,
+			"",
+			"",
+		},
 	}
-	assert.Equal(t, "newchannelname", channel.Name)
-	assert.Equal(t, "New Display Name", channel.DisplayName)
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			channel, err := th.App.RenameChannel(tc.Channel, "newchannelname", "New Display Name")
+			if tc.ExpectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Equal(t, tc.ExpectedName, channel.Name)
+				assert.Equal(t, tc.ExpectedDisplayName, channel.DisplayName)
+			}
+		})
+	}
 }

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -4,11 +4,11 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -518,7 +518,7 @@ func modifyChannelCmdF(command *cobra.Command, args []string) error {
 
 	user := getUserFromUserArg(a, username)
 	if _, err := a.UpdateChannelPrivacy(channel, user); err != nil {
-		return errors.New("Failed to update channel ('" + args[0] + "') privacy - " + err.Error())
+		return errors.Wrapf(err, "Failed to update channel ('%s') privacy", args[0])
 	}
 
 	return nil
@@ -549,7 +549,7 @@ func renameChannelCmdF(command *cobra.Command, args []string) error {
 
 	_, errch := a.RenameChannel(channel, newChannelName, newDisplayName)
 	if errch != nil {
-		return errors.New("Error in updating channel from " + channel.Name + " to " + newChannelName + ": " + errch.Error())
+		return errors.Wrapf(errch, "Error in updating channel from %s to %s", channel.Name, newChannelName)
 	}
 
 	return nil

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -549,7 +549,7 @@ func renameChannelCmdF(command *cobra.Command, args []string) error {
 
 	_, errch := a.RenameChannel(channel, newChannelName, newDisplayName)
 	if errch != nil {
-		return errors.New("Error in updating channel from " + channel.Name + " to " + newChannelName + err.Error())
+		return errors.New("Error in updating channel from " + channel.Name + " to " + newChannelName + ": " + errch.Error())
 	}
 
 	return nil

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -240,6 +240,14 @@
     "translation": "%v removed from the channel."
   },
   {
+    "id": "api.channel.rename_channel.cant_rename_direct_messages.app_error",
+    "translation": "You cannot rename a direct message channel"
+  },
+  {
+    "id": "api.channel.rename_channel.cant_rename_group_messages.app_error",
+    "translation": "You cannot rename a group message channel"
+  },
+  {
     "id": "api.channel.update_channel.deleted.app_error",
     "translation": "The channel has been archived or deleted"
   },


### PR DESCRIPTION
#### Summary
Disallow renaming direct and group message channels

#### Ticket Link
[MM-10699](https://mattermost.atlassian.net/browse/MM-10699)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates