### PR TITLE
Ignore "@" sign at the beginning of user searches

### DIFF
--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1167,7 +1167,7 @@ func generateSearchQuery(searchQuery string, terms []string, fields []string, pa
 			}
 		}
 		searchTerms = append(searchTerms, fmt.Sprintf("(%s)", strings.Join(searchFields, " OR ")))
-		parameters[fmt.Sprintf("Term%d", i)] = fmt.Sprintf("%s%%", term)
+		parameters[fmt.Sprintf("Term%d", i)] = fmt.Sprintf("%s%%", strings.TrimLeft(term, "@"))
 	}
 
 	searchClause := strings.Join(searchTerms, " AND ")

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1658,6 +1658,16 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 			},
 			[]*model.User{u1},
 		},
+		{
+			"leading @ should be ignored",
+			tid,
+			"@jimb",
+			&model.UserSearchOptions{
+				AllowFullNames: true,
+				Limit:          model.USER_SEARCH_DEFAULT_LIMIT,
+			},
+			[]*model.User{u1},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This trims the "@" symbol from the beginning of the search term before executing the query in the /api/v4/users/search API.

#### Summary
Allows for user searches to work as expected when an "@" is included at the beginning.

#### Ticket Link
[GH-9755](https://github.com/mattermost/mattermost-server/issues/9755)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
