### PR TITLE
[MM-10346] CSRF Token Implementation + Tests

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -31,17 +31,18 @@ func TestCreateUser(t *testing.T) {
 	_, resp = th.Client.Login(user.Email, user.Password)
 	session, _ := th.App.GetSession(th.Client.AuthToken)
 	expectedCsrf := "MMCSRF=" + session.GetCSRF()
+	actualCsrf := ""
 
 	for _, cookie := range resp.Header["Set-Cookie"] {
-		if !strings.HasPrefix(cookie, "MMCSRF") {
-			continue
+		if strings.HasPrefix(cookie, "MMCSRF") {
+			cookieParts := strings.Split(cookie, ";")
+			actualCsrf = cookieParts[0]
+			break
 		}
+	}
 
-		cookieParts := strings.Split(cookie, ";")
-
-		if expectedCsrf != cookieParts[0] {
-			t.Errorf("CSRF Mismatch - Expected %s, got %s", expectedCsrf, cookie)
-		}
+	if expectedCsrf != actualCsrf {
+		t.Errorf("CSRF Mismatch - Expected %s, got %s", expectedCsrf, actualCsrf)
 	}
 
 	if ruser.Nickname != user.Nickname {

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -260,6 +260,7 @@ func (a *App) trackConfig() {
 		"allow_cookies_for_subdomains":                            *cfg.ServiceSettings.AllowCookiesForSubdomains,
 		"enable_api_team_deletion":                                *cfg.ServiceSettings.EnableAPITeamDeletion,
 		"experimental_enable_hardened_mode":                       *cfg.ServiceSettings.ExperimentalEnableHardenedMode,
+		"experimental_strict_csrf_enforcement":                    *cfg.ServiceSettings.ExperimentalStrictCSRFEnforcement,
 		"enable_email_invitations":                                *cfg.ServiceSettings.EnableEmailInvitations,
 		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,
 		"experimental_ldap_group_sync":                            *cfg.ServiceSettings.ExperimentalLdapGroupSync,

--- a/app/login.go
+++ b/app/login.go
@@ -189,8 +189,19 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 		Secure:  secure,
 	}
 
+	csrfCookie := &http.Cookie{
+		Name:    model.SESSION_COOKIE_CSRF,
+		Value:   session.GetCSRF(),
+		Path:    "/",
+		MaxAge:  maxAge,
+		Expires: expiresAt,
+		Domain:  domain,
+		Secure:  secure,
+	}
+
 	http.SetCookie(w, sessionCookie)
 	http.SetCookie(w, userCookie)
+	http.SetCookie(w, csrfCookie)
 
 	return session, nil
 }

--- a/app/plugin_requests.go
+++ b/app/plugin_requests.go
@@ -65,21 +65,32 @@ func (a *App) servePluginRequest(w http.ResponseWriter, r *http.Request, handler
 	r.Header.Del("Mattermost-User-Id")
 	if token != "" {
 		session, err := a.GetSession(token)
-		csrfCheckPassed := true
+		csrfCheckPassed := false
 
-		if err == nil && cookieAuth && r.Method != "GET" && r.Header.Get(model.HEADER_REQUESTED_WITH) != model.HEADER_REQUESTED_WITH_XML {
-			bodyBytes, _ := ioutil.ReadAll(r.Body)
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
-			r.ParseForm()
-			sentToken := r.FormValue("csrf")
-			expectedToken := session.GetCSRF()
+		if err == nil && cookieAuth && r.Method != "GET" {
+			sentToken := ""
 
-			if sentToken != expectedToken {
-				csrfCheckPassed = false
+			if r.Header.Get(model.HEADER_CSRF_TOKEN) == "" {
+				bodyBytes, _ := ioutil.ReadAll(r.Body)
+				r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+				r.ParseForm()
+				sentToken = r.FormValue("csrf")
+				r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+			} else {
+				sentToken = r.Header.Get(model.HEADER_CSRF_TOKEN)
 			}
 
-			// Set Request Body again, since otherwise form values aren't accessible in plugin handler
-			r.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+			expectedToken := session.GetCSRF()
+
+			if sentToken == expectedToken {
+				csrfCheckPassed = true
+			}
+
+			// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
+			if !*a.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement && r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML && !csrfCheckPassed {
+				a.Log.Warn("CSRF Check failed for request - Please migrate your plugin to either send a CSRF Header or Form Field, XMLHttpRequest is deprecated")
+				csrfCheckPassed = true
+			}
 		}
 
 		if session != nil && err == nil && csrfCheckPassed {

--- a/app/plugin_requests.go
+++ b/app/plugin_requests.go
@@ -91,6 +91,8 @@ func (a *App) servePluginRequest(w http.ResponseWriter, r *http.Request, handler
 				a.Log.Warn("CSRF Check failed for request - Please migrate your plugin to either send a CSRF Header or Form Field, XMLHttpRequest is deprecated")
 				csrfCheckPassed = true
 			}
+		} else {
+			csrfCheckPassed = true
 		}
 
 		if session != nil && err == nil && csrfCheckPassed {

--- a/config/default.json
+++ b/config/default.json
@@ -74,7 +74,8 @@
         "EnableAPITeamDeletion": false,
         "ExperimentalEnableHardenedMode": false,
         "EnableEmailInvitations": false,
-        "ExperimentalLdapGroupSync": false
+        "ExperimentalLdapGroupSync": false,
+        "ExperimentalStrictCSRFEnforcement": false
     },
     "TeamSettings": {
         "SiteName": "Mattermost",

--- a/model/client4.go
+++ b/model/client4.go
@@ -27,6 +27,7 @@ const (
 	HEADER_REAL_IP            = "X-Real-IP"
 	HEADER_FORWARDED_PROTO    = "X-Forwarded-Proto"
 	HEADER_TOKEN              = "token"
+	HEADER_CSRF_TOKEN         = "X-CSRF-Token"
 	HEADER_BEARER             = "BEARER"
 	HEADER_AUTH               = "Authorization"
 	HEADER_REQUESTED_WITH     = "X-Requested-With"

--- a/model/config.go
+++ b/model/config.go
@@ -280,6 +280,7 @@ type ServiceSettings struct {
 	DEPRECATED_DO_NOT_USE_ImageProxyOptions           *string `json:"ImageProxyOptions"` // This field is deprecated and must not be used.
 	EnableAPITeamDeletion                             *bool
 	ExperimentalEnableHardenedMode                    *bool
+	ExperimentalStrictCSRFEnforcement                 *bool
 	EnableEmailInvitations                            *bool
 	ExperimentalLdapGroupSync                         *bool
 }
@@ -575,6 +576,10 @@ func (s *ServiceSettings) SetDefaults() {
 
 	if s.ExperimentalLdapGroupSync == nil {
 		s.ExperimentalLdapGroupSync = NewBool(false)
+	}
+
+	if s.ExperimentalStrictCSRFEnforcement == nil {
+		s.ExperimentalStrictCSRFEnforcement = NewBool(false)
 	}
 }
 

--- a/model/session.go
+++ b/model/session.go
@@ -12,6 +12,7 @@ import (
 const (
 	SESSION_COOKIE_TOKEN              = "MMAUTHTOKEN"
 	SESSION_COOKIE_USER               = "MMUSERID"
+	SESSION_COOKIE_CSRF               = "MMCSRF"
 	SESSION_CACHE_SIZE                = 35000
 	SESSION_PROP_PLATFORM             = "platform"
 	SESSION_PROP_OS                   = "os"

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -62,16 +62,6 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c.App.Path = r.URL.Path
 	c.Log = c.App.Log
 
-	token, tokenLocation := app.ParseAuthTokenFromRequest(r)
-
-	// CSRF Check
-	if tokenLocation == app.TokenLocationCookie && h.RequireSession && !h.TrustRequester {
-		if r.Header.Get(model.HEADER_REQUESTED_WITH) != model.HEADER_REQUESTED_WITH_XML {
-			c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token+" Appears to be a CSRF attempt", http.StatusUnauthorized)
-			token = ""
-		}
-	}
-
 	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
 	siteURLHeader := app.GetProtocol(r) + "://" + r.Host + subpath
 	c.SetSiteURLHeader(siteURLHeader)
@@ -97,26 +87,51 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	token, tokenLocation := app.ParseAuthTokenFromRequest(r)
+
 	if len(token) != 0 {
 		session, err := c.App.GetSession(token)
+		csrfCheckPassed := false
 
-		if err != nil {
-			c.Log.Info("Invalid session", mlog.Err(err))
-			if err.StatusCode == http.StatusInternalServerError {
-				c.Err = err
-			} else if h.RequireSession {
-				c.RemoveSessionCookie(w, r)
-				c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token, http.StatusUnauthorized)
+		// CSRF Check
+		if tokenLocation == app.TokenLocationCookie && h.RequireSession && !h.TrustRequester && r.Method != "GET" {
+			csrfHeader := r.Header.Get(model.HEADER_CSRF_TOKEN)
+			if csrfHeader == session.GetCSRF() {
+				csrfCheckPassed = true
+			} else if !*c.App.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement && r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML {
+				// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
+				c.Log.Warn("CSRF Header check failed for request - Please upgrade your web application or custom app to set a CSRF Header")
+				csrfCheckPassed = true
 			}
-		} else if !session.IsOAuth && tokenLocation == app.TokenLocationQueryString {
-			c.Err = model.NewAppError("ServeHTTP", "api.context.token_provided.app_error", nil, "token="+token, http.StatusUnauthorized)
+
+			if !csrfCheckPassed {
+				token = ""
+				session = nil
+				c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token+" Appears to be a CSRF attempt", http.StatusUnauthorized)
+			}
 		} else {
-			c.App.Session = *session
+			csrfCheckPassed = true
 		}
 
-		// Rate limit by UserID
-		if c.App.Srv.RateLimiter != nil && c.App.Srv.RateLimiter.UserIdRateLimit(c.App.Session.UserId, w) {
-			return
+		if csrfCheckPassed {
+			if err != nil {
+				c.Log.Info("Invalid session", mlog.Err(err))
+				if err.StatusCode == http.StatusInternalServerError {
+					c.Err = err
+				} else if h.RequireSession {
+					c.RemoveSessionCookie(w, r)
+					c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token, http.StatusUnauthorized)
+				}
+			} else if !session.IsOAuth && tokenLocation == app.TokenLocationQueryString {
+				c.Err = model.NewAppError("ServeHTTP", "api.context.token_provided.app_error", nil, "token="+token, http.StatusUnauthorized)
+			} else {
+				c.App.Session = *session
+			}
+
+			// Rate limit by UserID
+			if c.App.Srv.RateLimiter != nil && c.App.Srv.RateLimiter.UserIdRateLimit(c.App.Session.UserId, w) {
+				return
+			}
 		}
 	}
 

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -108,3 +108,105 @@ func TestHandlerServeHTTPSecureTransport(t *testing.T) {
 		t.Errorf("Strict-Transport-Security header is not expected, but returned")
 	}
 }
+
+
+func handlerForCSRFToken(c *Context, w http.ResponseWriter, r *http.Request) {
+}
+
+func TestHandlerServeCSRFToken(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	session :=&model.Session{
+		UserId: th.BasicUser.Id,
+		CreateAt: model.GetMillis(),
+		Roles: model.SYSTEM_USER_ROLE_ID,
+		IsOAuth: false,
+	}
+	session.GenerateCSRF()
+	session.SetExpireInDays(1)
+	session, err := th.App.CreateSession(session)
+	if err != nil {
+		t.Errorf("Expected nil, got %s", err)
+	}
+
+	web := New(th.Server, th.Server.AppOptions, th.Server.Router)
+
+	handler := Handler{
+		GetGlobalAppOptions: web.GetGlobalAppOptions,
+		HandleFunc:          handlerForCSRFToken,
+		RequireSession:      true,
+		TrustRequester:      false,
+		RequireMfa:          false,
+		IsStatic:            false,
+	}
+
+	cookie := &http.Cookie{
+		Name: model.SESSION_COOKIE_USER,
+		Value: th.BasicUser.Username,
+	}
+	cookie2 := &http.Cookie{
+		Name: model.SESSION_COOKIE_TOKEN,
+		Value: session.Token,
+	}
+	cookie3 := &http.Cookie{
+		Name: model.SESSION_COOKIE_CSRF,
+		Value: session.GetCSRF(),
+	}
+
+	// CSRF Token Used - Success Expected
+
+	request := httptest.NewRequest("POST", "/api/v4/test", nil)
+	request.AddCookie(cookie)
+	request.AddCookie(cookie2)
+	request.AddCookie(cookie3)
+	request.Header.Add(model.HEADER_CSRF_TOKEN, session.GetCSRF())
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != 200 {
+		t.Errorf("Expected status 200, got %d", response.Code)
+	}
+
+	// No CSRF Token Used - Failure Expected
+
+	request = httptest.NewRequest("POST", "/api/v4/test", nil)
+	request.AddCookie(cookie)
+	request.AddCookie(cookie2)
+	request.AddCookie(cookie3)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != 401 {
+		t.Errorf("Expected status 401, got %d", response.Code)
+	}
+
+	// Fallback Behavior Used - Success expected
+	// ToDo (DSchalla) 2019/01/04: Remove once legacy CSRF Handling is removed
+	th.App.UpdateConfig(func(config *model.Config){
+		*config.ServiceSettings.ExperimentalStrictCSRFEnforcement = false
+	})
+	request = httptest.NewRequest("POST", "/api/v4/test", nil)
+	request.AddCookie(cookie)
+	request.AddCookie(cookie2)
+	request.AddCookie(cookie3)
+	request.Header.Add(model.HEADER_REQUESTED_WITH, model.HEADER_REQUESTED_WITH_XML)
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != 200 {
+		t.Errorf("Expected status 200, got %d", response.Code)
+	}
+
+	// Fallback Behavior Used with Strict Enforcement - Failure Expected
+	// ToDo (DSchalla) 2019/01/04: Remove once legacy CSRF Handling is removed
+	th.App.UpdateConfig(func(config *model.Config){
+		*config.ServiceSettings.ExperimentalStrictCSRFEnforcement = true
+	})
+	response = httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	if response.Code != 401 {
+		t.Errorf("Expected status 200, got %d", response.Code)
+	}
+}


### PR DESCRIPTION
#### Summary
This PR implements CSRF protection tokens for additional hardening compared to the currently used custom header. When the user logs in, an additional cookie is created with the CSRF token contained. The webapp / redux will read that cookie and attach it as a custom header to each non-GET request made. 

Since the same origin policy will limit the access to the non-HTTP cookie for other domains, the value of the CSRF cookie is sent to the server when a CSRF attempt is made, but since it's value is not set accordingly as custom header the request is ignored.

As a deprecation step, the current method is still enabled but a warning will be printed to the system console to allow users to migrate towards the stricter enforcement step by step. While there won't be any issues with the official client since they are usually distributed together, this avoids any issues if cookie auth is used on some custom script / custom client. The enforcement can be enabled earlier using a custom experimental flag. Long-termish, the flag should be removed and the strict enforcement made default.

**Redux PR:** https://github.com/mattermost/mattermost-redux/pull/753
**WebApp PR:** https://github.com/mattermost/mattermost-webapp/pull/2248

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-10346

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
