### PR TITLE
MM-12818: Delete FileInfos when deleting the post they belong to.

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -594,7 +594,7 @@ func (a *App) DeleteFlaggedPosts(postId string) {
 }
 
 func (a *App) DeletePostFiles(post *model.Post) {
-	if len(post.FileIds) != 0 {
+	if len(post.FileIds) == 0 {
 		return
 	}
 


### PR DESCRIPTION
#### Summary
Delete FileInfos when deleting the post they belong to.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12818

#### Checklist
- [x] Added or updated unit tests (required for all new features)