### PR TITLE
Query builder

### DIFF
--- a/store/sqlstore/querybuilder/examples_test.go
+++ b/store/sqlstore/querybuilder/examples_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package querybuilder_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mattermost/mattermost-server/store/sqlstore/querybuilder"
+)
+
+func ExampleSelect_simple() {
+	query := querybuilder.
+		Select("u.*").
+		From("Users u").
+		Where("Id = :UserId").Bind("UserId", "id")
+
+	fmt.Println(query.String())
+	args, _ := json.Marshal(query.Args())
+	fmt.Printf("%+s\n", string(args))
+
+	// Output: SELECT u.* FROM Users u WHERE Id = :UserId
+	// {"UserId":"id"}
+}
+
+func ExampleSelect_complex() {
+	query := querybuilder.
+		Select("u.*").
+		Select("q.UserId IS NOT NULL AS IsBot").
+		From("Users u").
+		LeftJoin("Bots b ON ( q.UserId = u.Id )").
+		RightJoin("Admins a ON ( a.UserId = u.Id )").
+		Join("Status s ON ( s.UserId = u.Id )").
+		Where("Id NOT IN (:BadUserIds)").Bind("BadUserIds", []string{"badid1", "badid2"}).
+		Where("s.Status = :Status").Bind("Status", "OFFLINE").
+		OrderBy("u.Username ASC").
+		OrderBy("u.Id DESC").
+		Offset(40).
+		Limit(10)
+
+	fmt.Println(query.String())
+	args, _ := json.Marshal(query.Args())
+	fmt.Printf("%+s\n", string(args))
+
+	// Output: SELECT u.*, q.UserId IS NOT NULL AS IsBot FROM Users u LEFT JOIN Bots b ON ( q.UserId = u.Id ) RIGHT JOIN Admins a ON ( a.UserId = u.Id ) INNER JOIN Status s ON ( s.UserId = u.Id ) WHERE Id NOT IN (:BadUserIds_0, :BadUserIds_1) AND s.Status = :Status ORDER BY u.Username ASC, u.Id DESC LIMIT 10 OFFSET 40
+	// {"BadUserIds_0":"badid1","BadUserIds_1":"badid2","Status":"OFFLINE"}
+}

--- a/store/sqlstore/querybuilder/global.go
+++ b/store/sqlstore/querybuilder/global.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package querybuilder
+
+// newQuery returns a new Query object.
+func newQuery() *Query {
+	return &Query{}
+}
+
+// Select creates a new Query, adding a SELECT expression to the resulting query.
+func Select(sql string) *Query {
+	return newQuery().Select(sql)
+}
+
+// From creates a new Query, adding a FROM expression to the resulting query.
+func From(sql string) *Query {
+	return newQuery().From(sql)
+}
+
+// Join creates a new Query, adding an INNER JOIN expression to the resulting query.
+func Join(sql string) *Query {
+	return newQuery().Join(sql)
+}
+
+// LeftJoin creates a new Query, adding a LEFT JOIN expression to the resulting query.
+func LeftJoin(sql string) *Query {
+	return newQuery().LeftJoin(sql)
+}
+
+// RightJoin creates a new Query, adding a RIGHT JOIN expression to the resulting query.
+func RightJoin(sql string) *Query {
+	return newQuery().RightJoin(sql)
+}
+
+// Where creates a new Query, adding a WHERE expression to the resulting query.
+func Where(sql string) *Query {
+	return newQuery().Where(sql)
+}
+
+// OrderBy creates a new Query, adding an ORDER BY expression to the resulting query.
+func OrderBy(sql string) *Query {
+	return newQuery().OrderBy(sql)
+}
+
+// Offset creates a new Query, adding an OFFSET expression to the resulting query.
+// The given integer parameter is added to the set of arguments for use with the final query.
+func Offset(offset int) *Query {
+	return newQuery().Offset(offset)
+}
+
+// Limit creates a new Query, adding a LIMIT expression to the resulting query.
+// The given integer parameter is added to the set of arguments for use with the final query.
+func Limit(limit int) *Query {
+	return newQuery().Limit(limit)
+}
+
+// Bind creates a new Query, adding or replacing the given key and value as an argument to the
+// resulting query.
+// String and integer values are supported, and will be exploded automatically into a list of
+// arguments.
+func Bind(key string, value interface{}) *Query {
+	return newQuery().Bind(key, value)
+}

--- a/store/sqlstore/querybuilder/query.go
+++ b/store/sqlstore/querybuilder/query.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package querybuilder
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var argRe = regexp.MustCompile(`\B:[a-zA-Z_]+\b`)
+
+// Query builds dynamic SQL queries using a fluent and immutable interface.
+// At its core, it is nothing more than SQL-aware string concatenation library. It is not an ORM.
+//
+// Unlike similar libraries, it doesn't integrate with database/sql directly, doesn't read and
+// populate model structs, and generally doesn't try expose more of an API than needed. Feel free
+// to pass in entire SQL statements as necessary, but realize that this library won't try to parse
+// or validate the resulting SQL. Garbage in: garbage out.
+//
+// It doesn't current support INSERT, UPDATE or DELETE statements, but this would be a trivial
+// addition.
+type Query struct {
+	selectStatements  []string
+	fromStatements    []string
+	joinStatements    []string
+	whereStatements   []string
+	orderByStatements []string
+	offset            string
+	limit             string
+	args              map[string]interface{}
+}
+
+// clone duplicates the query object, enabling immutability in the exposed API.
+// Arrays and maps in the cloned query object are shallow copied here, and deep copied only when
+// modified.
+func (q *Query) clone() *Query {
+	clone := &Query{
+		selectStatements:  q.selectStatements,
+		fromStatements:    q.fromStatements,
+		joinStatements:    q.joinStatements,
+		whereStatements:   q.whereStatements,
+		orderByStatements: q.orderByStatements,
+		offset:            q.offset,
+		limit:             q.limit,
+		args:              q.args,
+	}
+
+	return clone
+}
+
+// Select clones the query object, adding a SELECT expression to the resulting query.
+func (q *Query) Select(sql string) *Query {
+	clone := q.clone()
+
+	clone.selectStatements = make([]string, len(q.selectStatements)+1)
+	copy(clone.selectStatements, q.selectStatements)
+	clone.selectStatements[len(q.selectStatements)] = sql
+
+	return clone
+}
+
+// From clones the query object, adding a FROM expression to the resulting query.
+func (q *Query) From(sql string) *Query {
+	clone := q.clone()
+
+	clone.fromStatements = make([]string, len(q.fromStatements)+1)
+	copy(clone.fromStatements, q.fromStatements)
+	clone.fromStatements[len(q.fromStatements)] = sql
+
+	return clone
+}
+
+// Join clones the query object, adding an INNER JOIN expression to the resulting query.
+func (q *Query) Join(sql string) *Query {
+	clone := q.clone()
+
+	clone.joinStatements = make([]string, len(q.joinStatements)+1)
+	copy(clone.joinStatements, q.joinStatements)
+	clone.joinStatements[len(q.joinStatements)] = "INNER JOIN " + sql
+
+	return clone
+}
+
+// LeftJoin clones the query object, adding a LEFT JOIN expression to the resulting query.
+func (q *Query) LeftJoin(sql string) *Query {
+	clone := q.clone()
+
+	clone.joinStatements = make([]string, len(q.joinStatements)+1)
+	copy(clone.joinStatements, q.joinStatements)
+	clone.joinStatements[len(q.joinStatements)] = "LEFT JOIN " + sql
+
+	return clone
+}
+
+// RightJoin clones the query object, adding a RIGHT JOIN expression to the resulting query.
+func (q *Query) RightJoin(sql string) *Query {
+	clone := q.clone()
+
+	clone.joinStatements = make([]string, len(q.joinStatements)+1)
+	copy(clone.joinStatements, q.joinStatements)
+	clone.joinStatements[len(q.joinStatements)] = "RIGHT JOIN " + sql
+
+	return clone
+}
+
+// Where clones the query object, adding a WHERE expression to the resulting query.
+func (q *Query) Where(sql string) *Query {
+	clone := q.clone()
+
+	clone.whereStatements = make([]string, len(q.whereStatements)+1)
+	copy(clone.whereStatements, q.whereStatements)
+	clone.whereStatements[len(q.whereStatements)] = sql
+
+	return clone
+}
+
+// OrderBy clones the query object, adding an ORDER BY expression to the resulting query.
+func (q *Query) OrderBy(sql string) *Query {
+	clone := q.clone()
+
+	clone.orderByStatements = make([]string, len(q.orderByStatements)+1)
+	copy(clone.orderByStatements, q.orderByStatements)
+	clone.orderByStatements[len(q.orderByStatements)] = sql
+
+	return clone
+}
+
+// Offset clones the query object, adding an OFFSET expression to the resulting query.
+// The given integer parameter is added to the set of arguments for use with the final query.
+func (q *Query) Offset(offset int) *Query {
+	clone := q.clone()
+	clone.offset = strconv.Itoa(offset)
+
+	return clone
+}
+
+// Limit clones the query object, adding a LIMIT expression to the resulting query.
+// The given integer parameter is added to the set of arguments for use with the final query.
+func (q *Query) Limit(limit int) *Query {
+	clone := q.clone()
+	clone.limit = strconv.Itoa(limit)
+
+	return clone
+}
+
+// Bind clones the query object, adding or replacing the given key and value as an argument to the
+// resulting query.
+// String and integer values are supported, and will be exploded automatically into a list of
+// arguments.
+func (q *Query) Bind(key string, value interface{}) *Query {
+	// It's a natural mistake to write the key prefixed with the colon: fix that and move on.
+	key = strings.TrimLeft(key, ":")
+
+	clone := q.clone()
+	clone.args = make(map[string]interface{})
+	for k, v := range q.args {
+		clone.args[k] = v
+	}
+	clone.args[key] = value
+
+	return clone
+}
+
+// String generates the final query for execution.
+func (q *Query) String() string {
+	var query string
+
+	if len(q.selectStatements) > 0 {
+		query += "SELECT " + strings.Join(q.selectStatements, ", ")
+	}
+	if len(q.fromStatements) > 0 {
+		query += " FROM " + strings.Join(q.fromStatements, ", ")
+	}
+	if len(q.joinStatements) > 0 {
+		query += " " + strings.Join(q.joinStatements, " ")
+	}
+	if len(q.whereStatements) > 0 {
+		query += " WHERE " + strings.Join(q.whereStatements, " AND ")
+	}
+	if len(q.orderByStatements) > 0 {
+		query += " ORDER BY " + strings.Join(q.orderByStatements, ", ")
+	}
+	if len(q.limit) > 0 {
+		query += " LIMIT " + q.limit
+	}
+	if len(q.offset) > 0 {
+		query += " OFFSET " + q.offset
+	}
+
+	// If an argument named :Ids is bound to an string or integer slice or array, explode in
+	// place as :Ids_0, :Ids_1, ... :Ids_N.
+	for key, value := range q.args {
+		rt := reflect.TypeOf(value)
+		switch rt.Kind() {
+		case reflect.Slice:
+			fallthrough
+		case reflect.Array:
+			switch rt.Elem().Kind() {
+			case reflect.String:
+				fallthrough
+			case reflect.Int:
+				valueLen := reflect.ValueOf(value).Len()
+
+				keys := []string{}
+				for index := 0; index < valueLen; index++ {
+					keys = append(keys, fmt.Sprintf(":%s_%d", key, index))
+				}
+
+				query = argRe.ReplaceAllStringFunc(query, func(match string) string {
+					if match != ":"+key {
+						return match
+					}
+
+					return strings.Join(keys, ", ")
+				})
+			}
+		}
+	}
+
+	return query
+}
+
+// Args shallow copies the argument map for use with the final query, exploding string and integer arrays as necessary.
+func (q *Query) Args() map[string]interface{} {
+	args := map[string]interface{}{}
+
+	for key, value := range q.args {
+		rt := reflect.TypeOf(value)
+		switch rt.Kind() {
+		case reflect.Slice:
+			fallthrough
+		case reflect.Array:
+			switch rt.Elem().Kind() {
+			case reflect.String:
+				for index, v := range value.([]string) {
+					args[fmt.Sprintf("%s_%d", key, index)] = v
+				}
+
+			case reflect.Int:
+				for index, v := range value.([]int) {
+					args[fmt.Sprintf("%s_%d", key, index)] = v
+				}
+
+			default:
+				args[key] = value
+			}
+		default:
+			args[key] = value
+		}
+	}
+
+	return args
+}

