### PR TITLE
Add GetPostsForChannel method to plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -307,6 +307,10 @@ func (api *PluginAPI) GetPost(postId string) (*model.Post, *model.AppError) {
 	return api.app.GetSinglePost(postId)
 }
 
+func (api *PluginAPI) GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError) {
+	return api.app.GetPostsPage(channelId, page, perPage)
+}
+
 func (api *PluginAPI) UpdatePost(post *model.Post) (*model.Post, *model.AppError) {
 	return api.app.UpdatePost(post, false)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -173,6 +173,9 @@ type API interface {
 	// GetPost gets a post.
 	GetPost(postId string) (*model.Post, *model.AppError)
 
+	// GetPostsForChannel gets a list of posts for a channel.
+	GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError)
+
 	// UpdatePost updates a post.
 	UpdatePost(post *model.Post) (*model.Post, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1979,6 +1979,37 @@ func (s *apiRPCServer) GetPost(args *Z_GetPostArgs, returns *Z_GetPostReturns) e
 	return nil
 }
 
+type Z_GetPostsForChannelArgs struct {
+	A string
+	B int
+	C int
+}
+
+type Z_GetPostsForChannelReturns struct {
+	A *model.PostList
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError) {
+	_args := &Z_GetPostsForChannelArgs{channelId, page, perPage}
+	_returns := &Z_GetPostsForChannelReturns{}
+	if err := g.client.Call("Plugin.GetPostsForChannel", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPostsForChannel API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetPostsForChannel(args *Z_GetPostsForChannelArgs, returns *Z_GetPostsForChannelReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetPostsForChannel(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("API GetPostsForChannel called but not implemented."))
+	}
+	return nil
+}
+
 type Z_UpdatePostArgs struct {
 	A *model.Post
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -599,6 +599,31 @@ func (_m *API) GetPost(postId string) (*model.Post, *model.AppError) {
 	return r0, r1
 }
 
+// GetPostsForChannel provides a mock function with given fields: channelId, page, perPage
+func (_m *API) GetPostsForChannel(channelId string, page int, perPage int) (*model.PostList, *model.AppError) {
+	ret := _m.Called(channelId, page, perPage)
+
+	var r0 *model.PostList
+	if rf, ok := ret.Get(0).(func(string, int, int) *model.PostList); ok {
+		r0 = rf(channelId, page, perPage)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PostList)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int, int) *model.AppError); ok {
+		r1 = rf(channelId, page, perPage)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPublicChannelsForTeam provides a mock function with given fields: teamId, offset, limit
 func (_m *API) GetPublicChannelsForTeam(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
 	ret := _m.Called(teamId, offset, limit)


### PR DESCRIPTION
#### Summary
Add GetPostsForChannel method to plugin API

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9458

#### Checklist
- [x] Added or updated unit tests (required for all new features)

Signed-off-by: Akash Srivastava <akash.srivastava@openebs.io>
