### PR TITLE
MM-13208 Rename DisablePostMetadata setting to EnablePostMetadata and turn off by default

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -494,6 +494,7 @@ func (a *App) trackConfig() {
 	a.SendDiagnostic(TRACK_CONFIG_EXPERIMENTAL, map[string]interface{}{
 		"client_side_cert_enable":          *cfg.ExperimentalSettings.ClientSideCertEnable,
 		"isdefault_client_side_cert_check": isDefault(*cfg.ExperimentalSettings.ClientSideCertCheck, model.CLIENT_SIDE_CERT_CHECK_PRIMARY_AUTH),
+		"enable_post_metadata":             *cfg.ExperimentalSettings.EnablePostMetadata,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_ANALYTICS, map[string]interface{}{

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -52,7 +52,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post) *model.Post {
 	// Proxy image links before constructing metadata so that requests go through the proxy
 	post = a.PostWithProxyAddedToImageURLs(post)
 
-	if *a.Config().ExperimentalSettings.DisablePostMetadata {
+	if !*a.Config().ExperimentalSettings.EnablePostMetadata {
 		return post
 	}
 

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -25,7 +25,7 @@ func TestPreparePostListForClient(t *testing.T) {
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ExperimentalSettings.DisablePostMetadata = false
+		*cfg.ExperimentalSettings.EnablePostMetadata = true
 	})
 
 	postList := model.NewPostList()
@@ -61,7 +61,7 @@ func TestPreparePostForClient(t *testing.T) {
 			*cfg.ServiceSettings.ImageProxyType = ""
 			*cfg.ServiceSettings.ImageProxyURL = ""
 			*cfg.ServiceSettings.ImageProxyOptions = ""
-			*cfg.ExperimentalSettings.DisablePostMetadata = false
+			*cfg.ExperimentalSettings.EnablePostMetadata = true
 		})
 
 		return th
@@ -395,7 +395,7 @@ func TestPreparePostForClient(t *testing.T) {
 		defer th.TearDown()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.ExperimentalSettings.DisablePostMetadata = true
+			*cfg.ExperimentalSettings.EnablePostMetadata = false
 		})
 
 		post := th.CreatePost(th.BasicChannel)
@@ -418,7 +418,7 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 			*cfg.ServiceSettings.ImageProxyType = "atmos/camo"
 			*cfg.ServiceSettings.ImageProxyURL = "https://127.0.0.1"
 			*cfg.ServiceSettings.ImageProxyOptions = "foo"
-			*cfg.ExperimentalSettings.DisablePostMetadata = false
+			*cfg.ExperimentalSettings.EnablePostMetadata = true
 		})
 
 		return th

--- a/config/default.json
+++ b/config/default.json
@@ -361,7 +361,7 @@
     "ExperimentalSettings": {
         "ClientSideCertEnable": false,
         "ClientSideCertCheck": "secondary",
-        "DisablePostMetadata": false
+        "EnablePostMetadata": false
     },
     "AnalyticsSettings": {
         "MaxUsersForStatistics": 2500

--- a/model/config.go
+++ b/model/config.go
@@ -651,7 +651,7 @@ func (s *MetricsSettings) SetDefaults() {
 type ExperimentalSettings struct {
 	ClientSideCertEnable *bool
 	ClientSideCertCheck  *string
-	DisablePostMetadata  *bool
+	EnablePostMetadata   *bool
 }
 
 func (s *ExperimentalSettings) SetDefaults() {
@@ -663,8 +663,8 @@ func (s *ExperimentalSettings) SetDefaults() {
 		s.ClientSideCertCheck = NewString(CLIENT_SIDE_CERT_CHECK_SECONDARY_AUTH)
 	}
 
-	if s.DisablePostMetadata == nil {
-		s.DisablePostMetadata = NewBool(false)
+	if s.EnablePostMetadata == nil {
+		s.EnablePostMetadata = NewBool(false)
 	}
 }
 


### PR DESCRIPTION
As discussed, the performance issues are big enough that we want to turn this off by default for 5.6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13208

#### Checklist
- Added or updated unit tests (required for all new features)