### PR TITLE
Add GetChannelMembers method to the plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -262,6 +262,10 @@ func (api *PluginAPI) GetChannelMember(channelId, userId string) (*model.Channel
 	return api.app.GetChannelMember(channelId, userId)
 }
 
+func (api *PluginAPI) GetChannelMembers(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError) {
+	return api.app.GetChannelMembersPage(channelId, page, perPage)
+}
+
 func (api *PluginAPI) UpdateChannelMemberRoles(channelId, userId, newRoles string) (*model.ChannelMember, *model.AppError) {
 	return api.app.UpdateChannelMemberRoles(channelId, userId, newRoles)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -140,6 +140,9 @@ type API interface {
 	// GetChannelMember gets a channel membership for a user.
 	GetChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError)
 
+	// GetChannelMembers gets a channel membership for all users.
+	GetChannelMembers(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError)
+
 	// UpdateChannelMemberRoles updates a user's roles for a channel.
 	UpdateChannelMemberRoles(channelId, userId, newRoles string) (*model.ChannelMember, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1656,6 +1656,37 @@ func (s *apiRPCServer) GetChannelMember(args *Z_GetChannelMemberArgs, returns *Z
 	return nil
 }
 
+type Z_GetChannelMembersArgs struct {
+	A string
+	B int
+	C int
+}
+
+type Z_GetChannelMembersReturns struct {
+	A *model.ChannelMembers
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetChannelMembers(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError) {
+	_args := &Z_GetChannelMembersArgs{channelId, page, perPage}
+	_returns := &Z_GetChannelMembersReturns{}
+	if err := g.client.Call("Plugin.GetChannelMembers", _args, _returns); err != nil {
+		log.Printf("RPC call to GetChannelMembers API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetChannelMembers(args *Z_GetChannelMembersArgs, returns *Z_GetChannelMembersReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetChannelMembers(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetChannelMembers(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("API GetChannelMembers called but not implemented."))
+	}
+	return nil
+}
+
 type Z_UpdateChannelMemberRolesArgs struct {
 	A string
 	B string

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -433,6 +433,31 @@ func (_m *API) GetChannelMember(channelId string, userId string) (*model.Channel
 	return r0, r1
 }
 
+// GetChannelMembers provides a mock function with given fields: channelId, page, perPage
+func (_m *API) GetChannelMembers(channelId string, page int, perPage int) (*model.ChannelMembers, *model.AppError) {
+	ret := _m.Called(channelId, page, perPage)
+
+	var r0 *model.ChannelMembers
+	if rf, ok := ret.Get(0).(func(string, int, int) *model.ChannelMembers); ok {
+		r0 = rf(channelId, page, perPage)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.ChannelMembers)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int, int) *model.AppError); ok {
+		r1 = rf(channelId, page, perPage)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetConfig provides a mock function with given fields:
 func (_m *API) GetConfig() *model.Config {
 	ret := _m.Called()


### PR DESCRIPTION
#### Summary
This PR will add GetChannelMembers method to the plugin API

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9458

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] Added or updated unit tests (required for all new features)

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>