### PR TITLE
Added TextArea (longstring) to the docs in manifest to be rendered in the documentation

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -45,6 +45,8 @@ type PluginSetting struct {
 	//
 	// "text" will result in a string setting that can be typed in manually.
 	//
+	// "longtext" will result in a multi line string that can be typed in manually.
+	//
 	// "username" will result in a text setting that will autocomplete to a username.
 	Type string `json:"type" yaml:"type"`
 


### PR DESCRIPTION
#### Summary
While developing a new plugin I need a setting that is a multi line string, reading the doc it did not mention. but I tried the longstring and it rendered the multi line string for me in the plugin setting

So I think it is usefull to add this reference in the doc as well for others see how powerfull is our plugin system 😄 

Do i need to do anything more?