### PR TITLE
[MM-13061] Improve error handling of slash command responses

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -360,6 +360,10 @@
     "translation": "This trigger word is already in use. Please choose another word."
   },
   {
+    "id": "api.command.execute_command.create_post_failed.app_error",
+    "translation": "Command '{{.Trigger}}' failed to post response. Please contact your System Administrator."
+  },
+  {
     "id": "api.command.execute_command.debug",
     "translation": "Executing cmd=%v userId=%v"
   },


### PR DESCRIPTION
#### Summary
This fixes the issue of errors being swallowed in the `HandleCommandResponse` method, and underlying methods within, namely `CreateCommandPost`.

#### Ticket Link
Github Ticket: https://github.com/mattermost/mattermost-server/issues/9862
Jira Ticket: https://mattermost.atlassian.net/browse/MM-13061

#### Checklist
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates

#### Details

It is still under discussion in this PR's comments how these errors should be handled.

---

Testing these code paths is covered in https://github.com/mattermost/mattermost-server/pull/9878      