### PR TITLE
MM-13678: fix web hub deadlock

### DIFF
--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -359,7 +359,7 @@ func (h *Hub) Register(webConn *WebConn) {
 func (h *Hub) Unregister(webConn *WebConn) {
 	select {
 	case h.unregister <- webConn:
-	case <-h.didStop:
+	case <-h.stop:
 	}
 }
 


### PR DESCRIPTION
#### Summary
The websocket hub, on stopping, closes all associated websocket connections, and each connection
in turn tries to unregister itself with the hub, but this naturally creates a deadlock.

This PR reverts the line commented (incorretly...) at
https://github.com/mattermost/mattermost-server/pull/9863/files#r235583929.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13678