### PR TITLE
Add timeout for jenkins pipeline

### DIFF
--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -13,7 +13,7 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: '3'))
-        timeout(time: 2, unit: 'HOURS')
+        timeout(time: 1, unit: 'HOURS')
     }
 
     environment {

--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -11,7 +11,10 @@ pipeline {
         label 'default-mm-builder'
     }
 
-    options { buildDiscarder(logRotator(numToKeepStr: '3')) }
+    options {
+        buildDiscarder(logRotator(numToKeepStr: '3'))
+        timeout(time: 2, unit: 'HOURS')
+    }
 
     environment {
         COMPOSE_PROJECT_NAME="${rnd}-${env.BUILD_NUMBER}"


### PR DESCRIPTION
#### Summary
Adding timeout for Jenkins pipeline to abort jobs that run for more than 2 hours.

This weekend on PR was running for more than 7 hours and did not get killed.
Adding this timeout is also a good practice to make Jenkins abort jobs running for a long time this save machine resource and avoid build queue get long.

Our build is running in mean for 30 min all the steps adding a 2-hour timeout is enough

#### Ticket Link
NA
