### PR TITLE
MM-13718 Prevent files from being attached to multiple posts

### DIFF
--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -951,7 +951,7 @@ func TestGetFileLink(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id, th.BasicUser.Id))
 
 	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FileSettings.EnablePublicLink = false })
 	_, resp = Client.GetFileLink(fileId)
@@ -1143,7 +1143,7 @@ func TestGetPublicFile(t *testing.T) {
 	}
 
 	// Hacky way to assign file to a post (usually would be done by CreatePost call)
-	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id))
+	store.Must(th.App.Srv.Store.FileInfo().AttachToPost(fileId, th.BasicPost.Id, th.BasicUser.Id))
 
 	result := <-th.App.Srv.Store.FileInfo().Get(fileId)
 	info := result.Data.(*model.FileInfo)

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -1028,7 +1028,7 @@ func (a *App) uploadAttachments(attachments *[]AttachmentImportData, post *model
 
 func (a *App) UpdateFileInfoWithPostId(post *model.Post) {
 	for _, fileId := range post.FileIds {
-		if result := <-a.Srv.Store.FileInfo().AttachToPost(fileId, post.Id); result.Err != nil {
+		if result := <-a.Srv.Store.FileInfo().AttachToPost(fileId, post.Id, post.UserId); result.Err != nil {
 			mlog.Error(fmt.Sprintf("Error attaching files to post. postId=%v, fileIds=%v, message=%v", post.Id, post.FileIds, result.Err), mlog.String("post_id", post.Id))
 		}
 	}

--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -248,7 +248,7 @@ func (a *App) SlackAddPosts(teamId string, channel *model.Channel, posts []Slack
 			}
 			a.OldImportPost(&newPost)
 			for _, fileId := range newPost.FileIds {
-				if result := <-a.Srv.Store.FileInfo().AttachToPost(fileId, newPost.Id); result.Err != nil {
+				if result := <-a.Srv.Store.FileInfo().AttachToPost(fileId, newPost.Id, newPost.UserId); result.Err != nil {
 					mlog.Error(fmt.Sprintf("Slack Import: An error occurred when attaching files to a message, post_id=%s, file_ids=%v, err=%v.", newPost.Id, newPost.FileIds, result.Err))
 				}
 			}
@@ -723,7 +723,7 @@ func (a *App) OldImportPost(post *model.Post) {
 		}
 
 		for _, fileId := range post.FileIds {
-			if result := <-a.Srv.Store.FileInfo().AttachToPost(fileId, post.Id); result.Err != nil {
+			if result := <-a.Srv.Store.FileInfo().AttachToPost(fileId, post.Id, post.UserId); result.Err != nil {
 				mlog.Error(fmt.Sprintf("Error attaching files to post. postId=%v, fileIds=%v, message=%v", post.Id, post.FileIds, result.Err), mlog.String("post_id", post.Id))
 			}
 		}

--- a/model/post.go
+++ b/model/post.go
@@ -291,6 +291,9 @@ func (o *Post) PreCommit() {
 	}
 
 	o.GenerateActionIds()
+
+	// There's a rare bug where the client sends up duplicate FileIds so protect against that
+	o.FileIds = RemoveDuplicateStrings(o.FileIds)
 }
 
 func (o *Post) MakeNonNil() {

--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -226,7 +226,7 @@ func (fs SqlFileInfoStore) AttachToPost(fileId, postId, creatorId string) store.
 		} else if count == 0 {
 			// Could not attach the file to the post
 			result.Err = model.NewAppError("SqlFileInfoStore.AttachToPost",
-				"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", file_id="+fileId, http.StatusInternalServerError)
+				"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", file_id="+fileId, http.StatusBadRequest)
 		}
 	})
 }

--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -201,48 +201,32 @@ func (fs SqlFileInfoStore) GetForUser(userId string) store.StoreChannel {
 	})
 }
 
