### PR TITLE
MM-13932 Fix image metadata for invalid image links

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -192,7 +192,7 @@ func (a *App) getImagesForPost(post *model.Post, imageURLs []string, isNewPost b
 		if _, image, err := a.getLinkMetadata(imageURL, post.CreateAt, isNewPost); err != nil {
 			mlog.Warn("Failed to get dimensions of an image in a post",
 				mlog.String("post_id", post.Id), mlog.String("image_url", imageURL), mlog.Any("err", err))
-		} else {
+		} else if image != nil {
 			images[imageURL] = image
 		}
 	}


### PR DESCRIPTION
`getLinkMetadata` returns nil image dimensions with a nil error if the server was able to get metadata for the link, but it was not an image.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13932

#### Checklist
- Added or updated unit tests (required for all new features)