### PR TITLE
Move CustomServiceTermsEnabled to the correct table in diagnostics

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -262,7 +262,7 @@ func (a *App) trackConfig() {
 		"experimental_enable_hardened_mode":                       *cfg.ServiceSettings.ExperimentalEnableHardenedMode,
 		"experimental_limit_client_config":                        *cfg.ServiceSettings.ExperimentalLimitClientConfig,
 		"enable_email_invitations":                                *cfg.ServiceSettings.EnableEmailInvitations,
-		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,,
+		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -262,8 +262,7 @@ func (a *App) trackConfig() {
 		"experimental_enable_hardened_mode":                       *cfg.ServiceSettings.ExperimentalEnableHardenedMode,
 		"experimental_limit_client_config":                        *cfg.ServiceSettings.ExperimentalLimitClientConfig,
 		"enable_email_invitations":                                *cfg.ServiceSettings.EnableEmailInvitations,
-		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,
-		"custom_service_terms_enabled":                            *cfg.SupportSettings.CustomServiceTermsEnabled,
+		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{
@@ -418,6 +417,7 @@ func (a *App) trackConfig() {
 		"isdefault_help_link":             isDefault(*cfg.SupportSettings.HelpLink, model.SUPPORT_SETTINGS_DEFAULT_HELP_LINK),
 		"isdefault_report_a_problem_link": isDefault(*cfg.SupportSettings.ReportAProblemLink, model.SUPPORT_SETTINGS_DEFAULT_REPORT_A_PROBLEM_LINK),
 		"isdefault_support_email":         isDefault(*cfg.SupportSettings.SupportEmail, model.SUPPORT_SETTINGS_DEFAULT_SUPPORT_EMAIL),
+		"custom_service_terms_enabled":    *cfg.SupportSettings.CustomServiceTermsEnabled,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_LDAP, map[string]interface{}{


### PR DESCRIPTION
PR that added the setting is at https://github.com/mattermost/mattermost-server/pull/9450