### PR TITLE
[MM-12476] Consistent paging arguments limit/offset vs page/perPage for plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -245,8 +245,9 @@ func (api *PluginAPI) DeleteChannel(channelId string) *model.AppError {
 	return api.app.DeleteChannel(channel, "")
 }
 
-func (api *PluginAPI) GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError) {
-	return api.app.GetPublicChannelsForTeam(teamId, page*perPage, perPage)
+func (api *PluginAPI) GetPublicChannelsForTeam(teamId string, page, perPage int) ([]*model.Channel, *model.AppError) {
+	channels, err := api.app.GetPublicChannelsForTeam(teamId, page*perPage, perPage)
+	return *channels, err
 }
 
 func (api *PluginAPI) GetChannel(channelId string) (*model.Channel, *model.AppError) {

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -131,8 +131,8 @@ func (api *PluginAPI) DeleteTeamMember(teamId, userId, requestorId string) *mode
 	return api.app.RemoveUserFromTeam(teamId, userId, requestorId)
 }
 
-func (api *PluginAPI) GetTeamMembers(teamId string, offset, limit int) ([]*model.TeamMember, *model.AppError) {
-	return api.app.GetTeamMembers(teamId, offset, limit)
+func (api *PluginAPI) GetTeamMembers(teamId string, page, perPage int) ([]*model.TeamMember, *model.AppError) {
+	return api.app.GetTeamMembers(teamId, page*perPage, perPage)
 }
 
 func (api *PluginAPI) GetTeamMember(teamId, userId string) (*model.TeamMember, *model.AppError) {
@@ -245,8 +245,8 @@ func (api *PluginAPI) DeleteChannel(channelId string) *model.AppError {
 	return api.app.DeleteChannel(channel, "")
 }
 
-func (api *PluginAPI) GetPublicChannelsForTeam(teamId string, offset, limit int) (*model.ChannelList, *model.AppError) {
-	return api.app.GetPublicChannelsForTeam(teamId, offset, limit)
+func (api *PluginAPI) GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError) {
+	return api.app.GetPublicChannelsForTeam(teamId, page*perPage, perPage)
 }
 
 func (api *PluginAPI) GetChannel(channelId string) (*model.Channel, *model.AppError) {

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -719,7 +719,8 @@ func TestGetTeamMembers(t *testing.T) {
 	// Fetch team members multipile times
 	members, err := th.App.GetTeamMembers(th.BasicTeam.Id, 0, 5)
 	require.Nil(t, err)
-	members2, err := th.App.GetTeamMembers(th.BasicTeam.Id, 5, 5)
+	// This should return 5 members
+	members2, err := th.App.GetTeamMembers(th.BasicTeam.Id, 5, 6)
 	require.Nil(t, err)
 	members = append(members, members2...)
 

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -4,10 +4,14 @@
 package app
 
 import (
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateTeam(t *testing.T) {
@@ -681,5 +685,46 @@ func TestAppUpdateTeamScheme(t *testing.T) {
 
 	if updatedTeam.SchemeId != mockID {
 		t.Fatal("Wrong Team SchemeId")
+	}
+}
+
+func TestGetTeamMembers(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	var userIDs sort.StringSlice
+	userIDs = append(userIDs, th.BasicUser.Id)
+	userIDs = append(userIDs, th.BasicUser2.Id)
+
+	for i := 0; i < 8; i++ {
+		user := model.User{
+			Email:    strings.ToLower(model.NewId()) + "success+test@example.com",
+			Username: fmt.Sprintf("user%v", i),
+			Password: "passwd1",
+		}
+		ruser, err := th.App.CreateUser(&user)
+		require.Nil(t, err)
+		require.NotNil(t, ruser)
+		defer th.App.PermanentDeleteUser(&user)
+
+		_, err = th.App.AddUserToTeam(th.BasicTeam.Id, ruser.Id, "")
+		require.Nil(t, err)
+
+		// Store the user ids for comparison later
+		userIDs = append(userIDs, ruser.Id)
+	}
+	// Sort them because the result of GetTeamMembers() is also sorted
+	sort.Sort(userIDs)
+
+	// Fetch team members multipile times
+	members, err := th.App.GetTeamMembers(th.BasicTeam.Id, 0, 5)
+	require.Nil(t, err)
+	members2, err := th.App.GetTeamMembers(th.BasicTeam.Id, 5, 5)
+	require.Nil(t, err)
+	members = append(members, members2...)
+
+	require.Equal(t, len(userIDs), len(members))
+	for i, member := range members {
+		assert.Equal(t, userIDs[i], member.UserId)
 	}
 }

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -129,7 +129,7 @@ type API interface {
 	DeleteTeamMember(teamId, userId, requestorId string) *model.AppError
 
 	// GetTeamMembers returns the memberships of a specific team.
-	GetTeamMembers(teamId string, offset, limit int) ([]*model.TeamMember, *model.AppError)
+	GetTeamMembers(teamId string, page, perPage int) ([]*model.TeamMember, *model.AppError)
 
 	// GetTeamMember returns a specific membership.
 	GetTeamMember(teamId, userId string) (*model.TeamMember, *model.AppError)
@@ -144,7 +144,7 @@ type API interface {
 	DeleteChannel(channelId string) *model.AppError
 
 	// GetPublicChannelsForTeam gets a list of all channels.
-	GetPublicChannelsForTeam(teamId string, offset, limit int) (*model.ChannelList, *model.AppError)
+	GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError)
 
 	// GetChannel gets a channel.
 	GetChannel(channelId string) (*model.Channel, *model.AppError)

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -144,7 +144,7 @@ type API interface {
 	DeleteChannel(channelId string) *model.AppError
 
 	// GetPublicChannelsForTeam gets a list of all channels.
-	GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError)
+	GetPublicChannelsForTeam(teamId string, page, perPage int) ([]*model.Channel, *model.AppError)
 
 	// GetChannel gets a channel.
 	GetChannel(channelId string) (*model.Channel, *model.AppError)

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1543,11 +1543,11 @@ type Z_GetPublicChannelsForTeamArgs struct {
 }
 
 type Z_GetPublicChannelsForTeamReturns struct {
-	A *model.ChannelList
+	A []*model.Channel
 	B *model.AppError
 }
 
-func (g *apiRPCClient) GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError) {
+func (g *apiRPCClient) GetPublicChannelsForTeam(teamId string, page, perPage int) ([]*model.Channel, *model.AppError) {
 	_args := &Z_GetPublicChannelsForTeamArgs{teamId, page, perPage}
 	_returns := &Z_GetPublicChannelsForTeamReturns{}
 	if err := g.client.Call("Plugin.GetPublicChannelsForTeam", _args, _returns); err != nil {
@@ -1558,7 +1558,7 @@ func (g *apiRPCClient) GetPublicChannelsForTeam(teamId string, page, perPage int
 
 func (s *apiRPCServer) GetPublicChannelsForTeam(args *Z_GetPublicChannelsForTeamArgs, returns *Z_GetPublicChannelsForTeamReturns) error {
 	if hook, ok := s.impl.(interface {
-		GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError)
+		GetPublicChannelsForTeam(teamId string, page, perPage int) ([]*model.Channel, *model.AppError)
 	}); ok {
 		returns.A, returns.B = hook.GetPublicChannelsForTeam(args.A, args.B, args.C)
 	} else {

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1398,8 +1398,8 @@ type Z_GetTeamMembersReturns struct {
 	B *model.AppError
 }
 
-func (g *apiRPCClient) GetTeamMembers(teamId string, offset, limit int) ([]*model.TeamMember, *model.AppError) {
-	_args := &Z_GetTeamMembersArgs{teamId, offset, limit}
+func (g *apiRPCClient) GetTeamMembers(teamId string, page, perPage int) ([]*model.TeamMember, *model.AppError) {
+	_args := &Z_GetTeamMembersArgs{teamId, page, perPage}
 	_returns := &Z_GetTeamMembersReturns{}
 	if err := g.client.Call("Plugin.GetTeamMembers", _args, _returns); err != nil {
 		log.Printf("RPC call to GetTeamMembers API failed: %s", err.Error())
@@ -1409,7 +1409,7 @@ func (g *apiRPCClient) GetTeamMembers(teamId string, offset, limit int) ([]*mode
 
 func (s *apiRPCServer) GetTeamMembers(args *Z_GetTeamMembersArgs, returns *Z_GetTeamMembersReturns) error {
 	if hook, ok := s.impl.(interface {
-		GetTeamMembers(teamId string, offset, limit int) ([]*model.TeamMember, *model.AppError)
+		GetTeamMembers(teamId string, page, perPage int) ([]*model.TeamMember, *model.AppError)
 	}); ok {
 		returns.A, returns.B = hook.GetTeamMembers(args.A, args.B, args.C)
 	} else {
@@ -1547,8 +1547,8 @@ type Z_GetPublicChannelsForTeamReturns struct {
 	B *model.AppError
 }
 
-func (g *apiRPCClient) GetPublicChannelsForTeam(teamId string, offset, limit int) (*model.ChannelList, *model.AppError) {
-	_args := &Z_GetPublicChannelsForTeamArgs{teamId, offset, limit}
+func (g *apiRPCClient) GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError) {
+	_args := &Z_GetPublicChannelsForTeamArgs{teamId, page, perPage}
 	_returns := &Z_GetPublicChannelsForTeamReturns{}
 	if err := g.client.Call("Plugin.GetPublicChannelsForTeam", _args, _returns); err != nil {
 		log.Printf("RPC call to GetPublicChannelsForTeam API failed: %s", err.Error())
@@ -1558,7 +1558,7 @@ func (g *apiRPCClient) GetPublicChannelsForTeam(teamId string, offset, limit int
 
 func (s *apiRPCServer) GetPublicChannelsForTeam(args *Z_GetPublicChannelsForTeamArgs, returns *Z_GetPublicChannelsForTeamReturns) error {
 	if hook, ok := s.impl.(interface {
-		GetPublicChannelsForTeam(teamId string, offset, limit int) (*model.ChannelList, *model.AppError)
+		GetPublicChannelsForTeam(teamId string, page, perPage int) (*model.ChannelList, *model.AppError)
 	}); ok {
 		returns.A, returns.B = hook.GetPublicChannelsForTeam(args.A, args.B, args.C)
 	} else {
@@ -2756,35 +2756,6 @@ func (s *apiRPCServer) GetPlugins(args *Z_GetPluginsArgs, returns *Z_GetPluginsR
 	return nil
 }
 
-type Z_GetPluginStatusArgs struct {
-	A string
-}
-
-type Z_GetPluginStatusReturns struct {
-	A *model.PluginStatus
-	B *model.AppError
-}
-
-func (g *apiRPCClient) GetPluginStatus(id string) (*model.PluginStatus, *model.AppError) {
-	_args := &Z_GetPluginStatusArgs{id}
-	_returns := &Z_GetPluginStatusReturns{}
-	if err := g.client.Call("Plugin.GetPluginStatus", _args, _returns); err != nil {
-		log.Printf("RPC call to GetPluginStatus API failed: %s", err.Error())
-	}
-	return _returns.A, _returns.B
-}
-
-func (s *apiRPCServer) GetPluginStatus(args *Z_GetPluginStatusArgs, returns *Z_GetPluginStatusReturns) error {
-	if hook, ok := s.impl.(interface {
-		GetPluginStatus(id string) (*model.PluginStatus, *model.AppError)
-	}); ok {
-		returns.A, returns.B = hook.GetPluginStatus(args.A)
-	} else {
-		return encodableError(fmt.Errorf("API GetPluginStatus called but not implemented."))
-	}
-	return nil
-}
-
 type Z_EnablePluginArgs struct {
 	A string
 }
@@ -2865,6 +2836,35 @@ func (s *apiRPCServer) RemovePlugin(args *Z_RemovePluginArgs, returns *Z_RemoveP
 		returns.A = hook.RemovePlugin(args.A)
 	} else {
 		return encodableError(fmt.Errorf("API RemovePlugin called but not implemented."))
+	}
+	return nil
+}
+
+type Z_GetPluginStatusArgs struct {
+	A string
+}
+
+type Z_GetPluginStatusReturns struct {
+	A *model.PluginStatus
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetPluginStatus(id string) (*model.PluginStatus, *model.AppError) {
+	_args := &Z_GetPluginStatusArgs{id}
+	_returns := &Z_GetPluginStatusReturns{}
+	if err := g.client.Call("Plugin.GetPluginStatus", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPluginStatus API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetPluginStatus(args *Z_GetPluginStatusArgs, returns *Z_GetPluginStatusReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPluginStatus(id string) (*model.PluginStatus, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetPluginStatus(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API GetPluginStatus called but not implemented."))
 	}
 	return nil
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1037,15 +1037,15 @@ func (_m *API) GetProfileImage(userId string) ([]byte, *model.AppError) {
 }
 
 // GetPublicChannelsForTeam provides a mock function with given fields: teamId, page, perPage
-func (_m *API) GetPublicChannelsForTeam(teamId string, page int, perPage int) (*model.ChannelList, *model.AppError) {
+func (_m *API) GetPublicChannelsForTeam(teamId string, page int, perPage int) ([]*model.Channel, *model.AppError) {
 	ret := _m.Called(teamId, page, perPage)
 
-	var r0 *model.ChannelList
-	if rf, ok := ret.Get(0).(func(string, int, int) *model.ChannelList); ok {
+	var r0 []*model.Channel
+	if rf, ok := ret.Get(0).(func(string, int, int) []*model.Channel); ok {
 		r0 = rf(teamId, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.ChannelList)
+			r0 = ret.Get(0).([]*model.Channel)
 		}
 	}
 

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1036,13 +1036,13 @@ func (_m *API) GetProfileImage(userId string) ([]byte, *model.AppError) {
 	return r0, r1
 }
 
-// GetPublicChannelsForTeam provides a mock function with given fields: teamId, offset, limit
-func (_m *API) GetPublicChannelsForTeam(teamId string, offset int, limit int) (*model.ChannelList, *model.AppError) {
-	ret := _m.Called(teamId, offset, limit)
+// GetPublicChannelsForTeam provides a mock function with given fields: teamId, page, perPage
+func (_m *API) GetPublicChannelsForTeam(teamId string, page int, perPage int) (*model.ChannelList, *model.AppError) {
+	ret := _m.Called(teamId, page, perPage)
 
 	var r0 *model.ChannelList
 	if rf, ok := ret.Get(0).(func(string, int, int) *model.ChannelList); ok {
-		r0 = rf(teamId, offset, limit)
+		r0 = rf(teamId, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.ChannelList)
@@ -1051,7 +1051,7 @@ func (_m *API) GetPublicChannelsForTeam(teamId string, offset int, limit int) (*
 
 	var r1 *model.AppError
 	if rf, ok := ret.Get(1).(func(string, int, int) *model.AppError); ok {
-		r1 = rf(teamId, offset, limit)
+		r1 = rf(teamId, page, perPage)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -1200,13 +1200,13 @@ func (_m *API) GetTeamMember(teamId string, userId string) (*model.TeamMember, *
 	return r0, r1
 }
 
-// GetTeamMembers provides a mock function with given fields: teamId, offset, limit
-func (_m *API) GetTeamMembers(teamId string, offset int, limit int) ([]*model.TeamMember, *model.AppError) {
-	ret := _m.Called(teamId, offset, limit)
+// GetTeamMembers provides a mock function with given fields: teamId, page, perPage
+func (_m *API) GetTeamMembers(teamId string, page int, perPage int) ([]*model.TeamMember, *model.AppError) {
+	ret := _m.Called(teamId, page, perPage)
 
 	var r0 []*model.TeamMember
 	if rf, ok := ret.Get(0).(func(string, int, int) []*model.TeamMember); ok {
-		r0 = rf(teamId, offset, limit)
+		r0 = rf(teamId, page, perPage)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.TeamMember)
@@ -1215,7 +1215,7 @@ func (_m *API) GetTeamMembers(teamId string, offset int, limit int) ([]*model.Te
 
 	var r1 *model.AppError
 	if rf, ok := ret.Get(1).(func(string, int, int) *model.AppError); ok {
-		r1 = rf(teamId, offset, limit)
+		r1 = rf(teamId, page, perPage)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)


### PR DESCRIPTION
#### Summary
This changes the parameter of two plugin API methods to use `page, perPage` instead of `offset, limit`.
Both API methods just call the respective method so the actual code for this ticket is very small.

Because both `GetPublicChannelsForTeam()` and `GetTeamMembers()` didn't had unit tests until now, I went ahead and added them. I _could_ add tests to `app/plugin_api_test.go` but these tests would mostly be a copy of the tests I added to `team_test.go` and `channel_test.go`.

#### Open Questions
I would like replace `*model.ChannelList` in the return value of `GetPublicChannelsForTeam()` with `[]*model.Channel`. This would make it easier to plugin developer to work with the method as they don't have to figure out what exactly `model.ChannelList` is. ~~Note that this would hard break old plugins. Which might be a good thing.~~ I think, it would not break it.

#### Ticket Link
Fixes #9814

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers
