### PR TITLE
MM-12364 - Added capability to modify the type of a team to either public or private

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -130,6 +130,7 @@ func (a *App) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {
 	oldTeam.CompanyName = team.CompanyName
 	oldTeam.AllowedDomains = team.AllowedDomains
 	oldTeam.LastTeamIconUpdate = team.LastTeamIconUpdate
+	oldTeam.Type = team.Type
 
 	oldTeam, err = a.updateTeamUnsanitized(oldTeam)
 	if err != nil {
@@ -1187,4 +1188,16 @@ func (a *App) RemoveTeamIcon(teamId string) *model.AppError {
 	a.sendTeamEvent(team, model.WEBSOCKET_EVENT_UPDATE_TEAM)
 
 	return nil
+}
+
+func (a *App) UpdateTeamPrivacy(oldTeam *model.Team, user *model.User) (*model.Team, *model.AppError) {
+	team, err := a.UpdateTeam(oldTeam)
+	if err != nil {
+		return team, err
+	}
+	messageWs := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_TEAM_CONVERTED, team.Id, "", "", nil)
+	messageWs.Add("team_id", team.Id)
+	a.Publish(messageWs)
+
+	return team, nil
 }

--- a/model/team.go
+++ b/model/team.go
@@ -23,6 +23,7 @@ const (
 	TEAM_EMAIL_MAX_LENGTH           = 128
 	TEAM_NAME_MAX_LENGTH            = 64
 	TEAM_NAME_MIN_LENGTH            = 2
+	TEAM_PRIVATE                    = "P"
 )
 
 type Team struct {
@@ -159,7 +160,7 @@ func (o *Team) IsValid() *AppError {
 		return NewAppError("Team.IsValid", "model.team.is_valid.characters.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
-	if !(o.Type == TEAM_OPEN || o.Type == TEAM_INVITE) {
+	if !(o.Type == TEAM_OPEN || o.Type == TEAM_INVITE || o.Type == TEAM_PRIVATE) {
 		return NewAppError("Team.IsValid", "model.team.is_valid.type.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -26,6 +26,7 @@ const (
 	WEBSOCKET_EVENT_LEAVE_TEAM              = "leave_team"
 	WEBSOCKET_EVENT_UPDATE_TEAM             = "update_team"
 	WEBSOCKET_EVENT_DELETE_TEAM             = "delete_team"
+	WEBSOCKET_EVENT_TEAM_CONVERTED          = "team_converted"
 	WEBSOCKET_EVENT_USER_ADDED              = "user_added"
 	WEBSOCKET_EVENT_USER_UPDATED            = "user_updated"
 	WEBSOCKET_EVENT_USER_ROLE_UPDATED       = "user_role_updated"


### PR DESCRIPTION
#### Summary
This PR add the capability to modify the type of a team to either public or private.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/9670

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
