### PR TITLE
MM-13526 Add validation when setting a user's Locale field

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/services/timezones"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -49,6 +50,7 @@ const (
 	USER_NAME_MAX_LENGTH      = 64
 	USER_NAME_MIN_LENGTH      = 1
 	USER_PASSWORD_MAX_LENGTH  = 72
+	USER_LOCALE_MAX_LENGTH    = 5
 )
 
 type User struct {
@@ -170,6 +172,10 @@ func (u *User) IsValid() *AppError {
 
 	if len(u.Password) > USER_PASSWORD_MAX_LENGTH {
 		return InvalidUserError("password_limit", u.Id)
+	}
+
+	if !IsValidLocale(u.Locale) {
+		return InvalidUserError("locale", u.Id)
 	}
 
 	return nil
@@ -643,4 +649,16 @@ func IsValidEmailBatchingInterval(emailInterval string) bool {
 	return emailInterval == PREFERENCE_EMAIL_INTERVAL_IMMEDIATELY ||
 		emailInterval == PREFERENCE_EMAIL_INTERVAL_FIFTEEN ||
 		emailInterval == PREFERENCE_EMAIL_INTERVAL_HOUR
+}
+
+func IsValidLocale(locale string) bool {
+	if locale != "" {
+		if len(locale) > USER_LOCALE_MAX_LENGTH {
+			return false
+		} else if _, err := language.Parse(locale); err != nil {
+			return false
+		}
+	}
+
+	return true
 }

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -332,3 +332,59 @@ func TestRoles(t *testing.T) {
 	require.True(t, IsInRole("system_admin junk", "system_admin"))
 	require.False(t, IsInRole("admin", "system_admin"))
 }
+
+func TestIsValidLocale(t *testing.T) {
+	for _, test := range []struct {
+		Name     string
+		Locale   string
+		Expected bool
+	}{
+		{
+			Name:     "empty locale",
+			Locale:   "",
+			Expected: true,
+		},
+		{
+			Name:     "locale with only language",
+			Locale:   "fr",
+			Expected: true,
+		},
+		{
+			Name:     "locale with region",
+			Locale:   "en-DE", // English, as used in Germany
+			Expected: true,
+		},
+		{
+			Name:     "invalid locale",
+			Locale:   "'",
+			Expected: false,
+		},
+
+		// Note that the following cases are all valid language tags, but they're considered invalid here because of
+		// the max length of the User.Locale field.
+		{
+			Name:     "locale with extended language subtag",
+			Locale:   "zh-yue-HK", // Chinese, Cantonese, as used in Hong Kong
+			Expected: false,
+		},
+		{
+			Name:     "locale with script",
+			Locale:   "hy-Latn-IT-arevela", // Eastern Armenian written in Latin script, as used in Italy
+			Expected: false,
+		},
+		{
+			Name:     "locale with variant",
+			Locale:   "sl-rozaj-biske", // San Giorgio dialect of Resian dialect of Slovenian
+			Expected: false,
+		},
+		{
+			Name:     "locale with extension",
+			Locale:   "de-DE-u-co-phonebk", // German, as used in Germany, using German phonebook sort order
+			Expected: false,
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			assert.Equal(t, test.Expected, IsValidLocale(test.Locale))
+		})
+	}
+}


### PR DESCRIPTION
Without this validation, a user could set their locale to something invalid which would prevent them from using the web app because it would crash whenever it tries calling `localeCompare` on two strings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13526

#### Checklist
- Added or updated unit tests (required for all new features)