### PR TITLE
MM-13917 Enable post metadata by default

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -495,7 +495,7 @@ func (a *App) trackConfig() {
 	a.SendDiagnostic(TRACK_CONFIG_EXPERIMENTAL, map[string]interface{}{
 		"client_side_cert_enable":            *cfg.ExperimentalSettings.ClientSideCertEnable,
 		"isdefault_client_side_cert_check":   isDefault(*cfg.ExperimentalSettings.ClientSideCertCheck, model.CLIENT_SIDE_CERT_CHECK_PRIMARY_AUTH),
-		"enable_post_metadata":               *cfg.ExperimentalSettings.EnablePostMetadata,
+		"enable_post_metadata":               !*cfg.ExperimentalSettings.DisablePostMetadata,
 		"link_metadata_timeout_milliseconds": *cfg.ExperimentalSettings.LinkMetadataTimeoutMilliseconds,
 	})
 

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -56,7 +56,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post, isNewPost bool) *mo
 	// Proxy image links before constructing metadata so that requests go through the proxy
 	post = a.PostWithProxyAddedToImageURLs(post)
 
-	if !*a.Config().ExperimentalSettings.EnablePostMetadata {
+	if *a.Config().ExperimentalSettings.DisablePostMetadata {
 		return post
 	}
 

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -31,7 +31,7 @@ func TestPreparePostListForClient(t *testing.T) {
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ExperimentalSettings.EnablePostMetadata = true
+		*cfg.ExperimentalSettings.DisablePostMetadata = false
 	})
 
 	postList := model.NewPostList()
@@ -65,7 +65,7 @@ func TestPreparePostForClient(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ImageProxySettings.Enable = false
-			*cfg.ExperimentalSettings.EnablePostMetadata = true
+			*cfg.ExperimentalSettings.DisablePostMetadata = false
 		})
 
 		return th
@@ -399,7 +399,7 @@ func TestPreparePostForClient(t *testing.T) {
 		defer th.TearDown()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.ExperimentalSettings.EnablePostMetadata = false
+			*cfg.ExperimentalSettings.DisablePostMetadata = true
 		})
 
 		post := th.CreatePost(th.BasicChannel)
@@ -423,7 +423,7 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
 			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
-			*cfg.ExperimentalSettings.EnablePostMetadata = true
+			*cfg.ExperimentalSettings.DisablePostMetadata = false
 		})
 
 		return th

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -594,7 +594,7 @@ func TestCreatePost(t *testing.T) {
 		defer th.TearDown()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.ExperimentalSettings.EnablePostMetadata = false
+			*cfg.ExperimentalSettings.DisablePostMetadata = true
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
@@ -622,7 +622,7 @@ func TestPatchPost(t *testing.T) {
 		defer th.TearDown()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.ExperimentalSettings.EnablePostMetadata = false
+			*cfg.ExperimentalSettings.DisablePostMetadata = true
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
@@ -658,7 +658,7 @@ func TestUpdatePost(t *testing.T) {
 		defer th.TearDown()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.ExperimentalSettings.EnablePostMetadata = false
+			*cfg.ExperimentalSettings.DisablePostMetadata = true
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"

--- a/config/default.json
+++ b/config/default.json
@@ -358,7 +358,7 @@
     "ExperimentalSettings": {
         "ClientSideCertEnable": false,
         "ClientSideCertCheck": "secondary",
-        "EnablePostMetadata": false,
+        "DisablePostMetadata": false,
         "LinkMetadataTimeoutMilliseconds": 5000
     },
     "AnalyticsSettings": {

--- a/model/config.go
+++ b/model/config.go
@@ -696,7 +696,7 @@ func (s *MetricsSettings) SetDefaults() {
 type ExperimentalSettings struct {
 	ClientSideCertEnable            *bool
 	ClientSideCertCheck             *string
-	EnablePostMetadata              *bool
+	DisablePostMetadata             *bool
 	LinkMetadataTimeoutMilliseconds *int64
 }
 
@@ -709,8 +709,8 @@ func (s *ExperimentalSettings) SetDefaults() {
 		s.ClientSideCertCheck = NewString(CLIENT_SIDE_CERT_CHECK_SECONDARY_AUTH)
 	}
 
-	if s.EnablePostMetadata == nil {
-		s.EnablePostMetadata = NewBool(false)
+	if s.DisablePostMetadata == nil {
+		s.DisablePostMetadata = NewBool(false)
 	}
 
 	if s.LinkMetadataTimeoutMilliseconds == nil {

--- a/utils/config.go
+++ b/utils/config.go
@@ -454,7 +454,9 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
 	props["ExperimentalEnableDefaultChannelLeaveJoinMessages"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages)
 	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
-	props["ExperimentalEnablePostMetadata"] = strconv.FormatBool(*c.ExperimentalSettings.EnablePostMetadata)
+
+	// This setting is only temporary, so keep using the old setting name for the mobile and web apps
+	props["ExperimentalEnablePostMetadata"] = strconv.FormatBool(!*c.ExperimentalSettings.DisablePostMetadata)
 
 	if *c.ServiceSettings.ExperimentalChannelOrganization || *c.ServiceSettings.ExperimentalGroupUnreadChannels != model.GROUP_UNREAD_CHANNELS_DISABLED {
 		props["ExperimentalChannelOrganization"] = strconv.FormatBool(true)


### PR DESCRIPTION
Since we're only renaming the setting to apply the new default to existing installations, and the setting itself is supposed to be temporary, so I didn't change the name of the setting on the clients.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13917

#### Checklist
- Added or updated unit tests (required for all new features)
