### PR TITLE
[GH-7494] Added the role to the user search filter

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -452,8 +452,7 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			if c.HandleEtag(etag, "Get Users in Team", w, r) {
 				return
 			}
-
-			profiles, err = c.App.GetUsersInTeamPage(inTeamId, c.Params.Page, c.Params.PerPage, c.IsSystemAdmin())
+			profiles, err = c.App.GetUsersInTeamPage(userGetOptions, c.IsSystemAdmin())
 		}
 	} else if len(inChannelId) > 0 {
 		if !c.App.SessionHasPermissionToChannel(c.App.Session, inChannelId, model.PERMISSION_READ_CHANNEL) {

--- a/api4/user.go
+++ b/api4/user.go
@@ -365,6 +365,8 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	inChannelId := r.URL.Query().Get("in_channel")
 	notInChannelId := r.URL.Query().Get("not_in_channel")
 	withoutTeam := r.URL.Query().Get("without_team")
+	inactive := r.URL.Query().Get("inactive")
+	role := r.URL.Query().Get("role")
 	sort := r.URL.Query().Get("sort")
 
 	if len(notInChannelId) > 0 && len(inTeamId) == 0 {
@@ -386,6 +388,22 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	if sort == "status" && inChannelId == "" {
 		c.SetInvalidUrlParam("sort")
 		return
+	}
+
+	withoutTeamBool, _ := strconv.ParseBool(withoutTeam)
+	inactiveBool, _ := strconv.ParseBool(inactive)
+
+	userGetOptions := &model.UserGetOptions{
+		InTeamId:       inTeamId,
+		InChannelId:    inChannelId,
+		NotInTeamId:    notInTeamId,
+		NotInChannelId: notInChannelId,
+		WithoutTeam:    withoutTeamBool,
+		Inactive:       inactiveBool,
+		Role:           role,
+		Sort:           sort,
+		Page:           c.Params.Page,
+		PerPage:        c.Params.PerPage,
 	}
 
 	var profiles []*model.User
@@ -454,7 +472,7 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		if c.HandleEtag(etag, "Get Users", w, r) {
 			return
 		}
-		profiles, err = c.App.GetUsersPage(c.Params.Page, c.Params.PerPage, c.IsSystemAdmin())
+		profiles, err = c.App.GetUsersPage(userGetOptions, c.IsSystemAdmin())
 	}
 
 	if err != nil {

--- a/api4/user.go
+++ b/api4/user.go
@@ -553,6 +553,7 @@ func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		IsAdmin:       c.IsSystemAdmin(),
 		AllowInactive: props.AllowInactive,
 		Limit:         props.Limit,
+		Role:          props.Role,
 	}
 
 	if c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_MANAGE_SYSTEM) {

--- a/app/channel.go
+++ b/app/channel.go
@@ -891,7 +891,8 @@ func (a *App) AddChannelMember(userId string, channel *model.Channel, userReques
 
 func (a *App) AddDirectChannels(teamId string, user *model.User) *model.AppError {
 	var profiles []*model.User
-	result := <-a.Srv.Store.User().GetProfiles(teamId, 0, 100)
+	options := &model.UserGetOptions{InTeamId: teamId, Page: 0, PerPage: 100}
+	result := <-a.Srv.Store.User().GetProfiles(options)
 	if result.Err != nil {
 		return model.NewAppError("AddDirectChannels", "api.user.add_direct_channels_and_forget.failed.error", map[string]interface{}{"UserId": user.Id, "TeamId": teamId, "Error": result.Err.Error()}, "", http.StatusInternalServerError)
 	}

--- a/app/command_loadtest.go
+++ b/app/command_loadtest.go
@@ -288,7 +288,8 @@ func (me *LoadTestProvider) PostsCommand(a *App, args *model.CommandArgs, messag
 	}
 
 	var usernames []string
-	if result := <-a.Srv.Store.User().GetProfiles(args.TeamId, 0, 1000); result.Err == nil {
+	options := &model.UserGetOptions{InTeamId: args.TeamId, Page: 0, PerPage: 1000}
+	if result := <-a.Srv.Store.User().GetProfiles(options); result.Err == nil {
 		profileUsers := result.Data.([]*model.User)
 		usernames = make([]string, len(profileUsers))
 		i := 0

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -188,7 +188,8 @@ func (api *PluginAPI) GetUsersByUsernames(usernames []string) ([]*model.User, *m
 }
 
 func (api *PluginAPI) GetUsersInTeam(teamId string, page int, perPage int) ([]*model.User, *model.AppError) {
-	return api.app.GetUsersInTeam(teamId, page*perPage, perPage)
+	options := &model.UserGetOptions{InTeamId: teamId, Page: page, PerPage: perPage}
+	return api.app.GetUsersInTeam(options)
 }
 
 func (api *PluginAPI) UpdateUser(user *model.User) (*model.User, *model.AppError) {

--- a/app/user.go
+++ b/app/user.go
@@ -394,8 +394,8 @@ func (a *App) GetUsersEtag() string {
 	return fmt.Sprintf("%v.%v.%v", (<-a.Srv.Store.User().GetEtagForAllProfiles()).Data.(string), a.Config().PrivacySettings.ShowFullName, a.Config().PrivacySettings.ShowEmailAddress)
 }
 
-func (a *App) GetUsersInTeam(teamId string, offset int, limit int) ([]*model.User, *model.AppError) {
-	result := <-a.Srv.Store.User().GetProfiles(teamId, offset, limit)
+func (a *App) GetUsersInTeam(options *model.UserGetOptions) ([]*model.User, *model.AppError) {
+	result := <-a.Srv.Store.User().GetProfiles(options)
 	if result.Err != nil {
 		return nil, result.Err
 	}
@@ -410,24 +410,8 @@ func (a *App) GetUsersNotInTeam(teamId string, offset int, limit int) ([]*model.
 	return result.Data.([]*model.User), nil
 }
 
-func (a *App) GetUsersInTeamMap(teamId string, offset int, limit int, asAdmin bool) (map[string]*model.User, *model.AppError) {
-	users, err := a.GetUsersInTeam(teamId, offset, limit)
-	if err != nil {
-		return nil, err
-	}
-
-	userMap := make(map[string]*model.User, len(users))
-
-	for _, user := range users {
-		a.SanitizeProfile(user, asAdmin)
-		userMap[user.Id] = user
-	}
-
-	return userMap, nil
-}
-
-func (a *App) GetUsersInTeamPage(teamId string, page int, perPage int, asAdmin bool) ([]*model.User, *model.AppError) {
-	users, err := a.GetUsersInTeam(teamId, page*perPage, perPage)
+func (a *App) GetUsersInTeamPage(options *model.UserGetOptions, asAdmin bool) ([]*model.User, *model.AppError) {
+	users, err := a.GetUsersInTeam(options)
 	if err != nil {
 		return nil, err
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -373,32 +373,16 @@ func (a *App) GetUserByAuth(authData *string, authService string) (*model.User, 
 	return result.Data.(*model.User), nil
 }
 
-func (a *App) GetUsers(offset int, limit int) ([]*model.User, *model.AppError) {
-	result := <-a.Srv.Store.User().GetAllProfiles(offset, limit)
+func (a *App) GetUsers(options *model.UserGetOptions) ([]*model.User, *model.AppError) {
+	result := <-a.Srv.Store.User().GetAllProfiles(options)
 	if result.Err != nil {
 		return nil, result.Err
 	}
 	return result.Data.([]*model.User), nil
 }
 
-func (a *App) GetUsersMap(offset int, limit int, asAdmin bool) (map[string]*model.User, *model.AppError) {
-	users, err := a.GetUsers(offset, limit)
-	if err != nil {
-		return nil, err
-	}
-
-	userMap := make(map[string]*model.User, len(users))
-
-	for _, user := range users {
-		a.SanitizeProfile(user, asAdmin)
-		userMap[user.Id] = user
-	}
-
-	return userMap, nil
-}
-
-func (a *App) GetUsersPage(page int, perPage int, asAdmin bool) ([]*model.User, *model.AppError) {
-	users, err := a.GetUsers(page*perPage, perPage)
+func (a *App) GetUsersPage(options *model.UserGetOptions, asAdmin bool) ([]*model.User, *model.AppError) {
+	users, err := a.GetUsers(options)
 	if err != nil {
 		return nil, err
 	}

--- a/model/user_get.go
+++ b/model/user_get.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2016-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package model
+
+type UserGetOptions struct {
+	// Filters the users in the team
+	InTeamId string
+	// Filters the Users not in the team
+	NotInTeamId string
+	// Filters the users in the channel
+	InChannelId string
+	// Filters the users not in the channel
+	NotInChannelId string
+	// Filters the users without the team
+	WithoutTeam bool
+	// Filters the inactive users
+	Inactive bool
+	// Filters for the given role
+	Role string
+	// Sorting option
+	Sort string
+	// Page
+	Page int
+	// Page size
+	PerPage int
+}

--- a/model/user_get.go
+++ b/model/user_get.go
@@ -6,13 +6,13 @@ package model
 type UserGetOptions struct {
 	// Filters the users in the team
 	InTeamId string
-	// Filters the Users not in the team
+	// Filters the users not in the team
 	NotInTeamId string
 	// Filters the users in the channel
 	InChannelId string
 	// Filters the users not in the channel
 	NotInChannelId string
-	// Filters the users without the team
+	// Filters the users without a team
 	WithoutTeam bool
 	// Filters the inactive users
 	Inactive bool

--- a/model/user_search.go
+++ b/model/user_search.go
@@ -21,6 +21,7 @@ type UserSearch struct {
 	AllowInactive  bool   `json:"allow_inactive"`
 	WithoutTeam    bool   `json:"without_team"`
 	Limit          int    `json:"limit"`
+	Role           string `json:"role"`
 }
 
 // ToJson convert a User to a json string
@@ -54,4 +55,6 @@ type UserSearchOptions struct {
 	AllowInactive bool
 	// Limit limits the total number of results returned.
 	Limit int
+	// Filters for the given role
+	Role string
 }

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -375,6 +375,9 @@ func (us SqlUserStore) GetAllProfiles(options *model.UserGetOptions) store.Store
 		if options.Role != "" {
 			whereClauses = append(whereClauses, fmt.Sprintf("Users.Roles like'%%%v%%'", options.Role))
 		}
+		if options.Inactive {
+			whereClauses = append(whereClauses, "Users.DeleteAt != 0")
+		}
 
 		searchQuery := generateQuery(baseQuery, whereClauses)
 		searchQuery = fmt.Sprintf("%v ORDER BY Username ASC LIMIT :Limit OFFSET :Offset", searchQuery)
@@ -395,7 +398,7 @@ func (us SqlUserStore) GetAllProfiles(options *model.UserGetOptions) store.Store
 func generateQuery(baseQuery string, whereClauses []string) string {
 	query := baseQuery
 	if len(whereClauses) > 0 {
-		query = fmt.Sprintf("%v WHERE %v", baseQuery, strings.Join(whereClauses, " "))
+		query = fmt.Sprintf("%v WHERE %v", baseQuery, strings.Join(whereClauses, " AND "))
 	}
 	return query
 }

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -364,9 +364,11 @@ func (s SqlUserStore) GetEtagForAllProfiles() store.StoreChannel {
 	})
 }
 
-func (us SqlUserStore) GetAllProfiles(offset int, limit int) store.StoreChannel {
+func (us SqlUserStore) GetAllProfiles(options *model.UserGetOptions) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		var users []*model.User
+		offset := options.Page * options.PerPage
+		limit := options.PerPage
 
 		if _, err := us.GetReplica().Select(&users, "SELECT * FROM Users ORDER BY Username ASC LIMIT :Limit OFFSET :Offset", map[string]interface{}{"Offset": offset, "Limit": limit}); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetAllProfiles", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/store/store.go
+++ b/store/store.go
@@ -249,7 +249,7 @@ type UserStore interface {
 	GetProfilesNotInChannel(teamId string, channelId string, offset int, limit int) StoreChannel
 	GetProfilesWithoutTeam(offset int, limit int) StoreChannel
 	GetProfilesByUsernames(usernames []string, teamId string) StoreChannel
-	GetAllProfiles(offset int, limit int) StoreChannel
+	GetAllProfiles(options *model.UserGetOptions) StoreChannel
 	GetProfiles(teamId string, offset int, limit int) StoreChannel
 	GetProfileByIds(userId []string, allowFromCache bool) StoreChannel
 	InvalidatProfileCacheForUser(userId string)

--- a/store/store.go
+++ b/store/store.go
@@ -250,7 +250,7 @@ type UserStore interface {
 	GetProfilesWithoutTeam(offset int, limit int) StoreChannel
 	GetProfilesByUsernames(usernames []string, teamId string) StoreChannel
 	GetAllProfiles(options *model.UserGetOptions) StoreChannel
-	GetProfiles(teamId string, offset int, limit int) StoreChannel
+	GetProfiles(options *model.UserGetOptions) StoreChannel
 	GetProfileByIds(userId []string, allowFromCache bool) StoreChannel
 	InvalidatProfileCacheForUser(userId string)
 	GetByEmail(email string) StoreChannel

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -354,13 +354,13 @@ func (_m *UserStore) GetProfileByIds(userId []string, allowFromCache bool) store
 	return r0
 }
 
-// GetProfiles provides a mock function with given fields: teamId, offset, limit
-func (_m *UserStore) GetProfiles(teamId string, offset int, limit int) store.StoreChannel {
-	ret := _m.Called(teamId, offset, limit)
+// GetProfiles provides a mock function with given fields: options
+func (_m *UserStore) GetProfiles(options *model.UserGetOptions) store.StoreChannel {
+	ret := _m.Called(options)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int, int) store.StoreChannel); ok {
-		r0 = rf(teamId, offset, limit)
+	if rf, ok := ret.Get(0).(func(*model.UserGetOptions) store.StoreChannel); ok {
+		r0 = rf(options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -146,13 +146,13 @@ func (_m *UserStore) GetAllAfter(limit int, afterId string) store.StoreChannel {
 	return r0
 }
 
-// GetAllProfiles provides a mock function with given fields: offset, limit
-func (_m *UserStore) GetAllProfiles(offset int, limit int) store.StoreChannel {
-	ret := _m.Called(offset, limit)
+// GetAllProfiles provides a mock function with given fields: options
+func (_m *UserStore) GetAllProfiles(options *model.UserGetOptions) store.StoreChannel {
+	ret := _m.Called(options)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(int, int) store.StoreChannel); ok {
-		r0 = rf(offset, limit)
+	if rf, ok := ret.Get(0).(func(*model.UserGetOptions) store.StoreChannel); ok {
+		r0 = rf(options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -307,7 +307,9 @@ func testUserStoreGetAllProfiles(t *testing.T, ss store.Store) {
 	store.Must(ss.User().Save(u2))
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 
-	if r1 := <-ss.User().GetAllProfiles(0, 100); r1.Err != nil {
+	options := &model.UserGetOptions{Page: 0, PerPage: 100}
+
+	if r1 := <-ss.User().GetAllProfiles(options); r1.Err != nil {
 		t.Fatal(r1.Err)
 	} else {
 		users := r1.Data.([]*model.User)
@@ -316,7 +318,8 @@ func testUserStoreGetAllProfiles(t *testing.T, ss store.Store) {
 		}
 	}
 
-	if r2 := <-ss.User().GetAllProfiles(0, 1); r2.Err != nil {
+	options = &model.UserGetOptions{Page: 0, PerPage: 1}
+	if r2 := <-ss.User().GetAllProfiles(options); r2.Err != nil {
 		t.Fatal(r2.Err)
 	} else {
 		users := r2.Data.([]*model.User)

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1822,7 +1822,7 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 			[]*model.User{u1},
 		},
 		{
-			"search j with system_admin roles",
+			"search ji with system_user roles",
 			tid,
 			"ji",
 			&model.UserSearchOptions{


### PR DESCRIPTION
#### Summary
Implement the role and inactive filters as part of the users search api

```
POST /users/search
```
and 

```
GET /users
```
For the get api the filter has been added just to support the getAllUsers and GetUsersInTeam. 

This is intended to validate the approach in the smaller scale and then propagate it to all the code branchings in `get /users` like in channel, in team with sorting etc

Also the permission `User with Access Token Permission` is ignored for this iteration. As discussed with @jasonblais  we will do this whole ticket in 2 iterations for easy delivery.
 
#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/7494

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
