### PR TITLE
Use constants for NotifyProps keys.

### DIFF
--- a/app/auto_responder.go
+++ b/app/auto_responder.go
@@ -13,8 +13,8 @@ func (a *App) SendAutoResponse(channel *model.Channel, receiver *model.User) {
 		return
 	}
 
-	active := receiver.NotifyProps["auto_responder_active"] == "true"
-	message := receiver.NotifyProps["auto_responder_message"]
+	active := receiver.NotifyProps[model.AUTO_RESPONDER_ACTIVE_NOTIFY_PROP] == "true"
+	message := receiver.NotifyProps[model.AUTO_RESPONDER_MESSAGE_NOTIFY_PROP]
 
 	if active && message != "" {
 		autoResponderPost := &model.Post{
@@ -33,8 +33,8 @@ func (a *App) SendAutoResponse(channel *model.Channel, receiver *model.User) {
 }
 
 func (a *App) SetAutoResponderStatus(user *model.User, oldNotifyProps model.StringMap) {
-	active := user.NotifyProps["auto_responder_active"] == "true"
-	oldActive := oldNotifyProps["auto_responder_active"] == "true"
+	active := user.NotifyProps[model.AUTO_RESPONDER_ACTIVE_NOTIFY_PROP] == "true"
+	oldActive := oldNotifyProps[model.AUTO_RESPONDER_ACTIVE_NOTIFY_PROP] == "true"
 
 	autoResponderEnabled := !oldActive && active
 	autoResponderDisabled := oldActive && !active
@@ -52,12 +52,12 @@ func (a *App) DisableAutoResponder(userId string, asAdmin bool) *model.AppError 
 		return err
 	}
 
-	active := user.NotifyProps["auto_responder_active"] == "true"
+	active := user.NotifyProps[model.AUTO_RESPONDER_ACTIVE_NOTIFY_PROP] == "true"
 
 	if active {
 		patch := &model.UserPatch{}
 		patch.NotifyProps = user.NotifyProps
-		patch.NotifyProps["auto_responder_active"] = "false"
+		patch.NotifyProps[model.AUTO_RESPONDER_ACTIVE_NOTIFY_PROP] = "false"
 
 		_, err := a.PatchUser(userId, patch, asAdmin)
 		if err != nil {

--- a/app/notification.go
+++ b/app/notification.go
@@ -104,7 +104,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 		if len(post.RootId) > 0 && parentPostList != nil {
 			for _, threadPost := range parentPostList.Posts {
 				profile := profileMap[threadPost.UserId]
-				if profile != nil && (profile.NotifyProps["comments"] == THREAD_ANY || (profile.NotifyProps["comments"] == THREAD_ROOT && threadPost.Id == parentPostList.Order[0])) {
+				if profile != nil && (profile.NotifyProps[model.COMMENTS_NOTIFY_PROP] == THREAD_ANY || (profile.NotifyProps[model.COMMENTS_NOTIFY_PROP] == THREAD_ROOT && threadPost.Id == parentPostList.Order[0])) {
 					if threadPost.Id == parentPostList.Order[0] {
 						threadMentionedUserIds[threadPost.UserId] = THREAD_ROOT
 					} else {
@@ -565,9 +565,9 @@ func (a *App) GetMentionKeywordsInChannel(profiles map[string]*model.User, lookF
 		userMention := "@" + strings.ToLower(profile.Username)
 		keywords[userMention] = append(keywords[userMention], id)
 
-		if len(profile.NotifyProps["mention_keys"]) > 0 {
+		if len(profile.NotifyProps[model.MENTION_KEYS_NOTIFY_PROP]) > 0 {
 			// Add all the user's mention keys
-			splitKeys := strings.Split(profile.NotifyProps["mention_keys"], ",")
+			splitKeys := strings.Split(profile.NotifyProps[model.MENTION_KEYS_NOTIFY_PROP], ",")
 			for _, k := range splitKeys {
 				// note that these are made lower case so that we can do a case insensitive check for them
 				key := strings.ToLower(k)
@@ -576,7 +576,7 @@ func (a *App) GetMentionKeywordsInChannel(profiles map[string]*model.User, lookF
 		}
 
 		// If turned on, add the user's case sensitive first name
-		if profile.NotifyProps["first_name"] == "true" {
+		if profile.NotifyProps[model.FIRST_NAME_NOTIFY_PROP] == "true" {
 			keywords[profile.FirstName] = append(keywords[profile.FirstName], profile.Id)
 		}
 
@@ -589,7 +589,7 @@ func (a *App) GetMentionKeywordsInChannel(profiles map[string]*model.User, lookF
 
 		// Add @channel and @all to keywords if user has them turned on
 		if lookForSpecialMentions {
-			if int64(len(profiles)) <= *a.Config().TeamSettings.MaxNotificationsPerChannel && profile.NotifyProps["channel"] == "true" && !ignoreChannelMentions {
+			if int64(len(profiles)) <= *a.Config().TeamSettings.MaxNotificationsPerChannel && profile.NotifyProps[model.CHANNEL_MENTIONS_NOTIFY_PROP] == "true" && !ignoreChannelMentions {
 				keywords["@channel"] = append(keywords["@channel"], profile.Id)
 				keywords["@all"] = append(keywords["@all"], profile.Id)
 

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -357,7 +357,7 @@ func DoesStatusAllowPushNotification(userNotifyProps model.StringMap, status *mo
 		return false
 	}
 
-	pushStatus, ok := userNotifyProps["push_status"]
+	pushStatus, ok := userNotifyProps[model.PUSH_STATUS_NOTIFY_PROP]
 	if (pushStatus == model.STATUS_ONLINE || !ok) && (status.ActiveChannel != channelId || model.GetMillis()-status.LastActivityAt > model.STATUS_CHANNEL_TIMEOUT) {
 		return true
 	}

--- a/app/team.go
+++ b/app/team.go
@@ -695,7 +695,7 @@ func (a *App) GetTeamUnread(teamId, userId string) (*model.TeamUnread, *model.Ap
 	for _, cu := range channelUnreads {
 		teamUnread.MentionCount += cu.MentionCount
 
-		if cu.NotifyProps["mark_unread"] != model.CHANNEL_MARK_UNREAD_MENTION {
+		if cu.NotifyProps[model.MARK_UNREAD_NOTIFY_PROP] != model.CHANNEL_MARK_UNREAD_MENTION {
 			teamUnread.MsgCount += cu.MsgCount
 		}
 	}
@@ -914,7 +914,7 @@ func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userId string) ([]*mod
 	unreads := func(cu *model.ChannelUnread, tu *model.TeamUnread) *model.TeamUnread {
 		tu.MentionCount += cu.MentionCount
 
-		if cu.NotifyProps["mark_unread"] != model.CHANNEL_MARK_UNREAD_MENTION {
+		if cu.NotifyProps[model.MARK_UNREAD_NOTIFY_PROP] != model.CHANNEL_MARK_UNREAD_MENTION {
 			tu.MsgCount += cu.MsgCount
 		}
 

--- a/model/user.go
+++ b/model/user.go
@@ -16,24 +16,27 @@ import (
 )
 
 const (
-	ME                             = "me"
-	USER_NOTIFY_ALL                = "all"
-	USER_NOTIFY_MENTION            = "mention"
-	USER_NOTIFY_NONE               = "none"
-	DESKTOP_NOTIFY_PROP            = "desktop"
-	DESKTOP_SOUND_NOTIFY_PROP      = "desktop_sound"
-	MARK_UNREAD_NOTIFY_PROP        = "mark_unread"
-	PUSH_NOTIFY_PROP               = "push"
-	PUSH_STATUS_NOTIFY_PROP        = "push_status"
-	EMAIL_NOTIFY_PROP              = "email"
-	MOBILE_NOTIFY_PROP             = "mobile"
-	MOBILE_PUSH_STATUS_NOTIFY_PROP = "mobile_push_status"
-	CHANNEL_MENTIONS_NOTIFY_PROP   = "channel"
-	COMMENTS_NOTIFY_PROP           = "comments"
-	MENTION_KEYS_NOTIFY_PROP       = "mention_keys"
-	COMMENTS_NOTIFY_NEVER          = "never"
-	COMMENTS_NOTIFY_ROOT           = "root"
-	COMMENTS_NOTIFY_ANY            = "any"
+	ME                                 = "me"
+	USER_NOTIFY_ALL                    = "all"
+	USER_NOTIFY_MENTION                = "mention"
+	USER_NOTIFY_NONE                   = "none"
+	DESKTOP_NOTIFY_PROP                = "desktop"
+	DESKTOP_SOUND_NOTIFY_PROP          = "desktop_sound"
+	MARK_UNREAD_NOTIFY_PROP            = "mark_unread"
+	PUSH_NOTIFY_PROP                   = "push"
+	PUSH_STATUS_NOTIFY_PROP            = "push_status"
+	EMAIL_NOTIFY_PROP                  = "email"
+	MOBILE_NOTIFY_PROP                 = "mobile"
+	MOBILE_PUSH_STATUS_NOTIFY_PROP     = "mobile_push_status"
+	CHANNEL_MENTIONS_NOTIFY_PROP       = "channel"
+	COMMENTS_NOTIFY_PROP               = "comments"
+	MENTION_KEYS_NOTIFY_PROP           = "mention_keys"
+	COMMENTS_NOTIFY_NEVER              = "never"
+	COMMENTS_NOTIFY_ROOT               = "root"
+	COMMENTS_NOTIFY_ANY                = "any"
+	FIRST_NAME_NOTIFY_PROP             = "first_name"
+	AUTO_RESPONDER_ACTIVE_NOTIFY_PROP  = "auto_responder_active"
+	AUTO_RESPONDER_MESSAGE_NOTIFY_PROP = "auto_responder_message"
 
 	DEFAULT_LOCALE          = "en"
 	USER_AUTH_SERVICE_EMAIL = "email"
@@ -249,44 +252,44 @@ func (u *User) PreUpdate() {
 
 	if u.NotifyProps == nil || len(u.NotifyProps) == 0 {
 		u.SetDefaultNotifications()
-	} else if _, ok := u.NotifyProps["mention_keys"]; ok {
+	} else if _, ok := u.NotifyProps[MENTION_KEYS_NOTIFY_PROP]; ok {
 		// Remove any blank mention keys
-		splitKeys := strings.Split(u.NotifyProps["mention_keys"], ",")
+		splitKeys := strings.Split(u.NotifyProps[MENTION_KEYS_NOTIFY_PROP], ",")
 		goodKeys := []string{}
 		for _, key := range splitKeys {
 			if len(key) > 0 {
 				goodKeys = append(goodKeys, strings.ToLower(key))
 			}
 		}
-		u.NotifyProps["mention_keys"] = strings.Join(goodKeys, ",")
+		u.NotifyProps[MENTION_KEYS_NOTIFY_PROP] = strings.Join(goodKeys, ",")
 	}
 }
 
 func (u *User) SetDefaultNotifications() {
 	u.NotifyProps = make(map[string]string)
-	u.NotifyProps["email"] = "true"
-	u.NotifyProps["push"] = USER_NOTIFY_MENTION
-	u.NotifyProps["desktop"] = USER_NOTIFY_MENTION
-	u.NotifyProps["desktop_sound"] = "true"
-	u.NotifyProps["mention_keys"] = u.Username + ",@" + u.Username
-	u.NotifyProps["channel"] = "true"
-	u.NotifyProps["push_status"] = STATUS_AWAY
-	u.NotifyProps["comments"] = "never"
-	u.NotifyProps["first_name"] = "false"
+	u.NotifyProps[EMAIL_NOTIFY_PROP] = "true"
+	u.NotifyProps[PUSH_NOTIFY_PROP] = USER_NOTIFY_MENTION
+	u.NotifyProps[DESKTOP_NOTIFY_PROP] = USER_NOTIFY_MENTION
+	u.NotifyProps[DESKTOP_SOUND_NOTIFY_PROP] = "true"
+	u.NotifyProps[MENTION_KEYS_NOTIFY_PROP] = u.Username + ",@" + u.Username
+	u.NotifyProps[CHANNEL_MENTIONS_NOTIFY_PROP] = "true"
+	u.NotifyProps[PUSH_STATUS_NOTIFY_PROP] = STATUS_AWAY
+	u.NotifyProps[COMMENTS_NOTIFY_PROP] = COMMENTS_NOTIFY_NEVER
+	u.NotifyProps[FIRST_NAME_NOTIFY_PROP] = "false"
 }
 
 func (user *User) UpdateMentionKeysFromUsername(oldUsername string) {
 	nonUsernameKeys := []string{}
-	splitKeys := strings.Split(user.NotifyProps["mention_keys"], ",")
+	splitKeys := strings.Split(user.NotifyProps[MENTION_KEYS_NOTIFY_PROP], ",")
 	for _, key := range splitKeys {
 		if key != oldUsername && key != "@"+oldUsername {
 			nonUsernameKeys = append(nonUsernameKeys, key)
 		}
 	}
 
-	user.NotifyProps["mention_keys"] = user.Username + ",@" + user.Username
+	user.NotifyProps[MENTION_KEYS_NOTIFY_PROP] = user.Username + ",@" + user.Username
 	if len(nonUsernameKeys) > 0 {
-		user.NotifyProps["mention_keys"] += "," + strings.Join(nonUsernameKeys, ",")
+		user.NotifyProps[MENTION_KEYS_NOTIFY_PROP] += "," + strings.Join(nonUsernameKeys, ",")
 	}
 }
 


### PR DESCRIPTION
#### Summary
We have constants for (most) of the notify props keys. We should use
them consistently, instead of sometimes and other times having strings
scattered around the place.