### PR TITLE
[GH-9486] Fix CMD Initilization Error Checks

### DIFF
--- a/cmd/mattermost/commands/init.go
+++ b/cmd/mattermost/commands/init.go
@@ -17,13 +17,13 @@ func InitDBCommandContextCobra(command *cobra.Command) (*app.App, error) {
 	}
 
 	a, err := InitDBCommandContext(config)
-	a.InitPlugins(*a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
 
 	if err != nil {
 		// Returning an error just prints the usage message, so actually panic
 		panic(err)
 	}
 
+	a.InitPlugins(*a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
 	a.DoAdvancedPermissionsMigration()
 	a.DoEmojisPermissionsMigration()
 


### PR DESCRIPTION
#### Summary
`cmd/mattermost/commands/init.go` doesn't check if the DB Command Context Init returns an error before initializating the plugin system, which can cause a null pointer exception without showing the user the actual error cause.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9496

cc @jwilander 