### PR TITLE
MM-12670: Accept and use "" for user/pass AuthService in import/export.

### DIFF
--- a/app/export_converters.go
+++ b/app/export_converters.go
@@ -38,18 +38,12 @@ func ImportLineFromChannel(channel *model.ChannelForExport) *LineImportData {
 }
 
 func ImportLineFromUser(user *model.User) *LineImportData {
-	// Bulk Importer doesn't accept "empty string" for AuthService.
-	var authService *string
-	if user.AuthService != "" {
-		authService = &user.AuthService
-	}
-
 	return &LineImportData{
 		Type: "user",
 		User: &UserImportData{
 			Username:    &user.Username,
 			Email:       &user.Email,
-			AuthService: authService,
+			AuthService: &user.AuthService,
 			AuthData:    user.AuthData,
 			Nickname:    &user.Nickname,
 			FirstName:   &user.FirstName,

--- a/app/import_validators.go
+++ b/app/import_validators.go
@@ -199,10 +199,6 @@ func validateUserImportData(data *UserImportData) *model.AppError {
 		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.email_length.error", nil, "", http.StatusBadRequest)
 	}
 
-	if data.AuthService != nil && len(*data.AuthService) == 0 {
-		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.auth_service_length.error", nil, "", http.StatusBadRequest)
-	}
-
 	if data.AuthData != nil && data.Password != nil {
 		return model.NewAppError("BulkImport", "app.import.validate_user_import_data.auth_data_and_password.error", nil, "", http.StatusBadRequest)
 	}

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -556,10 +556,9 @@ func TestImportValidateUserImportData(t *testing.T) {
 
 	data.Email = ptrStr("bob@example.com")
 
+	// Empty AuthService indicates user/password auth.
 	data.AuthService = ptrStr("")
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to 0-length auth service.")
-	}
+	checkNoError(t, validateUserImportData(&data))
 
 	data.AuthService = ptrStr("saml")
 	data.AuthData = ptrStr(strings.Repeat("abcdefghij", 15))

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2931,10 +2931,6 @@
     "translation": "User AuthData is too long."
   },
   {
-    "id": "app.import.validate_user_import_data.auth_service_length.error",
-    "translation": "User AuthService should not be empty if it is provided."
-  },
-  {
     "id": "app.import.validate_user_import_data.email_length.error",
     "translation": "User email has an invalid length."
   },


### PR DESCRIPTION
### Summary
Accept and use "" for user/pass AuthService in import/export. This brings consistency with the docs.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12670

#### Checklist
- [x] Added or updated unit tests (required for all new features)