### PR TITLE
MM-13852 Migrate example manifest to JSON

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -90,7 +90,7 @@ type PluginSettingsSchema struct {
 //    {
 //      "id": "com.mycompany.myplugin",
 //      "name": "My Plugin",
-//      "description": "This is my plugin. It does stuff.",
+//      "description": "This is my plugin",
 //      "version": "0.1.0",
 //      "min_server_version": "5.6.0",
 //      "server": {
@@ -108,9 +108,9 @@ type PluginSettingsSchema struct {
 //        "footer": "Some footer text",
 //        "settings": [{
 //          "key": "someKey",
-//          "display_name": "Enable Extra Thing",
+//          "display_name": "Enable Extra Feature",
 //          "type": "bool",
-//          "help_text": "When true, an extra thing will be enabled!",
+//          "help_text": "When true, an extra feature will be enabled!",
 //          "default": "false"
 //        }]
 //      },

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -84,20 +84,40 @@ type PluginSettingsSchema struct {
 // file should be named plugin.json or plugin.yaml and placed in the top of your
 // plugin bundle.
 //
-// Example plugin.yaml:
+// Example plugin.json:
 //
-//     id: com.mycompany.myplugin
-//     name: My Plugin
-//     description: This is my plugin. It does stuff.
-//     server:
-//         executable: myplugin
-//     settings_schema:
-//         settings:
-//             - key: enable_extra_thing
-//               type: bool
-//               display_name: Enable Extra Thing
-//               help_text: When true, an extra thing will be enabled!
-//               default: false
+//
+//    {
+//      "id": "com.mycompany.myplugin",
+//      "name": "My Plugin",
+//      "description": "This is my plugin. It does stuff.",
+//      "version": "0.1.0",
+//      "min_server_version": "5.6.0",
+//      "server": {
+//        "executables": {
+//          "linux-amd64": "server/dist/plugin-linux-amd64",
+//          "darwin-amd64": "server/dist/plugin-darwin-amd64",
+//          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
+//        }
+//      },
+//      "webapp": {
+//          "bundle_path": "webapp/dist/main.js"
+//      },
+//      "settings_schema": {
+//        "header": "Some header text",
+//        "footer": "Some footer text",
+//        "settings": [{
+//          "key": "someKey",
+//          "display_name": "Enable Extra Thing",
+//          "type": "bool",
+//          "help_text": "When true, an extra thing will be enabled!",
+//          "default": "false"
+//        }]
+//      },
+//      "props": {
+//        "someKey": "someData"
+//      }
+//    }
 type Manifest struct {
 	// The id is a globally unique identifier that represents your plugin. Ids must be at least
 	// 3 characters, at most 190 characters and must match ^[a-zA-Z0-9-_\.]+$.


### PR DESCRIPTION
#### Summary
This PR migrates the example plugin manifest to JSON.

This is how https://developers.mattermost.com/extend/plugins/manifest-reference/ would look like after this got merged.
![screenshot from 2019-01-29 12-58-02](https://user-images.githubusercontent.com/16541325/51906940-b264f100-23c5-11e9-9fdc-71c05105755a.png)


#### Ticket Link
Ref https://github.com/mattermost/mattermost-server/issues/10173

