### PR TITLE
[MM-9937] Add support for sending a message to a different channel than where the slash command was issued from

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -308,7 +308,7 @@ func (a *App) HandleCommandResponse(command *model.Command, args *model.CommandA
 	return response, nil
 }
 
-func (a *App) HandleCommandResponsePost(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {
+func (a *App) HandleCommandResponsePost(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.Post, *model.AppError) {
 	post := &model.Post{}
 	post.ChannelId = args.ChannelId
 	post.RootId = args.RootId
@@ -357,7 +357,7 @@ func (a *App) HandleCommandResponsePost(command *model.Command, args *model.Comm
 		mlog.Error(err.Error())
 	}
 
-	return response, nil
+	return post, nil
 }
 
 func (a *App) CreateCommand(cmd *model.Command) (*model.Command, *model.AppError) {

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -61,7 +61,142 @@ func TestCreateCommandPost(t *testing.T) {
 	}
 
 	_, err := th.App.CreateCommandPost(post, th.BasicTeam.Id, resp)
-	if err == nil && err.Id != "api.context.invalid_param.app_error" {
+	if err == nil || err.Id != "api.context.invalid_param.app_error" {
 		t.Fatal("should have failed - bad post type")
 	}
+
+	channel := th.CreateChannel(th.BasicTeam)
+
+	post = &model.Post{
+		ChannelId: th.BasicChannel.Id,
+		UserId:    channel.Id,
+	}
+
+	_, err = th.App.CreateCommandPost(post, th.BasicTeam.Id, resp)
+	if err == nil || err.Id != "api.command.command_post.forbidden.app_error" {
+		t.Fatal("should have failed - forbidden channel post")
+	}
+}
+
+func TestHandleCommandResponsePost(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	command := &model.Command{}
+	args := &model.CommandArgs{
+		ChannelId: th.BasicChannel.Id,
+		TeamId: th.BasicTeam.Id,
+		UserId: th.BasicUser.Id,
+		RootId: "root_id",
+		ParentId: "parent_id",
+	}
+
+	resp := &model.CommandResponse{
+		Type: model.POST_EPHEMERAL,
+		Props: model.StringInterface{"some_key": "some value"},
+		Text: "some message",
+	}
+
+	builtIn := true
+
+	post, err := th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, args.ChannelId, post.ChannelId)
+	assert.Equal(t, args.RootId, post.RootId)
+	assert.Equal(t, args.ParentId, post.ParentId)
+	assert.Equal(t, args.UserId, post.UserId)
+	assert.Equal(t, resp.Type, post.Type)
+	assert.Equal(t, resp.Props, post.Props)
+	assert.Equal(t, resp.Text, post.Message)
+	assert.Nil(t, post.Props["override_icon_url"])
+	assert.Nil(t, post.Props["override_username"])
+	assert.Nil(t, post.Props["from_webhook"])
+
+	// Command is not built in, so it is a bot command.
+	builtIn = false
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Equal(t, "true", post.Props["from_webhook"])
+
+	builtIn = true
+
+	// Channel id is specified by response, it should override the command args value.
+	channel := th.CreateChannel(th.BasicTeam)
+	resp.ChannelId = channel.Id
+	th.AddUserToChannel(th.BasicUser, channel)
+
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, resp.ChannelId, post.ChannelId)
+	assert.NotEqual(t, args.ChannelId, post.ChannelId)
+
+	// Override username config is turned off. No override should occur.
+	th.App.Config().ServiceSettings.EnablePostUsernameOverride = false
+	resp.ChannelId = ""
+	command.Username = "Command username"
+	resp.Username = "Response username"
+
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Nil(t, post.Props["override_username"])
+
+	th.App.Config().ServiceSettings.EnablePostUsernameOverride = true
+
+	// Override username config is turned on. Override username through command property.
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, command.Username, post.Props["override_username"])
+	assert.Equal(t, "true", post.Props["from_webhook"])
+
+	command.Username = ""
+
+	// Override username through response property.
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, resp.Username, post.Props["override_username"])
+	assert.Equal(t, "true", post.Props["from_webhook"])
+
+	th.App.Config().ServiceSettings.EnablePostUsernameOverride = false
+
+	// Override icon url config is turned off. No override should occur.
+	th.App.Config().ServiceSettings.EnablePostIconOverride = false
+	command.IconURL = "Command icon url"
+	resp.IconURL = "Response icon url"
+
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Nil(t, post.Props["override_icon_url"])
+
+	th.App.Config().ServiceSettings.EnablePostIconOverride = true
+
+	// Override icon url config is turned on. Override icon url through command property.
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, command.IconURL, post.Props["override_icon_url"])
+	assert.Equal(t, "true", post.Props["from_webhook"])
+
+	command.IconURL = ""
+
+	// Override icon url through response property.
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, resp.IconURL, post.Props["override_icon_url"])
+	assert.Equal(t, "true", post.Props["from_webhook"])
+
+	// Test Slack text conversion.
+	resp.Text = "<!channel>"
+
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, "@channel", post.Message)
+
+	// Test Slack attachments text conversion.
+	resp.Attachments = []*model.SlackAttachment{
+		&model.SlackAttachment{
+			Text: "<!here>",
+		},
+	}
+
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+	assert.Nil(t, err)
+	assert.Equal(t, "@here", resp.Attachments[0].Text)
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -384,6 +384,10 @@
     "translation": "No command trigger found"
   },
   {
+    "id": "api.command.command_post.forbidden.app_error",
+    "translation": "Specified user is not a member of specified channel."
+  },
+  {
     "id": "api.command.invite_people.desc",
     "translation": "Send an email invite to your Mattermost team"
   },

