### PR TITLE
MM-12419: Flush channels from cache when deleted/restored.

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -660,6 +660,8 @@ func (s SqlChannelStore) Restore(channelId string, time int64) store.StoreChanne
 // @see ChannelStoreExperimental for how this update propagates to the PublicChannels table.
 func (s SqlChannelStore) SetDeleteAt(channelId string, deleteAt, updateAt int64) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		defer s.InvalidateChannel(channelId)
+
 		transaction, err := s.GetMaster().Begin()
 		if err != nil {
 			result.Err = model.NewAppError("SqlChannelStore.SetDeleteAt", "store.sql_channel.set_delete_at.open_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/store/sqlstore/channel_store_experimental.go
+++ b/store/sqlstore/channel_store_experimental.go
@@ -283,6 +283,8 @@ func (s SqlChannelStoreExperimental) SetDeleteAt(channelId string, deleteAt, upd
 	}
 
 	return store.Do(func(result *store.StoreResult) {
+		defer s.InvalidateChannel(channelId)
+
 		transaction, err := s.GetMaster().Begin()
 		if err != nil {
 			result.Err = model.NewAppError("SqlChannelStoreExperimental.SetDeleteAt", "store.sql_channel.set_delete_at.open_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
#### Summary
This attempts to fix an issue with deleted/restored state of channels being reported incorrectly intermittently, as it looks like the cache sometimes contains invalid data. This should ensure the channel cache gets cleared at the appropriate times.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12419