### PR TITLE
GH-9629: Add GetPostThread() to plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -303,6 +303,10 @@ func (api *PluginAPI) DeletePost(postId string) *model.AppError {
 	return err
 }
 
+func (api *PluginAPI) GetPostThread(postId string) (*model.PostList, *model.AppError) {
+	return api.app.GetPostThread(postId)
+}
+
 func (api *PluginAPI) GetPost(postId string) (*model.Post, *model.AppError) {
 	return api.app.GetSinglePost(postId)
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -170,6 +170,9 @@ type API interface {
 	// DeletePost deletes a post.
 	DeletePost(postId string) *model.AppError
 
+	// GetPostThread gets a post with all the other posts in the same thread.
+	GetPostThread(postId string) (*model.PostList, *model.AppError)
+
 	// GetPost gets a post.
 	GetPost(postId string) (*model.Post, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1950,6 +1950,35 @@ func (s *apiRPCServer) DeletePost(args *Z_DeletePostArgs, returns *Z_DeletePostR
 	return nil
 }
 
+type Z_GetPostThreadArgs struct {
+	A string
+}
+
+type Z_GetPostThreadReturns struct {
+	A *model.PostList
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetPostThread(postId string) (*model.PostList, *model.AppError) {
+	_args := &Z_GetPostThreadArgs{postId}
+	_returns := &Z_GetPostThreadReturns{}
+	if err := g.client.Call("Plugin.GetPostThread", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPostThread API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetPostThread(args *Z_GetPostThreadArgs, returns *Z_GetPostThreadReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPostThread(postId string) (*model.PostList, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetPostThread(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API GetPostThread called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetPostArgs struct {
 	A string
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -599,6 +599,31 @@ func (_m *API) GetPost(postId string) (*model.Post, *model.AppError) {
 	return r0, r1
 }
 
+// GetPostThread provides a mock function with given fields: postId
+func (_m *API) GetPostThread(postId string) (*model.PostList, *model.AppError) {
+	ret := _m.Called(postId)
+
+	var r0 *model.PostList
+	if rf, ok := ret.Get(0).(func(string) *model.PostList); ok {
+		r0 = rf(postId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PostList)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(postId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPostsForChannel provides a mock function with given fields: channelId, page, perPage
 func (_m *API) GetPostsForChannel(channelId string, page int, perPage int) (*model.PostList, *model.AppError) {
 	ret := _m.Called(channelId, page, perPage)


### PR DESCRIPTION
#### Summary
This PR adds a `GetPostThread(postId string)` method to plugin API.

#### Ticket Link
Fixes  #9629 