--- a/store/sqlstore/querybuilder/query_test.go
+++ b/store/sqlstore/querybuilder/query_test.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package querybuilder_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/store/sqlstore/querybuilder"
+)
+
+func TestSelect(t *testing.T) {
+	var q1, q2, q3, q4 *querybuilder.Query
+
+	t.Run("empty query", func(t *testing.T) {
+		q1 = &querybuilder.Query{}
+		assert.Equal(t, "", q1.String())
+	})
+
+	t.Run("single select statement q1", func(t *testing.T) {
+		q2 = q1.Select("u.*")
+		assert.Equal(t, "SELECT u.*", q2.String())
+	})
+
+	t.Run("append select statement to q1", func(t *testing.T) {
+		q3 = q1.Select("FALSE AS IsBot")
+		assert.Equal(t, "SELECT FALSE AS IsBot", q3.String())
+	})
+
+	t.Run("append select statement to q2", func(t *testing.T) {
+		q4 = q2.Select("q.UserId IS NOT NULL AS IsBot")
+		assert.Equal(t, "SELECT u.*, q.UserId IS NOT NULL AS IsBot", q4.String())
+	})
+
+	t.Run("global", func(t *testing.T) {
+		q := querybuilder.Select("u.*")
+		assert.Equal(t, "SELECT u.*", q.String())
+	})
+
+	t.Run("immutable", func(t *testing.T) {
+		assert.Equal(t, "", q1.String())
+		assert.Equal(t, "SELECT u.*", q2.String())
+		assert.Equal(t, "SELECT FALSE AS IsBot", q3.String())
+		assert.Equal(t, "SELECT u.*, q.UserId IS NOT NULL AS IsBot", q4.String())
+	})
+}
+
+func TestFrom(t *testing.T) {
+	var q1, q2 *querybuilder.Query
+
+	t.Run("single from statement", func(t *testing.T) {
+		q1 = querybuilder.Select("u.*").From("Users u")
+		assert.Equal(t, "SELECT u.* FROM Users u", q1.String())
+	})
+
+	t.Run("append select statement to q1", func(t *testing.T) {
+		q2 = q1.From("Status s")
+		assert.Equal(t, "SELECT u.* FROM Users u, Status s", q2.String())
+	})
+
+	t.Run("global", func(t *testing.T) {
+		q := querybuilder.From("Users u").Select("u.*")
+		assert.Equal(t, "SELECT u.* FROM Users u", q.String())
+	})
+
+	t.Run("immutable", func(t *testing.T) {
+		assert.Equal(t, "SELECT u.* FROM Users u", q1.String())
+		assert.Equal(t, "SELECT u.* FROM Users u, Status s", q2.String())
+	})
+}
+
+func TestJoin(t *testing.T) {
+	var q1, q2, q3 *querybuilder.Query
+
+	t.Run("single join statement", func(t *testing.T) {
+		q1 = querybuilder.Select("u.*").From("Users u").Join("UserProps up ON ( up.UserId = u.Id )")
+		assert.Equal(t, "SELECT u.* FROM Users u INNER JOIN UserProps up ON ( up.UserId = u.Id )", q1.String())
+	})
+
+	t.Run("append left join statement to q1", func(t *testing.T) {
+		q2 = q1.LeftJoin("Status s ON ( s.UserId = u.Id )")
+		assert.Equal(t, "SELECT u.* FROM Users u INNER JOIN UserProps up ON ( up.UserId = u.Id ) LEFT JOIN Status s ON ( s.UserId = u.Id )", q2.String())
+	})
+
+	t.Run("append right join statement to q1", func(t *testing.T) {
+		q3 = q1.RightJoin("ChannelMember cm ON ( cm.UserId = u.Id )")
+		assert.Equal(t, "SELECT u.* FROM Users u INNER JOIN UserProps up ON ( up.UserId = u.Id ) RIGHT JOIN ChannelMember cm ON ( cm.UserId = u.Id )", q3.String())
+	})
+
+	t.Run("global, join", func(t *testing.T) {
+		q := querybuilder.Join("UserProps up ON ( up.UserId = u.Id )").From("Users u").Select("u.*")
+		assert.Equal(t, "SELECT u.* FROM Users u INNER JOIN UserProps up ON ( up.UserId = u.Id )", q.String())
+	})
+
+	t.Run("global, left join", func(t *testing.T) {
+		q := querybuilder.LeftJoin("Status s ON ( s.UserId = u.Id )").Join("UserProps up ON ( up.UserId = u.Id )").From("Users u").Select("u.*")
+		assert.Equal(t, "SELECT u.* FROM Users u LEFT JOIN Status s ON ( s.UserId = u.Id ) INNER JOIN UserProps up ON ( up.UserId = u.Id )", q.String())
+	})
+
+	t.Run("global, right join", func(t *testing.T) {
+		q := querybuilder.RightJoin("ChannelMember cm ON ( cm.UserId = u.Id )").Select("u.*").From("Users u").Join("UserProps up ON ( up.UserId = u.Id )")
+		assert.Equal(t, "SELECT u.* FROM Users u RIGHT JOIN ChannelMember cm ON ( cm.UserId = u.Id ) INNER JOIN UserProps up ON ( up.UserId = u.Id )", q.String())
+	})
+
+	t.Run("immutable", func(t *testing.T) {
+		assert.Equal(t, "SELECT u.* FROM Users u INNER JOIN UserProps up ON ( up.UserId = u.Id )", q1.String())
+		assert.Equal(t, "SELECT u.* FROM Users u INNER JOIN UserProps up ON ( up.UserId = u.Id ) LEFT JOIN Status s ON ( s.UserId = u.Id )", q2.String())
+		assert.Equal(t, "SELECT u.* FROM Users u INNER JOIN UserProps up ON ( up.UserId = u.Id ) RIGHT JOIN ChannelMember cm ON ( cm.UserId = u.Id )", q3.String())
+	})
+}
+
+func TestWhere(t *testing.T) {
+	var q1, q2 *querybuilder.Query
+
+	t.Run("single where statement", func(t *testing.T) {
+		q1 = querybuilder.Select("u.*").From("Users u").Where("u.Id = :Id")
+		assert.Equal(t, "SELECT u.* FROM Users u WHERE u.Id = :Id", q1.String())
+	})
+
+	t.Run("append where statement to q1", func(t *testing.T) {
+		q2 = q1.Where("u.Username = :Username")
+		assert.Equal(t, "SELECT u.* FROM Users u WHERE u.Id = :Id AND u.Username = :Username", q2.String())
+	})
+
+	t.Run("global", func(t *testing.T) {
+		q := querybuilder.Where("u.Username = :Username").Select("u.*").From("Users u")
+		assert.Equal(t, "SELECT u.* FROM Users u WHERE u.Username = :Username", q.String())
+	})
+
+	t.Run("immutable", func(t *testing.T) {
+		assert.Equal(t, "SELECT u.* FROM Users u WHERE u.Id = :Id", q1.String())
+		assert.Equal(t, "SELECT u.* FROM Users u WHERE u.Id = :Id AND u.Username = :Username", q2.String())
+	})
+}
+
+func TestOrderBy(t *testing.T) {
+	var q1, q2 *querybuilder.Query
+
+	t.Run("single order by statement", func(t *testing.T) {
+		q1 = querybuilder.Select("u.*").From("Users u").OrderBy("u.Username ASC")
+		assert.Equal(t, "SELECT u.* FROM Users u ORDER BY u.Username ASC", q1.String())
+	})
+
+	t.Run("append order by statement to q1", func(t *testing.T) {
+		q2 = q1.OrderBy("u.Id DESC")
+		assert.Equal(t, "SELECT u.* FROM Users u ORDER BY u.Username ASC, u.Id DESC", q2.String())
+	})
+
+	t.Run("global", func(t *testing.T) {
+		q := querybuilder.OrderBy("u.Username ASC").Select("u.*").From("Users u")
+		assert.Equal(t, "SELECT u.* FROM Users u ORDER BY u.Username ASC", q.String())
+	})
+
+	t.Run("immutable", func(t *testing.T) {
+		assert.Equal(t, "SELECT u.* FROM Users u ORDER BY u.Username ASC", q1.String())
+		assert.Equal(t, "SELECT u.* FROM Users u ORDER BY u.Username ASC, u.Id DESC", q2.String())
+	})
+}
+
+func TestOffsetLimit(t *testing.T) {
+	var q1, q2, q3 *querybuilder.Query
+
+	t.Run("offset 0, no limit", func(t *testing.T) {
+		q1 = querybuilder.Select("u.*").From("Users u").Offset(0)
+		assert.Equal(t, "SELECT u.* FROM Users u OFFSET 0", q1.String())
+	})
+
+	t.Run("no offset, limit 100", func(t *testing.T) {
+		q2 = querybuilder.Select("u.*").From("Users u").Limit(100)
+		assert.Equal(t, "SELECT u.* FROM Users u LIMIT 100", q2.String())
+	})
+
+	t.Run("offset 300, limit 100, replacing q1", func(t *testing.T) {
+		q3 = q1.Offset(300).Limit(100)
+		assert.Equal(t, "SELECT u.* FROM Users u LIMIT 100 OFFSET 300", q3.String())
+	})
+
+	t.Run("global offset", func(t *testing.T) {
+		q := querybuilder.Offset(300).Limit(100).Select("u.*").From("Users u")
+		assert.Equal(t, "SELECT u.* FROM Users u LIMIT 100 OFFSET 300", q.String())
+	})
+
+	t.Run("global offset", func(t *testing.T) {
+		q := querybuilder.Limit(100).Offset(300).Select("u.*").From("Users u")
+		assert.Equal(t, "SELECT u.* FROM Users u LIMIT 100 OFFSET 300", q.String())
+	})
+
+	t.Run("immutable", func(t *testing.T) {
+		assert.Equal(t, "SELECT u.* FROM Users u OFFSET 0", q1.String())
+		assert.Equal(t, "SELECT u.* FROM Users u LIMIT 100", q2.String())
+		assert.Equal(t, "SELECT u.* FROM Users u LIMIT 100 OFFSET 300", q3.String())
+	})
+}
+
+func TestBind(t *testing.T) {
+	var q1, q2, q3, q4, q5 *querybuilder.Query
+
+	t.Run("bind string", func(t *testing.T) {
+		q1 = querybuilder.Select("*").
+			From("Users").
+			Where("Id = :Id").
+			Bind("Id", "1")
+		assert.Equal(t, "SELECT * FROM Users WHERE Id = :Id", q1.String())
+		assert.Equal(t, map[string]interface{}{
+			"Id": "1",
+		}, q1.Args())
+	})
+
+	t.Run("replace integer to q1", func(t *testing.T) {
+		q2 = q1.Bind("Id", 1)
+		assert.Equal(t, "SELECT * FROM Users WHERE Id = :Id", q2.String())
+		assert.Equal(t, map[string]interface{}{
+			"Id": 1,
+		}, q2.Args())
+	})
+
+	t.Run("bind multiple", func(t *testing.T) {
+		q3 = querybuilder.Select("*").
+			From("Users").
+			Where("Id IN (:Id1, :Id2)").
+			Bind("Id1", 1).Bind("Id2", 2)
+		assert.Equal(t, "SELECT * FROM Users WHERE Id IN (:Id1, :Id2)", q3.String())
+		assert.Equal(t, map[string]interface{}{
+			"Id1": 1,
+			"Id2": 2,
+		}, q3.Args())
+	})
+
+	t.Run("array with multiple string elements", func(t *testing.T) {
+		q4 = querybuilder.Select("*").
+			From("Users").
+			Where("Id IN (:Ids)").
+			Bind("Ids", []string{"id1", "id2", "id3"})
+		assert.Equal(t, "SELECT * FROM Users WHERE Id IN (:Ids_0, :Ids_1, :Ids_2)", q4.String())
+		assert.Equal(t, map[string]interface{}{
+			"Ids_0": "id1",
+			"Ids_1": "id2",
+			"Ids_2": "id3",
+		}, q4.Args())
+	})
+
+	t.Run("array with multiple integer elements", func(t *testing.T) {
+		q5 = querybuilder.Select("*").
+			From("Users").
+			Where("Count IN (:Ids)").
+			Bind("Ids", []int{1, 2, 3})
+		assert.Equal(t, "SELECT * FROM Users WHERE Count IN (:Ids_0, :Ids_1, :Ids_2)", q5.String())
+		assert.Equal(t, map[string]interface{}{
+			"Ids_0": 1,
+			"Ids_1": 2,
+			"Ids_2": 3,
+		}, q5.Args())
+	})
+
+	t.Run("array with multiple string elements, prefix matches a non-array", func(t *testing.T) {
+		q := querybuilder.Select("*").
+			From("Users").
+			Where("Id IN (:Ids)").
+			Bind("Ids", []string{"id1", "id2", "id3"}).
+			Where("Id != :Idsomething").
+			Bind(":Idsomething", "x")
+		assert.Equal(t, "SELECT * FROM Users WHERE Id IN (:Ids_0, :Ids_1, :Ids_2) AND Id != :Idsomething", q.String())
+		assert.Equal(t, map[string]interface{}{
+			"Ids_0":       "id1",
+			"Ids_1":       "id2",
+			"Ids_2":       "id3",
+			"Idsomething": "x",
+		}, q.Args())
+	})
+
+	t.Run("array with multiple replacements", func(t *testing.T) {
+		q := querybuilder.Select("*").
+			From("Users").
+			Where("Id IN (:Ids)").
+			Where("Id NOT IN (:Ids)").
+			Bind("Ids", []string{"id1", "id2", "id3"})
+		assert.Equal(t, "SELECT * FROM Users WHERE Id IN (:Ids_0, :Ids_1, :Ids_2) AND Id NOT IN (:Ids_0, :Ids_1, :Ids_2)", q.String())
+		assert.Equal(t, map[string]interface{}{
+			"Ids_0": "id1",
+			"Ids_1": "id2",
+			"Ids_2": "id3",
+		}, q.Args())
+	})
+
+	t.Run("global bind", func(t *testing.T) {
+		q := querybuilder.Bind("Id", "a").Select("*").From("Users").Where("Id = :Id")
+		assert.Equal(t, "SELECT * FROM Users WHERE Id = :Id", q.String())
+		assert.Equal(t, map[string]interface{}{
+			"Id": "a",
+		}, q.Args())
+	})
+
+	t.Run("immutable", func(t *testing.T) {
+		assert.Equal(t, "SELECT * FROM Users WHERE Id = :Id", q1.String())
+		assert.Equal(t, map[string]interface{}{
+			"Id": "1",
+		}, q1.Args())
+
+		assert.Equal(t, "SELECT * FROM Users WHERE Id = :Id", q2.String())
+		assert.Equal(t, map[string]interface{}{
+			"Id": 1,
+		}, q2.Args())
+
+		assert.Equal(t, "SELECT * FROM Users WHERE Id IN (:Id1, :Id2)", q3.String())
+		assert.Equal(t, map[string]interface{}{
+			"Id1": 1,
+			"Id2": 2,
+		}, q3.Args())
+
+		assert.Equal(t, "SELECT * FROM Users WHERE Id IN (:Ids_0, :Ids_1, :Ids_2)", q4.String())
+		assert.Equal(t, map[string]interface{}{
+			"Ids_0": "id1",
+			"Ids_1": "id2",
+			"Ids_2": "id3",
+		}, q4.Args())
+
+		assert.Equal(t, "SELECT * FROM Users WHERE Count IN (:Ids_0, :Ids_1, :Ids_2)", q5.String())
+		assert.Equal(t, map[string]interface{}{
+			"Ids_0": 1,
+			"Ids_1": 2,
+			"Ids_2": 3,
+		}, q5.Args())
+	})
+}

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -7,7 +7,6 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/mattermost/gorp"
@@ -15,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/einterfaces"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
+	"github.com/mattermost/mattermost-server/store/sqlstore/querybuilder"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
@@ -205,7 +205,7 @@ func (us SqlUserStore) UpdateLastPictureUpdate(userId string) store.StoreChannel
 		curTime := model.GetMillis()
 
 		if _, err := us.GetMaster().Exec("UPDATE Users SET LastPictureUpdate = :Time, UpdateAt = :Time WHERE Id = :UserId", map[string]interface{}{"Time": curTime, "UserId": userId}); err != nil {
-			result.Err = model.NewAppError("SqlUserStore.UpdateUpdateAt", "store.sql_user.update_last_picture_update.app_error", nil, "user_id="+userId, http.StatusInternalServerError)
+			result.Err = model.NewAppError("SqlUserStore.UpdateLastPictureUpdate", "store.sql_user.update_last_picture_update.app_error", nil, "user_id="+userId, http.StatusInternalServerError)
 		} else {
 			result.Data = userId
 		}
@@ -215,7 +215,7 @@ func (us SqlUserStore) UpdateLastPictureUpdate(userId string) store.StoreChannel
 func (us SqlUserStore) ResetLastPictureUpdate(userId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if _, err := us.GetMaster().Exec("UPDATE Users SET LastPictureUpdate = :Time, UpdateAt = :Time WHERE Id = :UserId", map[string]interface{}{"Time": 0, "UserId": userId}); err != nil {
-			result.Err = model.NewAppError("SqlUserStore.UpdateUpdateAt", "store.sql_user.update_last_picture_update.app_error", nil, "user_id="+userId, http.StatusInternalServerError)
+			result.Err = model.NewAppError("SqlUserStore.ResetLastPictureUpdate", "store.sql_user.update_last_picture_update.app_error", nil, "user_id="+userId, http.StatusInternalServerError)
 		} else {
 			result.Data = userId
 		}
@@ -228,9 +228,10 @@ func (us SqlUserStore) UpdateUpdateAt(userId string) store.StoreChannel {
 
 		if _, err := us.GetMaster().Exec("UPDATE Users SET UpdateAt = :Time WHERE Id = :UserId", map[string]interface{}{"Time": curTime, "UserId": userId}); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.UpdateUpdateAt", "store.sql_user.update_update.app_error", nil, "user_id="+userId, http.StatusInternalServerError)
-		} else {
-			result.Data = userId
+			return
 		}
+
+		result.Data = curTime
 	})
 }
 
@@ -319,23 +320,36 @@ func (us SqlUserStore) UpdateMfaActive(userId string, active bool) store.StoreCh
 	})
 }
 
+// usersQuery is a starting point for all queries that return one or more Users.
+var usersQuery *querybuilder.Query = querybuilder.
+	Select("u.*").
+	From("Users u")
+
 func (us SqlUserStore) Get(id string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		if obj, err := us.GetReplica().Get(model.User{}, id); err != nil {
-			result.Err = model.NewAppError("SqlUserStore.Get", "store.sql_user.get.app_error", nil, "user_id="+id+", "+err.Error(), http.StatusInternalServerError)
-		} else if obj == nil {
+		query := usersQuery.Where("Id = :UserId").Bind("UserId", id)
+
+		user := &model.User{}
+		if err := us.GetReplica().SelectOne(user, query.String(), query.Args()); err == sql.ErrNoRows {
 			result.Err = model.NewAppError("SqlUserStore.Get", store.MISSING_ACCOUNT_ERROR, nil, "user_id="+id, http.StatusNotFound)
-		} else {
-			result.Data = obj.(*model.User)
+			return
+		} else if err != nil {
+			result.Err = model.NewAppError("SqlUserStore.Get", "store.sql_user.get.app_error", nil, "user_id="+id+", "+err.Error(), http.StatusInternalServerError)
+			return
 		}
+
+		result.Data = user
 	})
 }
 
 func (us SqlUserStore) GetAll() store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.OrderBy("Username ASC")
+
 		var data []*model.User
