### PR TITLE
[MM-13787] fixing mv channel CLI syntax

### DIFF
--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -86,12 +86,12 @@ Archived channels are appended with ' (archived)'.`,
 }
 
 var MoveChannelsCmd = &cobra.Command{
-	Use:   "mv [channels] [team] --username [user]",
+	Use:   "move [channels] [team] --username [user]",
 	Short: "Moves channels to the specified team",
 	Long: `Moves the provided channels to the specified team.
 Validates that all users in the channel belong to the target team. Incoming/Outgoing webhooks are moved along with the channel.
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
-	Example: "  channel mv oldteam:mychannel newteam --username myusername",
+	Example: "  channel move oldteam:mychannel newteam --username myusername",
 	Args:    cobra.MinimumNArgs(2),
 	RunE:    moveChannelsCmdF,
 }

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -86,12 +86,12 @@ Archived channels are appended with ' (archived)'.`,
 }
 
 var MoveChannelsCmd = &cobra.Command{
-	Use:   "move [team] [channels] --username [user]",
+	Use:   "mv [channels] [team] --username [user]",
 	Short: "Moves channels to the specified team",
 	Long: `Moves the provided channels to the specified team.
 Validates that all users in the channel belong to the target team. Incoming/Outgoing webhooks are moved along with the channel.
 Channels can be specified by [team]:[channel]. ie. myteam:mychannel or by channel ID.`,
-	Example: "  channel move newteam oldteam:mychannel --username myusername",
+	Example: "  channel mv oldteam:mychannel newteam --username myusername",
 	Args:    cobra.MinimumNArgs(2),
 	RunE:    moveChannelsCmdF,
 }
@@ -348,9 +348,10 @@ func moveChannelsCmdF(command *cobra.Command, args []string) error {
 	}
 	defer a.Shutdown()
 
-	team := getTeamFromTeamArg(a, args[0])
+	teamArgs := args[len(args)-1]
+	team := getTeamFromTeamArg(a, teamArgs)
 	if team == nil {
-		return errors.New("Unable to find destination team '" + args[0] + "'")
+		return errors.New("Unable to find destination team '" + teamArgs + "'")
 	}
 
 	username, erru := command.Flags().GetString("username")
@@ -361,10 +362,10 @@ func moveChannelsCmdF(command *cobra.Command, args []string) error {
 
 	removeDeactivatedMembers, _ := command.Flags().GetBool("remove-deactivated-users")
 
-	channels := getChannelsFromChannelArgs(a, args[1:])
+	channels := getChannelsFromChannelArgs(a, args[:len(args)-1])
 	for i, channel := range channels {
 		if channel == nil {
-			CommandPrintErrorln("Unable to find channel '" + args[i+1] + "'")
+			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
 			continue
 		}
 		originTeamID := channel.TeamId

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -71,9 +70,9 @@ func TestMoveChannel(t *testing.T) {
 	th.CheckCommand(t, "channel", "add", origin, adminEmail)
 
 	// should fail with nil because errors are logged instead of returned when a channel does not exist
-	fmt.Println(th.CheckCommand(t, "channel", "mv", team1.Name+":doesnotexist", dest, "--username", adminUsername))
+	th.CheckCommand(t, "channel", "mv", team1.Name+":doesnotexist", dest, "--username", adminUsername)
 
-	fmt.Println(th.CheckCommand(t, "channel", "mv", origin, dest, "--username", adminUsername))
+	th.CheckCommand(t, "channel", "mv", origin, dest, "--username", adminUsername)
 }
 
 func TestListChannels(t *testing.T) {

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -70,9 +70,9 @@ func TestMoveChannel(t *testing.T) {
 	th.CheckCommand(t, "channel", "add", origin, adminEmail)
 
 	// should fail with nil because errors are logged instead of returned when a channel does not exist
-	th.CheckCommand(t, "channel", "mv", team1.Name+":doesnotexist", dest, "--username", adminUsername)
+	th.CheckCommand(t, "channel", "move", team1.Name+":doesnotexist", dest, "--username", adminUsername)
 
-	th.CheckCommand(t, "channel", "mv", origin, dest, "--username", adminUsername)
+	th.CheckCommand(t, "channel", "move", origin, dest, "--username", adminUsername)
 }
 
 func TestListChannels(t *testing.T) {

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -70,9 +71,9 @@ func TestMoveChannel(t *testing.T) {
 	th.CheckCommand(t, "channel", "add", origin, adminEmail)
 
 	// should fail with nil because errors are logged instead of returned when a channel does not exist
-	th.CheckCommand(t, "channel", "move", dest, team1.Name+":doesnotexist", "--username", adminUsername)
+	fmt.Println(th.CheckCommand(t, "channel", "mv", team1.Name+":doesnotexist", dest, "--username", adminUsername))
 
-	th.CheckCommand(t, "channel", "move", dest, origin, "--username", adminUsername)
+	fmt.Println(th.CheckCommand(t, "channel", "mv", origin, dest, "--username", adminUsername))
 }
 
 func TestListChannels(t *testing.T) {


### PR DESCRIPTION
#### Summary
Change CLI  move channel syntax from `channel move [destteam] [sourcechannel]` to `channel mv [sourcechannel] [destteam]`

#### Ticket Link
Fixes #10115

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Added or updated unit tests (required for all new features)
