### PR TITLE
MM-13021 Fix warning logged when getting metadata for post without emojis

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -232,6 +232,10 @@ func (a *App) getCustomEmojisForPost(post *model.Post, reactions []*model.Reacti
 
 	names := getEmojiNamesForPost(post, reactions)
 
+	if len(names) == 0 {
+		return []*model.Emoji{}, nil
+	}
+
 	return a.GetMultipleEmojiByName(names)
 }
 

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -663,6 +663,17 @@ func TestGetCustomEmojisForPost(t *testing.T) {
 		assert.Nil(t, err, "failed to get emojis for post")
 		assert.ElementsMatch(t, emojisForPost, []*model.Emoji{emojis[0]}, "received incorrect emojis")
 	})
+
+	t.Run("with no emojis", func(t *testing.T) {
+		post := &model.Post{
+			Message: "this post is boring",
+			Props:   map[string]interface{}{},
+		}
+
+		emojisForPost, err := th.App.getCustomEmojisForPost(post, nil)
+		assert.Nil(t, err, "failed to get emojis for post")
+		assert.ElementsMatch(t, emojisForPost, []*model.Emoji{}, "should have received no emojis")
+	})
 }
 
 func TestGetFirstLinkAndImages(t *testing.T) {


### PR DESCRIPTION
The SQL statement generated by GetMultipleEmojiByName is invalid when an empty array is passed in

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13021

#### Checklist
- Added or updated unit tests (required for all new features)
