### PR TITLE
Add periods to api doc of `PublishWebSocketEvent`

### DIFF
--- a/plugin/api.go
+++ b/plugin/api.go
@@ -422,9 +422,9 @@ type API interface {
 	KVList(page, perPage int) ([]string, *model.AppError)
 
 	// PublishWebSocketEvent sends an event to WebSocket connections.
-	// event is the type and will be prepended with "custom_<pluginid>_"
-	// payload is the data sent with the event. Interface values must be primitive Go types or mattermost-server/model types
-	// broadcast determines to which users to send the event
+	// event is the type and will be prepended with "custom_<pluginid>_".
+	// payload is the data sent with the event. Interface values must be primitive Go types or mattermost-server/model types.
+	// broadcast determines to which users to send the event.
 	PublishWebSocketEvent(event string, payload map[string]interface{}, broadcast *model.WebsocketBroadcast)
 
 	// HasPermissionTo check if the user has the permission at system scope.


### PR DESCRIPTION
#### Summary
Without periods, it's difficult to read the api doc in developer documents.
https://developers.mattermost.com/extend/plugins/server/reference/#API.PublishWebSocketEvent

#### Ticket Link
N/A

#### Checklist
N/A