-		if _, err := us.GetReplica().Select(&data, "SELECT * FROM Users"); err != nil {
+		if _, err := us.GetReplica().Select(&data, query.String()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetAll", "store.sql_user.get.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 		result.Data = data
@@ -344,8 +358,13 @@ func (us SqlUserStore) GetAll() store.StoreChannel {
 
 func (us SqlUserStore) GetAllAfter(limit int, afterId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			Where("Id > :AfterId").Bind("AfterId", afterId).
+			OrderBy("Id ASC").
+			Limit(limit)
+
 		var data []*model.User
-		if _, err := us.GetReplica().Select(&data, "SELECT * FROM Users WHERE Id > :AfterId ORDER BY Id LIMIT :Limit", map[string]interface{}{"AfterId": afterId, "Limit": limit}); err != nil {
+		if _, err := us.GetReplica().Select(&data, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetAllAfter", "store.sql_user.get.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 
@@ -367,61 +386,42 @@ func (s SqlUserStore) GetEtagForAllProfiles() store.StoreChannel {
 func (us SqlUserStore) GetAllProfiles(options *model.UserGetOptions) store.StoreChannel {
 	isPostgreSQL := us.DriverName() == model.DATABASE_DRIVER_POSTGRES
 	return store.Do(func(result *store.StoreResult) {
-		var users []*model.User
-		offset := options.Page * options.PerPage
-		limit := options.PerPage
+		query := usersQuery.
+			OrderBy("u.Username ASC").
+			Offset(options.Page * options.PerPage).Limit(options.PerPage)
 
-		searchQuery := `
-			SELECT * FROM Users
-			WHERE_CONDITION
-			ORDER BY Username ASC LIMIT :Limit OFFSET :Offset
-		`
+		query = applyRoleFilter(query, options.Role, isPostgreSQL)
 
-		parameters := map[string]interface{}{"Offset": offset, "Limit": limit}
-		searchQuery = substituteWhereClause(searchQuery, options, parameters, isPostgreSQL)
-
-		if _, err := us.GetReplica().Select(&users, searchQuery, parameters); err != nil {
-			result.Err = model.NewAppError("SqlUserStore.GetAllProfiles", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+		if options.Inactive {
+			query = query.Where("u.DeleteAt != 0")
 		}
+
+		var users []*model.User
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
+			result.Err = model.NewAppError("SqlUserStore.GetAllProfiles", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+
+		result.Data = users
 	})
 }
 
-func substituteWhereClause(searchQuery string, options *model.UserGetOptions, parameters map[string]interface{}, isPostgreSQL bool) string {
-	whereClause := ""
-	whereClauses := []string{}
-	if options.Role != "" {
-		whereClauses = append(whereClauses, getRoleFilter(isPostgreSQL))
-		parameters["Role"] = fmt.Sprintf("%%%s%%", options.Role)
-	}
-	if options.Inactive {
-		whereClauses = append(whereClauses, " Users.DeleteAt != 0 ")
+func applyRoleFilter(query *querybuilder.Query, role string, isPostgreSQL bool) *querybuilder.Query {
+	if role == "" {
+		return query
 	}
 
-	if len(whereClauses) > 0 {
-		whereClause = strings.Join(whereClauses, " AND ")
-		searchQuery = strings.Replace(searchQuery, "WHERE_CONDITION", fmt.Sprintf(" WHERE %s ", whereClause), 1)
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", fmt.Sprintf(" AND %s ", whereClause), 1)
-	} else {
-		searchQuery = strings.Replace(searchQuery, "WHERE_CONDITION", "", 1)
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
-	}
-
-	return searchQuery
-}
-
-func getRoleFilter(isPostgreSQL bool) string {
 	if isPostgreSQL {
-		return fmt.Sprintf("Users.Roles like lower(%s)", ":Role")
+		query = query.Where("u.Roles LIKE LOWER(:Role)")
 	} else {
-		return fmt.Sprintf("Users.Roles LIKE %s escape '*' ", ":Role")
+		query = query.Where("u.Roles LIKE :Role ESCAPE '*'")
 	}
+
+	return query.Bind("Role", fmt.Sprintf("%%%s%%", role))
 }
 
 func (s SqlUserStore) GetEtagForProfiles(teamId string) store.StoreChannel {
@@ -437,33 +437,29 @@ func (s SqlUserStore) GetEtagForProfiles(teamId string) store.StoreChannel {
 
 func (us SqlUserStore) GetProfiles(options *model.UserGetOptions) store.StoreChannel {
 	isPostgreSQL := us.DriverName() == model.DATABASE_DRIVER_POSTGRES
-	teamId := options.InTeamId
-	offset := options.Page * options.PerPage
-	limit := options.PerPage
-
-	searchQuery := `
-		SELECT Users.* FROM Users, TeamMembers 
-		WHERE TeamMembers.TeamId = :TeamId AND Users.Id = TeamMembers.UserId AND TeamMembers.DeleteAt = 0
-		SEARCH_CLAUSE
-		ORDER BY Users.Username ASC LIMIT :Limit OFFSET :Offset
-		`
-
-	parameters := map[string]interface{}{"TeamId": teamId, "Offset": offset, "Limit": limit}
-	searchQuery = substituteWhereClause(searchQuery, options, parameters, isPostgreSQL)
-
 	return store.Do(func(result *store.StoreResult) {
-		var users []*model.User
+		query := usersQuery.
+			Join("TeamMembers tm ON ( tm.UserId = u.Id AND tm.DeleteAt = 0 )").
+			Where("tm.TeamId = :TeamId").Bind("TeamId", options.InTeamId).
+			OrderBy("u.Username ASC").
+			Offset(options.Page * options.PerPage).Limit(options.PerPage)
 
-		if _, err := us.GetReplica().Select(&users, searchQuery, parameters); err != nil {
-			result.Err = model.NewAppError("SqlUserStore.GetProfiles", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
+		query = applyRoleFilter(query, options.Role, isPostgreSQL)
 
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+		if options.Inactive {
+			query = query.Where("u.DeleteAt != 0")
 		}
+
+		var users []*model.User
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
+			result.Err = model.NewAppError("SqlUserStore.GetProfiles", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+		result.Data = users
 	})
 }
 
@@ -492,67 +488,54 @@ func (us SqlUserStore) InvalidateProfilesInChannelCache(channelId string) {
 
 func (us SqlUserStore) GetProfilesInChannel(channelId string, offset int, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			Join("ChannelMembers cm ON ( cm.UserId = u.Id )").
+			Where("cm.ChannelId = :ChannelId").Bind("ChannelId", channelId).
+			OrderBy("u.Username ASC").
+			Offset(offset).Limit(limit)
+
 		var users []*model.User
-
-		query := `
-				SELECT 
-					Users.* 
-				FROM 
-					Users, ChannelMembers 
-				WHERE 
-					ChannelMembers.ChannelId = :ChannelId 
-					AND Users.Id = ChannelMembers.UserId 
-				ORDER BY 
-					Users.Username ASC 
-				LIMIT :Limit OFFSET :Offset
-		`
-
-		if _, err := us.GetReplica().Select(&users, query, map[string]interface{}{"ChannelId": channelId, "Offset": offset, "Limit": limit}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetProfilesInChannel", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+			return
 		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+
+		result.Data = users
 	})
 }
 
 func (us SqlUserStore) GetProfilesInChannelByStatus(channelId string, offset int, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		var users []*model.User
-
-		query := `
-			SELECT 
-				Users.*
-			FROM Users
-				INNER JOIN ChannelMembers ON Users.Id = ChannelMembers.UserId
-				LEFT JOIN Status  ON Users.Id = Status.UserId
-			WHERE
-				ChannelMembers.ChannelId = :ChannelId
-			ORDER BY 
-				CASE Status
+		query := usersQuery.
+			Join("ChannelMembers cm ON ( cm.UserId = u.Id )").
+			LeftJoin("Status s ON ( s.UserId = u.Id )").
+			Where("cm.ChannelId = :ChannelId").Bind("ChannelId", channelId).
+			OrderBy(`
+				CASE s.Status
 					WHEN 'online' THEN 1
 					WHEN 'away' THEN 2
 					WHEN 'dnd' THEN 3
 					ELSE 4
-				END,
-				Users.Username ASC 
-			LIMIT :Limit OFFSET :Offset
-		`
+				END
+			`).
+			OrderBy("u.Username ASC").
+			Offset(offset).Limit(limit)
 
-		if _, err := us.GetReplica().Select(&users, query, map[string]interface{}{"ChannelId": channelId, "Offset": offset, "Limit": limit}); err != nil {
+		var users []*model.User
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetProfilesInChannelByStatus", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+			return
 		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+
+		result.Data = users
 	})
 }
 
@@ -576,127 +559,106 @@ func (us SqlUserStore) GetAllProfilesInChannel(channelId string, allowFromCache 
 			}
 		}
 
+		query := usersQuery.
+			Join("ChannelMembers cm ON ( cm.UserId = u.Id )").
+			Where("cm.ChannelId = :ChannelId").Bind("ChannelId", channelId).
+			Where("u.DeleteAt = 0").
+			OrderBy("u.Username ASC")
+
 		var users []*model.User
-
-		query := "SELECT Users.* FROM Users, ChannelMembers WHERE ChannelMembers.ChannelId = :ChannelId AND Users.Id = ChannelMembers.UserId AND Users.DeleteAt = 0"
-
-		if _, err := us.GetReplica().Select(&users, query, map[string]interface{}{"ChannelId": channelId}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetAllProfilesInChannel", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
+			return
+		}
 
-			userMap := make(map[string]*model.User)
+		userMap := make(map[string]*model.User)
 
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-				userMap[u.Id] = u
-			}
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+			userMap[u.Id] = u
+		}
 
-			result.Data = userMap
+		result.Data = userMap
 
-			if allowFromCache {
-				profilesInChannelCache.AddWithExpiresInSecs(channelId, userMap, PROFILES_IN_CHANNEL_CACHE_SEC)
-			}
+		if allowFromCache {
+			profilesInChannelCache.AddWithExpiresInSecs(channelId, userMap, PROFILES_IN_CHANNEL_CACHE_SEC)
 		}
 	})
 }
 
 func (us SqlUserStore) GetProfilesNotInChannel(teamId string, channelId string, offset int, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			Join("TeamMembers tm ON ( tm.UserId = u.Id AND tm.DeleteAt = 0 AND tm.TeamId = :TeamId )").Bind("TeamId", teamId).
+			LeftJoin("ChannelMembers cm ON ( cm.UserId = u.Id AND cm.ChannelId = :ChannelId )").Bind("ChannelId", channelId).
+			Where("cm.UserId IS NULL").
+			OrderBy("u.Username ASC").
+			Offset(offset).Limit(limit)
+
 		var users []*model.User
-
-		if _, err := us.GetReplica().Select(&users, `
-            SELECT
-                u.*
-            FROM Users u
-            INNER JOIN TeamMembers tm
-                ON tm.UserId = u.Id
-                AND tm.TeamId = :TeamId
-                AND tm.DeleteAt = 0
-            LEFT JOIN ChannelMembers cm
-                ON cm.UserId = u.Id
-                AND cm.ChannelId = :ChannelId
-            WHERE cm.UserId IS NULL
-            ORDER BY u.Username ASC
-            LIMIT :Limit OFFSET :Offset
-            `, map[string]interface{}{"TeamId": teamId, "ChannelId": channelId, "Offset": offset, "Limit": limit}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetProfilesNotInChannel", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+			return
 		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+
+		result.Data = users
 	})
 }
 
 func (us SqlUserStore) GetProfilesWithoutTeam(offset int, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			Where(`(
+				SELECT
+					COUNT(0)
+				FROM
+					TeamMembers
+				WHERE
+					TeamMembers.UserId = u.Id
+					AND TeamMembers.DeleteAt = 0
+			) = 0`).
+			OrderBy("u.Username ASC").
+			Offset(offset).Limit(limit)
+
 		var users []*model.User
-
-		query := `
-		SELECT
-			*
-		FROM
-			Users
-		WHERE
-			(SELECT
-				COUNT(0)
-			FROM
-				TeamMembers
-			WHERE
-				TeamMembers.UserId = Users.Id
-				AND TeamMembers.DeleteAt = 0) = 0
-		ORDER BY
-			Username ASC
-		LIMIT
-			:Limit
-		OFFSET
-			:Offset`
-
-		if _, err := us.GetReplica().Select(&users, query, map[string]interface{}{"Offset": offset, "Limit": limit}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetProfilesWithoutTeam", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+			return
 		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+
+		result.Data = users
 	})
 }
 
 func (us SqlUserStore) GetProfilesByUsernames(usernames []string, teamId string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery
+
+		if teamId != "" {
+			query = query.
+				Join("TeamMembers tm ON (tm.UserId = u.Id AND tm.TeamId = :TeamId)").
+				Bind("TeamId", teamId)
+		}
+
+		query = query.
+			Where("Username IN (:Usernames)").Bind("Usernames", usernames).
+			OrderBy("u.Username ASC")
+
 		var users []*model.User
-		props := make(map[string]interface{})
-		idQuery := ""
-
-		for index, usernames := range usernames {
-			if len(idQuery) > 0 {
-				idQuery += ", "
-			}
-
-			props["username"+strconv.Itoa(index)] = usernames
-			idQuery += ":username" + strconv.Itoa(index)
-		}
-
-		var query string
-		if teamId == "" {
-			query = `SELECT * FROM Users WHERE Username IN (` + idQuery + `)`
-		} else {
-			query = `SELECT Users.* FROM Users INNER JOIN TeamMembers ON
-				Users.Id = TeamMembers.UserId AND Users.Username IN (` + idQuery + `) AND TeamMembers.TeamId = :TeamId `
-			props["TeamId"] = teamId
-		}
-
-		if _, err := us.GetReplica().Select(&users, query, props); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetProfilesByUsernames", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-			result.Data = users
+			return
 		}
+
+		result.Data = users
 	})
 }
 
@@ -707,65 +669,58 @@ type UserWithLastActivityAt struct {
 
 func (us SqlUserStore) GetRecentlyActiveUsersForTeam(teamId string, offset, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			Select("s.LastActivityAt").
+			Join("TeamMembers tm ON (tm.UserId = u.Id AND tm.TeamId = :TeamId)").Bind("TeamId", teamId).
+			Join("Status s ON (s.UserId = u.Id)").
+			OrderBy("s.LastActivityAt DESC").
+			OrderBy("u.Username ASC").
+			Offset(offset).Limit(limit)
+
 		var users []*UserWithLastActivityAt
-
-		if _, err := us.GetReplica().Select(&users, `
-            SELECT
-                u.*,
-                s.LastActivityAt
-            FROM Users AS u
-                INNER JOIN TeamMembers AS t ON u.Id = t.UserId
-                INNER JOIN Status AS s ON s.UserId = t.UserId
-            WHERE t.TeamId = :TeamId
-            ORDER BY s.LastActivityAt DESC
-            LIMIT :Limit OFFSET :Offset
-            `, map[string]interface{}{"TeamId": teamId, "Offset": offset, "Limit": limit}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetRecentlyActiveUsers", "store.sql_user.get_recently_active_users.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			userList := []*model.User{}
-
-			for _, userWithLastActivityAt := range users {
-				u := userWithLastActivityAt.User
-				u.Sanitize(map[string]bool{})
-				u.LastActivityAt = userWithLastActivityAt.LastActivityAt
-				userList = append(userList, &u)
-			}
-
-			result.Data = userList
+			return
 		}
+
+		userList := []*model.User{}
+
+		for _, userWithLastActivityAt := range users {
+			u := userWithLastActivityAt.User
+			u.Sanitize(map[string]bool{})
+			u.LastActivityAt = userWithLastActivityAt.LastActivityAt
+			userList = append(userList, &u)
+		}
+
+		result.Data = userList
 	})
 }
 
 func (us SqlUserStore) GetNewUsersForTeam(teamId string, offset, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			Join("TeamMembers tm ON (tm.UserId = u.Id AND tm.TeamId = :TeamId)").Bind("TeamId", teamId).
+			OrderBy("u.CreateAt DESC").
+			OrderBy("u.Username ASC").
+			Offset(offset).Limit(limit)
+
 		var users []*model.User
-
-		if _, err := us.GetReplica().Select(&users, `
-            SELECT
-                u.*
-            FROM Users AS u
-                INNER JOIN TeamMembers AS t ON u.Id = t.UserId
-            WHERE t.TeamId = :TeamId
-            ORDER BY u.CreateAt DESC
-            LIMIT :Limit OFFSET :Offset
-            `, map[string]interface{}{"TeamId": teamId, "Offset": offset, "Limit": limit}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetNewUsersForTeam", "store.sql_user.get_new_users.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+			return
 		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+
+		result.Data = users
 	})
 }
 
 func (us SqlUserStore) GetProfileByIds(userIds []string, allowFromCache bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		users := []*model.User{}
-		props := make(map[string]interface{})
-		idQuery := ""
 		remainingUserIds := make([]string, 0)
 
 		if allowFromCache {
@@ -795,49 +750,47 @@ func (us SqlUserStore) GetProfileByIds(userIds []string, allowFromCache bool) st
 			return
 		}
 
-		for index, userId := range remainingUserIds {
-			if len(idQuery) > 0 {
-				idQuery += ", "
-			}
+		query := usersQuery.
+			Where("u.Id IN (:Ids)").Bind(":Ids", remainingUserIds).
+			OrderBy("u.Username ASC")
 
-			props["userId"+strconv.Itoa(index)] = userId
-			idQuery += ":userId" + strconv.Itoa(index)
-		}
-
-		if _, err := us.GetReplica().Select(&users, "SELECT * FROM Users WHERE Users.Id IN ("+idQuery+")", props); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetProfileByIds", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-
-				cpy := &model.User{}
-				*cpy = *u
-				profileByIdsCache.AddWithExpiresInSecs(cpy.Id, cpy, PROFILE_BY_IDS_CACHE_SEC)
-			}
-
-			result.Data = users
+			return
 		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+
+			cpy := &model.User{}
+			*cpy = *u
+			profileByIdsCache.AddWithExpiresInSecs(cpy.Id, cpy, PROFILE_BY_IDS_CACHE_SEC)
+		}
+
+		result.Data = users
 	})
 }
 
 func (us SqlUserStore) GetSystemAdminProfiles() store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			Where("Roles LIKE :Roles").Bind("Roles", "%system_admin%").
