### PR TITLE
MM-13190: Fix NotifyProps in Bulk Import.

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -279,6 +279,7 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 	} else {
 		user = &model.User{}
 		user.MakeNonNil()
+		user.SetDefaultNotifications()
 		hasUserChanged = true
 	}
 


### PR DESCRIPTION
#### Summary
If some, but not all, notify props are specified for a user in the bulk
import data, and that is a newly created user, we must explicitly
initialise all the other notify props to their default values to avoid
breaking client assumptions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13190

#### Checklist
- [x] Added or updated unit tests (required for all new features)