### PR TITLE
[MM-11937] Add "previous_post_id" to WEBSOCKET_EVENT_POSTED

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -126,6 +126,9 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	var since int64
 	var parseError error
 
+	var nextPostId string
+	var previousPostId string
+
 	if len(sinceString) > 0 {
 		since, parseError = strconv.ParseInt(sinceString, 10, 64)
 		if parseError != nil {
@@ -153,6 +156,9 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		list, err = c.App.GetPostsAfterPost(c.Params.ChannelId, afterPost, c.Params.Page, c.Params.PerPage)
+		if len(list.Order) > 0 {
+			previousPostId = afterPost
+		}
 	} else if len(beforePost) > 0 {
 		etag = c.App.GetPostsEtag(c.Params.ChannelId)
 
@@ -161,6 +167,9 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		list, err = c.App.GetPostsBeforePost(c.Params.ChannelId, beforePost, c.Params.Page, c.Params.PerPage)
+		if len(list.Order) > 0 {
+			nextPostId = beforePost
+		}
 	} else {
 		etag = c.App.GetPostsEtag(c.Params.ChannelId)
 
@@ -184,6 +193,17 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		mlog.Error("Failed to prepare posts for getPostsForChannel response", mlog.Any("err", err))
 	}
+
+	if nextPostId == "" {
+		nextPostId = c.App.GetNextPostFromPostList(clientPostList)
+	}
+
+	if previousPostId == "" {
+		previousPostId = c.App.GetPreviousPostFromPostList(clientPostList)
+	}
+
+	clientPostList.NextPostId = nextPostId
+	clientPostList.PreviousPostId = previousPostId
 
 	w.Write([]byte(clientPostList.ToJson()))
 }
@@ -227,6 +247,9 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 	if err != nil {
 		mlog.Error("Failed to prepare posts for getPostsForChannelAroundLastUnread response", mlog.Any("err", err))
 	}
+
+	clientPostList.NextPostId = c.App.GetNextPostFromPostList(clientPostList)
+	clientPostList.PreviousPostId = c.App.GetPreviousPostFromPostList(clientPostList)
 
 	if len(etag) > 0 {
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1110,11 +1110,27 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 		}
 	}
 
-	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post3.Id, 1, 1, "")
+	if posts.NextPostId != post3.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PreviousPostId != "" {
+		t.Fatal("should match empty PreviousPostId")
+	}
+
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post4.Id, 1, 1, "")
 	CheckNoError(t, resp)
 
 	if len(posts.Posts) != 1 {
 		t.Fatal("too many posts returned")
+	}
+	if posts.Order[0] != post2.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post4.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PreviousPostId != post1.Id {
+		t.Fatal("should match PreviousPostId")
 	}
 
 	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, "junk", 1, 1, "")
@@ -1122,6 +1138,9 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 
 	if len(posts.Posts) != 0 {
 		t.Fatal("should have no posts")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should match empty NextPostId")
 	}
 
 	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post3.Id, 0, 100, "")
@@ -1146,11 +1165,27 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 		}
 	}
 
-	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post3.Id, 1, 1, "")
+	if posts.NextPostId != "" {
+		t.Fatal("should match empty NextPostId")
+	}
+	if posts.PreviousPostId != post3.Id {
+		t.Fatal("should match PreviousPostId")
+	}
+
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post2.Id, 1, 1, "")
 	CheckNoError(t, resp)
 
 	if len(posts.Posts) != 1 {
 		t.Fatal("too many posts returned")
+	}
+	if posts.Order[0] != post4.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post5.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PreviousPostId != post2.Id {
+		t.Fatal("should match PreviousPostId")
 	}
 
 	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, "junk", 1, 1, "")
@@ -1158,6 +1193,9 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 
 	if len(posts.Posts) != 0 {
 		t.Fatal("should have no posts")
+	}
+	if posts.PreviousPostId != "" {
+		t.Fatal("should match empty PreviousPostId")
 	}
 }
 

--- a/app/notification.go
+++ b/app/notification.go
@@ -356,6 +356,14 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 		message.Add("mentions", model.ArrayToJson(mentionedUsersList))
 	}
 