-func (fs SqlFileInfoStore) AttachToPost(fileId, postId string) store.StoreChannel {
+func (fs SqlFileInfoStore) AttachToPost(fileId, postId, creatorId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		if _, err := fs.GetMaster().Exec(
-			`UPDATE
-					FileInfo
-				SET
-					PostId = :PostId
-				WHERE
-					Id = :Id
-					AND PostId = ''`, map[string]interface{}{"PostId": postId, "Id": fileId}); err != nil {
-			result.Err = model.NewAppError("SqlFileInfoStore.AttachToPost",
-				"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", file_id="+fileId+", err="+err.Error(), http.StatusInternalServerError)
-		}
-	})
-}
-
-func (fs SqlFileInfoStore) AttachMultipleToPost(fileIds []string, postId string, creatorId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		keys, params := MapStringsToQueryParams(fileIds, "FileId")
-
-		params["PostId"] = postId
-		params["CreatorId"] = creatorId
-
 		sqlResult, err := fs.GetMaster().Exec(
 			`UPDATE
 					FileInfo
 				SET
 					PostId = :PostId
 				WHERE
-					Id IN `+keys+`
+					Id = :Id
 					AND PostId = ''
-					AND CreatorId = :CreatorId`, params)
+					AND CreatorId = :CreatorId`, map[string]interface{}{"PostId": postId, "Id": fileId, "CreatorId": creatorId})
 		if err != nil {
-			result.Err = model.NewAppError("SqlFileInfoStore.AttachMultipleToPost",
-				"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", err="+err.Error(), http.StatusInternalServerError)
+			result.Err = model.NewAppError("SqlFileInfoStore.AttachToPost",
+				"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", file_id="+fileId+", err="+err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		result.Data, err = sqlResult.RowsAffected()
+		count, err := sqlResult.RowsAffected()
 		if err != nil {
-			// This error should only occur if the database driver does not support counting rows affected
-			result.Data = int64(-1)
+			// RowsAffected should never fail with the MySQL or Postgres drivers
+			result.Err = model.NewAppError("SqlFileInfoStore.AttachToPost",
+				"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", file_id="+fileId+", err="+err.Error(), http.StatusInternalServerError)
+		} else if count == 0 {
+			// Could not attach the file to the post
+			result.Err = model.NewAppError("SqlFileInfoStore.AttachToPost",
+				"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", file_id="+fileId, http.StatusInternalServerError)
 		}
 	})
 }

--- a/store/store.go
+++ b/store/store.go
@@ -457,6 +457,7 @@ type FileInfoStore interface {
 	GetForUser(userId string) StoreChannel
 	InvalidateFileInfosForPostCache(postId string)
 	AttachToPost(fileId string, postId string) StoreChannel
+	AttachMultipleToPost(fileIds []string, postId string, creatorId string) StoreChannel
 	DeleteForPost(postId string) StoreChannel
 	PermanentDelete(fileId string) StoreChannel
 	PermanentDeleteBatch(endTime int64, limit int64) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -456,8 +456,7 @@ type FileInfoStore interface {
 	GetForPost(postId string, readFromMaster bool, allowFromCache bool) StoreChannel
 	GetForUser(userId string) StoreChannel
 	InvalidateFileInfosForPostCache(postId string)
-	AttachToPost(fileId string, postId string) StoreChannel
-	AttachMultipleToPost(fileIds []string, postId string, creatorId string) StoreChannel
+	AttachToPost(fileId string, postId string, creatorId string) StoreChannel
 	DeleteForPost(postId string) StoreChannel
 	PermanentDelete(fileId string) StoreChannel
 	PermanentDeleteBatch(endTime int64, limit int64) StoreChannel

--- a/store/storetest/mocks/FileInfoStore.go
+++ b/store/storetest/mocks/FileInfoStore.go
@@ -13,6 +13,22 @@ type FileInfoStore struct {
 	mock.Mock
 }
 
+// AttachMultipleToPost provides a mock function with given fields: fileIds, postId, userId
+func (_m *FileInfoStore) AttachMultipleToPost(fileIds []string, postId string, userId string) store.StoreChannel {
+	ret := _m.Called(fileIds, postId, userId)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func([]string, string, string) store.StoreChannel); ok {
+		r0 = rf(fileIds, postId, userId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // AttachToPost provides a mock function with given fields: fileId, postId
 func (_m *FileInfoStore) AttachToPost(fileId string, postId string) store.StoreChannel {
 	ret := _m.Called(fileId, postId)

--- a/store/storetest/mocks/FileInfoStore.go
+++ b/store/storetest/mocks/FileInfoStore.go
@@ -13,29 +13,13 @@ type FileInfoStore struct {
 	mock.Mock
 }
 
-// AttachMultipleToPost provides a mock function with given fields: fileIds, postId, userId
-func (_m *FileInfoStore) AttachMultipleToPost(fileIds []string, postId string, userId string) store.StoreChannel {
-	ret := _m.Called(fileIds, postId, userId)
+// AttachToPost provides a mock function with given fields: fileId, postId, creatorId
+func (_m *FileInfoStore) AttachToPost(fileId string, postId string, creatorId string) store.StoreChannel {
+	ret := _m.Called(fileId, postId, creatorId)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func([]string, string, string) store.StoreChannel); ok {
-		r0 = rf(fileIds, postId, userId)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
-		}
-	}
-
-	return r0
-}
-
-// AttachToPost provides a mock function with given fields: fileId, postId
-func (_m *FileInfoStore) AttachToPost(fileId string, postId string) store.StoreChannel {
-	ret := _m.Called(fileId, postId)
-
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
-		r0 = rf(fileId, postId)
+	if rf, ok := ret.Get(0).(func(string, string, string) store.StoreChannel); ok {
+		r0 = rf(fileId, postId, creatorId)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)


### PR DESCRIPTION
This can cause some weird behaviour in the UI, especially because the files are only partly attached (the post thinks it has files because `post.FileIds` is set, but the files are still attached to their original post because `file.PostId` is the original value).

To prevent this, we now track whether we were able to set the file's `PostId` when creating the post. If we couldn't, we have some extra logic to go back and set `post.FileIds` to match what was actually attached.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13718

#### Checklist
- Added or updated unit tests (required for all new features)
