### PR TITLE
Remove comments about deprecating FileIds and HasReactions

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -99,7 +99,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post) *model.Post {
 }
 
 func (a *App) getFileMetadataForPost(post *model.Post) ([]*model.FileInfo, *model.AppError) {
-	if len(post.FileIds) == 0 { // This field is deprecated, but still use it for now to avoid unnecessary database hits
+	if len(post.FileIds) == 0 {
 		return nil, nil
 	}
 
@@ -108,7 +108,7 @@ func (a *App) getFileMetadataForPost(post *model.Post) ([]*model.FileInfo, *mode
 
 func (a *App) getEmojisAndReactionsForPost(post *model.Post) ([]*model.Emoji, []*model.Reaction, *model.AppError) {
 	var reactions []*model.Reaction
-	if post.HasReactions { // This field is deprecated, but still use it for now to avoid unnecessary database hits
+	if post.HasReactions {
 		var err *model.AppError
 		reactions, err = a.GetReactionsForPost(post.Id)
 		if err != nil {

--- a/model/post.go
+++ b/model/post.go
@@ -76,9 +76,9 @@ type Post struct {
 	Props         StringInterface `json:"props"`
 	Hashtags      string          `json:"hashtags"`
 	Filenames     StringArray     `json:"filenames,omitempty"` // Deprecated, do not use this field any more
-	FileIds       StringArray     `json:"file_ids,omitempty"`  // Deprecated, do not use this field any more
+	FileIds       StringArray     `json:"file_ids,omitempty"`
 	PendingPostId string          `json:"pending_post_id" db:"-"`
-	HasReactions  bool            `json:"has_reactions,omitempty"` // Deprecated, do not use this field any more
+	HasReactions  bool            `json:"has_reactions,omitempty"`
 
 	// Transient data populated before sending a post to the client
 	Metadata *PostMetadata `json:"metadata" db:"-"`


### PR DESCRIPTION
As I explained [here](https://github.com/mattermost/mattermost-server/pull/9786#discussion_r235758827), it'd be nice to deprecate these to remove the two way data linkage that's hard to track, but we use them to simplify PreparePostForClient, so they'll stay for now.