### PR TITLE
[MM-13791] Starts Elasticsearch and Metrics when running the server.

### DIFF
--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -48,6 +48,8 @@ func runServer(configFileLocation string, disableConfigWatch bool, usedPlatform 
 		app.ConfigFile(configFileLocation),
 		app.RunJobs,
 		app.JoinCluster,
+		app.StartElasticsearch,
+		app.StartMetrics,
 	}
 	if disableConfigWatch {
 		options = append(options, app.DisableConfigWatch)


### PR DESCRIPTION
#### Summary
This PR loads Elasticsearch and the Metrics as part of the server instance.

#### Ticket Link
[MM-13791](https://mattermost.atlassian.net/browse/MM-13791)

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
