### PR TITLE
[MM-13820] Sort modified PostList in flags endpoint to return the correct order

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -217,8 +217,9 @@ func getFlaggedPostsForUser(c *Context, w http.ResponseWriter, r *http.Request) 
 
 		pl.AddPost(post)
 		pl.AddOrder(post.Id)
-
 	}
+
+	pl.SortByCreateAt()
 
 	if err != nil {
 		c.Err = err


### PR DESCRIPTION
#### Summary
This is a second patch of https://github.com/mattermost/mattermost-server/pull/10135, which sorts the modified `PostList` again by the creation date, avoiding that the flagged post list is rendered with random order. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13820
