### PR TITLE
[MM-13891] Enable team domain restriction for AuthService users

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -89,11 +89,6 @@ func (a *App) isTeamEmailAddressAllowed(email string, allowedDomains string) boo
 
 func (a *App) isTeamEmailAllowed(user *model.User, team *model.Team) bool {
 	email := strings.ToLower(user.Email)
-
-	if len(user.AuthService) > 0 && len(*user.AuthData) > 0 {
-		return true
-	}
-
 	return a.isTeamEmailAddressAllowed(email, team.AllowedDomains)
 }
 

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -113,12 +113,27 @@ func TestAddUserToTeam(t *testing.T) {
 		}
 
 		user := model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
-		ruser, _ := th.App.CreateUser(&user)
+		ruser, err := th.App.CreateUser(&user)
+		if err != nil {
+			t.Fatalf("Error creating user: %s", err)
+		}
 		defer th.App.PermanentDeleteUser(&user)
 
 		if _, err := th.App.AddUserToTeam(th.BasicTeam.Id, ruser.Id, ""); err == nil || err.Where != "JoinUserToTeam" {
 			t.Log(err)
 			t.Fatal("Should not add restricted user")
+		}
+
+		user = model.User{Email: strings.ToLower(model.NewId()) + "test@invalid.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), AuthService: "notnil", AuthData: model.NewString("notnil")}
+		ruser, err = th.App.CreateUser(&user)
+		if err != nil {
+			t.Fatalf("Error creating authservice user: %s", err)
+		}
+		defer th.App.PermanentDeleteUser(&user)
+
+		if _, err := th.App.AddUserToTeam(th.BasicTeam.Id, ruser.Id, ""); err == nil || err.Where != "JoinUserToTeam" {
+			t.Log(err)
+			t.Fatal("Should not add authservice user")
 		}
 	})
 


### PR DESCRIPTION
#### Summary
Currently the team domain restriction does not apply to users using a auth. service. The PR changes the domain validation to also apply for those users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13891

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
