### PR TITLE
Fix typo: (*App).CheckForClienSideCert to (*App).CheckForClientSideCert

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1076,7 +1076,7 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewAppError("ClientSideCertNotAllowed", "api.user.login.client_side_cert.license.app_error", nil, "", http.StatusBadRequest)
 			return
 		}
-		certPem, certSubject, certEmail := c.App.CheckForClienSideCert(r)
+		certPem, certSubject, certEmail := c.App.CheckForClientSideCert(r)
 		mlog.Debug("Client Cert", mlog.String("cert_subject", certSubject), mlog.String("cert_email", certEmail))
 
 		if len(certPem) == 0 || len(certEmail) == 0 {

--- a/app/login.go
+++ b/app/login.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/store"
 )
 
-func (a *App) CheckForClienSideCert(r *http.Request) (string, string, string) {
+func (a *App) CheckForClientSideCert(r *http.Request) (string, string, string) {
 	pem := r.Header.Get("X-SSL-Client-Cert")                // mapped to $ssl_client_cert from nginx
 	subject := r.Header.Get("X-SSL-Client-Cert-Subject-DN") // mapped to $ssl_client_s_dn from nginx
 	email := ""

--- a/app/login_test.go
+++ b/app/login_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestCheckForClienSideCert(t *testing.T) {
+func TestCheckForClientSideCert(t *testing.T) {
 	th := Setup()
 	defer th.TearDown()
 
@@ -28,10 +28,10 @@ func TestCheckForClienSideCert(t *testing.T) {
 		r.Header.Add("X-SSL-Client-Cert", tt.pem)
 		r.Header.Add("X-SSL-Client-Cert-Subject-DN", tt.subject)
 
-		_, _, actualEmail := th.App.CheckForClienSideCert(r)
+		_, _, actualEmail := th.App.CheckForClientSideCert(r)
 
 		if actualEmail != tt.expectedEmail {
-			t.Fatalf("CheckForClienSideCert(%v): expected %v, actual %v", tt.subject, tt.expectedEmail, actualEmail)
+			t.Fatalf("CheckForClientSideCert(%v): expected %v, actual %v", tt.subject, tt.expectedEmail, actualEmail)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
Fix typo: (*App).CheckForClienSideCert to (*App).CheckForClientSideCert

#### Ticket Link
N/A

#### Checklist
- [X] Touches critical sections of the codebase (auth, upgrade, etc.)