### PR TITLE
Add Fallback to master in jekinsfile when checkout webapp/enterprise repos

### DIFF
--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -45,7 +45,7 @@ pipeline {
                     ansiColor('xterm') {
                         sh """
                             #!/bin/bash -ex
-                            git checkout $env.BRANCH_NAME || git checkout $env.CHANGE_BRANCH || git checkout $env.GIT_BRANCH || git checkout $env.CHANGE_TARGET || echo 1
+                            git checkout $env.BRANCH_NAME || git checkout $env.CHANGE_BRANCH || git checkout $env.GIT_BRANCH || git checkout $env.CHANGE_TARGET || git checkout master || echo 1
                             export EE_GIT_COMMIT=\$(git rev-parse HEAD)
 
                             echo EE Commit: \${EE_GIT_COMMIT}
@@ -57,7 +57,7 @@ pipeline {
                         ansiColor('xterm') {
                             sh """
                                 #!/bin/bash -ex
-                                git checkout $env.BRANCH_NAME || git checkout $env.CHANGE_BRANCH || git checkout $env.GIT_BRANCH || git checkout $env.CHANGE_TARGET
+                                git checkout $env.BRANCH_NAME || git checkout $env.CHANGE_BRANCH || git checkout $env.GIT_BRANCH || git checkout $env.CHANGE_TARGET || git checkout master
                                 rm -rf ./dist
                                 export WEBAPP_GIT_COMMIT=\$(git rev-parse HEAD)
 


### PR DESCRIPTION
#### Summary
follow up from this https://github.com/mattermost/mattermost-server/pull/10228

When building PR from upstream, Jenkins is building the PR and the Branch.
for the branch build, some git environment variables are not available as the target branch, because it is not a PR.

to be in the safe side we need to checkout from master, we don't know in the branch build for which branch it will be merged.

But in most of the times, we are interested only on the PR build.

