### PR TITLE
[MM-13417] Add custom header to interactive messages

### DIFF
--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -71,7 +71,7 @@ func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) (str
 		request.Context["selected_option"] = selectedOption
 	}
 
-	resp, err := a.DoActionRequest(action.Integration.URL, request.ToJson())
+	resp, err := a.DoActionRequest(action.Integration.URL, request.ToJson(), action.Integration.CustomHeader)
 	if resp != nil {
 		defer consumeAndClose(resp)
 	}
@@ -126,11 +126,14 @@ func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) (str
 
 // Perform an HTTP POST request to an integration's action endpoint.
 // Caller must consume and close returned http.Response as necessary.
-func (a *App) DoActionRequest(rawURL string, body []byte) (*http.Response, *model.AppError) {
+func (a *App) DoActionRequest(rawURL string, body []byte, header_optional ...string) (*http.Response, *model.AppError) {
 	req, _ := http.NewRequest("POST", rawURL, bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-
+	// Include custom header if presented
+	if len(header_optional) > 0 {
+		req.Header.Set("X-Custom-Header", header_optional[0])
+	}
 	// Allow access to plugin routes for action buttons
 	var httpClient *httpservice.Client
 	url, _ := url.Parse(rawURL)

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -42,8 +42,9 @@ type PostActionOptions struct {
 }
 
 type PostActionIntegration struct {
-	URL     string                 `json:"url,omitempty"`
-	Context map[string]interface{} `json:"context,omitempty"`
+	URL          string                 `json:"url,omitempty"`
+	Context      map[string]interface{} `json:"context,omitempty"`
+	CustomHeader string                 `json:"custom_header,omitempty"`
 }
 
 type PostActionIntegrationRequest struct {


### PR DESCRIPTION
`DO NOT MERGE`
#### Summary
Include custom header field for Interactive message. 
PR is to demonstrate code change necessary to add custom header for interactive message response. 

Use case [added by @jasonblais after discussing with contributor]:

As a system administrator, I want to be able to add a custom header in interactive messages, so that responses created by the integration can verify the authenticity of actions that was taken by the user. 

For instance, if the JSON payload contains the key X, the value associated with that will form a custom header when the response is sent. This is beneficial when admins wants to get users response on an action but wants to forward it directly to target machine instead of having a round trip back to where the message originated from. This is a better way of handling such case in terms of security.

Doc PR can be found here: https://github.com/mattermost/docs/pull/2408

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13417

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
