### PR TITLE
[MM-13610] Trigger Login Hooks with OAuth

### DIFF
--- a/app/oauth.go
+++ b/app/oauth.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/plugin"
 	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
 )
@@ -556,6 +557,27 @@ func (a *App) LoginByOAuth(service string, userData io.Reader, teamId string) (*
 
 	if err != nil {
 		return nil, err
+	}
+
+	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
+		var rejectionReason string
+		pluginContext := a.PluginContext()
+		pluginsEnvironment.RunMultiPluginHook(func(hooks plugin.Hooks) bool {
+			rejectionReason = hooks.UserWillLogIn(pluginContext, user)
+			return rejectionReason == ""
+		}, plugin.UserWillLogInId)
+
+		if rejectionReason != "" {
+			return nil, model.NewAppError("LoginByOAuth", "Login rejected by plugin: "+rejectionReason, nil, "", http.StatusBadRequest)
+		}
+
+		a.Srv.Go(func() {
+			pluginContext := a.PluginContext()
+			pluginsEnvironment.RunMultiPluginHook(func(hooks plugin.Hooks) bool {
+				hooks.UserHasLoggedIn(pluginContext, user)
+				return true
+			}, plugin.UserHasLoggedInId)
+		})
 	}
 
 	return user, nil


### PR DESCRIPTION
#### Summary
Since OAuth has a different login flow than normal logins, currently the login hooks weren't trigger. This PR fixes this situation.

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-13610

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
