### PR TITLE
[GH-9639] Add plugin API for SearchUsers method

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -316,6 +316,10 @@ func (api *PluginAPI) SearchChannels(teamId string, term string) ([]*model.Chann
 	return *channels, err
 }
 
+func (api *PluginAPI) SearchUsers(search *model.UserSearch) ([]*model.User, *model.AppError) {
+	return api.app.SearchUsers(search)
+}
+
 func (api *PluginAPI) AddChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {
 	// For now, don't allow overriding these via the plugin API.
 	userRequestorId := ""

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -317,7 +317,12 @@ func (api *PluginAPI) SearchChannels(teamId string, term string) ([]*model.Chann
 }
 
 func (api *PluginAPI) SearchUsers(search *model.UserSearch) ([]*model.User, *model.AppError) {
-	return api.app.SearchUsers(search)
+	pluginSearchUsersOptions := &model.UserSearchOptions{
+		IsAdmin:       true,
+		AllowInactive: search.AllowInactive,
+		Limit:         search.Limit,
+	}
+	return api.app.SearchUsers(search, pluginSearchUsersOptions)
 }
 
 func (api *PluginAPI) AddChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError) {

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -206,6 +206,11 @@ type API interface {
 	// Minimum server version: 5.6
 	SearchChannels(teamId string, term string) ([]*model.Channel, *model.AppError)
 
+	// SearchUsers returns a list of users based on some search criteria.
+	//
+	// Minimum server version: 5.6
+	SearchUsers(search *model.UserSearch) ([]*model.User, *model.AppError)
+
 	// AddChannelMember creates a channel membership for a user.
 	AddChannelMember(channelId, userId string) (*model.ChannelMember, *model.AppError)
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1977,6 +1977,35 @@ func (s *apiRPCServer) SearchChannels(args *Z_SearchChannelsArgs, returns *Z_Sea
 	return nil
 }
 
+type Z_SearchUsersArgs struct {
+	A *model.UserSearch
+}
+
+type Z_SearchUsersReturns struct {
+	A []*model.User
+	B *model.AppError
+}
+
+func (g *apiRPCClient) SearchUsers(search *model.UserSearch) ([]*model.User, *model.AppError) {
+	_args := &Z_SearchUsersArgs{search}
+	_returns := &Z_SearchUsersReturns{}
+	if err := g.client.Call("Plugin.SearchUsers", _args, _returns); err != nil {
+		log.Printf("RPC call to SearchUsers API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) SearchUsers(args *Z_SearchUsersArgs, returns *Z_SearchUsersReturns) error {
+	if hook, ok := s.impl.(interface {
+		SearchUsers(search *model.UserSearch) ([]*model.User, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.SearchUsers(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API SearchUsers called but not implemented."))
+	}
+	return nil
+}
+
 type Z_AddChannelMemberArgs struct {
 	A string
 	B string

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1908,6 +1908,31 @@ func (_m *API) SearchChannels(teamId string, term string) ([]*model.Channel, *mo
 	return r0, r1
 }
 
+// SearchUsers provides a mock function with given fields: search
+func (_m *API) SearchUsers(search *model.UserSearch) ([]*model.User, *model.AppError) {
+	ret := _m.Called(search)
+
+	var r0 []*model.User
+	if rf, ok := ret.Get(0).(func(*model.UserSearch) []*model.User); ok {
+		r0 = rf(search)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.User)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(*model.UserSearch) *model.AppError); ok {
+		r1 = rf(search)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // SendEphemeralPost provides a mock function with given fields: userId, post
 func (_m *API) SendEphemeralPost(userId string, post *model.Post) *model.Post {
 	ret := _m.Called(userId, post)


### PR DESCRIPTION
#### Summary
This PR adds a `SearchUsers(search *UserSearch)` method to plugin API.

#### Ticket Link
Fixes [#9639](https://github.com/mattermost/mattermost-server/issues/9639)