### PR TITLE
Updating content security policy.

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -84,7 +84,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.IsStatic {
 		// Instruct the browser not to display us in an iframe unless is the same origin for anti-clickjacking
 		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
-		w.Header().Set("Content-Security-Policy", "frame-ancestors 'self'")
+		// Set content security policy. This is also specified in the root.html of the webapp in a meta tag.
+		w.Header().Set("Content-Security-Policy", "frame-ancestors 'self'; script-src 'self' cdn.segment.com/analytics.js/")
 	} else {
 		// All api response bodies will be JSON formatted by default
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Updating CSP header to specify script-src as well. This was already specified in the HTML of the webapp.
`frame-ancestors 'self'` is not specified in the HTML of the webapp because it is not supported there (you must specify it using the header)

Webapp Changes: https://github.com/mattermost/mattermost-webapp/pull/2102