### PR TITLE
MM-12036 Add image dimensions for other fields in message attachments

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -248,6 +248,22 @@ func getImagesInMessageAttachments(post *model.Post) []string {
 				images = append(images, imagesInFieldValue...)
 			}
 		}
+
+		if attachment.AuthorIcon != "" {
+			images = append(images, attachment.AuthorIcon)
+		}
+
+		if attachment.ImageURL != "" {
+			images = append(images, attachment.ImageURL)
+		}
+
+		if attachment.ThumbURL != "" {
+			images = append(images, attachment.ThumbURL)
+		}
+
+		if attachment.FooterIcon != "" {
+			images = append(images, attachment.FooterIcon)
+		}
 	}
 
 	return images

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -693,6 +693,58 @@ func TestGetImagesInMessageAttachments(t *testing.T) {
 			Expected: []string{"https://example.com/logo2", "https://example.com/icon2"},
 		},
 		{
+			Name: "image in author_icon",
+			Post: &model.Post{
+				Props: map[string]interface{}{
+					"attachments": []*model.SlackAttachment{
+						{
+							AuthorIcon: "https://example.com/icon2",
+						},
+					},
+				},
+			},
+			Expected: []string{"https://example.com/icon2"},
+		},
+		{
+			Name: "image in image_url",
+			Post: &model.Post{
+				Props: map[string]interface{}{
+					"attachments": []*model.SlackAttachment{
+						{
+							ImageURL: "https://example.com/image",
+						},
+					},
+				},
+			},
+			Expected: []string{"https://example.com/image"},
+		},
+		{
+			Name: "image in thumb_url",
+			Post: &model.Post{
+				Props: map[string]interface{}{
+					"attachments": []*model.SlackAttachment{
+						{
+							ThumbURL: "https://example.com/image",
+						},
+					},
+				},
+			},
+			Expected: []string{"https://example.com/image"},
+		},
+		{
+			Name: "image in footer_icon",
+			Post: &model.Post{
+				Props: map[string]interface{}{
+					"attachments": []*model.SlackAttachment{
+						{
+							FooterIcon: "https://example.com/image",
+						},
+					},
+				},
+			},
+			Expected: []string{"https://example.com/image"},
+		},
+		{
 			Name: "images in multiple fields",
 			Post: &model.Post{
 				Props: map[string]interface{}{


### PR DESCRIPTION
This checks the `author_icon`, `image_url`, `thumb_url`, and `footer_icon` of each attachment 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12036

#### Checklist
- Added or updated unit tests (required for all new features)