### PR TITLE
[MM-12464] [Bulk Export] Include DM/GM Channels and Their Posts in the Bulk Export

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -197,6 +197,11 @@ func (a *App) ExportAllDirectChannels(writer io.Writer) *model.AppError {
 			members := strings.Split(channel.Usernames, ",")
 			channel.Members = &members
 
+			// Skip single member channel
+			if len(members) == 1 {
+				continue
+			}
+
 			channelLine := ImportLineFromDirectChannel(channel)
 			if err := a.ExportWriteLine(writer, channelLine); err != nil {
 				return err

--- a/app/export_converters.go
+++ b/app/export_converters.go
@@ -122,3 +122,15 @@ func ImportReplyFromPost(post *model.ReplyForExport) *ReplyImportData {
 		CreateAt: &post.CreateAt,
 	}
 }
+
+func ImportLineForDirectPost(post *model.DirectPostForExport) *LineImportData {
+	return &LineImportData{
+		Type: "direct_post",
+		DirectPost: &DirectPostImportData{
+			ChannelMembers: post.ChannelMembers,
+			User:           &post.Username,
+			Message:        &post.Message,
+			CreateAt:       &post.CreateAt,
+		},
+	}
+}

--- a/app/export_converters.go
+++ b/app/export_converters.go
@@ -4,8 +4,9 @@
 package app
 
 import (
-	"github.com/mattermost/mattermost-server/model"
 	"strings"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 func ImportLineFromTeam(team *model.TeamForExport) *LineImportData {
@@ -33,6 +34,16 @@ func ImportLineFromChannel(channel *model.ChannelForExport) *LineImportData {
 			Header:      &channel.Header,
 			Purpose:     &channel.Purpose,
 			Scheme:      channel.SchemeName,
+		},
+	}
+}
+
+func ImportLineFromDirectChannel(channel *model.DirectChannelForExport) *LineImportData {
+	return &LineImportData{
+		Type: "direct_channel",
+		DirectChannel: &DirectChannelImportData{
+			Header:  &channel.Header,
+			Members: channel.Members,
 		},
 	}
 }

--- a/model/channel.go
+++ b/model/channel.go
@@ -63,6 +63,12 @@ type ChannelForExport struct {
 	SchemeName *string
 }
 
+type DirectChannelForExport struct {
+	Channel
+	Usernames string
+	Members   *[]string
+}
+
 func (o *Channel) DeepCopy() *Channel {
 	copy := *o
 	if copy.SchemeId != nil {

--- a/model/post.go
+++ b/model/post.go
@@ -126,6 +126,13 @@ type ReplyForExport struct {
 	Username string
 }
 
+type DirectPostForExport struct {
+	Post
+	UserIds        string
+	Username       string
+	ChannelMembers *[]string
+}
+
 type PostForIndexing struct {
 	Post
 	TeamId         string `json:"team_id"`

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2251,6 +2251,35 @@ func (s SqlChannelStore) GetAllChannelsForExportAfter(limit int, afterId string)
 	})
 }
 
+func (s SqlChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var data []*model.DirectChannelForExport
+		if _, err := s.GetReplica().Select(&data, `
+			SELECT
+				Channels.*,
+				GROUP_CONCAT(Users.Username SEPARATOR ',') AS Usernames
+			FROM Channels
+			LEFT JOIN
+				ChannelMembers CM ON CM.ChannelId = Channels.Id
+			LEFT JOIN
+				Users ON Users.Id = CM.UserId
+			WHERE
+				Channels.Id > :AfterId
+				AND Channels.Type IN ('D', 'G')
+			GROUP BY
+				Id
+			ORDER BY
+				Id
+			LIMIT :Limit`,
+			map[string]interface{}{"AfterId": afterId, "Limit": limit}); err != nil {
+			result.Err = model.NewAppError("SqlTeamStore.GetAllDirectChannelsForExportAfter", "store.sql_channel.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		result.Data = data
+	})
+}
+
 func (s SqlChannelStore) GetChannelMembersForExport(userId string, teamId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var members []*model.ChannelMemberForExport

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2272,7 +2272,7 @@ func (s SqlChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterId s
 				Id
 			LIMIT :Limit`,
 			map[string]interface{}{"AfterId": afterId, "Limit": limit}); err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.GetAllDirectChannelsForExportAfter", "store.sql_channel.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
+			result.Err = model.NewAppError("SqlTeamStore.GetAllDirectChannelsForExportAfter", "store.sql_channel.get_all_direct.app_error", nil, err.Error(), http.StatusInternalServerError)
 			return
 		}
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1373,3 +1373,42 @@ func (s *SqlPostStore) GetRepliesForExport(parentId string) store.StoreChannel {
 		}
 	})
 }
+
+func (s *SqlPostStore) GetDirectPostParentsForExportAfter(limit int, afterId string) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var posts []*model.DirectPostForExport
+		_, err1 := s.GetSearchReplica().Select(&posts, `
+                SELECT
+                    p1.*,
+                    Users.Username as Username,
+					group_concat(
+                    	(SELECT UserName from Users where Id = cm.UserId)
+                    ) as Usernames
+                FROM
+                    Posts p1
+                INNER JOIN
+                    Channels ON p1.ChannelId = Channels.Id AND Channels.Type in ('D','G')
+                INNER JOIN
+					Users ON p1.UserId = Users.Id
+				INNER JOIN
+                	ChannelMembers cm ON cm.ChannelId = Channels.Id
+                WHERE
+                    p1.Id > :AfterId
+                    AND p1.ParentId = ''
+                    AND p1.DeleteAt = 0
+					AND Channels.DeleteAt = 0
+					AND Users.DeleteAt = 0
+				GROUP BY Channels.Id,p1.Id
+                ORDER BY
+                    p1.Id
+                LIMIT
+                    :Limit`,
+			map[string]interface{}{"Limit": limit, "AfterId": afterId})
+
+		if err1 != nil {
+			result.Err = model.NewAppError("SqlPostStore.GetDirectPostParentsForExportAfter", "store.sql_post.get_direct_posts.app_error", nil, err1.Error(), http.StatusInternalServerError)
+		} else {
+			result.Data = posts
+		}
+	})
+}

--- a/store/store.go
+++ b/store/store.go
@@ -225,6 +225,7 @@ type PostStore interface {
 	GetMaxPostSize() StoreChannel
 	GetParentsForExportAfter(limit int, afterId string) StoreChannel
 	GetRepliesForExport(parentId string) StoreChannel
+	GetDirectPostParentsForExportAfter(limit int, afterId string) StoreChannel
 }
 
 type UserStore interface {

--- a/store/store.go
+++ b/store/store.go
@@ -183,6 +183,7 @@ type ChannelStore interface {
 	DisableExperimentalPublicChannelsMaterialization()
 	IsExperimentalPublicChannelsMaterializationEnabled() bool
 	GetAllChannelsForExportAfter(limit int, afterId string) StoreChannel
+	GetAllDirectChannelsForExportAfter(limit int, afterId string) StoreChannel
 	GetChannelMembersForExport(userId string, teamId string) StoreChannel
 }
 

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -234,6 +234,22 @@ func (_m *ChannelStore) GetAllChannelsForExportAfter(limit int, afterId string) 
 	return r0
 }
 
+// GetAllDirectChannelsForExportAfter provides a mock function with given fields: limit, afterId
+func (_m *ChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterId string) store.StoreChannel {
+	ret := _m.Called(limit, afterId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(int, string) store.StoreChannel); ok {
+		r0 = rf(limit, afterId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetByName provides a mock function with given fields: team_id, name, allowFromCache
 func (_m *ChannelStore) GetByName(team_id string, name string, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(team_id, name, allowFromCache)

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -98,6 +98,22 @@ func (_m *PostStore) Get(id string) store.StoreChannel {
 	return r0
 }
 
+// GetDirectPostParentsForExportAfter provides a mock function with given fields: limit, afterId
+func (_m *PostStore) GetDirectPostParentsForExportAfter(limit int, afterId string) store.StoreChannel {
+	ret := _m.Called(limit, afterId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(int, string) store.StoreChannel); ok {
+		r0 = rf(limit, afterId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetEtag provides a mock function with given fields: channelId, allowFromCache
 func (_m *PostStore) GetEtag(channelId string, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(channelId, allowFromCache)


### PR DESCRIPTION
#### Summary
Added DM/GM Channels exporter including their respective posts. I skipped the ability to export the single (you) channel in this PR, will do on different issue.

I will need some suggestion on how to handle postgressql compatibility for GROUP_CONCAT query being used in this PR.

#### Ticket Link
#9544 

#### Checklist
