### PR TITLE
[MM-12613] Update apps download link in config

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -336,7 +336,7 @@
         "LoginButtonTextColor": ""
     },
     "NativeAppSettings": {
-        "AppDownloadLink": "https://about.mattermost.com/downloads/",
+        "AppDownloadLink": "https://mattermost.com/download/#mobile",
         "AndroidAppDownloadLink": "https://about.mattermost.com/mattermost-android-app/",
         "IosAppDownloadLink": "https://about.mattermost.com/mattermost-ios-app/"
     },

--- a/config/default.json
+++ b/config/default.json
@@ -336,7 +336,7 @@
         "LoginButtonTextColor": ""
     },
     "NativeAppSettings": {
-        "AppDownloadLink": "https://mattermost.com/download/#mobile",
+        "AppDownloadLink": "https://about.mattermost.com/mattermost-apps",
         "AndroidAppDownloadLink": "https://about.mattermost.com/mattermost-android-app/",
         "IosAppDownloadLink": "https://about.mattermost.com/mattermost-ios-app/"
     },


### PR DESCRIPTION
Update app download link to go directly to the clients section rather than the server download section.

https://mattermost.atlassian.net/browse/MM-12613