### PR TITLE
Fix various unit tests

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1790,7 +1790,7 @@ func (a *App) ToggleMuteChannel(channelId string, userId string) *model.ChannelM
 		member.NotifyProps[model.MARK_UNREAD_NOTIFY_PROP] = model.CHANNEL_NOTIFY_MENTION
 	}
 
-	a.Srv.Store.Channel().UpdateMember(member)
+	<-a.Srv.Store.Channel().UpdateMember(member)
 	return member
 }
 

--- a/app/command_mute_test.go
+++ b/app/command_mute_test.go
@@ -99,7 +99,6 @@ func TestMuteCommandSpecificChannel(t *testing.T) {
 		UserId:    th.BasicUser.Id,
 	}, channel2.Name)
 	assert.Equal(t, "api.command_mute.success_mute", resp.Text)
-	time.Sleep(time.Millisecond)
 	channel2M, _ = th.App.GetChannelMember(channel2.Id, th.BasicUser.Id)
 	assert.Equal(t, model.CHANNEL_NOTIFY_MENTION, channel2M.NotifyProps[model.MARK_UNREAD_NOTIFY_PROP])
 
@@ -111,7 +110,6 @@ func TestMuteCommandSpecificChannel(t *testing.T) {
 	}, "~"+channel2.Name)
 
 	assert.Equal(t, "api.command_mute.success_unmute", resp.Text)
-	time.Sleep(time.Millisecond)
 	channel2M, _ = th.App.GetChannelMember(channel2.Id, th.BasicUser.Id)
 	assert.Equal(t, model.CHANNEL_NOTIFY_ALL, channel2M.NotifyProps[model.MARK_UNREAD_NOTIFY_PROP])
 }

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/store"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,8 +83,8 @@ func TestExportUserChannels(t *testing.T) {
 		ChannelId: channel.Id,
 		UserId:    user.Id,
 	}
-	th.App.Srv.Store.Channel().SaveMember(&channelMember)
-	th.App.Srv.Store.Preference().Save(&preferences)
+	store.Must(th.App.Srv.Store.Channel().SaveMember(&channelMember))
+	store.Must(th.App.Srv.Store.Preference().Save(&preferences))
 	th.App.UpdateChannelMemberNotifyProps(notifyProps, channel.Id, user.Id)
 	exportData, err := th.App.buildUserChannelMemberships(user.Id, team.Id)
 	require.Nil(t, err)

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -79,11 +79,6 @@ func TestExportUserChannels(t *testing.T) {
 	}
 	var preferences model.Preferences
 	preferences = append(preferences, preference)
-	channelMember := model.ChannelMember{
-		ChannelId: channel.Id,
-		UserId:    user.Id,
-	}
-	store.Must(th.App.Srv.Store.Channel().SaveMember(&channelMember))
 	store.Must(th.App.Srv.Store.Preference().Save(&preferences))
 	th.App.UpdateChannelMemberNotifyProps(notifyProps, channel.Id, user.Id)
 	exportData, err := th.App.buildUserChannelMemberships(user.Id, team.Id)


### PR DESCRIPTION
#### Summary
While iterating on the bots feature branch, I ran into some spurious unit test failures that I've fixed below. As discussed in https://community-daily.mattermost.com/core/pl/px9p8s3dzbg1pf3ddrm5cr36uw, this also makes `ToggleMuteChannel` wait for the database to be updated.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)