### PR TITLE
MM-12375 added webhook show command

### DIFF
--- a/cmd/mattermost/commands/webhook.go
+++ b/cmd/mattermost/commands/webhook.go
@@ -25,6 +25,15 @@ var WebhookListCmd = &cobra.Command{
 	RunE:    listWebhookCmdF,
 }
 
+var WebhookShowCmd = &cobra.Command{
+	Use:     "show [webhookId]",
+	Short:   "Show a webhook",
+	Long:    "Show the webhook specified by [webhookId]",
+	Args:    cobra.ExactArgs(1),
+	Example: "  webhook show w16zb5tu3n1zkqo18goqry1je",
+	RunE:    showWebhookCmdF,
+}
+
 var WebhookCreateIncomingCmd = &cobra.Command{
 	Use:     "create-incoming",
 	Short:   "Create incoming webhook",
@@ -408,6 +417,26 @@ func deleteWebhookCmdF(command *cobra.Command, args []string) error {
 	return nil
 }
 
+func showWebhookCmdF(command *cobra.Command, args []string) error {
+	app, err := InitDBCommandContextCobra(command)
+	if err != nil {
+		return err
+	}
+	defer app.Shutdown()
+
+	webhookId := args[0]
+	if incomingWebhook, err := app.GetIncomingWebhook(webhookId); err == nil {
+		fmt.Printf("%s", prettyPrintStruct(*incomingWebhook))
+		return nil
+	}
+	if outgoingWebhook, err := app.GetOutgoingWebhook(webhookId); err == nil {
+		fmt.Printf("%s", prettyPrintStruct(*outgoingWebhook))
+		return nil
+	}
+
+	return errors.New("Webhook with id " + webhookId + " not found")
+}
+
 func init() {
 	WebhookCreateIncomingCmd.Flags().String("channel", "", "Channel ID (required)")
 	WebhookCreateIncomingCmd.Flags().String("user", "", "User ID (required)")
@@ -449,6 +478,7 @@ func init() {
 		WebhookCreateOutgoingCmd,
 		WebhookModifyOutgoingCmd,
 		WebhookDeleteCmd,
+		WebhookShowCmd,
 	)
 
 	RootCmd.AddCommand(WebhookCmd)

--- a/cmd/mattermost/commands/webhook_test.go
+++ b/cmd/mattermost/commands/webhook_test.go
@@ -61,6 +61,78 @@ func TestListWebhooks(t *testing.T) {
 
 }
 
+func TestShowWebhook(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	adminClient := th.SystemAdminClient
+
+	config := th.Config()
+	*config.ServiceSettings.EnableCommands = true
+	config.ServiceSettings.EnableIncomingWebhooks = true
+	config.ServiceSettings.EnableOutgoingWebhooks = true
+	config.ServiceSettings.EnablePostUsernameOverride = true
+	config.ServiceSettings.EnablePostIconOverride = true
+	th.SetConfig(config)
+
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostUsernameOverride = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = true })
+
+	defaultRolePermissions := th.SaveDefaultRolePermissions()
+	defer func() {
+		th.RestoreDefaultRolePermissions(defaultRolePermissions)
+	}()
+	th.AddPermissionToRole(model.PERMISSION_MANAGE_WEBHOOKS.Id, model.TEAM_ADMIN_ROLE_ID)
+	th.RemovePermissionFromRole(model.PERMISSION_MANAGE_WEBHOOKS.Id, model.TEAM_USER_ROLE_ID)
+
+	dispName := "incominghook"
+	hook := &model.IncomingWebhook{
+		DisplayName: dispName,
+		ChannelId:   th.BasicChannel.Id,
+		TeamId:      th.BasicChannel.TeamId,
+	}
+	incomingWebhook, resp := adminClient.CreateIncomingWebhook(hook)
+	api4.CheckNoError(t, resp)
+
+	// should return an error when no webhookid is provided
+	require.Error(t, th.RunCommand(t, "webhook", "show"))
+
+	// invalid webhook should return error
+	require.Error(t, th.RunCommand(t, "webhook", "show", "invalid-webhook"))
+
+	// valid incoming webhook should return webhook data
+	output := th.CheckCommand(t, "webhook", "show", incomingWebhook.Id)
+	if !strings.Contains(string(output), "DisplayName: \""+dispName+"\"") {
+		t.Fatal("incoming: should have incominghook as displayname")
+	}
+	if !strings.Contains(string(output), "ChannelId: \""+hook.ChannelId+"\"") {
+		t.Fatal("incoming: should have a valid channelId")
+	}
+
+	dispName = "outgoinghook"
+	outgoingHook := &model.OutgoingWebhook{
+		DisplayName:  dispName,
+		ChannelId:    th.BasicChannel.Id,
+		TeamId:       th.BasicChannel.TeamId,
+		CallbackURLs: []string{"http://nowhere.com"},
+		Username:     "some-user-name",
+		IconURL:      "http://some-icon-url/",
+	}
+	outgoingWebhook, resp := adminClient.CreateOutgoingWebhook(outgoingHook)
+	api4.CheckNoError(t, resp)
+
+	// valid outgoing webhook should return webhook data
+	output = th.CheckCommand(t, "webhook", "show", outgoingWebhook.Id)
+	if !strings.Contains(string(output), "DisplayName: \""+dispName+"\"") {
+		t.Fatal("outgoing: should have outgoinghook as displayname")
+	}
+	if !strings.Contains(string(output), "ChannelId: \""+hook.ChannelId+"\"") {
+		t.Fatal("outgoing: should have a valid channelId")
+	}
+
+}
+
 func TestCreateIncomingWebhook(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()


### PR DESCRIPTION
#### Summary
Added support to show webhook data based on webhookId

Mattermost is improving its CLI interface and we're looking for contributors to help with that effort. This Help Wanted issue is to implement webhook show command in the CLI.

Allow seeing the webhook detailed information.

Example: `webhook show w16zb5tu3n1zkqo18goqry1je`

#### Ticket Link
[MM-12375](https://mattermost.atlassian.net/browse/MM-12375)
#9562 

#### Checklist
- [x] Added or updated unit tests (required for all new features)
