### PR TITLE
Fix panic with customurlschemes

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -551,7 +551,7 @@ func (a *App) trackConfig() {
 
 	a.SendDiagnostic(TRACK_CONFIG_DISPLAY, map[string]interface{}{
 		"experimental_timezone":        *cfg.DisplaySettings.ExperimentalTimezone,
-		"isdefault_custom_url_schemes": len(*cfg.DisplaySettings.CustomUrlSchemes) != 0,
+		"isdefault_custom_url_schemes": len(cfg.DisplaySettings.CustomUrlSchemes) != 0,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TIMEZONE, map[string]interface{}{

--- a/model/config.go
+++ b/model/config.go
@@ -1897,14 +1897,14 @@ func (s *MessageExportSettings) SetDefaults() {
 }
 
 type DisplaySettings struct {
-	CustomUrlSchemes     *[]string
+	CustomUrlSchemes     []string
 	ExperimentalTimezone *bool
 }
 
 func (s *DisplaySettings) SetDefaults() {
 	if s.CustomUrlSchemes == nil {
 		customUrlSchemes := []string{}
-		s.CustomUrlSchemes = &customUrlSchemes
+		s.CustomUrlSchemes = customUrlSchemes
 	}
 
 	if s.ExperimentalTimezone == nil {
@@ -2495,10 +2495,10 @@ func (mes *MessageExportSettings) isValid(fs FileSettings) *AppError {
 }
 
 func (ds *DisplaySettings) isValid() *AppError {
-	if len(*ds.CustomUrlSchemes) != 0 {
+	if len(ds.CustomUrlSchemes) != 0 {
 		validProtocolPattern := regexp.MustCompile(`(?i)^\s*[a-z][a-z0-9-]*\s*$`)
 
-		for _, scheme := range *ds.CustomUrlSchemes {
+		for _, scheme := range ds.CustomUrlSchemes {
 			if !validProtocolPattern.MatchString(scheme) {
 				return NewAppError(
 					"Config.IsValid",

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -512,7 +512,7 @@ func TestDisplaySettingsIsValidCustomUrlSchemes(t *testing.T) {
 			ds := &DisplaySettings{}
 			ds.SetDefaults()
 
-			ds.CustomUrlSchemes = &test.value
+			ds.CustomUrlSchemes = test.value
 
 			if err := ds.isValid(); err != nil && test.valid {
 				t.Error("Expected CustomUrlSchemes to be valid but got error:", err)

--- a/utils/config.go
+++ b/utils/config.go
@@ -625,7 +625,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["PasswordRequireUppercase"] = strconv.FormatBool(*c.PasswordSettings.Uppercase)
 	props["PasswordRequireNumber"] = strconv.FormatBool(*c.PasswordSettings.Number)
 	props["PasswordRequireSymbol"] = strconv.FormatBool(*c.PasswordSettings.Symbol)
-	props["CustomUrlSchemes"] = strings.Join(*c.DisplaySettings.CustomUrlSchemes, ",")
+	props["CustomUrlSchemes"] = strings.Join(c.DisplaySettings.CustomUrlSchemes, ",")
 
 	if license != nil {
 		props["ExperimentalHideTownSquareinLHS"] = strconv.FormatBool(*c.TeamSettings.ExperimentalHideTownSquareinLHS)


### PR DESCRIPTION
Converts type from `*[]string` to `[]string`. 

Not sure why this fixes this panic...

```
goroutine 1 [running]:
github.com/mattermost/mattermost-server/utils.GenerateClientConfig(0xc001ff6000, 0xc002450ba0, 0x1a, 0x0, 0x0)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/utils/config.go:628 +0x2daa
github.com/mattermost/mattermost-server/app.(*App).regenerateClientConfig(0xc00105a700)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/app/config.go:283 +0x148
github.com/mattermost/mattermost-server/app.(*App).configOrLicenseListener(0xc00105a700)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/app/app.go:67 +0x2b
github.com/mattermost/mattermost-server/app.(*Server).RunOldAppInitalization.func1(0xc001d88000, 0xc001ff6000)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/app/server.go:152 +0x33
github.com/mattermost/mattermost-server/app.(*Server).InvokeConfigListeners(0xc0001d6600, 0xc001d88000, 0xc001ff6000)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/app/config.go:169 +0x99
github.com/mattermost/mattermost-server/app.(*Server).UpdateConfig(0xc0001d6600, 0x168bc18)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/app/config.go:58 +0xeb
github.com/mattermost/mattermost-server/app.NewServer(0xc000015680, 0x1, 0x1, 0x0, 0x0, 0x0)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/app/server.go:345 +0xb69
github.com/mattermost/mattermost-server/cmd/mattermost/commands.runServer(0x15df3ef, 0xb, 0xc001020000, 0xc0010243c0, 0x0, 0x0)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/cmd/mattermost/commands/server.go:57 +0xcf
github.com/mattermost/mattermost-server/cmd/mattermost/commands.serverCmdF(0x25edbc0, 0x263e108, 0x0, 0x0, 0x0, 0x0)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/cmd/mattermost/commands/server.go:49 +0x150
github.com/mattermost/mattermost-server/vendor/github.com/spf13/cobra.(*Command).execute(0x25edbc0, 0xc0000b8170, 0x0, 0x0, 0x25edbc0, 0xc0000b8170)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/vendor/github.com/spf13/cobra/command.go:762 +0x473
github.com/mattermost/mattermost-server/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0x25edbc0, 0xc0001c65a0, 0xc0000f5f58, 0x12585dc)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/vendor/github.com/spf13/cobra/command.go:852 +0x2fd
github.com/mattermost/mattermost-server/vendor/github.com/spf13/cobra.(*Command).Execute(0x25edbc0, 0x4075d0, 0xc0000ae058)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/vendor/github.com/spf13/cobra/command.go:800 +0x2b
github.com/mattermost/mattermost-server/cmd/mattermost/commands.Run(0xc0000b8170, 0x0, 0x0, 0xc0000f5f88, 0xc0000ae058)
	/home/christopher/go/src/github.com/mattermost/mattermost-server/cmd/mattermost/commands/root.go:14 +0x65
```