### PR TITLE
MM-13492 Allow empty channel in /channels/view

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -917,7 +917,7 @@ func viewChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	view := model.ChannelViewFromJson(r.Body)
-	if view == nil || !model.IsValidId(view.ChannelId) || (view.PrevChannelId != "" && !model.IsValidId(view.PrevChannelId)) {
+	if view == nil || (view.ChannelId != "" && !model.IsValidId(view.ChannelId)) || (view.PrevChannelId != "" && !model.IsValidId(view.PrevChannelId)) {
 		c.SetInvalidParam("channel_view")
 		return
 	}

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -917,8 +917,19 @@ func viewChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	view := model.ChannelViewFromJson(r.Body)
-	if view == nil || (view.ChannelId != "" && !model.IsValidId(view.ChannelId)) || (view.PrevChannelId != "" && !model.IsValidId(view.PrevChannelId)) {
+	if view == nil {
 		c.SetInvalidParam("channel_view")
+		return
+	}
+
+	// Validate view struct
+	// Check IDs are valid or blank. Blank IDs are used to denote focus loss or inital channel view.
+	if view.ChannelId != "" && !model.IsValidId(view.ChannelId) {
+		c.SetInvalidParam("channel_view.channel_id")
+		return
+	}
+	if view.PrevChannelId != "" && !model.IsValidId(view.PrevChannelId) {
+		c.SetInvalidParam("channel_view.prev_channel_id")
 		return
 	}
 

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1418,6 +1418,12 @@ func TestViewChannel(t *testing.T) {
 	_, resp = Client.ViewChannel(th.BasicUser.Id, view)
 	CheckBadRequestStatus(t, resp)
 
+	// All blank is OK we use it for clicking off of the browser.
+	view.PrevChannelId = ""
+	view.ChannelId = ""
+	_, resp = Client.ViewChannel(th.BasicUser.Id, view)
+	CheckNoError(t, resp)
+
 	view.PrevChannelId = ""
 	view.ChannelId = "junk"
 	_, resp = Client.ViewChannel(th.BasicUser.Id, view)


### PR DESCRIPTION
Fixes a bug where the server was rejecting viewing no channel represented by "". This happens when the browser loses focus.