### PR TITLE
MM-12781 Fix display of timestamp on generic email. This is a regression.

### DIFF
--- a/templates/post_body_generic.html
+++ b/templates/post_body_generic.html
@@ -18,7 +18,7 @@
                                         <tr>
                                             <td style="border-bottom: 1px solid #ddd; padding: 0 0 20px;">
                                                 <h2 style="font-weight: normal; margin-top: 10px;">{{.Props.BodyText}}</h2>
-                                                <p>{{.Html.Info}}</p>
+                                                <p>{{.Props.Info}}</p>
                                                 <p style="margin: 20px 0 15px">
                                                     <a href="{{.Props.TeamLink}}" style="background: #2389D7; display: inline-block; border-radius: 3px; color: #fff; border: none; outline: none; min-width: 170px; padding: 15px 25px; font-size: 14px; font-family: inherit; cursor: pointer; -webkit-appearance: none;text-decoration: none;">{{.Props.Button}}</a>
                                                 </p>
@@ -42,4 +42,3 @@
 </table>
 
 {{end}}
-


### PR DESCRIPTION
### Summary
Timestamp is not being displayed when the setting for generic emails is active: `"EmailNotificationContentsType": "generic"`

This refactoring added the regression on the generic email: 
https://github.com/mattermost/mattermost-server/commit/178ccd16cba26144eac404f413440867b360033c#diff-0721f391e39910fa6d56994bae49e7b4