### PR TITLE
MM-13238 Fix link cache being cleared too often with image proxy

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -26,7 +26,7 @@ func (a *App) InitPostMetadata() {
 	// Dump any cached links if the proxy settings have changed so image URLs can be updated
 	a.AddConfigListener(func(before, after *model.Config) {
 		if (before.ServiceSettings.ImageProxyType != after.ServiceSettings.ImageProxyType) ||
-			(before.ServiceSettings.ImageProxyURL != after.ServiceSettings.ImageProxyType) {
+			(before.ServiceSettings.ImageProxyURL != after.ServiceSettings.ImageProxyURL) {
 			linkCache.Purge()
 		}
 	})


### PR DESCRIPTION
This will be fixed when the image proxy is added, but this fix is is needed for 5.7

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13238