+	var previousPostId string
+	previousPost, err := a.GetPostBefore(post.ChannelId, post.CreateAt)
+	if previousPost != nil {
+		previousPostId = previousPost.Id
+	}
+
+	message.Add("previous_post_id", previousPostId)
+
 	a.Publish(message)
 	return mentionedUsersList, nil
 }

--- a/app/post.go
+++ b/app/post.go
@@ -577,8 +577,8 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 	}
 }
 
-func (a *App) GetPostAfter(channelId, postId string) (*model.Post, *model.AppError) {
-	result := <-a.Srv.Store.Post().GetPostAfter(channelId, postId)
+func (a *App) GetPostAfter(channelId string, time int64) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostAfter(channelId, time)
 	if result.Err != nil {
 		return nil, result.Err
 	}
@@ -586,8 +586,8 @@ func (a *App) GetPostAfter(channelId, postId string) (*model.Post, *model.AppErr
 	return result.Data.(*model.Post), nil
 }
 
-func (a *App) GetPostBefore(channelId, postId string) (*model.Post, *model.AppError) {
-	result := <-a.Srv.Store.Post().GetPostBefore(channelId, postId)
+func (a *App) GetPostBefore(channelId string, time int64) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostBefore(channelId, time)
 	if result.Err != nil {
 		return nil, result.Err
 	}
@@ -599,7 +599,7 @@ func (a *App) GetNextPostFromPostList(postList *model.PostList) string {
 	if len(postList.Order) > 0 {
 		firstPostId := postList.Order[0]
 		firstPost := postList.Posts[firstPostId]
-		nextPost, err := a.GetPostAfter(firstPost.ChannelId, firstPost.Id)
+		nextPost, err := a.GetPostAfter(firstPost.ChannelId, firstPost.CreateAt)
 		if err != nil {
 			mlog.Error("GetNextPostFromPostList: failed in getting next post", mlog.Any("err", err))
 		}
@@ -616,7 +616,7 @@ func (a *App) GetPreviousPostFromPostList(postList *model.PostList) string {
 	if len(postList.Order) > 0 {
 		lastPostId := postList.Order[len(postList.Order)-1]
 		lastPost := postList.Posts[lastPostId]
-		previousPost, err := a.GetPostBefore(lastPost.ChannelId, lastPost.Id)
+		previousPost, err := a.GetPostBefore(lastPost.ChannelId, lastPost.CreateAt)
 		if err != nil {
 			mlog.Error("GetPreviousPostFromPostList: failed in getting previous post", mlog.Any("err", err))
 		}

--- a/app/post.go
+++ b/app/post.go
@@ -577,6 +577,58 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 	}
 }
 
+func (a *App) GetPostAfter(channelId, postId string) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostAfter(channelId, postId)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.(*model.Post), nil
+}
+
+func (a *App) GetPostBefore(channelId, postId string) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostBefore(channelId, postId)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.(*model.Post), nil
+}
+
+func (a *App) GetNextPostFromPostList(postList *model.PostList) string {
+	if len(postList.Order) > 0 {
+		firstPostId := postList.Order[0]
+		firstPost := postList.Posts[firstPostId]
+		nextPost, err := a.GetPostAfter(firstPost.ChannelId, firstPost.Id)
+		if err != nil {
+			mlog.Error("GetNextPostFromPostList: failed in getting next post", mlog.Any("err", err))
+		}
+
+		if nextPost != nil {
+			return nextPost.Id
+		}
+	}
+
+	return ""
+}
+
+func (a *App) GetPreviousPostFromPostList(postList *model.PostList) string {
+	if len(postList.Order) > 0 {
+		lastPostId := postList.Order[len(postList.Order)-1]
+		lastPost := postList.Posts[lastPostId]
+		previousPost, err := a.GetPostBefore(lastPost.ChannelId, lastPost.Id)
+		if err != nil {
+			mlog.Error("GetPreviousPostFromPostList: failed in getting previous post", mlog.Any("err", err))
+		}
+
+		if previousPost != nil {
+			return previousPost.Id
+		}
+	}
+
+	return ""
+}
+
 func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string, limitBefore, limitAfter int) (*model.PostList, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError

--- a/app/post.go
+++ b/app/post.go
@@ -595,13 +595,13 @@ func (a *App) GetPostBefore(channelId string, time int64) (*model.Post, *model.A
 	return result.Data.(*model.Post), nil
 }
 
-func (a *App) GetNextPostFromPostList(postList *model.PostList) string {
+func (a *App) GetNextPostIdFromPostList(postList *model.PostList) string {
 	if len(postList.Order) > 0 {
 		firstPostId := postList.Order[0]
 		firstPost := postList.Posts[firstPostId]
 		nextPost, err := a.GetPostAfter(firstPost.ChannelId, firstPost.CreateAt)
 		if err != nil {
-			mlog.Error("GetNextPostFromPostList: failed in getting next post", mlog.Any("err", err))
+			mlog.Error("GetNextPostIdFromPostList: failed in getting next post", mlog.Any("err", err))
 		}
 
 		if nextPost != nil {
@@ -612,13 +612,13 @@ func (a *App) GetNextPostFromPostList(postList *model.PostList) string {
 	return ""
 }
 
-func (a *App) GetPreviousPostFromPostList(postList *model.PostList) string {
+func (a *App) GetPreviousPostIdFromPostList(postList *model.PostList) string {
 	if len(postList.Order) > 0 {
 		lastPostId := postList.Order[len(postList.Order)-1]
 		lastPost := postList.Posts[lastPostId]
 		previousPost, err := a.GetPostBefore(lastPost.ChannelId, lastPost.CreateAt)
 		if err != nil {
-			mlog.Error("GetPreviousPostFromPostList: failed in getting previous post", mlog.Any("err", err))
+			mlog.Error("GetPreviousPostIdFromPostList: failed in getting previous post", mlog.Any("err", err))
 		}
 
 		if previousPost != nil {

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
+	"strings"
 	"testing"
 	"time"
 

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
-	"strings"
 	"testing"
 	"time"
 

--- a/model/post_list.go
+++ b/model/post_list.go
@@ -10,8 +10,10 @@ import (
 )
 
 type PostList struct {
-	Order []string         `json:"order"`
-	Posts map[string]*Post `json:"posts"`
+	Order          []string         `json:"order"`
+	Posts          map[string]*Post `json:"posts"`
+	NextPostId     string           `json:"next_post_id,omitempty"`
+	PreviousPostId string           `json:"previous_post_id,omitempty"`
 }
 
 func NewPostList() *PostList {

--- a/model/post_list.go
+++ b/model/post_list.go
@@ -12,8 +12,8 @@ import (
 type PostList struct {
 	Order          []string         `json:"order"`
 	Posts          map[string]*Post `json:"posts"`
-	NextPostId     string           `json:"next_post_id,omitempty"`
-	PreviousPostId string           `json:"previous_post_id,omitempty"`
+	NextPostId     string           `json:"next_post_id"`
+	PreviousPostId string           `json:"previous_post_id"`
 }
 
 func NewPostList() *PostList {

--- a/store/store.go
+++ b/store/store.go
@@ -210,6 +210,8 @@ type PostStore interface {
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) StoreChannel
+	GetPostAfter(channelId, postId string) StoreChannel
+	GetPostBefore(channelId, postId string) StoreChannel
 	GetEtag(channelId string, allowFromCache bool) StoreChannel
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -210,8 +210,8 @@ type PostStore interface {
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) StoreChannel
-	GetPostAfter(channelId, postId string) StoreChannel
-	GetPostBefore(channelId, postId string) StoreChannel
+	GetPostAfter(channelId string, time int64) StoreChannel
+	GetPostBefore(channelId string, time int64) StoreChannel
 	GetEtag(channelId string, allowFromCache bool) StoreChannel
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -210,6 +210,38 @@ func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) store.S
 	return r0
 }
 
+// GetPostAfter provides a mock function with given fields: channelId, postId
+func (_m *PostStore) GetPostAfter(channelId string, postId string) store.StoreChannel {
+	ret := _m.Called(channelId, postId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+		r0 = rf(channelId, postId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+// GetPostBefore provides a mock function with given fields: channelId, postId
+func (_m *PostStore) GetPostBefore(channelId string, postId string) store.StoreChannel {
+	ret := _m.Called(channelId, postId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+		r0 = rf(channelId, postId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetPosts provides a mock function with given fields: channelId, offset, limit, allowFromCache
 func (_m *PostStore) GetPosts(channelId string, offset int, limit int, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(channelId, offset, limit, allowFromCache)

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -210,13 +210,13 @@ func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) store.S
 	return r0
 }
 
-// GetPostAfter provides a mock function with given fields: channelId, postId
-func (_m *PostStore) GetPostAfter(channelId string, postId string) store.StoreChannel {
-	ret := _m.Called(channelId, postId)
+// GetPostAfter provides a mock function with given fields: channelId, time
+func (_m *PostStore) GetPostAfter(channelId string, time int64) store.StoreChannel {
+	ret := _m.Called(channelId, time)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
-		r0 = rf(channelId, postId)
+	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)
@@ -226,13 +226,13 @@ func (_m *PostStore) GetPostAfter(channelId string, postId string) store.StoreCh
 	return r0
 }
 
-// GetPostBefore provides a mock function with given fields: channelId, postId
-func (_m *PostStore) GetPostBefore(channelId string, postId string) store.StoreChannel {
-	ret := _m.Called(channelId, postId)
+// GetPostBefore provides a mock function with given fields: channelId, time
+func (_m *PostStore) GetPostBefore(channelId string, time int64) store.StoreChannel {
+	ret := _m.Called(channelId, time)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
-		r0 = rf(channelId, postId)
+	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -878,32 +878,32 @@ func testPostStoreGetPostBeforeAfter(t *testing.T, ss store.Store) {
 	o2a.RootId = o2.Id
 	o2a = (<-ss.Post().Save(o2a)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetPostBefore(channelId, o0a.Id))
+	r1 := (<-ss.Post().GetPostBefore(channelId, o0a.CreateAt))
 	if r1.Data.(*model.Post).Id != o1.Id || r1.Err != nil {
 		t.Fatal("should return before post o1")
 	}
 
-	r1 = (<-ss.Post().GetPostAfter(channelId, o0b.Id))
+	r1 = (<-ss.Post().GetPostAfter(channelId, o0b.CreateAt))
 	if r1.Data.(*model.Post).Id != o2.Id || r1.Err != nil {
 		t.Fatal("should return before post o2")
 	}
 
-	r2 := (<-ss.Post().GetPostBefore(channelId, o0.Id))
+	r2 := (<-ss.Post().GetPostBefore(channelId, o0.CreateAt))
 	if r2.Data.(*model.Post) != nil || r2.Err != nil {
 		t.Fatal("should return no post")
 	}
 
-	r2 = (<-ss.Post().GetPostAfter(channelId, o0.Id))
+	r2 = (<-ss.Post().GetPostAfter(channelId, o0.CreateAt))
 	if r2.Data.(*model.Post).Id != o1.Id || r2.Err != nil {
 		t.Fatal("should return before post o1")
 	}
 
-	r3 := (<-ss.Post().GetPostBefore(channelId, o2a.Id))
+	r3 := (<-ss.Post().GetPostBefore(channelId, o2a.CreateAt))
 	if r3.Data.(*model.Post).Id != o2.Id || r2.Err != nil {
 		t.Fatal("should return before post o2")
 	}
 
-	r3 = (<-ss.Post().GetPostAfter(channelId, o2a.Id))
+	r3 = (<-ss.Post().GetPostAfter(channelId, o2a.CreateAt))
 	if r3.Data.(*model.Post) != nil || r3.Err != nil {
 		t.Fatal("should return no post")
 	}

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -31,6 +31,7 @@ func TestPostStore(t *testing.T, ss store.Store) {
 	t.Run("GetPostsWithDetails", func(t *testing.T) { testPostStoreGetPostsWithDetails(t, ss) })
 	t.Run("GetPostsBeforeAfter", func(t *testing.T) { testPostStoreGetPostsBeforeAfter(t, ss) })
 	t.Run("GetPostsSince", func(t *testing.T) { testPostStoreGetPostsSince(t, ss) })
+	t.Run("GetPostBeforeAfter", func(t *testing.T) { testPostStoreGetPostBeforeAfter(t, ss) })
 	t.Run("Search", func(t *testing.T) { testPostStoreSearch(t, ss) })
 	t.Run("UserCountsWithPostsByDay", func(t *testing.T) { testUserCountsWithPostsByDay(t, ss) })
 	t.Run("PostCountsByDay", func(t *testing.T) { testPostCountsByDay(t, ss) })
@@ -815,6 +816,96 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 
 	if len(r2.Order) != 0 {
 		t.Fatal("wrong size ", len(r2.Posts))
+	}
+}
+
+func testPostStoreGetPostBeforeAfter(t *testing.T, ss store.Store) {
+	channelId := model.NewId()
+
+	o0 := &model.Post{}
+	o0.ChannelId = channelId
+	o0.UserId = model.NewId()
+	o0.Message = "zz" + model.NewId() + "b"
+	o0 = (<-ss.Post().Save(o0)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o1 := &model.Post{}
+	o1.ChannelId = channelId
+	o1.Type = model.POST_JOIN_CHANNEL
+	o1.UserId = model.NewId()
+	o1.Message = "system_join_channel message"
+	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o0a := &model.Post{}
+	o0a.ChannelId = channelId
+	o0a.UserId = model.NewId()
+	o0a.Message = "zz" + model.NewId() + "b"
+	o0a.ParentId = o1.Id
+	o0a.RootId = o1.Id
+	o0a = (<-ss.Post().Save(o0a)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o0b := &model.Post{}
+	o0b.ChannelId = channelId
+	o0b.UserId = model.NewId()
+	o0b.Message = "deleted message"
+	o0b.ParentId = o1.Id
+	o0b.RootId = o1.Id
+	o0b.DeleteAt = 1
+	o0b = (<-ss.Post().Save(o0b)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	otherChannlPost := &model.Post{}
+	otherChannlPost.ChannelId = model.NewId()
+	otherChannlPost.UserId = model.NewId()
+	otherChannlPost.Message = "zz" + model.NewId() + "b"
+	otherChannlPost = (<-ss.Post().Save(otherChannlPost)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o2 := &model.Post{}
+	o2.ChannelId = channelId
+	o2.UserId = model.NewId()
+	o2.Message = "zz" + model.NewId() + "b"
+	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o2a := &model.Post{}
+	o2a.ChannelId = channelId
+	o2a.UserId = model.NewId()
+	o2a.Message = "zz" + model.NewId() + "b"
+	o2a.ParentId = o2.Id
+	o2a.RootId = o2.Id
+	o2a = (<-ss.Post().Save(o2a)).Data.(*model.Post)
+
+	r1 := (<-ss.Post().GetPostBefore(channelId, o0a.Id))
+	if r1.Data.(*model.Post).Id != o1.Id || r1.Err != nil {
+		t.Fatal("should return before post o1")
+	}
+
+	r1 = (<-ss.Post().GetPostAfter(channelId, o0b.Id))
+	if r1.Data.(*model.Post).Id != o2.Id || r1.Err != nil {
+		t.Fatal("should return before post o2")
+	}
+
+	r2 := (<-ss.Post().GetPostBefore(channelId, o0.Id))
+	if r2.Data.(*model.Post) != nil || r2.Err != nil {
+		t.Fatal("should return no post")
+	}
+
+	r2 = (<-ss.Post().GetPostAfter(channelId, o0.Id))
+	if r2.Data.(*model.Post).Id != o1.Id || r2.Err != nil {
+		t.Fatal("should return before post o1")
+	}
+
+	r3 := (<-ss.Post().GetPostBefore(channelId, o2a.Id))
+	if r3.Data.(*model.Post).Id != o2.Id || r2.Err != nil {
+		t.Fatal("should return before post o2")
+	}
+
+	r3 = (<-ss.Post().GetPostAfter(channelId, o2a.Id))
+	if r3.Data.(*model.Post) != nil || r3.Err != nil {
+		t.Fatal("should return no post")
 	}
 }
 


### PR DESCRIPTION
#### Summary
This is submitted on top of https://github.com/mattermost/mattermost-server/pull/9707.  `3ae8c8e` commit is the specific change of this PR.

- Add "previous_post_id" to WEBSOCKET_EVENT_POSTED.
- Not add "next_post_id" for the assumption that it's always empty.

This change has added an extra DB call to get the previous post every time it sends notifications.  I'm not sure how to particularly measure performance implication of this and so I'd like to get help from @crspeller to verify via load testing. 

#### Ticket Link
Jira ticket: [MM-11937](https://mattermost.atlassian.net/browse/MM-11937)

#### Checklist
- [ ] Added or updated unit tests (required for all new features) - would love to add test but I can't find a way to test it.
