### PR TITLE
MM-8662: Added `force` flag to uploadPlugin http API

### DIFF
--- a/api4/plugin.go
+++ b/api4/plugin.go
@@ -66,7 +66,11 @@ func uploadPlugin(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	manifest, unpackErr := c.App.InstallPlugin(file, false)
+	force := false
+	if len(m.Value["force"]) > 0 && m.Value["force"][0] != "" {
+		force = true
+	}
+	manifest, unpackErr := c.App.InstallPlugin(file, force)
 
 	if unpackErr != nil {
 		c.Err = unpackErr

--- a/api4/plugin.go
+++ b/api4/plugin.go
@@ -67,7 +67,7 @@ func uploadPlugin(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer file.Close()
 
 	force := false
-	if len(m.Value["force"]) > 0 && m.Value["force"][0] != "" {
+	if len(m.Value["force"]) > 0 && m.Value["force"][0] == "true" {
 		force = true
 	}
 	manifest, unpackErr := c.App.InstallPlugin(file, force)

--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -45,29 +45,31 @@ func TestPlugin(t *testing.T) {
 	defer file.Close()
 
 	// Successful upload
-	manifest, resp := th.SystemAdminClient.UploadPlugin(file)
+	manifest, resp := th.SystemAdminClient.UploadPlugin(file, false)
+	//CheckNoError(t, resp)
+	//manifest, resp = th.SystemAdminClient.UploadPlugin(file, true)
 	defer os.RemoveAll("plugins/testplugin")
 	CheckNoError(t, resp)
 
 	assert.Equal(t, "testplugin", manifest.Id)
 
 	// Upload error cases
-	_, resp = th.SystemAdminClient.UploadPlugin(bytes.NewReader([]byte("badfile")))
+	_, resp = th.SystemAdminClient.UploadPlugin(bytes.NewReader([]byte("badfile")), false)
 	CheckBadRequestStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = false })
-	_, resp = th.SystemAdminClient.UploadPlugin(file)
+	_, resp = th.SystemAdminClient.UploadPlugin(file, false)
 	CheckNotImplementedStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.PluginSettings.Enable = true
 		*cfg.PluginSettings.EnableUploads = false
 	})
-	_, resp = th.SystemAdminClient.UploadPlugin(file)
+	_, resp = th.SystemAdminClient.UploadPlugin(file, false)
 	CheckNotImplementedStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.EnableUploads = true })
-	_, resp = th.Client.UploadPlugin(file)
+	_, resp = th.Client.UploadPlugin(file, false)
 	CheckForbiddenStatus(t, resp)
 
 	// Successful gets

--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -6,6 +6,7 @@ package api4
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,38 +39,37 @@ func TestPlugin(t *testing.T) {
 	})
 
 	path, _ := utils.FindDir("tests")
-	file, err := os.Open(filepath.Join(path, "testplugin.tar.gz"))
+	tarData, err := ioutil.ReadFile(filepath.Join(path, "testplugin.tar.gz"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
 
 	// Successful upload
-	manifest, resp := th.SystemAdminClient.UploadPlugin(file, false)
-	//CheckNoError(t, resp)
-	//manifest, resp = th.SystemAdminClient.UploadPlugin(file, true)
+	manifest, resp := th.SystemAdminClient.UploadPlugin(bytes.NewReader(tarData))
+	CheckNoError(t, resp)
+	manifest, resp = th.SystemAdminClient.UploadPluginForced(bytes.NewReader(tarData))
 	defer os.RemoveAll("plugins/testplugin")
 	CheckNoError(t, resp)
 
 	assert.Equal(t, "testplugin", manifest.Id)
 
 	// Upload error cases
-	_, resp = th.SystemAdminClient.UploadPlugin(bytes.NewReader([]byte("badfile")), false)
+	_, resp = th.SystemAdminClient.UploadPlugin(bytes.NewReader([]byte("badfile")))
 	CheckBadRequestStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = false })
-	_, resp = th.SystemAdminClient.UploadPlugin(file, false)
+	_, resp = th.SystemAdminClient.UploadPlugin(bytes.NewReader(tarData))
 	CheckNotImplementedStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.PluginSettings.Enable = true
 		*cfg.PluginSettings.EnableUploads = false
 	})
-	_, resp = th.SystemAdminClient.UploadPlugin(file, false)
+	_, resp = th.SystemAdminClient.UploadPlugin(bytes.NewReader(tarData))
 	CheckNotImplementedStatus(t, resp)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.EnableUploads = true })
-	_, resp = th.Client.UploadPlugin(file, false)
+	_, resp = th.Client.UploadPlugin(bytes.NewReader(tarData))
 	CheckForbiddenStatus(t, resp)
 
 	// Successful gets

--- a/model/client4.go
+++ b/model/client4.go
@@ -3782,7 +3782,15 @@ func (c *Client4) GetChannelsForScheme(schemeId string, page int, perPage int) (
 
 // UploadPlugin takes an io.Reader stream pointing to the contents of a .tar.gz plugin.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
-func (c *Client4) UploadPlugin(file io.Reader, force bool) (*Manifest, *Response) {
+func (c *Client4) UploadPlugin(file io.Reader) (*Manifest, *Response) {
+	return c.uploadPlugin(file, false)
+}
+
+func (c *Client4) UploadPluginForced(file io.Reader) (*Manifest, *Response) {
+	return c.uploadPlugin(file, true)
+}
+
+func (c *Client4) uploadPlugin(file io.Reader, force bool) (*Manifest, *Response) {
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -3782,9 +3782,16 @@ func (c *Client4) GetChannelsForScheme(schemeId string, page int, perPage int) (
 
 // UploadPlugin takes an io.Reader stream pointing to the contents of a .tar.gz plugin.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
-func (c *Client4) UploadPlugin(file io.Reader) (*Manifest, *Response) {
+func (c *Client4) UploadPlugin(file io.Reader, force bool) (*Manifest, *Response) {
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
+
+	if force {
+		err := writer.WriteField("force", "true")
+		if err != nil {
+			return nil, &Response{Error: NewAppError("UploadPlugin", "model.client.writer.app_error", nil, err.Error(), 0)}
+		}
+	}
 
 	part, err := writer.CreateFormFile("plugin", "plugin.tar.gz")
 	if err != nil {


### PR DESCRIPTION
#### Summary
Added support for the `force` flag in the `updatePlugin` http API (as a multipart form value) to enable plugin replacement.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-8662

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [x] Added API documentation (required for all new APIs)
- [x] All new/modified APIs include changes to the drivers

#### See Also
https://github.com/mattermost/mattermost-redux/pull/732
https://github.com/mattermost/mattermost-api-reference/pull/409
https://github.com/mattermost/mattermost-webapp/pull/2147