### PR TITLE
add output when creating webhooks with the CLI

### DIFF
--- a/cmd/mattermost/commands/webhook.go
+++ b/cmd/mattermost/commands/webhook.go
@@ -161,8 +161,8 @@ func createIncomingWebhookCmdF(command *cobra.Command, args []string) error {
 		return errIncomingWebhook
 	}
 
-	CommandPrettyPrintln("Display Name: " + createdIncoming.DisplayName)
 	CommandPrettyPrintln("Id: " + createdIncoming.Id)
+	CommandPrettyPrintln("Display Name: " + createdIncoming.DisplayName)
 
 	return nil
 }
@@ -296,8 +296,8 @@ func createOutgoingWebhookCmdF(command *cobra.Command, args []string) error {
 		return errOutgoing
 	}
 
-	CommandPrettyPrintln("Display Name: " + createdOutgoing.DisplayName)
 	CommandPrettyPrintln("Id: " + createdOutgoing.Id)
+	CommandPrettyPrintln("Display Name: " + createdOutgoing.DisplayName)
 
 	return nil
 }

--- a/cmd/mattermost/commands/webhook.go
+++ b/cmd/mattermost/commands/webhook.go
@@ -156,9 +156,13 @@ func createIncomingWebhookCmdF(command *cobra.Command, args []string) error {
 		ChannelLocked: channelLocked,
 	}
 
-	if _, err := app.CreateIncomingWebhookForChannel(user.Id, channel, incomingWebhook); err != nil {
-		return err
+	createdIncoming, errIncomingWebhook := app.CreateIncomingWebhookForChannel(user.Id, channel, incomingWebhook)
+	if errIncomingWebhook != nil {
+		return errIncomingWebhook
 	}
+
+	CommandPrettyPrintln("Display Name: " + createdIncoming.DisplayName)
+	CommandPrettyPrintln("Token Id: " + createdIncoming.Id)
 
 	return nil
 }
@@ -287,9 +291,13 @@ func createOutgoingWebhookCmdF(command *cobra.Command, args []string) error {
 		}
 	}
 
-	if _, err := app.CreateOutgoingWebhook(outgoingWebhook); err != nil {
-		return err
+	createdOutgoing, errOutgoing := app.CreateOutgoingWebhook(outgoingWebhook)
+	if errOutgoing != nil {
+		return errOutgoing
 	}
+
+	CommandPrettyPrintln("Display Name: " + createdOutgoing.DisplayName)
+	CommandPrettyPrintln("Token Id: " + createdOutgoing.Id)
 
 	return nil
 }

--- a/cmd/mattermost/commands/webhook.go
+++ b/cmd/mattermost/commands/webhook.go
@@ -162,7 +162,7 @@ func createIncomingWebhookCmdF(command *cobra.Command, args []string) error {
 	}
 
 	CommandPrettyPrintln("Display Name: " + createdIncoming.DisplayName)
-	CommandPrettyPrintln("Token Id: " + createdIncoming.Id)
+	CommandPrettyPrintln("Id: " + createdIncoming.Id)
 
 	return nil
 }
@@ -297,7 +297,7 @@ func createOutgoingWebhookCmdF(command *cobra.Command, args []string) error {
 	}
 
 	CommandPrettyPrintln("Display Name: " + createdOutgoing.DisplayName)
-	CommandPrettyPrintln("Token Id: " + createdOutgoing.Id)
+	CommandPrettyPrintln("Id: " + createdOutgoing.Id)
 
 	return nil
 }


### PR DESCRIPTION
#### Summary
I was creating some scripts using the CLI and notice that some commands do not output some information that we might need as input for others commands.

This PR adds some outputs when using the CLI to create webhooks

#### Ticket Link
N/A

