### PR TITLE
Add props to plugin manifest

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -130,6 +130,9 @@ type Manifest struct {
 	// To allow administrators to configure your plugin via the Mattermost system console, you can
 	// provide your settings schema.
 	SettingsSchema *PluginSettingsSchema `json:"settings_schema,omitempty" yaml:"settings_schema,omitempty"`
+
+	// Plugins can store any kind of data in Propos to allow other plugins to us it.
+	Props map[string]interface{} `json:"props,omitempty" yaml:"props,omitempty"`
 }
 
 type ManifestServer struct {

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -131,7 +131,7 @@ type Manifest struct {
 	// provide your settings schema.
 	SettingsSchema *PluginSettingsSchema `json:"settings_schema,omitempty" yaml:"settings_schema,omitempty"`
 
-	// Plugins can store any kind of data in Propos to allow other plugins to us it.
+	// Plugins can store any kind of data in Props to allow other plugins to use it.
 	Props map[string]interface{} `json:"props,omitempty" yaml:"props,omitempty"`
 }
 


### PR DESCRIPTION
#### Summary
This PR allows plugin to include arbitrary data in the manifest. This data can be used by other plugin. My use case is the update plugin (https://github.com/hanzei/plugin-update/).

See https://github.com/hanzei/mattermost-plugin-sample/blob/master/plugin.json for an example how this looks like.

1/5 on the naming.