### PR TITLE
MM-12957: Fix moving a channel with no members.

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1710,13 +1710,15 @@ func (a *App) MoveChannel(team *model.Team, channel *model.Channel, user *model.
 		channelMemberIds = append(channelMemberIds, channelMember.UserId)
 	}
 
-	teamMembers, err2 := a.GetTeamMembersByIds(team.Id, channelMemberIds)
-	if err2 != nil {
-		return err2
-	}
+	if len(channelMemberIds) > 0 {
+		teamMembers, err2 := a.GetTeamMembersByIds(team.Id, channelMemberIds)
+		if err2 != nil {
+			return err2
+		}
 
-	if len(teamMembers) != len(*channelMembers) {
-		return model.NewAppError("MoveChannel", "app.channel.move_channel.members_do_not_match.error", nil, "", http.StatusInternalServerError)
+		if len(teamMembers) != len(*channelMembers) {
+			return model.NewAppError("MoveChannel", "app.channel.move_channel.members_do_not_match.error", nil, "", http.StatusInternalServerError)
+		}
 	}
 
 	// keep instance of the previous team

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/store"
 )
 
 func TestPermanentDeleteChannel(t *testing.T) {
@@ -137,6 +138,22 @@ func TestMoveChannel(t *testing.T) {
 	if err := th.App.MoveChannel(targetTeam, channel2, th.BasicUser, true); err != nil {
 		t.Fatal(err)
 	}
+
+	// Test moving a channel with no members.
+	channel3 := &model.Channel{
+		DisplayName: "dn_" + model.NewId(),
+		Name:        "name_" + model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+		TeamId:      sourceTeam.Id,
+		CreatorId:   th.BasicUser.Id,
+	}
+
+	var err *model.AppError
+	channel3, err = th.App.CreateChannel(channel3, false)
+	require.Nil(t, err)
+
+	err = th.App.MoveChannel(targetTeam, channel3, th.BasicUser, false)
+	assert.Nil(t, err)
 }
 
 func TestJoinDefaultChannelsCreatesChannelMemberHistoryRecordTownSquare(t *testing.T) {


### PR DESCRIPTION
#### Summary
Fix moving a channel with no members.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12957

#### Checklist
- [x] Added or updated unit tests (required for all new features)