### PR TITLE
Update default MySQL password for unit tests

### DIFF
--- a/store/sqlstore/supplier.go
+++ b/store/sqlstore/supplier.go
@@ -699,6 +699,10 @@ func (ss *SqlSupplier) AlterColumnDefaultIfExists(tableName string, columnName s
 		tableName = strings.ToLower(tableName)
 		columnName = strings.ToLower(columnName)
 		defaultValue = *postgresColDefault
+	} else if ss.DriverName() == model.DATABASE_DRIVER_SQLITE {
+		// SQLite doesn't support altering column defaults, but we don't use this in
+		// production so just ignore.
+		return true
 	} else {
 		mlog.Critical("Failed to alter column default because of missing driver")
 		time.Sleep(time.Second)

--- a/store/storetest/settings.go
+++ b/store/storetest/settings.go
@@ -23,7 +23,7 @@ import (
 const (
 	defaultMysqlDSN      = "mmuser:mostest@tcp(dockerhost:3306)/mattermost_test?charset=utf8mb4,utf8\u0026readTimeout=30s\u0026writeTimeout=30s"
 	defaultPostgresqlDSN = "postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
-	defaultMysqlRootPWD  = "passwd"
+	defaultMysqlRootPWD  = "mostest"
 )
 
 func getEnv(name, defaultValue string) string {


### PR DESCRIPTION
This matches the default root password set when the database is created by `make start-docker`