### PR TITLE
MM-11905: deactivate plugins before unregistering

### DIFF
--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -120,9 +120,8 @@ func (a *App) removePlugin(id string) *model.AppError {
 		a.Publish(message)
 	}
 
-	a.UnregisterPluginCommands(id)
-
 	a.Plugins.Deactivate(id)
+	a.UnregisterPluginCommands(id)
 
 	err = os.RemoveAll(pluginPath)
 	if err != nil {


### PR DESCRIPTION
#### Summary
Plugins that listen for config changes might incorrectly re-register
their commands before being /actually/ deactivated, leaving the new
commands alive thereafter.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11905

#### Checklist
- [ ] Added or updated unit tests (required for all new features)