### PR TITLE
Block to override post_type if already set

### DIFF
--- a/model/slack_attachment.go
+++ b/model/slack_attachment.go
@@ -64,7 +64,9 @@ func StringifySlackFieldValue(a []*SlackAttachment) []*SlackAttachment {
 // This method only parses and processes the attachments,
 // all else should be set in the post which is passed
 func ParseSlackAttachment(post *Post, attachments []*SlackAttachment) {
-	post.Type = POST_SLACK_ATTACHMENT
+	if post.Type == "" {
+		post.Type = POST_SLACK_ATTACHMENT
+	}
 
 	for _, attachment := range attachments {
 		attachment.Text = ParseSlackLinksToMarkdown(attachment.Text)


### PR DESCRIPTION
#### Summary
Now, when returning CommandResponse that has post.type, it's overridden by `slack_attachment` anyway. So we can't replace it by custom post type of webapp plugin.
With this fix, if post.type is already set, it will not overwrite the type.

**Caution**: This fix has tiny breaking changes. If there are integrations that create posts with attachments props and post.type (not `slack_attachments`), it will not create attachment post successfully. 

#### Ticket Link
N/A
(Refs: https://pre-release.mattermost.com/core/pl/3oex4ng45brpfx3gfkr1o6oy8c)

#### Checklist
N/A