### PR TITLE
MM-13371 Fix error checking when setting profile image

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -850,8 +850,8 @@ func (a *App) SetProfileImageFromFile(userId string, file io.Reader) *model.AppE
 
 	a.InvalidateCacheForUser(userId)
 
-	user, err := a.GetUser(userId)
-	if err != nil {
+	user, userErr := a.GetUser(userId)
+	if userErr != nil {
 		mlog.Error(fmt.Sprintf("Error in getting users profile for id=%v forcing logout", userId), mlog.String("user_id", userId))
 		return nil
 	}


### PR DESCRIPTION
#### Summary
We were trying to set a *model.AppError to an error type and that was causing the nil check to pass when it should have failed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13371
