### PR TITLE
Skip getting the post again when getting file metadata for a post

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -528,7 +528,7 @@ func getFileInfosForPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	infos, err := c.App.GetFileInfosForPost(c.Params.PostId, false)
+	infos, err := c.App.GetFileInfosForPostWithMigration(c.Params.PostId)
 	if err != nil {
 		c.Err = err
 		return

--- a/app/post.go
+++ b/app/post.go
@@ -752,14 +752,13 @@ func (a *App) SearchPostsInTeam(terms string, userId string, teamId string, isOr
 	return model.MakePostSearchResults(posts, nil), nil
 }
 
-func (a *App) GetFileInfosForPost(postId string, readFromMaster bool) ([]*model.FileInfo, *model.AppError) {
+func (a *App) GetFileInfosForPostWithMigration(postId string) ([]*model.FileInfo, *model.AppError) {
 	pchan := a.Srv.Store.Post().GetSingle(postId)
 
-	result := <-a.Srv.Store.FileInfo().GetForPost(postId, readFromMaster, true)
-	if result.Err != nil {
-		return nil, result.Err
+	infos, err := a.GetFileInfosForPost(postId)
+	if err != nil {
+		return nil, err
 	}
-	infos := result.Data.([]*model.FileInfo)
 
 	if len(infos) == 0 {
 		// No FileInfos were returned so check if they need to be created for this post
@@ -777,6 +776,15 @@ func (a *App) GetFileInfosForPost(postId string, readFromMaster bool) ([]*model.
 	}
 
 	return infos, nil
+}
+
+func (a *App) GetFileInfosForPost(postId string) ([]*model.FileInfo, *model.AppError) {
+	result := <-a.Srv.Store.FileInfo().GetForPost(postId, false, true)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.([]*model.FileInfo), nil
 }
 
 func (a *App) PostWithProxyAddedToImageURLs(post *model.Post) *model.Post {

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -94,7 +94,7 @@ func (a *App) getFileMetadataForPost(post *model.Post) ([]*model.FileInfo, *mode
 		return nil, nil
 	}
 
-	return a.GetFileInfosForPost(post.Id, false)
+	return a.GetFileInfosForPost(post.Id)
 }
 
 func (a *App) getEmojisAndReactionsForPost(post *model.Post) ([]*model.Emoji, []*model.Reaction, *model.AppError) {


### PR DESCRIPTION
`app.GetFileInfosForPost` (which is now called `app.GetFileInfosForPostWithMigration`) tries to get the post from the database to run some outdated migration logic. Since we already have the post when we're getting metadata for it, we can skip that extra database hit
