### PR TITLE
Enable PluginJobs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -90,6 +90,9 @@ func (s *Server) initJobs() {
 	if jobsMigrationsInterface != nil {
 		s.Jobs.Migrations = jobsMigrationsInterface(s.FakeApp())
 	}
+	if jobsPluginsInterface != nil {
+		s.Jobs.Plugins = jobsPluginsInterface(s.FakeApp())
+	}
 	s.Jobs.Workers = s.Jobs.InitWorkers()
 	s.Jobs.Schedulers = s.Jobs.InitSchedulers()
 }

--- a/app/enterprise.go
+++ b/app/enterprise.go
@@ -77,6 +77,12 @@ func RegisterJobsMigrationsJobInterface(f func(*App) tjobs.MigrationsJobInterfac
 	jobsMigrationsInterface = f
 }
 
+var jobsPluginsInterface func(*App) tjobs.PluginsJobInterface
+
+func RegisterJobsPluginsJobInterface(f func(*App) tjobs.PluginsJobInterface) {
+	jobsPluginsInterface = f
+}
+
 var ldapInterface func(*App) einterfaces.LdapInterface
 
 func RegisterLdapInterface(f func(*App) einterfaces.LdapInterface) {

--- a/imports/placeholder.go
+++ b/imports/placeholder.go
@@ -7,4 +7,5 @@ package imports
 
 import (
 	_ "github.com/mattermost/mattermost-server/migrations"
+	_ "github.com/mattermost/mattermost-server/plugin/scheduler"
 )

--- a/jobs/jobs_watcher.go
+++ b/jobs/jobs_watcher.go
@@ -114,6 +114,13 @@ func (watcher *Watcher) PollAndNotify() {
 					default:
 					}
 				}
+			} else if job.Type == model.JOB_TYPE_PLUGINS {
+				if watcher.workers.Plugins != nil {
+					select {
+					case watcher.workers.Plugins.JobChannel() <- *job:
+					default:
+					}
+				}
 			}
 		}
 	}

--- a/jobs/workers.go
+++ b/jobs/workers.go
@@ -58,7 +58,7 @@ func (srv *JobServer) InitWorkers() *Workers {
 	}
 
 	if pluginsInterface := srv.Plugins; pluginsInterface != nil {
-		workers.Migrations = pluginsInterface.MakeWorker()
+		workers.Plugins = pluginsInterface.MakeWorker()
 	}
 
 	return workers
@@ -90,6 +90,10 @@ func (workers *Workers) Start() *Workers {
 
 		if workers.Migrations != nil {
 			go workers.Migrations.Run()
+		}
+
+		if workers.Plugins != nil {
+			go workers.Plugins.Run()
 		}
 
 		go workers.Watcher.Start()
@@ -171,6 +175,10 @@ func (workers *Workers) Stop() *Workers {
 
 	if workers.Migrations != nil {
 		workers.Migrations.Stop()
+	}
+
+	if workers.Plugins != nil {
+		workers.Plugins.Stop()
 	}
 
 	mlog.Info("Stopped workers")

--- a/model/job.go
+++ b/model/job.go
@@ -55,6 +55,7 @@ func (j *Job) IsValid() *AppError {
 	case JOB_TYPE_LDAP_SYNC:
 	case JOB_TYPE_MESSAGE_EXPORT:
 	case JOB_TYPE_MIGRATIONS:
+	case JOB_TYPE_PLUGINS:
 	default:
 		return NewAppError("Job.IsValid", "model.job.is_valid.type.app_error", nil, "id="+j.Id, http.StatusBadRequest)
 	}

--- a/plugin/scheduler/plugin.go
+++ b/plugin/scheduler/plugin.go
@@ -13,7 +13,7 @@ type PluginsJobInterfaceImpl struct {
 }
 
 func init() {
-	app.RegisterJobsMigrationsJobInterface(func(a *app.App) tjobs.MigrationsJobInterface {
+	app.RegisterJobsPluginsJobInterface(func(a *app.App) tjobs.PluginsJobInterface {
 		return &PluginsJobInterfaceImpl{a}
 	})
 }


### PR DESCRIPTION
#### Summary
Since scheduled PluginsJob isn't executed, KeyValue entries stored by `KVSetWithExpiry` are never deleted.
With this PR, scheduled PluginsJob run successfully.

Reported in https://pre-release.mattermost.com/core/pl/x3enjzhbwfr77xocfqd8edptga

#### Ticket Link
N/A

#### Checklist
N/A