### PR TITLE
Fix shadowed variables in app package: Part 4

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -517,24 +517,24 @@ func (a *App) PatchChannel(channel *model.Channel, patch *model.ChannelPatch, us
 	}
 
 	if oldChannelDisplayName != channel.DisplayName {
-		if err := a.PostUpdateChannelDisplayNameMessage(userId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
+		if err = a.PostUpdateChannelDisplayNameMessage(userId, channel, oldChannelDisplayName, channel.DisplayName); err != nil {
 			mlog.Error(err.Error())
 		}
 	}
 
 	if channel.Header != oldChannelHeader {
-		if err := a.PostUpdateChannelHeaderMessage(userId, channel, oldChannelHeader, channel.Header); err != nil {
+		if err = a.PostUpdateChannelHeaderMessage(userId, channel, oldChannelHeader, channel.Header); err != nil {
 			mlog.Error(err.Error())
 		}
 	}
 
 	if channel.Purpose != oldChannelPurpose {
-		if err := a.PostUpdateChannelPurposeMessage(userId, channel, oldChannelPurpose, channel.Purpose); err != nil {
+		if err = a.PostUpdateChannelPurposeMessage(userId, channel, oldChannelPurpose, channel.Purpose); err != nil {
 			mlog.Error(err.Error())
 		}
 	}
 
-	return channel, err
+	return channel, nil
 }
 
 func (a *App) GetSchemeRolesForChannel(channelId string) (string, string, *model.AppError) {


### PR DESCRIPTION
#### Summary
Follow up on #10000

The changes will let the CI fail. I'm not sure if the tests are wrong and relied on an bug or my changes are bad. They problem is that it's not clear to me if https://github.com/mattermost/mattermost-server/blob/6dbd7bbef2b5d31b146a120ac562d1989026d12a/app/channel.go#L537 should return an error from `PostUpdateChannelDisplayNameMessage()`, `PostUpdateChannelHeaderMessage()` and `PostUpdateChannelPurposeMessage()`. I would like to hear your thoughts on this. @jespino @grundleborg 

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)