### PR TITLE
MM-12009 Resolve relative links in posts as the web app does

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/dyatlov/go-opengraph/opengraph"
@@ -315,6 +316,8 @@ func getImagesInMessageAttachments(post *model.Post) []string {
 }
 
 func (a *App) getLinkMetadata(requestURL string, useCache bool) (*opengraph.OpenGraph, *model.PostImage, error) {
+	requestURL = resolveMetadataURL(requestURL, a.GetSiteURL())
+
 	// Check cache
 	if useCache {
 		og, image, ok := getLinkMetadataFromCache(requestURL)
@@ -347,6 +350,21 @@ func (a *App) getLinkMetadata(requestURL string, useCache bool) (*opengraph.Open
 	}
 
 	return og, image, err
+}
+
+// resolveMetadataURL resolves a given URL relative to the server's site URL.
+func resolveMetadataURL(requestURL string, siteURL string) string {
+	base, err := url.Parse(siteURL)
+	if err != nil {
+		return ""
+	}
+
+	resolved, err := base.Parse(requestURL)
+	if err != nil {
+		return ""
+	}
+
+	return resolved.String()
 }
 
 func getLinkMetadataFromCache(requestURL string) (*opengraph.OpenGraph, *model.PostImage, bool) {

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -994,6 +994,47 @@ func TestGetImagesInMessageAttachments(t *testing.T) {
 	}
 }
 
+func TestResolveMetadataURL(t *testing.T) {
+	for _, test := range []struct {
+		Name       string
+		RequestURL string
+		SiteURL    string
+		Expected   string
+	}{
+		{
+			Name:       "with HTTPS",
+			RequestURL: "https://example.com/file?param=1",
+			Expected:   "https://example.com/file?param=1",
+		},
+		{
+			Name:       "with HTTP",
+			RequestURL: "http://example.com/file?param=1",
+			Expected:   "http://example.com/file?param=1",
+		},
+		{
+			Name:       "with FTP",
+			RequestURL: "ftp://example.com/file?param=1",
+			Expected:   "ftp://example.com/file?param=1",
+		},
+		{
+			Name:       "relative to root",
+			RequestURL: "/file?param=1",
+			SiteURL:    "https://mattermost.example.com:123",
+			Expected:   "https://mattermost.example.com:123/file?param=1",
+		},
+		{
+			Name:       "relative to root with subpath",
+			RequestURL: "/file?param=1",
+			SiteURL:    "https://mattermost.example.com:123/subpath",
+			Expected:   "https://mattermost.example.com:123/file?param=1",
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert.Equal(t, resolveMetadataURL(test.RequestURL, test.SiteURL), test.Expected)
+		})
+	}
+}
+
 func TestParseLinkMetadata(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()


### PR DESCRIPTION
This turns out to support a rather contrived case since relative links are prevented from accessing dimensions of local images due to the default security settings, but I don't think it hurts to still include this code.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12009

#### Checklist
- Added or updated unit tests (required for all new features)
