### PR TITLE
[MM-9938] Add support for multiple responses from a slash command

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -279,9 +279,9 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 func (a *App) HandleCommandResponse(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {
 	a.HandleCommandResponsePost(command, args, response, builtIn)
 
-	if response.Posts != nil {
-		for _, post := range response.Posts {
-			a.HandleCommandResponsePost(command, args, post, builtIn)
+	if response.ExtraResponses != nil {
+		for _, resp := range response.ExtraResponses {
+			a.HandleCommandResponsePost(command, args, resp, builtIn)
 		}
 	}
 

--- a/app/command.go
+++ b/app/command.go
@@ -277,6 +277,18 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 }
 
 func (a *App) HandleCommandResponse(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {
+	a.HandleCommandResponsePost(command, args, response, builtIn)
+
+	if response.Posts != nil {
+		for _, post := range response.Posts {
+			a.HandleCommandResponsePost(command, args, post, builtIn)
+		}
+	}
+
+	return response, nil
+}
+
+func (a *App) HandleCommandResponsePost(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {
 	post := &model.Post{}
 	post.ChannelId = args.ChannelId
 	post.RootId = args.RootId

--- a/model/command_response.go
+++ b/model/command_response.go
@@ -26,6 +26,7 @@ type CommandResponse struct {
 	Props        StringInterface    `json:"props"`
 	GotoLocation string             `json:"goto_location"`
 	Attachments  []*SlackAttachment `json:"attachments"`
+	Posts        []*CommandResponse `json:"posts"`
 }
 
 func (o *CommandResponse) ToJson() string {
@@ -62,6 +63,12 @@ func CommandResponseFromJson(data io.Reader) (*CommandResponse, error) {
 	}
 
 	o.Attachments = StringifySlackFieldValue(o.Attachments)
+
+	if o.Posts != nil {
+		for _, post := range o.Posts {
+			post.Attachments = StringifySlackFieldValue(post.Attachments)
+		}
+	}
 
 	return &o, nil
 }

--- a/model/command_response.go
+++ b/model/command_response.go
@@ -18,15 +18,15 @@ const (
 )
 
 type CommandResponse struct {
-	ResponseType string             `json:"response_type"`
-	Text         string             `json:"text"`
-	Username     string             `json:"username"`
-	IconURL      string             `json:"icon_url"`
-	Type         string             `json:"type"`
-	Props        StringInterface    `json:"props"`
-	GotoLocation string             `json:"goto_location"`
-	Attachments  []*SlackAttachment `json:"attachments"`
-	Posts        []*CommandResponse `json:"posts"`
+	ResponseType   string             `json:"response_type"`
+	Text           string             `json:"text"`
+	Username       string             `json:"username"`
+	IconURL        string             `json:"icon_url"`
+	Type           string             `json:"type"`
+	Props          StringInterface    `json:"props"`
+	GotoLocation   string             `json:"goto_location"`
+	Attachments    []*SlackAttachment `json:"attachments"`
+	ExtraResponses []*CommandResponse `json:"extra_responses"`
 }
 
 func (o *CommandResponse) ToJson() string {
@@ -64,9 +64,9 @@ func CommandResponseFromJson(data io.Reader) (*CommandResponse, error) {
 
 	o.Attachments = StringifySlackFieldValue(o.Attachments)
 
-	if o.Posts != nil {
-		for _, post := range o.Posts {
-			post.Attachments = StringifySlackFieldValue(post.Attachments)
+	if o.ExtraResponses != nil {
+		for _, resp := range o.ExtraResponses {
+			resp.Attachments = StringifySlackFieldValue(resp.Attachments)
 		}
 	}
 

--- a/model/command_response_test.go
+++ b/model/command_response_test.go
@@ -132,18 +132,18 @@ func TestCommandResponseFromJson(t *testing.T) {
 			false,
 		},
 		{
-			"multiple posts returned",
+			"multiple responses returned",
 			`
 			{
 				"text": "message 1",
-				"posts": [
+				"extra_responses": [
 					{"text": "message 2"}
 				]
 			}
 			`,
 			&CommandResponse{
 				Text: "message 1",
-				Posts: []*CommandResponse{
+				ExtraResponses: []*CommandResponse{
 					&CommandResponse{
 						Text: "message 2",
 					},
@@ -152,12 +152,12 @@ func TestCommandResponseFromJson(t *testing.T) {
 			false,
 		},
 		{
-			"multiple posts returned, with attachments",
+			"multiple responses returned, with attachments",
 			`
 			{
 				"text": "message 1",
 				"attachments":[{"fields":[{"title":"foo","value":"bar","short":true}]}],
-				"posts": [
+				"extra_responses": [
 					{
 						"text": "message 2",
 						"attachments":[{"fields":[{"title":"foo 2","value":"bar 2","short":false}]}]
@@ -177,7 +177,7 @@ func TestCommandResponseFromJson(t *testing.T) {
 						},
 					},
 				},
-				Posts: []*CommandResponse{
+				ExtraResponses: []*CommandResponse{
 					&CommandResponse{
 						Text: "message 2",
 						Attachments: []*SlackAttachment{

--- a/model/command_response_test.go
+++ b/model/command_response_test.go
@@ -131,6 +131,71 @@ func TestCommandResponseFromJson(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"multiple posts returned",
+			`
+			{
+				"text": "message 1",
+				"posts": [
+					{"text": "message 2"}
+				]
+			}
+			`,
+			&CommandResponse{
+				Text: "message 1",
+				Posts: []*CommandResponse{
+					&CommandResponse{
+						Text: "message 2",
+					},
+				},
+			},
+			false,
+		},
+		{
+			"multiple posts returned, with attachments",
+			`
+			{
+				"text": "message 1",
+				"attachments":[{"fields":[{"title":"foo","value":"bar","short":true}]}],
+				"posts": [
+					{
+						"text": "message 2",
+						"attachments":[{"fields":[{"title":"foo 2","value":"bar 2","short":false}]}]
+					}
+				]
+			}`,
+			&CommandResponse{
+				Text: "message 1",
+				Attachments: []*SlackAttachment{
+					{
+						Fields: []*SlackAttachmentField{
+							{
+								Title: "foo",
+								Value: "bar",
+								Short: true,
+							},
+						},
+					},
+				},
+				Posts: []*CommandResponse{
+					&CommandResponse{
+						Text: "message 2",
+						Attachments: []*SlackAttachment{
+							{
+								Fields: []*SlackAttachmentField{
+									{
+										Title: "foo 2",
+										Value: "bar 2",
+										Short: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
#### Summary
Allows a slash command response to send multiple posts back to the UI.

#### Ticket Link
[Github Ticket](https://github.com/mattermost/mattermost-server/issues/8511)
[JIRA Ticket](https://mattermost.atlassian.net/browse/MM-9938)

Originally reported at: https://forum.mattermost.org/t/mention-or-push-message-to-another-channel-from-a-slash-command/4393

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
  - I have a draft on my fork [here](https://github.com/mickmister/mattermost-developer-documentation/commit/0cbd1d7280581d4cd64e5ee865f5b57e42479a85)

#### Details

The original proposed structure is
```
[
  {
    "text": "message 1",
  },
  {
    "text": "message 2"
  },
  {
    "text": "message 3"
  }
]
```
We have to keep the integrity of the current API, while supporting the new functionality of sending multiple messages. As far as the code processing this response is concerned, it has to hold the contract of the current struct. I propose the following structure:

```
type CommandResponse struct {
	ResponseType string             `json:"response_type"`
	Text         string             `json:"text"`
	Username     string             `json:"username"`
	IconURL      string             `json:"icon_url"`
	Type         string             `json:"type"`
	Props        StringInterface    `json:"props"`
	GotoLocation string             `json:"goto_location"`
	Attachments  []*SlackAttachment `json:"attachments"`
	Posts        []*CommandResponse `json:"posts"` // <= holds other posts
}
```

The "extra" messages are stored in the Posts field, and they are processed as separate posts. The top level needs to remain the first post, as this has already been established throughout the codebase. If this is the structure decided, the structure returned from the user's API should match it, so I propose this for the JSON structure:

```
{
  "text": "message 1",
  "posts": [
    {
      "text": "message 2
    },
    {
      "text": "message 3"
    }
  ]
}
```

Since the response structure for the custom slash command is changing, the documentation at this link needs to change to support the new structure:
https://developers.mattermost.com/integrate/slash-commands
I'll submit a PR for that once the structure and field name has been decided.


#### Notes:

- The naming is a bit weird here. I have considered swapping `Posts` out for `Messages` or `Responses`

- I'm not sure if unmarshalling a recursive structure is an issue, though security and performance come to mind.

- The field `GotoLocation` will be ignored on extra posts since that is separate functionality from a post. However, all other fields apply to posts, so they can be used in the extra post objects.

- This ticket is tied together with the ticket for sending a response to a specific channel: https://github.com/mattermost/mattermost-server/issues/8512 I'm working on this in parallel, but want to get the structure on this PR confirmed since it's touching the same code.