+			OrderBy("u.Username ASC")
+
 		var users []*model.User
-
-		if _, err := us.GetReplica().Select(&users, "SELECT * FROM Users WHERE Roles LIKE :Roles", map[string]interface{}{"Roles": "%system_admin%"}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetSystemAdminProfiles", "store.sql_user.get_sysadmin_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			userMap := make(map[string]*model.User)
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-				userMap[u.Id] = u
-			}
-
-			result.Data = userMap
+			return
 		}
+
+		userMap := make(map[string]*model.User)
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+			userMap[u.Id] = u
+		}
+
+		result.Data = userMap
 	})
 }
 
@@ -845,9 +798,11 @@ func (us SqlUserStore) GetByEmail(email string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		email = strings.ToLower(email)
 
-		user := model.User{}
+		query := usersQuery.
+			Where("Email = :Email").Bind("Email", email)
 
-		if err := us.GetReplica().SelectOne(&user, "SELECT * FROM Users WHERE Email = :Email", map[string]interface{}{"Email": email}); err != nil {
+		user := model.User{}
+		if err := us.GetReplica().SelectOne(&user, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetByEmail", store.MISSING_ACCOUNT_ERROR, nil, "email="+email+", "+err.Error(), http.StatusInternalServerError)
 		}
 
@@ -862,14 +817,17 @@ func (us SqlUserStore) GetByAuth(authData *string, authService string) store.Sto
 			return
 		}
 
-		user := model.User{}
+		query := usersQuery.
+			Where("u.AuthData = :AuthData").Bind("AuthData", authData).
+			Where("u.AuthService = :AuthService").Bind("AuthService", authService)
 
-		if err := us.GetReplica().SelectOne(&user, "SELECT * FROM Users WHERE AuthData = :AuthData AND AuthService = :AuthService", map[string]interface{}{"AuthData": authData, "AuthService": authService}); err != nil {
-			if err == sql.ErrNoRows {
-				result.Err = model.NewAppError("SqlUserStore.GetByAuth", store.MISSING_AUTH_ACCOUNT_ERROR, nil, "authData="+*authData+", authService="+authService+", "+err.Error(), http.StatusInternalServerError)
-			} else {
-				result.Err = model.NewAppError("SqlUserStore.GetByAuth", "store.sql_user.get_by_auth.other.app_error", nil, "authData="+*authData+", authService="+authService+", "+err.Error(), http.StatusInternalServerError)
-			}
+		user := model.User{}
+		if err := us.GetReplica().SelectOne(&user, query.String(), query.Args()); err == sql.ErrNoRows {
+			result.Err = model.NewAppError("SqlUserStore.GetByAuth", store.MISSING_AUTH_ACCOUNT_ERROR, nil, "authData="+*authData+", authService="+authService+", "+err.Error(), http.StatusInternalServerError)
+			return
+		} else if err != nil {
+			result.Err = model.NewAppError("SqlUserStore.GetByAuth", "store.sql_user.get_by_auth.other.app_error", nil, "authData="+*authData+", authService="+authService+", "+err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 		result.Data = &user
@@ -878,10 +836,14 @@ func (us SqlUserStore) GetByAuth(authData *string, authService string) store.Sto
 
 func (us SqlUserStore) GetAllUsingAuthService(authService string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		var data []*model.User
+		query := usersQuery.
+			Where("u.AuthService = :AuthService").Bind("AuthService", authService).
+			OrderBy("u.Username ASC")
 
-		if _, err := us.GetReplica().Select(&data, "SELECT * FROM Users WHERE AuthService = :AuthService", map[string]interface{}{"AuthService": authService}); err != nil {
+		var data []*model.User
+		if _, err := us.GetReplica().Select(&data, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetByAuth", "store.sql_user.get_by_auth.other.app_error", nil, "authService="+authService+", "+err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 		result.Data = data
@@ -890,10 +852,13 @@ func (us SqlUserStore) GetAllUsingAuthService(authService string) store.StoreCha
 
 func (us SqlUserStore) GetByUsername(username string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		user := model.User{}
+		query := usersQuery.
+			Where("u.Username = :Username").Bind("Username", username)
 
-		if err := us.GetReplica().SelectOne(&user, "SELECT * FROM Users WHERE Username = :Username", map[string]interface{}{"Username": username}); err != nil {
+		user := model.User{}
+		if err := us.GetReplica().SelectOne(&user, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetByUsername", "store.sql_user.get_by_username.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 		result.Data = &user
@@ -902,31 +867,38 @@ func (us SqlUserStore) GetByUsername(username string) store.StoreChannel {
 
 func (us SqlUserStore) GetForLogin(loginId string, allowSignInWithUsername, allowSignInWithEmail bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		params := map[string]interface{}{
-			"LoginId":                 loginId,
-			"AllowSignInWithUsername": allowSignInWithUsername,
-			"AllowSignInWithEmail":    allowSignInWithEmail,
-		}
+		query := usersQuery
 
-		users := []*model.User{}
-		if _, err := us.GetReplica().Select(
-			&users,
-			`SELECT
-				*
-			FROM
-				Users
-			WHERE
-				(:AllowSignInWithUsername AND Username = :LoginId)
-				OR (:AllowSignInWithEmail AND Email = :LoginId)`,
-			params); err != nil {
-			result.Err = model.NewAppError("SqlUserStore.GetForLogin", "store.sql_user.get_for_login.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else if len(users) == 1 {
-			result.Data = users[0]
-		} else if len(users) > 1 {
-			result.Err = model.NewAppError("SqlUserStore.GetForLogin", "store.sql_user.get_for_login.multiple_users", nil, "", http.StatusInternalServerError)
+		if allowSignInWithUsername && allowSignInWithEmail {
+			query = query.Where("Username = :LoginId OR Email = :LoginId")
+		} else if allowSignInWithUsername {
+			query = query.Where("Username = :LoginId")
+		} else if allowSignInWithEmail {
+			query = query.Where("Email = :LoginId")
 		} else {
 			result.Err = model.NewAppError("SqlUserStore.GetForLogin", "store.sql_user.get_for_login.app_error", nil, "", http.StatusInternalServerError)
+			return
 		}
+
+		query = query.Bind("LoginId", loginId)
+
+		users := []*model.User{}
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
+			result.Err = model.NewAppError("SqlUserStore.GetForLogin", "store.sql_user.get_for_login.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if len(users) == 0 {
+			result.Err = model.NewAppError("SqlUserStore.GetForLogin", "store.sql_user.get_for_login.app_error", nil, "", http.StatusInternalServerError)
+			return
+		}
+
+		if len(users) > 1 {
+			result.Err = model.NewAppError("SqlUserStore.GetForLogin", "store.sql_user.get_for_login.multiple_users", nil, "", http.StatusInternalServerError)
+			return
+		}
+
+		result.Data = users[0]
 	})
 }
 
@@ -1029,162 +1001,73 @@ func (us SqlUserStore) GetAnyUnreadPostCountForChannel(userId string, channelId 
 
 func (us SqlUserStore) Search(teamId string, term string, options *model.UserSearchOptions) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		searchQuery := ""
+		query := usersQuery.
+			OrderBy("Username ASC").
+			Limit(options.Limit)
 
-		if teamId == "" {
-			// Id != '' is added because both SEARCH_CLAUSE and INACTIVE_CLAUSE start with an AND
-			searchQuery = `
-			SELECT
-				*
-			FROM
-				Users
-			WHERE
-				Id != ''
-				SEARCH_CLAUSE
-				INACTIVE_CLAUSE
-			ORDER BY Username ASC
-			LIMIT :Limit`
-		} else {
-			searchQuery = `
-			SELECT
-				Users.*
-			FROM
-				Users, TeamMembers
-			WHERE
-				TeamMembers.TeamId = :TeamId
-				AND Users.Id = TeamMembers.UserId
-				AND TeamMembers.DeleteAt = 0
-				SEARCH_CLAUSE
-				INACTIVE_CLAUSE
-			ORDER BY Users.Username ASC
-			LIMIT :Limit`
+		if teamId != "" {
+			query = query.Join("TeamMembers tm ON ( tm.UserId = u.Id AND tm.DeleteAt = 0 AND tm.TeamId = :TeamId )").Bind("TeamId", teamId)
 		}
 
-		*result = us.performSearch(searchQuery, term, options, map[string]interface{}{
-			"TeamId": teamId,
-			"Limit":  options.Limit,
-		})
-
+		*result = us.performSearch(query, term, options)
 	})
 }
 
 func (us SqlUserStore) SearchWithoutTeam(term string, options *model.UserSearchOptions) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		searchQuery := `
-		SELECT
-			*
-		FROM
-			Users
-		WHERE
-			(SELECT
-				COUNT(0)
-			FROM
-				TeamMembers
-			WHERE
-				TeamMembers.UserId = Users.Id
-				AND TeamMembers.DeleteAt = 0) = 0
-			SEARCH_CLAUSE
-			INACTIVE_CLAUSE
-			ORDER BY Username ASC
-		LIMIT :Limit`
+		query := usersQuery.
+			Where(`(
+				SELECT
+					COUNT(0)
+				FROM
+					TeamMembers
+				WHERE
+					TeamMembers.UserId = u.Id
+					AND TeamMembers.DeleteAt = 0
+			) = 0`).
+			OrderBy("u.Username ASC").
+			Limit(options.Limit)
 
-		*result = us.performSearch(searchQuery, term, options, map[string]interface{}{
-			"Limit": options.Limit,
-		})
-
+		*result = us.performSearch(query, term, options)
 	})
 }
 
 func (us SqlUserStore) SearchNotInTeam(notInTeamId string, term string, options *model.UserSearchOptions) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		searchQuery := `
-			SELECT
-				Users.*
-			FROM Users
-			LEFT JOIN TeamMembers tm
-				ON tm.UserId = Users.Id
-				AND tm.TeamId = :NotInTeamId
-			WHERE
-				(tm.UserId IS NULL OR tm.DeleteAt != 0)
-				SEARCH_CLAUSE
-				INACTIVE_CLAUSE
-			ORDER BY Users.Username ASC
-			LIMIT :Limit`
+		query := usersQuery.
+			LeftJoin("TeamMembers tm ON ( tm.UserId = u.Id AND tm.DeleteAt = 0 AND tm.TeamId = :TeamId )").Bind("TeamId", notInTeamId).
+			Where("tm.UserId IS NULL").
+			OrderBy("u.Username ASC").
+			Limit(options.Limit)
 
-		*result = us.performSearch(searchQuery, term, options, map[string]interface{}{
-			"NotInTeamId": notInTeamId,
-			"Limit":       options.Limit,
-		})
-
+		*result = us.performSearch(query, term, options)
 	})
 }
 
 func (us SqlUserStore) SearchNotInChannel(teamId string, channelId string, term string, options *model.UserSearchOptions) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		searchQuery := ""
-		if teamId == "" {
-			searchQuery = `
-			SELECT
-				Users.*
-			FROM Users
-			LEFT JOIN ChannelMembers cm
-				ON cm.UserId = Users.Id
-				AND cm.ChannelId = :ChannelId
-			WHERE
-				cm.UserId IS NULL
-				SEARCH_CLAUSE
-				INACTIVE_CLAUSE
-			ORDER BY Users.Username ASC
-			LIMIT :Limit`
-		} else {
-			searchQuery = `
-			SELECT
-				Users.*
-			FROM Users
-			INNER JOIN TeamMembers tm
-				ON tm.UserId = Users.Id
-				AND tm.TeamId = :TeamId
-				AND tm.DeleteAt = 0
-			LEFT JOIN ChannelMembers cm
-				ON cm.UserId = Users.Id
-				AND cm.ChannelId = :ChannelId
-			WHERE
-				cm.UserId IS NULL
-				SEARCH_CLAUSE
-				INACTIVE_CLAUSE
-			ORDER BY Users.Username ASC
-			LIMIT :Limit`
+		query := usersQuery.
+			LeftJoin("ChannelMembers cm ON ( cm.UserId = u.Id AND cm.ChannelId = :ChannelId )").Bind("ChannelId", channelId).
+			Where("cm.UserId IS NULL").
+			OrderBy("Username ASC").
+			Limit(options.Limit)
+
+		if teamId != "" {
+			query = query.Join("TeamMembers tm ON ( tm.UserId = u.Id AND tm.DeleteAt = 0 AND tm.TeamId = :TeamId )").Bind("TeamId", teamId)
 		}
 
-		*result = us.performSearch(searchQuery, term, options, map[string]interface{}{
-			"TeamId":    teamId,
-			"ChannelId": channelId,
-			"Limit":     options.Limit,
-		})
+		*result = us.performSearch(query, term, options)
 	})
 }
 
 func (us SqlUserStore) SearchInChannel(channelId string, term string, options *model.UserSearchOptions) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
-		searchQuery := `
-			SELECT
-			    Users.*
-			FROM
-			    Users, ChannelMembers
-			WHERE
-			    ChannelMembers.ChannelId = :ChannelId
-			    AND ChannelMembers.UserId = Users.Id
-			    SEARCH_CLAUSE
-			    INACTIVE_CLAUSE
-			    ORDER BY Users.Username ASC
-		    LIMIT :Limit
-		`
+		query := usersQuery.
+			Join("ChannelMembers cm ON ( cm.UserId = u.Id AND cm.ChannelId = :ChannelId )").Bind("ChannelId", channelId).
+			OrderBy("Username ASC").
+			Limit(options.Limit)
 
-		*result = us.performSearch(searchQuery, term, options, map[string]interface{}{
-			"ChannelId": channelId,
-			"Limit":     options.Limit,
-		})
-
+		*result = us.performSearch(query, term, options)
 	})
 }
 
@@ -1212,8 +1095,7 @@ var spaceFulltextSearchChar = []string{
 	"@",
 }
 
