### PR TITLE
MM-10188 extra large file upload

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -702,7 +702,7 @@ func (a *App) UploadFileX(channelId, name string, input io.Reader,
 			if t.decoded == nil {
 				t.decodeImage(pr)
 				// Fully drain the pipe reader.
-				defer io.Copy(ioutil.Discard, pr)
+				io.Copy(ioutil.Discard, pr)
 			}
 			t.postprocessImage()
 		}()

--- a/app/file_bench_test.go
+++ b/app/file_bench_test.go
@@ -21,8 +21,24 @@ import (
 
 var randomJPEG []byte
 var randomGIF []byte
-var zero10M = make([]byte, 10*1024*1024)
 var rgba *image.RGBA
+
+type zeroReader struct {
+	limit int
+}
+
+func (z *zeroReader) Read(b []byte) (int, error) {
+	if z.limit <= 0 {
+		return 0, io.EOF
+	}
+
+	n := len(b)
+	if n > z.limit {
+		n = z.limit
+	}
+	z.limit -= n
+	return n, nil
+}
 
 func prepareTestImages(tb testing.TB) {
 	if rgba != nil {
@@ -69,23 +85,50 @@ func BenchmarkUploadFile(b *testing.B) {
 		return (i + 512*1024) / (1024 * 1024)
 	}
 
+	// Set 1Gb upload size limit, test up to that
+	const maxsize = 1 * 1024 * 1024 * 1024
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.MaxFileSize = maxsize })
+
 	files := []struct {
-		title string
-		ext   string
-		data  []byte
+		title  string
+		ext    string
+		length int64
+		in     func() io.Reader
 	}{
-		{fmt.Sprintf("random-%dMb-gif", mb(len(randomGIF))), ".gif", randomGIF},
-		{fmt.Sprintf("random-%dMb-jpg", mb(len(randomJPEG))), ".jpg", randomJPEG},
-		{fmt.Sprintf("zero-%dMb", mb(len(zero10M))), ".zero", zero10M},
+		{
+			title:  fmt.Sprintf("random-%dMb-gif", mb(len(randomGIF))),
+			ext:    ".gif",
+			length: int64(len(randomGIF)),
+			in: func() io.Reader {
+				return bytes.NewReader(randomGIF)
+			},
+		},
+		{
+			title:  fmt.Sprintf("random-%dMb-jpg", mb(len(randomJPEG))),
+			ext:    ".jpg",
+			length: int64(len(randomJPEG)),
+			in: func() io.Reader {
+				return bytes.NewReader(randomJPEG)
+			},
+		},
+		{
+			title:  fmt.Sprintf("zero-%dMb", mb(maxsize-1)),
+			ext:    ".zero",
+			length: maxsize - 1,
+			in: func() io.Reader {
+				return &zeroReader{limit: maxsize - 1}
+			},
+		},
 	}
 
 	file_benchmarks := []struct {
 		title string
-		f     func(b *testing.B, n int, data []byte, ext string)
+		f     func(b *testing.B, n int, in io.Reader, length int64, ext string)
 	}{
 		{
-			title: "raw-ish DoUploadFile",
-			f: func(b *testing.B, n int, data []byte, ext string) {
+			title: "DoUploadFile raw",
+			f: func(b *testing.B, n int, in io.Reader, length int64, ext string) {
+				data, _ := ioutil.ReadAll(in)
 				info1, err := th.App.DoUploadFile(time.Now(), teamId, channelId,
 					userId, fmt.Sprintf("BenchmarkDoUploadFile-%d%s", n, ext), data)
 				if err != nil {
@@ -97,29 +140,11 @@ func BenchmarkUploadFile(b *testing.B) {
 			},
 		},
 		{
-			title: "raw UploadFileX Content-Length",
-			f: func(b *testing.B, n int, data []byte, ext string) {
+			title: "UploadFileX raw chunked",
+			f: func(b *testing.B, n int, in io.Reader, length int64, ext string) {
 				info, aerr := th.App.UploadFileX(channelId,
 					fmt.Sprintf("BenchmarkUploadFileTask-%d%s", n, ext),
-					bytes.NewReader(data),
-					UploadFileSetTeamId(teamId),
-					UploadFileSetUserId(userId),
-					UploadFileSetTimestamp(time.Now()),
-					UploadFileSetContentLength(int64(len(data))),
-					UploadFileSetRaw())
-				if aerr != nil {
-					b.Fatal(aerr)
-				}
-				<-th.App.Srv.Store.FileInfo().PermanentDelete(info.Id)
-				th.App.RemoveFile(info.Path)
-			},
-		},
-		{
-			title: "raw UploadFileX chunked",
-			f: func(b *testing.B, n int, data []byte, ext string) {
-				info, aerr := th.App.UploadFileX(channelId,
-					fmt.Sprintf("BenchmarkUploadFileTask-%d%s", n, ext),
-					bytes.NewReader(data),
+					in,
 					UploadFileSetTeamId(teamId),
 					UploadFileSetUserId(userId),
 					UploadFileSetTimestamp(time.Now()),
@@ -133,10 +158,10 @@ func BenchmarkUploadFile(b *testing.B) {
 			},
 		},
 		{
-			title: "image UploadFiles",
-			f: func(b *testing.B, n int, data []byte, ext string) {
+			title: "UploadFiles",
+			f: func(b *testing.B, n int, in io.Reader, length int64, ext string) {
 				resp, err := th.App.UploadFiles(teamId, channelId, userId,
-					[]io.ReadCloser{ioutil.NopCloser(bytes.NewReader(data))},
+					[]io.ReadCloser{ioutil.NopCloser(in)},
 					[]string{fmt.Sprintf("BenchmarkDoUploadFiles-%d%s", n, ext)},
 					[]string{},
 					time.Now())
@@ -148,32 +173,15 @@ func BenchmarkUploadFile(b *testing.B) {
 			},
 		},
 		{
-			title: "image UploadFileX Content-Length",
-			f: func(b *testing.B, n int, data []byte, ext string) {
+			title: "UploadFileX chunked",
+			f: func(b *testing.B, n int, in io.Reader, length int64, ext string) {
 				info, aerr := th.App.UploadFileX(channelId,
 					fmt.Sprintf("BenchmarkUploadFileTask-%d%s", n, ext),
-					bytes.NewReader(data),
+					in,
 					UploadFileSetTeamId(teamId),
 					UploadFileSetUserId(userId),
 					UploadFileSetTimestamp(time.Now()),
-					UploadFileSetContentLength(int64(len(data))))
-				if aerr != nil {
-					b.Fatal(aerr)
-				}
-				<-th.App.Srv.Store.FileInfo().PermanentDelete(info.Id)
-				th.App.RemoveFile(info.Path)
-			},
-		},
-		{
-			title: "image UploadFileX chunked",
-			f: func(b *testing.B, n int, data []byte, ext string) {
-				info, aerr := th.App.UploadFileX(channelId,
-					fmt.Sprintf("BenchmarkUploadFileTask-%d%s", n, ext),
-					bytes.NewReader(data),
-					UploadFileSetTeamId(teamId),
-					UploadFileSetUserId(userId),
-					UploadFileSetTimestamp(time.Now()),
-					UploadFileSetContentLength(int64(len(data))))
+					UploadFileSetContentLength(-1))
 				if aerr != nil {
 					b.Fatal(aerr)
 				}
@@ -187,7 +195,7 @@ func BenchmarkUploadFile(b *testing.B) {
 		for _, fb := range file_benchmarks {
 			b.Run(file.title+"-"+fb.title, func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					fb.f(b, i, file.data, file.ext)
+					fb.f(b, i, file.in(), file.length, file.ext)
 				}
 			})
 		}

--- a/app/file_plugin_test.go
+++ b/app/file_plugin_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package app
+
+import (
+	"bytes"
+	_ "fmt"
+	"testing"
+	_ "time"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin"
+	"github.com/mattermost/mattermost-server/plugin/plugintest"
+	"github.com/mattermost/mattermost-server/plugin/plugintest/mock"
+	_ "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadFilePlugins(t *testing.T) {
+	var large = []byte("0123456789ABCDEF__XYZ")
+
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.FileSettings.MaxFileSize = 1024
+		*cfg.FileSettings.MaxMemoryBuffer = 4
+	})
+
+	var mockAPI plugintest.API
+	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+	tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+		`
+		package main
+
+		import (
+			"io"
+			"fmt"
+			"io/ioutil"
+			"github.com/mattermost/mattermost-server/plugin"
+			"github.com/mattermost/mattermost-server/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) FileWillBeUploaded(c *plugin.Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string) {
+			data, err := ioutil.ReadAll(file)
+			return nil, fmt.Sprintf("%v-%v", string(data), err)
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+		`,
+	}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+	defer tearDown()
+
+	t.Run("happy", func(t *testing.T) {
+		_, err := th.App.UploadFileX(th.BasicChannel.Id,
+			"testhook.txt",
+			bytes.NewReader(large),
+			UploadFileSetTeamId("noteam"),
+			UploadFileSetUserId(th.BasicUser.Id),
+		)
+
+		require.NotNil(t, err)
+		require.Equal(t, "Unable to upload file(s). Error reading or processing request data.", err.Message)
+		require.Equal(t, "File rejected by plugin. 0123456789ABCDEF__XYZ-<nil>", err.DetailedError)
+
+	})
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1206,7 +1206,7 @@
   },
   {
     "id": "api.file.upload_file.read_request.app_error",
-    "translation": "Unable to upload file(s). Error reading or parsing request data."
+    "translation": "Unable to upload file(s). Error reading or processing request data."
   },
   {
     "id": "api.file.upload_file.read_form_value.app_error",
@@ -4237,6 +4237,10 @@
   {
     "id": "model.config.is_valid.max_file_size.app_error",
     "translation": "Invalid max file size for file settings. Must be a whole number greater than zero."
+  },
+  {
+    "id": "model.config.is_valid.max_memory_buffer.app_error",
+    "translation": "Invalid max memory buffer for file settings. Must be a whole number greater than zero."
   },
   {
     "id": "model.config.is_valid.max_notify_per_channel.app_error",

--- a/model/config.go
+++ b/model/config.go
@@ -802,6 +802,7 @@ type FileSettings struct {
 	EnableMobileUpload      *bool
 	EnableMobileDownload    *bool
 	MaxFileSize             *int64
+	MaxMemoryBuffer         *int64
 	DriverName              *string
 	Directory               string
 	EnablePublicLink        bool
@@ -859,6 +860,10 @@ func (s *FileSettings) SetDefaults() {
 
 	if s.MaxFileSize == nil {
 		s.MaxFileSize = NewInt64(52428800) // 50 MB
+	}
+
+	if s.MaxMemoryBuffer == nil {
+		s.MaxMemoryBuffer = NewInt64(48 * 1024 * 1024) // 48MB
 	}
 
 	if s.PublicLinkSalt == nil || len(*s.PublicLinkSalt) == 0 {
@@ -2220,6 +2225,10 @@ func (ss *SqlSettings) isValid() *AppError {
 func (fs *FileSettings) isValid() *AppError {
 	if *fs.MaxFileSize <= 0 {
 		return NewAppError("Config.IsValid", "model.config.is_valid.max_file_size.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if *fs.MaxMemoryBuffer <= 0 {
+		return NewAppError("Config.IsValid", "model.config.is_valid.max_memory_buffer.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if !(*fs.DriverName == IMAGE_DRIVER_LOCAL || *fs.DriverName == IMAGE_DRIVER_S3) {

--- a/utils/config.go
+++ b/utils/config.go
@@ -483,6 +483,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["GfycatApiKey"] = *c.ServiceSettings.GfycatApiKey
 	props["GfycatApiSecret"] = *c.ServiceSettings.GfycatApiSecret
 	props["MaxFileSize"] = strconv.FormatInt(*c.FileSettings.MaxFileSize, 10)
+	props["MaxMemoryBuffer"] = strconv.FormatInt(*c.FileSettings.MaxMemoryBuffer, 10)
 
 	props["MaxNotificationsPerChannel"] = strconv.FormatInt(*c.TeamSettings.MaxNotificationsPerChannel, 10)
 	props["EnableConfirmNotificationsToChannel"] = strconv.FormatBool(*c.TeamSettings.EnableConfirmNotificationsToChannel)

--- a/utils/large_buffer.go
+++ b/utils/large_buffer.go
@@ -59,7 +59,7 @@ var ErrLargeBufferMustClose = errors.New("LargeBuffer must be Closed before read
 // Type LargeBuffer implements a buffer backed by a bytes.Buffer up to
 // maxMemoryBuffer bytes. It uses a temporary file for any extra payload bytes.
 // The file can be optionally encoded to alleviate concerns about saving
-// maliciopus contents to disk.
+// malicious contents to disk.
 //
 // NewReadCloser returns the stream for the entire payload. However, clients
 // should not Read beyond what's buffered in memory until the LargeBuffer is

--- a/utils/large_buffer.go
+++ b/utils/large_buffer.go
@@ -1,0 +1,318 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package utils
+
+import (
+	"bytes"
+	"encoding/ascii85"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+const initialMemoryBuffer = 2 * 1024 * 1024 // 2Mb
+
+type tempFileEncoding interface {
+	NewEncoder(io.Writer) io.WriteCloser
+	NewDecoder(io.Reader) io.Reader
+}
+
+type ascii85Encoding struct{}
+
+func (e *ascii85Encoding) NewEncoder(w io.Writer) io.WriteCloser {
+	return ascii85.NewEncoder(w)
+}
+func (e *ascii85Encoding) NewDecoder(r io.Reader) io.Reader {
+	return ascii85.NewDecoder(r)
+}
+func (e ascii85Encoding) String() string {
+	return "ascii85"
+}
+
+type base64Encoding struct{}
+
+func (e *base64Encoding) NewEncoder(w io.Writer) io.WriteCloser {
+	return base64.NewEncoder(base64.StdEncoding, w)
+}
+func (e *base64Encoding) NewDecoder(r io.Reader) io.Reader {
+	return base64.NewDecoder(base64.StdEncoding, r)
+}
+func (e base64Encoding) String() string {
+	return "base64"
+}
+
+var ascii85Enc = &ascii85Encoding{}
+var base64Enc = &base64Encoding{}
+var tempFileEncodings = map[string]tempFileEncoding{
+	ascii85Enc.String(): ascii85Enc,
+	base64Enc.String():  base64Enc,
+}
+
+var ErrLargeBufferMustClose = errors.New("LargeBuffer must be Closed before reading from file")
+
+// TODO: consider using https://github.com/djherbis/buffer for better performance
+
+// Type LargeBuffer implements a buffer backed by a bytes.Buffer up to
+// maxMemoryBuffer bytes. It uses a temporary file for any extra payload bytes.
+// The file can be optionally encoded to alleviate concerns about saving
+// maliciopus contents to disk.
+//
+// NewReadCloser returns the stream for the entire payload. However, clients
+// should not Read beyond what's buffered in memory until the LargeBuffer is
+// closed for writing.  Doing so will return in ErrLargeBufferMustClose.  The
+// reason for this is that encodings work in 4-byte chunks and require
+// flushing, when the tempFile is closed.
+//
+// Close flushes the encoding, and closes the file for writing. Remove deletes
+// the file and unreferences the in-memory buffer.
+type LargeBuffer struct {
+	maxMemoryBuffer  int
+	tempFileEncoding tempFileEncoding
+	tempFileName     string
+
+	buffer    *bytes.Buffer
+	writeFile *os.File
+	encoder   io.WriteCloser
+	out       io.Writer
+}
+
+var _ io.WriteCloser = (*LargeBuffer)(nil)
+
+func NewLargeBuffer(maxMemoryBuffer int, enc string) *LargeBuffer {
+	if maxMemoryBuffer < 0 {
+		maxMemoryBuffer = 0
+	}
+
+	lbuf := &LargeBuffer{
+		maxMemoryBuffer:  maxMemoryBuffer,
+		buffer:           &bytes.Buffer{},
+		tempFileEncoding: tempFileEncodings[enc],
+	}
+
+	// Pre-grow the buffer for optimal performance
+	lbuf.buffer.Grow(initialMemoryBuffer)
+
+	return lbuf
+}
+
+func NewLargeBufferFrom(buffered []byte, tempFileName string, enc string) *LargeBuffer {
+	lbuf := &LargeBuffer{}
+	lbuf.InitFrom(buffered, tempFileName, enc)
+	return lbuf
+}
+
+func (lbuf *LargeBuffer) InitFrom(buffered []byte, tempFileName string, enc string) {
+	lbuf.Clear()
+	lbuf.maxMemoryBuffer = len(buffered)
+	lbuf.buffer = bytes.NewBuffer(buffered)
+	lbuf.tempFileName = tempFileName
+	lbuf.tempFileEncoding = tempFileEncodings[enc]
+}
+
+func (lbuf *LargeBuffer) Bytes() []byte {
+	if lbuf.buffer == nil {
+		return []byte{}
+	}
+	return lbuf.buffer.Bytes()
+}
+
+func (lbuf *LargeBuffer) TempFileEncoding() string {
+	if lbuf.tempFileEncoding != nil {
+		stringer := lbuf.tempFileEncoding.(fmt.Stringer)
+		if stringer != nil {
+			return stringer.String()
+		}
+	}
+	return ""
+}
+
+func (lbuf *LargeBuffer) TempFileName() string {
+	return lbuf.tempFileName
+}
+
+func (lbuf LargeBuffer) IsEmpty() bool {
+	return lbuf.tempFileName == "" && (lbuf.buffer == nil || lbuf.buffer.Len() == 0)
+}
+
+func (lbuf LargeBuffer) IsClosed() bool {
+	return lbuf.tempFileName != "" && lbuf.writeFile == nil
+}
+
+func (lbuf *LargeBuffer) NewReadCloser() (io.ReadCloser, error) {
+	r := &largeBufferReader{
+		lbuf:         lbuf,
+		memoryReader: bytes.NewReader(lbuf.buffer.Bytes()),
+	}
+
+	return r, nil
+}
+
+func (lbuf *LargeBuffer) Write(p []byte) (written int, err error) {
+	if lbuf.IsClosed() {
+		return 0, fmt.Errorf("Attempted to Write into a closed LargeBuffer.")
+	}
+
+	memSize := lbuf.maxMemoryBuffer - lbuf.buffer.Len()
+	if memSize > 0 {
+		if memSize > len(p) {
+			memSize = len(p)
+		}
+		n, err := lbuf.buffer.Write(p[:memSize])
+		written += n
+		if err != nil {
+			return written, err
+		}
+		p = p[memSize:]
+	}
+	if len(p) == 0 {
+		return written, nil
+	}
+
+	if lbuf.out == nil {
+		file, err := ioutil.TempFile("", "mattermost-upload-*.tmp")
+		if err != nil {
+			return written, err
+		}
+
+		lbuf.tempFileName = file.Name()
+		lbuf.writeFile = file
+		lbuf.out = file
+		if lbuf.tempFileEncoding != nil {
+			lbuf.encoder = lbuf.tempFileEncoding.NewEncoder(file)
+			lbuf.out = lbuf.encoder
+		}
+	}
+
+	n, err := lbuf.out.Write(p)
+	written += n
+	return written, err
+}
+
+func (lbuf *LargeBuffer) Close() error {
+	if lbuf.out == nil {
+		return nil
+	}
+	if lbuf.encoder != nil {
+		err := lbuf.encoder.Close()
+		if err != nil {
+			return err
+		}
+		lbuf.encoder = nil
+	}
+	if lbuf.writeFile != nil {
+		err := lbuf.writeFile.Close()
+		if err != nil {
+			return err
+		}
+		lbuf.writeFile = nil
+	}
+	lbuf.out = nil
+	return nil
+}
+
+func (lbuf *LargeBuffer) Clear() error {
+	err := lbuf.Close()
+	if err != nil {
+		return err
+	}
+	if lbuf.tempFileName != "" {
+		err := os.Remove(lbuf.tempFileName)
+		if err != nil {
+			return err
+		}
+		lbuf.tempFileName = ""
+	}
+	// Reset the buffer in case there are stray readers, and trash it to GC.
+	if lbuf.buffer != nil {
+		lbuf.buffer.Reset()
+	}
+	lbuf.buffer = &bytes.Buffer{}
+	return nil
+}
+
+type largeBufferReader struct {
+	lbuf         *LargeBuffer
+	memoryReader io.Reader
+	fileReader   io.Reader
+	closer       io.Closer
+	read         int64
+	count        int
+	lastLogged   int64
+}
+
+func (r *largeBufferReader) Read(p []byte) (bytesRead int, err error) {
+	defer func() {
+		r.read += int64(bytesRead)
+		r.count++
+	}()
+
+	nmem, err := r.memoryReader.Read(p)
+	switch {
+	case err != nil && err != io.EOF:
+		return nmem, err
+	case nmem == len(p):
+		return nmem, nil
+	case r.lbuf.tempFileName == "":
+		return nmem, io.EOF
+	case !r.lbuf.IsClosed():
+		return nmem, ErrLargeBufferMustClose
+	}
+
+	// Continue reading from the temp file, the first time open it.
+	if r.fileReader == nil {
+		file, err := os.Open(r.lbuf.tempFileName)
+		if err != nil {
+			return nmem, err
+		}
+
+		r.fileReader = file
+		if r.lbuf.tempFileEncoding != nil {
+			r.fileReader = r.lbuf.tempFileEncoding.NewDecoder(file)
+		}
+		r.closer = file
+	}
+
+	nfile, err := r.fileReader.Read(p[nmem:])
+	return nmem + nfile, err
+}
+
+func (r *largeBufferReader) Close() error {
+	c := r.closer
+	r.fileReader = nil
+	r.closer = nil
+	if c == nil {
+		return nil
+	}
+	err := c.Close()
+	return err
+}
+
+type LimitedReader struct {
+	R            io.Reader // underlying reader
+	N            int64     // max bytes remaining
+	LimitReached func(l *LimitedReader) error
+	BytesRead    int64
+}
+
+func (l *LimitedReader) Read(p []byte) (int, error) {
+	if l.N <= 0 {
+		err := io.EOF
+		if l.LimitReached != nil {
+			err = l.LimitReached(l)
+
+		}
+		return 0, err
+	}
+
+	if int64(len(p)) > l.N {
+		p = p[0:l.N]
+	}
+	n, err := l.R.Read(p)
+	l.N -= int64(n)
+	l.BytesRead += int64(n)
+	return n, err
+}

--- a/utils/large_buffer_test.go
+++ b/utils/large_buffer_test.go
@@ -1,0 +1,162 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLargeBufferHappy(t *testing.T) {
+	for testName, tc := range map[string]struct {
+		chunks                [][]byte
+		expectedBufferedBytes []byte
+		expectedFileBytes     []byte
+		expectedReadBackBytes []byte
+	}{
+		"happy memory buffered": {
+			chunks:                [][]byte{[]byte("123")},
+			expectedBufferedBytes: []byte("123"),
+			expectedReadBackBytes: []byte("123"),
+		},
+		"happy memory plus file": {
+			chunks: [][]byte{
+				[]byte("0123456789ABCDEF"),
+				[]byte("XYZ"),
+			},
+			expectedBufferedBytes: []byte("0123456789ABCDEF"),
+			expectedFileBytes:     []byte("=BSf"),
+			expectedReadBackBytes: []byte("0123456789ABCDEFXYZ"),
+		},
+	} {
+		testfunc := func(t *testing.T, lbuf *LargeBuffer) {
+			a := assert.New(t)
+			for _, chunk := range tc.chunks {
+				n, err := lbuf.Write(chunk)
+				a.Empty(err, "Expected no error")
+				a.Equal(len(chunk), n, "Wrong n returned (bytes written)")
+			}
+
+			a.Equal(lbuf.buffer.Bytes(), tc.expectedBufferedBytes, "Buffered contents differs")
+
+			err := lbuf.Close()
+			a.Empty(err, "Expected no error")
+
+			a.Empty(lbuf.writeFile)
+			if len(tc.expectedFileBytes) > 0 {
+				fileBytes, err := ioutil.ReadFile(lbuf.tempFileName)
+				a.Empty(err, "Expected no error")
+				a.Equalf(tc.expectedFileBytes, fileBytes, "File contents differs, actual: %q", string(fileBytes))
+			}
+
+			rc1, err := lbuf.NewReadCloser()
+			a.Empty(err, "Expected no error")
+			rc2, err := lbuf.NewReadCloser()
+			a.Empty(err, "Expected no error")
+
+			readBackBytes1, err := ioutil.ReadAll(rc1)
+			a.Empty(err, "Expected no error")
+			readBackBytes2, err := ioutil.ReadAll(rc2)
+			a.Empty(err, "Expected no error")
+
+			err = rc1.Close()
+			a.Empty(err, "Expected no error")
+			err = rc2.Close()
+			a.Empty(err, "Expected no error")
+
+			a.Equal(tc.expectedReadBackBytes, readBackBytes1, "Readback contents differs")
+			a.Equal(tc.expectedReadBackBytes, readBackBytes2, "Readback contents differs")
+
+			filename := lbuf.tempFileName
+			if filename != "" {
+				err = lbuf.Clear()
+				a.Empty(err, "Expected no error")
+				_, err = os.Stat(filename)
+				a.Equalf(os.IsNotExist(err), true, "File %q should have been deleted", filename)
+			}
+		}
+
+		lbuf := NewLargeBuffer(16, "ascii85")
+		t.Run(testName, func(t *testing.T) {
+			testfunc(t, lbuf)
+		})
+	}
+}
+
+func TestLimitedReader(t *testing.T) {
+	t.Run("no callback", func(t *testing.T) {
+		lr := &LimitedReader{R: bytes.NewReader([]byte("0123456789")), N: 10}
+
+		to := make([]byte, 5)
+		n, err := lr.Read(to)
+		assert.Equal(t, 5, n)
+		assert.Nil(t, err)
+
+		to = make([]byte, 4)
+		n, err = lr.Read(to)
+		assert.Equal(t, 4, n)
+		assert.Nil(t, err)
+
+		to = make([]byte, 2)
+		n, err = lr.Read(to)
+		assert.Equal(t, 1, n)
+		assert.Nil(t, err)
+
+		to = make([]byte, 2)
+		n, err = lr.Read(to)
+		assert.Equal(t, 0, n)
+		assert.Equal(t, io.EOF, err)
+	})
+
+	t.Run("no callback exact", func(t *testing.T) {
+		lr := &LimitedReader{R: bytes.NewReader([]byte("0123456789")), N: 10}
+
+		to := make([]byte, 5)
+		n, err := lr.Read(to)
+		assert.Equal(t, 5, n)
+		assert.Nil(t, err)
+
+		to = make([]byte, 5)
+		n, err = lr.Read(to)
+		assert.Equal(t, 5, n)
+		assert.Nil(t, err)
+
+		to = make([]byte, 1)
+		n, err = lr.Read(to)
+		assert.Equal(t, 0, n)
+		assert.Equal(t, io.EOF, err)
+	})
+
+	t.Run("callback", func(t *testing.T) {
+		exceeded := false
+		exceededAfter := 0
+
+		lr := &LimitedReader{
+			R: bytes.NewReader([]byte("0123456789")),
+			N: 10,
+			LimitReached: func(l *LimitedReader) error {
+				exceeded = true
+				exceededAfter = int(l.BytesRead)
+				return fmt.Errorf("something else")
+			},
+		}
+
+		to := make([]byte, 12)
+		n, err := lr.Read(to)
+		assert.Equal(t, 10, n)
+		assert.Nil(t, err)
+		assert.False(t, exceeded)
+
+		to = make([]byte, 1)
+		n, err = lr.Read(to)
+		require.NotNil(t, err)
+		assert.Equal(t, "something else", err.Error())
+		assert.True(t, exceeded)
+		assert.Equal(t, 10, exceededAfter)
+	})
+}


### PR DESCRIPTION
#### Summary
Support extra large file uploads (1Tb+)

- Implemented the change to bypass buffering when there are no applicable plugins
- Implemented utils.LargeBuffer
- Switched app.UploadFileX to use LargeBuffer
- Updated tests

Current performance improvements:
```
$ go test -v --run=nothing --bench=UploadFile -benchmem ./app
BenchmarkUploadFile/random-5Mb-gif-DoUploadFile_raw-8         	      20	  62801004 ns/op	21211826 B/op	    1009 allocs/op
BenchmarkUploadFile/random-5Mb-gif-UploadFileX_raw_chunked-8  	     200	   8943735 ns/op	 2140430 B/op	     136 allocs/op
BenchmarkUploadFile/random-5Mb-gif-UploadFiles-8              	       3	 522987944 ns/op	81938776 B/op	 3705029 allocs/op
BenchmarkUploadFile/random-5Mb-gif-UploadFileX_chunked-8      	       3	 458466725 ns/op	67183885 B/op	 3704449 allocs/op
BenchmarkUploadFile/random-2Mb-jpg-DoUploadFile_raw-8         	     200	   6672348 ns/op	 6032712 B/op	    8052 allocs/op
BenchmarkUploadFile/random-2Mb-jpg-UploadFileX_raw_chunked-8  	     300	   6103151 ns/op	 2140423 B/op	     135 allocs/op
BenchmarkUploadFile/random-2Mb-jpg-UploadFiles-8              	       3	 486272277 ns/op	70458458 B/op	 3718874 allocs/op
BenchmarkUploadFile/random-2Mb-jpg-UploadFileX_chunked-8      	       2	 515760044 ns/op	58288376 B/op	 3710983 allocs/op
BenchmarkUploadFile/zero-1024Mb-DoUploadFile_raw-8            	       1	3540935025 ns/op	6478521056 B/op	  262329 allocs/op
BenchmarkUploadFile/zero-1024Mb-UploadFileX_raw_chunked-8     	       2	 637574425 ns/op	 2141284 B/op	     142 allocs/op
BenchmarkUploadFile/zero-1024Mb-UploadFiles-8                 	       1	3084544538 ns/op	6478520888 B/op	  262329 allocs/op
BenchmarkUploadFile/zero-1024Mb-UploadFileX_chunked-8         	       2	 636665350 ns/op	 2140964 B/op	     137 allocs/op
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-10188
https://github.com/mattermost/mattermost-server/issues/8641

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)

STILL TODO:
- Add config for temp file encoding
- Update documentation with the new config settings