### PR TITLE
[MM-12304] Add channel search support in mattermost cli

### DIFF
--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -116,6 +116,17 @@ Channel can be specified by [team]:[channel]. ie. myteam:mychannel or by channel
 	RunE:    modifyChannelCmdF,
 }
 
+var SearchChannelCmd = &cobra.Command{
+	Use:   "search [channel]\n  mattermost search --team [team] [channel]",
+	Short: "Search a channel",
+	Long: `Search a channel by channel name.
+Channel can be specified by team. ie. --team myTeam myChannel or by team ID.`,
+	Example: `  channel search myChannel
+  channel search --team myTeam myChannel`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: searchChannelCmdF,
+}
+
 func init() {
 	ChannelCreateCmd.Flags().String("name", "", "Channel Name")
 	ChannelCreateCmd.Flags().String("display_name", "", "Channel Display Name")
@@ -134,6 +145,7 @@ func init() {
 	ModifyChannelCmd.Flags().String("username", "", "Required. Username who changes the channel privacy.")
 
 	ChannelRenameCmd.Flags().String("display_name", "", "Channel Display Name")
+	SearchChannelCmd.Flags().Bool("team", false, "Team name or ID")
 
 	RemoveChannelUsersCmd.Flags().Bool("all-users", false, "Remove all users from the indicated channel.")
 
@@ -148,6 +160,7 @@ func init() {
 		RestoreChannelsCmd,
 		ModifyChannelCmd,
 		ChannelRenameCmd,
+		SearchChannelCmd,
 	)
 
 	RootCmd.AddCommand(ChannelCmd)
@@ -531,5 +544,64 @@ func renameChannelCmdF(command *cobra.Command, args []string) error {
 		return errors.Wrapf(errch, "Error in updating channel from %s to %s", channel.Name, newChannelName)
 	}
 
+	return nil
+}
+
+func searchChannelCmdF(command *cobra.Command, args []string) error {
+
+	var (
+		aErr      *model.AppError
+		teamFound bool
+		channel   *model.Channel
+		teamId    string
+	)
+
+	a, err := InitDBCommandContextCobra(command)
+	if err != nil {
+		return errors.Wrap(err, "failed to InitDBCommandContextCobra")
+	}
+	defer a.Shutdown()
+
+	teams, aErr := a.GetAllTeams()
+	if aErr != nil {
+		return errors.Wrap(err, "failed to GetAllTeams")
+	}
+
+	for i, team := range teams {
+		if withTeam, _ := command.Flags().GetBool("team"); !withTeam {
+			channel, aErr = a.GetChannelByName(args[0], team.Id, true)
+			if i == len(teams)-1 && (aErr != nil || channel.Name != args[0]) {
+				CommandPrettyPrintln("channel " + args[0] + " not found")
+			} else if aErr != nil {
+				continue
+			} else if channel.DeleteAt > 0 {
+				CommandPrettyPrintln(channel.Name + " (archived)")
+			} else {
+				CommandPrettyPrintln(channel.Name)
+			}
+			return nil
+		} else if team.Name == args[0] || team.Id == args[0] {
+			teamFound = true
+			teamId = team.Id
+			break
+		}
+
+	}
+
+	if !teamFound {
+		_, _ = CommandPrettyPrintln(fmt.Sprintf(" team %s not found", args[0]))
+		return nil
+	}
+
+	channel, aErr = a.GetChannelByName(args[1], teamId, true)
+	if aErr != nil {
+		return errors.Wrap(err, "failed to GetChannelByName")
+	}
+
+	if channel.DeleteAt > 0 {
+		CommandPrettyPrintln(channel.Name + " (archived)")
+	} else {
+		CommandPrettyPrintln(channel.Name)
+	}
 	return nil
 }

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -566,7 +566,7 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 
 		var aErr *model.AppError
 		channel, aErr = a.GetChannelByName(args[1], team.Id, true)
-		if aErr != nil {
+		if aErr != nil || channel == nil {
 			CommandPrettyPrintln(fmt.Sprintf("Channel %s is not found in team %s", args[1], args[0]))
 			return nil
 		}
@@ -577,16 +577,16 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 		}
 
 		for _, team := range teams {
-			channel, aErr = a.GetChannelByName(args[0], team.Id, true)
-			if channel != nil {
+			channel, _ = a.GetChannelByName(args[0], team.Id, true)
+			if channel != nil && channel.Name == args[0] {
 				break
 			}
 		}
-	}
 
-	if channel == nil {
-		CommandPrettyPrintln(fmt.Sprintf("Channel %s is not found in any team", args[0]))
-		return nil
+		if channel == nil {
+			CommandPrettyPrintln(fmt.Sprintf("Channel %s is not found in any team", args[0]))
+			return nil
+		}
 	}
 
 	if channel.DeleteAt > 0 {

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -123,7 +123,7 @@ var SearchChannelCmd = &cobra.Command{
 Channel can be specified by team. ie. --team myTeam myChannel or by team ID.`,
 	Example: `  channel search myChannel
   channel search --team myTeam myChannel`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.ExactArgs(1),
 	RunE: searchChannelCmdF,
 }
 
@@ -145,7 +145,7 @@ func init() {
 	ModifyChannelCmd.Flags().String("username", "", "Required. Username who changes the channel privacy.")
 
 	ChannelRenameCmd.Flags().String("display_name", "", "Channel Display Name")
-	SearchChannelCmd.Flags().Bool("team", false, "Team name or ID")
+	SearchChannelCmd.Flags().String("team", "", "Team name or ID")
 
 	RemoveChannelUsersCmd.Flags().Bool("all-users", false, "Remove all users from the indicated channel.")
 
@@ -557,17 +557,17 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 
 	var channel *model.Channel
 
-	if withTeam, _ := command.Flags().GetBool("team"); withTeam {
-		team := getTeamFromTeamArg(a, args[0])
+	if teamArg, _ := command.Flags().GetString("team"); teamArg != "" {
+		team := getTeamFromTeamArg(a, teamArg)
 		if team == nil {
-			CommandPrettyPrintln(fmt.Sprintf("Team %s is not found", args[0]))
+			CommandPrettyPrintln(fmt.Sprintf("Team %s is not found", teamArg))
 			return nil
 		}
 
 		var aErr *model.AppError
-		channel, aErr = a.GetChannelByName(args[1], team.Id, true)
+		channel, aErr = a.GetChannelByName(args[0], team.Id, true)
 		if aErr != nil || channel == nil {
-			CommandPrettyPrintln(fmt.Sprintf("Channel %s is not found in team %s", args[1], args[0]))
+			CommandPrettyPrintln(fmt.Sprintf("Channel %s is not found in team %s", args[0], teamArg))
 			return nil
 		}
 	} else {

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -575,9 +575,9 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 			} else if aErr != nil {
 				continue
 			} else if channel.DeleteAt > 0 {
-				CommandPrettyPrintln(channel.Name + " (archived)")
+				CommandPrettyPrintln(fmt.Sprintf(`%s : %s (%s) (archived)`, channel.Name, channel.DisplayName, channel.Id))
 			} else {
-				CommandPrettyPrintln(channel.Name)
+				CommandPrettyPrintln(fmt.Sprintf(`%s : %s (%s)`, channel.Name, channel.DisplayName, channel.Id))
 			}
 			return nil
 		} else if team.Name == args[0] || team.Id == args[0] {
@@ -589,7 +589,7 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 	}
 
 	if !teamFound {
-		_, _ = CommandPrettyPrintln(fmt.Sprintf(" team %s not found", args[0]))
+		CommandPrettyPrintln(fmt.Sprintf(" team %s not found", args[0]))
 		return nil
 	}
 
@@ -599,9 +599,9 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 	}
 
 	if channel.DeleteAt > 0 {
-		CommandPrettyPrintln(channel.Name + " (archived)")
+		CommandPrettyPrintln(fmt.Sprintf(`%s : %s (%s) (archived)`, channel.Name, channel.DisplayName, channel.Id))
 	} else {
-		CommandPrettyPrintln(channel.Name)
+		CommandPrettyPrintln(fmt.Sprintf(`%s : %s (%s)`, channel.Name, channel.DisplayName, channel.Id))
 	}
 	return nil
 }

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -181,6 +181,16 @@ func Test_searchChannelCmdF(t *testing.T) {
 			[]string{"channel", "search", "--team", channel.TeamId + "404", channel.Name},
 			fmt.Sprintf("Team %s is not found", channel.TeamId+"404"),
 		},
+		{
+			"Success find Channel with param team ID",
+			[]string{"channel", "search", channel.Name, "--team", channel.TeamId},
+			fmt.Sprintf("Channel Name :%s, Display Name :%s, Channel ID :%s", channel.Name, channel.DisplayName, channel.Id),
+		},
+		{
+			"Success find Channel with param team ID",
+			[]string{"channel", "search", channel.Name, "--team=" + channel.TeamId},
+			fmt.Sprintf("Channel Name :%s, Display Name :%s, Channel ID :%s", channel.Name, channel.DisplayName, channel.Id),
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -139,9 +138,9 @@ func Test_searchChannelCmdF(t *testing.T) {
 
 	channel := th.CreatePublicChannel()
 
-	fmt.Println(th.CheckCommand(t, "channel", "search", channel.Name))
-	fmt.Println(th.CheckCommand(t, "channel", "search", channel.Name+"404"))
+	th.CheckCommand(t, "channel", "search", channel.Name)
+	th.CheckCommand(t, "channel", "search", channel.Name+"404")
 
-	fmt.Println(th.CheckCommand(t, "channel", "search", "--team", channel.TeamId, channel.Name))
-	fmt.Println(th.CheckCommand(t, "channel", "search", "--team", channel.TeamId+"404", channel.Name))
+	th.CheckCommand(t, "channel", "search", "--team", channel.TeamId, channel.Name)
+	th.CheckCommand(t, "channel", "search", "--team", channel.TeamId+"404", channel.Name)
 }

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -130,4 +131,17 @@ func TestRenameChannel(t *testing.T) {
 	updatedChannel, _ := th.App.GetChannel(channel.Id)
 	assert.Equal(t, "newchannelname10", updatedChannel.Name)
 	assert.Equal(t, "New Display Name", updatedChannel.DisplayName)
+}
+
+func Test_searchChannelCmdF(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	channel := th.CreatePublicChannel()
+
+	fmt.Println(th.CheckCommand(t, "channel", "search", channel.Name))
+	fmt.Println(th.CheckCommand(t, "channel", "search", channel.Name+"404"))
+
+	fmt.Println(th.CheckCommand(t, "channel", "search", "--team", channel.TeamId, channel.Name))
+	fmt.Println(th.CheckCommand(t, "channel", "search", "--team", channel.TeamId+"404", channel.Name))
 }

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -176,6 +176,11 @@ func Test_searchChannelCmdF(t *testing.T) {
 			[]string{"channel", "search", "--team", channel2.TeamId, channel2.Name},
 			fmt.Sprintf("Channel Name :%s, Display Name :%s, Channel ID :%s (archived)", channel2.Name, channel2.DisplayName, channel2.Id),
 		},
+		{
+			"Failed find team",
+			[]string{"channel", "search", "--team", channel.TeamId + "404", channel.Name},
+			fmt.Sprintf("Team %s is not found", channel.TeamId+"404"),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
#### Summary
add command search on channel group.
it could search channel by name or id in general
and search channel with team by team name or id

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/9491
https://mattermost.atlassian.net/browse/MM-12304

#### Checklist
- [x] Added or updated unit tests (required for all new features)
