### PR TITLE
Add a delete brand image action on the APIv4

### DIFF
--- a/api4/brand.go
+++ b/api4/brand.go
@@ -14,6 +14,7 @@ import (
 func (api *API) InitBrand() {
 	api.BaseRoutes.Brand.Handle("/image", api.ApiHandlerTrustRequester(getBrandImage)).Methods("GET")
 	api.BaseRoutes.Brand.Handle("/image", api.ApiSessionRequired(uploadBrandImage)).Methods("POST")
+	api.BaseRoutes.Brand.Handle("/image", api.ApiSessionRequired(deleteBrandImage)).Methods("DELETE")
 }
 
 func getBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -69,5 +70,19 @@ func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.LogAudit("")
 
 	w.WriteHeader(http.StatusCreated)
+	ReturnStatusOK(w)
+}
+
+func deleteBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !c.App.SessionHasPermissionTo(c.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	if err := c.App.DeleteBrandImage(); err != nil {
+		c.Err = err
+		return
+	}
+
 	ReturnStatusOK(w)
 }

--- a/api4/brand_test.go
+++ b/api4/brand_test.go
@@ -52,3 +52,30 @@ func TestUploadBrandImage(t *testing.T) {
 	_, resp = th.SystemAdminClient.UploadBrandImage(data)
 	CheckCreatedStatus(t, resp)
 }
+
+func TestDeleteBrandImage(t *testing.T) {
+	th := Setup().InitBasic().InitSystemAdmin()
+	defer th.TearDown()
+
+	data, err := readTestFile("test.png")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, resp := th.SystemAdminClient.UploadBrandImage(data)
+	CheckCreatedStatus(t, resp)
+
+	resp = th.Client.DeleteBrandImage()
+	CheckForbiddenStatus(t, resp)
+
+	th.Client.Logout()
+
+	resp = th.Client.DeleteBrandImage()
+	CheckUnauthorizedStatus(t, resp)
+
+	resp = th.SystemAdminClient.DeleteBrandImage()
+	CheckOKStatus(t, resp)
+
+	resp = th.SystemAdminClient.DeleteBrandImage()
+	CheckNotFoundStatus(t, resp)
+}

--- a/app/brand.go
+++ b/app/brand.go
@@ -77,3 +77,19 @@ func (a *App) GetBrandImage() ([]byte, *model.AppError) {
 
 	return img, nil
 }
+
+func (a *App) DeleteBrandImage() *model.AppError {
+	filePath := BRAND_FILE_PATH + BRAND_FILE_NAME
+
+	fileExists, err := a.FileExists(filePath)
+
+	if err != nil {
+		return err
+	}
+
+	if !fileExists {
+		return model.NewAppError("DeleteBrandImage", "api.admin.delete_brand_image.storage.not_found", nil, "", http.StatusNotFound)
+	}
+
+	return a.RemoveFile(filePath)
+}

--- a/model/client4.go
+++ b/model/client4.go
@@ -2986,6 +2986,16 @@ func (c *Client4) GetBrandImage() ([]byte, *Response) {
 	}
 }
 
+func (c *Client4) DeleteBrandImage() *Response {
+	r, err := c.DoApiDelete(c.GetBrandRoute() + "/image")
+
+	if err != nil {
+		return BuildErrorResponse(r, err)
+	}
+
+	return BuildResponse(r)
+}
+
 // UploadBrandImage sets the brand image for the system.
 func (c *Client4) UploadBrandImage(data []byte) (bool, *Response) {
 	body := &bytes.Buffer{}


### PR DESCRIPTION
#### Summary
This PR adds a delete brand image action to the API v4.
It is needed in order to fulfill #9507 as discussed in the contributors channel of the pre-release instance.

Cheers !

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9507

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