--- a/model/command_response.go
+++ b/model/command_response.go
@@ -21,6 +21,7 @@ type CommandResponse struct {
 	ResponseType   string             `json:"response_type"`
 	Text           string             `json:"text"`
 	Username       string             `json:"username"`
+	ChannelId      string             `json:"channel_id"`
 	IconURL        string             `json:"icon_url"`
 	Type           string             `json:"type"`
 	Props          StringInterface    `json:"props"`

--- a/model/command_response_test.go
+++ b/model/command_response_test.go
@@ -65,6 +65,7 @@ func TestCommandResponseFromJson(t *testing.T) {
 				"response_type": "ephemeral",
 				"text": "response text",
 				"username": "response username",
+				"channel_id": "response channel id",
 				"icon_url": "response icon url",
 				"goto_location": "response goto location",
 				"attachments": [{
@@ -87,6 +88,7 @@ func TestCommandResponseFromJson(t *testing.T) {
 				ResponseType: "ephemeral",
 				Text:         "response text",
 				Username:     "response username",
+				ChannelId:    "response channel id",
 				IconURL:      "response icon url",
 				GotoLocation: "response goto location",
 				Attachments: []*SlackAttachment{


### PR DESCRIPTION
#### Summary

This allows a slash command's response to decide which channel the response post will be sent to, rather than defaulting to the channel that the command was used in.

#### Ticket Link

Jira ticket: https://mattermost.atlassian.net/browse/MM-9937
GitHub ticket: https://github.com/mattermost/mattermost-server/issues/8512

#### Checklist

- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)

I have docs update here: https://github.com/mattermost/mattermost-developer-documentation/pull/190
There may be a change (like adding a config for overriding the channel to post to)

#### Details

Permissions:

There was some discussion on permissions on this PR https://github.com/mattermost/mattermost-server/pull/8678 pertaining to a similar situation with slash commands and posting to a different channel. If this permission check is appropriate, which user needs to have posting privileges, the slash command issuer and/or potentially the payload's username if it is overridden? I've noticed that there is no check for channel membership on a general post creation. For example, I can arbitrarily set the post.UserId to a user id that is not in the channel the slash command was issued in, and the post will go through. Is this a security issue?

---

Override Settings:

Similar to the setting `EnablePostUsernameOverride`, we may need to add a new setting called `EnablePostChannelOverride` since we are overriding the `ChannelId` value in a similar way of overriding the `Username`. I'll include this in my docs changes for slash command responses for this PR and the one on multiple responses https://github.com/mattermost/mattermost-server/pull/9836.

Another idea is to let the slash command admin decide which channels are acceptable to post in, configurable within the integrations UI. In this scenario, the channel that initiated the slash command is automatically allowed.

---

There is a ticket out https://github.com/mattermost/mattermost-server/issues/9862 for improving error handling for this method. I've claimed the ticket, as I am adding more code paths here with no error handling. Here's a PR: https://github.com/mattermost/mattermost-server/pull/9888