### PR TITLE
MM-13599 Unregistering plugin commands on disabling of plugin.

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -286,6 +286,7 @@ func (a *App) DisablePlugin(id string) *model.AppError {
 	a.UpdateConfig(func(cfg *model.Config) {
 		cfg.PluginSettings.PluginStates[id] = &model.PluginState{Enable: false}
 	})
+	a.UnregisterPluginCommands(id)
 
 	if err := a.SaveConfig(a.Config(), true); err != nil {
 		return model.NewAppError("DisablePlugin", "app.plugin.config.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/app/plugin_commands_test.go
+++ b/app/plugin_commands_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,6 +66,8 @@ func TestPluginCommand(t *testing.T) {
 					TeamId: p.configuration.TeamId,
 					Trigger: "plugin",
 					DisplayName: "Plugin Command",
+					AutoComplete: true,
+					AutoCompleteDesc: "autocomplete",
 				})
 				if err != nil {
 					p.API.LogError("error", "err", err)
@@ -93,6 +96,16 @@ func TestPluginCommand(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, resp.ResponseType)
 		require.Equal(t, "text", resp.Text)
+
+		err2 := th.App.DisablePlugin(pluginIds[0])
+		require.Nil(t, err2)
+
+		commands, err3 := th.App.ListAutocompleteCommands(args.TeamId, utils.T)
+		require.Nil(t, err3)
+
+		for _, commands := range commands {
+			require.NotEqual(t, "plugin", commands.Trigger)
+		}
 
 		th.App.RemovePlugin(pluginIds[0])
 	})


### PR DESCRIPTION
If a plugin is disabled we should unregister the slash commands associated with it. Otherwise they appear in autocomplete and throw errors on execution. 