### PR TITLE
 GH-9632: Add GetPostsSince() to plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -307,6 +307,10 @@ func (api *PluginAPI) GetPost(postId string) (*model.Post, *model.AppError) {
 	return api.app.GetSinglePost(postId)
 }
 
+func (api *PluginAPI) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
+	return api.app.GetPostsSince(channelId, time)
+}
+
 func (api *PluginAPI) GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError) {
 	return api.app.GetPostsPage(channelId, page, perPage)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -173,6 +173,9 @@ type API interface {
 	// GetPost gets a post.
 	GetPost(postId string) (*model.Post, *model.AppError)
 
+	// GetPostsSince gets posts created after a specified time as Unix time in milliseconds.
+	GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError)
+
 	// GetPostsForChannel gets a list of posts for a channel.
 	GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1979,6 +1979,36 @@ func (s *apiRPCServer) GetPost(args *Z_GetPostArgs, returns *Z_GetPostReturns) e
 	return nil
 }
 
+type Z_GetPostsSinceArgs struct {
+	A string
+	B int64
+}
+
+type Z_GetPostsSinceReturns struct {
+	A *model.PostList
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
+	_args := &Z_GetPostsSinceArgs{channelId, time}
+	_returns := &Z_GetPostsSinceReturns{}
+	if err := g.client.Call("Plugin.GetPostsSince", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPostsSince API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetPostsSince(args *Z_GetPostsSinceArgs, returns *Z_GetPostsSinceReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetPostsSince(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API GetPostsSince called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetPostsForChannelArgs struct {
 	A string
 	B int

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -624,6 +624,31 @@ func (_m *API) GetPostsForChannel(channelId string, page int, perPage int) (*mod
 	return r0, r1
 }
 
+// GetPostsSince provides a mock function with given fields: channelId, time
+func (_m *API) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
+	ret := _m.Called(channelId, time)
+
+	var r0 *model.PostList
+	if rf, ok := ret.Get(0).(func(string, int64) *model.PostList); ok {
+		r0 = rf(channelId, time)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PostList)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
+		r1 = rf(channelId, time)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPublicChannelsForTeam provides a mock function with given fields: teamId, offset, limit
 func (_m *API) GetPublicChannelsForTeam(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
 	ret := _m.Called(teamId, offset, limit)


### PR DESCRIPTION
#### Summary
This PR adds a `GetPostsSince(channelId string, time int64)` method to plugin API.

#### Ticket Link
Fixes  #9632