### PR TITLE
MM-12355: Add CLI command "command create" revision

### DIFF
--- a/cmd/mattermost/commands/command.go
+++ b/cmd/mattermost/commands/command.go
@@ -99,7 +99,7 @@ func createCommandCmdF(command *cobra.Command, args []string) error {
 
 	// check if creator has permission to create slash commands
 	if !a.HasPermissionToTeam(user.Id, team.Id, model.PERMISSION_MANAGE_SLASH_COMMANDS) {
-		return errors.New("only team admins can create slash commands")
+		return errors.New("the creator must be a user who has permissions to manage slash commands")
 	}
 
 	title, _ := command.Flags().GetString("title")

--- a/cmd/mattermost/commands/command.go
+++ b/cmd/mattermost/commands/command.go
@@ -85,9 +85,6 @@ func createCommandCmdF(command *cobra.Command, args []string) error {
 	}
 	defer a.Shutdown()
 
-	// check if only admins can manage slash commands
-	enableOnlyAdminIntegrations := *a.Config().ServiceSettings.EnableOnlyAdminIntegrations
-
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
 		return errors.New("unable to find team '" + args[0] + "'")
@@ -99,11 +96,9 @@ func createCommandCmdF(command *cobra.Command, args []string) error {
 	if user == nil {
 		return errors.New("unable to find user '" + creator + "'")
 	}
-	// check the creator's permissions
-	hasPermission := a.HasPermissionToTeam(user.Id, team.Id, model.PERMISSION_MANAGE_SLASH_COMMANDS)
 
-	// if only admins can manage slash commands and creator is not an admin do not create the command
-	if enableOnlyAdminIntegrations && !hasPermission {
+	// check if creator has permission to create slash commands
+	if !a.HasPermissionToTeam(user.Id, team.Id, model.PERMISSION_MANAGE_SLASH_COMMANDS) {
 		return errors.New("only team admins can create slash commands")
 	}
 

--- a/cmd/mattermost/commands/command_test.go
+++ b/cmd/mattermost/commands/command_test.go
@@ -19,6 +19,7 @@ func TestCreateCommand(t *testing.T) {
 	th.InitSystemAdmin()
 	defer th.TearDown()
 	team := th.BasicTeam
+	adminUser := th.TeamAdminUser
 	user := th.BasicUser
 
 	testCases := []struct {
@@ -28,17 +29,17 @@ func TestCreateCommand(t *testing.T) {
 	}{
 		{
 			"nil error",
-			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"",
 		},
 		{
 			"Team not specified",
-			[]string{"command", "create", "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Error: requires at least 1 arg(s), only received 0",
 		},
 		{
 			"Team not found",
-			[]string{"command", "create", "fakeTeam", "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", "fakeTeam", "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Error: unable to find team",
 		},
 		{
@@ -52,53 +53,58 @@ func TestCreateCommand(t *testing.T) {
 			"unable to find user",
 		},
 		{
+			"Creator not team admin",
+			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			"only team admins can create slash commands",
+		},
+		{
 			"Command not specified",
-			[]string{"command", "", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Error: unknown flag: --trigger-word",
 		},
 		{
 			"Trigger not specified",
-			[]string{"command", "create", team.Name, "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			`Error: required flag(s) "trigger-word" not set`,
 		},
 		{
 			"Blank trigger",
-			[]string{"command", "create", team.Name, "--trigger-word", "", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Invalid trigger",
 		},
 		{
 			"Trigger with space",
-			[]string{"command", "create", team.Name, "--trigger-word", "test cmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "test cmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Error: a trigger word must not contain spaces",
 		},
 		{
 			"Trigger starting with /",
-			[]string{"command", "create", team.Name, "--trigger-word", "/testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "/testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Error: a trigger word cannot begin with a /",
 		},
 		{
 			"URL not specified",
-			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--creator", adminUser.Username},
 			`Error: required flag(s) "url" not set`,
 		},
 		{
 			"Blank URL",
-			[]string{"command", "create", team.Name, "--trigger-word", "testcmd2", "--url", "", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "testcmd2", "--url", "", "--creator", adminUser.Username},
 			"Invalid URL",
 		},
 		{
 			"Invalid URL",
-			[]string{"command", "create", team.Name, "--trigger-word", "testcmd2", "--url", "localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "testcmd2", "--url", "localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Invalid URL",
 		},
 		{
 			"Duplicate Command",
-			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"This trigger word is already in use",
 		},
 		{
 			"Misspelled flag",
-			[]string{"command", "create", team.Name, "--trigger-wor", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
+			[]string{"command", "create", team.Name, "--trigger-wor", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", adminUser.Username},
 			"Error: unknown flag:",
 		},
 	}

--- a/cmd/mattermost/commands/command_test.go
+++ b/cmd/mattermost/commands/command_test.go
@@ -55,7 +55,7 @@ func TestCreateCommand(t *testing.T) {
 		{
 			"Creator not team admin",
 			[]string{"command", "create", team.Name, "--trigger-word", "testcmd", "--url", "http://localhost:8000/my-slash-handler", "--creator", user.Username},
-			"only team admins can create slash commands",
+			"the creator must be a user who has permissions to manage slash commands",
 		},
 		{
 			"Command not specified",


### PR DESCRIPTION
#### Summary
Checks the `EnableOnlyAdminIntegrations` setting and only allows team admins to create slash commands if set to `true`

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9489

#### Checklist
- [x] Added or updated unit tests (required for all new features)
