### PR TITLE
MM-8860: Bulk import email intervals (#8498)

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -581,7 +581,7 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 		})
 	}
 
-	if data.EmailInterval != nil || savedUser.NotifyProps[model.EMAIL_NOTIFY_PROP] == "false"{
+	if data.EmailInterval != nil || savedUser.NotifyProps[model.EMAIL_NOTIFY_PROP] == "false" {
 		var intervalSeconds string
 		if value := savedUser.NotifyProps[model.EMAIL_NOTIFY_PROP]; value == "false" {
 			intervalSeconds = "0"

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -587,12 +587,12 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 			intervalSeconds = "0"
 		} else {
 			switch *data.EmailInterval {
-			case "immediately":
+			case model.PREFERENCE_EMAIL_INTERVAL_IMMEDIATELY:
 				intervalSeconds = model.PREFERENCE_EMAIL_INTERVAL_NO_BATCHING_SECONDS
-			case "fifteen":
-				intervalSeconds = "900"
-			case "hour":
-				intervalSeconds = "3600"
+			case model.PREFERENCE_EMAIL_INTERVAL_FIFTEEN:
+				intervalSeconds = model.PREFERENCE_EMAIL_INTERVAL_FIFTEEN_AS_SECONDS
+			case model.PREFERENCE_EMAIL_INTERVAL_HOUR:
+				intervalSeconds = model.PREFERENCE_EMAIL_INTERVAL_HOUR_AS_SECONDS
 			}
 		}
 		if intervalSeconds != "" {

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -581,6 +581,30 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 		})
 	}
 
+	if data.EmailInterval != nil || savedUser.NotifyProps[model.EMAIL_NOTIFY_PROP] == "false"{
+		var intervalSeconds string
+		if value := savedUser.NotifyProps[model.EMAIL_NOTIFY_PROP]; value == "false" {
+			intervalSeconds = "0"
+		} else {
+			switch *data.EmailInterval {
+			case "immediately":
+				intervalSeconds = model.PREFERENCE_EMAIL_INTERVAL_NO_BATCHING_SECONDS
+			case "fifteen":
+				intervalSeconds = "900"
+			case "hour":
+				intervalSeconds = "3600"
+			}
+		}
+		if intervalSeconds != "" {
+			preferences = append(preferences, model.Preference{
+				UserId:   savedUser.Id,
+				Category: model.PREFERENCE_CATEGORY_NOTIFICATIONS,
+				Name:     model.PREFERENCE_NAME_EMAIL_INTERVAL,
+				Value:    intervalSeconds,
+			})
+		}
+	}
+
 	if len(preferences) > 0 {
 		if result := <-a.Srv.Store.Preference().Save(&preferences); result.Err != nil {
 			return model.NewAppError("BulkImport", "app.import.import_user.save_preferences.error", nil, result.Err.Error(), http.StatusInternalServerError)

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -1079,6 +1079,7 @@ func TestImportImportUser(t *testing.T) {
 		UseMarkdownPreview: ptrStr("true"),
 		UseFormatting:      ptrStr("true"),
 		ShowUnreadSection:  ptrStr("true"),
+		EmailInterval:		ptrStr("immediately"),
 	}
 	if err := th.App.ImportUser(&data, false); err != nil {
 		t.Fatalf("Should have succeeded.")
@@ -1099,6 +1100,7 @@ func TestImportImportUser(t *testing.T) {
 	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS, "feature_enabled_markdown_preview", *data.UseMarkdownPreview)
 	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS, "formatting", *data.UseFormatting)
 	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_SIDEBAR_SETTINGS, "show_unread_section", *data.ShowUnreadSection)
+	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_NOTIFICATIONS, model.PREFERENCE_NAME_EMAIL_INTERVAL, "30")
 
 	// Change those preferences.
 	data = UserImportData{
@@ -1110,6 +1112,7 @@ func TestImportImportUser(t *testing.T) {
 		MessageDisplay:     ptrStr("clean"),
 		ChannelDisplayMode: ptrStr("full"),
 		TutorialStep:       ptrStr("2"),
+		EmailInterval:		ptrStr("hour"),
 	}
 	if err := th.App.ImportUser(&data, false); err != nil {
 		t.Fatalf("Should have succeeded.")
@@ -1122,6 +1125,7 @@ func TestImportImportUser(t *testing.T) {
 	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_DISPLAY_SETTINGS, model.PREFERENCE_NAME_MESSAGE_DISPLAY, *data.MessageDisplay)
 	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_DISPLAY_SETTINGS, model.PREFERENCE_NAME_CHANNEL_DISPLAY_MODE, *data.ChannelDisplayMode)
 	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_TUTORIAL_STEPS, user.Id, *data.TutorialStep)
