### PR TITLE
GH-9631: Add GetPostsBefore() to plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -327,6 +327,10 @@ func (api *PluginAPI) GetPostsSince(channelId string, time int64) (*model.PostLi
 	return api.app.GetPostsSince(channelId, time)
 }
 
+func (api *PluginAPI) GetPostsBefore(channelId, postId string, page, perPage int) (*model.PostList, *model.AppError) {
+	return api.app.GetPostsBeforePost(channelId, postId, page, perPage)
+}
+
 func (api *PluginAPI) GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError) {
 	return api.app.GetPostsPage(channelId, page, perPage)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -188,6 +188,9 @@ type API interface {
 	// GetPostsSince gets posts created after a specified time as Unix time in milliseconds.
 	GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError)
 
+	// GetPostsBefore gets a page of posts that were posted before the post provided.
+	GetPostsBefore(channelId, postId string, page, perPage int) (*model.PostList, *model.AppError)
+
 	// GetPostsForChannel gets a list of posts for a channel.
 	GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2130,6 +2130,38 @@ func (s *apiRPCServer) GetPostsSince(args *Z_GetPostsSinceArgs, returns *Z_GetPo
 	return nil
 }
 
+type Z_GetPostsBeforeArgs struct {
+	A string
+	B string
+	C int
+	D int
+}
+
+type Z_GetPostsBeforeReturns struct {
+	A *model.PostList
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetPostsBefore(channelId, postId string, page, perPage int) (*model.PostList, *model.AppError) {
+	_args := &Z_GetPostsBeforeArgs{channelId, postId, page, perPage}
+	_returns := &Z_GetPostsBeforeReturns{}
+	if err := g.client.Call("Plugin.GetPostsBefore", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPostsBefore API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetPostsBefore(args *Z_GetPostsBeforeArgs, returns *Z_GetPostsBeforeReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPostsBefore(channelId, postId string, page, perPage int) (*model.PostList, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetPostsBefore(args.A, args.B, args.C, args.D)
+	} else {
+		return encodableError(fmt.Errorf("API GetPostsBefore called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetPostsForChannelArgs struct {
 	A string
 	B int

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -649,6 +649,31 @@ func (_m *API) GetPostThread(postId string) (*model.PostList, *model.AppError) {
 	return r0, r1
 }
 
+// GetPostsBefore provides a mock function with given fields: channelId, postId, page, perPage
+func (_m *API) GetPostsBefore(channelId string, postId string, page int, perPage int) (*model.PostList, *model.AppError) {
+	ret := _m.Called(channelId, postId, page, perPage)
+
+	var r0 *model.PostList
+	if rf, ok := ret.Get(0).(func(string, string, int, int) *model.PostList); ok {
+		r0 = rf(channelId, postId, page, perPage)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PostList)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, string, int, int) *model.AppError); ok {
+		r1 = rf(channelId, postId, page, perPage)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPostsForChannel provides a mock function with given fields: channelId, page, perPage
 func (_m *API) GetPostsForChannel(channelId string, page int, perPage int) (*model.PostList, *model.AppError) {
 	ret := _m.Called(channelId, page, perPage)


### PR DESCRIPTION
#### Summary
This PR adds a `GetPostsBefore(channelId, postId string, page, perPage int)` method to plugin API.

#### Ticket Link
Fixes  #9631