### PR TITLE
Add helper methods for SubmitDialog structs

### DIFF
--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -114,11 +114,6 @@ type SubmitDialogResponse struct {
 	Errors map[string]string `json:"errors,omitempty"`
 }
 
-func (r *PostActionIntegrationRequest) ToJson() []byte {
-	b, _ := json.Marshal(r)
-	return b
-}
-
 func GenerateTriggerId(userId string, s crypto.Signer) (string, string, *AppError) {
 	clientTriggerId := NewId()
 	triggerData := strings.Join([]string{clientTriggerId, userId, strconv.FormatInt(GetMillis(), 10)}, ":") + ":"
@@ -196,6 +191,11 @@ func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey) (string, st
 
 func (r *OpenDialogRequest) DecodeAndVerifyTriggerId(s *ecdsa.PrivateKey) (string, string, *AppError) {
 	return DecodeAndVerifyTriggerId(r.TriggerId, s)
+}
+
+func (r *PostActionIntegrationRequest) ToJson() []byte {
+	b, _ := json.Marshal(r)
+	return b
 }
 
 func PostActionIntegrationRequestFromJson(data io.Reader) *PostActionIntegrationRequest {

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -221,6 +221,34 @@ func PostActionIntegrationResponseFromJson(data io.Reader) *PostActionIntegratio
 	return o
 }
 
+func SubmitDialogRequestFromJson(data io.Reader) *SubmitDialogRequest {
+	var o *SubmitDialogRequest
+	err := json.NewDecoder(data).Decode(&o)
+	if err != nil {
+		return nil
+	}
+	return o
+}
+
+func (r *SubmitDialogRequest) ToJson() []byte {
+	b, _ := json.Marshal(r)
+	return b
+}
+
+func SubmitDialogResponseFromJson(data io.Reader) *SubmitDialogResponse {
+	var o *SubmitDialogResponse
+	err := json.NewDecoder(data).Decode(&o)
+	if err != nil {
+		return nil
+	}
+	return o
+}
+
+func (r *SubmitDialogResponse) ToJson() []byte {
+	b, _ := json.Marshal(r)
+	return b
+}
+
 func (o *Post) StripActionIntegrations() {
 	attachments := o.Attachments()
 	if o.Props["attachments"] != nil {

--- a/model/integration_action_test.go
+++ b/model/integration_action_test.go
@@ -109,3 +109,52 @@ func TestPostActionIntegrationResponseFromJsonError(t *testing.T) {
 	ro := PostActionIntegrationResponseFromJson(strings.NewReader(""))
 	assert.Nil(t, ro)
 }
+
+func TestSubmitDialogRequestToJson(t *testing.T) {
+	t.Run("all fine", func(t *testing.T) {
+		request := SubmitDialogRequest{
+			URL:        "http://example.org",
+			CallbackId: NewId(),
+			State:      "some state",
+			UserId:     NewId(),
+			ChannelId:  NewId(),
+			TeamId:     NewId(),
+			Submission: map[string]interface{}{
+				"text":  "some text",
+				"float": 1.2,
+				"bool":  true,
+			},
+			Cancelled: true,
+		}
+		jsonRequest := request.ToJson()
+		r := SubmitDialogRequestFromJson(bytes.NewReader(jsonRequest))
+
+		require.NotNil(t, r)
+		assert.Equal(t, request, *r)
+	})
+	t.Run("error", func(t *testing.T) {
+		r := SubmitDialogRequestFromJson(strings.NewReader(""))
+		assert.Nil(t, r)
+	})
+}
+
+func TestSubmitDialogResponseToJson(t *testing.T) {
+	t.Run("all fine", func(t *testing.T) {
+		request := SubmitDialogResponse{
+			Errors: map[string]string{
+				"text":  "some text",
+				"float": "1.2",
+				"bool":  "true",
+			},
+		}
+		jsonRequest := request.ToJson()
+		r := SubmitDialogResponseFromJson(bytes.NewReader(jsonRequest))
+
+		require.NotNil(t, r)
+		assert.Equal(t, request, *r)
+	})
+	t.Run("error", func(t *testing.T) {
+		r := SubmitDialogResponseFromJson(strings.NewReader(""))
+		assert.Nil(t, r)
+	})
+}


### PR DESCRIPTION
#### Summary
This PR adds To/FromJson methods to `SubmitDialogResponse` and `SubmitDialogRequest`. This is useful for plugins and other integrations.

#### Ticket Link
NA

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] All new/modified APIs include changes to the drivers