### PR TITLE
Fix shadowed variables in app package: Part 1 of 3

### DIFF
--- a/app/analytics.go
+++ b/app/analytics.go
@@ -79,7 +79,7 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 		if postChan == nil {
 			rows[2].Value = -1
 		} else {
-			r := <-postChan
+			r = <-postChan
 			if r.Err != nil {
 				return nil, r.Err
 			}
@@ -89,7 +89,7 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 		if userChan == nil {
 			rows[3].Value = float64(systemUserCount)
 		} else {
-			r := <-userChan
+			r = <-userChan
 			if r.Err != nil {
 				return nil, r.Err
 			}
@@ -99,7 +99,7 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 		if userInactiveChan == nil {
 			rows[10].Value = -1
 		} else {
-			r := <-userInactiveChan
+			r = <-userInactiveChan
 			if r.Err != nil {
 				return nil, r.Err
 			}

--- a/app/channel.go
+++ b/app/channel.go
@@ -34,8 +34,6 @@ func (a *App) CreateDefaultChannels(teamId string) ([]*model.Channel, *model.App
 }
 
 func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin bool, userRequestorId string) *model.AppError {
-	var err *model.AppError = nil
-
 	var requestor *model.User
 	if userRequestorId != "" {
 		u := <-a.Srv.Store.User().Get(userRequestorId)
@@ -59,9 +57,10 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 		}
 	}
 
+	var returnErr *model.AppError
 	for _, channelName := range defaultChannelList {
 		if result := <-a.Srv.Store.Channel().GetByName(teamId, channelName, true); result.Err != nil {
-			err = result.Err
+			returnErr = result.Err
 		} else {
 
 			channel := result.Data.(*model.Channel)
@@ -79,10 +78,10 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 			}
 
 			if cmResult := <-a.Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
-				err = cmResult.Err
+				returnErr = cmResult.Err
 			}
-			if result := <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(user.Id, channel.Id, model.GetMillis()); result.Err != nil {
-				mlog.Warn(fmt.Sprintf("Failed to update ChannelMemberHistory table %v", result.Err))
+			if resultEvent := <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(user.Id, channel.Id, model.GetMillis()); resultEvent.Err != nil {
+				mlog.Warn(fmt.Sprintf("Failed to update ChannelMemberHistory table %v", resultEvent.Err))
 			}
 
 			if *a.Config().ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages {
@@ -113,7 +112,7 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 		}
 	}
 
-	return err
+	return returnErr
 }
 
 func (a *App) CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channel, *model.AppError) {
@@ -538,24 +537,22 @@ func (a *App) PatchChannel(channel *model.Channel, patch *model.ChannelPatch, us
 }
 
 func (a *App) GetSchemeRolesForChannel(channelId string) (string, string, *model.AppError) {
-	var channel *model.Channel
-	var err *model.AppError
-
-	if channel, err = a.GetChannel(channelId); err != nil {
+	channel, err := a.GetChannel(channelId)
+	if err != nil {
 		return "", "", err
 	}
 
 	if channel.SchemeId != nil && len(*channel.SchemeId) != 0 {
-		scheme, err := a.GetScheme(*channel.SchemeId)
+		var scheme *model.Scheme
+		scheme, err = a.GetScheme(*channel.SchemeId)
 		if err != nil {
 			return "", "", err
 		}
 		return scheme.DefaultChannelUserRole, scheme.DefaultChannelAdminRole, nil
 	}
 
-	var team *model.Team
-
-	if team, err = a.GetTeam(channel.TeamId); err != nil {
+	team, err := a.GetTeam(channel.TeamId)
+	if err != nil {
 		return "", "", err
 	}
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -80,8 +80,8 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 			if cmResult := <-a.Srv.Store.Channel().SaveMember(cm); cmResult.Err != nil {
 				returnErr = cmResult.Err
 			}
-			if resultEvent := <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(user.Id, channel.Id, model.GetMillis()); resultEvent.Err != nil {
-				mlog.Warn(fmt.Sprintf("Failed to update ChannelMemberHistory table %v", resultEvent.Err))
+			if result = <-a.Srv.Store.ChannelMemberHistory().LogJoinEvent(user.Id, channel.Id, model.GetMillis()); result.Err != nil {
+				mlog.Warn(fmt.Sprintf("Failed to update ChannelMemberHistory table %v", result.Err))
 			}
 
 			if *a.Config().ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages {

--- a/app/channel.go
+++ b/app/channel.go
@@ -108,7 +108,7 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 				}
 			}
 
-			a.InvalidateCacheForChannelMembers(result.Data.(*model.Channel).Id)
+			a.InvalidateCacheForChannelMembers(channel.Id)
 		}
 	}
 

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -664,7 +664,7 @@ func (a *App) ImportUserTeams(user *model.User, data *[]UserTeamImportData) *mod
 		}
 
 		if member.ExplicitRoles != roles {
-			if _, err := a.UpdateTeamMemberRoles(team.Id, user.Id, roles); err != nil {
+			if _, err = a.UpdateTeamMemberRoles(team.Id, user.Id, roles); err != nil {
 				return err
 			}
 		}

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -33,7 +33,7 @@ func (a *App) installPlugin(pluginFile io.Reader, replace bool) (*model.Manifest
 	}
 	defer os.RemoveAll(tmpDir)
 
-	if err := utils.ExtractTarGz(pluginFile, tmpDir); err != nil {
+	if err = utils.ExtractTarGz(pluginFile, tmpDir); err != nil {
 		return nil, model.NewAppError("installPlugin", "app.plugin.extract.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 


### PR DESCRIPTION
This PR fixes shadowed variables in some files of the `app` package. The issues where found with `go tool vet -shadow ./app/`. This PR is mostly for paying technical debts.

This PR is part of a small campaign to remove all shadowed variables in `app`.

If this kind of PR is appreciated, I would be happy to do this code improvements in other packages.

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)