### PR TITLE
Fix downloading of prepackaged plugins for releases

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -5,11 +5,11 @@ build-linux:
 	@echo Build Linux amd64
 	env GOOS=linux GOARCH=amd64 $(GO) install -i $(GOFLAGS) $(GO_LINKER_FLAGS) ./...
 
-build-osx: 
+build-osx:
 	@echo Build OSX amd64
 	env GOOS=darwin GOARCH=amd64 $(GO) install -i $(GOFLAGS) $(GO_LINKER_FLAGS) ./...
 
-build-windows: 
+build-windows:
 	@echo Build Windows amd64
 	env GOOS=windows GOARCH=amd64 $(GO) install -i $(GOFLAGS) $(GO_LINKER_FLAGS) ./...
 
@@ -60,6 +60,11 @@ endif
 	cp NOTICE.txt $(DIST_PATH)
 	cp README.md $(DIST_PATH)
 
+	@# Download prepackaged plugins
+	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
+		curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | grep browser_download_url | cut -d '"' -f 4 | wget -qi - -P  $(DIST_PATH)/prepackaged_plugins/ ;\
+	done
+
 	@# ----- PLATFORM SPECIFIC -----
 
 	@# Make osx package
@@ -67,60 +72,39 @@ endif
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
 	cp $(GOPATH)/bin/mattermost $(DIST_PATH)/bin # from native bin dir, not cross-compiled
 	cp $(GOPATH)/bin/platform $(DIST_PATH)/bin # from native bin dir, not cross-compiled
-	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
-    curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | grep browser_download_url | grep darwin | cut -d '"' -f 4 | wget -qi - -P  $(DIST_PATH)/prepackaged_plugins/ ;\
-	done
 else
 	cp $(GOPATH)/bin/darwin_amd64/mattermost $(DIST_PATH)/bin # from cross-compiled bin dir
 	cp $(GOPATH)/bin/darwin_amd64/platform $(DIST_PATH)/bin # from cross-compiled bin dir
-	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
-    curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | grep browser_download_url | grep darwin | cut -d '"' -f 4 | wget -qi - -P  $(DIST_PATH)/prepackaged_plugins/ ;\
-	done
 endif
 	@# Package
 	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-osx-amd64.tar.gz mattermost
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/mattermost
 	rm -f $(DIST_PATH)/bin/platform
-	rm -f $(DIST_PATH)/prepackaged_plugins/*
 
 	@# Make windows package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
 	cp $(GOPATH)/bin/mattermost.exe $(DIST_PATH)/bin # from native bin dir, not cross-compiled
 	cp $(GOPATH)/bin/platform.exe $(DIST_PATH)/bin # from native bin dir, not cross-compiled
-	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
-    curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | grep browser_download_url | grep windows | cut -d '"' -f 4 | wget -qi - -P $(DIST_PATH)/prepackaged_plugins/ ;\
-	done
 else
 	cp $(GOPATH)/bin/windows_amd64/mattermost.exe $(DIST_PATH)/bin # from cross-compiled bin dir
 	cp $(GOPATH)/bin/windows_amd64/platform.exe $(DIST_PATH)/bin # from cross-compiled bin dir
-	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
-    curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | grep browser_download_url | grep windows | cut -d '"' -f 4 | wget -qi - -P  $(DIST_PATH)/prepackaged_plugins/ ;\
-	done
-
 endif
 	@# Package
 	cd $(DIST_ROOT) && zip -9 -r -q -l mattermost-$(BUILD_TYPE_NAME)-windows-amd64.zip mattermost && cd ..
 	@# Cleanup
 	rm -f $(DIST_PATH)/bin/mattermost.exe
 	rm -f $(DIST_PATH)/bin/platform.exe
-	rm -f $(DIST_PATH)/prepackaged_plugins/*
 
 	@# Make linux package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
 	cp $(GOPATH)/bin/mattermost $(DIST_PATH)/bin # from native bin dir, not cross-compiled
 	cp $(GOPATH)/bin/platform $(DIST_PATH)/bin # from native bin dir, not cross-compiled
-	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
-    curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | grep browser_download_url | grep linux | cut -d '"' -f 4 | wget -qi - -P  $(DIST_PATH)/prepackaged_plugins/ ;\
-	done
 else
 	cp $(GOPATH)/bin/linux_amd64/mattermost $(DIST_PATH)/bin # from cross-compiled bin dir
 	cp $(GOPATH)/bin/linux_amd64/platform $(DIST_PATH)/bin # from cross-compiled bin dir
-	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
-    curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | grep browser_download_url | grep linux | cut -d '"' -f 4 | wget -qi - -P  $(DIST_PATH)/prepackaged_plugins/ ;\
-	done
 endif
 	@# Package
 	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-linux-amd64.tar.gz mattermost


### PR DESCRIPTION
#### Summary
This PR fixes the downloading of prepackaged plugins for the package process.

The root cause of the problem is, that previously plugin-packages where platform specific. This changed recently and it was forgotten to update the package script.

This PR requires a new release of https://github.com/mattermost/mattermost-plugin-jira.