-func generateSearchQuery(searchQuery string, terms []string, fields []string, parameters map[string]interface{}, isPostgreSQL bool, role string) string {
-	searchTerms := []string{}
+func generateSearchQuery(query *querybuilder.Query, terms []string, fields []string, isPostgreSQL bool) *querybuilder.Query {
 	for i, term := range terms {
 		searchFields := []string{}
 		for _, field := range fields {
@@ -1223,20 +1105,15 @@ func generateSearchQuery(searchQuery string, terms []string, fields []string, pa
 				searchFields = append(searchFields, fmt.Sprintf("%s LIKE %s escape '*' ", field, fmt.Sprintf(":Term%d", i)))
 			}
 		}
-		searchTerms = append(searchTerms, fmt.Sprintf("(%s)", strings.Join(searchFields, " OR ")))
-		parameters[fmt.Sprintf("Term%d", i)] = fmt.Sprintf("%s%%", strings.TrimLeft(term, "@"))
+		query = query.
+			Where(fmt.Sprintf("(%s)", strings.Join(searchFields, " OR "))).
+			Bind(fmt.Sprintf("Term%d", i), fmt.Sprintf("%s%%", strings.TrimLeft(term, "@")))
 	}
 
-	if role != "" {
-		searchTerms = append(searchTerms, getRoleFilter(isPostgreSQL))
-		parameters["Role"] = fmt.Sprintf("%%%s%%", role)
-	}
-
-	searchClause := strings.Join(searchTerms, " AND ")
-	return strings.Replace(searchQuery, "SEARCH_CLAUSE", fmt.Sprintf(" AND %s ", searchClause), 1)
+	return query
 }
 
-func (us SqlUserStore) performSearch(searchQuery string, term string, options *model.UserSearchOptions, parameters map[string]interface{}) store.StoreResult {
+func (us SqlUserStore) performSearch(query *querybuilder.Query, term string, options *model.UserSearchOptions) store.StoreResult {
 	result := store.StoreResult{}
 
 	// These chars must be removed from the like query.
@@ -1264,27 +1141,21 @@ func (us SqlUserStore) performSearch(searchQuery string, term string, options *m
 		}
 	}
 
-	role := ""
-	if options.Role != "" {
-		role = options.Role
+	isPostgreSQL := us.DriverName() == model.DATABASE_DRIVER_POSTGRES
+
+	query = applyRoleFilter(query, options.Role, isPostgreSQL)
+
+	if !options.AllowInactive {
+		query = query.Where("u.DeleteAt = 0")
 	}
 
-	if ok := options.AllowInactive; ok {
-		searchQuery = strings.Replace(searchQuery, "INACTIVE_CLAUSE", "", 1)
-	} else {
-		searchQuery = strings.Replace(searchQuery, "INACTIVE_CLAUSE", "AND Users.DeleteAt = 0", 1)
-	}
-
-	if strings.TrimSpace(term) == "" {
-		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", "", 1)
-	} else {
-		isPostgreSQL := us.DriverName() == model.DATABASE_DRIVER_POSTGRES
-		searchQuery = generateSearchQuery(searchQuery, strings.Fields(term), searchType, parameters, isPostgreSQL, role)
+	if strings.TrimSpace(term) != "" {
+		query = generateSearchQuery(query, strings.Fields(term), searchType, isPostgreSQL)
 	}
 
 	var users []*model.User
 
-	if _, err := us.GetReplica().Select(&users, searchQuery, parameters); err != nil {
+	if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 		result.Err = model.NewAppError("SqlUserStore.Search", "store.sql_user.search.app_error", nil,
 			fmt.Sprintf("term=%v, search_type=%v, %v", term, searchType, err.Error()), http.StatusInternalServerError)
 	} else {
@@ -1320,29 +1191,23 @@ func (us SqlUserStore) AnalyticsGetSystemAdminCount() store.StoreChannel {
 
 func (us SqlUserStore) GetProfilesNotInTeam(teamId string, offset int, limit int) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
+		query := usersQuery.
+			LeftJoin("TeamMembers tm ON ( tm.UserId = u.Id AND tm.DeleteAt = 0 AND tm.TeamId = :TeamId )").Bind("TeamId", teamId).
+			Where("tm.UserId IS NULL").
+			OrderBy("u.Username ASC").
+			Offset(offset).Limit(limit)
+
 		var users []*model.User
-
-		if _, err := us.GetReplica().Select(&users, `
-            SELECT
-                u.*
-            FROM Users u
-            LEFT JOIN TeamMembers tm
-                ON tm.UserId = u.Id
-                AND tm.TeamId = :TeamId
-                AND tm.DeleteAt = 0
-            WHERE tm.UserId IS NULL
-            ORDER BY u.Username ASC
-            LIMIT :Limit OFFSET :Offset
-            `, map[string]interface{}{"TeamId": teamId, "Offset": offset, "Limit": limit}); err != nil {
+		if _, err := us.GetReplica().Select(&users, query.String(), query.Args()); err != nil {
 			result.Err = model.NewAppError("SqlUserStore.GetProfilesNotInTeam", "store.sql_user.get_profiles.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-
-			for _, u := range users {
-				u.Sanitize(map[string]bool{})
-			}
-
-			result.Data = users
+			return
 		}
+
+		for _, u := range users {
+			u.Sanitize(map[string]bool{})
+		}
+
+		result.Data = users
 	})
 }
 

--- a/store/storetest/settings.go
+++ b/store/storetest/settings.go
@@ -37,10 +37,10 @@ func getEnv(name, defaultValue string) string {
 func log(message string) {
 	verbose := false
 	if verboseFlag := flag.Lookup("test.v"); verboseFlag != nil {
-		verbose = verboseFlag.Value.String() == "true"
+		verbose = verboseFlag.Value.String() != ""
 	}
 	if verboseFlag := flag.Lookup("v"); verboseFlag != nil {
-		verbose = verboseFlag.Value.String() == "true"
+		verbose = verboseFlag.Value.String() != ""
 	}
 
 	if verbose {
@@ -207,7 +207,7 @@ func MakeSqlSettings(driver string) *model.SqlSettings {
 		panic("unsupported driver " + driver)
 	}
 
-	log("Created temporary database " + dbName)
+	log("Created temporary " + driver + " database " + dbName)
 
 	return settings
 }

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -70,9 +70,10 @@ func testUserStoreSave(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 	maxUsersPerTeam := 50
 
-	u1 := model.User{}
-	u1.Email = MakeEmail()
-	u1.Username = model.NewId()
+	u1 := model.User{
+		Email:    MakeEmail(),
+		Username: model.NewId(),
+	}
 
 	if err := (<-ss.User().Save(&u1)).Err; err != nil {
 		t.Fatal("couldn't save user", err)
@@ -85,41 +86,45 @@ func testUserStoreSave(t *testing.T, ss store.Store) {
 		t.Fatal("shouldn't be able to update user from save")
 	}
 
-	u1.Id = ""
-	if err := (<-ss.User().Save(&u1)).Err; err == nil {
+	u2 := model.User{
+		Email:    u1.Email,
+		Username: model.NewId(),
+	}
+	if err := (<-ss.User().Save(&u2)).Err; err == nil {
 		t.Fatal("should be unique email")
 	}
 
-	u1.Email = ""
+	u2.Email = MakeEmail()
+	u2.Username = u1.Username
 	if err := (<-ss.User().Save(&u1)).Err; err == nil {
 		t.Fatal("should be unique username")
 	}
 
-	u1.Email = strings.Repeat("0123456789", 20)
-	u1.Username = ""
+	u2.Username = ""
 	if err := (<-ss.User().Save(&u1)).Err; err == nil {
 		t.Fatal("should be unique username")
 	}
 
 	for i := 0; i < 49; i++ {
-		u1.Id = ""
-		u1.Email = MakeEmail()
-		u1.Username = model.NewId()
-		if err := (<-ss.User().Save(&u1)).Err; err != nil {
+		u := model.User{
+			Email:    MakeEmail(),
+			Username: model.NewId(),
+		}
+		if err := (<-ss.User().Save(&u)).Err; err != nil {
 			t.Fatal("couldn't save item", err)
 		}
-		defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+		defer func() { store.Must(ss.User().PermanentDelete(u.Id)) }()
 
-		store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, maxUsersPerTeam))
+		store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u.Id}, maxUsersPerTeam))
 	}
 
-	u1.Id = ""
-	u1.Email = MakeEmail()
-	u1.Username = model.NewId()
-	if err := (<-ss.User().Save(&u1)).Err; err != nil {
+	u2.Id = ""
+	u2.Email = MakeEmail()
+	u2.Username = model.NewId()
+	if err := (<-ss.User().Save(&u2)).Err; err != nil {
 		t.Fatal("couldn't save item", err)
 	}
-	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 
 	if err := (<-ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, maxUsersPerTeam)).Err; err == nil {
 		t.Fatal("should be the limit")
@@ -127,15 +132,17 @@ func testUserStoreSave(t *testing.T, ss store.Store) {
 }
 
 func testUserStoreUpdate(t *testing.T, ss store.Store) {
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
+	u1 := &model.User{
+		Email: MakeEmail(),
+	}
 	store.Must(ss.User().Save(u1))
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	u2.AuthService = "ldap"
+	u2 := &model.User{
+		Email:       MakeEmail(),
+		AuthService: "ldap",
+	}
 	store.Must(ss.User().Save(u2))
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u2.Id}, -1))
@@ -146,14 +153,16 @@ func testUserStoreUpdate(t *testing.T, ss store.Store) {
 		t.Fatal(err)
 	}
 
-	u1.Id = "missing"
-	if err := (<-ss.User().Update(u1, false)).Err; err == nil {
+	missing := &model.User{}
+	if err := (<-ss.User().Update(missing, false)).Err; err == nil {
 		t.Fatal("Update should have failed because of missing key")
 	}
 
-	u1.Id = model.NewId()
-	if err := (<-ss.User().Update(u1, false)).Err; err == nil {
-		t.Fatal("Update should have faile because id change")
+	newId := &model.User{
+		Id: model.NewId(),
+	}
+	if err := (<-ss.User().Update(newId, false)).Err; err == nil {
+		t.Fatal("Update should have failed because id change")
 	}
 
 	u2.Email = MakeEmail()
@@ -161,10 +170,11 @@ func testUserStoreUpdate(t *testing.T, ss store.Store) {
 		t.Fatal("Update should have failed because you can't modify AD/LDAP fields")
 	}
 
-	u3 := &model.User{}
-	u3.Email = MakeEmail()
+	u3 := &model.User{
+		Email:       MakeEmail(),
+		AuthService: "gitlab",
+	}
 	oldEmail := u3.Email
-	u3.AuthService = "gitlab"
 	store.Must(ss.User().Save(u3))
 	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u3.Id}, -1))
@@ -239,23 +249,39 @@ func testUserStoreUpdateFailedPasswordAttempts(t *testing.T, ss store.Store) {
 }
 
 func testUserStoreGet(t *testing.T, ss store.Store) {
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
+	u1 := &model.User{
+		Email: MakeEmail(),
+	}
 	store.Must(ss.User().Save(u1))
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1))
 
-	if r1 := <-ss.User().Get(u1.Id); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		if r1.Data.(*model.User).ToJson() != u1.ToJson() {
-			t.Fatal("invalid returned user")
-		}
-	}
+	t.Run("fetch empty id", func(t *testing.T) {
+		require.NotNil(t, (<-ss.User().Get("")).Err)
+	})
 
-	if err := (<-ss.User().Get("")).Err; err == nil {
-		t.Fatal("Missing id should have failed")
-	}
+	t.Run("fetch user 1", func(t *testing.T) {
+		result := <-ss.User().Get(u1.Id)
+		require.Nil(t, result.Err)
+
+		actual := result.Data.(*model.User)
+		require.Equal(t, u1, actual)
+	})
+
+	t.Run("fetch user 2", func(t *testing.T) {
+		result := <-ss.User().Get(u2.Id)
+		require.Nil(t, result.Err)
+
+		actual := result.Data.(*model.User)
+		require.Equal(t, u2, actual)
+	})
 }
 
 func testUserCount(t *testing.T, ss store.Store) {
@@ -274,545 +300,648 @@ func testUserCount(t *testing.T, ss store.Store) {
 }
 
 func testGetAllUsingAuthService(t *testing.T, ss store.Store) {
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	u1.AuthService = "someservice"
-	store.Must(ss.User().Save(u1))
+	teamId := model.NewId()
+
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:       MakeEmail(),
+		Username:    "u1" + model.NewId(),
+		AuthService: "service",
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	u2.AuthService = "someservice"
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:       MakeEmail(),
+		Username:    "u2" + model.NewId(),
+		AuthService: "service",
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	if r1 := <-ss.User().GetAllUsingAuthService(u1.AuthService); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) < 2 {
-			t.Fatal("invalid returned users")
-		}
-	}
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:       MakeEmail(),
+		Username:    "u3" + model.NewId(),
+		AuthService: "service2",
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+
+	t.Run("get by unknown auth service", func(t *testing.T) {
+		result := <-ss.User().GetAllUsingAuthService("unknown")
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{}, result.Data.([]*model.User))
+	})
+
+	t.Run("get by auth service", func(t *testing.T) {
+		result := <-ss.User().GetAllUsingAuthService("service")
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{u1, u2}, result.Data.([]*model.User))
+	})
+
+	t.Run("get by other auth service", func(t *testing.T) {
+		result := <-ss.User().GetAllUsingAuthService("service2")
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{u3}, result.Data.([]*model.User))
+	})
+}
+
+func sanitized(user *model.User) *model.User {
+	clonedUser := model.UserFromJson(strings.NewReader(user.ToJson()))
+	clonedUser.AuthData = new(string)
+	*clonedUser.AuthData = ""
+	clonedUser.Props = model.StringMap{}
+
+	return clonedUser
 }
 
 func testUserStoreGetAllProfiles(t *testing.T, ss store.Store) {
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 
-	options := &model.UserGetOptions{Page: 0, PerPage: 100}
-
-	if r1 := <-ss.User().GetAllProfiles(options); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) < 2 {
-			t.Fatal("invalid returned users")
-		}
-	}
-
-	options = &model.UserGetOptions{Page: 0, PerPage: 1}
-	if r2 := <-ss.User().GetAllProfiles(options); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		users := r2.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users, limit did not work")
-		}
-	}
-
-	if r2 := <-ss.User().GetAll(); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		users := r2.Data.([]*model.User)
-		if len(users) < 2 {
-			t.Fatal("invalid returned users")
-		}
-	}
-
-	etag := ""
-	if r2 := <-ss.User().GetEtagForAllProfiles(); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		etag = r2.Data.(string)
-	}
-
-	u3 := &model.User{}
-	u3.Email = MakeEmail()
-	u3.Roles = "system_user some-other-role"
-	store.Must(ss.User().Save(u3))
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
 
-	if r2 := <-ss.User().GetEtagForAllProfiles(); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if etag == r2.Data.(string) {
-			t.Fatal("etags should not match")
-		}
-	}
-
-	u4 := &model.User{}
-	u4.Email = MakeEmail()
-	u4.Roles = "system_admin some-other-role"
-	store.Must(ss.User().Save(u4))
+	u4 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u4" + model.NewId(),
+		Roles:    "system_user some-other-role",
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u4.Id)) }()
 
-	u5 := &model.User{}
-	u5.Email = MakeEmail()
-	u5.Roles = "system_admin"
-	store.Must(ss.User().Save(u5))
+	u5 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u5" + model.NewId(),
+		Roles:    "system_admin",
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u5.Id)) }()
 
-	options = &model.UserGetOptions{Page: 0, PerPage: 10, Role: "system_admin"}
-	if r2 := <-ss.User().GetAllProfiles(options); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		users := r2.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users, role filter did not work")
-		}
-		assert.ElementsMatch(t, []string{u4.Id, u5.Id}, []string{users[0].Id, users[1].Id})
-	}
-
-	u6 := &model.User{}
-	u6.Email = MakeEmail()
-	u6.DeleteAt = model.GetMillis()
-	u6.Roles = "system_admin"
-	store.Must(ss.User().Save(u6))
+	u6 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u6" + model.NewId(),
+		DeleteAt: model.GetMillis(),
+		Roles:    "system_admin",
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u6.Id)) }()
 
-	u7 := &model.User{}
-	u7.Email = MakeEmail()
-	u7.DeleteAt = model.GetMillis()
-	store.Must(ss.User().Save(u7))
+	u7 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u7" + model.NewId(),
+		DeleteAt: model.GetMillis(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u7.Id)) }()
 
