### PR TITLE
MM-13220: Fixes for bulk export problems

### DIFF
--- a/app/export_converters.go
+++ b/app/export_converters.go
@@ -132,9 +132,9 @@ func ImportReplyFromPost(post *model.ReplyForExport) *ReplyImportData {
 	}
 }
 
-func ImportReactionFromPost(reaction *model.Reaction) *ReactionImportData {
+func ImportReactionFromPost(user *model.User, reaction *model.Reaction) *ReactionImportData {
 	return &ReactionImportData{
-		User:      &reaction.UserId,
+		User:      &user.Username,
 		EmojiName: &reaction.EmojiName,
 		CreateAt:  &reaction.CreateAt,
 	}

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -40,14 +40,14 @@ func TestExportUserNotifyProps(t *testing.T) {
 	defer th.TearDown()
 
 	userNotifyProps := model.StringMap{
-		model.DESKTOP_NOTIFY_PROP:            model.USER_NOTIFY_ALL,
-		model.DESKTOP_SOUND_NOTIFY_PROP:      "true",
-		model.EMAIL_NOTIFY_PROP:              "true",
-		model.MOBILE_NOTIFY_PROP:             model.USER_NOTIFY_ALL,
-		model.MOBILE_PUSH_STATUS_NOTIFY_PROP: model.STATUS_ONLINE,
-		model.CHANNEL_MENTIONS_NOTIFY_PROP:   "true",
-		model.COMMENTS_NOTIFY_PROP:           model.COMMENTS_NOTIFY_ROOT,
-		model.MENTION_KEYS_NOTIFY_PROP:       "valid,misc",
+		model.DESKTOP_NOTIFY_PROP:          model.USER_NOTIFY_ALL,
+		model.DESKTOP_SOUND_NOTIFY_PROP:    "true",
+		model.EMAIL_NOTIFY_PROP:            "true",
+		model.PUSH_NOTIFY_PROP:             model.USER_NOTIFY_ALL,
+		model.PUSH_STATUS_NOTIFY_PROP:      model.STATUS_ONLINE,
+		model.CHANNEL_MENTIONS_NOTIFY_PROP: "true",
+		model.COMMENTS_NOTIFY_PROP:         model.COMMENTS_NOTIFY_ROOT,
+		model.MENTION_KEYS_NOTIFY_PROP:     "valid,misc",
 	}
 
 	exportNotifyProps := th.App.buildUserNotifyProps(userNotifyProps)
@@ -55,8 +55,8 @@ func TestExportUserNotifyProps(t *testing.T) {
 	require.Equal(t, userNotifyProps[model.DESKTOP_NOTIFY_PROP], *exportNotifyProps.Desktop)
 	require.Equal(t, userNotifyProps[model.DESKTOP_SOUND_NOTIFY_PROP], *exportNotifyProps.DesktopSound)
 	require.Equal(t, userNotifyProps[model.EMAIL_NOTIFY_PROP], *exportNotifyProps.Email)
-	require.Equal(t, userNotifyProps[model.MOBILE_NOTIFY_PROP], *exportNotifyProps.Mobile)
-	require.Equal(t, userNotifyProps[model.MOBILE_PUSH_STATUS_NOTIFY_PROP], *exportNotifyProps.MobilePushStatus)
+	require.Equal(t, userNotifyProps[model.PUSH_NOTIFY_PROP], *exportNotifyProps.Mobile)
+	require.Equal(t, userNotifyProps[model.PUSH_STATUS_NOTIFY_PROP], *exportNotifyProps.MobilePushStatus)
 	require.Equal(t, userNotifyProps[model.CHANNEL_MENTIONS_NOTIFY_PROP], *exportNotifyProps.ChannelTrigger)
 	require.Equal(t, userNotifyProps[model.COMMENTS_NOTIFY_PROP], *exportNotifyProps.CommentsTrigger)
 	require.Equal(t, userNotifyProps[model.MENTION_KEYS_NOTIFY_PROP], *exportNotifyProps.MentionKeys)

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -18,7 +18,7 @@ func TestReactionsOfPost(t *testing.T) {
 	post.HasReactions = true
 
 	reactionObject := model.Reaction{
-		UserId:    model.NewId(),
+		UserId:    th.BasicUser.Id,
 		PostId:    post.Id,
 		EmojiName: "emoji",
 		CreateAt:  model.GetMillis(),
@@ -26,10 +26,7 @@ func TestReactionsOfPost(t *testing.T) {
 
 	th.App.SaveReactionForPost(&reactionObject)
 	reactionsOfPost, err := th.App.BuildPostReactions(post.Id)
-
-	if err != nil {
-		t.Fatal("should have reactions")
-	}
+	require.Nil(t, err)
 
 	assert.Equal(t, reactionObject.EmojiName, *(*reactionsOfPost)[0].EmojiName)
 }

--- a/model/user.go
+++ b/model/user.go
@@ -26,8 +26,6 @@ const (
 	PUSH_NOTIFY_PROP                   = "push"
 	PUSH_STATUS_NOTIFY_PROP            = "push_status"
 	EMAIL_NOTIFY_PROP                  = "email"
-	MOBILE_NOTIFY_PROP                 = "mobile"
-	MOBILE_PUSH_STATUS_NOTIFY_PROP     = "mobile_push_status"
 	CHANNEL_MENTIONS_NOTIFY_PROP       = "channel"
 	COMMENTS_NOTIFY_PROP               = "comments"
 	MENTION_KEYS_NOTIFY_PROP           = "mention_keys"


### PR DESCRIPTION
#### Summary
Fixes for bulk export problems

- the favorite detection may fail if the user preferes aren't set.
- The reactions where exported using the UserId instead of the Username as is expected
- The mobile notify props are the constants "PUSH", no the new added "MOBILE"

#### Ticket Link
[MM-13220](https://mattermost.atlassian.net/browse/MM-13220)