### PR TITLE
add output when creating channel using cli

### DIFF
--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -201,9 +201,9 @@ func createChannelCmdF(command *cobra.Command, args []string) error {
 		return errCreatedChannel
 	}
 
-	CommandPrettyPrintln("Channel Id: " + createdChannel.Id)
-	CommandPrettyPrintln("Channel Name: " + createdChannel.Name)
-	CommandPrettyPrintln("Channel Display Name: " + createdChannel.DisplayName)
+	CommandPrettyPrintln("Id: " + createdChannel.Id)
+	CommandPrettyPrintln("Name: " + createdChannel.Name)
+	CommandPrettyPrintln("Display Name: " + createdChannel.DisplayName)
 	return nil
 }
 

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -196,10 +196,14 @@ func createChannelCmdF(command *cobra.Command, args []string) error {
 		CreatorId:   "",
 	}
 
-	if _, err := a.CreateChannel(channel, false); err != nil {
-		return err
+	createdChannel, errCreatedChannel := a.CreateChannel(channel, false)
+	if errCreatedChannel != nil {
+		return errCreatedChannel
 	}
 
+	CommandPrettyPrintln("Channel Id: " + createdChannel.Id)
+	CommandPrettyPrintln("Channel Name: " + createdChannel.Name)
+	CommandPrettyPrintln("Channel Display Name: " + createdChannel.DisplayName)
 	return nil
 }
 


### PR DESCRIPTION
#### Summary
I was creating some scripts using the CLI and notice that some commands do not output some information that we might need as input for others commands.

This PR adds some outputs when using the CLI to create a channel

#### Ticket Link
N/A