-	options = &model.UserGetOptions{Page: 0, PerPage: 10, Role: "system_admin", Inactive: true}
-	if r2 := <-ss.User().GetAllProfiles(options); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		users := r2.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users, Role and Inactive filter did not work")
-		}
-		assert.Equal(t, u6.Id, users[0].Id)
-	}
+	t.Run("get offset 0, limit 100", func(t *testing.T) {
+		options := &model.UserGetOptions{Page: 0, PerPage: 100}
+		result := <-ss.User().GetAllProfiles(options)
+		require.Nil(t, result.Err)
 
-	options = &model.UserGetOptions{Page: 0, PerPage: 10, Inactive: true}
-	if r2 := <-ss.User().GetAllProfiles(options); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		users := r2.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users, Inactive filter did not work")
-		}
-		assert.ElementsMatch(t, []string{u6.Id, u7.Id}, []string{users[0].Id, users[1].Id})
-	}
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u2),
+			sanitized(u3),
+			sanitized(u4),
+			sanitized(u5),
+			sanitized(u6),
+			sanitized(u7),
+		}, actual)
+	})
+
+	t.Run("get offset 0, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetAllProfiles(&model.UserGetOptions{
+			Page:    0,
+			PerPage: 1,
+		})
+		require.Nil(t, result.Err)
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u1),
+		}, actual)
+	})
+
+	t.Run("get all", func(t *testing.T) {
+		result := <-ss.User().GetAll()
+		require.Nil(t, result.Err)
+
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			u1,
+			u2,
+			u3,
+			u4,
+			u5,
+			u6,
+			u7,
+		}, actual)
+	})
+
+	t.Run("etag changes for all after user creation", func(t *testing.T) {
+		result := <-ss.User().GetEtagForAllProfiles()
+		require.Nil(t, result.Err)
+		etag := result.Data.(string)
+
+		uNew := &model.User{}
+		uNew.Email = MakeEmail()
+		store.Must(ss.User().Save(uNew))
+		defer func() { store.Must(ss.User().PermanentDelete(uNew.Id)) }()
+
+		result = <-ss.User().GetEtagForAllProfiles()
+		require.Nil(t, result.Err)
+		updatedEtag := result.Data.(string)
+
+		require.NotEqual(t, etag, updatedEtag)
+	})
+
+	t.Run("filter to system_admin role", func(t *testing.T) {
+		result := <-ss.User().GetAllProfiles(&model.UserGetOptions{
+			Page:    0,
+			PerPage: 10,
+			Role:    "system_admin",
+		})
+		require.Nil(t, result.Err)
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u5),
+			sanitized(u6),
+		}, actual)
+	})
+
+	t.Run("filter to system_admin role, inactive", func(t *testing.T) {
+		result := <-ss.User().GetAllProfiles(&model.UserGetOptions{
+			Page:     0,
+			PerPage:  10,
+			Role:     "system_admin",
+			Inactive: true,
+		})
+		require.Nil(t, result.Err)
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u6),
+		}, actual)
+	})
+
+	t.Run("filter to inactive", func(t *testing.T) {
+		result := <-ss.User().GetAllProfiles(&model.UserGetOptions{
+			Page:     0,
+			PerPage:  10,
+			Inactive: true,
+		})
+		require.Nil(t, result.Err)
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u6),
+			sanitized(u7),
+		}, actual)
+	})
 }
 
 func testUserStoreGetProfiles(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	options := &model.UserGetOptions{InTeamId: teamId, Page: 0, PerPage: 100}
-	if r1 := <-ss.User().GetProfiles(options); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
-
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
-
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	options = &model.UserGetOptions{InTeamId: "123", Page: 0, PerPage: 100}
-	if r2 := <-ss.User().GetProfiles(options); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.([]*model.User)) != 0 {
-			t.Fatal("should have returned empty map")
-		}
-	}
-
-	etag := ""
-	if r2 := <-ss.User().GetEtagForProfiles(teamId); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		etag = r2.Data.(string)
-	}
-
-	u3 := &model.User{}
-	u3.Email = MakeEmail()
-	store.Must(ss.User().Save(u3))
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
-	if r2 := <-ss.User().GetEtagForProfiles(teamId); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if etag == r2.Data.(string) {
-			t.Fatal("etags should not match")
-		}
-	}
-
-	u4 := &model.User{}
-	u4.Email = MakeEmail()
-	u4.Roles = "system_admin"
-	store.Must(ss.User().Save(u4))
+	u4 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u4" + model.NewId(),
+		Roles:    "system_admin",
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u4.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u4.Id}, -1))
 
-	u5 := &model.User{}
-	u5.Email = MakeEmail()
-	u5.DeleteAt = model.GetMillis()
-	store.Must(ss.User().Save(u5))
+	u5 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u5" + model.NewId(),
+		DeleteAt: model.GetMillis(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u5.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u5.Id}, -1))
 
-	options = &model.UserGetOptions{InTeamId: teamId, Page: 0, PerPage: 100}
-	if r1 := <-ss.User().GetProfiles(options); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 5 {
-			t.Fatal("invalid returned users")
-		}
-	}
+	t.Run("get page 0, perPage 100", func(t *testing.T) {
+		result := <-ss.User().GetProfiles(&model.UserGetOptions{
+			InTeamId: teamId,
+			Page:     0,
+			PerPage:  100,
+		})
+		require.Nil(t, result.Err)
 
-	options = &model.UserGetOptions{InTeamId: teamId, Role: "system_admin", Inactive: false, Page: 0, PerPage: 100}
-	if r1 := <-ss.User().GetProfiles(options); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users")
-		}
-		assert.Equal(t, u4.Id, users[0].Id)
-	}
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u2),
+			sanitized(u3),
+			sanitized(u4),
+			sanitized(u5),
+		}, actual)
+	})
 
-	options = &model.UserGetOptions{InTeamId: teamId, Inactive: true, Page: 0, PerPage: 100}
-	if r1 := <-ss.User().GetProfiles(options); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users")
-		}
-		assert.Equal(t, u5.Id, users[0].Id)
-	}
+	t.Run("get page 0, perPage 1", func(t *testing.T) {
+		result := <-ss.User().GetProfiles(&model.UserGetOptions{
+			InTeamId: teamId,
+			Page:     0,
+			PerPage:  1,
+		})
+		require.Nil(t, result.Err)
 
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{sanitized(u1)}, actual)
+	})
+
+	t.Run("get unknown team id", func(t *testing.T) {
+		result := <-ss.User().GetProfiles(&model.UserGetOptions{
+			InTeamId: "123",
+			Page:     0,
+			PerPage:  100,
+		})
+		require.Nil(t, result.Err)
+
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{}, actual)
+	})
+
+	t.Run("etag changes for all after user creation", func(t *testing.T) {
+		result := <-ss.User().GetEtagForProfiles(teamId)
+		require.Nil(t, result.Err)
+		etag := result.Data.(string)
+
+		uNew := &model.User{}
+		uNew.Email = MakeEmail()
+		store.Must(ss.User().Save(uNew))
+		defer func() { store.Must(ss.User().PermanentDelete(uNew.Id)) }()
+		store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: uNew.Id}, -1))
+
+		result = <-ss.User().GetEtagForProfiles(teamId)
+		require.Nil(t, result.Err)
+		updatedEtag := result.Data.(string)
+
+		require.NotEqual(t, etag, updatedEtag)
+	})
+
+	t.Run("filter to system_admin role", func(t *testing.T) {
+		result := <-ss.User().GetProfiles(&model.UserGetOptions{
+			InTeamId: teamId,
+			Page:     0,
+			PerPage:  10,
+			Role:     "system_admin",
+		})
+		require.Nil(t, result.Err)
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u4),
+		}, actual)
+	})
+
+	t.Run("filter to inactive", func(t *testing.T) {
+		result := <-ss.User().GetProfiles(&model.UserGetOptions{
+			InTeamId: teamId,
+			Page:     0,
+			PerPage:  10,
+			Inactive: true,
+		})
+		require.Nil(t, result.Err)
+		actual := result.Data.([]*model.User)
+		require.Equal(t, []*model.User{
+			sanitized(u5),
+		}, actual)
+	})
 }
 
 func testUserStoreGetProfilesInChannel(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	c1 := model.Channel{}
-	c1.TeamId = teamId
-	c1.DisplayName = "Profiles in channel"
-	c1.Name = "profiles-" + model.NewId()
-	c1.Type = model.CHANNEL_OPEN
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
-	c2 := model.Channel{}
-	c2.TeamId = teamId
-	c2.DisplayName = "Profiles in private"
-	c2.Name = "profiles-" + model.NewId()
-	c2.Type = model.CHANNEL_PRIVATE
+	c1 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in channel",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}, -1)).(*model.Channel)
 
-	store.Must(ss.Channel().Save(&c1, -1))
-	store.Must(ss.Channel().Save(&c2, -1))
+	c2 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in private",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_PRIVATE,
+	}, -1)).(*model.Channel)
 
-	m1 := model.ChannelMember{}
-	m1.ChannelId = c1.Id
-	m1.UserId = u1.Id
-	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m2 := model.ChannelMember{}
-	m2.ChannelId = c1.Id
-	m2.UserId = u2.Id
-	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u2.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m3 := model.ChannelMember{}
-	m3.ChannelId = c2.Id
-	m3.UserId = u1.Id
-	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u3.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	store.Must(ss.Channel().SaveMember(&m1))
-	store.Must(ss.Channel().SaveMember(&m2))
-	store.Must(ss.Channel().SaveMember(&m3))
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c2.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	if r1 := <-ss.User().GetProfilesInChannel(c1.Id, 0, 100); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
+	t.Run("get in channel 1, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetProfilesInChannel(c1.Id, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u1), sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+	})
 
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
+	t.Run("get in channel 1, offset 1, limit 2", func(t *testing.T) {
+		result := <-ss.User().GetProfilesInChannel(c1.Id, 1, 2)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+	})
 
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	if r2 := <-ss.User().GetProfilesInChannel(c2.Id, 0, 1); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.([]*model.User)) != 1 {
-			t.Fatal("should have returned only 1 user")
-		}
-	}
+	t.Run("get in channel 2, offset 0, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesInChannel(c2.Id, 0, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u1)}, result.Data.([]*model.User))
+	})
 }
 
 func testUserStoreGetProfilesInChannelByStatus(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	c1 := model.Channel{}
-	c1.TeamId = teamId
-	c1.DisplayName = "Profiles in channel"
-	c1.Name = "profiles-" + model.NewId()
-	c1.Type = model.CHANNEL_OPEN
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
-	c2 := model.Channel{}
-	c2.TeamId = teamId
-	c2.DisplayName = "Profiles in private"
-	c2.Name = "profiles-" + model.NewId()
-	c2.Type = model.CHANNEL_PRIVATE
+	c1 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in channel",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}, -1)).(*model.Channel)
 
-	store.Must(ss.Channel().Save(&c1, -1))
-	store.Must(ss.Channel().Save(&c2, -1))
+	c2 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in private",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_PRIVATE,
+	}, -1)).(*model.Channel)
 
-	m1 := model.ChannelMember{}
-	m1.ChannelId = c1.Id
-	m1.UserId = u1.Id
-	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m2 := model.ChannelMember{}
-	m2.ChannelId = c1.Id
-	m2.UserId = u2.Id
-	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u2.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m3 := model.ChannelMember{}
-	m3.ChannelId = c2.Id
-	m3.UserId = u1.Id
-	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u3.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	store.Must(ss.Channel().SaveMember(&m1))
-	store.Must(ss.Channel().SaveMember(&m2))
-	store.Must(ss.Channel().SaveMember(&m3))
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c2.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	if r1 := <-ss.User().GetProfilesInChannelByStatus(c1.Id, 0, 100); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
+	store.Must(ss.Status().SaveOrUpdate(&model.Status{
+		UserId: u1.Id,
+		Status: model.STATUS_DND,
+	}))
+	store.Must(ss.Status().SaveOrUpdate(&model.Status{
+		UserId: u2.Id,
+		Status: model.STATUS_AWAY,
+	}))
+	store.Must(ss.Status().SaveOrUpdate(&model.Status{
+		UserId: u3.Id,
+		Status: model.STATUS_ONLINE,
+	}))
 
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
+	t.Run("get in channel 1 by status, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetProfilesInChannelByStatus(c1.Id, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u3), sanitized(u2), sanitized(u1)}, result.Data.([]*model.User))
+	})
 
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	if r2 := <-ss.User().GetProfilesInChannelByStatus(c2.Id, 0, 1); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.([]*model.User)) != 1 {
-			t.Fatal("should have returned only 1 user")
-		}
-	}
+	t.Run("get in channel 2 by status, offset 0, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesInChannelByStatus(c2.Id, 0, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u1)}, result.Data.([]*model.User))
+	})
 }
 
 func testUserStoreGetProfilesWithoutTeam(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	// These usernames need to appear in the first 100 users for this to work
-
-	u1 := &model.User{}
-	u1.Username = "a000000000" + model.NewId()
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
-	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Username = "a000000001" + model.NewId()
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 
-	if r1 := <-ss.User().GetProfilesWithoutTeam(0, 100); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
 
-		found1 := false
-		found2 := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found1 = true
-			} else if u.Id == u2.Id {
-				found2 = true
-			}
-		}
+	t.Run("get, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetProfilesWithoutTeam(0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+	})
 
-		if found1 {
-			t.Fatal("shouldn't have returned user on team")
-		} else if !found2 {
-			t.Fatal("should've returned user without any teams")
-		}
-	}
+	t.Run("get, offset 1, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesWithoutTeam(1, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u3)}, result.Data.([]*model.User))
+	})
+
+	t.Run("get, offset 2, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesWithoutTeam(2, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{}, result.Data.([]*model.User))
+	})
 }
 
 func testUserStoreGetAllProfilesInChannel(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	c1 := model.Channel{}
-	c1.TeamId = teamId
-	c1.DisplayName = "Profiles in channel"
-	c1.Name = "profiles-" + model.NewId()
-	c1.Type = model.CHANNEL_OPEN
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
-	c2 := model.Channel{}
-	c2.TeamId = teamId
-	c2.DisplayName = "Profiles in private"
-	c2.Name = "profiles-" + model.NewId()
-	c2.Type = model.CHANNEL_PRIVATE
+	c1 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in channel",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}, -1)).(*model.Channel)
 
-	store.Must(ss.Channel().Save(&c1, -1))
-	store.Must(ss.Channel().Save(&c2, -1))
+	c2 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in private",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_PRIVATE,
+	}, -1)).(*model.Channel)
 
-	m1 := model.ChannelMember{}
-	m1.ChannelId = c1.Id
-	m1.UserId = u1.Id
-	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m2 := model.ChannelMember{}
-	m2.ChannelId = c1.Id
-	m2.UserId = u2.Id
-	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u2.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m3 := model.ChannelMember{}
-	m3.ChannelId = c2.Id
-	m3.UserId = u1.Id
-	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u3.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	store.Must(ss.Channel().SaveMember(&m1))
-	store.Must(ss.Channel().SaveMember(&m2))
-	store.Must(ss.Channel().SaveMember(&m3))
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c2.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	if r1 := <-ss.User().GetAllProfilesInChannel(c1.Id, false); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.(map[string]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
+	t.Run("all profiles in channel 1, no caching", func(t *testing.T) {
+		result := <-ss.User().GetAllProfilesInChannel(c1.Id, false)
+		require.Nil(t, result.Err)
+		assert.Equal(t, map[string]*model.User{
+			u1.Id: sanitized(u1),
+			u2.Id: sanitized(u2),
+			u3.Id: sanitized(u3),
+		}, result.Data.(map[string]*model.User))
+	})
 
-		if users[u1.Id].Id != u1.Id {
-			t.Fatal("invalid returned user")
-		}
-	}
+	t.Run("all profiles in channel 2, no caching", func(t *testing.T) {
+		result := <-ss.User().GetAllProfilesInChannel(c2.Id, false)
+		require.Nil(t, result.Err)
+		assert.Equal(t, map[string]*model.User{
+			u1.Id: sanitized(u1),
+		}, result.Data.(map[string]*model.User))
+	})
 
-	if r2 := <-ss.User().GetAllProfilesInChannel(c2.Id, false); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.(map[string]*model.User)) != 1 {
-			t.Fatal("should have returned empty map")
-		}
-	}
+	t.Run("all profiles in channel 2, caching", func(t *testing.T) {
+		result := <-ss.User().GetAllProfilesInChannel(c2.Id, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, map[string]*model.User{
+			u1.Id: sanitized(u1),
+		}, result.Data.(map[string]*model.User))
+	})
 
