### PR TITLE
fix test

### DIFF
--- a/cmd/mattermost/commands/webhook_test.go
+++ b/cmd/mattermost/commands/webhook_test.go
@@ -68,16 +68,16 @@ func TestShowWebhook(t *testing.T) {
 
 	config := th.Config()
 	*config.ServiceSettings.EnableCommands = true
-	config.ServiceSettings.EnableIncomingWebhooks = true
-	config.ServiceSettings.EnableOutgoingWebhooks = true
-	config.ServiceSettings.EnablePostUsernameOverride = true
-	config.ServiceSettings.EnablePostIconOverride = true
+	*config.ServiceSettings.EnableIncomingWebhooks = true
+	*config.ServiceSettings.EnableOutgoingWebhooks = true
+	*config.ServiceSettings.EnablePostUsernameOverride = true
+	*config.ServiceSettings.EnablePostIconOverride = true
 	th.SetConfig(config)
 
-	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableIncomingWebhooks = true })
-	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableOutgoingWebhooks = true })
-	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostUsernameOverride = true })
-	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnablePostIconOverride = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableIncomingWebhooks = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOutgoingWebhooks = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnablePostUsernameOverride = true })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnablePostIconOverride = true })
 
 	defaultRolePermissions := th.SaveDefaultRolePermissions()
 	defer func() {


### PR DESCRIPTION
#### Summary
```
# github.com/mattermost/mattermost-server/cmd/mattermost/commands [github.com/mattermost/mattermost-server/cmd/mattermost/commands.test]
cmd/mattermost/commands/webhook_test.go:71:48: cannot use true (type bool) as type *bool in assignment
cmd/mattermost/commands/webhook_test.go:72:48: cannot use true (type bool) as type *bool in assignment
cmd/mattermost/commands/webhook_test.go:73:52: cannot use true (type bool) as type *bool in assignment
cmd/mattermost/commands/webhook_test.go:74:48: cannot use true (type bool) as type *bool in assignment
cmd/mattermost/commands/webhook_test.go:77:91: cannot use true (type bool) as type *bool in assignment
cmd/mattermost/commands/webhook_test.go:78:91: cannot use true (type bool) as type *bool in assignment
cmd/mattermost/commands/webhook_test.go:79:95: cannot use true (type bool) as type *bool in assignment
cmd/mattermost/commands/webhook_test.go:80:91: cannot use true (type bool) as type *bool in assignment
````
