### PR TITLE
MM-12463 : Added capability to bulk export custom emojis

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-func (a *App) BulkExport(writer io.Writer, file string) *model.AppError {
+func (a *App) BulkExport(writer io.Writer, file string, pathToEmojiDir string, dirNameToExportEmoji string) *model.AppError {
 	if err := a.ExportVersion(writer); err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func (a *App) BulkExport(writer io.Writer, file string) *model.AppError {
 	if err := a.ExportAllPosts(writer); err != nil {
 		return err
 	}
-	if err := a.ExportCustomEmoji(writer, file); err != nil {
+	if err := a.ExportCustomEmoji(writer, file, pathToEmojiDir, dirNameToExportEmoji); err != nil {
 		return err
 	}
 
@@ -345,7 +345,7 @@ func (a *App) BuildPostReactions(postId string) (*[]ReactionImportData, *model.A
 
 }
 
-func (a *App) ExportCustomEmoji(writer io.Writer, file string) *model.AppError {
+func (a *App) ExportCustomEmoji(writer io.Writer, file string, pathToEmojiDir string, dirNameToExportEmoji string) *model.AppError {
 	pageNumber := 0
 	for {
 		customEmojiList, err := a.GetEmojiList(pageNumber, 100, model.EMOJI_SORT_BY_NAME)
@@ -360,18 +360,16 @@ func (a *App) ExportCustomEmoji(writer io.Writer, file string) *model.AppError {
 
 		pageNumber++
 
-		var dirName = "exported_emoji"
-
-		pathToDir := a.createDirForEmoji(file, dirName)
+		pathToDir := a.createDirForEmoji(file, dirNameToExportEmoji)
 
 		for _, emoji := range customEmojiList {
-			emojiImagePath := "data/emoji/" + emoji.Id + "/image"
+			emojiImagePath := pathToEmojiDir + emoji.Id + "/image"
 			err := a.copyEmojiImages(emoji.Id, emojiImagePath, pathToDir)
 			if err != nil {
 				return model.NewAppError("BulkExport", "app.export.export_custom_emoji.copy_emoji_images.error", nil, "err="+err.Error(), http.StatusBadRequest)
 			}
 
-			filePath := dirName + "/" + emoji.Id + "/image"
+			filePath := dirNameToExportEmoji + "/" + emoji.Id + "/image"
 
 			emojiImportObject := ImportLineFromEmoji(emoji, filePath)
 

--- a/app/export.go
+++ b/app/export.go
@@ -365,7 +365,8 @@ func (a *App) ExportCustomEmoji(writer io.Writer, file string) *model.AppError {
 		pathToDir := a.createDirForEmoji(file, dirName)
 
 		for _, emoji := range customEmojiList {
-			err := a.copyEmojiImages(emoji.Id, pathToDir)
+			emojiImagePath := "data/emoji/" + emoji.Id + "/image"
+			err := a.copyEmojiImages(emoji.Id, emojiImagePath, pathToDir)
 			if err != nil {
 				return model.NewAppError("BulkExport", "app.export.export_custom_emoji.copy_emoji_images.error", nil, "err="+err.Error(), http.StatusBadRequest)
 			}
@@ -400,9 +401,9 @@ func (a *App) createDirForEmoji(file string, dirName string) string {
 }
 
 // Copies emoji files from 'data/emoji' dir to 'exported_emoji' dir
-func (a *App) copyEmojiImages(emojiId string, pathToDir string) error {
+func (a *App) copyEmojiImages(emojiId string, emojiImagePath string, pathToDir string) error {
 	var err error
-	var emojiImagePath = "data/emoji/" + emojiId + "/image"
+
 	fromPath, err := os.Open(emojiImagePath)
 	if fromPath == nil || err != nil {
 		return errors.New("Error reading " + emojiImagePath + "file")

--- a/app/export_converters.go
+++ b/app/export_converters.go
@@ -139,3 +139,13 @@ func ImportReactionFromPost(reaction *model.Reaction) *ReactionImportData {
 		CreateAt:  &reaction.CreateAt,
 	}
 }
+
+func ImportCustomEmoji(emoji *model.EmojiForExport) *LineImportData {
+	return &LineImportData{
+		Type: "emoji",
+		Emoji: &EmojiImportData{
+			Name:  &emoji.Name,
+			Image: &emoji.Image,
+		},
+	}
+}

--- a/app/export_converters.go
+++ b/app/export_converters.go
@@ -140,12 +140,12 @@ func ImportReactionFromPost(reaction *model.Reaction) *ReactionImportData {
 	}
 }
 
-func ImportCustomEmoji(emoji *model.EmojiForExport) *LineImportData {
+func ImportLineFromEmoji(emoji *model.Emoji, filePath string) *LineImportData {
 	return &LineImportData{
 		Type: "emoji",
 		Emoji: &EmojiImportData{
 			Name:  &emoji.Name,
-			Image: &emoji.Image,
+			Image: &filePath,
 		},
 	}
 }

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -151,3 +151,22 @@ func TestCopyEmojiImages(t *testing.T) {
 		t.Fatal("File should exist ", err)
 	}
 }
+
+func TestExportCustomEmoji(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	filePath := "../demo.json"
+
+	fileWriter, _ := os.Create(filePath)
+	defer os.Remove(filePath)
+
+	pathToEmojiDir := "../data/emoji/"
+	dirNameToExportEmoji := "exported_emoji_test"
+
+	err := th.App.ExportCustomEmoji(fileWriter, filePath, pathToEmojiDir, dirNameToExportEmoji)
+	defer os.RemoveAll("../" + dirNameToExportEmoji)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,5 +102,52 @@ func TestExportUserChannels(t *testing.T) {
 			assert.Equal(t, *data.NotifyProps.MarkUnread, "all")
 			assert.False(t, *data.Favorite)
 		}
+	}
+}
+
+func TestDirCreationForEmoji(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	pathToDir := th.App.createDirForEmoji("test.json", "exported_emoji_test")
+	defer os.Remove(pathToDir)
+	if _, err := os.Stat(pathToDir); os.IsNotExist(err) {
+		t.Fatal("Directory exported_emoji_test should exist")
+	}
+}
+
+func TestCopyEmojiImages(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	emoji := &model.Emoji{
+		Id: th.BasicUser.Id,
+	}
+
+	// Creating a dir named `exported_emoji_test` in the root of the repo
+	pathToDir := "../exported_emoji_test"
+
+	os.Mkdir(pathToDir, 0777)
+	defer os.RemoveAll(pathToDir)
+
+	filePath := "../data/emoji/" + emoji.Id
+	emojiImagePath := filePath + "/image"
+
+	var _, err = os.Stat(filePath)
+	if os.IsNotExist(err) {
+		os.MkdirAll(filePath, 0777)
+	}
+
+	// Creating a file with the name `image` to copy it to `exported_emoji_test`
+	os.OpenFile(filePath+"/image", os.O_RDONLY|os.O_CREATE, 0777)
+	defer os.RemoveAll(filePath)
+
+	copyError := th.App.copyEmojiImages(emoji.Id, emojiImagePath, pathToDir)
+	if copyError != nil {
+		t.Fatal(copyError)
+	}
+
+	if _, err := os.Stat(pathToDir + "/" + emoji.Id + "/image"); os.IsNotExist(err) {
+		t.Fatal("File should exist ", err)
 	}
 }

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -180,7 +180,14 @@ func bulkExportCmdF(command *cobra.Command, args []string) error {
 	}
 	defer fileWriter.Close()
 
-	if err := a.BulkExport(fileWriter, args[0]); err != nil {
+	// Path to directory of custom emoji
+	pathToEmojiDir := "data/emoji/"
+
+	// Name of the directory to export custom emoji
+	dirNameToExportEmoji := "exported_emoji"
+
+	// args[0] points to the filename/filepath passed with export bulk command
+	if err := a.BulkExport(fileWriter, args[0], pathToEmojiDir, dirNameToExportEmoji); err != nil {
 		CommandPrettyPrintln(err.Error())
 		return err
 	}

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -180,7 +180,7 @@ func bulkExportCmdF(command *cobra.Command, args []string) error {
 	}
 	defer fileWriter.Close()
 
-	if err := a.BulkExport(fileWriter); err != nil {
+	if err := a.BulkExport(fileWriter, args[0]); err != nil {
 		CommandPrettyPrintln(err.Error())
 		return err
 	}

--- a/model/emoji.go
+++ b/model/emoji.go
@@ -23,11 +23,6 @@ type Emoji struct {
 	Name      string `json:"name"`
 }
 
-type EmojiForExport struct {
-	*Emoji
-	Image string
-}
-
 func inSystemEmoji(emojiName string) bool {
 	_, ok := SystemEmojis[emojiName]
 	return ok

--- a/model/emoji.go
+++ b/model/emoji.go
@@ -23,6 +23,11 @@ type Emoji struct {
 	Name      string `json:"name"`
 }
 
+type EmojiForExport struct {
+	*Emoji
+	Image string
+}
+
 func inSystemEmoji(emojiName string) bool {
 	_, ok := SystemEmojis[emojiName]
 	return ok


### PR DESCRIPTION
#### Summary
Added capability to bulk export custom emojis.

Whenever the command to bulk export custom emoji's is entered, a directory named `exported_emoji` is created in the same location of the file specified in the bulk export command. And the emojis from `data/emoji` directory are copied into this new directory.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/9542

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)