### PR TITLE
MM-11868/MM-12010/MM-12011/MM-12036 Improve post metadata structure

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
+	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 	"github.com/mattermost/mattermost-server/utils/markdown"
@@ -51,106 +52,129 @@ func (a *App) PreparePostListForClient(originalList *model.PostList) (*model.Pos
 func (a *App) PreparePostForClient(originalPost *model.Post) (*model.Post, *model.AppError) {
 	post := originalPost.Clone()
 
-	needReactionCounts := post.ReactionCounts == nil
-	needEmojis := post.Emojis == nil
-	needOpenGraphData := post.OpenGraphData == nil
-	needImageDimensions := post.ImageDimensions == nil
-
-	// Get reactions to post
-	var reactions []*model.Reaction
-	if needReactionCounts || needEmojis {
-		var err *model.AppError
-		reactions, err = a.GetReactionsForPost(post.Id)
-		if err != nil {
-			return post, err
-		}
-	}
-
-	if needReactionCounts {
-		post.ReactionCounts = model.CountReactions(reactions)
-	}
-
-	// Get emojis for post
-	if needEmojis {
-		emojis, err := a.getCustomEmojisForPost(post.Message, reactions)
-		if err != nil {
-			return post, err
-		}
-
-		post.Emojis = emojis
-	}
-
-	// Get files for post
-	if post.FileInfos == nil {
-		fileInfos, err := a.GetFileInfosForPost(post.Id, false)
-		if err != nil {
-			return post, err
-		}
-
-		post.FileInfos = fileInfos
-	}
-
-	// Proxy image links in post
+	// Proxy image links before constructing metadata so that requests go through the proxy
 	post = a.PostWithProxyAddedToImageURLs(post)
 
-	// Get OpenGraph and image metadata
-	if needOpenGraphData || needImageDimensions {
-		err := a.preparePostWithOpenGraphAndImageMetadata(post, needOpenGraphData, needImageDimensions)
-		if err != nil {
-			return post, err
+	if post.Metadata == nil {
+		post.Metadata = &model.PostMetadata{}
+
+		// Emojis and reaction counts
+		if emojis, reactionCounts, err := a.getEmojisAndReactionCountsForPost(post); err != nil {
+			mlog.Warn("Failed to get emojis and reactions for a post", mlog.String("post_id", post.Id), mlog.Any("err", err))
+		} else {
+			post.Metadata.Emojis = emojis
+			post.Metadata.ReactionCounts = reactionCounts
 		}
+
+		// Files
+		if fileInfos, err := a.GetFileInfosForPost(post.Id, false); err != nil {
+			mlog.Warn("Failed to get files for a post", mlog.String("post_id", post.Id), mlog.Any("err", err))
+		} else {
+			post.Metadata.FileInfos = fileInfos
+		}
+
+		// Embeds and image dimensions
+		firstLink, images := getFirstLinkAndImages(post.Message)
+
+		if embed, err := a.getEmbedForPost(post, firstLink); err != nil {
+			mlog.Warn("Failed to get embedded content for a post", mlog.String("post_id", post.Id), mlog.Any("err", err))
+		} else if embed == nil {
+			post.Metadata.Embeds = []*model.PostEmbed{}
+		} else {
+			post.Metadata.Embeds = []*model.PostEmbed{embed}
+		}
+
+		post.Metadata.ImageDimensions = a.getImageDimensionsForPost(post, images)
 	}
 
 	return post, nil
 }
 
-func (a *App) preparePostWithOpenGraphAndImageMetadata(post *model.Post, needOpenGraphData, needImageDimensions bool) *model.AppError {
-	var appError *model.AppError
-
-	if needOpenGraphData {
-		post.OpenGraphData = []*opengraph.OpenGraph{}
+func (a *App) getEmojisAndReactionCountsForPost(post *model.Post) ([]*model.Emoji, model.ReactionCounts, *model.AppError) {
+	reactions, err := a.GetReactionsForPost(post.Id)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	if needImageDimensions {
-		post.ImageDimensions = []*model.PostImageDimensions{}
+	emojis, err := a.getCustomEmojisForPost(post.Message, reactions)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	firstLink, images := getFirstLinkAndImages(post.Message)
+	return emojis, model.CountReactions(reactions), nil
+}
 
-	// Look at the first link to see if it's a web page or an image
+func (a *App) getEmbedForPost(post *model.Post, firstLink string) (*model.PostEmbed, error) {
+	if _, ok := post.Props["attachments"]; ok {
+		return &model.PostEmbed{
+			Type: model.POST_EMBED_MESSAGE_ATTACHMENT,
+		}, nil
+	}
+
 	if firstLink != "" {
 		og, dimensions, err := a.getLinkMetadata(firstLink, true)
 		if err != nil {
-			// Keep going so that one bad link doesn't prevent other image dimensions from being sent to the client
-			appError = model.NewAppError("PreparePostForClient", "app.post.metadata.link.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return nil, err
 		}
 
-		if needOpenGraphData {
-			post.OpenGraphData = append(post.OpenGraphData, og)
+		if og != nil {
+			return &model.PostEmbed{
+				Type: model.POST_EMBED_OPENGRAPH,
+				URL:  firstLink,
+				Data: og,
+			}, nil
 		}
 
-		if needImageDimensions {
-			post.ImageDimensions = append(post.ImageDimensions, dimensions)
-		}
-	}
-
-	if needImageDimensions {
-		// And dimensions for other images
-		for _, image := range images {
-			_, dimensions, err := a.getLinkMetadata(image, true)
-			if err != nil {
-				// Keep going so that one bad link doesn't prevent other image dimensions from being sent to the client
-				appError = model.NewAppError("PreparePostForClient", "app.post.metadata.link.app_error", nil, err.Error(), http.StatusInternalServerError)
-				continue
-			}
-
-			if dimensions != nil {
-				post.ImageDimensions = append(post.ImageDimensions, dimensions)
-			}
+		if dimensions != nil {
+			// Note that we're not passing the dimensions here since they'll be part of the PostMetadata.ImageDimensions field
+			return &model.PostEmbed{
+				Type: model.POST_EMBED_IMAGE,
+				URL:  firstLink,
+			}, nil
 		}
 	}
 
-	return appError
+	return nil, nil
+}
+
+func (a *App) getImageDimensionsForPost(post *model.Post, images []string) map[string]*model.PostImageDimensions {
+	allDimensions := map[string]*model.PostImageDimensions{}
+
+	for _, embed := range post.Metadata.Embeds {
+		switch embed.Type {
+		case model.POST_EMBED_IMAGE:
+			// These dimensions will generally be cached by a previous call to getEmbedForPost
+			images = append(images, embed.URL)
+
+		case model.POST_EMBED_MESSAGE_ATTACHMENT:
+			images = append(images, getImagesInPostAttachments(post)...)
+
+		case model.POST_EMBED_OPENGRAPH:
+			for _, image := range embed.Data.(*opengraph.OpenGraph).Images {
+				if image.Width != 0 || image.Height != 0 {
+					// The site has already told us the image dimensions
+					allDimensions[image.URL] = &model.PostImageDimensions{
+						Width:  int(image.Width),
+						Height: int(image.Height),
+					}
+				} else {
+					// The site did not specify its image dimensions
+					images = append(images, image.URL)
+				}
+			}
+		}
+	}
+
+	for _, imageURL := range images {
+		if _, dimensions, err := a.getLinkMetadata(imageURL, true); err != nil {
+			mlog.Warn("Failed to get dimensions of an image in a post",
+				mlog.String("post_id", post.Id), mlog.String("image_url", imageURL), mlog.Any("err", err))
+		} else {
+			allDimensions[imageURL] = dimensions
+		}
+	}
+
+	return allDimensions
 }
 
 func (a *App) getCustomEmojisForPost(message string, reactions []*model.Reaction) ([]*model.Emoji, *model.AppError) {
@@ -205,6 +229,27 @@ func getFirstLinkAndImages(str string) (string, []string) {
 	}
 
 	return firstLink, images
+}
+
+func getImagesInPostAttachments(post *model.Post) []string {
+	var images []string
+
+	for _, attachment := range post.Attachments() {
+		_, imagesInText := getFirstLinkAndImages(attachment.Text)
+		images = append(images, imagesInText...)
+
+		_, imagesInPretext := getFirstLinkAndImages(attachment.Pretext)
+		images = append(images, imagesInPretext...)
+
+		for _, field := range attachment.Fields {
+			if value, ok := field.Value.(string); ok {
+				_, imagesInFieldValue := getFirstLinkAndImages(value)
+				images = append(images, imagesInFieldValue...)
+			}
+		}
+	}
+
+	return images
 }
 
 func (a *App) getLinkMetadata(requestURL string, useCache bool) (*opengraph.OpenGraph, *model.PostImageDimensions, error) {
@@ -271,7 +316,7 @@ func cacheLinkMetadata(requestURL string, og *opengraph.OpenGraph, dimensions *m
 
 func (a *App) parseLinkMetadata(requestURL string, body io.Reader, contentType string) (*opengraph.OpenGraph, *model.PostImageDimensions, error) {
 	if strings.HasPrefix(contentType, "image") {
-		dimensions, err := parseImageDimensions(requestURL, body)
+		dimensions, err := parseImageDimensions(body)
 		return nil, dimensions, err
 	} else if strings.HasPrefix(contentType, "text/html") {
 		og := a.ParseOpenGraphMetadata(requestURL, body, contentType)
@@ -289,14 +334,13 @@ func (a *App) parseLinkMetadata(requestURL string, body io.Reader, contentType s
 	}
 }
 
-func parseImageDimensions(requestURL string, body io.Reader) (*model.PostImageDimensions, error) {
+func parseImageDimensions(body io.Reader) (*model.PostImageDimensions, error) {
 	config, _, err := image.DecodeConfig(body)
 	if err != nil {
 		return nil, err
 	}
 
 	dimensions := &model.PostImageDimensions{
-		URL:    requestURL,
 		Width:  config.Width,
 		Height: config.Height,
 	}

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -165,6 +165,11 @@ func (a *App) getImageDimensionsForPost(post *model.Post, images []string) map[s
 		}
 	}
 
+	// Removing duplicates isn't strictly since allDimensions is a map, but it feels safer to do it beforehand
+	if len(images) > 1 {
+		images = model.RemoveDuplicateStrings(images)
+	}
+
 	for _, imageURL := range images {
 		if _, dimensions, err := a.getLinkMetadata(imageURL, true); err != nil {
 			mlog.Warn("Failed to get dimensions of an image in a post",
@@ -223,10 +228,6 @@ func getFirstLinkAndImages(str string) (string, []string) {
 
 		return true
 	})
-
-	if len(images) > 1 {
-		images = model.RemoveDuplicateStrings(images)
-	}
 
 	return firstLink, images
 }

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -147,7 +147,7 @@ func (a *App) getImageDimensionsForPost(post *model.Post, images []string) map[s
 			images = append(images, embed.URL)
 
 		case model.POST_EMBED_MESSAGE_ATTACHMENT:
-			images = append(images, getImagesInPostAttachments(post)...)
+			images = append(images, getImagesInMessageAttachments(post)...)
 
 		case model.POST_EMBED_OPENGRAPH:
 			for _, image := range embed.Data.(*opengraph.OpenGraph).Images {
@@ -232,7 +232,7 @@ func getFirstLinkAndImages(str string) (string, []string) {
 	return firstLink, images
 }
 
-func getImagesInPostAttachments(post *model.Post) []string {
+func getImagesInMessageAttachments(post *model.Post) []string {
 	var images []string
 
 	for _, attachment := range post.Attachments() {

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -70,7 +70,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post) (*model.Post, *mode
 		if fileInfos, err := a.GetFileInfosForPost(post.Id, false); err != nil {
 			mlog.Warn("Failed to get files for a post", mlog.String("post_id", post.Id), mlog.Any("err", err))
 		} else {
-			post.Metadata.FileInfos = fileInfos
+			post.Metadata.Files = fileInfos
 		}
 
 		// Embeds and image dimensions

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -585,7 +585,7 @@ func TestGetFirstLinkAndImages(t *testing.T) {
 		"multiple images with duplicate": {
 			Input:             "this is a ![our logo](http://example.com/logo) and ![their logo](http://example.com/logo2) and ![my logo which is their logo](http://example.com/logo2)",
 			ExpectedFirstLink: "",
-			ExpectedImages:    []string{"http://example.com/logo", "http://example.com/logo2"},
+			ExpectedImages:    []string{"http://example.com/logo", "http://example.com/logo2", "http://example.com/logo2"},
 		},
 		"reference image": {
 			Input: `this is a ![our logo][logo]

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -53,7 +53,7 @@ func TestPreparePostForClient(t *testing.T) {
 			assert.NotEqual(t, nil, clientPost.Metadata, "should've populated Metadata")
 			assert.Len(t, clientPost.Metadata.Embeds, 0, "should've populated Embeds")
 			assert.Len(t, clientPost.Metadata.ReactionCounts, 0, "should've populated ReactionCounts")
-			assert.Len(t, clientPost.Metadata.FileInfos, 0, "should've populated FileInfos")
+			assert.Len(t, clientPost.Metadata.Files, 0, "should've populated Files")
 			assert.Len(t, clientPost.Metadata.Emojis, 0, "should've populated Emojis")
 			assert.Len(t, clientPost.Metadata.ImageDimensions, 0, "should've populated ImageDimensions")
 		})
@@ -88,7 +88,7 @@ func TestPreparePostForClient(t *testing.T) {
 		}, clientPost.Metadata.ReactionCounts, "should've populated ReactionCounts")
 	})
 
-	t.Run("file infos", func(t *testing.T) {
+	t.Run("files", func(t *testing.T) {
 		th := setup()
 		defer th.TearDown()
 
@@ -107,7 +107,7 @@ func TestPreparePostForClient(t *testing.T) {
 		clientPost, err := th.App.PreparePostForClient(post)
 		require.Nil(t, err)
 
-		assert.Equal(t, []*model.FileInfo{fileInfo}, clientPost.Metadata.FileInfos, "should've populated FileInfos")
+		assert.Equal(t, []*model.FileInfo{fileInfo}, clientPost.Metadata.Files, "should've populated Files")
 	})
 
 	t.Run("emojis without custom emojis enabled", func(t *testing.T) {

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -55,7 +55,7 @@ func TestPreparePostForClient(t *testing.T) {
 			assert.Len(t, clientPost.Metadata.ReactionCounts, 0, "should've populated ReactionCounts")
 			assert.Len(t, clientPost.Metadata.Files, 0, "should've populated Files")
 			assert.Len(t, clientPost.Metadata.Emojis, 0, "should've populated Emojis")
-			assert.Len(t, clientPost.Metadata.ImageDimensions, 0, "should've populated ImageDimensions")
+			assert.Len(t, clientPost.Metadata.Images, 0, "should've populated Images")
 		})
 	})
 
@@ -201,13 +201,13 @@ func TestPreparePostForClient(t *testing.T) {
 		require.Nil(t, err)
 
 		t.Run("populates image dimensions", func(t *testing.T) {
-			imageDimensions := clientPost.Metadata.ImageDimensions
+			imageDimensions := clientPost.Metadata.Images
 			assert.Len(t, imageDimensions, 2)
-			assert.Equal(t, &model.PostImageDimensions{
+			assert.Equal(t, &model.PostImage{
 				Width:  1068,
 				Height: 552,
 			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/logoVertical.png"])
-			assert.Equal(t, &model.PostImageDimensions{
+			assert.Equal(t, &model.PostImage{
 				Width:  501,
 				Height: 501,
 			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/icon.png"])
@@ -255,9 +255,9 @@ func TestPreparePostForClient(t *testing.T) {
 		})
 
 		t.Run("populates image dimensions", func(t *testing.T) {
-			imageDimensions := clientPost.Metadata.ImageDimensions
+			imageDimensions := clientPost.Metadata.Images
 			assert.Len(t, imageDimensions, 1)
-			assert.Equal(t, &model.PostImageDimensions{
+			assert.Equal(t, &model.PostImage{
 				Width:  1068,
 				Height: 552,
 			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/logoVertical.png"])
@@ -300,9 +300,9 @@ func TestPreparePostForClient(t *testing.T) {
 		})
 
 		t.Run("populates image dimensions", func(t *testing.T) {
-			imageDimensions := clientPost.Metadata.ImageDimensions
+			imageDimensions := clientPost.Metadata.Images
 			assert.Len(t, imageDimensions, 1)
-			assert.Equal(t, &model.PostImageDimensions{
+			assert.Equal(t, &model.PostImage{
 				Width:  420,
 				Height: 420,
 			}, imageDimensions["https://avatars1.githubusercontent.com/u/3277310?s=400&v=4"])
@@ -338,9 +338,9 @@ func TestPreparePostForClient(t *testing.T) {
 		})
 
 		t.Run("populates image dimensions", func(t *testing.T) {
-			imageDimensions := clientPost.Metadata.ImageDimensions
+			imageDimensions := clientPost.Metadata.Images
 			assert.Len(t, imageDimensions, 1)
-			assert.Equal(t, &model.PostImageDimensions{
+			assert.Equal(t, &model.PostImage{
 				Width:  501,
 				Height: 501,
 			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/icon.png"])
@@ -807,7 +807,7 @@ func TestParseLinkMetadata(t *testing.T) {
 		assert.Nil(t, err)
 
 		assert.Nil(t, og)
-		assert.Equal(t, &model.PostImageDimensions{
+		assert.Equal(t, &model.PostImage{
 			Width:  408,
 			Height: 336,
 		}, dimensions)
@@ -849,7 +849,7 @@ func TestParseLinkMetadata(t *testing.T) {
 	})
 }
 
-func TestParseImageDimensions(t *testing.T) {
+func TestParseImages(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		FileName       string
 		ExpectedWidth  int
@@ -875,7 +875,7 @@ func TestParseImageDimensions(t *testing.T) {
 			file, err := testutils.ReadTestFile(testCase.FileName)
 			require.Nil(t, err)
 
-			dimensions, err := parseImageDimensions(bytes.NewReader(file))
+			dimensions, err := parseImages(bytes.NewReader(file))
 			if testCase.ExpectError {
 				require.NotNil(t, err)
 			} else {

--- a/model/post.go
+++ b/model/post.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/dyatlov/go-opengraph/opengraph"
 	"github.com/mattermost/mattermost-server/utils/markdown"
 )
 
@@ -83,18 +82,8 @@ type Post struct {
 	PendingPostId string          `json:"pending_post_id" db:"-"`
 	HasReactions  bool            `json:"has_reactions,omitempty"` // Deprecated, do not use this field any more
 
-	// Transient fields populated before sending posts to the client
-	ReactionCounts  ReactionCounts         `json:"reaction_counts" db:"-"`
-	FileInfos       []*FileInfo            `json:"file_infos" db:"-"`
-	ImageDimensions []*PostImageDimensions `json:"image_dimensions" db:"-"`
-	OpenGraphData   []*opengraph.OpenGraph `json:"opengraph_data" db:"-"`
-	Emojis          []*Emoji               `json:"emojis" db:"-"`
-}
-
-type PostImageDimensions struct {
-	URL    string `json:"url"`
-	Width  int    `json:"width"`
-	Height int    `json:"height"`
+	// Transient data populated before sending a post to the client
+	Metadata *PostMetadata `json:"metadata" db:"-"`
 }
 
 type PostEphemeral struct {

--- a/model/post_embed.go
+++ b/model/post_embed.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+const (
+	POST_EMBED_IMAGE              PostEmbedType = "image"
+	POST_EMBED_MESSAGE_ATTACHMENT PostEmbedType = "message_attachment"
+	POST_EMBED_OPENGRAPH          PostEmbedType = "opengraph"
+)
+
+type PostEmbedType string
+
+type PostEmbed struct {
+	Type PostEmbedType `json:"type"`
+
+	// The URL of the embedded content. Used for image and OpenGraph embeds.
+	URL string `json:"url,omitempty"`
+
+	// Any additional data for the embedded content. Only used for OpenGraph embeds.
+	Data interface{} `json:"data,omitempty"`
+}

--- a/model/post_metadata.go
+++ b/model/post_metadata.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+type PostMetadata struct {
+	// An array of the information required to render additional details about the contents of this post.
+	Embeds []*PostEmbed `json:"embeds,omitempty"`
+
+	// An arrayof the  custom emojis used in the post or in reactions to the post.
+	Emojis []*Emoji `json:"emojis,omitempty"`
+
+	// An array of information about the files attached to the post.
+	FileInfos []*FileInfo `json:"files_infos,omitempty"`
+
+	// A map of image URL to dimensions for all external images in the post. This includes image embeds,
+	// inline Markdown images, OpenGraph images, and message attachment images, but it does not contain the dimensions
+	// of file attachments which are contained in PostMetadata.FileInfos.
+	ImageDimensions map[string]*PostImageDimensions `json:"images_dimensions,omitempty"`
+
+	// A map of emoji names to a count of users that reacted with the given emoji.
+	ReactionCounts ReactionCounts `json:"reaction_counts,omitempty"`
+}
+
+type PostImageDimensions struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}

--- a/model/post_metadata.go
+++ b/model/post_metadata.go
@@ -13,16 +13,16 @@ type PostMetadata struct {
 	// An array of information about the file attachments on the post.
 	Files []*FileInfo `json:"files,omitempty"`
 
-	// A map of image URL to dimensions for all external images in the post. This includes image embeds,
+	// A map of image URL to information about  all external images in the post. This includes image embeds,
 	// inline Markdown images, OpenGraph images, and message attachment images, but it does not contain the dimensions
 	// of file attachments which are contained in PostMetadata.FileInfos.
-	ImageDimensions map[string]*PostImageDimensions `json:"images_dimensions,omitempty"`
+	Images map[string]*PostImage `json:"images,omitempty"`
 
 	// A map of emoji names to a count of users that reacted with the given emoji.
 	ReactionCounts ReactionCounts `json:"reaction_counts,omitempty"`
 }
 
-type PostImageDimensions struct {
+type PostImage struct {
 	Width  int `json:"width"`
 	Height int `json:"height"`
 }

--- a/model/post_metadata.go
+++ b/model/post_metadata.go
@@ -10,8 +10,8 @@ type PostMetadata struct {
 	// An arrayof the  custom emojis used in the post or in reactions to the post.
 	Emojis []*Emoji `json:"emojis,omitempty"`
 
-	// An array of information about the files attached to the post.
-	FileInfos []*FileInfo `json:"files_infos,omitempty"`
+	// An array of information about the file attachments on the post.
+	Files []*FileInfo `json:"files,omitempty"`
 
 	// A map of image URL to dimensions for all external images in the post. This includes image embeds,
 	// inline Markdown images, OpenGraph images, and message attachment images, but it does not contain the dimensions


### PR DESCRIPTION
As discussed previously, this changes the following:
1. The structure of the post metadata has been changed so that:
    1. All metadata is now in its own `post.Metadata` struct to make it easier to tell whether or not it was populated by the server
    2. `ImageDimensions` is now a map of image URL to dimensions to allow for multiple images coming from different parts of the post
    3. There's a new `Embeds` field containing whether the post has message attachments, has an image preview, or has an OpenGraph preview. For image previews, this also includes the URL of the image. For OpenGraph, this contains a URL as well as the previous the OpenGraph data.
2. Image dimensions for OpenGraph images are now always included in `ImageDimensions` instead of only sometimes existing in the OpenGraph data ([MM-11868](https://mattermost.atlassian.net/browse/MM-11868))
3. Image dimensions for message attachments are now included in `ImageDimensions` ([MM-12036](https://mattermost.atlassian.net/browse/MM-12036))
4. Post metadata processing no longer immediately aborts if it encounters an error getting one of the fields so that the other fields can be populated ([MM-12010](https://mattermost.atlassian.net/browse/MM-12010)). It now logs a warning and continues processing when possible.
5. Null entries are no longer added to `ImageDimensions` ([MM-12011](https://mattermost.atlassian.net/browse/MM-12011))

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11868
https://mattermost.atlassian.net/browse/MM-12036
https://mattermost.atlassian.net/browse/MM-12010
https://mattermost.atlassian.net/browse/MM-12011

#### Checklist
- Added or updated unit tests (required for all new features)
- Touches critical sections of the codebase (auth, upgrade, etc.)
