### PR TITLE
leverage CheckCommand when a cmd should pass

### DIFF
--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -70,8 +70,8 @@ func TestMoveChannel(t *testing.T) {
 
 	CheckCommand(t, "channel", "add", origin, adminEmail)
 
-	// should fail with nill because errors are logged instead of returned when a channel does not exist
-	require.Nil(t, RunCommand(t, "channel", "move", dest, team1.Name+":doesnotexist", "--username", adminUsername))
+	// should fail with nil because errors are logged instead of returned when a channel does not exist
+	CheckCommand(t, "channel", "move", dest, team1.Name+":doesnotexist", "--username", adminUsername)
 
 	CheckCommand(t, "channel", "move", dest, origin, "--username", adminUsername)
 }

--- a/cmd/mattermost/commands/command_test.go
+++ b/cmd/mattermost/commands/command_test.go
@@ -159,7 +159,7 @@ func TestDeleteCommand(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, len(commands), 1)
 
-		assert.Nil(t, RunCommand(t, "command", "delete", command.Id))
+		CheckCommand(t, "command", "delete", command.Id)
 		commands, err = th.App.ListTeamCommands(team.Id)
 		require.Nil(t, err)
 		assert.Equal(t, len(commands), 0)

--- a/cmd/mattermost/commands/config_test.go
+++ b/cmd/mattermost/commands/config_test.go
@@ -82,7 +82,7 @@ func TestConfigValidate(t *testing.T) {
 	require.NoError(t, ioutil.WriteFile(path, []byte(config.ToJson()), 0600))
 
 	assert.Error(t, RunCommand(t, "--config", "foo.json", "config", "validate"))
-	assert.NoError(t, RunCommand(t, "--config", path, "config", "validate"))
+	CheckCommand(t, "--config", path, "config", "validate")
 }
 
 func TestConfigGet(t *testing.T) {
@@ -96,9 +96,9 @@ func TestConfigGet(t *testing.T) {
 	assert.Error(t, RunCommand(t, "config", "get", "abc"))
 
 	// No Error when a config setting which is  in the config.json is given
-	assert.NoError(t, RunCommand(t, "config", "get", "MessageExportSettings"))
-	assert.NoError(t, RunCommand(t, "config", "get", "MessageExportSettings.GlobalRelaySettings"))
-	assert.NoError(t, RunCommand(t, "config", "get", "MessageExportSettings.GlobalRelaySettings.CustomerType"))
+	CheckCommand(t, "config", "get", "MessageExportSettings")
+	CheckCommand(t, "config", "get", "MessageExportSettings.GlobalRelaySettings")
+	CheckCommand(t, "config", "get", "MessageExportSettings.GlobalRelaySettings.CustomerType")
 
 	// check output
 	output := CheckCommand(t, "config", "get", "MessageExportSettings")
@@ -135,19 +135,19 @@ func TestConfigSet(t *testing.T) {
 	assert.NotContains(t, string(output), "invalid")
 
 	// Error when the wrong locale is set
-	assert.NoError(t, RunCommand(t, "--config", path, "config", "set", "LocalizationSettings.DefaultServerLocale", "es"))
+	CheckCommand(t, "--config", path, "config", "set", "LocalizationSettings.DefaultServerLocale", "es")
 	assert.Error(t, RunCommand(t, "--config", path, "config", "set", "LocalizationSettings.DefaultServerLocale", "invalid"))
 	output = CheckCommand(t, "--config", path, "config", "get", "LocalizationSettings.DefaultServerLocale")
 	assert.NotContains(t, string(output), "invalid")
 	assert.NotContains(t, string(output), "\"en\"")
 
 	// Success when a valid value is set
-	assert.NoError(t, RunCommand(t, "--config", path, "config", "set", "EmailSettings.ConnectionSecurity", "TLS"))
+	CheckCommand(t, "--config", path, "config", "set", "EmailSettings.ConnectionSecurity", "TLS")
 	output = CheckCommand(t, "--config", path, "config", "get", "EmailSettings.ConnectionSecurity")
 	assert.Contains(t, string(output), "TLS")
 
 	// Success when a valid locale is set
-	assert.NoError(t, RunCommand(t, "--config", path, "config", "set", "LocalizationSettings.DefaultServerLocale", "es"))
+	CheckCommand(t, "--config", path, "config", "set", "LocalizationSettings.DefaultServerLocale", "es")
 	output = CheckCommand(t, "--config", path, "config", "get", "LocalizationSettings.DefaultServerLocale")
 	assert.Contains(t, string(output), "\"es\"")
 }
@@ -469,7 +469,7 @@ func TestConfigShow(t *testing.T) {
 	assert.Error(t, RunCommand(t, "config", "show", "abc"))
 
 	// no error
-	assert.NoError(t, RunCommand(t, "config", "show"))
+	CheckCommand(t, "config", "show")
 
 	// check the output
 	output := CheckCommand(t, "config", "show")
@@ -483,10 +483,10 @@ func TestSetConfig(t *testing.T) {
 	assert.Error(t, RunCommand(t, "config", "set"))
 
 	// No Error when more than one argument is given
-	assert.NoError(t, RunCommand(t, "config", "set", "ThemeSettings.AllowedThemes", "hello", "World"))
+	CheckCommand(t, "config", "set", "ThemeSettings.AllowedThemes", "hello", "World")
 
 	// No Error when two arguments are given
-	assert.NoError(t, RunCommand(t, "config", "set", "ThemeSettings.AllowedThemes", "hello"))
+	CheckCommand(t, "config", "set", "ThemeSettings.AllowedThemes", "hello")
 
 	// Error when only one argument is given
 	assert.Error(t, RunCommand(t, "config", "set", "ThemeSettings.AllowedThemes"))


### PR DESCRIPTION
#### Summary
Using `RunCommand` obscures the error if, indeed, the assertion fails because the cmd fails to run.

#### Ticket Link
None.

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
