### PR TITLE
MM-12378: synchronize migrations with actual schema

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -59,6 +59,7 @@ type SqlStore interface {
 	RenameColumnIfExists(tableName string, oldColumnName string, newColumnName string, colType string) bool
 	GetMaxLengthOfColumnIfExists(tableName string, columnName string) string
 	AlterColumnTypeIfExists(tableName string, columnName string, mySqlColType string, postgresColType string) bool
+	AlterColumnDefaultIfExists(tableName string, columnName string, mySqlColDefault *string, postgresColDefault *string) bool
 	CreateUniqueIndexIfNotExists(indexName string, tableName string, columnName string) bool
 	CreateIndexIfNotExists(indexName string, tableName string, columnName string) bool
 	CreateCompositeIndexIfNotExists(indexName string, tableName string, columnNames []string) bool

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -92,6 +92,7 @@ func UpgradeDatabase(sqlStore SqlStore) {
 	UpgradeDatabaseToVersion55(sqlStore)
 	UpgradeDatabaseToVersion56(sqlStore)
 	UpgradeDatabaseToVersion57(sqlStore)
+	UpgradeDatabaseToVersion58(sqlStore)
 
 	// If the SchemaVersion is empty this this is the first time it has ran
 	// so lets set it to the current version.
@@ -536,9 +537,31 @@ func UpgradeDatabaseToVersion56(sqlStore SqlStore) {
 }
 
 func UpgradeDatabaseToVersion57(sqlStore SqlStore) {
-	// TODO: Uncomment following condition when version 5.5.0 is released
+	// TODO: Uncomment following condition when version 5.7.0 is released
 	// if shouldPerformUpgrade(sqlStore, VERSION_5_6_0, VERSION_5_7_0) {
 
 	// 	saveSchemaVersion(sqlStore, VERSION_5_7_0)
+	// }
+}
+
+func UpgradeDatabaseToVersion58(sqlStore SqlStore) {
+	// TODO: Uncomment following condition when version 5.8.0 is released
+	// if shouldPerformUpgrade(sqlStore, VERSION_5_7_0, VERSION_5_8_0) {
+
+	// idx_channels_txt was removed in `UpgradeDatabaseToVersion50`, but merged as part of
+	// v5.1, so the migration wouldn't apply to anyone upgrading from v5.0. Remove it again to
+	// bring the upgraded (from v5.0) and fresh install schemas back in sync.
+	sqlStore.RemoveIndexIfExists("idx_channels_txt", "Channels")
+
+	// Fix column types and defaults where gorp converged on a different schema value than the
+	// original migration.
+	sqlStore.AlterColumnTypeIfExists("OutgoingWebhooks", "Description", "text", "VARCHAR(500)")
+	sqlStore.AlterColumnTypeIfExists("IncomingWebhooks", "Description", "text", "VARCHAR(500)")
+	sqlStore.AlterColumnTypeIfExists("OutgoingWebhooks", "IconURL", "text", "VARCHAR(1024)")
+	sqlStore.AlterColumnDefaultIfExists("OutgoingWebhooks", "Username", model.NewString("NULL"), model.NewString(""))
+	sqlStore.AlterColumnDefaultIfExists("OutgoingWebhooks", "IconURL", nil, model.NewString(""))
+	sqlStore.AlterColumnDefaultIfExists("PluginKeyValueStore", "ExpireAt", model.NewString("NULL"), model.NewString("NULL"))
+
+	// 	saveSchemaVersion(sqlStore, VERSION_5_8_0)
 	// }
 }


### PR DESCRIPTION
#### Summary
Upgrading from `v5.0` to `master` produced a different schema than running a fresh install from `master`. Except in one case, this is entirely the result of a mismatch between the hand-written migration and the underlying gorp library.

Filed https://mattermost.atlassian.net/browse/MM-13341 to track the work required to automate these checks going forward and prevent future mismatches.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-12378

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)