### PR TITLE
[MM-13889] Limit OpenGraph data response size

### DIFF
--- a/app/opengraph.go
+++ b/app/opengraph.go
@@ -14,6 +14,8 @@ import (
 	"github.com/mattermost/mattermost-server/mlog"
 )
 
+const MaxOpenGraphResponseSize = 1024 * 1024 * 50
+
 func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
 	res, err := a.HTTPService.MakeClient(false).Get(requestURL)
 	if err != nil {
@@ -21,14 +23,12 @@ func (a *App) GetOpenGraphMetadata(requestURL string) *opengraph.OpenGraph {
 		return nil
 	}
 	defer res.Body.Close()
-
 	return a.ParseOpenGraphMetadata(requestURL, res.Body, res.Header.Get("Content-Type"))
 }
 
 func (a *App) ParseOpenGraphMetadata(requestURL string, body io.Reader, contentType string) *opengraph.OpenGraph {
 	og := opengraph.NewOpenGraph()
-
-	body = forceHTMLEncodingToUTF8(body, contentType)
+	body = forceHTMLEncodingToUTF8(io.LimitReader(body, MaxOpenGraphResponseSize), contentType)
 
 	if err := og.ProcessHTML(body); err != nil {
 		mlog.Error("ParseOpenGraphMetadata processing failed", mlog.String("requestURL", requestURL), mlog.Any("err", err))

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -20,6 +20,7 @@ import (
 
 const LINK_CACHE_SIZE = 10000
 const LINK_CACHE_DURATION = 3600
+const MaxMetadataImageSize = MaxOpenGraphResponseSize
 
 var linkCache = utils.NewLru(LINK_CACHE_SIZE)
 
@@ -451,7 +452,7 @@ func cacheLinkMetadata(requestURL string, timestamp int64, og *opengraph.OpenGra
 
 func (a *App) parseLinkMetadata(requestURL string, body io.Reader, contentType string) (*opengraph.OpenGraph, *model.PostImage, error) {
 	if strings.HasPrefix(contentType, "image") {
-		image, err := parseImages(body)
+		image, err := parseImages(io.LimitReader(body, MaxMetadataImageSize))
 		return nil, image, err
 	} else if strings.HasPrefix(contentType, "text/html") {
 		og := a.ParseOpenGraphMetadata(requestURL, body, contentType)


### PR DESCRIPTION
#### Summary
Currently the OpenGraph metadata requests aren't limited in response size, this PR introduces a 50mb limit for responses, which should be sufficient for any scenarios.

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-13889