### PR TITLE
MM-13015 Remove metadata field from post when metadata is disabled

### DIFF
--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -402,6 +402,10 @@ func TestPreparePostForClient(t *testing.T) {
 		post = th.App.PreparePostForClient(post)
 
 		assert.Nil(t, post.Metadata)
+
+		b := post.ToJson()
+
+		assert.NotContains(t, string(b), "metadata", "json shouldn't include a metadata field, not even a falsey one")
 	})
 }
 

--- a/model/post.go
+++ b/model/post.go
@@ -81,7 +81,7 @@ type Post struct {
 	HasReactions  bool            `json:"has_reactions,omitempty"`
 
 	// Transient data populated before sending a post to the client
-	Metadata *PostMetadata `json:"metadata" db:"-"`
+	Metadata *PostMetadata `json:"metadata,omitempty" db:"-"`
 }
 
 type PostEphemeral struct {


### PR DESCRIPTION
This change makes it so that a server with metadata disabled returns posts exactly as a pre-metadata server would.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13015

#### Checklist
- Added or updated unit tests (required for all new features)