### PR TITLE
[MM-12753] Fix missing message when using unread API

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -369,7 +369,7 @@ func (s *SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 func (s *SqlPostStore) GetEtag(channelId string, allowFromCache bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if allowFromCache {
-			if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok {
+			if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) > 0 {
 				if s.metrics != nil {
 					s.metrics.IncrementMemCacheHitCounter("Last Post Time")
 				}


### PR DESCRIPTION
#### Summary
Fix missing message when using unread API
- the status returns 304 (not modified) when the cache item in getting the etag has a value of 0 (initial value).

Note:  Attempted to add test but can't see how to test it effectively.

#### Ticket Link
Jira ticket: [MM-12753](https://mattermost.atlassian.net/browse/MM-12753)

