### PR TITLE
MM-12648: Properly unescape OpenGraph metadata containing HTML entities.

### DIFF
--- a/app/opengraph.go
+++ b/app/opengraph.go
@@ -4,12 +4,14 @@
 package app
 
 import (
+	"html"
 	"io"
 	"net/url"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
-	"github.com/mattermost/mattermost-server/mlog"
 	"golang.org/x/net/html/charset"
+
+	"github.com/mattermost/mattermost-server/mlog"
 )
 
 func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
@@ -33,6 +35,8 @@ func (a *App) ParseOpenGraphMetadata(requestURL string, body io.Reader, contentT
 	}
 
 	makeOpenGraphURLsAbsolute(og, requestURL)
+
+	openGraphDecodeHtmlEntities(og)
 
 	// If image proxy enabled modify open graph data to feed though proxy
 	if toProxyURL := a.ImageProxyAdder(); toProxyURL != nil {
@@ -113,4 +117,9 @@ func OpenGraphDataWithProxyAddedToImageURLs(ogdata *opengraph.OpenGraph, toProxy
 	}
 
 	return ogdata
+}
+
+func openGraphDecodeHtmlEntities(og *opengraph.OpenGraph) {
+	og.Title = html.UnescapeString(og.Title)
+	og.Description = html.UnescapeString(og.Description)
 }

--- a/app/opengraph_test.go
+++ b/app/opengraph_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkForceHTMLEncodingToUTF8(b *testing.B) {
@@ -126,4 +127,15 @@ func TestMakeOpenGraphURLsAbsolute(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOpenGraphDecodeHtmlEntities(t *testing.T) {
+	og := opengraph.NewOpenGraph()
+	og.Title = "Test&#39;s are the best.&copy;"
+	og.Description = "Test&#39;s are the worst.&copy;"
+
+	openGraphDecodeHtmlEntities(og)
+
+	assert.Equal(t, og.Title, "Test's are the best.©")
+	assert.Equal(t, og.Description, "Test's are the worst.©")
 }


### PR DESCRIPTION
#### Summary
Properly unescape OpenGraph metadata containing HTML entities.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12648

#### Checklist
- [x] Added or updated unit tests (required for all new features)