### PR TITLE
MM-12708: tack on signin_change when completing email to saml change

### DIFF
--- a/web/saml.go
+++ b/web/saml.go
@@ -149,16 +149,19 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if action == model.OAUTH_ACTION_MOBILE {
+		switch action {
+		case model.OAUTH_ACTION_MOBILE:
 			ReturnStatusOK(w)
-		} else if action == model.OAUTH_ACTION_CLIENT {
+		case model.OAUTH_ACTION_CLIENT:
 			err = c.App.SendMessageToExtension(w, relayProps["extension_id"], c.Session.Token)
 
 			if err != nil {
 				c.Err = err
 				return
 			}
-		} else {
+		case model.OAUTH_ACTION_EMAIL_TO_SSO:
+			http.Redirect(w, r, c.GetSiteURLHeader()+"/login?extra=signin_change", http.StatusFound)
+		default:
 			http.Redirect(w, r, c.GetSiteURLHeader(), http.StatusFound)
 		}
 	}


### PR DESCRIPTION
#### Summary
The missing `signin_change` is necessary to triggered the desired behaviour client-side when switching from SAML/OAuth back to email.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12708

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
