### PR TITLE
Validating config on set command

### DIFF
--- a/cmd/mattermost/commands/config.go
+++ b/cmd/mattermost/commands/config.go
@@ -261,6 +261,15 @@ func configSetCmdF(command *cobra.Command, args []string) error {
 	// update the config
 	app.UpdateConfig(f)
 
+	// Verify new config
+	if err := newConfig.IsValid(); err != nil {
+		return err
+	}
+
+	if err := utils.ValidateLocales(app.Config()); err != nil {
+		return errors.New("Invalid locale configuration")
+	}
+
 	// make the changes persist
 	app.PersistConfig()
 


### PR DESCRIPTION
#### Summary
Validating config before save it on `mattermost config set` command

#### Checklist
- [x] Added or updated unit tests (required for all new features)