### PR TITLE
[WIP][MM-12304] Add channel search support in mattermost cli

### DIFF
--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -127,3 +127,18 @@ func TestRenameChannel(t *testing.T) {
 	assert.Equal(t, "newchannelname10", updatedChannel.Name)
 	assert.Equal(t, "New Display Name", updatedChannel.DisplayName)
 }
+
+func TestSearchChannel(t *testing.T) {
+	th := api4.Setup().InitBasic()
+	defer th.TearDown()
+
+	id := model.NewId()
+	name := "name" + id
+
+	CheckCommand(t, "channel", "create", "--display_name", name, "--team", th.BasicTeam.Name, "--name", name)
+	out := CheckCommand(t, "channel", "search", th.BasicTeam.Id+":"+name)
+
+	assert.Contains(t, out, name)
+	assert.NotContains(t, out, "random-channel")
+
+}


### PR DESCRIPTION
#### Summary
This will add support to search channel based on the teamID.
for example: `channel search jdlfndalkn34242:dev`

#### Ticket Link
[Jira Ticket](https://mattermost.atlassian.net/browse/MM-12304)
fixes: #9491 
#### Checklist
- [x] Added or updated unit tests (required for all new features)

Signed-off-by: Satyam Zode <satyamzode@gmail.com>