### PR TITLE
 MM-13838 Bypass the HTTP client when getting image dimensions from the image proxy

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -345,18 +345,34 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 		return nil, nil, err
 	}
 
-	request.Header.Add("Accept", "text/html, image/*")
+	var body io.ReadCloser
+	var contentType string
 
-	client := a.HTTPService.MakeClient(false)
-	client.Timeout = time.Duration(*a.Config().ExperimentalSettings.LinkMetadataTimeoutMilliseconds) * time.Millisecond
+	if (request.URL.Scheme+"://"+request.URL.Host) == a.GetSiteURL() && request.URL.Path == "/api/v4/image" {
+		// /api/v4/image requires authentication, so bypass the API by hitting the proxy directly
+		body, contentType, err = a.ImageProxy.GetImageDirect(a.ImageProxy.GetUnproxiedImageURL(request.URL.String()))
+	} else {
+		request.Header.Add("Accept", "text/html, image/*")
 
-	res, err := client.Do(request)
+		client := a.HTTPService.MakeClient(false)
+		client.Timeout = time.Duration(*a.Config().ExperimentalSettings.LinkMetadataTimeoutMilliseconds) * time.Millisecond
+
+		var res *http.Response
+		res, err = client.Do(request)
+
+		if res != nil {
+			body = res.Body
+			contentType = res.Header.Get("Content-Type")
+		}
+	}
+
+	if body != nil {
+		defer body.Close()
+	}
 
 	if err == nil {
-		defer res.Body.Close()
-
 		// Parse the data
-		og, image, err = a.parseLinkMetadata(requestURL, res.Body, res.Header.Get("Content-Type"))
+		og, image, err = a.parseLinkMetadata(requestURL, body, contentType)
 	}
 
 	// Write back to cache and database, even if there was an error and the results are nil

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -1479,12 +1479,15 @@ func TestGetLinkMetadata(t *testing.T) {
 
 		// Disable AllowedUntrustedInternalConnections since it's turned on for the previous tests
 		oldAllowUntrusted := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
+		oldSiteURL := *th.App.Config().ServiceSettings.SiteURL
 		defer th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = oldAllowUntrusted
+			*cfg.ServiceSettings.SiteURL = oldSiteURL
 		})
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = ""
+			*cfg.ServiceSettings.SiteURL = "http://mattermost.example.com"
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "local"
 		})
@@ -1507,8 +1510,6 @@ func TestGetLinkMetadata(t *testing.T) {
 		assert.Nil(t, img)
 		assert.NotNil(t, err)
 		assert.IsType(t, imageproxy.Error{}, err)
-		t.Log(fmt.Sprint("SiteURL", th.App.GetSiteURL()))
-		t.Log(fmt.Sprint("err", err))
 	})
 }
 

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -1507,6 +1507,8 @@ func TestGetLinkMetadata(t *testing.T) {
 		assert.Nil(t, img)
 		assert.NotNil(t, err)
 		assert.IsType(t, imageproxy.Error{}, err)
+		t.Log(fmt.Sprint("SiteURL", th.App.GetSiteURL()))
+		t.Log(fmt.Sprint("err", err))
 	})
 }
 

--- a/services/imageproxy/error.go
+++ b/services/imageproxy/error.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package imageproxy
+
+type Error struct {
+	error
+}

--- a/services/imageproxy/local.go
+++ b/services/imageproxy/local.go
@@ -4,7 +4,11 @@
 package imageproxy
 
 import (
+	"errors"
+	"io"
+	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"time"
@@ -26,6 +30,8 @@ var imageContentTypes = []string{
 	"image/x-portable-bitmap", "image/x-portable-graymap", "image/x-portable-pixmap",
 	"image/x-quicktime", "image/x-rgb", "image/x-xbitmap", "image/x-xpixmap", "image/x-xwindowdump",
 }
+
+var ErrLocalRequestFailed = Error{errors.New("imageproxy.LocalBackend: failed to request proxied image")}
 
 type LocalBackend struct {
 	proxy *ImageProxy
@@ -66,6 +72,24 @@ func (backend *LocalBackend) GetImage(w http.ResponseWriter, r *http.Request, im
 	}
 
 	backend.impl.ServeHTTP(w, req)
+}
+
+func (backend *LocalBackend) GetImageDirect(imageURL string) (io.ReadCloser, string, error) {
+	// The interface to the proxy only exposes a ServeHTTP method, so fake a request to it
+	req, err := http.NewRequest(http.MethodGet, "/"+imageURL, nil)
+	if err != nil {
+		return nil, "", Error{err}
+	}
+
+	recorder := httptest.NewRecorder()
+
+	backend.impl.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		return nil, "", ErrLocalRequestFailed
+	}
+
+	return ioutil.NopCloser(recorder.Body), recorder.Header().Get("Content-Type"), nil
 }
 
 func (backend *LocalBackend) GetProxiedImageURL(imageURL string) string {


### PR DESCRIPTION
There's two reasons we can't just hit the image proxy API directly when getting these dimensions:
1. The AllowUntrustedInternalConnections setting rightfully prevents it
2. The image proxy API requires that the user is logged in, but the server can't log into itself
So instead, we just bypass the API entirely and talk directly to the image proxy. Due to how the image proxy is set up for both the local one and the atmos/camo one, this isn't exactly straightforward, but it's not completely terrible.

This is based off of #10188, but you can see the changes specific to this PR here: https://github.com/mattermost/mattermost-server/compare/mm13207...mm13838

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13838

#### Checklist
- Added or updated unit tests (required for all new features)