### PR TITLE
MM-13015 Add safety valve setting to disable post metadata

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -52,6 +52,10 @@ func (a *App) PreparePostForClient(originalPost *model.Post) *model.Post {
 	// Proxy image links before constructing metadata so that requests go through the proxy
 	post = a.PostWithProxyAddedToImageURLs(post)
 
+	if *a.Config().ExperimentalSettings.DisablePostMetadata {
+		return post
+	}
+
 	post.Metadata = &model.PostMetadata{}
 
 	// Emojis and reaction counts

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -24,6 +24,10 @@ func TestPreparePostListForClient(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ExperimentalSettings.DisablePostMetadata = false
+	})
+
 	postList := model.NewPostList()
 	for i := 0; i < 5; i++ {
 		postList.AddPost(&model.Post{})
@@ -57,6 +61,7 @@ func TestPreparePostForClient(t *testing.T) {
 			*cfg.ServiceSettings.ImageProxyType = ""
 			*cfg.ServiceSettings.ImageProxyURL = ""
 			*cfg.ServiceSettings.ImageProxyOptions = ""
+			*cfg.ExperimentalSettings.DisablePostMetadata = false
 		})
 
 		return th
@@ -384,6 +389,20 @@ func TestPreparePostForClient(t *testing.T) {
 			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/icon.png"])
 		})
 	})
+
+	t.Run("when disabled", func(t *testing.T) {
+		th := setup()
+		defer th.TearDown()
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ExperimentalSettings.DisablePostMetadata = true
+		})
+
+		post := th.CreatePost(th.BasicChannel)
+		post = th.App.PreparePostForClient(post)
+
+		assert.Nil(t, post.Metadata)
+	})
 }
 
 func TestPreparePostForClientWithImageProxy(t *testing.T) {
@@ -395,6 +414,7 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 			*cfg.ServiceSettings.ImageProxyType = "atmos/camo"
 			*cfg.ServiceSettings.ImageProxyURL = "https://127.0.0.1"
 			*cfg.ServiceSettings.ImageProxyOptions = "foo"
+			*cfg.ExperimentalSettings.DisablePostMetadata = false
 		})
 
 		return th

--- a/config/default.json
+++ b/config/default.json
@@ -360,7 +360,8 @@
     },
     "ExperimentalSettings": {
         "ClientSideCertEnable": false,
-        "ClientSideCertCheck": "secondary"
+        "ClientSideCertCheck": "secondary",
+        "DisablePostMetadata": false
     },
     "AnalyticsSettings": {
         "MaxUsersForStatistics": 2500

--- a/model/config.go
+++ b/model/config.go
@@ -651,6 +651,7 @@ func (s *MetricsSettings) SetDefaults() {
 type ExperimentalSettings struct {
 	ClientSideCertEnable *bool
 	ClientSideCertCheck  *string
+	DisablePostMetadata  *bool
 }
 
 func (s *ExperimentalSettings) SetDefaults() {
@@ -660,6 +661,10 @@ func (s *ExperimentalSettings) SetDefaults() {
 
 	if s.ClientSideCertCheck == nil {
 		s.ClientSideCertCheck = NewString(CLIENT_SIDE_CERT_CHECK_SECONDARY_AUTH)
+	}
+
+	if s.DisablePostMetadata == nil {
+		s.DisablePostMetadata = NewBool(false)
 	}
 }
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -586,8 +586,6 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 
 	props["EnableEmailInvitations"] = strconv.FormatBool(*c.ServiceSettings.EnableEmailInvitations)
 
-	props["ExperimentalDisablePostMetadata"] = strconv.FormatBool(*c.ExperimentalSettings.DisablePostMetadata)
-
 	// Set default values for all options that require a license.
 	props["ExperimentalHideTownSquareinLHS"] = "false"
 	props["ExperimentalTownSquareIsReadOnly"] = "false"

--- a/utils/config.go
+++ b/utils/config.go
@@ -586,6 +586,8 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 
 	props["EnableEmailInvitations"] = strconv.FormatBool(*c.ServiceSettings.EnableEmailInvitations)
 
+	props["ExperimentalDisablePostMetadata"] = strconv.FormatBool(*c.ExperimentalSettings.DisablePostMetadata)
+
 	// Set default values for all options that require a license.
 	props["ExperimentalHideTownSquareinLHS"] = "false"
 	props["ExperimentalTownSquareIsReadOnly"] = "false"


### PR DESCRIPTION
This is a temporary setting to disable post metadata in case it causes major performance concerns for larger deployments. We're planning on removing it in the next feature release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13015

#### Checklist
- Added or updated unit tests (required for all new features)