### PR TITLE
Fix panicing of ParseSlackAttachment for nil in attachments list

### DIFF
--- a/model/slack_attachment.go
+++ b/model/slack_attachment.go
@@ -68,7 +68,13 @@ func ParseSlackAttachment(post *Post, attachments []*SlackAttachment) {
 		post.Type = POST_SLACK_ATTACHMENT
 	}
 
+	postAttachments := []*SlackAttachment{}
+
 	for _, attachment := range attachments {
+		if attachment == nil {
+			continue
+		}
+
 		attachment.Text = ParseSlackLinksToMarkdown(attachment.Text)
 		attachment.Pretext = ParseSlackLinksToMarkdown(attachment.Pretext)
 
@@ -77,8 +83,9 @@ func ParseSlackAttachment(post *Post, attachments []*SlackAttachment) {
 				field.Value = ParseSlackLinksToMarkdown(value)
 			}
 		}
+		postAttachments = append(postAttachments, attachment)
 	}
-	post.AddProp("attachments", attachments)
+	post.AddProp("attachments", postAttachments)
 }
 
 func ParseSlackLinksToMarkdown(text string) string {

--- a/model/slack_attachment_test.go
+++ b/model/slack_attachment_test.go
@@ -1,0 +1,41 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSlackAttachment(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		post := &Post{}
+		attachments := []*SlackAttachment{}
+
+		ParseSlackAttachment(post, attachments)
+
+		expectedPost := &Post{
+			Type: POST_SLACK_ATTACHMENT,
+			Props: map[string]interface{}{
+				"attachments": []*SlackAttachment{},
+			},
+		}
+		assert.Equal(t, expectedPost, post)
+	})
+
+	t.Run("list with nil", func(t *testing.T) {
+		post := &Post{}
+		attachments := []*SlackAttachment{
+			nil,
+		}
+
+		ParseSlackAttachment(post, attachments)
+
+		expectedPost := &Post{
+			Type: POST_SLACK_ATTACHMENT,
+			Props: map[string]interface{}{
+				"attachments": []*SlackAttachment{},
+			},
+		}
+		assert.Equal(t, expectedPost, post)
+	})
+}


### PR DESCRIPTION
#### Summary
This PR fixes a panic in `ParseSlackAttachment` if it got called with `nil` as a element of `attachments []*SlackAttachment`. The method now skips every `nil` passed to it.

I would also like to change the method so it would do nothing if you can it with `[]*SlackAttachment{}`. See the first test case https://github.com/mattermost/mattermost-server/blob/6f8f3b401d45133f84c84d6605ef047c0581ad2b/model/slack_attachment_test.go#L10-L23. But since this technical a breaking change, I thought it would be our of scope.

#### Ticket Link
Ref https://github.com/mattermost/mattermost-plugin-jira/pull/19

#### Checklist
- [x] Added or updated unit tests (required for all new features)