### PR TITLE
fix two page, perPage -> offset, limit mistranslations

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -188,7 +188,7 @@ func (api *PluginAPI) GetUsersByUsernames(usernames []string) ([]*model.User, *m
 }
 
 func (api *PluginAPI) GetUsersInTeam(teamId string, page int, perPage int) ([]*model.User, *model.AppError) {
-	return api.app.GetUsersInTeam(teamId, page, perPage)
+	return api.app.GetUsersInTeam(teamId, page*perPage, perPage)
 }
 
 func (api *PluginAPI) UpdateUser(user *model.User) (*model.User, *model.AppError) {

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -104,7 +104,7 @@ func (a *App) DeleteAllExpiredPluginKeys() *model.AppError {
 }
 
 func (a *App) ListPluginKeys(pluginId string, page, perPage int) ([]string, *model.AppError) {
-	result := <-a.Srv.Store.Plugin().List(pluginId, page, perPage)
+	result := <-a.Srv.Store.Plugin().List(pluginId, page*perPage, perPage)
 
 	if result.Err != nil {
 		mlog.Error("Failed to list plugin key values", mlog.Int("page", page), mlog.Int("perPage", perPage), mlog.Err(result.Err))

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -34,6 +34,8 @@ func TestPluginKeyValueStore(t *testing.T) {
 	defer func() {
 		assert.Nil(t, th.App.DeletePluginKey(pluginId, "key"))
 		assert.Nil(t, th.App.DeletePluginKey(pluginId, "key2"))
+		assert.Nil(t, th.App.DeletePluginKey(pluginId, "key3"))
+		assert.Nil(t, th.App.DeletePluginKey(pluginId, "key4"))
 	}()
 
 	assert.Nil(t, th.App.SetPluginKey(pluginId, "key", []byte("test")))
@@ -78,36 +80,49 @@ func TestPluginKeyValueStore(t *testing.T) {
 	assert.Equal(t, kv.Value, ret)
 
 	// Test ListKeys
+	assert.Nil(t, th.App.SetPluginKey(pluginId, "key3", []byte("test3")))
+	assert.Nil(t, th.App.SetPluginKey(pluginId, "key4", []byte("test4")))
+
 	list, err := th.App.ListPluginKeys(pluginId, 0, 1)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(list))
-	assert.Equal(t, "key", list[0])
+	assert.Equal(t, []string{"key"}, list)
 
 	list, err = th.App.ListPluginKeys(pluginId, 1, 1)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(list))
-	assert.Equal(t, hashedKey2, list[0])
+	assert.Equal(t, []string{"key3"}, list)
+
+	list, err = th.App.ListPluginKeys(pluginId, 0, 4)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"key", "key3", "key4", hashedKey2}, list)
+
+	list, err = th.App.ListPluginKeys(pluginId, 0, 2)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"key", "key3"}, list)
+
+	list, err = th.App.ListPluginKeys(pluginId, 1, 2)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"key4", hashedKey2}, list)
+
+	list, err = th.App.ListPluginKeys(pluginId, 2, 2)
+	assert.Nil(t, err)
+	assert.Equal(t, []string{}, list)
 
 	// List Keys bad input
 	list, err = th.App.ListPluginKeys(pluginId, 0, 0)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(list))
+	assert.Equal(t, []string{"key", "key3", "key4", hashedKey2}, list)
 
 	list, err = th.App.ListPluginKeys(pluginId, 0, -1)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(list))
+	assert.Equal(t, []string{"key", "key3", "key4", hashedKey2}, list)
 
 	list, err = th.App.ListPluginKeys(pluginId, -1, 1)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(list))
+	assert.Equal(t, []string{"key"}, list)
 
 	list, err = th.App.ListPluginKeys(pluginId, -1, 0)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(list))
-
-	list, err = th.App.ListPluginKeys(pluginId, 2, 2)
-	assert.Nil(t, err)
-	assert.Equal(t, 0, len(list))
+	assert.Equal(t, []string{"key", "key3", "key4", hashedKey2}, list)
 }
 
 func TestServePluginRequest(t *testing.T) {


### PR DESCRIPTION
#### Summary
I ran across an instance where `page, perPage` was being passed down to the store but being interpreted as `offset, limit`. Fixing these in place, but it would be nice to converge on `offset, limit` even in the store to make this easier to verify during code review.

For reference in reviewing this, the plugin store accepts `offset, limit`:
https://github.com/mattermost/mattermost-server/blob/da265fbaf78a02333c00eec167540ac2119b2b89/store/sqlstore/plugin_store.go#L121

And the app `GetUsersInTeam` accepts `offset, limit` directly:
https://github.com/mattermost/mattermost-server/blob/da265fbaf78a02333c00eec167540ac2119b2b89/app/user.go#L411

#### Ticket Link
None.

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
