### PR TITLE
Add plugin API for UploadFile method

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -397,6 +397,25 @@ func (a *App) UploadFiles(teamId string, channelId string, userId string, files 
 	return resStruct, nil
 }
 
+// UploadFile uploads a single file in form of a completely constructed byte array for a channel.
+func (a *App) UploadFile(data []byte, channelId string, filename string) (*model.FileInfo, *model.AppError) {
+	info, _, appError := a.DoUploadFileExpectModification(time.Now(), "noteam", channelId, "nouser", filename, data)
+
+	if appError != nil {
+		return nil, appError
+	}
+
+	if info.PreviewPath != "" || info.ThumbnailPath != "" {
+		previewPathList := []string{info.PreviewPath}
+		thumbnailPathList := []string{info.ThumbnailPath}
+		imageDataList := [][]byte{data}
+
+		a.HandleImages(previewPathList, thumbnailPathList, imageDataList)
+	}
+
+	return info, nil
+}
+
 func (a *App) DoUploadFile(now time.Time, rawTeamId string, rawChannelId string, rawUserId string, rawFilename string, data []byte) (*model.FileInfo, *model.AppError) {
 	info, _, err := a.DoUploadFileExpectModification(now, rawTeamId, rawChannelId, rawUserId, rawFilename, data)
 	return info, err

--- a/app/file_test.go
+++ b/app/file_test.go
@@ -107,6 +107,30 @@ func TestDoUploadFile(t *testing.T) {
 	}
 }
 
+func TestUploadFile(t *testing.T) {
+	th := Setup()
+	defer th.TearDown()
+
+	channelId := model.NewId()
+	filename := "test"
+	data := []byte("abcd")
+
+	info1, err := th.App.UploadFile(data, channelId, filename)
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		defer func() {
+			<-th.App.Srv.Store.FileInfo().PermanentDelete(info1.Id)
+			th.App.RemoveFile(info1.Path)
+		}()
+	}
+
+	if info1.Path != fmt.Sprintf("%v/teams/noteam/channels/%v/users/nouser/%v/%v",
+		time.Now().Format("20060102"), channelId, info1.Id, filename) {
+		t.Fatal("stored file at incorrect path", info1.Path)
+	}
+}
+
 func TestGetInfoForFilename(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -6,11 +6,10 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"strings"
-
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
+	"net/http"
+	"strings"
 )
 
 type PluginAPI struct {
@@ -325,6 +324,10 @@ func (api *PluginAPI) GetFileInfo(fileId string) (*model.FileInfo, *model.AppErr
 
 func (api *PluginAPI) ReadFile(path string) ([]byte, *model.AppError) {
 	return api.app.ReadFile(path)
+}
+
+func (api *PluginAPI) UploadFile(data []byte, channelId string, filename string) (*model.FileInfo, *model.AppError) {
+	return api.app.UploadFile(data, channelId, filename)
 }
 
 func (api *PluginAPI) KVSet(key string, value []byte) *model.AppError {

--- a/model/file_info.go
+++ b/model/file_info.go
@@ -85,7 +85,7 @@ func (o *FileInfo) IsValid() *AppError {
 		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	if len(o.CreatorId) != 26 {
+	if len(o.CreatorId) != 26 && o.CreatorId != "nouser" {
 		return NewAppError("FileInfo.IsValid", "model.file_info.is_valid.user_id.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -193,6 +193,9 @@ type API interface {
 	// ReadFileAtPath reads the file from the backend for a specific path
 	ReadFile(path string) ([]byte, *model.AppError)
 
+	// UploadFile will upload a file to a channel using a multipart request, to be later attached to a post.
+	UploadFile(data []byte, channelId string, filename string) (*model.FileInfo, *model.AppError)
+
 	// KVSet will store a key-value pair, unique per plugin.
 	KVSet(key string, value []byte) *model.AppError
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2127,6 +2127,37 @@ func (s *apiRPCServer) ReadFile(args *Z_ReadFileArgs, returns *Z_ReadFileReturns
 	return nil
 }
 
+type Z_UploadFileArgs struct {
+	A []byte
+	B string
+	C string
+}
+
+type Z_UploadFileReturns struct {
+	A *model.FileInfo
+	B *model.AppError
+}
+
+func (g *apiRPCClient) UploadFile(data []byte, channelId string, filename string) (*model.FileInfo, *model.AppError) {
+	_args := &Z_UploadFileArgs{data, channelId, filename}
+	_returns := &Z_UploadFileReturns{}
+	if err := g.client.Call("Plugin.UploadFile", _args, _returns); err != nil {
+		log.Printf("RPC call to UploadFile API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) UploadFile(args *Z_UploadFileArgs, returns *Z_UploadFileReturns) error {
+	if hook, ok := s.impl.(interface {
+		UploadFile(data []byte, channelId string, filename string) (*model.FileInfo, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.UploadFile(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("API UploadFile called but not implemented."))
+	}
+	return nil
+}
+
 type Z_KVSetArgs struct {
 	A string
 	B []byte

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1470,3 +1470,28 @@ func (_m *API) UpdateUserStatus(userId string, status string) (*model.Status, *m
 
 	return r0, r1
 }
+
+// UploadFile provides a mock function with given fields: data, channelId, filename
+func (_m *API) UploadFile(data []byte, channelId string, filename string) (*model.FileInfo, *model.AppError) {
+	ret := _m.Called(data, channelId, filename)
+
+	var r0 *model.FileInfo
+	if rf, ok := ret.Get(0).(func([]byte, string, string) *model.FileInfo); ok {
+		r0 = rf(data, channelId, filename)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.FileInfo)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func([]byte, string, string) *model.AppError); ok {
+		r1 = rf(data, channelId, filename)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}


### PR DESCRIPTION
I decided to change the function return type to a FileInfo struct instead of a FileUploadResponse like in the ticket description. Furthermore I created a synthetic user _nouser_ as equivalent to the synthetic team _noteam_ and changed the validation function of the FileInfo model to meet these conditions.

#### Summary
Add plugin API for UploadFile method

#### Ticket Link
Github: #9640

#### Checklist
- [x] Added or updated unit tests (required for all new features)