+	checkPreference(t, th.App, user.Id, model.PREFERENCE_CATEGORY_NOTIFICATIONS, model.PREFERENCE_NAME_EMAIL_INTERVAL, "3600")
 
 	// Set Notify Props
 	data.NotifyProps = &UserNotifyPropsImportData{

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -1079,7 +1079,7 @@ func TestImportImportUser(t *testing.T) {
 		UseMarkdownPreview: ptrStr("true"),
 		UseFormatting:      ptrStr("true"),
 		ShowUnreadSection:  ptrStr("true"),
-		EmailInterval:		ptrStr("immediately"),
+		EmailInterval:      ptrStr("immediately"),
 	}
 	if err := th.App.ImportUser(&data, false); err != nil {
 		t.Fatalf("Should have succeeded.")
@@ -1112,7 +1112,7 @@ func TestImportImportUser(t *testing.T) {
 		MessageDisplay:     ptrStr("clean"),
 		ChannelDisplayMode: ptrStr("full"),
 		TutorialStep:       ptrStr("2"),
-		EmailInterval:		ptrStr("hour"),
+		EmailInterval:      ptrStr("hour"),
 	}
 	if err := th.App.ImportUser(&data, false); err != nil {
 		t.Fatalf("Should have succeeded.")

--- a/app/import_types.go
+++ b/app/import_types.go
@@ -64,6 +64,7 @@ type UserImportData struct {
 	MessageDisplay     *string `json:"message_display,omitempty"`
 	ChannelDisplayMode *string `json:"channel_display_mode,omitempty"`
 	TutorialStep       *string `json:"tutorial_step,omitempty"`
+	EmailInterval      *string `json:"email_interval",omitempty"`
 
 	NotifyProps *UserNotifyPropsImportData `json:"notify_props,omitempty"`
 }

--- a/app/import_types.go
+++ b/app/import_types.go
@@ -64,7 +64,7 @@ type UserImportData struct {
 	MessageDisplay     *string `json:"message_display,omitempty"`
 	ChannelDisplayMode *string `json:"channel_display_mode,omitempty"`
 	TutorialStep       *string `json:"tutorial_step,omitempty"`
-	EmailInterval      *string `json:"email_interval",omitempty"`
+	EmailInterval      *string `json:"email_interval,omitempty"`
 
 	NotifyProps *UserNotifyPropsImportData `json:"notify_props,omitempty"`
 }

--- a/app/import_validators.go
+++ b/app/import_validators.go
@@ -281,6 +281,10 @@ func validateUserImportData(data *UserImportData) *model.AppError {
 		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.advanced_props_show_unread_section.error", nil, "", http.StatusBadRequest)
 	}
 
+	if data.EmailInterval != nil && !model.IsValidEmailBatchingInterval(*data.EmailInterval) {
+		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.advanced_props_email_interval.error", nil, "", http.StatusBadRequest)
+	}
+
 	if data.Teams != nil {
 		return validateUserTeamsImportData(data.Teams)
 	}

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -660,6 +660,24 @@ func TestImportValidateUserImportData(t *testing.T) {
 	data.NotifyProps.CommentsTrigger = ptrStr(model.COMMENTS_NOTIFY_ROOT)
 	data.NotifyProps.MentionKeys = ptrStr("valid")
 	checkNoError(t, validateUserImportData(&data))
+
+	//Test the emai batching interval validators
+	//Happy paths
+	data.EmailInterval = ptrStr("immediately")
+	checkNoError(t,validateUserImportData(&data))
+
+	data.EmailInterval = ptrStr("fifteen")
+	checkNoError(t,validateUserImportData(&data))
+
+	data.EmailInterval = ptrStr("hour")
+	checkNoError(t,validateUserImportData(&data))
+
+	//Invalid values
+	data.EmailInterval = ptrStr("invalid")
+	checkError(t,validateUserImportData(&data))
+
+	data.EmailInterval = ptrStr("")
+	checkError(t,validateUserImportData(&data))
 }
 
 func TestImportValidateUserTeamsImportData(t *testing.T) {

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -664,20 +664,20 @@ func TestImportValidateUserImportData(t *testing.T) {
 	//Test the emai batching interval validators
 	//Happy paths
 	data.EmailInterval = ptrStr("immediately")
-	checkNoError(t,validateUserImportData(&data))
+	checkNoError(t, validateUserImportData(&data))
 
 	data.EmailInterval = ptrStr("fifteen")
-	checkNoError(t,validateUserImportData(&data))
+	checkNoError(t, validateUserImportData(&data))
 
 	data.EmailInterval = ptrStr("hour")
-	checkNoError(t,validateUserImportData(&data))
+	checkNoError(t, validateUserImportData(&data))
 
 	//Invalid values
 	data.EmailInterval = ptrStr("invalid")
-	checkError(t,validateUserImportData(&data))
+	checkError(t, validateUserImportData(&data))
 
 	data.EmailInterval = ptrStr("")
-	checkError(t,validateUserImportData(&data))
+	checkError(t, validateUserImportData(&data))
 }
 
 func TestImportValidateUserTeamsImportData(t *testing.T) {

--- a/model/preference.go
+++ b/model/preference.go
@@ -42,6 +42,11 @@ const (
 
 	PREFERENCE_EMAIL_INTERVAL_NO_BATCHING_SECONDS = "30"  // the "immediate" setting is actually 30s
 	PREFERENCE_EMAIL_INTERVAL_BATCHING_SECONDS    = "900" // fifteen minutes is 900 seconds
+	PREFERENCE_EMAIL_INTERVAL_IMMEDIATELY         = "immediately"
+	PREFERENCE_EMAIL_INTERVAL_FIFTEEN             = "fifteen"
+	PREFERENCE_EMAIL_INTERVAL_FIFTEEN_AS_SECONDS  = "900"
+	PREFERENCE_EMAIL_INTERVAL_HOUR                = "hour"
+	PREFERENCE_EMAIL_INTERVAL_HOUR_AS_SECONDS     = "3600"
 )
 
 type Preference struct {

--- a/model/user.go
+++ b/model/user.go
@@ -639,3 +639,9 @@ func IsValidCommentsNotifyLevel(notifyLevel string) bool {
 		notifyLevel == COMMENTS_NOTIFY_ROOT ||
 		notifyLevel == COMMENTS_NOTIFY_NEVER
 }
+
+func IsValidEmailBatchingInterval(emailInterval string) bool {
+	return emailInterval == "immediately" ||
+		emailInterval == "fifteen" ||
+		emailInterval == "hour"
+}

--- a/model/user.go
+++ b/model/user.go
@@ -641,7 +641,7 @@ func IsValidCommentsNotifyLevel(notifyLevel string) bool {
 }
 
 func IsValidEmailBatchingInterval(emailInterval string) bool {
-	return emailInterval == "immediately" ||
-		emailInterval == "fifteen" ||
-		emailInterval == "hour"
+	return emailInterval == PREFERENCE_EMAIL_INTERVAL_IMMEDIATELY ||
+		emailInterval == PREFERENCE_EMAIL_INTERVAL_FIFTEEN ||
+		emailInterval == PREFERENCE_EMAIL_INTERVAL_HOUR
 }


### PR DESCRIPTION
#### Summary
This pull request provides the necessary changes to specify an email batching interval while during bulk import.
The supported values are:
immediately
fifteen
hour
If the user specifies false as email NotifyProp, the bulk email interval preference will be 0.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8860
https://github.com/mattermost/mattermost-server/issues/8498

#### Checklist
- [x] Added or updated unit tests (required for all new features)

