### PR TITLE
GH-9846: Migrate to idiomatic error handling in model/client4.go

### DIFF
--- a/model/client4.go
+++ b/model/client4.go
@@ -63,15 +63,14 @@ type Client4 struct {
 
 func closeBody(r *http.Response) {
 	if r.Body != nil {
-		ioutil.ReadAll(r.Body)
-		r.Body.Close()
+		_, _ = ioutil.ReadAll(r.Body)
+		_ = r.Body.Close()
 	}
 }
 
 // Must is a convenience function used for testing.
 func (c *Client4) Must(result interface{}, resp *Response) interface{} {
 	if resp.Error != nil {
-
 		time.Sleep(time.Second)
 		panic(resp.Error)
 	}
@@ -450,22 +449,26 @@ func (c *Client4) doApiRequestReader(method, url string, data io.Reader, etag st
 	}
 
 	if c.HttpHeader != nil && len(c.HttpHeader) > 0 {
-
 		for k, v := range c.HttpHeader {
 			rq.Header.Set(k, v)
 		}
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return nil, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0)
-	} else if rp.StatusCode == 304 {
-		return rp, nil
-	} else if rp.StatusCode >= 300 {
-		defer closeBody(rp)
-		return rp, AppErrorFromJson(rp.Body)
-	} else {
+	}
+
+	if rp.StatusCode == 304 {
 		return rp, nil
 	}
+
+	if rp.StatusCode >= 300 {
+		defer closeBody(rp)
+		return rp, AppErrorFromJson(rp.Body)
+	}
+
+	return rp, nil
 }
 
 func (c *Client4) DoUploadFile(url string, data []byte, contentType string) (*FileUploadResponse, *Response) {
@@ -476,17 +479,17 @@ func (c *Client4) DoUploadFile(url string, data []byte, contentType string) (*Fi
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return nil, BuildErrorResponse(rp, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0))
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return FileUploadResponseFromJson(rp.Body), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return FileUploadResponseFromJson(rp.Body), BuildResponse(rp)
 }
 
 func (c *Client4) DoEmojiUploadFile(url string, data []byte, contentType string) (*Emoji, *Response) {
@@ -497,17 +500,17 @@ func (c *Client4) DoEmojiUploadFile(url string, data []byte, contentType string)
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return nil, BuildErrorResponse(rp, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0))
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return EmojiFromJson(rp.Body), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return EmojiFromJson(rp.Body), BuildResponse(rp)
 }
 
 func (c *Client4) DoUploadImportTeam(url string, data []byte, contentType string) (map[string]string, *Response) {
@@ -518,17 +521,17 @@ func (c *Client4) DoUploadImportTeam(url string, data []byte, contentType string
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return nil, BuildErrorResponse(rp, NewAppError(url, "model.client.connecting.app_error", nil, err.Error(), 0))
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return MapFromJson(rp.Body), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return MapFromJson(rp.Body), BuildResponse(rp)
 }
 
 // CheckStatusOK is a convenience function for checking the standard OK response
@@ -584,156 +587,155 @@ func (c *Client4) LoginWithDevice(loginId string, password string, deviceId stri
 }
 
 func (c *Client4) login(m map[string]string) (*User, *Response) {
-	if r, err := c.DoApiPost("/users/login", MapToJson(m)); err != nil {
+	r, err := c.DoApiPost("/users/login", MapToJson(m))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		c.AuthToken = r.Header.Get(HEADER_TOKEN)
-		c.AuthType = HEADER_BEARER
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	c.AuthToken = r.Header.Get(HEADER_TOKEN)
+	c.AuthType = HEADER_BEARER
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // Logout terminates the current user's session.
 func (c *Client4) Logout() (bool, *Response) {
-	if r, err := c.DoApiPost("/users/logout", ""); err != nil {
+	r, err := c.DoApiPost("/users/logout", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		c.AuthToken = ""
-		c.AuthType = HEADER_BEARER
-
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	c.AuthToken = ""
+	c.AuthType = HEADER_BEARER
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // SwitchAccountType changes a user's login type from one type to another.
 func (c *Client4) SwitchAccountType(switchRequest *SwitchRequest) (string, *Response) {
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/login/switch", switchRequest.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/login/switch", switchRequest.ToJson())
+	if err != nil {
 		return "", BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body)["follow_link"], BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body)["follow_link"], BuildResponse(r)
 }
 
 // User Section
 
 // CreateUser creates a user in the system based on the provided user struct.
 func (c *Client4) CreateUser(user *User) (*User, *Response) {
-	if r, err := c.DoApiPost(c.GetUsersRoute(), user.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute(), user.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // CreateUserWithToken creates a user in the system based on the provided tokenId.
 func (c *Client4) CreateUserWithToken(user *User, tokenId string) (*User, *Response) {
-	var query string
-	if tokenId != "" {
-		query = fmt.Sprintf("?t=%v", tokenId)
-	} else {
+	if tokenId == "" {
 		err := NewAppError("MissingHashOrData", "api.user.create_user.missing_token.app_error", nil, "", http.StatusBadRequest)
 		return nil, &Response{StatusCode: err.StatusCode, Error: err}
 	}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+query, user.ToJson()); err != nil {
+
+	query := fmt.Sprintf("?t=%v", tokenId)
+	r, err := c.DoApiPost(c.GetUsersRoute()+query, user.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // CreateUserWithInviteId creates a user in the system based on the provided invited id.
 func (c *Client4) CreateUserWithInviteId(user *User, inviteId string) (*User, *Response) {
-	var query string
-	if inviteId != "" {
-		query = fmt.Sprintf("?iid=%v", url.QueryEscape(inviteId))
-	} else {
+	if inviteId == "" {
 		err := NewAppError("MissingInviteId", "api.user.create_user.missing_invite_id.app_error", nil, "", http.StatusBadRequest)
 		return nil, &Response{StatusCode: err.StatusCode, Error: err}
 	}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+query, user.ToJson()); err != nil {
+
+	query := fmt.Sprintf("?iid=%v", url.QueryEscape(inviteId))
+	r, err := c.DoApiPost(c.GetUsersRoute()+query, user.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // GetMe returns the logged in user.
 func (c *Client4) GetMe(etag string) (*User, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(ME), etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(ME), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUser returns a user based on the provided user id string.
 func (c *Client4) GetUser(userId, etag string) (*User, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUserByUsername returns a user based on the provided user name string.
 func (c *Client4) GetUserByUsername(userName, etag string) (*User, *Response) {
-	if r, err := c.DoApiGet(c.GetUserByUsernameRoute(userName), etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserByUsernameRoute(userName), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUserByEmail returns a user based on the provided user email string.
 func (c *Client4) GetUserByEmail(email, etag string) (*User, *Response) {
-	if r, err := c.DoApiGet(c.GetUserByEmailRoute(email), etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserByEmailRoute(email), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // AutocompleteUsersInTeam returns the users on a team based on search term.
 func (c *Client4) AutocompleteUsersInTeam(teamId string, username string, limit int, etag string) (*UserAutocomplete, *Response) {
 	query := fmt.Sprintf("?in_team=%v&name=%v&limit=%d", teamId, username, limit)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+"/autocomplete"+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+"/autocomplete"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAutocompleteFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAutocompleteFromJson(r.Body), BuildResponse(r)
 }
 
 // AutocompleteUsersInChannel returns the users in a channel based on search term.
 func (c *Client4) AutocompleteUsersInChannel(teamId string, channelId string, username string, limit int, etag string) (*UserAutocomplete, *Response) {
 	query := fmt.Sprintf("?in_team=%v&in_channel=%v&name=%v&limit=%d", teamId, channelId, username, limit)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+"/autocomplete"+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+"/autocomplete"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAutocompleteFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAutocompleteFromJson(r.Body), BuildResponse(r)
 }
 
 // AutocompleteUsers returns the users in the system based on search term.
 func (c *Client4) AutocompleteUsers(username string, limit int, etag string) (*UserAutocomplete, *Response) {
 	query := fmt.Sprintf("?name=%v&limit=%d", username, limit)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+"/autocomplete"+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+"/autocomplete"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAutocompleteFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAutocompleteFromJson(r.Body), BuildResponse(r)
 }
 
 // GetDefaultProfileImage gets the default user's profile image. Must be logged in.
@@ -754,176 +756,176 @@ func (c *Client4) GetDefaultProfileImage(userId string) ([]byte, *Response) {
 
 // GetProfileImage gets user's profile image. Must be logged in.
 func (c *Client4) GetProfileImage(userId, etag string) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/image", etag); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetProfileImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetUserRoute(userId)+"/image", etag)
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetProfileImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
 // GetUsers returns a page of users on the system. Page counting starts at 0.
 func (c *Client4) GetUsers(page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersInTeam returns a page of users on a team. Page counting starts at 0.
 func (c *Client4) GetUsersInTeam(teamId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?in_team=%v&page=%v&per_page=%v", teamId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetNewUsersInTeam returns a page of users on a team. Page counting starts at 0.
 func (c *Client4) GetNewUsersInTeam(teamId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?sort=create_at&in_team=%v&page=%v&per_page=%v", teamId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetRecentlyActiveUsersInTeam returns a page of users on a team. Page counting starts at 0.
 func (c *Client4) GetRecentlyActiveUsersInTeam(teamId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?sort=last_activity_at&in_team=%v&page=%v&per_page=%v", teamId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersNotInTeam returns a page of users who are not in a team. Page counting starts at 0.
 func (c *Client4) GetUsersNotInTeam(teamId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?not_in_team=%v&page=%v&per_page=%v", teamId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersInChannel returns a page of users in a channel. Page counting starts at 0.
 func (c *Client4) GetUsersInChannel(channelId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?in_channel=%v&page=%v&per_page=%v", channelId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersInChannelByStatus returns a page of users in a channel. Page counting starts at 0. Sorted by Status
 func (c *Client4) GetUsersInChannelByStatus(channelId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?in_channel=%v&page=%v&per_page=%v&sort=status", channelId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersNotInChannel returns a page of users not in a channel. Page counting starts at 0.
 func (c *Client4) GetUsersNotInChannel(teamId, channelId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?in_team=%v&not_in_channel=%v&page=%v&per_page=%v", teamId, channelId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersWithoutTeam returns a page of users on the system that aren't on any teams. Page counting starts at 0.
 func (c *Client4) GetUsersWithoutTeam(page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?without_team=1&page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetUsersRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersByIds returns a list of users based on the provided user ids.
 func (c *Client4) GetUsersByIds(userIds []string) ([]*User, *Response) {
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/ids", ArrayToJson(userIds)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/ids", ArrayToJson(userIds))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersByUsernames returns a list of users based on the provided usernames.
 func (c *Client4) GetUsersByUsernames(usernames []string) ([]*User, *Response) {
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/usernames", ArrayToJson(usernames)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/usernames", ArrayToJson(usernames))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // SearchUsers returns a list of users based on some search criteria.
 func (c *Client4) SearchUsers(search *UserSearch) ([]*User, *Response) {
-	if r, err := c.doApiPostBytes(c.GetUsersRoute()+"/search", search.ToJson()); err != nil {
+	r, err := c.doApiPostBytes(c.GetUsersRoute()+"/search", search.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateUser updates a user in the system based on the provided user struct.
 func (c *Client4) UpdateUser(user *User) (*User, *Response) {
-	if r, err := c.DoApiPut(c.GetUserRoute(user.Id), user.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetUserRoute(user.Id), user.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // PatchUser partially updates a user in the system. Any missing fields are not updated.
 func (c *Client4) PatchUser(userId string, patch *UserPatch) (*User, *Response) {
-	if r, err := c.DoApiPut(c.GetUserRoute(userId)+"/patch", patch.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetUserRoute(userId)+"/patch", patch.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateUserAuth updates a user AuthData (uthData, authService and password) in the system.
 func (c *Client4) UpdateUserAuth(userId string, userAuth *UserAuth) (*UserAuth, *Response) {
-	if r, err := c.DoApiPut(c.GetUserRoute(userId)+"/auth", userAuth.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetUserRoute(userId)+"/auth", userAuth.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAuthFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAuthFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateUserMfa activates multi-factor authentication for a user if activate
@@ -934,12 +936,12 @@ func (c *Client4) UpdateUserMfa(userId, code string, activate bool) (bool, *Resp
 	requestBody["activate"] = activate
 	requestBody["code"] = code
 
-	if r, err := c.DoApiPut(c.GetUserRoute(userId)+"/mfa", StringInterfaceToJson(requestBody)); err != nil {
+	r, err := c.DoApiPut(c.GetUserRoute(userId)+"/mfa", StringInterfaceToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // CheckUserMfa checks whether a user has MFA active on their account or not based on the
@@ -947,178 +949,178 @@ func (c *Client4) UpdateUserMfa(userId, code string, activate bool) (bool, *Resp
 func (c *Client4) CheckUserMfa(loginId string) (bool, *Response) {
 	requestBody := make(map[string]interface{})
 	requestBody["login_id"] = loginId
-
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/mfa", StringInterfaceToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/mfa", StringInterfaceToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		data := StringInterfaceFromJson(r.Body)
-		if mfaRequired, ok := data["mfa_required"].(bool); !ok {
-			return false, BuildResponse(r)
-		} else {
-			return mfaRequired, BuildResponse(r)
-		}
 	}
+	defer closeBody(r)
+
+	data := StringInterfaceFromJson(r.Body)
+	mfaRequired, ok := data["mfa_required"].(bool)
+	if !ok {
+		return false, BuildResponse(r)
+	}
+	return mfaRequired, BuildResponse(r)
 }
 
 // GenerateMfaSecret will generate a new MFA secret for a user and return it as a string and
 // as a base64 encoded image QR code.
 func (c *Client4) GenerateMfaSecret(userId string) (*MfaSecret, *Response) {
-	if r, err := c.DoApiPost(c.GetUserRoute(userId)+"/mfa/generate", ""); err != nil {
+	r, err := c.DoApiPost(c.GetUserRoute(userId)+"/mfa/generate", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MfaSecretFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MfaSecretFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateUserPassword updates a user's password. Must be logged in as the user or be a system administrator.
 func (c *Client4) UpdateUserPassword(userId, currentPassword, newPassword string) (bool, *Response) {
 	requestBody := map[string]string{"current_password": currentPassword, "new_password": newPassword}
-	if r, err := c.DoApiPut(c.GetUserRoute(userId)+"/password", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPut(c.GetUserRoute(userId)+"/password", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateUserRoles updates a user's roles in the system. A user can have "system_user" and "system_admin" roles.
 func (c *Client4) UpdateUserRoles(userId, roles string) (bool, *Response) {
 	requestBody := map[string]string{"roles": roles}
-	if r, err := c.DoApiPut(c.GetUserRoute(userId)+"/roles", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPut(c.GetUserRoute(userId)+"/roles", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateUserActive updates status of a user whether active or not.
 func (c *Client4) UpdateUserActive(userId string, active bool) (bool, *Response) {
 	requestBody := make(map[string]interface{})
 	requestBody["active"] = active
-
-	if r, err := c.DoApiPut(c.GetUserRoute(userId)+"/active", StringInterfaceToJson(requestBody)); err != nil {
+	r, err := c.DoApiPut(c.GetUserRoute(userId)+"/active", StringInterfaceToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // DeleteUser deactivates a user in the system based on the provided user id string.
 func (c *Client4) DeleteUser(userId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetUserRoute(userId)); err != nil {
+	r, err := c.DoApiDelete(c.GetUserRoute(userId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // SendPasswordResetEmail will send a link for password resetting to a user with the
 // provided email.
 func (c *Client4) SendPasswordResetEmail(email string) (bool, *Response) {
 	requestBody := map[string]string{"email": email}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/password/reset/send", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/password/reset/send", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // ResetPassword uses a recovery code to update reset a user's password.
 func (c *Client4) ResetPassword(token, newPassword string) (bool, *Response) {
 	requestBody := map[string]string{"token": token, "new_password": newPassword}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/password/reset", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/password/reset", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetSessions returns a list of sessions based on the provided user id string.
 func (c *Client4) GetSessions(userId, etag string) ([]*Session, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/sessions", etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/sessions", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return SessionsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return SessionsFromJson(r.Body), BuildResponse(r)
 }
 
 // RevokeSession revokes a user session based on the provided user id and session id strings.
 func (c *Client4) RevokeSession(userId, sessionId string) (bool, *Response) {
 	requestBody := map[string]string{"session_id": sessionId}
-	if r, err := c.DoApiPost(c.GetUserRoute(userId)+"/sessions/revoke", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUserRoute(userId)+"/sessions/revoke", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // RevokeAllSessions revokes all sessions for the provided user id string.
 func (c *Client4) RevokeAllSessions(userId string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetUserRoute(userId)+"/sessions/revoke/all", ""); err != nil {
+	r, err := c.DoApiPost(c.GetUserRoute(userId)+"/sessions/revoke/all", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // AttachDeviceId attaches a mobile device ID to the current session.
 func (c *Client4) AttachDeviceId(deviceId string) (bool, *Response) {
 	requestBody := map[string]string{"device_id": deviceId}
-	if r, err := c.DoApiPut(c.GetUsersRoute()+"/sessions/device", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPut(c.GetUsersRoute()+"/sessions/device", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetTeamsUnreadForUser will return an array with TeamUnread objects that contain the amount
 // of unread messages and mentions the current user has for the teams it belongs to.
 // An optional team ID can be set to exclude that team from the results. Must be authenticated.
 func (c *Client4) GetTeamsUnreadForUser(userId, teamIdToExclude string) ([]*TeamUnread, *Response) {
-	optional := ""
+	var optional string
 	if teamIdToExclude != "" {
 		optional += fmt.Sprintf("?exclude_team=%s", url.QueryEscape(teamIdToExclude))
 	}
 
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/unread"+optional, ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/unread"+optional, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamsUnreadFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamsUnreadFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUserAudits returns a list of audit based on the provided user id string.
 func (c *Client4) GetUserAudits(userId string, page int, perPage int, etag string) (Audits, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/audits"+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/audits"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return AuditsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return AuditsFromJson(r.Body), BuildResponse(r)
 }
 
 // VerifyUserEmail will verify a user's email using the supplied token.
 func (c *Client4) VerifyUserEmail(token string) (bool, *Response) {
 	requestBody := map[string]string{"token": token}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/email/verify", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/email/verify", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // SendVerificationEmail will send an email to the user with the provided email address, if
@@ -1126,15 +1128,15 @@ func (c *Client4) VerifyUserEmail(token string) (bool, *Response) {
 // email address.
 func (c *Client4) SendVerificationEmail(email string) (bool, *Response) {
 	requestBody := map[string]string{"email": email}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/email/verify/send", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/email/verify/send", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
-// SetDefaultProfileImage resets the profile image to a default generated one
+// SetDefaultProfileImage resets the profile image to a default generated one.
 func (c *Client4) SetDefaultProfileImage(userId string) (bool, *Response) {
 	r, err := c.DoApiDelete(c.GetUserRoute(userId) + "/image")
 	if err != nil {
@@ -1143,18 +1145,21 @@ func (c *Client4) SetDefaultProfileImage(userId string) (bool, *Response) {
 	return CheckStatusOK(r), BuildResponse(r)
 }
 
-// SetProfileImage sets profile image of the user
+// SetProfileImage sets profile image of the user.
 func (c *Client4) SetProfileImage(userId string, data []byte) (bool, *Response) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("image", "profile.png"); err != nil {
-		return false, &Response{Error: NewAppError("SetProfileImage", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+	part, err := writer.CreateFormFile("image", "profile.png")
+	if err != nil {
 		return false, &Response{Error: NewAppError("SetProfileImage", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	if err := writer.Close(); err != nil {
+	if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+		return false, &Response{Error: NewAppError("SetProfileImage", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
+	}
+
+	if err = writer.Close(); err != nil {
 		return false, &Response{Error: NewAppError("SetProfileImage", "model.client.set_profile_user.writer.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
@@ -1165,18 +1170,18 @@ func (c *Client4) SetProfileImage(userId string, data []byte) (bool, *Response) 
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		// set to http.StatusForbidden(403)
 		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetUserRoute(userId)+"/image", "model.client.connecting.app_error", nil, err.Error(), 403)}
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return CheckStatusOK(rp), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return CheckStatusOK(rp), BuildResponse(rp)
 }
 
 // CreateUserAccessToken will generate a user access token that can be used in place
@@ -1185,12 +1190,12 @@ func (c *Client4) SetProfileImage(userId string, data []byte) (bool, *Response) 
 // permission. A non-blank description is required.
 func (c *Client4) CreateUserAccessToken(userId, description string) (*UserAccessToken, *Response) {
 	requestBody := map[string]string{"description": description}
-	if r, err := c.DoApiPost(c.GetUserRoute(userId)+"/tokens", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUserRoute(userId)+"/tokens", MapToJson(requestBody))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAccessTokenFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAccessTokenFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUserAccessTokens will get a page of access tokens' id, description, is_active
@@ -1198,12 +1203,12 @@ func (c *Client4) CreateUserAccessToken(userId, description string) (*UserAccess
 // the 'manage_system' permission.
 func (c *Client4) GetUserAccessTokens(page int, perPage int) ([]*UserAccessToken, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetUserAccessTokensRoute()+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserAccessTokensRoute()+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUserAccessToken will get a user access tokens' id, description, is_active
@@ -1211,12 +1216,12 @@ func (c *Client4) GetUserAccessTokens(page int, perPage int) ([]*UserAccessToken
 // Must have the 'read_user_access_token' permission and if getting for another
 // user, must have the 'edit_other_users' permission.
 func (c *Client4) GetUserAccessToken(tokenId string) (*UserAccessToken, *Response) {
-	if r, err := c.DoApiGet(c.GetUserAccessTokenRoute(tokenId), ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserAccessTokenRoute(tokenId), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAccessTokenFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAccessTokenFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUserAccessTokensForUser will get a paged list of user access tokens showing id,
@@ -1225,12 +1230,12 @@ func (c *Client4) GetUserAccessToken(tokenId string) (*UserAccessToken, *Respons
 // 'edit_other_users' permission.
 func (c *Client4) GetUserAccessTokensForUser(userId string, page, perPage int) ([]*UserAccessToken, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/tokens"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/tokens"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
 }
 
 // RevokeUserAccessToken will revoke a user access token by id. Must have the
@@ -1238,22 +1243,22 @@ func (c *Client4) GetUserAccessTokensForUser(userId string, page, perPage int) (
 // 'edit_other_users' permission.
 func (c *Client4) RevokeUserAccessToken(tokenId string) (bool, *Response) {
 	requestBody := map[string]string{"token_id": tokenId}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/revoke", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/revoke", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // SearchUserAccessTokens returns user access tokens matching the provided search term.
 func (c *Client4) SearchUserAccessTokens(search *UserAccessTokenSearch) ([]*UserAccessToken, *Response) {
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/search", search.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/search", search.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserAccessTokenListFromJson(r.Body), BuildResponse(r)
 }
 
 // DisableUserAccessToken will disable a user access token by id. Must have the
@@ -1261,12 +1266,12 @@ func (c *Client4) SearchUserAccessTokens(search *UserAccessTokenSearch) ([]*User
 // 'edit_other_users' permission.
 func (c *Client4) DisableUserAccessToken(tokenId string) (bool, *Response) {
 	requestBody := map[string]string{"token_id": tokenId}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/disable", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/disable", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // EnableUserAccessToken will enable a user access token by id. Must have the
@@ -1274,202 +1279,201 @@ func (c *Client4) DisableUserAccessToken(tokenId string) (bool, *Response) {
 // 'edit_other_users' permission.
 func (c *Client4) EnableUserAccessToken(tokenId string) (bool, *Response) {
 	requestBody := map[string]string{"token_id": tokenId}
-	if r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/enable", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetUsersRoute()+"/tokens/enable", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // Team Section
 
 // CreateTeam creates a team in the system based on the provided team struct.
 func (c *Client4) CreateTeam(team *Team) (*Team, *Response) {
-	if r, err := c.DoApiPost(c.GetTeamsRoute(), team.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetTeamsRoute(), team.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamFromJson(r.Body), BuildResponse(r)
 }
 
 // GetTeam returns a team based on the provided team id string.
 func (c *Client4) GetTeam(teamId, etag string) (*Team, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamRoute(teamId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetTeamRoute(teamId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamFromJson(r.Body), BuildResponse(r)
 }
 
 // GetAllTeams returns all teams based on permissions.
 func (c *Client4) GetAllTeams(etag string, page int, perPage int) ([]*Team, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetTeamsRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetTeamsRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetTeamByName returns a team based on the provided team name string.
 func (c *Client4) GetTeamByName(name, etag string) (*Team, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamByNameRoute(name), etag); err != nil {
+	r, err := c.DoApiGet(c.GetTeamByNameRoute(name), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamFromJson(r.Body), BuildResponse(r)
 }
 
 // SearchTeams returns teams matching the provided search term.
 func (c *Client4) SearchTeams(search *TeamSearch) ([]*Team, *Response) {
-	if r, err := c.DoApiPost(c.GetTeamsRoute()+"/search", search.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetTeamsRoute()+"/search", search.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamListFromJson(r.Body), BuildResponse(r)
 }
 
 // TeamExists returns true or false if the team exist or not.
 func (c *Client4) TeamExists(name, etag string) (bool, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamByNameRoute(name)+"/exists", etag); err != nil {
+	r, err := c.DoApiGet(c.GetTeamByNameRoute(name)+"/exists", etag)
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapBoolFromJson(r.Body)["exists"], BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapBoolFromJson(r.Body)["exists"], BuildResponse(r)
 }
 
 // GetTeamsForUser returns a list of teams a user is on. Must be logged in as the user
 // or be a system administrator.
 func (c *Client4) GetTeamsForUser(userId, etag string) ([]*Team, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams", etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetTeamMember returns a team member based on the provided team and user id strings.
 func (c *Client4) GetTeamMember(teamId, userId, etag string) (*TeamMember, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamMemberRoute(teamId, userId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetTeamMemberRoute(teamId, userId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamMemberFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamMemberFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateTeamMemberRoles will update the roles on a team for a user.
 func (c *Client4) UpdateTeamMemberRoles(teamId, userId, newRoles string) (bool, *Response) {
 	requestBody := map[string]string{"roles": newRoles}
-	if r, err := c.DoApiPut(c.GetTeamMemberRoute(teamId, userId)+"/roles", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPut(c.GetTeamMemberRoute(teamId, userId)+"/roles", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateTeamMemberSchemeRoles will update the scheme-derived roles on a team for a user.
 func (c *Client4) UpdateTeamMemberSchemeRoles(teamId string, userId string, schemeRoles *SchemeRoles) (bool, *Response) {
-	if r, err := c.DoApiPut(c.GetTeamMemberRoute(teamId, userId)+"/schemeRoles", schemeRoles.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetTeamMemberRoute(teamId, userId)+"/schemeRoles", schemeRoles.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateTeam will update a team.
 func (c *Client4) UpdateTeam(team *Team) (*Team, *Response) {
-	if r, err := c.DoApiPut(c.GetTeamRoute(team.Id), team.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetTeamRoute(team.Id), team.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamFromJson(r.Body), BuildResponse(r)
 }
 
 // PatchTeam partially updates a team. Any missing fields are not updated.
 func (c *Client4) PatchTeam(teamId string, patch *TeamPatch) (*Team, *Response) {
-	if r, err := c.DoApiPut(c.GetTeamRoute(teamId)+"/patch", patch.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetTeamRoute(teamId)+"/patch", patch.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamFromJson(r.Body), BuildResponse(r)
 }
 
 // SoftDeleteTeam deletes the team softly (archive only, not permanent delete).
 func (c *Client4) SoftDeleteTeam(teamId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetTeamRoute(teamId)); err != nil {
+	r, err := c.DoApiDelete(c.GetTeamRoute(teamId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // PermanentDeleteTeam deletes the team, should only be used when needed for
-// compliance and the like
+// compliance and the like.
 func (c *Client4) PermanentDeleteTeam(teamId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetTeamRoute(teamId) + "?permanent=true"); err != nil {
+	r, err := c.DoApiDelete(c.GetTeamRoute(teamId) + "?permanent=true")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetTeamMembers returns team members based on the provided team id string.
 func (c *Client4) GetTeamMembers(teamId string, page int, perPage int, etag string) ([]*TeamMember, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetTeamMembersRoute(teamId)+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetTeamMembersRoute(teamId)+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamMembersFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamMembersFromJson(r.Body), BuildResponse(r)
 }
 
 // GetTeamMembersForUser returns the team members for a user.
 func (c *Client4) GetTeamMembersForUser(userId string, etag string) ([]*TeamMember, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/members", etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/members", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamMembersFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamMembersFromJson(r.Body), BuildResponse(r)
 }
 
 // GetTeamMembersByIds will return an array of team members based on the
 // team id and a list of user ids provided. Must be authenticated.
 func (c *Client4) GetTeamMembersByIds(teamId string, userIds []string) ([]*TeamMember, *Response) {
-	if r, err := c.DoApiPost(fmt.Sprintf("/teams/%v/members/ids", teamId), ArrayToJson(userIds)); err != nil {
+	r, err := c.DoApiPost(fmt.Sprintf("/teams/%v/members/ids", teamId), ArrayToJson(userIds))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamMembersFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamMembersFromJson(r.Body), BuildResponse(r)
 }
 
 // AddTeamMember adds user to a team and return a team member.
 func (c *Client4) AddTeamMember(teamId, userId string) (*TeamMember, *Response) {
 	member := &TeamMember{TeamId: teamId, UserId: userId}
-
-	if r, err := c.DoApiPost(c.GetTeamMembersRoute(teamId), member.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetTeamMembersRoute(teamId), member.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamMemberFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamMemberFromJson(r.Body), BuildResponse(r)
 }
 
 // AddTeamMemberFromInvite adds a user to a team and return a team member using an invite id
@@ -1485,12 +1489,12 @@ func (c *Client4) AddTeamMemberFromInvite(token, inviteId string) (*TeamMember, 
 		query += fmt.Sprintf("?token=%v", token)
 	}
 
-	if r, err := c.DoApiPost(c.GetTeamsRoute()+"/members/invite"+query, ""); err != nil {
+	r, err := c.DoApiPost(c.GetTeamsRoute()+"/members/invite"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamMemberFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamMemberFromJson(r.Body), BuildResponse(r)
 }
 
 // AddTeamMembers adds a number of users to a team and returns the team members.
@@ -1501,56 +1505,56 @@ func (c *Client4) AddTeamMembers(teamId string, userIds []string) ([]*TeamMember
 		members = append(members, member)
 	}
 
-	if r, err := c.DoApiPost(c.GetTeamMembersRoute(teamId)+"/batch", TeamMembersToJson(members)); err != nil {
+	r, err := c.DoApiPost(c.GetTeamMembersRoute(teamId)+"/batch", TeamMembersToJson(members))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamMembersFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamMembersFromJson(r.Body), BuildResponse(r)
 }
 
 // RemoveTeamMember will remove a user from a team.
 func (c *Client4) RemoveTeamMember(teamId, userId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetTeamMemberRoute(teamId, userId)); err != nil {
+	r, err := c.DoApiDelete(c.GetTeamMemberRoute(teamId, userId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetTeamStats returns a team stats based on the team id string.
 // Must be authenticated.
 func (c *Client4) GetTeamStats(teamId, etag string) (*TeamStats, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamStatsRoute(teamId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetTeamStatsRoute(teamId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamStatsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamStatsFromJson(r.Body), BuildResponse(r)
 }
 
 // GetTotalUsersStats returns a total system user stats.
 // Must be authenticated.
 func (c *Client4) GetTotalUsersStats(etag string) (*UsersStats, *Response) {
-	if r, err := c.DoApiGet(c.GetTotalUsersStatsRoute(), etag); err != nil {
+	r, err := c.DoApiGet(c.GetTotalUsersStatsRoute(), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UsersStatsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UsersStatsFromJson(r.Body), BuildResponse(r)
 }
 
 // GetTeamUnread will return a TeamUnread object that contains the amount of
 // unread messages and mentions the user has for the specified team.
 // Must be authenticated.
 func (c *Client4) GetTeamUnread(teamId, userId string) (*TeamUnread, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetTeamRoute(teamId)+"/unread", ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetTeamRoute(teamId)+"/unread", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamUnreadFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamUnreadFromJson(r.Body), BuildResponse(r)
 }
 
 // ImportTeam will import an exported team from other app into a existing team.
@@ -1558,21 +1562,30 @@ func (c *Client4) ImportTeam(data []byte, filesize int, importFrom, filename, te
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("file", filename); err != nil {
-		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
 		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	if part, err := writer.CreateFormField("filesize"); err != nil {
-		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.file_size.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, strings.NewReader(strconv.Itoa(filesize))); err != nil {
+	if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
+	}
+
+	part, err = writer.CreateFormField("filesize")
+	if err != nil {
 		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.file_size.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	if part, err := writer.CreateFormField("importFrom"); err != nil {
+	if _, err = io.Copy(part, strings.NewReader(strconv.Itoa(filesize))); err != nil {
+		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.file_size.app_error", nil, err.Error(), http.StatusBadRequest)}
+	}
+
+	part, err = writer.CreateFormField("importFrom")
+	if err != nil {
 		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.import_from.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, strings.NewReader(importFrom)); err != nil {
+	}
+
+	if _, err := io.Copy(part, strings.NewReader(importFrom)); err != nil {
 		return nil, &Response{Error: NewAppError("UploadImportTeam", "model.client.upload_post_attachment.import_from.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
@@ -1585,37 +1598,39 @@ func (c *Client4) ImportTeam(data []byte, filesize int, importFrom, filename, te
 
 // InviteUsersToTeam invite users by email to the team.
 func (c *Client4) InviteUsersToTeam(teamId string, userEmails []string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/invite/email", ArrayToJson(userEmails)); err != nil {
+	r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/invite/email", ArrayToJson(userEmails))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetTeamInviteInfo returns a team object from an invite id containing sanitized information.
 func (c *Client4) GetTeamInviteInfo(inviteId string) (*Team, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamsRoute()+"/invite/"+inviteId, ""); err != nil {
+	r, err := c.DoApiGet(c.GetTeamsRoute()+"/invite/"+inviteId, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamFromJson(r.Body), BuildResponse(r)
 }
 
-// SetTeamIcon sets team icon of the team
+// SetTeamIcon sets team icon of the team.
 func (c *Client4) SetTeamIcon(teamId string, data []byte) (bool, *Response) {
-
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("image", "teamIcon.png"); err != nil {
-		return false, &Response{Error: NewAppError("SetTeamIcon", "model.client.set_team_icon.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+	part, err := writer.CreateFormFile("image", "teamIcon.png")
+	if err != nil {
 		return false, &Response{Error: NewAppError("SetTeamIcon", "model.client.set_team_icon.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	if err := writer.Close(); err != nil {
+	if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+		return false, &Response{Error: NewAppError("SetTeamIcon", "model.client.set_team_icon.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
+	}
+
+	if err = writer.Close(); err != nil {
 		return false, &Response{Error: NewAppError("SetTeamIcon", "model.client.set_team_icon.writer.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
@@ -1626,137 +1641,137 @@ func (c *Client4) SetTeamIcon(teamId string, data []byte) (bool, *Response) {
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		// set to http.StatusForbidden(403)
 		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetTeamRoute(teamId)+"/image", "model.client.connecting.app_error", nil, err.Error(), 403)}
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return CheckStatusOK(rp), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return CheckStatusOK(rp), BuildResponse(rp)
 }
 
-// GetTeamIcon gets the team icon of the team
+// GetTeamIcon gets the team icon of the team.
 func (c *Client4) GetTeamIcon(teamId, etag string) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamRoute(teamId)+"/image", etag); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetTeamIcon", "model.client.get_team_icon.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetTeamRoute(teamId)+"/image", etag)
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetTeamIcon", "model.client.get_team_icon.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
 // RemoveTeamIcon updates LastTeamIconUpdate to 0 which indicates team icon is removed.
 func (c *Client4) RemoveTeamIcon(teamId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetTeamRoute(teamId) + "/image"); err != nil {
+	r, err := c.DoApiDelete(c.GetTeamRoute(teamId) + "/image")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // Channel Section
 
 // CreateChannel creates a channel based on the provided channel struct.
 func (c *Client4) CreateChannel(channel *Channel) (*Channel, *Response) {
-	if r, err := c.DoApiPost(c.GetChannelsRoute(), channel.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetChannelsRoute(), channel.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
-// UpdateChannel update a channel based on the provided channel struct.
+// UpdateChannel updates a channel based on the provided channel struct.
 func (c *Client4) UpdateChannel(channel *Channel) (*Channel, *Response) {
-	if r, err := c.DoApiPut(c.GetChannelRoute(channel.Id), channel.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetChannelRoute(channel.Id), channel.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // PatchChannel partially updates a channel. Any missing fields are not updated.
 func (c *Client4) PatchChannel(channelId string, patch *ChannelPatch) (*Channel, *Response) {
-	if r, err := c.DoApiPut(c.GetChannelRoute(channelId)+"/patch", patch.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetChannelRoute(channelId)+"/patch", patch.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // ConvertChannelToPrivate converts public to private channel.
 func (c *Client4) ConvertChannelToPrivate(channelId string) (*Channel, *Response) {
-	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/convert", ""); err != nil {
+	r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/convert", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // RestoreChannel restores a previously deleted channel. Any missing fields are not updated.
 func (c *Client4) RestoreChannel(channelId string) (*Channel, *Response) {
-	if r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/restore", ""); err != nil {
+	r, err := c.DoApiPost(c.GetChannelRoute(channelId)+"/restore", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // CreateDirectChannel creates a direct message channel based on the two user
 // ids provided.
 func (c *Client4) CreateDirectChannel(userId1, userId2 string) (*Channel, *Response) {
 	requestBody := []string{userId1, userId2}
-	if r, err := c.DoApiPost(c.GetChannelsRoute()+"/direct", ArrayToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetChannelsRoute()+"/direct", ArrayToJson(requestBody))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
-// CreateGroupChannel creates a group message channel based on userIds provided
+// CreateGroupChannel creates a group message channel based on userIds provided.
 func (c *Client4) CreateGroupChannel(userIds []string) (*Channel, *Response) {
-	if r, err := c.DoApiPost(c.GetChannelsRoute()+"/group", ArrayToJson(userIds)); err != nil {
+	r, err := c.DoApiPost(c.GetChannelsRoute()+"/group", ArrayToJson(userIds))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannel returns a channel based on the provided channel id string.
 func (c *Client4) GetChannel(channelId, etag string) (*Channel, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelStats returns statistics for a channel.
 func (c *Client4) GetChannelStats(channelId string, etag string) (*ChannelStats, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/stats", etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/stats", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelStatsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelStatsFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelMembersTimezones gets a list of timezones for a channel.
@@ -1765,382 +1780,380 @@ func (c *Client4) GetChannelMembersTimezones(channelId string) ([]string, *Respo
 	if err != nil {
 		return nil, BuildErrorResponse(r, err)
 	}
-
 	defer closeBody(r)
 	return ArrayFromJson(r.Body), BuildResponse(r)
 }
 
 // GetPinnedPosts gets a list of pinned posts.
 func (c *Client4) GetPinnedPosts(channelId string, etag string) (*PostList, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/pinned", etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/pinned", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetPublicChannelsForTeam returns a list of public channels based on the provided team id string.
 func (c *Client4) GetPublicChannelsForTeam(teamId string, page int, perPage int, etag string) ([]*Channel, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelSliceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelSliceFromJson(r.Body), BuildResponse(r)
 }
 
 // GetDeletedChannelsForTeam returns a list of public channels based on the provided team id string.
 func (c *Client4) GetDeletedChannelsForTeam(teamId string, page int, perPage int, etag string) ([]*Channel, *Response) {
 	query := fmt.Sprintf("/deleted?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelSliceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelSliceFromJson(r.Body), BuildResponse(r)
 }
 
-// GetPublicChannelsByIdsForTeam returns a list of public channels based on provided team id string
+// GetPublicChannelsByIdsForTeam returns a list of public channels based on provided team id string.
 func (c *Client4) GetPublicChannelsByIdsForTeam(teamId string, channelIds []string) ([]*Channel, *Response) {
-	if r, err := c.DoApiPost(c.GetChannelsForTeamRoute(teamId)+"/ids", ArrayToJson(channelIds)); err != nil {
+	r, err := c.DoApiPost(c.GetChannelsForTeamRoute(teamId)+"/ids", ArrayToJson(channelIds))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelSliceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelSliceFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelsForTeamForUser returns a list channels of on a team for a user.
 func (c *Client4) GetChannelsForTeamForUser(teamId, userId, etag string) ([]*Channel, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetTeamRoute(teamId)+"/channels", etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetTeamRoute(teamId)+"/channels", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelSliceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelSliceFromJson(r.Body), BuildResponse(r)
 }
 
 // SearchChannels returns the channels on a team matching the provided search term.
 func (c *Client4) SearchChannels(teamId string, search *ChannelSearch) ([]*Channel, *Response) {
-	if r, err := c.DoApiPost(c.GetChannelsForTeamRoute(teamId)+"/search", search.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetChannelsForTeamRoute(teamId)+"/search", search.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelSliceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelSliceFromJson(r.Body), BuildResponse(r)
 }
 
 // DeleteChannel deletes channel based on the provided channel id string.
 func (c *Client4) DeleteChannel(channelId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetChannelRoute(channelId)); err != nil {
+	r, err := c.DoApiDelete(c.GetChannelRoute(channelId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetChannelByName returns a channel based on the provided channel name and team id strings.
 func (c *Client4) GetChannelByName(channelName, teamId string, etag string) (*Channel, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelByNameRoute(channelName, teamId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelByNameRoute(channelName, teamId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 func (c *Client4) GetChannelByNameIncludeDeleted(channelName, teamId string, etag string) (*Channel, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelByNameRoute(channelName, teamId)+"?include_deleted=true", etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelByNameRoute(channelName, teamId)+"?include_deleted=true", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelByNameForTeamName returns a channel based on the provided channel name and team name strings.
 func (c *Client4) GetChannelByNameForTeamName(channelName, teamName string, etag string) (*Channel, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelByNameForTeamNameRoute(channelName, teamName), etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelByNameForTeamNameRoute(channelName, teamName), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 func (c *Client4) GetChannelByNameForTeamNameIncludeDeleted(channelName, teamName string, etag string) (*Channel, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelByNameForTeamNameRoute(channelName, teamName)+"?include_deleted=true", etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelByNameForTeamNameRoute(channelName, teamName)+"?include_deleted=true", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelMembers gets a page of channel members.
 func (c *Client4) GetChannelMembers(channelId string, page, perPage int, etag string) (*ChannelMembers, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetChannelMembersRoute(channelId)+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelMembersRoute(channelId)+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelMembersFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelMembersFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelMembersByIds gets the channel members in a channel for a list of user ids.
 func (c *Client4) GetChannelMembersByIds(channelId string, userIds []string) (*ChannelMembers, *Response) {
-	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"/ids", ArrayToJson(userIds)); err != nil {
+	r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"/ids", ArrayToJson(userIds))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelMembersFromJson(r.Body), BuildResponse(r)
-
 	}
+	defer closeBody(r)
+	return ChannelMembersFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelMember gets a channel member.
 func (c *Client4) GetChannelMember(channelId, userId, etag string) (*ChannelMember, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelMemberRoute(channelId, userId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelMemberRoute(channelId, userId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelMemberFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelMemberFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelMembersForUser gets all the channel members for a user on a team.
 func (c *Client4) GetChannelMembersForUser(userId, teamId, etag string) (*ChannelMembers, *Response) {
-	if r, err := c.DoApiGet(fmt.Sprintf(c.GetUserRoute(userId)+"/teams/%v/channels/members", teamId), etag); err != nil {
+	r, err := c.DoApiGet(fmt.Sprintf(c.GetUserRoute(userId)+"/teams/%v/channels/members", teamId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelMembersFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelMembersFromJson(r.Body), BuildResponse(r)
 }
 
 // ViewChannel performs a view action for a user. Synonymous with switching channels or marking channels as read by a user.
 func (c *Client4) ViewChannel(userId string, view *ChannelView) (*ChannelViewResponse, *Response) {
 	url := fmt.Sprintf(c.GetChannelsRoute()+"/members/%v/view", userId)
-	if r, err := c.DoApiPost(url, view.ToJson()); err != nil {
+	r, err := c.DoApiPost(url, view.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelViewResponseFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelViewResponseFromJson(r.Body), BuildResponse(r)
 }
 
 // GetChannelUnread will return a ChannelUnread object that contains the number of
 // unread messages and mentions for a user.
 func (c *Client4) GetChannelUnread(channelId, userId string) (*ChannelUnread, *Response) {
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetChannelRoute(channelId)+"/unread", ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetChannelRoute(channelId)+"/unread", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelUnreadFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelUnreadFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateChannelRoles will update the roles on a channel for a user.
 func (c *Client4) UpdateChannelRoles(channelId, userId, roles string) (bool, *Response) {
 	requestBody := map[string]string{"roles": roles}
-	if r, err := c.DoApiPut(c.GetChannelMemberRoute(channelId, userId)+"/roles", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPut(c.GetChannelMemberRoute(channelId, userId)+"/roles", MapToJson(requestBody))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateChannelMemberSchemeRoles will update the scheme-derived roles on a channel for a user.
 func (c *Client4) UpdateChannelMemberSchemeRoles(channelId string, userId string, schemeRoles *SchemeRoles) (bool, *Response) {
-	if r, err := c.DoApiPut(c.GetChannelMemberRoute(channelId, userId)+"/schemeRoles", schemeRoles.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetChannelMemberRoute(channelId, userId)+"/schemeRoles", schemeRoles.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateChannelNotifyProps will update the notification properties on a channel for a user.
 func (c *Client4) UpdateChannelNotifyProps(channelId, userId string, props map[string]string) (bool, *Response) {
-	if r, err := c.DoApiPut(c.GetChannelMemberRoute(channelId, userId)+"/notify_props", MapToJson(props)); err != nil {
+	r, err := c.DoApiPut(c.GetChannelMemberRoute(channelId, userId)+"/notify_props", MapToJson(props))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // AddChannelMember adds user to channel and return a channel member.
 func (c *Client4) AddChannelMember(channelId, userId string) (*ChannelMember, *Response) {
 	requestBody := map[string]string{"user_id": userId}
-	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", MapToJson(requestBody))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelMemberFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelMemberFromJson(r.Body), BuildResponse(r)
 }
 
 // AddChannelMemberWithRootId adds user to channel and return a channel member. Post add to channel message has the postRootId.
 func (c *Client4) AddChannelMemberWithRootId(channelId, userId, postRootId string) (*ChannelMember, *Response) {
 	requestBody := map[string]string{"user_id": userId, "post_root_id": postRootId}
-	if r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"", MapToJson(requestBody))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelMemberFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelMemberFromJson(r.Body), BuildResponse(r)
 }
 
 // RemoveUserFromChannel will delete the channel member object for a user, effectively removing the user from a channel.
 func (c *Client4) RemoveUserFromChannel(channelId, userId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetChannelMemberRoute(channelId, userId)); err != nil {
+	r, err := c.DoApiDelete(c.GetChannelMemberRoute(channelId, userId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
-// AutocompleteChannelsForTeam will return an ordered list of channels autocomplete suggestions
+// AutocompleteChannelsForTeam will return an ordered list of channels autocomplete suggestions.
 func (c *Client4) AutocompleteChannelsForTeam(teamId, name string) (*ChannelList, *Response) {
 	query := fmt.Sprintf("?name=%v", name)
-	if r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+"/autocomplete"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+"/autocomplete"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelListFromJson(r.Body), BuildResponse(r)
 }
 
-// AutocompleteChannelsForTeamForSearch will return an ordered list of your channels autocomplete suggestions
+// AutocompleteChannelsForTeamForSearch will return an ordered list of your channels autocomplete suggestions.
 func (c *Client4) AutocompleteChannelsForTeamForSearch(teamId, name string) (*ChannelList, *Response) {
 	query := fmt.Sprintf("?name=%v", name)
-	if r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+"/search_autocomplete"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+"/search_autocomplete"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ChannelListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ChannelListFromJson(r.Body), BuildResponse(r)
 }
 
 // Post Section
 
 // CreatePost creates a post based on the provided post struct.
 func (c *Client4) CreatePost(post *Post) (*Post, *Response) {
-	if r, err := c.DoApiPost(c.GetPostsRoute(), post.ToUnsanitizedJson()); err != nil {
+	r, err := c.DoApiPost(c.GetPostsRoute(), post.ToUnsanitizedJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostFromJson(r.Body), BuildResponse(r)
 }
 
-// CreatePostEphemeral creates a ephemeral post based on the provided post struct which is send to the given user id
+// CreatePostEphemeral creates a ephemeral post based on the provided post struct which is send to the given user id.
 func (c *Client4) CreatePostEphemeral(post *PostEphemeral) (*Post, *Response) {
-	if r, err := c.DoApiPost(c.GetPostsEphemeralRoute(), post.ToUnsanitizedJson()); err != nil {
+	r, err := c.DoApiPost(c.GetPostsEphemeralRoute(), post.ToUnsanitizedJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdatePost updates a post based on the provided post struct.
 func (c *Client4) UpdatePost(postId string, post *Post) (*Post, *Response) {
-	if r, err := c.DoApiPut(c.GetPostRoute(postId), post.ToUnsanitizedJson()); err != nil {
+	r, err := c.DoApiPut(c.GetPostRoute(postId), post.ToUnsanitizedJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostFromJson(r.Body), BuildResponse(r)
 }
 
 // PatchPost partially updates a post. Any missing fields are not updated.
 func (c *Client4) PatchPost(postId string, patch *PostPatch) (*Post, *Response) {
-	if r, err := c.DoApiPut(c.GetPostRoute(postId)+"/patch", patch.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetPostRoute(postId)+"/patch", patch.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostFromJson(r.Body), BuildResponse(r)
 }
 
 // PinPost pin a post based on provided post id string.
 func (c *Client4) PinPost(postId string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetPostRoute(postId)+"/pin", ""); err != nil {
+	r, err := c.DoApiPost(c.GetPostRoute(postId)+"/pin", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UnpinPost unpin a post based on provided post id string.
 func (c *Client4) UnpinPost(postId string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetPostRoute(postId)+"/unpin", ""); err != nil {
+	r, err := c.DoApiPost(c.GetPostRoute(postId)+"/unpin", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetPost gets a single post.
 func (c *Client4) GetPost(postId string, etag string) (*Post, *Response) {
-	if r, err := c.DoApiGet(c.GetPostRoute(postId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetPostRoute(postId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostFromJson(r.Body), BuildResponse(r)
 }
 
 // DeletePost deletes a post from the provided post id string.
 func (c *Client4) DeletePost(postId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetPostRoute(postId)); err != nil {
+	r, err := c.DoApiDelete(c.GetPostRoute(postId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetPostThread gets a post with all the other posts in the same thread.
 func (c *Client4) GetPostThread(postId string, etag string) (*PostList, *Response) {
-	if r, err := c.DoApiGet(c.GetPostRoute(postId)+"/thread", etag); err != nil {
+	r, err := c.DoApiGet(c.GetPostRoute(postId)+"/thread", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetPostsForChannel gets a page of posts with an array for ordering for a channel.
 func (c *Client4) GetPostsForChannel(channelId string, page, perPage int, etag string) (*PostList, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetFlaggedPostsForUser returns flagged posts of a user based on user id string.
 func (c *Client4) GetFlaggedPostsForUser(userId string, page int, perPage int) (*PostList, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/posts/flagged"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/posts/flagged"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetFlaggedPostsForUserInTeam returns flagged posts in team of a user based on user id string.
@@ -2150,12 +2163,12 @@ func (c *Client4) GetFlaggedPostsForUserInTeam(userId string, teamId string, pag
 	}
 
 	query := fmt.Sprintf("?team_id=%v&page=%v&per_page=%v", teamId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/posts/flagged"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/posts/flagged"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetFlaggedPostsForUserInChannel returns flagged posts in channel of a user based on user id string.
@@ -2165,45 +2178,45 @@ func (c *Client4) GetFlaggedPostsForUserInChannel(userId string, channelId strin
 	}
 
 	query := fmt.Sprintf("?channel_id=%v&page=%v&per_page=%v", channelId, page, perPage)
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/posts/flagged"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/posts/flagged"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetPostsSince gets posts created after a specified time as Unix time in milliseconds.
 func (c *Client4) GetPostsSince(channelId string, time int64) (*PostList, *Response) {
 	query := fmt.Sprintf("?since=%v", time)
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetPostsAfter gets a page of posts that were posted after the post provided.
 func (c *Client4) GetPostsAfter(channelId, postId string, page, perPage int, etag string) (*PostList, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v&after=%v", page, perPage, postId)
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetPostsBefore gets a page of posts that were posted before the post provided.
 func (c *Client4) GetPostsBefore(channelId, postId string, page, perPage int, etag string) (*PostList, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v&before=%v", page, perPage, postId)
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
 // SearchPosts returns any posts with matching terms string.
@@ -2215,35 +2228,35 @@ func (c *Client4) SearchPosts(teamId string, terms string, isOrSearch bool) (*Po
 	return c.SearchPostsWithParams(teamId, &params)
 }
 
-// SearchPosts returns any posts with matching terms string.
+// SearchPostsWithParams returns any posts with matching terms string.
 func (c *Client4) SearchPostsWithParams(teamId string, params *SearchParameter) (*PostList, *Response) {
-	if r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/posts/search", params.SearchParameterToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/posts/search", params.SearchParameterToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
-// SearchPosts returns any posts with matching terms string, including.
+// SearchPostsWithMatches returns any posts with matching terms string, including.
 func (c *Client4) SearchPostsWithMatches(teamId string, terms string, isOrSearch bool) (*PostSearchResults, *Response) {
 	requestBody := map[string]interface{}{"terms": terms, "is_or_search": isOrSearch}
-	if r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/posts/search", StringInterfaceToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetTeamRoute(teamId)+"/posts/search", StringInterfaceToJson(requestBody))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PostSearchResultsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PostSearchResultsFromJson(r.Body), BuildResponse(r)
 }
 
 // DoPostAction performs a post action.
 func (c *Client4) DoPostAction(postId, actionId string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetPostRoute(postId)+"/actions/"+actionId, ""); err != nil {
+	r, err := c.DoApiPost(c.GetPostRoute(postId)+"/actions/"+actionId, "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // OpenInteractiveDialog sends a WebSocket event to a user's clients to
@@ -2252,26 +2265,27 @@ func (c *Client4) DoPostAction(postId, actionId string) (bool, *Response) {
 // slash commands.
 func (c *Client4) OpenInteractiveDialog(request OpenDialogRequest) (bool, *Response) {
 	b, _ := json.Marshal(request)
-	if r, err := c.DoApiPost("/actions/dialogs/open", string(b)); err != nil {
+	r, err := c.DoApiPost("/actions/dialogs/open", string(b))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // SubmitInteractiveDialog will submit the provided dialog data to the integration
 // configured by the URL. Used with the interactive dialogs integration feature.
 func (c *Client4) SubmitInteractiveDialog(request SubmitDialogRequest) (*SubmitDialogResponse, *Response) {
 	b, _ := json.Marshal(request)
-	if r, err := c.DoApiPost("/actions/dialogs/submit", string(b)); err != nil {
+	r, err := c.DoApiPost("/actions/dialogs/submit", string(b))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		var resp SubmitDialogResponse
-		json.NewDecoder(r.Body).Decode(&resp)
-		return &resp, BuildResponse(r)
 	}
+	defer closeBody(r)
+
+	var resp SubmitDialogResponse
+	json.NewDecoder(r.Body).Decode(&resp)
+	return &resp, BuildResponse(r)
 }
 
 // File Section
@@ -2282,15 +2296,22 @@ func (c *Client4) UploadFile(data []byte, channelId string, filename string) (*F
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("files", filename); err != nil {
-		return nil, &Response{Error: NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+	part, err := writer.CreateFormFile("files", filename)
+	if err != nil {
 		return nil, &Response{Error: NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	if part, err := writer.CreateFormField("channel_id"); err != nil {
+	_, err = io.Copy(part, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, &Response{Error: NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
+	}
+
+	part, err = writer.CreateFormField("channel_id")
+	if err != nil {
 		return nil, &Response{Error: NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.channel_id.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, strings.NewReader(channelId)); err != nil {
+	}
+
+	if _, err := io.Copy(part, strings.NewReader(channelId)); err != nil {
 		return nil, &Response{Error: NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.channel_id.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
@@ -2309,242 +2330,242 @@ func (c *Client4) UploadFileAsRequestBody(data []byte, channelId string, filenam
 
 // GetFile gets the bytes for a file by id.
 func (c *Client4) GetFile(fileId string) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId), ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetFileRoute(fileId), "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
-// DownloadFile gets the bytes for a file by id, optionally adding headers to force the browser to download it
+// DownloadFile gets the bytes for a file by id, optionally adding headers to force the browser to download it.
 func (c *Client4) DownloadFile(fileId string, download bool) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("?download=%v", download), ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("DownloadFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("?download=%v", download), "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("DownloadFile", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
 // GetFileThumbnail gets the bytes for a file by id.
 func (c *Client4) GetFileThumbnail(fileId string) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/thumbnail", ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetFileRoute(fileId)+"/thumbnail", "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
 // DownloadFileThumbnail gets the bytes for a file by id, optionally adding headers to force the browser to download it.
 func (c *Client4) DownloadFileThumbnail(fileId string, download bool) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("/thumbnail?download=%v", download), ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("DownloadFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("/thumbnail?download=%v", download), "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("DownloadFileThumbnail", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
 // GetFileLink gets the public link of a file by id.
 func (c *Client4) GetFileLink(fileId string) (string, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/link", ""); err != nil {
+	r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/link", "")
+	if err != nil {
 		return "", BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		return MapFromJson(r.Body)["link"], BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body)["link"], BuildResponse(r)
 }
 
 // GetFilePreview gets the bytes for a file by id.
 func (c *Client4) GetFilePreview(fileId string) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/preview", ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetFileRoute(fileId)+"/preview", "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
 // DownloadFilePreview gets the bytes for a file by id.
 func (c *Client4) DownloadFilePreview(fileId string, download bool) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("/preview?download=%v", download), ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("DownloadFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetFileRoute(fileId)+fmt.Sprintf("/preview?download=%v", download), "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("DownloadFilePreview", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+	return data, BuildResponse(r)
 }
 
 // GetFileInfo gets all the file info objects.
 func (c *Client4) GetFileInfo(fileId string) (*FileInfo, *Response) {
-	if r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/info", ""); err != nil {
+	r, err := c.DoApiGet(c.GetFileRoute(fileId)+"/info", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return FileInfoFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return FileInfoFromJson(r.Body), BuildResponse(r)
 }
 
 // GetFileInfosForPost gets all the file info objects attached to a post.
 func (c *Client4) GetFileInfosForPost(postId string, etag string) ([]*FileInfo, *Response) {
-	if r, err := c.DoApiGet(c.GetPostRoute(postId)+"/files/info", etag); err != nil {
+	r, err := c.DoApiGet(c.GetPostRoute(postId)+"/files/info", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return FileInfosFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return FileInfosFromJson(r.Body), BuildResponse(r)
 }
 
 // General/System Section
 
 // GetPing will return ok if the running goRoutines are below the threshold and unhealthy for above.
 func (c *Client4) GetPing() (string, *Response) {
-	if r, err := c.DoApiGet(c.GetSystemRoute()+"/ping", ""); r != nil && r.StatusCode == 500 {
+	r, err := c.DoApiGet(c.GetSystemRoute()+"/ping", "")
+	if r != nil && r.StatusCode == 500 {
 		defer r.Body.Close()
 		return "unhealthy", BuildErrorResponse(r, err)
-	} else if err != nil {
-		return "", BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body)["status"], BuildResponse(r)
 	}
+	if err != nil {
+		return "", BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	return MapFromJson(r.Body)["status"], BuildResponse(r)
 }
 
 // TestEmail will attempt to connect to the configured SMTP server.
 func (c *Client4) TestEmail(config *Config) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetTestEmailRoute(), config.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetTestEmailRoute(), config.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // TestS3Connection will attempt to connect to the AWS S3.
 func (c *Client4) TestS3Connection(config *Config) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetTestS3Route(), config.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetTestS3Route(), config.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetConfig will retrieve the server config with some sanitized items.
 func (c *Client4) GetConfig() (*Config, *Response) {
-	if r, err := c.DoApiGet(c.GetConfigRoute(), ""); err != nil {
+	r, err := c.DoApiGet(c.GetConfigRoute(), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ConfigFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ConfigFromJson(r.Body), BuildResponse(r)
 }
 
 // ReloadConfig will reload the server configuration.
 func (c *Client4) ReloadConfig() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetConfigRoute()+"/reload", ""); err != nil {
+	r, err := c.DoApiPost(c.GetConfigRoute()+"/reload", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetOldClientConfig will retrieve the parts of the server configuration needed by the
 // client, formatted in the old format.
 func (c *Client4) GetOldClientConfig(etag string) (map[string]string, *Response) {
-	if r, err := c.DoApiGet(c.GetConfigRoute()+"/client?format=old", etag); err != nil {
+	r, err := c.DoApiGet(c.GetConfigRoute()+"/client?format=old", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body), BuildResponse(r)
 }
 
 // GetEnvironmentConfig will retrieve a map mirroring the server configuration where fields
 // are set to true if the corresponding config setting is set through an environment variable.
 // Settings that haven't been set through environment variables will be missing from the map.
 func (c *Client4) GetEnvironmentConfig() (map[string]interface{}, *Response) {
-	if r, err := c.DoApiGet(c.GetConfigRoute()+"/environment", ""); err != nil {
+	r, err := c.DoApiGet(c.GetConfigRoute()+"/environment", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return StringInterfaceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return StringInterfaceFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOldClientLicense will retrieve the parts of the server license needed by the
 // client, formatted in the old format.
 func (c *Client4) GetOldClientLicense(etag string) (map[string]string, *Response) {
-	if r, err := c.DoApiGet(c.GetLicenseRoute()+"/client?format=old", etag); err != nil {
+	r, err := c.DoApiGet(c.GetLicenseRoute()+"/client?format=old", etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body), BuildResponse(r)
 }
 
 // DatabaseRecycle will recycle the connections. Discard current connection and get new one.
 func (c *Client4) DatabaseRecycle() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetDatabaseRoute()+"/recycle", ""); err != nil {
+	r, err := c.DoApiPost(c.GetDatabaseRoute()+"/recycle", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // InvalidateCaches will purge the cache and can affect the performance while is cleaning.
 func (c *Client4) InvalidateCaches() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetCacheRoute()+"/invalidate", ""); err != nil {
+	r, err := c.DoApiPost(c.GetCacheRoute()+"/invalidate", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateConfig will update the server configuration.
 func (c *Client4) UpdateConfig(config *Config) (*Config, *Response) {
-	if r, err := c.DoApiPut(c.GetConfigRoute(), config.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetConfigRoute(), config.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ConfigFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ConfigFromJson(r.Body), BuildResponse(r)
 }
 
 // UploadLicenseFile will add a license file to the system.
@@ -2552,13 +2573,16 @@ func (c *Client4) UploadLicenseFile(data []byte) (bool, *Response) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("license", "test-license.mattermost-license"); err != nil {
-		return false, &Response{Error: NewAppError("UploadLicenseFile", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+	part, err := writer.CreateFormFile("license", "test-license.mattermost-license")
+	if err != nil {
 		return false, &Response{Error: NewAppError("UploadLicenseFile", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	if err := writer.Close(); err != nil {
+	if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+		return false, &Response{Error: NewAppError("UploadLicenseFile", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
+	}
+
+	if err = writer.Close(); err != nil {
 		return false, &Response{Error: NewAppError("UploadLicenseFile", "model.client.set_profile_user.writer.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
@@ -2569,28 +2593,28 @@ func (c *Client4) UploadLicenseFile(data []byte) (bool, *Response) {
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetLicenseRoute(), "model.client.connecting.app_error", nil, err.Error(), http.StatusForbidden)}
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return CheckStatusOK(rp), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return CheckStatusOK(rp), BuildResponse(rp)
 }
 
 // RemoveLicenseFile will remove the server license it exists. Note that this will
 // disable all enterprise features.
 func (c *Client4) RemoveLicenseFile() (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetLicenseRoute()); err != nil {
+	r, err := c.DoApiDelete(c.GetLicenseRoute())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetAnalyticsOld will retrieve analytics using the old format. New format is not
@@ -2599,238 +2623,241 @@ func (c *Client4) RemoveLicenseFile() (bool, *Response) {
 // to a specific team.
 func (c *Client4) GetAnalyticsOld(name, teamId string) (AnalyticsRows, *Response) {
 	query := fmt.Sprintf("?name=%v&team_id=%v", name, teamId)
-	if r, err := c.DoApiGet(c.GetAnalyticsRoute()+"/old"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetAnalyticsRoute()+"/old"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return AnalyticsRowsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return AnalyticsRowsFromJson(r.Body), BuildResponse(r)
 }
 
 // Webhooks Section
 
 // CreateIncomingWebhook creates an incoming webhook for a channel.
 func (c *Client4) CreateIncomingWebhook(hook *IncomingWebhook) (*IncomingWebhook, *Response) {
-	if r, err := c.DoApiPost(c.GetIncomingWebhooksRoute(), hook.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetIncomingWebhooksRoute(), hook.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return IncomingWebhookFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return IncomingWebhookFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateIncomingWebhook updates an incoming webhook for a channel.
 func (c *Client4) UpdateIncomingWebhook(hook *IncomingWebhook) (*IncomingWebhook, *Response) {
-	if r, err := c.DoApiPut(c.GetIncomingWebhookRoute(hook.Id), hook.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetIncomingWebhookRoute(hook.Id), hook.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return IncomingWebhookFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return IncomingWebhookFromJson(r.Body), BuildResponse(r)
 }
 
 // GetIncomingWebhooks returns a page of incoming webhooks on the system. Page counting starts at 0.
 func (c *Client4) GetIncomingWebhooks(page int, perPage int, etag string) ([]*IncomingWebhook, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetIncomingWebhooksRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetIncomingWebhooksRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return IncomingWebhookListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return IncomingWebhookListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetIncomingWebhooksForTeam returns a page of incoming webhooks for a team. Page counting starts at 0.
 func (c *Client4) GetIncomingWebhooksForTeam(teamId string, page int, perPage int, etag string) ([]*IncomingWebhook, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v&team_id=%v", page, perPage, teamId)
-	if r, err := c.DoApiGet(c.GetIncomingWebhooksRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetIncomingWebhooksRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return IncomingWebhookListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return IncomingWebhookListFromJson(r.Body), BuildResponse(r)
 }
 
-// GetIncomingWebhook returns an Incoming webhook given the hook ID
+// GetIncomingWebhook returns an Incoming webhook given the hook ID.
 func (c *Client4) GetIncomingWebhook(hookID string, etag string) (*IncomingWebhook, *Response) {
-	if r, err := c.DoApiGet(c.GetIncomingWebhookRoute(hookID), etag); err != nil {
+	r, err := c.DoApiGet(c.GetIncomingWebhookRoute(hookID), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return IncomingWebhookFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return IncomingWebhookFromJson(r.Body), BuildResponse(r)
 }
 
-// DeleteIncomingWebhook deletes and Incoming Webhook given the hook ID
+// DeleteIncomingWebhook deletes and Incoming Webhook given the hook ID.
 func (c *Client4) DeleteIncomingWebhook(hookID string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetIncomingWebhookRoute(hookID)); err != nil {
+	r, err := c.DoApiDelete(c.GetIncomingWebhookRoute(hookID))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // CreateOutgoingWebhook creates an outgoing webhook for a team or channel.
 func (c *Client4) CreateOutgoingWebhook(hook *OutgoingWebhook) (*OutgoingWebhook, *Response) {
-	if r, err := c.DoApiPost(c.GetOutgoingWebhooksRoute(), hook.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetOutgoingWebhooksRoute(), hook.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateOutgoingWebhook creates an outgoing webhook for a team or channel.
 func (c *Client4) UpdateOutgoingWebhook(hook *OutgoingWebhook) (*OutgoingWebhook, *Response) {
-	if r, err := c.DoApiPut(c.GetOutgoingWebhookRoute(hook.Id), hook.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetOutgoingWebhookRoute(hook.Id), hook.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOutgoingWebhooks returns a page of outgoing webhooks on the system. Page counting starts at 0.
 func (c *Client4) GetOutgoingWebhooks(page int, perPage int, etag string) ([]*OutgoingWebhook, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetOutgoingWebhooksRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetOutgoingWebhooksRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OutgoingWebhookListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OutgoingWebhookListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOutgoingWebhook outgoing webhooks on the system requested by Hook Id.
 func (c *Client4) GetOutgoingWebhook(hookId string) (*OutgoingWebhook, *Response) {
-	if r, err := c.DoApiGet(c.GetOutgoingWebhookRoute(hookId), ""); err != nil {
+	r, err := c.DoApiGet(c.GetOutgoingWebhookRoute(hookId), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOutgoingWebhooksForChannel returns a page of outgoing webhooks for a channel. Page counting starts at 0.
 func (c *Client4) GetOutgoingWebhooksForChannel(channelId string, page int, perPage int, etag string) ([]*OutgoingWebhook, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v&channel_id=%v", page, perPage, channelId)
-	if r, err := c.DoApiGet(c.GetOutgoingWebhooksRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetOutgoingWebhooksRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OutgoingWebhookListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OutgoingWebhookListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOutgoingWebhooksForTeam returns a page of outgoing webhooks for a team. Page counting starts at 0.
 func (c *Client4) GetOutgoingWebhooksForTeam(teamId string, page int, perPage int, etag string) ([]*OutgoingWebhook, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v&team_id=%v", page, perPage, teamId)
-	if r, err := c.DoApiGet(c.GetOutgoingWebhooksRoute()+query, etag); err != nil {
+	r, err := c.DoApiGet(c.GetOutgoingWebhooksRoute()+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OutgoingWebhookListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OutgoingWebhookListFromJson(r.Body), BuildResponse(r)
 }
 
 // RegenOutgoingHookToken regenerate the outgoing webhook token.
 func (c *Client4) RegenOutgoingHookToken(hookId string) (*OutgoingWebhook, *Response) {
-	if r, err := c.DoApiPost(c.GetOutgoingWebhookRoute(hookId)+"/regen_token", ""); err != nil {
+	r, err := c.DoApiPost(c.GetOutgoingWebhookRoute(hookId)+"/regen_token", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OutgoingWebhookFromJson(r.Body), BuildResponse(r)
 }
 
 // DeleteOutgoingWebhook delete the outgoing webhook on the system requested by Hook Id.
 func (c *Client4) DeleteOutgoingWebhook(hookId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetOutgoingWebhookRoute(hookId)); err != nil {
+	r, err := c.DoApiDelete(c.GetOutgoingWebhookRoute(hookId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // Preferences Section
 
 // GetPreferences returns the user's preferences.
 func (c *Client4) GetPreferences(userId string) (Preferences, *Response) {
-	if r, err := c.DoApiGet(c.GetPreferencesRoute(userId), ""); err != nil {
+	r, err := c.DoApiGet(c.GetPreferencesRoute(userId), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		preferences, _ := PreferencesFromJson(r.Body)
-		defer closeBody(r)
-		return preferences, BuildResponse(r)
 	}
+	defer closeBody(r)
+	preferences, _ := PreferencesFromJson(r.Body)
+	return preferences, BuildResponse(r)
 }
 
 // UpdatePreferences saves the user's preferences.
 func (c *Client4) UpdatePreferences(userId string, preferences *Preferences) (bool, *Response) {
-	if r, err := c.DoApiPut(c.GetPreferencesRoute(userId), preferences.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetPreferencesRoute(userId), preferences.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return true, BuildResponse(r)
 	}
+	defer closeBody(r)
+	return true, BuildResponse(r)
 }
 
 // DeletePreferences deletes the user's preferences.
 func (c *Client4) DeletePreferences(userId string, preferences *Preferences) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetPreferencesRoute(userId)+"/delete", preferences.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetPreferencesRoute(userId)+"/delete", preferences.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return true, BuildResponse(r)
 	}
+	defer closeBody(r)
+	return true, BuildResponse(r)
 }
 
 // GetPreferencesByCategory returns the user's preferences from the provided category string.
 func (c *Client4) GetPreferencesByCategory(userId string, category string) (Preferences, *Response) {
 	url := fmt.Sprintf(c.GetPreferencesRoute(userId)+"/%s", category)
-	if r, err := c.DoApiGet(url, ""); err != nil {
+	r, err := c.DoApiGet(url, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		preferences, _ := PreferencesFromJson(r.Body)
-		defer closeBody(r)
-		return preferences, BuildResponse(r)
 	}
+	defer closeBody(r)
+	preferences, _ := PreferencesFromJson(r.Body)
+	return preferences, BuildResponse(r)
 }
 
 // GetPreferenceByCategoryAndName returns the user's preferences from the provided category and preference name string.
 func (c *Client4) GetPreferenceByCategoryAndName(userId string, category string, preferenceName string) (*Preference, *Response) {
 	url := fmt.Sprintf(c.GetPreferencesRoute(userId)+"/%s/name/%v", category, preferenceName)
-	if r, err := c.DoApiGet(url, ""); err != nil {
+	r, err := c.DoApiGet(url, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PreferenceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PreferenceFromJson(r.Body), BuildResponse(r)
 }
 
 // SAML Section
 
 // GetSamlMetadata returns metadata for the SAML configuration.
 func (c *Client4) GetSamlMetadata() (string, *Response) {
-	if r, err := c.DoApiGet(c.GetSamlRoute()+"/metadata", ""); err != nil {
+	r, err := c.DoApiGet(c.GetSamlRoute()+"/metadata", "")
+	if err != nil {
 		return "", BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		buf := new(bytes.Buffer)
-		buf.ReadFrom(r.Body)
-		return buf.String(), BuildResponse(r)
 	}
+	defer closeBody(r)
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(r.Body)
+	return buf.String(), BuildResponse(r)
 }
 
 func samlFileToMultipart(data []byte, filename string) ([]byte, *multipart.Writer, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("certificate", filename); err != nil {
+	part, err := writer.CreateFormFile("certificate", filename)
+	if err != nil {
 		return nil, nil, err
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+	}
+
+	if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
 		return nil, nil, err
 	}
 
@@ -2876,134 +2903,136 @@ func (c *Client4) UploadSamlPrivateCertificate(data []byte, filename string) (bo
 
 // DeleteSamlIdpCertificate deletes the SAML IDP certificate from the server and updates the config to not use it and disable SAML.
 func (c *Client4) DeleteSamlIdpCertificate() (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetSamlRoute() + "/certificate/idp"); err != nil {
+	r, err := c.DoApiDelete(c.GetSamlRoute() + "/certificate/idp")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // DeleteSamlPublicCertificate deletes the SAML IDP certificate from the server and updates the config to not use it and disable SAML.
 func (c *Client4) DeleteSamlPublicCertificate() (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetSamlRoute() + "/certificate/public"); err != nil {
+	r, err := c.DoApiDelete(c.GetSamlRoute() + "/certificate/public")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // DeleteSamlPrivateCertificate deletes the SAML IDP certificate from the server and updates the config to not use it and disable SAML.
 func (c *Client4) DeleteSamlPrivateCertificate() (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetSamlRoute() + "/certificate/private"); err != nil {
+	r, err := c.DoApiDelete(c.GetSamlRoute() + "/certificate/private")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetSamlCertificateStatus returns metadata for the SAML configuration.
 func (c *Client4) GetSamlCertificateStatus() (*SamlCertificateStatus, *Response) {
-	if r, err := c.DoApiGet(c.GetSamlRoute()+"/certificate/status", ""); err != nil {
+	r, err := c.DoApiGet(c.GetSamlRoute()+"/certificate/status", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return SamlCertificateStatusFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return SamlCertificateStatusFromJson(r.Body), BuildResponse(r)
 }
 
 // Compliance Section
 
 // CreateComplianceReport creates an incoming webhook for a channel.
 func (c *Client4) CreateComplianceReport(report *Compliance) (*Compliance, *Response) {
-	if r, err := c.DoApiPost(c.GetComplianceReportsRoute(), report.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetComplianceReportsRoute(), report.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ComplianceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ComplianceFromJson(r.Body), BuildResponse(r)
 }
 
 // GetComplianceReports returns list of compliance reports.
 func (c *Client4) GetComplianceReports(page, perPage int) (Compliances, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetComplianceReportsRoute()+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetComplianceReportsRoute()+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CompliancesFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CompliancesFromJson(r.Body), BuildResponse(r)
 }
 
 // GetComplianceReport returns a compliance report.
 func (c *Client4) GetComplianceReport(reportId string) (*Compliance, *Response) {
-	if r, err := c.DoApiGet(c.GetComplianceReportRoute(reportId), ""); err != nil {
+	r, err := c.DoApiGet(c.GetComplianceReportRoute(reportId), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ComplianceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ComplianceFromJson(r.Body), BuildResponse(r)
 }
 
 // DownloadComplianceReport returns a full compliance report as a file.
 func (c *Client4) DownloadComplianceReport(reportId string) ([]byte, *Response) {
-	var rq *http.Request
-	rq, _ = http.NewRequest("GET", c.ApiUrl+c.GetComplianceReportRoute(reportId), nil)
+	rq, _ := http.NewRequest("GET", c.ApiUrl+c.GetComplianceReportRoute(reportId), nil)
 
 	if len(c.AuthToken) > 0 {
 		rq.Header.Set(HEADER_AUTH, "BEARER "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return nil, &Response{Error: NewAppError("DownloadComplianceReport", "model.client.connecting.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else if data, err := ioutil.ReadAll(rp.Body); err != nil {
-			return nil, BuildErrorResponse(rp, NewAppError("DownloadComplianceReport", "model.client.read_file.app_error", nil, err.Error(), rp.StatusCode))
-		} else {
-			return data, BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	data, err := ioutil.ReadAll(rp.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(rp, NewAppError("DownloadComplianceReport", "model.client.read_file.app_error", nil, err.Error(), rp.StatusCode))
+	}
+
+	return data, BuildResponse(rp)
 }
 
 // Cluster Section
 
 // GetClusterStatus returns the status of all the configured cluster nodes.
 func (c *Client4) GetClusterStatus() ([]*ClusterInfo, *Response) {
-	if r, err := c.DoApiGet(c.GetClusterRoute()+"/status", ""); err != nil {
+	r, err := c.DoApiGet(c.GetClusterRoute()+"/status", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ClusterInfosFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ClusterInfosFromJson(r.Body), BuildResponse(r)
 }
 
 // LDAP Section
 
 // SyncLdap will force a sync with the configured LDAP server.
 func (c *Client4) SyncLdap() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetLdapRoute()+"/sync", ""); err != nil {
+	r, err := c.DoApiPost(c.GetLdapRoute()+"/sync", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // TestLdap will attempt to connect to the configured LDAP server and return OK if configured
 // correctly.
 func (c *Client4) TestLdap() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetLdapRoute()+"/test", ""); err != nil {
+	r, err := c.DoApiPost(c.GetLdapRoute()+"/test", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // Audits Section
@@ -3011,40 +3040,41 @@ func (c *Client4) TestLdap() (bool, *Response) {
 // GetAudits returns a list of audits for the whole system.
 func (c *Client4) GetAudits(page int, perPage int, etag string) (Audits, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet("/audits"+query, etag); err != nil {
+	r, err := c.DoApiGet("/audits"+query, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return AuditsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return AuditsFromJson(r.Body), BuildResponse(r)
 }
 
 // Brand Section
 
 // GetBrandImage retrieves the previously uploaded brand image.
 func (c *Client4) GetBrandImage() ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetBrandRoute()+"/image", ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if r.StatusCode >= 300 {
-			return nil, BuildErrorResponse(r, AppErrorFromJson(r.Body))
-		} else if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetBrandImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, appErr := c.DoApiGet(c.GetBrandRoute()+"/image", "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
 	}
+	defer closeBody(r)
+
+	if r.StatusCode >= 300 {
+		return nil, BuildErrorResponse(r, AppErrorFromJson(r.Body))
+	}
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetBrandImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+
+	return data, BuildResponse(r)
 }
 
 func (c *Client4) DeleteBrandImage() *Response {
 	r, err := c.DoApiDelete(c.GetBrandRoute() + "/image")
-
 	if err != nil {
 		return BuildErrorResponse(r, err)
 	}
-
 	return BuildResponse(r)
 }
 
@@ -3053,13 +3083,16 @@ func (c *Client4) UploadBrandImage(data []byte) (bool, *Response) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("image", "brand.png"); err != nil {
-		return false, &Response{Error: NewAppError("UploadBrandImage", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+	part, err := writer.CreateFormFile("image", "brand.png")
+	if err != nil {
 		return false, &Response{Error: NewAppError("UploadBrandImage", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	if err := writer.Close(); err != nil {
+	if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
+		return false, &Response{Error: NewAppError("UploadBrandImage", "model.client.set_profile_user.no_file.app_error", nil, err.Error(), http.StatusBadRequest)}
+	}
+
+	if err = writer.Close(); err != nil {
 		return false, &Response{Error: NewAppError("UploadBrandImage", "model.client.set_profile_user.writer.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
@@ -3070,17 +3103,17 @@ func (c *Client4) UploadBrandImage(data []byte) (bool, *Response) {
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return false, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.GetBrandRoute()+"/image", "model.client.connecting.app_error", nil, err.Error(), http.StatusForbidden)}
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return CheckStatusOK(rp), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return false, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return CheckStatusOK(rp), BuildResponse(rp)
 }
 
 // Logs Section
@@ -3088,129 +3121,129 @@ func (c *Client4) UploadBrandImage(data []byte) (bool, *Response) {
 // GetLogs page of logs as a string array.
 func (c *Client4) GetLogs(page, perPage int) ([]string, *Response) {
 	query := fmt.Sprintf("?page=%v&logs_per_page=%v", page, perPage)
-	if r, err := c.DoApiGet("/logs"+query, ""); err != nil {
+	r, err := c.DoApiGet("/logs"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ArrayFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ArrayFromJson(r.Body), BuildResponse(r)
 }
 
 // PostLog is a convenience Web Service call so clients can log messages into
-// the server-side logs.  For example we typically log javascript error messages
-// into the server-side.  It returns the log message if the logging was successful.
+// the server-side logs. For example we typically log javascript error messages
+// into the server-side. It returns the log message if the logging was successful.
 func (c *Client4) PostLog(message map[string]string) (map[string]string, *Response) {
-	if r, err := c.DoApiPost("/logs", MapToJson(message)); err != nil {
+	r, err := c.DoApiPost("/logs", MapToJson(message))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body), BuildResponse(r)
 }
 
 // OAuth Section
 
 // CreateOAuthApp will register a new OAuth 2.0 client application with Mattermost acting as an OAuth 2.0 service provider.
 func (c *Client4) CreateOAuthApp(app *OAuthApp) (*OAuthApp, *Response) {
-	if r, err := c.DoApiPost(c.GetOAuthAppsRoute(), app.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetOAuthAppsRoute(), app.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OAuthAppFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OAuthAppFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateOAuthApp
 func (c *Client4) UpdateOAuthApp(app *OAuthApp) (*OAuthApp, *Response) {
-	if r, err := c.DoApiPut(c.GetOAuthAppRoute(app.Id), app.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetOAuthAppRoute(app.Id), app.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OAuthAppFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OAuthAppFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOAuthApps gets a page of registered OAuth 2.0 client applications with Mattermost acting as an OAuth 2.0 service provider.
 func (c *Client4) GetOAuthApps(page, perPage int) ([]*OAuthApp, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetOAuthAppsRoute()+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetOAuthAppsRoute()+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OAuthAppListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OAuthAppListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOAuthApp gets a registered OAuth 2.0 client application with Mattermost acting as an OAuth 2.0 service provider.
 func (c *Client4) GetOAuthApp(appId string) (*OAuthApp, *Response) {
-	if r, err := c.DoApiGet(c.GetOAuthAppRoute(appId), ""); err != nil {
+	r, err := c.DoApiGet(c.GetOAuthAppRoute(appId), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OAuthAppFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OAuthAppFromJson(r.Body), BuildResponse(r)
 }
 
 // GetOAuthAppInfo gets a sanitized version of a registered OAuth 2.0 client application with Mattermost acting as an OAuth 2.0 service provider.
 func (c *Client4) GetOAuthAppInfo(appId string) (*OAuthApp, *Response) {
-	if r, err := c.DoApiGet(c.GetOAuthAppRoute(appId)+"/info", ""); err != nil {
+	r, err := c.DoApiGet(c.GetOAuthAppRoute(appId)+"/info", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OAuthAppFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OAuthAppFromJson(r.Body), BuildResponse(r)
 }
 
 // DeleteOAuthApp deletes a registered OAuth 2.0 client application.
 func (c *Client4) DeleteOAuthApp(appId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetOAuthAppRoute(appId)); err != nil {
+	r, err := c.DoApiDelete(c.GetOAuthAppRoute(appId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // RegenerateOAuthAppSecret regenerates the client secret for a registered OAuth 2.0 client application.
 func (c *Client4) RegenerateOAuthAppSecret(appId string) (*OAuthApp, *Response) {
-	if r, err := c.DoApiPost(c.GetOAuthAppRoute(appId)+"/regen_secret", ""); err != nil {
+	r, err := c.DoApiPost(c.GetOAuthAppRoute(appId)+"/regen_secret", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OAuthAppFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OAuthAppFromJson(r.Body), BuildResponse(r)
 }
 
 // GetAuthorizedOAuthAppsForUser gets a page of OAuth 2.0 client applications the user has authorized to use access their account.
 func (c *Client4) GetAuthorizedOAuthAppsForUser(userId string, page, perPage int) ([]*OAuthApp, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetUserRoute(userId)+"/oauth/apps/authorized"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/oauth/apps/authorized"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return OAuthAppListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return OAuthAppListFromJson(r.Body), BuildResponse(r)
 }
 
 // AuthorizeOAuthApp will authorize an OAuth 2.0 client application to access a user's account and provide a redirect link to follow.
 func (c *Client4) AuthorizeOAuthApp(authRequest *AuthorizeRequest) (string, *Response) {
-	if r, err := c.DoApiRequest(http.MethodPost, c.Url+"/oauth/authorize", authRequest.ToJson(), ""); err != nil {
+	r, err := c.DoApiRequest(http.MethodPost, c.Url+"/oauth/authorize", authRequest.ToJson(), "")
+	if err != nil {
 		return "", BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body)["redirect"], BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body)["redirect"], BuildResponse(r)
 }
 
 // DeauthorizeOAuthApp will deauthorize an OAuth 2.0 client application from accessing a user's account.
 func (c *Client4) DeauthorizeOAuthApp(appId string) (bool, *Response) {
 	requestData := map[string]string{"client_id": appId}
-	if r, err := c.DoApiRequest(http.MethodPost, c.Url+"/oauth/deauthorize", MapToJson(requestData), ""); err != nil {
+	r, err := c.DoApiRequest(http.MethodPost, c.Url+"/oauth/deauthorize", MapToJson(requestData), "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetOAuthAccessToken is a test helper function for the OAuth access token endpoint.
@@ -3222,94 +3255,95 @@ func (c *Client4) GetOAuthAccessToken(data url.Values) (*AccessResponse, *Respon
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewAppError(c.Url+"/oauth/access_token", "model.client.connecting.app_error", nil, err.Error(), 403)}
-	} else {
-		defer closeBody(rp)
-		if rp.StatusCode >= 300 {
-			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return AccessResponseFromJson(rp.Body), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return AccessResponseFromJson(rp.Body), BuildResponse(rp)
 }
 
 // Elasticsearch Section
 
-// TestElasticsearch will attempt to connect to the configured Elasticsearch server and return OK if configured
+// TestElasticsearch will attempt to connect to the configured Elasticsearch server and return OK if configured.
 // correctly.
 func (c *Client4) TestElasticsearch() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/test", ""); err != nil {
+	r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/test", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // PurgeElasticsearchIndexes immediately deletes all Elasticsearch indexes.
 func (c *Client4) PurgeElasticsearchIndexes() (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/purge_indexes", ""); err != nil {
+	r, err := c.DoApiPost(c.GetElasticsearchRoute()+"/purge_indexes", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // Data Retention Section
 
 // GetDataRetentionPolicy will get the current server data retention policy details.
 func (c *Client4) GetDataRetentionPolicy() (*DataRetentionPolicy, *Response) {
-	if r, err := c.DoApiGet(c.GetDataRetentionRoute()+"/policy", ""); err != nil {
+	r, err := c.DoApiGet(c.GetDataRetentionRoute()+"/policy", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return DataRetentionPolicyFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return DataRetentionPolicyFromJson(r.Body), BuildResponse(r)
 }
 
 // Commands Section
 
 // CreateCommand will create a new command if the user have the right permissions.
 func (c *Client4) CreateCommand(cmd *Command) (*Command, *Response) {
-	if r, err := c.DoApiPost(c.GetCommandsRoute(), cmd.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetCommandsRoute(), cmd.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CommandFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CommandFromJson(r.Body), BuildResponse(r)
 }
 
-// UpdateCommand updates a command based on the provided Command struct
+// UpdateCommand updates a command based on the provided Command struct.
 func (c *Client4) UpdateCommand(cmd *Command) (*Command, *Response) {
-	if r, err := c.DoApiPut(c.GetCommandRoute(cmd.Id), cmd.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetCommandRoute(cmd.Id), cmd.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CommandFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CommandFromJson(r.Body), BuildResponse(r)
 }
 
-// DeleteCommand deletes a command based on the provided command id string
+// DeleteCommand deletes a command based on the provided command id string.
 func (c *Client4) DeleteCommand(commandId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetCommandRoute(commandId)); err != nil {
+	r, err := c.DoApiDelete(c.GetCommandRoute(commandId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // ListCommands will retrieve a list of commands available in the team.
 func (c *Client4) ListCommands(teamId string, customOnly bool) ([]*Command, *Response) {
 	query := fmt.Sprintf("?team_id=%v&custom_only=%v", teamId, customOnly)
-	if r, err := c.DoApiGet(c.GetCommandsRoute()+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetCommandsRoute()+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CommandListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CommandListFromJson(r.Body), BuildResponse(r)
 }
 
 // ExecuteCommand executes a given slash command.
@@ -3318,85 +3352,84 @@ func (c *Client4) ExecuteCommand(channelId, command string) (*CommandResponse, *
 		ChannelId: channelId,
 		Command:   command,
 	}
-	if r, err := c.DoApiPost(c.GetCommandsRoute()+"/execute", commandArgs.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetCommandsRoute()+"/execute", commandArgs.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		response, _ := CommandResponseFromJson(r.Body)
-		return response, BuildResponse(r)
 	}
+	defer closeBody(r)
+
+	response, _ := CommandResponseFromJson(r.Body)
+	return response, BuildResponse(r)
 }
 
-// ExecuteCommand executes a given slash command against the specified team
-// Use this when executing slash commands in a DM/GM, since the team id cannot be inferred in that case
+// ExecuteCommandWithTeam executes a given slash command against the specified team.
+// Use this when executing slash commands in a DM/GM, since the team id cannot be inferred in that case.
 func (c *Client4) ExecuteCommandWithTeam(channelId, teamId, command string) (*CommandResponse, *Response) {
 	commandArgs := &CommandArgs{
 		ChannelId: channelId,
 		TeamId:    teamId,
 		Command:   command,
 	}
-	if r, err := c.DoApiPost(c.GetCommandsRoute()+"/execute", commandArgs.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetCommandsRoute()+"/execute", commandArgs.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		response, _ := CommandResponseFromJson(r.Body)
-		return response, BuildResponse(r)
 	}
+	defer closeBody(r)
+
+	response, _ := CommandResponseFromJson(r.Body)
+	return response, BuildResponse(r)
 }
 
-// ListCommands will retrieve a list of commands available in the team.
+// ListAutocompleteCommands will retrieve a list of commands available in the team.
 func (c *Client4) ListAutocompleteCommands(teamId string) ([]*Command, *Response) {
-	if r, err := c.DoApiGet(c.GetTeamAutoCompleteCommandsRoute(teamId), ""); err != nil {
+	r, err := c.DoApiGet(c.GetTeamAutoCompleteCommandsRoute(teamId), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CommandListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CommandListFromJson(r.Body), BuildResponse(r)
 }
 
 // RegenCommandToken will create a new token if the user have the right permissions.
 func (c *Client4) RegenCommandToken(commandId string) (string, *Response) {
-	if r, err := c.DoApiPut(c.GetCommandRoute(commandId)+"/regen_token", ""); err != nil {
+	r, err := c.DoApiPut(c.GetCommandRoute(commandId)+"/regen_token", "")
+	if err != nil {
 		return "", BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body)["token"], BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body)["token"], BuildResponse(r)
 }
 
 // Status Section
 
 // GetUserStatus returns a user based on the provided user id string.
 func (c *Client4) GetUserStatus(userId, etag string) (*Status, *Response) {
-	if r, err := c.DoApiGet(c.GetUserStatusRoute(userId), etag); err != nil {
+	r, err := c.DoApiGet(c.GetUserStatusRoute(userId), etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return StatusFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return StatusFromJson(r.Body), BuildResponse(r)
 }
 
 // GetUsersStatusesByIds returns a list of users status based on the provided user ids.
 func (c *Client4) GetUsersStatusesByIds(userIds []string) ([]*Status, *Response) {
-	if r, err := c.DoApiPost(c.GetUserStatusesRoute()+"/ids", ArrayToJson(userIds)); err != nil {
+	r, err := c.DoApiPost(c.GetUserStatusesRoute()+"/ids", ArrayToJson(userIds))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return StatusListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return StatusListFromJson(r.Body), BuildResponse(r)
 }
 
 // UpdateUserStatus sets a user's status based on the provided user id string.
 func (c *Client4) UpdateUserStatus(userId string, userStatus *Status) (*Status, *Response) {
-	if r, err := c.DoApiPut(c.GetUserStatusRoute(userId), userStatus.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetUserStatusRoute(userId), userStatus.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return StatusFromJson(r.Body), BuildResponse(r)
-
 	}
+	defer closeBody(r)
+	return StatusFromJson(r.Body), BuildResponse(r)
 }
 
 // Emoji Section
@@ -3408,9 +3441,12 @@ func (c *Client4) CreateEmoji(emoji *Emoji, image []byte, filename string) (*Emo
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("image", filename); err != nil {
+	part, err := writer.CreateFormFile("image", filename)
+	if err != nil {
 		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error(), 0)}
-	} else if _, err = io.Copy(part, bytes.NewBuffer(image)); err != nil {
+	}
+
+	if _, err := io.Copy(part, bytes.NewBuffer(image)); err != nil {
 		return nil, &Response{StatusCode: http.StatusForbidden, Error: NewAppError("CreateEmoji", "model.client.create_emoji.image.app_error", nil, err.Error(), 0)}
 	}
 
@@ -3428,315 +3464,316 @@ func (c *Client4) CreateEmoji(emoji *Emoji, image []byte, filename string) (*Emo
 // GetEmojiList returns a page of custom emoji on the system.
 func (c *Client4) GetEmojiList(page, perPage int) ([]*Emoji, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
-	if r, err := c.DoApiGet(c.GetEmojisRoute()+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetEmojisRoute()+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return EmojiListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return EmojiListFromJson(r.Body), BuildResponse(r)
 }
 
 // GetSortedEmojiList returns a page of custom emoji on the system sorted based on the sort
 // parameter, blank for no sorting and "name" to sort by emoji names.
 func (c *Client4) GetSortedEmojiList(page, perPage int, sort string) ([]*Emoji, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v&sort=%v", page, perPage, sort)
-	if r, err := c.DoApiGet(c.GetEmojisRoute()+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetEmojisRoute()+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return EmojiListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return EmojiListFromJson(r.Body), BuildResponse(r)
 }
 
 // DeleteEmoji delete an custom emoji on the provided emoji id string.
 func (c *Client4) DeleteEmoji(emojiId string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetEmojiRoute(emojiId)); err != nil {
+	r, err := c.DoApiDelete(c.GetEmojiRoute(emojiId))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetEmoji returns a custom emoji based on the emojiId string.
 func (c *Client4) GetEmoji(emojiId string) (*Emoji, *Response) {
-	if r, err := c.DoApiGet(c.GetEmojiRoute(emojiId), ""); err != nil {
+	r, err := c.DoApiGet(c.GetEmojiRoute(emojiId), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return EmojiFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return EmojiFromJson(r.Body), BuildResponse(r)
 }
 
 // GetEmojiByName returns a custom emoji based on the name string.
 func (c *Client4) GetEmojiByName(name string) (*Emoji, *Response) {
-	if r, err := c.DoApiGet(c.GetEmojiByNameRoute(name), ""); err != nil {
+	r, err := c.DoApiGet(c.GetEmojiByNameRoute(name), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return EmojiFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return EmojiFromJson(r.Body), BuildResponse(r)
 }
 
 // GetEmojiImage returns the emoji image.
 func (c *Client4) GetEmojiImage(emojiId string) ([]byte, *Response) {
-	if r, err := c.DoApiGet(c.GetEmojiRoute(emojiId)+"/image", ""); err != nil {
-		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-
-		if data, err := ioutil.ReadAll(r.Body); err != nil {
-			return nil, BuildErrorResponse(r, NewAppError("GetEmojiImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
-		} else {
-			return data, BuildResponse(r)
-		}
+	r, apErr := c.DoApiGet(c.GetEmojiRoute(emojiId)+"/image", "")
+	if apErr != nil {
+		return nil, BuildErrorResponse(r, apErr)
 	}
+	defer closeBody(r)
+
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, BuildErrorResponse(r, NewAppError("GetEmojiImage", "model.client.read_file.app_error", nil, err.Error(), r.StatusCode))
+	}
+
+	return data, BuildResponse(r)
 }
 
 // SearchEmoji returns a list of emoji matching some search criteria.
 func (c *Client4) SearchEmoji(search *EmojiSearch) ([]*Emoji, *Response) {
-	if r, err := c.DoApiPost(c.GetEmojisRoute()+"/search", search.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetEmojisRoute()+"/search", search.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return EmojiListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return EmojiListFromJson(r.Body), BuildResponse(r)
 }
 
 // AutocompleteEmoji returns a list of emoji starting with or matching name.
 func (c *Client4) AutocompleteEmoji(name string, etag string) ([]*Emoji, *Response) {
 	query := fmt.Sprintf("?name=%v", name)
-	if r, err := c.DoApiGet(c.GetEmojisRoute()+"/autocomplete"+query, ""); err != nil {
+	r, err := c.DoApiGet(c.GetEmojisRoute()+"/autocomplete"+query, "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return EmojiListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return EmojiListFromJson(r.Body), BuildResponse(r)
 }
 
 // Reaction Section
 
 // SaveReaction saves an emoji reaction for a post. Returns the saved reaction if successful, otherwise an error will be returned.
 func (c *Client4) SaveReaction(reaction *Reaction) (*Reaction, *Response) {
-	if r, err := c.DoApiPost(c.GetReactionsRoute(), reaction.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetReactionsRoute(), reaction.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ReactionFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ReactionFromJson(r.Body), BuildResponse(r)
 }
 
 // GetReactions returns a list of reactions to a post.
 func (c *Client4) GetReactions(postId string) ([]*Reaction, *Response) {
-	if r, err := c.DoApiGet(c.GetPostRoute(postId)+"/reactions", ""); err != nil {
+	r, err := c.DoApiGet(c.GetPostRoute(postId)+"/reactions", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ReactionsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ReactionsFromJson(r.Body), BuildResponse(r)
 }
 
 // DeleteReaction deletes reaction of a user in a post.
 func (c *Client4) DeleteReaction(reaction *Reaction) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetUserRoute(reaction.UserId) + c.GetPostRoute(reaction.PostId) + fmt.Sprintf("/reactions/%v", reaction.EmojiName)); err != nil {
+	r, err := c.DoApiDelete(c.GetUserRoute(reaction.UserId) + c.GetPostRoute(reaction.PostId) + fmt.Sprintf("/reactions/%v", reaction.EmojiName))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // Timezone Section
 
 // GetSupportedTimezone returns a page of supported timezones on the system.
 func (c *Client4) GetSupportedTimezone() (SupportedTimezones, *Response) {
-	if r, err := c.DoApiGet(c.GetTimezonesRoute(), ""); err != nil {
+	r, err := c.DoApiGet(c.GetTimezonesRoute(), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TimezonesFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TimezonesFromJson(r.Body), BuildResponse(r)
 }
 
 // Open Graph Metadata Section
 
-// OpenGraph return the open graph metadata for a particular url if the site have the metadata
+// OpenGraph return the open graph metadata for a particular url if the site have the metadata.
 func (c *Client4) OpenGraph(url string) (map[string]string, *Response) {
 	requestBody := make(map[string]string)
 	requestBody["url"] = url
 
-	if r, err := c.DoApiPost(c.GetOpenGraphRoute(), MapToJson(requestBody)); err != nil {
+	r, err := c.DoApiPost(c.GetOpenGraphRoute(), MapToJson(requestBody))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body), BuildResponse(r)
 }
 
 // Jobs Section
 
 // GetJob gets a single job.
 func (c *Client4) GetJob(id string) (*Job, *Response) {
-	if r, err := c.DoApiGet(c.GetJobsRoute()+fmt.Sprintf("/%v", id), ""); err != nil {
+	r, err := c.DoApiGet(c.GetJobsRoute()+fmt.Sprintf("/%v", id), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return JobFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return JobFromJson(r.Body), BuildResponse(r)
 }
 
-// Get all jobs, sorted with the job that was created most recently first.
+// GetJobs gets all jobs, sorted with the job that was created most recently first.
 func (c *Client4) GetJobs(page int, perPage int) ([]*Job, *Response) {
-	if r, err := c.DoApiGet(c.GetJobsRoute()+fmt.Sprintf("?page=%v&per_page=%v", page, perPage), ""); err != nil {
+	r, err := c.DoApiGet(c.GetJobsRoute()+fmt.Sprintf("?page=%v&per_page=%v", page, perPage), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return JobsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return JobsFromJson(r.Body), BuildResponse(r)
 }
 
 // GetJobsByType gets all jobs of a given type, sorted with the job that was created most recently first.
 func (c *Client4) GetJobsByType(jobType string, page int, perPage int) ([]*Job, *Response) {
-	if r, err := c.DoApiGet(c.GetJobsRoute()+fmt.Sprintf("/type/%v?page=%v&per_page=%v", jobType, page, perPage), ""); err != nil {
+	r, err := c.DoApiGet(c.GetJobsRoute()+fmt.Sprintf("/type/%v?page=%v&per_page=%v", jobType, page, perPage), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return JobsFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return JobsFromJson(r.Body), BuildResponse(r)
 }
 
 // CreateJob creates a job based on the provided job struct.
 func (c *Client4) CreateJob(job *Job) (*Job, *Response) {
-	if r, err := c.DoApiPost(c.GetJobsRoute(), job.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetJobsRoute(), job.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return JobFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return JobFromJson(r.Body), BuildResponse(r)
 }
 
 // CancelJob requests the cancellation of the job with the provided Id.
 func (c *Client4) CancelJob(jobId string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetJobsRoute()+fmt.Sprintf("/%v/cancel", jobId), ""); err != nil {
+	r, err := c.DoApiPost(c.GetJobsRoute()+fmt.Sprintf("/%v/cancel", jobId), "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // Roles Section
 
 // GetRole gets a single role by ID.
 func (c *Client4) GetRole(id string) (*Role, *Response) {
-	if r, err := c.DoApiGet(c.GetRolesRoute()+fmt.Sprintf("/%v", id), ""); err != nil {
+	r, err := c.DoApiGet(c.GetRolesRoute()+fmt.Sprintf("/%v", id), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return RoleFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return RoleFromJson(r.Body), BuildResponse(r)
 }
 
 // GetRoleByName gets a single role by Name.
 func (c *Client4) GetRoleByName(name string) (*Role, *Response) {
-	if r, err := c.DoApiGet(c.GetRolesRoute()+fmt.Sprintf("/name/%v", name), ""); err != nil {
+	r, err := c.DoApiGet(c.GetRolesRoute()+fmt.Sprintf("/name/%v", name), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return RoleFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return RoleFromJson(r.Body), BuildResponse(r)
 }
 
 // GetRolesByNames returns a list of roles based on the provided role names.
 func (c *Client4) GetRolesByNames(roleNames []string) ([]*Role, *Response) {
-	if r, err := c.DoApiPost(c.GetRolesRoute()+"/names", ArrayToJson(roleNames)); err != nil {
+	r, err := c.DoApiPost(c.GetRolesRoute()+"/names", ArrayToJson(roleNames))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return RoleListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return RoleListFromJson(r.Body), BuildResponse(r)
 }
 
 // PatchRole partially updates a role in the system. Any missing fields are not updated.
 func (c *Client4) PatchRole(roleId string, patch *RolePatch) (*Role, *Response) {
-	if r, err := c.DoApiPut(c.GetRolesRoute()+fmt.Sprintf("/%v/patch", roleId), patch.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetRolesRoute()+fmt.Sprintf("/%v/patch", roleId), patch.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return RoleFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return RoleFromJson(r.Body), BuildResponse(r)
 }
 
 // Schemes Section
 
 // CreateScheme creates a new Scheme.
 func (c *Client4) CreateScheme(scheme *Scheme) (*Scheme, *Response) {
-	if r, err := c.DoApiPost(c.GetSchemesRoute(), scheme.ToJson()); err != nil {
+	r, err := c.DoApiPost(c.GetSchemesRoute(), scheme.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return SchemeFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return SchemeFromJson(r.Body), BuildResponse(r)
 }
 
 // GetScheme gets a single scheme by ID.
 func (c *Client4) GetScheme(id string) (*Scheme, *Response) {
-	if r, err := c.DoApiGet(c.GetSchemeRoute(id), ""); err != nil {
+	r, err := c.DoApiGet(c.GetSchemeRoute(id), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return SchemeFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return SchemeFromJson(r.Body), BuildResponse(r)
 }
 
-// Get all schemes, sorted with the most recently created first, optionally filtered by scope.
+// GetSchemes gets all schemes, sorted with the most recently created first, optionally filtered by scope.
 func (c *Client4) GetSchemes(scope string, page int, perPage int) ([]*Scheme, *Response) {
-	if r, err := c.DoApiGet(c.GetSchemesRoute()+fmt.Sprintf("?scope=%v&page=%v&per_page=%v", scope, page, perPage), ""); err != nil {
+	r, err := c.DoApiGet(c.GetSchemesRoute()+fmt.Sprintf("?scope=%v&page=%v&per_page=%v", scope, page, perPage), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return SchemesFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return SchemesFromJson(r.Body), BuildResponse(r)
 }
 
 // DeleteScheme deletes a single scheme by ID.
 func (c *Client4) DeleteScheme(id string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetSchemeRoute(id)); err != nil {
+	r, err := c.DoApiDelete(c.GetSchemeRoute(id))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // PatchScheme partially updates a scheme in the system. Any missing fields are not updated.
 func (c *Client4) PatchScheme(id string, patch *SchemePatch) (*Scheme, *Response) {
-	if r, err := c.DoApiPut(c.GetSchemeRoute(id)+"/patch", patch.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetSchemeRoute(id)+"/patch", patch.ToJson())
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return SchemeFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return SchemeFromJson(r.Body), BuildResponse(r)
 }
 
-// Get the teams using this scheme, sorted alphabetically by display name.
+// GetTeamsForScheme gets the teams using this scheme, sorted alphabetically by display name.
 func (c *Client4) GetTeamsForScheme(schemeId string, page int, perPage int) ([]*Team, *Response) {
-	if r, err := c.DoApiGet(c.GetSchemeRoute(schemeId)+fmt.Sprintf("/teams?page=%v&per_page=%v", page, perPage), ""); err != nil {
+	r, err := c.DoApiGet(c.GetSchemeRoute(schemeId)+fmt.Sprintf("/teams?page=%v&per_page=%v", page, perPage), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TeamListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TeamListFromJson(r.Body), BuildResponse(r)
 }
 
-// Get the channels using this scheme, sorted alphabetically by display name.
+// GetChannelsForScheme gets the channels using this scheme, sorted alphabetically by display name.
 func (c *Client4) GetChannelsForScheme(schemeId string, page int, perPage int) (ChannelList, *Response) {
-	if r, err := c.DoApiGet(c.GetSchemeRoute(schemeId)+fmt.Sprintf("/channels?page=%v&per_page=%v", page, perPage), ""); err != nil {
+	r, err := c.DoApiGet(c.GetSchemeRoute(schemeId)+fmt.Sprintf("/channels?page=%v&per_page=%v", page, perPage), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return *ChannelListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return *ChannelListFromJson(r.Body), BuildResponse(r)
 }
 
 // Plugin Section
@@ -3747,13 +3784,16 @@ func (c *Client4) UploadPlugin(file io.Reader) (*Manifest, *Response) {
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
 
-	if part, err := writer.CreateFormFile("plugin", "plugin.tar.gz"); err != nil {
-		return nil, &Response{Error: NewAppError("UploadPlugin", "model.client.writer.app_error", nil, err.Error(), 0)}
-	} else if _, err = io.Copy(part, file); err != nil {
+	part, err := writer.CreateFormFile("plugin", "plugin.tar.gz")
+	if err != nil {
 		return nil, &Response{Error: NewAppError("UploadPlugin", "model.client.writer.app_error", nil, err.Error(), 0)}
 	}
 
-	if err := writer.Close(); err != nil {
+	if _, err = io.Copy(part, file); err != nil {
+		return nil, &Response{Error: NewAppError("UploadPlugin", "model.client.writer.app_error", nil, err.Error(), 0)}
+	}
+
+	if err = writer.Close(); err != nil {
 		return nil, &Response{Error: NewAppError("UploadPlugin", "model.client.writer.app_error", nil, err.Error(), 0)}
 	}
 
@@ -3764,161 +3804,157 @@ func (c *Client4) UploadPlugin(file io.Reader) (*Manifest, *Response) {
 		rq.Header.Set(HEADER_AUTH, c.AuthType+" "+c.AuthToken)
 	}
 
-	if rp, err := c.HttpClient.Do(rq); err != nil || rp == nil {
+	rp, err := c.HttpClient.Do(rq)
+	if err != nil || rp == nil {
 		return nil, BuildErrorResponse(rp, NewAppError("UploadPlugin", "model.client.connecting.app_error", nil, err.Error(), 0))
-	} else {
-		defer closeBody(rp)
-
-		if rp.StatusCode >= 300 {
-			return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
-		} else {
-			return ManifestFromJson(rp.Body), BuildResponse(rp)
-		}
 	}
+	defer closeBody(rp)
+
+	if rp.StatusCode >= 300 {
+		return nil, BuildErrorResponse(rp, AppErrorFromJson(rp.Body))
+	}
+
+	return ManifestFromJson(rp.Body), BuildResponse(rp)
 }
 
 // GetPlugins will return a list of plugin manifests for currently active plugins.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
 func (c *Client4) GetPlugins() (*PluginsResponse, *Response) {
-	if r, err := c.DoApiGet(c.GetPluginsRoute(), ""); err != nil {
+	r, err := c.DoApiGet(c.GetPluginsRoute(), "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PluginsResponseFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PluginsResponseFromJson(r.Body), BuildResponse(r)
 }
 
 // GetPluginStatuses will return the plugins installed on any server in the cluster, for reporting
 // to the administrator via the system console.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
 func (c *Client4) GetPluginStatuses() (PluginStatuses, *Response) {
-	if r, err := c.DoApiGet(c.GetPluginsRoute(), "/statuses"); err != nil {
+	r, err := c.DoApiGet(c.GetPluginsRoute(), "/statuses")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return PluginStatusesFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return PluginStatusesFromJson(r.Body), BuildResponse(r)
 }
 
 // RemovePlugin will disable and delete a plugin.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
 func (c *Client4) RemovePlugin(id string) (bool, *Response) {
-	if r, err := c.DoApiDelete(c.GetPluginRoute(id)); err != nil {
+	r, err := c.DoApiDelete(c.GetPluginRoute(id))
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetWebappPlugins will return a list of plugins that the webapp should download.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
 func (c *Client4) GetWebappPlugins() ([]*Manifest, *Response) {
-	if r, err := c.DoApiGet(c.GetPluginsRoute()+"/webapp", ""); err != nil {
+	r, err := c.DoApiGet(c.GetPluginsRoute()+"/webapp", "")
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return ManifestListFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return ManifestListFromJson(r.Body), BuildResponse(r)
 }
 
 // EnablePlugin will enable an plugin installed.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
 func (c *Client4) EnablePlugin(id string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetPluginRoute(id)+"/enable", ""); err != nil {
+	r, err := c.DoApiPost(c.GetPluginRoute(id)+"/enable", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // DisablePlugin will disable an enabled plugin.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
 func (c *Client4) DisablePlugin(id string) (bool, *Response) {
-	if r, err := c.DoApiPost(c.GetPluginRoute(id)+"/disable", ""); err != nil {
+	r, err := c.DoApiPost(c.GetPluginRoute(id)+"/disable", "")
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateChannelScheme will update a channel's scheme.
 func (c *Client4) UpdateChannelScheme(channelId, schemeId string) (bool, *Response) {
 	sip := &SchemeIDPatch{SchemeID: &schemeId}
-	if r, err := c.DoApiPut(c.GetChannelSchemeRoute(channelId), sip.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetChannelSchemeRoute(channelId), sip.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // UpdateTeamScheme will update a team's scheme.
 func (c *Client4) UpdateTeamScheme(teamId, schemeId string) (bool, *Response) {
 	sip := &SchemeIDPatch{SchemeID: &schemeId}
-	if r, err := c.DoApiPut(c.GetTeamSchemeRoute(teamId), sip.ToJson()); err != nil {
+	r, err := c.DoApiPut(c.GetTeamSchemeRoute(teamId), sip.ToJson())
+	if err != nil {
 		return false, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return CheckStatusOK(r), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
 }
 
 // GetRedirectLocation retrieves the value of the 'Location' header of an HTTP response for a given URL.
 func (c *Client4) GetRedirectLocation(urlParam, etag string) (string, *Response) {
 	url := fmt.Sprintf("%s?url=%s", c.GetRedirectLocationRoute(), url.QueryEscape(urlParam))
-	if r, err := c.DoApiGet(url, etag); err != nil {
+	r, err := c.DoApiGet(url, etag)
+	if err != nil {
 		return "", BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return MapFromJson(r.Body)["location"], BuildResponse(r)
 	}
+	defer closeBody(r)
+	return MapFromJson(r.Body)["location"], BuildResponse(r)
 }
 
 func (c *Client4) RegisteTermsOfServiceAction(userId, termsOfServiceId string, accepted bool) (*bool, *Response) {
 	url := c.GetUserTermsOfServiceRoute(userId)
 	data := map[string]interface{}{"termsOfServiceId": termsOfServiceId, "accepted": accepted}
-
-	if r, err := c.DoApiPost(url, StringInterfaceToJson(data)); err != nil {
+	r, err := c.DoApiPost(url, StringInterfaceToJson(data))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return NewBool(CheckStatusOK(r)), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return NewBool(CheckStatusOK(r)), BuildResponse(r)
 }
 
 func (c *Client4) GetTermsOfService(etag string) (*TermsOfService, *Response) {
 	url := c.GetTermsOfServiceRoute()
-
-	if r, err := c.DoApiGet(url, etag); err != nil {
+	r, err := c.DoApiGet(url, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TermsOfServiceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TermsOfServiceFromJson(r.Body), BuildResponse(r)
 }
 
 func (c *Client4) GetUserTermsOfService(userId, etag string) (*UserTermsOfService, *Response) {
 	url := c.GetUserTermsOfServiceRoute(userId)
-
-	if r, err := c.DoApiGet(url, etag); err != nil {
+	r, err := c.DoApiGet(url, etag)
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return UserTermsOfServiceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return UserTermsOfServiceFromJson(r.Body), BuildResponse(r)
 }
 
 func (c *Client4) CreateTermsOfService(text, userId string) (*TermsOfService, *Response) {
 	url := c.GetTermsOfServiceRoute()
-
 	data := map[string]interface{}{"text": text}
-	if r, err := c.DoApiPost(url, StringInterfaceToJson(data)); err != nil {
+	r, err := c.DoApiPost(url, StringInterfaceToJson(data))
+	if err != nil {
 		return nil, BuildErrorResponse(r, err)
-	} else {
-		defer closeBody(r)
-		return TermsOfServiceFromJson(r.Body), BuildResponse(r)
 	}
+	defer closeBody(r)
+	return TermsOfServiceFromJson(r.Body), BuildResponse(r)
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -1866,6 +1866,7 @@ func (c *Client4) GetChannelByName(channelName, teamId string, etag string) (*Ch
 	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
+// GetChannelByNameIncludeDeleted returns a channel based on the provided channel name and team id strings. Other then GetChannelByName it will also return deleted channels.
 func (c *Client4) GetChannelByNameIncludeDeleted(channelName, teamId string, etag string) (*Channel, *Response) {
 	r, err := c.DoApiGet(c.GetChannelByNameRoute(channelName, teamId)+"?include_deleted=true", etag)
 	if err != nil {
@@ -1885,6 +1886,7 @@ func (c *Client4) GetChannelByNameForTeamName(channelName, teamName string, etag
 	return ChannelFromJson(r.Body), BuildResponse(r)
 }
 
+// GetChannelByNameForTeamNameIncludeDeleted returns a channel based on the provided channel name and team name strings. Other then GetChannelByNameForTeamName it will also return deleted channels.
 func (c *Client4) GetChannelByNameForTeamNameIncludeDeleted(channelName, teamName string, etag string) (*Channel, *Response) {
 	r, err := c.DoApiGet(c.GetChannelByNameForTeamNameRoute(channelName, teamName)+"?include_deleted=true", etag)
 	if err != nil {
@@ -3069,6 +3071,7 @@ func (c *Client4) GetBrandImage() ([]byte, *Response) {
 	return data, BuildResponse(r)
 }
 
+// DeleteBrandImage delets the brand image for the system.
 func (c *Client4) DeleteBrandImage() *Response {
 	r, err := c.DoApiDelete(c.GetBrandRoute() + "/image")
 	if err != nil {
@@ -3152,7 +3155,7 @@ func (c *Client4) CreateOAuthApp(app *OAuthApp) (*OAuthApp, *Response) {
 	return OAuthAppFromJson(r.Body), BuildResponse(r)
 }
 
-// UpdateOAuthApp
+// UpdateOAuthApp updates a page of registered OAuth 2.0 client applications with Mattermost acting as an OAuth 2.0 service provider.
 func (c *Client4) UpdateOAuthApp(app *OAuthApp) (*OAuthApp, *Response) {
 	r, err := c.DoApiPut(c.GetOAuthAppRoute(app.Id), app.ToJson())
 	if err != nil {

--- a/model/client4.go
+++ b/model/client4.go
@@ -2301,8 +2301,7 @@ func (c *Client4) UploadFile(data []byte, channelId string, filename string) (*F
 		return nil, &Response{Error: NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 
-	_, err = io.Copy(part, bytes.NewBuffer(data))
-	if err != nil {
+	if _, err = io.Copy(part, bytes.NewBuffer(data)); err != nil {
 		return nil, &Response{Error: NewAppError("UploadPostAttachment", "model.client.upload_post_attachment.file.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}
 


### PR DESCRIPTION
#### Summary
Migrate to idiomatic error handling in the file `model/client4.go` in the mattermost-server repo.

#### Ticket Link
Fixes #9846

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] All new/modified APIs include changes to the drivers
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
