### PR TITLE
[MM-12484] Fix return search posts on date filters

### DIFF
--- a/model/search_params.go
+++ b/model/search_params.go
@@ -27,7 +27,11 @@ type SearchParams struct {
 
 // Returns the epoch timestamp of the start of the day specified by SearchParams.AfterDate
 func (p *SearchParams) GetAfterDateMillis() int64 {
-	date := ParseDateFilterToTime(p.AfterDate)
+	date, err := time.Parse("2006-01-02", PadDateStringZeros(p.AfterDate))
+	if err != nil {
+		date = time.Now()
+	}
+
 	// travel forward 1 day
 	oneDay := time.Hour * 24
 	afterDate := date.Add(oneDay)
@@ -36,7 +40,11 @@ func (p *SearchParams) GetAfterDateMillis() int64 {
 
 // Returns the epoch timestamp of the end of the day specified by SearchParams.BeforeDate
 func (p *SearchParams) GetBeforeDateMillis() int64 {
-	date := ParseDateFilterToTime(p.BeforeDate)
+	date, err := time.Parse("2006-01-02", PadDateStringZeros(p.BeforeDate))
+	if err != nil {
+		return 0
+	}
+
 	// travel back 1 day
 	oneDay := time.Hour * -24
 	beforeDate := date.Add(oneDay)
@@ -45,7 +53,11 @@ func (p *SearchParams) GetBeforeDateMillis() int64 {
 
 // Returns the epoch timestamps of the start and end of the day specified by SearchParams.OnDate
 func (p *SearchParams) GetOnDateMillis() (int64, int64) {
-	date := ParseDateFilterToTime(p.OnDate)
+	date, err := time.Parse("2006-01-02", PadDateStringZeros(p.OnDate))
+	if err != nil {
+		return 0, 0
+	}
+
 	return GetStartOfDayMillis(date, p.TimeZoneOffset), GetEndOfDayMillis(date, p.TimeZoneOffset)
 }
 

--- a/model/search_params_test.go
+++ b/model/search_params_test.go
@@ -5,6 +5,9 @@ package model
 
 import (
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitWords(t *testing.T) {
@@ -299,5 +302,101 @@ func TestParseSearchParams(t *testing.T) {
 
 	if sp := ParseSearchParams("after:2018-8-1", 0); len(sp) != 1 || sp[0].Terms != "" || len(sp[0].AfterDate) == 0 || sp[0].AfterDate != "2018-8-1" {
 		t.Fatalf("Incorrect output from parse search params: %v", sp)
+	}
+}
+
+func TestGetOnDateMillis(t *testing.T) {
+	for _, testCase := range []struct {
+		Input       string
+		StartOnDate int64
+		EndOnDate   int64
+	}{
+		{
+			Input:       "2018-08-01",
+			StartOnDate: 1533081600000,
+			EndOnDate:   1533167999999,
+		},
+		{
+			Input:       "2018-8-1",
+			StartOnDate: 1533081600000,
+			EndOnDate:   1533167999999,
+		},
+		{
+			Input:       "2018-02-29",
+			StartOnDate: 0,
+			EndOnDate:   0,
+		},
+		{
+			Input:       "holiday",
+			StartOnDate: 0,
+			EndOnDate:   0,
+		},
+	} {
+		t.Run(testCase.Input, func(t *testing.T) {
+			sp := &SearchParams{OnDate: testCase.Input, TimeZoneOffset: 0}
+			startOnDate, endOnDate := sp.GetOnDateMillis()
+			assert.Equal(t, testCase.StartOnDate, startOnDate)
+			assert.Equal(t, testCase.EndOnDate, endOnDate)
+		})
+	}
+}
+
+func TestGetBeforeDateMillis(t *testing.T) {
+	for _, testCase := range []struct {
+		Input      string
+		BeforeDate int64
+	}{
+		{
+			Input:      "2018-08-01",
+			BeforeDate: 1533081599999,
+		},
+		{
+			Input:      "2018-8-1",
+			BeforeDate: 1533081599999,
+		},
+		{
+			Input:      "2018-02-29",
+			BeforeDate: 0,
+		},
+		{
+			Input:      "holiday",
+			BeforeDate: 0,
+		},
+	} {
+		t.Run(testCase.Input, func(t *testing.T) {
+			sp := &SearchParams{BeforeDate: testCase.Input, TimeZoneOffset: 0}
+			beforeDate := sp.GetBeforeDateMillis()
+			assert.Equal(t, testCase.BeforeDate, beforeDate)
+		})
+	}
+}
+
+func TestGetAfterDateMillis(t *testing.T) {
+	for _, testCase := range []struct {
+		Input     string
+		AfterDate int64
+	}{
+		{
+			Input:     "2018-08-01",
+			AfterDate: 1533168000000,
+		},
+		{
+			Input:     "2018-8-1",
+			AfterDate: 1533168000000,
+		},
+		{
+			Input:     "2018-02-29",
+			AfterDate: GetStartOfDayMillis(time.Now().Add(time.Hour*24), 0),
+		},
+		{
+			Input:     "holiday",
+			AfterDate: GetStartOfDayMillis(time.Now().Add(time.Hour*24), 0),
+		},
+	} {
+		t.Run(testCase.Input, func(t *testing.T) {
+			sp := &SearchParams{AfterDate: testCase.Input, TimeZoneOffset: 0}
+			afterDate := sp.GetAfterDateMillis()
+			assert.Equal(t, testCase.AfterDate, afterDate)
+		})
 	}
 }

--- a/model/utils.go
+++ b/model/utils.go
@@ -141,26 +141,17 @@ func NewRandomString(length int) string {
 	return b.String()
 }
 
-// GetMillis is a convience method to get milliseconds since epoch.
+// GetMillis is a convenience method to get milliseconds since epoch.
 func GetMillis() int64 {
 	return time.Now().UnixNano() / int64(time.Millisecond)
 }
 
-// GetMillisForTime is a convience method to get milliseconds since epoch for provided Time.
+// GetMillisForTime is a convenience method to get milliseconds since epoch for provided Time.
 func GetMillisForTime(thisTime time.Time) int64 {
 	return thisTime.UnixNano() / int64(time.Millisecond)
 }
 
-// ParseDateFilterToTime is a convience method to get Time from string
-func ParseDateFilterToTime(filterString string) time.Time {
-	resultTime, err := time.Parse("2006-01-02", PadDateStringZeros(filterString))
-	if err != nil {
-		return time.Now()
-	}
-	return resultTime
-}
-
-// PadDateStringZeros is a convience method to pad 2 digit date parts with zeros to meet ISO 8601 format
+// PadDateStringZeros is a convenience method to pad 2 digit date parts with zeros to meet ISO 8601 format
 func PadDateStringZeros(dateString string) string {
 	parts := strings.Split(dateString, "-")
 	for index, part := range parts {
@@ -172,14 +163,14 @@ func PadDateStringZeros(dateString string) string {
 	return dateString
 }
 
-// GetStartOfDayMillis is a convience method to get milliseconds since epoch for provided date's start of day
+// GetStartOfDayMillis is a convenience method to get milliseconds since epoch for provided date's start of day
 func GetStartOfDayMillis(thisTime time.Time, timeZoneOffset int) int64 {
 	localSearchTimeZone := time.FixedZone("Local Search Time Zone", timeZoneOffset)
 	resultTime := time.Date(thisTime.Year(), thisTime.Month(), thisTime.Day(), 0, 0, 0, 0, localSearchTimeZone)
 	return GetMillisForTime(resultTime)
 }
 
-// GetEndOfDayMillis is a convience method to get milliseconds since epoch for provided date's end of day
+// GetEndOfDayMillis is a convenience method to get milliseconds since epoch for provided date's end of day
 func GetEndOfDayMillis(thisTime time.Time, timeZoneOffset int) int64 {
 	localSearchTimeZone := time.FixedZone("Local Search Time Zone", timeZoneOffset)
 	resultTime := time.Date(thisTime.Year(), thisTime.Month(), thisTime.Day(), 23, 59, 59, 999999999, localSearchTimeZone)

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -44,25 +44,23 @@ func TestGetMillisForTime(t *testing.T) {
 	}
 }
 
-func TestParseDateFilterToTimeISO8601(t *testing.T) {
-	testString := "2016-08-01"
-	compareTime := time.Date(2016, time.August, 1, 0, 0, 0, 0, time.UTC)
-
-	result := ParseDateFilterToTime(testString)
-
-	if result != compareTime {
-		t.Fatalf(fmt.Sprintf("parsed date doesn't match the expected result: parsed result %v and expected time %v", result, compareTime))
-	}
-}
-
-func TestParseDateFilterToTimeNeedZeroPadding(t *testing.T) {
-	testString := "2016-8-1"
-	compareTime := time.Date(2016, time.August, 1, 0, 0, 0, 0, time.UTC)
-
-	result := ParseDateFilterToTime(testString)
-
-	if result != compareTime {
-		t.Fatalf(fmt.Sprintf("parsed date doesn't match the expected result: parsed result %v and expected time %v", result, compareTime))
+func TestPadDateStringZeros(t *testing.T) {
+	for _, testCase := range []struct {
+		Input    string
+		Expected string
+	}{
+		{
+			Input:    "2016-08-01",
+			Expected: "2016-08-01",
+		},
+		{
+			Input:    "2016-8-1",
+			Expected: "2016-08-01",
+		},
+	} {
+		t.Run(testCase.Input, func(t *testing.T) {
+			assert.Equal(t, testCase.Expected, PadDateStringZeros(testCase.Input))
+		})
 	}
 }
 


### PR DESCRIPTION
#### Summary
Fix return search posts on date filters.

On current implementation, invalid date on search filter always return the current date/time.  This is now change with the following:
- For `on` and `before` invalid date, return `0` (it's less than the epoch date so searching post will yield no post)
- For `after` invalid date, remain as is which to return current time + 1 day (searching after a future date will yield no post)

For robust implementation, I believe there should be a "client validation" to prevent querying invalid date into the server and "error feedback" so that the user will know why it's not returning searched post.

But to fix this bug for this release, I believe this should be enough.

#### Ticket Link
Jira ticket: [MM-12484](https://mattermost.atlassian.net/browse/MM-12484)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