-	if r2 := <-ss.User().GetAllProfilesInChannel(c2.Id, true); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.(map[string]*model.User)) != 1 {
-			t.Fatal("should have returned empty map")
-		}
-	}
-
-	if r2 := <-ss.User().GetAllProfilesInChannel(c2.Id, true); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.(map[string]*model.User)) != 1 {
-			t.Fatal("should have returned empty map")
-		}
-	}
+	t.Run("all profiles in channel 2, caching [repeated]", func(t *testing.T) {
+		result := <-ss.User().GetAllProfilesInChannel(c2.Id, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, map[string]*model.User{
+			u1.Id: sanitized(u1),
+		}, result.Data.(map[string]*model.User))
+	})
 
 	ss.User().InvalidateProfilesInChannelCacheByUser(u1.Id)
 	ss.User().InvalidateProfilesInChannelCache(c2.Id)
@@ -821,459 +950,495 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, ss store.Store) {
 func testUserStoreGetProfilesNotInChannel(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	c1 := model.Channel{}
-	c1.TeamId = teamId
-	c1.DisplayName = "Profiles in channel"
-	c1.Name = "profiles-" + model.NewId()
-	c1.Type = model.CHANNEL_OPEN
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
-	c2 := model.Channel{}
-	c2.TeamId = teamId
-	c2.DisplayName = "Profiles in private"
-	c2.Name = "profiles-" + model.NewId()
-	c2.Type = model.CHANNEL_PRIVATE
+	c1 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in channel",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}, -1)).(*model.Channel)
 
-	store.Must(ss.Channel().Save(&c1, -1))
-	store.Must(ss.Channel().Save(&c2, -1))
+	c2 := store.Must(ss.Channel().Save(&model.Channel{
+		TeamId:      teamId,
+		DisplayName: "Profiles in private",
+		Name:        "profiles-" + model.NewId(),
+		Type:        model.CHANNEL_PRIVATE,
+	}, -1)).(*model.Channel)
 
-	if r1 := <-ss.User().GetProfilesNotInChannel(teamId, c1.Id, 0, 100); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
+	t.Run("get team 1, channel 1, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInChannel(teamId, c1.Id, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u2),
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
+	t.Run("get team 1, channel 2, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInChannel(teamId, c2.Id, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u2),
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	if r2 := <-ss.User().GetProfilesNotInChannel(teamId, c2.Id, 0, 100); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.([]*model.User)) != 2 {
-			t.Fatal("invalid returned users")
-		}
-	}
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u2.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m1 := model.ChannelMember{}
-	m1.ChannelId = c1.Id
-	m1.UserId = u1.Id
-	m1.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c1.Id,
+		UserId:      u3.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m2 := model.ChannelMember{}
-	m2.ChannelId = c1.Id
-	m2.UserId = u2.Id
-	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
+	store.Must(ss.Channel().SaveMember(&model.ChannelMember{
+		ChannelId:   c2.Id,
+		UserId:      u1.Id,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}))
 
-	m3 := model.ChannelMember{}
-	m3.ChannelId = c2.Id
-	m3.UserId = u1.Id
-	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
+	t.Run("get team 1, channel 1, offset 0, limit 100, after update", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInChannel(teamId, c1.Id, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{}, result.Data.([]*model.User))
+	})
 
-	store.Must(ss.Channel().SaveMember(&m1))
-	store.Must(ss.Channel().SaveMember(&m2))
-	store.Must(ss.Channel().SaveMember(&m3))
-
-	if r1 := <-ss.User().GetProfilesNotInChannel(teamId, c1.Id, 0, 100); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 0 {
-			t.Fatal("invalid returned users")
-		}
-	}
-
-	if r2 := <-ss.User().GetProfilesNotInChannel(teamId, c2.Id, 0, 100); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.([]*model.User)) != 1 {
-			t.Fatal("should have had 1 user not in channel")
-		}
-	}
+	t.Run("get team 1, channel 2, offset 0, limit 100, after update", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInChannel(teamId, c2.Id, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u2),
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 }
 
 func testUserStoreGetProfilesByIds(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	if r1 := <-ss.User().GetProfileByIds([]string{u1.Id}, false); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users")
-		}
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
+	t.Run("get u1 by id, no caching", func(t *testing.T) {
+		result := <-ss.User().GetProfileByIds([]string{u1.Id}, false)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u1)}, result.Data.([]*model.User))
+	})
 
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
+	t.Run("get u1 by id, caching", func(t *testing.T) {
+		result := <-ss.User().GetProfileByIds([]string{u1.Id}, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u1)}, result.Data.([]*model.User))
+	})
 
-	if r1 := <-ss.User().GetProfileByIds([]string{u1.Id}, true); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users")
-		}
+	t.Run("get u1, u2, u3 by id, no caching", func(t *testing.T) {
+		result := <-ss.User().GetProfileByIds([]string{u1.Id, u2.Id, u3.Id}, false)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u1), sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+	})
 
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
+	t.Run("get u1, u2, u3 by id, caching", func(t *testing.T) {
+		result := <-ss.User().GetProfileByIds([]string{u1.Id, u2.Id, u3.Id}, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{sanitized(u1), sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+	})
 
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	if r1 := <-ss.User().GetProfileByIds([]string{u1.Id, u2.Id}, true); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
-
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
-
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	if r1 := <-ss.User().GetProfileByIds([]string{u1.Id, u2.Id}, true); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
-
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
-
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	if r1 := <-ss.User().GetProfileByIds([]string{u1.Id, u2.Id}, false); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
-
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
-
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	if r1 := <-ss.User().GetProfileByIds([]string{u1.Id}, false); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users")
-		}
-
-		found := false
-		for _, u := range users {
-			if u.Id == u1.Id {
-				found = true
-			}
-		}
-
-		if !found {
-			t.Fatal("missing user")
-		}
-	}
-
-	options := &model.UserGetOptions{InTeamId: "123", Page: 0, PerPage: 100}
-	if r2 := <-ss.User().GetProfiles(options); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		if len(r2.Data.([]*model.User)) != 0 {
-			t.Fatal("should have returned empty array")
-		}
-	}
+	t.Run("get unknown id, caching", func(t *testing.T) {
+		result := <-ss.User().GetProfileByIds([]string{"123"}, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{}, result.Data.([]*model.User))
+	})
 }
 
 func testUserStoreGetProfilesByUsernames(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
+	team2Id := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	u1.Username = "username1" + model.NewId()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	u2.Username = "username2" + model.NewId()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	if r1 := <-ss.User().GetProfilesByUsernames([]string{u1.Username, u2.Username}, teamId); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
-
-		if users[0].Id != u1.Id && users[1].Id != u1.Id {
-			t.Fatal("invalid returned user 1")
-		}
-
-		if users[0].Id != u2.Id && users[1].Id != u2.Id {
-			t.Fatal("invalid returned user 2")
-		}
-	}
-
-	if r1 := <-ss.User().GetProfilesByUsernames([]string{u1.Username}, teamId); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users")
-		}
-
-		if users[0].Id != u1.Id {
-			t.Fatal("invalid returned user")
-		}
-	}
-
-	team2Id := model.NewId()
-
-	u3 := &model.User{}
-	u3.Email = MakeEmail()
-	u3.Username = "username3" + model.NewId()
-	store.Must(ss.User().Save(u3))
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: team2Id, UserId: u3.Id}, -1))
 
-	if r1 := <-ss.User().GetProfilesByUsernames([]string{u1.Username, u3.Username}, ""); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 2 {
-			t.Fatal("invalid returned users")
-		}
+	t.Run("get by u1 and u2 usernames, team id 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesByUsernames([]string{u1.Username, u2.Username}, teamId)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{u1, u2}, result.Data.([]*model.User))
+	})
 
-		if users[0].Id != u1.Id && users[1].Id != u1.Id {
-			t.Fatal("invalid returned user 1")
-		}
+	t.Run("get by u1 username, team id 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesByUsernames([]string{u1.Username}, teamId)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{u1}, result.Data.([]*model.User))
+	})
 
-		if users[0].Id != u3.Id && users[1].Id != u3.Id {
-			t.Fatal("invalid returned user 3")
-		}
-	}
+	t.Run("get by u1 and u3 usernames, no team id", func(t *testing.T) {
+		result := <-ss.User().GetProfilesByUsernames([]string{u1.Username, u3.Username}, "")
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{u1, u3}, result.Data.([]*model.User))
+	})
 
-	if r1 := <-ss.User().GetProfilesByUsernames([]string{u1.Username, u3.Username}, teamId); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		if len(users) != 1 {
-			t.Fatal("invalid returned users")
-		}
+	t.Run("get by u1 and u3 usernames, team id 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesByUsernames([]string{u1.Username, u3.Username}, teamId)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{u1}, result.Data.([]*model.User))
+	})
 
-		if users[0].Id != u1.Id {
-			t.Fatal("invalid returned user")
-		}
-	}
+	t.Run("get by u1 and u3 usernames, team id 2", func(t *testing.T) {
+		result := <-ss.User().GetProfilesByUsernames([]string{u1.Username, u3.Username}, team2Id)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{u3}, result.Data.([]*model.User))
+	})
 }
 
 func testUserStoreGetSystemAdminProfiles(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	u1.Roles = model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Roles:    model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID,
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	if r1 := <-ss.User().GetSystemAdminProfiles(); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.(map[string]*model.User)
-		if len(users) <= 0 {
-			t.Fatal("invalid returned system admin users")
-		}
-	}
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Roles:    model.SYSTEM_USER_ROLE_ID + " " + model.SYSTEM_ADMIN_ROLE_ID,
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
+
+	t.Run("all system admin profiles", func(t *testing.T) {
+		result := <-ss.User().GetSystemAdminProfiles()
+		require.Nil(t, result.Err)
+		assert.Equal(t, map[string]*model.User{
+			u1.Id: sanitized(u1),
+			u3.Id: sanitized(u3),
+		}, result.Data.(map[string]*model.User))
+	})
 }
 
 func testUserStoreGetByEmail(t *testing.T, ss store.Store) {
-	teamid := model.NewId()
+	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
-	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamid, UserId: u1.Id}, -1))
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	if err := (<-ss.User().GetByEmail(u1.Email)).Err; err != nil {
-		t.Fatal(err)
-	}
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	if err := (<-ss.User().GetByEmail("")).Err; err == nil {
-		t.Fatal("Should have failed because of missing email")
-	}
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
+
+	t.Run("get u1 by email", func(t *testing.T) {
+		result := <-ss.User().GetByEmail(u1.Email)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u1, result.Data.(*model.User))
+	})
+
+	t.Run("get u2 by email", func(t *testing.T) {
+		result := <-ss.User().GetByEmail(u2.Email)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u2, result.Data.(*model.User))
+	})
+
+	t.Run("get u3 by email", func(t *testing.T) {
+		result := <-ss.User().GetByEmail(u3.Email)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u3, result.Data.(*model.User))
+	})
+
+	t.Run("get by empty email", func(t *testing.T) {
+		result := <-ss.User().GetByEmail("")
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, store.MISSING_ACCOUNT_ERROR)
+	})
+
+	t.Run("get by unknown", func(t *testing.T) {
+		result := <-ss.User().GetByEmail("unknown")
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, store.MISSING_ACCOUNT_ERROR)
+	})
 }
 
 func testUserStoreGetByAuthData(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
+	auth1 := model.NewId()
+	auth3 := model.NewId()
 
-	auth := "123" + model.NewId()
-
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	u1.AuthData = &auth
-	u1.AuthService = "service"
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:       MakeEmail(),
+		Username:    "u1" + model.NewId(),
+		AuthData:    &auth1,
+		AuthService: "service",
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	if err := (<-ss.User().GetByAuth(u1.AuthData, u1.AuthService)).Err; err != nil {
-		t.Fatal(err)
-	}
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	rauth := ""
-	if err := (<-ss.User().GetByAuth(&rauth, "")).Err; err == nil {
-		t.Fatal("Should have failed because of missing auth data")
-	}
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:       MakeEmail(),
+		Username:    "u3" + model.NewId(),
+		AuthData:    &auth3,
+		AuthService: "service2",
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
+
+	t.Run("get by u1 auth", func(t *testing.T) {
+		result := <-ss.User().GetByAuth(u1.AuthData, u1.AuthService)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u1, result.Data.(*model.User))
+	})
+
+	t.Run("get by u3 auth", func(t *testing.T) {
+		result := <-ss.User().GetByAuth(u3.AuthData, u3.AuthService)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u3, result.Data.(*model.User))
+	})
+
+	t.Run("get by u1 auth, unknown service", func(t *testing.T) {
+		result := <-ss.User().GetByAuth(u1.AuthData, "unknown")
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, store.MISSING_AUTH_ACCOUNT_ERROR)
+	})
+
+	t.Run("get by unknown auth, u1 service", func(t *testing.T) {
+		unknownAuth := ""
+		result := <-ss.User().GetByAuth(&unknownAuth, u1.AuthService)
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, store.MISSING_AUTH_ACCOUNT_ERROR)
+	})
+
+	t.Run("get by unknown auth, unknown service", func(t *testing.T) {
+		unknownAuth := ""
+		result := <-ss.User().GetByAuth(&unknownAuth, "unknown")
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, store.MISSING_AUTH_ACCOUNT_ERROR)
+	})
 }
 
 func testUserStoreGetByUsername(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	u1.Username = model.NewId()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	if err := (<-ss.User().GetByUsername(u1.Username)).Err; err != nil {
-		t.Fatal(err)
-	}
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	if err := (<-ss.User().GetByUsername("")).Err; err == nil {
-		t.Fatal("Should have failed because of missing username")
-	}
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
+
+	t.Run("get u1 by username", func(t *testing.T) {
+		result := <-ss.User().GetByUsername(u1.Username)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u1, result.Data.(*model.User))
+	})
+
+	t.Run("get u2 by username", func(t *testing.T) {
+		result := <-ss.User().GetByUsername(u2.Username)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u2, result.Data.(*model.User))
+	})
+
+	t.Run("get u3 by username", func(t *testing.T) {
+		result := <-ss.User().GetByUsername(u3.Username)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u3, result.Data.(*model.User))
+	})
+
+	t.Run("get by empty username", func(t *testing.T) {
+		result := <-ss.User().GetByUsername("")
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, "store.sql_user.get_by_username.app_error")
+	})
+
+	t.Run("get by unknown", func(t *testing.T) {
+		result := <-ss.User().GetByUsername("unknown")
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, "store.sql_user.get_by_username.app_error")
+	})
 }
 
 func testUserStoreGetForLogin(t *testing.T, ss store.Store) {
+	teamId := model.NewId()
 	auth := model.NewId()
+	auth2 := model.NewId()
+	auth3 := model.NewId()
 
-	u1 := &model.User{
+	u1 := store.Must(ss.User().Save(&model.User{
 		Email:       MakeEmail(),
-		Username:    model.NewId(),
+		Username:    "u1" + model.NewId(),
 		AuthService: model.USER_AUTH_SERVICE_GITLAB,
 		AuthData:    &auth,
-	}
-	store.Must(ss.User().Save(u1))
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
 
-	auth2 := model.NewId()
-
-	u2 := &model.User{
+	u2 := store.Must(ss.User().Save(&model.User{
 		Email:       MakeEmail(),
-		Username:    model.NewId(),
+		Username:    "u2" + model.NewId(),
 		AuthService: model.USER_AUTH_SERVICE_LDAP,
 		AuthData:    &auth2,
-	}
-	store.Must(ss.User().Save(u2))
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
 
-	if result := <-ss.User().GetForLogin(u1.Username, true, true); result.Err != nil {
-		t.Fatal("Should have gotten user by username", result.Err)
-	} else if result.Data.(*model.User).Id != u1.Id {
-		t.Fatal("Should have gotten user1 by username")
-	}
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:       MakeEmail(),
+		Username:    "u3" + model.NewId(),
+		AuthService: model.USER_AUTH_SERVICE_LDAP,
+		AuthData:    &auth3,
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
 
-	if result := <-ss.User().GetForLogin(u1.Email, true, true); result.Err != nil {
-		t.Fatal("Should have gotten user by email", result.Err)
-	} else if result.Data.(*model.User).Id != u1.Id {
-		t.Fatal("Should have gotten user1 by email")
-	}
+	t.Run("get u1 by username, allow both", func(t *testing.T) {
+		result := <-ss.User().GetForLogin(u1.Username, true, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u1, result.Data.(*model.User))
+	})
 
-	// prevent getting user when different login methods are disabled
-	if result := <-ss.User().GetForLogin(u1.Username, false, true); result.Err == nil {
-		t.Fatal("Should have failed to get user1 by username")
-	}
+	t.Run("get u1 by username, allow only email", func(t *testing.T) {
+		result := <-ss.User().GetForLogin(u1.Username, false, true)
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, "store.sql_user.get_for_login.app_error")
+	})
 
-	if result := <-ss.User().GetForLogin(u1.Email, true, false); result.Err == nil {
-		t.Fatal("Should have failed to get user1 by email")
-	}
+	t.Run("get u1 by email, allow both", func(t *testing.T) {
+		result := <-ss.User().GetForLogin(u1.Email, true, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u1, result.Data.(*model.User))
+	})
+
+	t.Run("get u1 by email, allow only username", func(t *testing.T) {
+		result := <-ss.User().GetForLogin(u1.Email, true, false)
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, "store.sql_user.get_for_login.app_error")
+	})
+
+	t.Run("get u2 by username, allow both", func(t *testing.T) {
+		result := <-ss.User().GetForLogin(u2.Username, true, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u2, result.Data.(*model.User))
+	})
+
+	t.Run("get u2 by email, allow both", func(t *testing.T) {
+		result := <-ss.User().GetForLogin(u2.Email, true, true)
+		require.Nil(t, result.Err)
+		assert.Equal(t, u2, result.Data.(*model.User))
+	})
+
+	t.Run("get u2 by username, allow neither", func(t *testing.T) {
+		result := <-ss.User().GetForLogin(u2.Username, false, false)
+		require.NotNil(t, result.Err)
+		require.Equal(t, result.Err.Id, "store.sql_user.get_for_login.app_error")
+	})
 }
 
 func testUserStoreUpdatePassword(t *testing.T, ss store.Store) {
@@ -1479,31 +1644,130 @@ func testUserStoreUpdateMfaActive(t *testing.T, ss store.Store) {
 }
 
 func testUserStoreGetRecentlyActiveUsersForTeam(t *testing.T, ss store.Store) {
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
-	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
-	store.Must(ss.Status().SaveOrUpdate(&model.Status{UserId: u1.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}))
-	tid := model.NewId()
-	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u1.Id}, -1))
+	teamId := model.NewId()
 
-	if r1 := <-ss.User().GetRecentlyActiveUsersForTeam(tid, 0, 100); r1.Err != nil {
-		t.Fatal(r1.Err)
-	}
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
+
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
+
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
+
+	millis := model.GetMillis()
+	u3.LastActivityAt = millis
+	u2.LastActivityAt = millis - 1
+	u1.LastActivityAt = millis - 1
+
+	store.Must(ss.Status().SaveOrUpdate(&model.Status{UserId: u1.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: u1.LastActivityAt, ActiveChannel: ""}))
+	store.Must(ss.Status().SaveOrUpdate(&model.Status{UserId: u2.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: u2.LastActivityAt, ActiveChannel: ""}))
+	store.Must(ss.Status().SaveOrUpdate(&model.Status{UserId: u3.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: u3.LastActivityAt, ActiveChannel: ""}))
+
+	t.Run("get team 1, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetRecentlyActiveUsersForTeam(teamId, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u3),
+			sanitized(u1),
+			sanitized(u2),
+		}, result.Data.([]*model.User))
+	})
+
+	t.Run("get team 1, offset 0, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetRecentlyActiveUsersForTeam(teamId, 0, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
+
+	t.Run("get team 1, offset 2, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetRecentlyActiveUsersForTeam(teamId, 2, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u2),
+		}, result.Data.([]*model.User))
+	})
 }
 
 func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
