### PR TITLE
Improves messaging and agreement input to delete channels.

### DIFF
--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -315,22 +315,27 @@ func deleteChannelsCmdF(command *cobra.Command, args []string) error {
 	}
 	defer a.Shutdown()
 
-	confirmFlag, _ := command.Flags().GetBool("confirm")
-	if !confirmFlag {
-		var confirm string
-		CommandPrettyPrintln("Are you sure you want to delete the channels specified?  All data will be permanently deleted? (YES/NO): ")
-		fmt.Scanln(&confirm)
-		if confirm != "YES" {
-			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
-		}
-	}
-
 	channels := getChannelsFromChannelArgs(a, args)
-	for i, channel := range channels {
-		if channel == nil {
+	var channelNames []string
+	for i, ch := range channels {
+		if ch == nil {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
 			continue
 		}
+		channelNames = append(channelNames, ch.Name)
+	}
+
+	confirmFlag, _ := command.Flags().GetBool("confirm")
+	if !confirmFlag {
+		var confirm string
+		CommandPrettyPrintln(fmt.Sprintf("Are you sure you want to PERMANENTLY DELETE the channels %v? (YES-DELETE-CHANNELS/NO): ", channelNames))
+		fmt.Scanln(&confirm)
+		if confirm != "YES-DELETE-CHANNELS" {
+			return errors.New("ABORTED: You did not answer YES-DELETE-CHANNELS exactly, in all capitals.")
+		}
+	}
+
+	for _, channel := range channels {
 		if err := deleteChannel(a, channel); err != nil {
 			CommandPrintErrorln("Unable to delete channel '" + channel.Name + "' error: " + err.Error())
 		} else {


### PR DESCRIPTION
#### Summary
There have been some cases of people accidentally deleting channels. This is an attempt to help mitigate the occurrences of accidental deletions.

0/5 on the exact wording of the warning or the required prompt input. Just that it needs to be clear that it's not removing a user from a channel (as has been the confusion for several users).

#### Ticket Link
n/a

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
