### PR TITLE
Register opengraph struct with gob for plugins

### DIFF
--- a/plugin/client_rpc.go
+++ b/plugin/client_rpc.go
@@ -18,7 +18,8 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/hashicorp/go-plugin"
+	"github.com/dyatlov/go-opengraph/opengraph"
+	plugin "github.com/hashicorp/go-plugin"
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 )
@@ -95,6 +96,7 @@ func init() {
 	gob.Register(map[string]interface{}{})
 	gob.Register(&model.AppError{})
 	gob.Register(&ErrorString{})
+	gob.Register(&opengraph.OpenGraph{})
 }
 
 // These enforce compile time checks to make sure types implement the interface


### PR DESCRIPTION
#### Summary
This was causing the server's plugin RPC client to error out with:
```
{"level":"error","ts":1544618340.2658787,"caller":"log/log.go:301","msg":"rpc: gob error encoding body: gob: type not registered for interface: opengraph.OpenGraph","source":"stdlog"}
```