### PR TITLE
[MM-13750] Add ability to search teams to plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -118,6 +118,10 @@ func (api *PluginAPI) GetTeam(teamId string) (*model.Team, *model.AppError) {
 	return api.app.GetTeam(teamId)
 }
 
+func (api *PluginAPI) SearchTeams(term string) ([]*model.Team, *model.AppError) {
+	return api.app.SearchAllTeams(term)
+}
+
 func (api *PluginAPI) GetTeamByName(name string) (*model.Team, *model.AppError) {
 	return api.app.GetTeamByName(name)
 }

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -721,3 +721,30 @@ func TestPluginAPISendMail(t *testing.T) {
 	require.Equal(t, resultsEmail.Body.Text, body)
 
 }
+
+func TestPluginAPI_SearchTeams(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	api := th.SetupPluginAPI()
+
+	t.Run("all fine", func(t *testing.T) {
+		teams, err := api.SearchTeams(th.BasicTeam.Name)
+		assert.Nil(t, err)
+		assert.Len(t, teams, 1)
+
+		teams, err = api.SearchTeams(th.BasicTeam.DisplayName)
+		assert.Nil(t, err)
+		assert.Len(t, teams, 1)
+
+		teams, err = api.SearchTeams(th.BasicTeam.Name[:3])
+		assert.Nil(t, err)
+		assert.Len(t, teams, 1)
+	})
+
+	t.Run("invalid team name", func(t *testing.T) {
+		teams, err := api.SearchTeams("not found")
+		assert.Nil(t, err)
+		assert.Empty(t, teams)
+	})
+}

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -145,6 +145,8 @@ type API interface {
 	UpdateTeam(team *model.Team) (*model.Team, *model.AppError)
 
 	// SearchTeams search a team.
+	//
+	// Minimum server version: 5.6
 	SearchTeams(term string) ([]*model.Team, *model.AppError)
 
 	// GetTeamsForUser returns list of teams of given user ID.

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -147,8 +147,6 @@ type API interface {
 	// SearchTeams search a team.
 	//
 	// Minimum server version: 5.6
-	//
-	// Minimum server version: 5.6
 	SearchTeams(term string) ([]*model.Team, *model.AppError)
 
 	// GetTeamsForUser returns list of teams of given user ID.

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -147,6 +147,8 @@ type API interface {
 	// SearchTeams search a team.
 	//
 	// Minimum server version: 5.6
+	//
+	// Minimum server version: 5.6
 	SearchTeams(term string) ([]*model.Team, *model.AppError)
 
 	// GetTeamsForUser returns list of teams of given user ID.

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -144,6 +144,9 @@ type API interface {
 	// UpdateTeam updates a team.
 	UpdateTeam(team *model.Team) (*model.Team, *model.AppError)
 
+	// SearchTeams search a team.
+	SearchTeams(term string) ([]*model.Team, *model.AppError)
+
 	// GetTeamsForUser returns list of teams of given user ID.
 	//
 	// Minimum server version: 5.6

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -146,7 +146,7 @@ type API interface {
 
 	// SearchTeams search a team.
 	//
-	// Minimum server version: 5.6
+	// Minimum server version: 5.8
 	SearchTeams(term string) ([]*model.Team, *model.AppError)
 
 	// GetTeamsForUser returns list of teams of given user ID.

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -1437,6 +1437,35 @@ func (s *apiRPCServer) UpdateTeam(args *Z_UpdateTeamArgs, returns *Z_UpdateTeamR
 	return nil
 }
 
+type Z_SearchTeamsArgs struct {
+	A string
+}
+
+type Z_SearchTeamsReturns struct {
+	A []*model.Team
+	B *model.AppError
+}
+
+func (g *apiRPCClient) SearchTeams(term string) ([]*model.Team, *model.AppError) {
+	_args := &Z_SearchTeamsArgs{term}
+	_returns := &Z_SearchTeamsReturns{}
+	if err := g.client.Call("Plugin.SearchTeams", _args, _returns); err != nil {
+		log.Printf("RPC call to SearchTeams API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) SearchTeams(args *Z_SearchTeamsArgs, returns *Z_SearchTeamsReturns) error {
+	if hook, ok := s.impl.(interface {
+		SearchTeams(term string) ([]*model.Team, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.SearchTeams(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API SearchTeams called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetTeamsForUserArgs struct {
 	A string
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1933,6 +1933,31 @@ func (_m *API) SearchChannels(teamId string, term string) ([]*model.Channel, *mo
 	return r0, r1
 }
 
+// SearchTeams provides a mock function with given fields: term
+func (_m *API) SearchTeams(term string) ([]*model.Team, *model.AppError) {
+	ret := _m.Called(term)
+
+	var r0 []*model.Team
+	if rf, ok := ret.Get(0).(func(string) []*model.Team); ok {
+		r0 = rf(term)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Team)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(term)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // SearchUsers provides a mock function with given fields: search
 func (_m *API) SearchUsers(search *model.UserSearch) ([]*model.User, *model.AppError) {
 	ret := _m.Called(search)


### PR DESCRIPTION
#### Summary
Add SearchTeams in plugin/api,

#### Ticket Link
[10100](https://github.com/mattermost/mattermost-server/issues/10100)

#### Checklist

- [x] Added or updated unit tests (required for all new features)
