### PR TITLE
[MM-13839] Return password check error as API response to failed eMail patch

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -762,7 +762,7 @@ func patchUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err = c.App.DoubleCheckPassword(ouser, *patch.Password); err != nil {
-			c.SetInvalidParam("password")
+			c.Err = err
 			return
 		}
 	}


### PR DESCRIPTION
#### Summary
This PR is an addition to https://github.com/mattermost/mattermost-server/pull/10207 changing the error returned in the case of an invalid password to the following message:
`{"id":"api.user.check_user_password.invalid.app_error","message":"Login failed because of invalid password","detailed_error":"user_id=xr3qg3g6mbd7ujigksp6ckpjcy","request_id":"u37ffkjfnbbfippqhgybzpmrer","status_code":401}`

Since it has an unique error id, we can intercept it properly within the webapp to display the correct error to the end user:
https://github.com/mattermost/mattermost-webapp/pull/2304/commits/09a41df1456436855cdf11918f950dcffc4168cc#diff-384b37409a3c3d1830b7bc3d042ce794R282

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-13839