### PR TITLE
MM-13851 Added a UserWasCreated hook for server-side plugins

### DIFF
--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -120,6 +120,112 @@ func (s *hooksRPCServer) ExecuteCommand(args *Z_ExecuteCommandArgs, returns *Z_E
 }
 
 func init() {
+	hookNameToId["UserHasBeenCreated"] = UserHasBeenCreatedId
+}
+
+type Z_UserHasBeenCreatedArgs struct {
+	A *Context
+	B *model.User
+}
+
+type Z_UserHasBeenCreatedReturns struct {
+}
+
+func (g *hooksRPCClient) UserHasBeenCreated(c *Context, user *model.User) {
+	_args := &Z_UserHasBeenCreatedArgs{c, user}
+	_returns := &Z_UserHasBeenCreatedReturns{}
+	if g.implemented[UserHasBeenCreatedId] {
+		if err := g.client.Call("Plugin.UserHasBeenCreated", _args, _returns); err != nil {
+			g.log.Error("RPC call UserHasBeenCreated to plugin failed.", mlog.Err(err))
+		}
+	}
+
+}
+
+func (s *hooksRPCServer) UserHasBeenCreated(args *Z_UserHasBeenCreatedArgs, returns *Z_UserHasBeenCreatedReturns) error {
+	if hook, ok := s.impl.(interface {
+		UserHasBeenCreated(c *Context, user *model.User)
+	}); ok {
+		hook.UserHasBeenCreated(args.A, args.B)
+
+	} else {
+		return encodableError(fmt.Errorf("Hook UserHasBeenCreated called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
+	hookNameToId["UserWillLogIn"] = UserWillLogInId
+}
+
+type Z_UserWillLogInArgs struct {
+	A *Context
+	B *model.User
+}
+
+type Z_UserWillLogInReturns struct {
+	A string
+}
+
+func (g *hooksRPCClient) UserWillLogIn(c *Context, user *model.User) string {
+	_args := &Z_UserWillLogInArgs{c, user}
+	_returns := &Z_UserWillLogInReturns{}
+	if g.implemented[UserWillLogInId] {
+		if err := g.client.Call("Plugin.UserWillLogIn", _args, _returns); err != nil {
+			g.log.Error("RPC call UserWillLogIn to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A
+}
+
+func (s *hooksRPCServer) UserWillLogIn(args *Z_UserWillLogInArgs, returns *Z_UserWillLogInReturns) error {
+	if hook, ok := s.impl.(interface {
+		UserWillLogIn(c *Context, user *model.User) string
+	}); ok {
+		returns.A = hook.UserWillLogIn(args.A, args.B)
+
+	} else {
+		return encodableError(fmt.Errorf("Hook UserWillLogIn called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
+	hookNameToId["UserHasLoggedIn"] = UserHasLoggedInId
+}
+
+type Z_UserHasLoggedInArgs struct {
+	A *Context
+	B *model.User
+}
+
+type Z_UserHasLoggedInReturns struct {
+}
+
+func (g *hooksRPCClient) UserHasLoggedIn(c *Context, user *model.User) {
+	_args := &Z_UserHasLoggedInArgs{c, user}
+	_returns := &Z_UserHasLoggedInReturns{}
+	if g.implemented[UserHasLoggedInId] {
+		if err := g.client.Call("Plugin.UserHasLoggedIn", _args, _returns); err != nil {
+			g.log.Error("RPC call UserHasLoggedIn to plugin failed.", mlog.Err(err))
+		}
+	}
+
+}
+
+func (s *hooksRPCServer) UserHasLoggedIn(args *Z_UserHasLoggedInArgs, returns *Z_UserHasLoggedInReturns) error {
+	if hook, ok := s.impl.(interface {
+		UserHasLoggedIn(c *Context, user *model.User)
+	}); ok {
+		hook.UserHasLoggedIn(args.A, args.B)
+
+	} else {
+		return encodableError(fmt.Errorf("Hook UserHasLoggedIn called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
 	hookNameToId["MessageHasBeenPosted"] = MessageHasBeenPostedId
 }
 
@@ -365,77 +471,6 @@ func (s *hooksRPCServer) UserHasLeftTeam(args *Z_UserHasLeftTeamArgs, returns *Z
 
 	} else {
 		return encodableError(fmt.Errorf("Hook UserHasLeftTeam called but not implemented."))
-	}
-	return nil
-}
-
-func init() {
-	hookNameToId["UserWillLogIn"] = UserWillLogInId
-}
-
-type Z_UserWillLogInArgs struct {
-	A *Context
-	B *model.User
-}
-
-type Z_UserWillLogInReturns struct {
-	A string
-}
-
-func (g *hooksRPCClient) UserWillLogIn(c *Context, user *model.User) string {
-	_args := &Z_UserWillLogInArgs{c, user}
-	_returns := &Z_UserWillLogInReturns{}
-	if g.implemented[UserWillLogInId] {
-		if err := g.client.Call("Plugin.UserWillLogIn", _args, _returns); err != nil {
-			g.log.Error("RPC call UserWillLogIn to plugin failed.", mlog.Err(err))
-		}
-	}
-	return _returns.A
-}
-
-func (s *hooksRPCServer) UserWillLogIn(args *Z_UserWillLogInArgs, returns *Z_UserWillLogInReturns) error {
-	if hook, ok := s.impl.(interface {
-		UserWillLogIn(c *Context, user *model.User) string
-	}); ok {
-		returns.A = hook.UserWillLogIn(args.A, args.B)
-
-	} else {
-		return encodableError(fmt.Errorf("Hook UserWillLogIn called but not implemented."))
-	}
-	return nil
-}
-
-func init() {
-	hookNameToId["UserHasLoggedIn"] = UserHasLoggedInId
-}
-
-type Z_UserHasLoggedInArgs struct {
-	A *Context
-	B *model.User
-}
-
-type Z_UserHasLoggedInReturns struct {
-}
-
-func (g *hooksRPCClient) UserHasLoggedIn(c *Context, user *model.User) {
-	_args := &Z_UserHasLoggedInArgs{c, user}
-	_returns := &Z_UserHasLoggedInReturns{}
-	if g.implemented[UserHasLoggedInId] {
-		if err := g.client.Call("Plugin.UserHasLoggedIn", _args, _returns); err != nil {
-			g.log.Error("RPC call UserHasLoggedIn to plugin failed.", mlog.Err(err))
-		}
-	}
-
-}
-
-func (s *hooksRPCServer) UserHasLoggedIn(args *Z_UserHasLoggedInArgs, returns *Z_UserHasLoggedInReturns) error {
-	if hook, ok := s.impl.(interface {
-		UserHasLoggedIn(c *Context, user *model.User)
-	}); ok {
-		hook.UserHasLoggedIn(args.A, args.B)
-
-	} else {
-		return encodableError(fmt.Errorf("Hook UserHasLoggedIn called but not implemented."))
 	}
 	return nil
 }

--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -74,7 +74,7 @@ type Hooks interface {
 
 	// UserHasBeenCreated is invoked after a user was created.
 	//
-	// Minimum server version: 5.8
+	// Minimum server version: 5.10
 	UserHasBeenCreated(c *Context, user *model.User)
 
 	// UserWillLogIn before the login of the user is returned. Returning a non empty string will reject the login event.

--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -32,6 +32,7 @@ const (
 	FileWillBeUploadedId    = 14
 	UserWillLogInId         = 15
 	UserHasLoggedInId       = 16
+	UserHasBeenCreatedId    = 17
 	TotalHooksId            = iota
 )
 
@@ -70,6 +71,18 @@ type Hooks interface {
 	// ExecuteCommand executes a command that has been previously registered via the RegisterCommand
 	// API.
 	ExecuteCommand(c *Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError)
+
+	// UserHasBeenCreated is invoked after a user was created.
+	//
+	// Minimum server version: 5.8
+	UserHasBeenCreated(c *Context, user *model.User)
+
+	// UserWillLogIn before the login of the user is returned. Returning a non empty string will reject the login event.
+	// If you don't need to reject the login event, see UserHasLoggedIn
+	UserWillLogIn(c *Context, user *model.User) string
+
+	// UserHasLoggedIn is invoked after a user has logged in.
+	UserHasLoggedIn(c *Context, user *model.User)
 
 	// MessageWillBePosted is invoked when a message is posted by a user before it is committed
 	// to the database. If you also want to act on edited posts, see MessageWillBeUpdated.
@@ -125,13 +138,6 @@ type Hooks interface {
 	// UserHasLeftTeam is invoked after the membership has been removed from the database.
 	// If actor is not nil, the user was removed from the team by the actor.
 	UserHasLeftTeam(c *Context, teamMember *model.TeamMember, actor *model.User)
-
-	// UserWillLogIn before the login of the user is returned. Returning a non empty string will reject the login event.
-	// If you don't need to reject the login event, see UserHasLoggedIn
-	UserWillLogIn(c *Context, user *model.User) string
-
-	// UserHasLoggedIn is invoked after a user has logged in.
-	UserHasLoggedIn(c *Context, user *model.User)
 
 	// FileWillBeUploaded is invoked when a file is uploaded, but before it is committed to backing store.
 	// Read from file to retrieve the body of the uploaded file.

--- a/plugin/plugintest/hooks.go
+++ b/plugin/plugintest/hooks.go
@@ -194,6 +194,11 @@ func (_m *Hooks) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 	_m.Called(c, w, r)
 }
 
+// UserHasBeenCreated provides a mock function with given fields: c, user
+func (_m *Hooks) UserHasBeenCreated(c *plugin.Context, user *model.User) {
+	_m.Called(c, user)
+}
+
 // UserHasJoinedChannel provides a mock function with given fields: c, channelMember, actor
 func (_m *Hooks) UserHasJoinedChannel(c *plugin.Context, channelMember *model.ChannelMember, actor *model.User) {
 	_m.Called(c, channelMember, actor)


### PR DESCRIPTION
#### Summary
Added a UserWasCreated(c *plugin.Context, user *model.User) hook for server-side plugins.

#### Ticket Link
[Jira ticket](https://mattermost.atlassian.net/browse/MM-13851) | Fixes [GitHub Issue #10174](https://github.com/mattermost/mattermost-server/issues/10174)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
