### PR TITLE
MM-13606 Remove consumeAndClose and clean up integration response handling

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -331,7 +331,9 @@ func (a *App) doCommandRequest(cmd *model.Command, p url.Values) (*model.Command
 	body := io.LimitReader(resp.Body, MaxIntegrationResponseSize)
 
 	if resp.StatusCode != http.StatusOK {
+		// Ignore the error below because the resulting string will just be the empty string if bodyBytes is nil
 		bodyBytes, _ := ioutil.ReadAll(body)
+
 		return cmd, nil, model.NewAppError("command", "api.command.execute_command.failed_resp.app_error", map[string]interface{}{"Trigger": cmd.Trigger, "Status": resp.Status}, string(bodyBytes), http.StatusInternalServerError)
 	}
 

--- a/app/command.go
+++ b/app/command.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -167,7 +168,6 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 	trigger := parts[0][1:]
 	trigger = strings.ToLower(trigger)
 	message := strings.Join(parts[1:], " ")
-	provider := GetCommandProvider(trigger)
 
 	clientTriggerId, triggerId, appErr := model.GenerateTriggerId(args.UserId, a.AsymmetricSigningKey())
 	if appErr != nil {
@@ -176,24 +176,45 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 
 	args.TriggerId = triggerId
 
-	if provider != nil {
-		if cmd := provider.GetCommand(a, args.T); cmd != nil {
-			response := provider.DoCommand(a, args, message)
-			return a.HandleCommandResponse(cmd, args, response, true)
-		}
+	if cmd, response := a.tryExecuteBuiltInCommand(args, trigger, message); cmd != nil && response != nil {
+		return a.HandleCommandResponse(cmd, args, response, true)
 	}
 
-	cmd, response, appErr := a.ExecutePluginCommand(args)
-	if appErr != nil {
+	if cmd, response, appErr := a.ExecutePluginCommand(args); appErr != nil {
 		return nil, appErr
-	}
-	if cmd != nil {
+	} else if cmd != nil && response != nil {
 		response.TriggerId = clientTriggerId
 		return a.HandleCommandResponse(cmd, args, response, true)
 	}
 
+	if cmd, response, appErr := a.tryExecuteCustomCommand(args, trigger, message); appErr != nil {
+		return nil, appErr
+	} else if cmd != nil && response != nil {
+		response.TriggerId = clientTriggerId
+		return a.HandleCommandResponse(cmd, args, response, false)
+	}
+
+	return nil, model.NewAppError("command", "api.command.execute_command.not_found.app_error", map[string]interface{}{"Trigger": trigger}, "", http.StatusNotFound)
+}
+
+func (a *App) tryExecuteBuiltInCommand(args *model.CommandArgs, trigger string, message string) (*model.Command, *model.CommandResponse) {
+	provider := GetCommandProvider(trigger)
+	if provider == nil {
+		return nil, nil
+	}
+
+	cmd := provider.GetCommand(a, args.T)
+	if cmd == nil {
+		return nil, nil
+	}
+
+	return cmd, provider.DoCommand(a, args, message)
+}
+
+func (a *App) tryExecuteCustomCommand(args *model.CommandArgs, trigger string, message string) (*model.Command, *model.CommandResponse, *model.AppError) {
+	// Handle custom commands
 	if !*a.Config().ServiceSettings.EnableCommands {
-		return nil, model.NewAppError("ExecuteCommand", "api.command.disabled.app_error", nil, "", http.StatusNotImplemented)
+		return nil, nil, model.NewAppError("ExecuteCommand", "api.command.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	chanChan := a.Srv.Store.Channel().Get(args.ChannelId, true)
@@ -202,98 +223,112 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 
 	result := <-a.Srv.Store.Command().GetByTeam(args.TeamId)
 	if result.Err != nil {
-		return nil, result.Err
+		return nil, nil, result.Err
 	}
 
 	tr := <-teamChan
 	if tr.Err != nil {
-		return nil, tr.Err
+		return nil, nil, tr.Err
 	}
 	team := tr.Data.(*model.Team)
 
 	ur := <-userChan
 	if ur.Err != nil {
-		return nil, ur.Err
+		return nil, nil, ur.Err
 	}
 	user := ur.Data.(*model.User)
 
 	cr := <-chanChan
 	if cr.Err != nil {
-		return nil, cr.Err
+		return nil, nil, cr.Err
 	}
 	channel := cr.Data.(*model.Channel)
 
+	var cmd *model.Command
+
 	teamCmds := result.Data.([]*model.Command)
-	for _, cmd := range teamCmds {
-		if trigger == cmd.Trigger {
-			mlog.Debug(fmt.Sprintf(utils.T("api.command.execute_command.debug"), trigger, args.UserId))
-
-			p := url.Values{}
-			p.Set("token", cmd.Token)
-
-			p.Set("team_id", cmd.TeamId)
-			p.Set("team_domain", team.Name)
-
-			p.Set("channel_id", args.ChannelId)
-			p.Set("channel_name", channel.Name)
-
-			p.Set("user_id", args.UserId)
-			p.Set("user_name", user.Username)
-
-			p.Set("command", "/"+trigger)
-			p.Set("text", message)
-
-			p.Set("trigger_id", triggerId)
-
-			hook, appErr := a.CreateCommandWebhook(cmd.Id, args)
-			if appErr != nil {
-				return nil, model.NewAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": trigger}, appErr.Error(), http.StatusInternalServerError)
-			}
-			p.Set("response_url", args.SiteURL+"/hooks/commands/"+hook.Id)
-
-			var req *http.Request
-			if cmd.Method == model.COMMAND_METHOD_GET {
-				req, _ = http.NewRequest(http.MethodGet, cmd.URL, nil)
-
-				if req.URL.RawQuery != "" {
-					req.URL.RawQuery += "&"
-				}
-				req.URL.RawQuery += p.Encode()
-			} else {
-				req, _ = http.NewRequest(http.MethodPost, cmd.URL, strings.NewReader(p.Encode()))
-			}
-
-			req.Header.Set("Accept", "application/json")
-			req.Header.Set("Authorization", "Token "+cmd.Token)
-			if cmd.Method == model.COMMAND_METHOD_POST {
-				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			}
-
-			resp, err := a.HTTPService.MakeClient(false).Do(req)
-			if err != nil {
-				return nil, model.NewAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": trigger}, err.Error(), http.StatusInternalServerError)
-			}
-			if resp.StatusCode != http.StatusOK {
-				defer resp.Body.Close()
-				body, _ := ioutil.ReadAll(resp.Body)
-				return nil, model.NewAppError("command", "api.command.execute_command.failed_resp.app_error", map[string]interface{}{"Trigger": trigger, "Status": resp.Status}, string(body), http.StatusInternalServerError)
-			}
-
-			response, err := model.CommandResponseFromHTTPBody(resp.Header.Get("Content-Type"), resp.Body)
-			if err != nil {
-				return nil, model.NewAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": trigger}, err.Error(), http.StatusInternalServerError)
-			}
-			if response == nil {
-				return nil, model.NewAppError("command", "api.command.execute_command.failed_empty.app_error", map[string]interface{}{"Trigger": trigger}, "", http.StatusInternalServerError)
-			}
-
-			response.TriggerId = clientTriggerId
-
-			return a.HandleCommandResponse(cmd, args, response, false)
+	for _, teamCmd := range teamCmds {
+		if trigger == teamCmd.Trigger {
+			cmd = teamCmd
 		}
 	}
 
-	return nil, model.NewAppError("command", "api.command.execute_command.not_found.app_error", map[string]interface{}{"Trigger": trigger}, "", http.StatusNotFound)
+	if cmd == nil {
+		return nil, nil, nil
+	}
+
+	mlog.Debug(fmt.Sprintf(utils.T("api.command.execute_command.debug"), trigger, args.UserId))
+
+	p := url.Values{}
+	p.Set("token", cmd.Token)
+
+	p.Set("team_id", cmd.TeamId)
+	p.Set("team_domain", team.Name)
+
+	p.Set("channel_id", args.ChannelId)
+	p.Set("channel_name", channel.Name)
+
+	p.Set("user_id", args.UserId)
+	p.Set("user_name", user.Username)
+
+	p.Set("command", "/"+trigger)
+	p.Set("text", message)
+
+	p.Set("trigger_id", args.TriggerId)
+
+	hook, appErr := a.CreateCommandWebhook(cmd.Id, args)
+	if appErr != nil {
+		return cmd, nil, model.NewAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": trigger}, appErr.Error(), http.StatusInternalServerError)
+	}
+	p.Set("response_url", args.SiteURL+"/hooks/commands/"+hook.Id)
+
+	return a.doCommandRequest(cmd, p)
+}
+
+func (a *App) doCommandRequest(cmd *model.Command, p url.Values) (*model.Command, *model.CommandResponse, *model.AppError) {
+	// Prepare the request
+	var req *http.Request
+	if cmd.Method == model.COMMAND_METHOD_GET {
+		req, _ = http.NewRequest(http.MethodGet, cmd.URL, nil)
+
+		if req.URL.RawQuery != "" {
+			req.URL.RawQuery += "&"
+		}
+		req.URL.RawQuery += p.Encode()
+	} else {
+		req, _ = http.NewRequest(http.MethodPost, cmd.URL, strings.NewReader(p.Encode()))
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Token "+cmd.Token)
+	if cmd.Method == model.COMMAND_METHOD_POST {
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	}
+
+	// Send the request
+	resp, err := a.HTTPService.MakeClient(false).Do(req)
+	if err != nil {
+		return cmd, nil, model.NewAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": cmd.Trigger}, err.Error(), http.StatusInternalServerError)
+	}
+
+	defer resp.Body.Close()
+
+	// Handle the response
+	body := io.LimitReader(resp.Body, MaxIntegrationResponseSize)
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := ioutil.ReadAll(body)
+		return cmd, nil, model.NewAppError("command", "api.command.execute_command.failed_resp.app_error", map[string]interface{}{"Trigger": cmd.Trigger, "Status": resp.Status}, string(bodyBytes), http.StatusInternalServerError)
+	}
+
+	response, err := model.CommandResponseFromHTTPBody(resp.Header.Get("Content-Type"), body)
+	if err != nil {
+		return cmd, nil, model.NewAppError("command", "api.command.execute_command.failed.app_error", map[string]interface{}{"Trigger": cmd.Trigger}, err.Error(), http.StatusInternalServerError)
+	} else if response == nil {
+		return cmd, nil, model.NewAppError("command", "api.command.execute_command.failed_empty.app_error", map[string]interface{}{"Trigger": cmd.Trigger}, "", http.StatusInternalServerError)
+	}
+
+	return cmd, response, nil
 }
 
 func (a *App) HandleCommandResponse(command *model.Command, args *model.CommandArgs, response *model.CommandResponse, builtIn bool) (*model.CommandResponse, *model.AppError) {

--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -71,12 +71,11 @@ func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) (str
 	}
 
 	resp, err := a.DoActionRequest(action.Integration.URL, request.ToJson())
-	if resp != nil {
-		defer consumeAndClose(resp)
-	}
 	if err != nil {
 		return "", err
 	}
+
+	defer resp.Body.Close()
 
 	var response model.PostActionIntegrationResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
@@ -181,13 +180,11 @@ func (a *App) SubmitInteractiveDialog(request model.SubmitDialogRequest) (*model
 	}
 
 	resp, err := a.DoActionRequest(url, b)
-	if resp != nil {
-		defer consumeAndClose(resp)
-	}
-
 	if err != nil {
 		return nil, err
 	}
+
+	defer resp.Body.Close()
 
 	var response model.SubmitDialogResponse
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -281,10 +281,9 @@ func (a *App) sendToPushProxy(msg model.PushNotification, session *model.Session
 		return
 	}
 
+	defer resp.Body.Close()
+
 	pushResponse := model.PushResponseFromJson(resp.Body)
-	if resp.Body != nil {
-		consumeAndClose(resp)
-	}
 
 	if pushResponse[model.PUSH_STATUS] == model.PUSH_STATUS_REMOVE {
 		mlog.Info(fmt.Sprintf("Device was reported as removed for UserId=%v SessionId=%v removing push for this session", session.UserId, session.Id), mlog.String("user_id", session.UserId))

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -823,6 +823,7 @@ func (a *App) AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service
 	} else if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
 
+		// Ignore the error below because the resulting string will just be the empty string if bodyBytes is nil
 		bodyBytes, _ := ioutil.ReadAll(resp.Body)
 		bodyString := string(bodyBytes)
 

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -792,20 +792,18 @@ func (a *App) AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service
 
 	var buf bytes.Buffer
 	tee := io.TeeReader(resp.Body, &buf)
-
 	ar := model.AccessResponseFromJson(tee)
-	bodyBytes := buf.Bytes()
 
 	if ar == nil || resp.StatusCode != http.StatusOK {
-		return nil, "", stateProps, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.bad_response.app_error", nil, "response_body="+string(bodyBytes), http.StatusInternalServerError)
+		return nil, "", stateProps, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.bad_response.app_error", nil, "response_body="+buf.String(), http.StatusInternalServerError)
 	}
 
 	if strings.ToLower(ar.TokenType) != model.ACCESS_TOKEN_TYPE {
-		return nil, "", stateProps, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.bad_token.app_error", nil, "token_type="+ar.TokenType+", response_body="+string(bodyBytes), http.StatusInternalServerError)
+		return nil, "", stateProps, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.bad_token.app_error", nil, "token_type="+ar.TokenType+", response_body="+buf.String(), http.StatusInternalServerError)
 	}
 
 	if len(ar.AccessToken) == 0 {
-		return nil, "", stateProps, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.missing.app_error", nil, "response_body="+string(bodyBytes), http.StatusInternalServerError)
+		return nil, "", stateProps, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.missing.app_error", nil, "response_body="+buf.String(), http.StatusInternalServerError)
 	}
 
 	p = url.Values{}

--- a/app/opengraph.go
+++ b/app/opengraph.go
@@ -20,7 +20,7 @@ func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
 		mlog.Error("GetOpenGraphMetadata request failed", mlog.String("requestURL", requestURL), mlog.Any("err", err))
 		return nil
 	}
-	defer consumeAndClose(res)
+	defer res.Body.Close()
 
 	return a.ParseOpenGraphMetadata(requestURL, res.Body, res.Header.Get("Content-Type"))
 }

--- a/app/plugin_commands.go
+++ b/app/plugin_commands.go
@@ -90,7 +90,9 @@ func (a *App) PluginCommandsForTeam(teamId string) []*model.Command {
 	return commands
 }
 
-func (a *App) ExecutePluginCommand(args *model.CommandArgs) (*model.Command, *model.CommandResponse, *model.AppError) {
+// tryExecutePluginCommand attempts to run a command provided by a plugin based on the given arguments. If no such
+// command can be found, returns nil for all arguments.
+func (a *App) tryExecutePluginCommand(args *model.CommandArgs) (*model.Command, *model.CommandResponse, *model.AppError) {
 	parts := strings.Split(args.Command, " ")
 	trigger := parts[0][1:]
 	trigger = strings.ToLower(trigger)

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -339,7 +339,8 @@ func (a *App) getLinkMetadata(requestURL string, useCache bool) (*opengraph.Open
 	if err != nil {
 		return nil, nil, err
 	}
-	defer consumeAndClose(res)
+
+	defer res.Body.Close()
 
 	// Parse the data
 	og, image, err := a.parseLinkMetadata(requestURL, res.Body, res.Header.Get("Content-Type"))

--- a/app/security_update_check.go
+++ b/app/security_update_check.go
@@ -81,8 +81,9 @@ func (s *Server) DoSecurityUpdateCheck() {
 					return
 				}
 
+				defer res.Body.Close()
+
 				bulletins := model.SecurityBulletinsFromJson(res.Body)
-				consumeAndClose(res)
 
 				for _, bulletin := range bulletins {
 					if bulletin.AppliesToVersion == model.CurrentVersion {

--- a/app/server.go
+++ b/app/server.go
@@ -8,8 +8,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/tls"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -594,14 +592,6 @@ func (a *App) OriginChecker() func(*http.Request) bool {
 		return utils.OriginChecker(allowed)
 	}
 	return nil
-}
-
-// This is required to re-use the underlying connection and not take up file descriptors
-func consumeAndClose(r *http.Response) {
-	if r.Body != nil {
-		io.Copy(ioutil.Discard, r.Body)
-		r.Body.Close()
-	}
 }
 
 func runSecurityJob(s *Server) {

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -20,6 +20,8 @@ import (
 const (
 	TRIGGERWORDS_EXACT_MATCH = 0
 	TRIGGERWORDS_STARTS_WITH = 1
+
+	MaxIntegrationResponseSize = 1024 * 1024 // Posts can be <100KB at most, so this is likely more than enough
 )
 
 func (a *App) handleWebhookEvents(post *model.Post, team *model.Team, channel *model.Channel, user *model.User) *model.AppError {
@@ -101,54 +103,64 @@ func (a *App) TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.
 		contentType = "application/x-www-form-urlencoded"
 	}
 
-	for _, url := range hook.CallbackURLs {
-		a.Srv.Go(func(url string) func() {
-			return func() {
-				req, _ := http.NewRequest("POST", url, body)
-				req.Header.Set("Content-Type", contentType)
-				req.Header.Set("Accept", "application/json")
+	for i := range hook.CallbackURLs {
+		// Get the callback URL by index to properly capture it for the go func
+		url := hook.CallbackURLs[i]
 
-				if resp, err := a.HTTPService.MakeClient(false).Do(req); err != nil {
-					mlog.Error(fmt.Sprintf("Event POST failed, err=%s", err.Error()))
-				} else {
-					defer resp.Body.Close()
+		a.Srv.Go(func() {
+			webhookResp, err := a.doOutgoingWebhookRequest(url, body, contentType)
+			if err != nil {
+				mlog.Error(fmt.Sprintf("Event POST failed, err=%s", err.Error()))
+				return
+			}
 
-					webhookResp := model.OutgoingWebhookResponseFromJson(resp.Body)
+			if webhookResp != nil && (webhookResp.Text != nil || len(webhookResp.Attachments) > 0) {
+				postRootId := ""
+				if webhookResp.ResponseType == model.OUTGOING_HOOK_RESPONSE_TYPE_COMMENT {
+					postRootId = post.Id
+				}
+				if len(webhookResp.Props) == 0 {
+					webhookResp.Props = make(model.StringInterface)
+				}
+				webhookResp.Props["webhook_display_name"] = hook.DisplayName
 
-					if webhookResp != nil && (webhookResp.Text != nil || len(webhookResp.Attachments) > 0) {
-						postRootId := ""
-						if webhookResp.ResponseType == model.OUTGOING_HOOK_RESPONSE_TYPE_COMMENT {
-							postRootId = post.Id
-						}
-						if len(webhookResp.Props) == 0 {
-							webhookResp.Props = make(model.StringInterface)
-						}
-						webhookResp.Props["webhook_display_name"] = hook.DisplayName
+				text := ""
+				if webhookResp.Text != nil {
+					text = a.ProcessSlackText(*webhookResp.Text)
+				}
+				webhookResp.Attachments = a.ProcessSlackAttachments(webhookResp.Attachments)
+				// attachments is in here for slack compatibility
+				if len(webhookResp.Attachments) > 0 {
+					webhookResp.Props["attachments"] = webhookResp.Attachments
+				}
+				if a.Config().ServiceSettings.EnablePostUsernameOverride && hook.Username != "" && webhookResp.Username == "" {
+					webhookResp.Username = hook.Username
+				}
 
-						text := ""
-						if webhookResp.Text != nil {
-							text = a.ProcessSlackText(*webhookResp.Text)
-						}
-						webhookResp.Attachments = a.ProcessSlackAttachments(webhookResp.Attachments)
-						// attachments is in here for slack compatibility
-						if len(webhookResp.Attachments) > 0 {
-							webhookResp.Props["attachments"] = webhookResp.Attachments
-						}
-						if a.Config().ServiceSettings.EnablePostUsernameOverride && hook.Username != "" && webhookResp.Username == "" {
-							webhookResp.Username = hook.Username
-						}
-
-						if a.Config().ServiceSettings.EnablePostIconOverride && hook.IconURL != "" && webhookResp.IconURL == "" {
-							webhookResp.IconURL = hook.IconURL
-						}
-						if _, err := a.CreateWebhookPost(hook.CreatorId, channel, text, webhookResp.Username, webhookResp.IconURL, webhookResp.Props, webhookResp.Type, postRootId); err != nil {
-							mlog.Error(fmt.Sprintf("Failed to create response post, err=%v", err))
-						}
-					}
+				if a.Config().ServiceSettings.EnablePostIconOverride && hook.IconURL != "" && webhookResp.IconURL == "" {
+					webhookResp.IconURL = hook.IconURL
+				}
+				if _, err := a.CreateWebhookPost(hook.CreatorId, channel, text, webhookResp.Username, webhookResp.IconURL, webhookResp.Props, webhookResp.Type, postRootId); err != nil {
+					mlog.Error(fmt.Sprintf("Failed to create response post, err=%v", err))
 				}
 			}
-		}(url))
+		})
 	}
+}
+
+func (a *App) doOutgoingWebhookRequest(url string, body io.Reader, contentType string) (*model.OutgoingWebhookResponse, error) {
+	req, _ := http.NewRequest("POST", url, body)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := a.HTTPService.MakeClient(false).Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	return model.OutgoingWebhookResponseFromJson(io.LimitReader(resp.Body, MaxIntegrationResponseSize))
 }
 
 func SplitWebhookPost(post *model.Post, maxPostSize int) ([]*model.Post, *model.AppError) {

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -149,7 +149,11 @@ func (a *App) TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.
 }
 
 func (a *App) doOutgoingWebhookRequest(url string, body io.Reader, contentType string) (*model.OutgoingWebhookResponse, error) {
-	req, _ := http.NewRequest("POST", url, body)
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", "application/json")
 

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -107,10 +107,11 @@ func (a *App) TriggerWebhook(payload *model.OutgoingWebhookPayload, hook *model.
 				req, _ := http.NewRequest("POST", url, body)
 				req.Header.Set("Content-Type", contentType)
 				req.Header.Set("Accept", "application/json")
+
 				if resp, err := a.HTTPService.MakeClient(false).Do(req); err != nil {
 					mlog.Error(fmt.Sprintf("Event POST failed, err=%s", err.Error()))
 				} else {
-					defer consumeAndClose(resp)
+					defer resp.Body.Close()
 
 					webhookResp := model.OutgoingWebhookResponseFromJson(resp.Body)
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2123,6 +2123,10 @@
     "translation": "Missing access token"
   },
   {
+    "id": "api.user.authorize_oauth_user.response.app_error",
+    "translation": "Received invalid response from OAuth service provider"
+  },
+  {
     "id": "api.user.authorize_oauth_user.service.app_error",
     "translation": "Token request to {{.Service}} failed"
   },

--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -109,10 +109,10 @@ func (o *OutgoingWebhookResponse) ToJson() string {
 	return string(b)
 }
 
-func OutgoingWebhookResponseFromJson(data io.Reader) *OutgoingWebhookResponse {
+func OutgoingWebhookResponseFromJson(data io.Reader) (*OutgoingWebhookResponse, error) {
 	var o *OutgoingWebhookResponse
-	json.NewDecoder(data).Decode(&o)
-	return o
+	err := json.NewDecoder(data).Decode(&o)
+	return o, err
 }
 
 func (o *OutgoingWebhook) IsValid() *AppError {

--- a/model/outgoing_webhook_test.go
+++ b/model/outgoing_webhook_test.go
@@ -202,7 +202,7 @@ func TestOutgoingWebhookResponseJson(t *testing.T) {
 	o.Text = NewString("some text")
 
 	json := o.ToJson()
-	ro := OutgoingWebhookResponseFromJson(strings.NewReader(json))
+	ro, _ := OutgoingWebhookResponseFromJson(strings.NewReader(json))
 
 	if *o.Text != *ro.Text {
 		t.Fatal("Text does not match")

--- a/services/httpservice/client.go
+++ b/services/httpservice/client.go
@@ -126,10 +126,3 @@ func NewTransport(enableInsecureConnections bool, allowHost func(host string) bo
 		},
 	}
 }
-
-func NewHTTPClient(transport http.RoundTripper) *http.Client {
-	return &http.Client{
-		Transport: transport,
-		Timeout:   RequestTimeout,
-	}
-}

--- a/services/httpservice/client_test.go
+++ b/services/httpservice/client_test.go
@@ -139,3 +139,9 @@ func TestUserAgentIsSet(t *testing.T) {
 	}
 	client.Do(req)
 }
+
+func NewHTTPClient(transport http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: transport,
+	}
+}


### PR DESCRIPTION
It may be easier to review this PR if you look at the individual commits since it accomplishes two main things:
1. I removed the `consumeAndClose` function used throughout the app layer since it seems like you don't need to read from a TCP request's body any more to have the connection reused
2. I did some refactoring of the outgoing webhook and slash command code so that I add some tests for that code

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13606

#### Checklist
- Added or updated unit tests (required for all new features)
- Touches critical sections of the codebase (auth, upgrade, etc.)