-	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
-	store.Must(ss.Status().SaveOrUpdate(&model.Status{UserId: u1.Id, Status: model.STATUS_ONLINE, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}))
-	tid := model.NewId()
-	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: tid, UserId: u1.Id}, -1))
+	teamId := model.NewId()
+	teamId2 := model.NewId()
 
-	if r1 := <-ss.User().GetNewUsersForTeam(tid, 0, 100); r1.Err != nil {
-		t.Fatal(r1.Err)
-	}
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
+
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
+
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
+
+	u4 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u4" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u4.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId2, UserId: u4.Id}, -1))
+
+	t.Run("get team 1, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetNewUsersForTeam(teamId, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u3),
+			sanitized(u2),
+			sanitized(u1),
+		}, result.Data.([]*model.User))
+	})
+
+	t.Run("get team 1, offset 0, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetNewUsersForTeam(teamId, 0, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
+
+	t.Run("get team 1, offset 2, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetNewUsersForTeam(teamId, 2, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u1),
+		}, result.Data.([]*model.User))
+	})
+
+	t.Run("get team 2, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetNewUsersForTeam(teamId2, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u4),
+		}, result.Data.([]*model.User))
+	})
 }
 
 func assertUsers(t *testing.T, expected, actual []*model.User) {
@@ -2558,137 +2822,134 @@ func testUserStoreAnalyticsGetSystemAdminCount(t *testing.T, ss store.Store) {
 
 func testUserStoreGetProfilesNotInTeam(t *testing.T, ss store.Store) {
 	teamId := model.NewId()
+	teamId2 := model.NewId()
 
-	u1 := &model.User{}
-	u1.Email = MakeEmail()
-	store.Must(ss.User().Save(u1))
+	u1 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u1" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u1.Id}, -1))
-	store.Must(ss.User().UpdateUpdateAt(u1.Id))
 
-	u2 := &model.User{}
-	u2.Email = MakeEmail()
-	store.Must(ss.User().Save(u2))
+	// Ensure update at timestamp changes
+	time.Sleep(time.Millisecond * 10)
+
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
-	store.Must(ss.User().UpdateUpdateAt(u2.Id))
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId2, UserId: u2.Id}, -1))
 
-	var initialUsersNotInTeam int
+	// Ensure update at timestamp changes
+	time.Sleep(time.Millisecond * 10)
+
+	u3 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u3" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
+
 	var etag1, etag2, etag3 string
 
-	if er1 := <-ss.User().GetEtagForProfilesNotInTeam(teamId); er1.Err != nil {
-		t.Fatal(er1.Err)
-	} else {
-		etag1 = er1.Data.(string)
-	}
+	t.Run("etag for profiles not in team 1", func(t *testing.T) {
+		result := <-ss.User().GetEtagForProfilesNotInTeam(teamId)
+		require.Nil(t, result.Err)
+		etag1 = result.Data.(string)
+	})
 
-	if r1 := <-ss.User().GetProfilesNotInTeam(teamId, 0, 100000); r1.Err != nil {
-		t.Fatal(r1.Err)
-	} else {
-		users := r1.Data.([]*model.User)
-		initialUsersNotInTeam = len(users)
-		if initialUsersNotInTeam < 1 {
-			t.Fatalf("Should be at least 1 user not in the team")
-		}
+	t.Run("get not in team 1, offset 0, limit 100000", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInTeam(teamId, 0, 100000)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u2),
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 
-		found := false
-		for _, u := range users {
-			if u.Id == u2.Id {
-				found = true
-			}
-			if u.Id == u1.Id {
-				t.Fatalf("Should not have found user1")
-			}
-		}
+	t.Run("get not in team 1, offset 1, limit 1", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInTeam(teamId, 1, 1)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 
-		if !found {
-			t.Fatal("missing user2")
-		}
-	}
+	t.Run("get not in team 2, offset 0, limit 100", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInTeam(teamId2, 0, 100)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 
+	// Ensure update at timestamp changes
 	time.Sleep(time.Millisecond * 10)
+
+	// Add u2 to team 1
 	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1))
-	store.Must(ss.User().UpdateUpdateAt(u2.Id))
+	u2.UpdateAt = store.Must(ss.User().UpdateUpdateAt(u2.Id)).(int64)
 
-	if er2 := <-ss.User().GetEtagForProfilesNotInTeam(teamId); er2.Err != nil {
-		t.Fatal(er2.Err)
-	} else {
-		etag2 = er2.Data.(string)
-		if etag1 == etag2 {
-			t.Fatalf("etag should have changed")
-		}
-	}
+	// GetEtagForProfilesNotInTeam only works if the most recent user is added to the team,
+	// otherwise the timestamp simply never changes: see https://mattermost.atlassian.net/browse/MM-13721.
+	t.Run("etag for profiles not in team 1 after update", func(t *testing.T) {
+		t.Skip()
+		result := <-ss.User().GetEtagForProfilesNotInTeam(teamId)
+		require.Nil(t, result.Err)
+		etag2 = result.Data.(string)
+		require.NotEqual(t, etag2, etag1, "etag should have changed")
+	})
 
-	if r2 := <-ss.User().GetProfilesNotInTeam(teamId, 0, 100000); r2.Err != nil {
-		t.Fatal(r2.Err)
-	} else {
-		users := r2.Data.([]*model.User)
+	t.Run("get not in team 1, offset 0, limit 100000 after update", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInTeam(teamId, 0, 100000)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 
-		if len(users) != initialUsersNotInTeam-1 {
-			t.Fatalf("Should be one less user not in team")
-		}
-
-		for _, u := range users {
-			if u.Id == u2.Id {
-				t.Fatalf("Should not have found user2")
-			}
-			if u.Id == u1.Id {
-				t.Fatalf("Should not have found user1")
-			}
-		}
-	}
-
+	// Ensure update at timestamp changes
 	time.Sleep(time.Millisecond * 10)
+
 	store.Must(ss.Team().RemoveMember(teamId, u1.Id))
 	store.Must(ss.Team().RemoveMember(teamId, u2.Id))
-	store.Must(ss.User().UpdateUpdateAt(u1.Id))
-	store.Must(ss.User().UpdateUpdateAt(u2.Id))
+	u1.UpdateAt = store.Must(ss.User().UpdateUpdateAt(u1.Id)).(int64)
+	u2.UpdateAt = store.Must(ss.User().UpdateUpdateAt(u2.Id)).(int64)
 
-	if er3 := <-ss.User().GetEtagForProfilesNotInTeam(teamId); er3.Err != nil {
-		t.Fatal(er3.Err)
-	} else {
-		etag3 = er3.Data.(string)
-		t.Log(etag3)
-		if etag1 == etag3 || etag3 == etag2 {
-			t.Fatalf("etag should have changed")
-		}
-	}
+	t.Run("etag for profiles not in team 1 after second update", func(t *testing.T) {
+		result := <-ss.User().GetEtagForProfilesNotInTeam(teamId)
+		require.Nil(t, result.Err)
+		etag3 = result.Data.(string)
+		require.NotEqual(t, etag1, etag3, "etag should have changed")
+		require.NotEqual(t, etag2, etag3, "etag should have changed")
+	})
 
-	if r3 := <-ss.User().GetProfilesNotInTeam(teamId, 0, 100000); r3.Err != nil {
-		t.Fatal(r3.Err)
-	} else {
-		users := r3.Data.([]*model.User)
-		found1, found2 := false, false
-		for _, u := range users {
-			if u.Id == u2.Id {
-				found2 = true
-			}
-			if u.Id == u1.Id {
-				found1 = true
-			}
-		}
+	t.Run("get not in team 1, offset 0, limit 100000 after second update", func(t *testing.T) {
+		result := <-ss.User().GetProfilesNotInTeam(teamId, 0, 100000)
+		require.Nil(t, result.Err)
+		assert.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u2),
+			sanitized(u3),
+		}, result.Data.([]*model.User))
+	})
 
-		if !found1 || !found2 {
-			t.Fatal("missing user1 or user2")
-		}
-	}
-
+	// Ensure update at timestamp changes
 	time.Sleep(time.Millisecond * 10)
-	u3 := &model.User{}
-	u3.Email = MakeEmail()
-	store.Must(ss.User().Save(u3))
-	defer func() { store.Must(ss.User().PermanentDelete(u3.Id)) }()
-	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u3.Id}, -1))
-	store.Must(ss.User().UpdateUpdateAt(u3.Id))
 
-	if er4 := <-ss.User().GetEtagForProfilesNotInTeam(teamId); er4.Err != nil {
-		t.Fatal(er4.Err)
-	} else {
-		etag4 := er4.Data.(string)
-		t.Log(etag4)
-		if etag4 != etag3 {
-			t.Fatalf("etag should be the same")
-		}
-	}
+	u4 := &model.User{}
+	u4.Email = MakeEmail()
+	store.Must(ss.User().Save(u4))
+	defer func() { store.Must(ss.User().PermanentDelete(u4.Id)) }()
+	store.Must(ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u4.Id}, -1))
+
+	t.Run("etag for profiles not in team 1 after addition to team", func(t *testing.T) {
+		result := <-ss.User().GetEtagForProfilesNotInTeam(teamId)
+		require.Nil(t, result.Err)
+		etag4 := result.Data.(string)
+		require.Equal(t, etag3, etag4, "etag should not have changed")
+	})
 }
 
 func testUserStoreClearAllCustomRoleAssignments(t *testing.T, ss store.Store) {
@@ -2742,35 +3003,45 @@ func testUserStoreClearAllCustomRoleAssignments(t *testing.T, ss store.Store) {
 }
 
 func testUserStoreGetAllAfter(t *testing.T, ss store.Store) {
-	u1 := model.User{
+	u1 := store.Must(ss.User().Save(&model.User{
 		Email:    MakeEmail(),
 		Username: model.NewId(),
 		Roles:    "system_user system_admin system_post_all",
-	}
-	store.Must(ss.User().Save(&u1))
+	})).(*model.User)
 	defer func() { store.Must(ss.User().PermanentDelete(u1.Id)) }()
 
-	r1 := <-ss.User().GetAllAfter(10000, strings.Repeat("0", 26))
-	require.Nil(t, r1.Err)
+	u2 := store.Must(ss.User().Save(&model.User{
+		Email:    MakeEmail(),
+		Username: "u2" + model.NewId(),
+	})).(*model.User)
+	defer func() { store.Must(ss.User().PermanentDelete(u2.Id)) }()
 
-	d1 := r1.Data.([]*model.User)
-
-	found := false
-	for _, u := range d1 {
-
-		if u.Id == u1.Id {
-			found = true
-			assert.Equal(t, u1.Id, u.Id)
-			assert.Equal(t, u1.Email, u.Email)
-		}
+	expected := []*model.User{u1, u2}
+	if strings.Compare(u2.Id, u1.Id) < 0 {
+		expected = []*model.User{u2, u1}
 	}
-	assert.True(t, found)
 
-	r2 := <-ss.User().GetAllAfter(10000, u1.Id)
-	require.Nil(t, r2.Err)
+	t.Run("get after lowest possible id", func(t *testing.T) {
+		result := <-ss.User().GetAllAfter(10000, strings.Repeat("0", 26))
+		require.Nil(t, result.Err)
 
-	d2 := r2.Data.([]*model.User)
-	for _, u := range d2 {
-		assert.NotEqual(t, u1.Id, u.Id)
-	}
+		actual := result.Data.([]*model.User)
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("get after first user", func(t *testing.T) {
+		result := <-ss.User().GetAllAfter(10000, expected[0].Id)
+		require.Nil(t, result.Err)
+
+		actual := result.Data.([]*model.User)
+		assert.Equal(t, []*model.User{expected[1]}, actual)
+	})
+
+	t.Run("get after second user", func(t *testing.T) {
+		result := <-ss.User().GetAllAfter(10000, expected[1].Id)
+		require.Nil(t, result.Err)
+
+		actual := result.Data.([]*model.User)
+		assert.Equal(t, []*model.User{}, actual)
+	})
 }


### PR DESCRIPTION
#### Summary
This PR introduces a `querybuilder` package to facilitate the construction of dynamic SQL. As noted in the documentation:
> Query builds dynamic SQL queries using a fluent and immutable interface. At its core, it is nothing more than SQL-aware string concatenation library. It is not an ORM.
> Unlike similar libraries, it doesn't integrate with database/sql directly, doesn't read and populate model structs, and generally doesn't try expose more of an API than needed. Feel free to pass in entire SQL statements as necessary, but realize that this library won't try to parse or validate the resulting SQL. Garbage in: garbage out.
> It doesn't current support INSERT, UPDATE or DELETE statements, but this would be a trivial addition.

I was originally planning on merging this as part of https://github.com/mattermost/mattermost-server/pull/10103 into the `bots` branch, but a recent refactor of the user store suggested I get this into `master` sooner to avoid further merge conflicts.

#### Ticket Link
Related to https://mattermost.atlassian.net/browse/MM-13120

#### Checklist
- [x] Added or updated unit tests (required for all new features)