### PR TITLE
MM-13129 Adding functionality to deal with orphaned bots

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -25,7 +25,7 @@ type Routes struct {
 	UserByEmail    *mux.Router // 'api/v4/users/email/{email}'
 
 	Bots *mux.Router // 'api/v4/bots'
-	Bot  *mux.Router // 'api/v4/bots/{user_id:[A-Za-z0-9]+}'
+	Bot  *mux.Router // 'api/v4/bots/{bot_user_id:[A-Za-z0-9]+}'
 
 	Teams              *mux.Router // 'api/v4/teams'
 	TeamsForUser       *mux.Router // 'api/v4/users/{user_id:[A-Za-z0-9]+}/teams'
@@ -136,7 +136,7 @@ func Init(configservice configservice.ConfigService, globalOptionsFunc app.AppOp
 	api.BaseRoutes.UserByEmail = api.BaseRoutes.Users.PathPrefix("/email/{email}").Subrouter()
 
 	api.BaseRoutes.Bots = api.BaseRoutes.ApiRoot.PathPrefix("/bots").Subrouter()
-	api.BaseRoutes.Bot = api.BaseRoutes.ApiRoot.PathPrefix("/bots/{user_id:[A-Za-z0-9]+}").Subrouter()
+	api.BaseRoutes.Bot = api.BaseRoutes.ApiRoot.PathPrefix("/bots/{bot_user_id:[A-Za-z0-9]+}").Subrouter()
 
 	api.BaseRoutes.Teams = api.BaseRoutes.ApiRoot.PathPrefix("/teams").Subrouter()
 	api.BaseRoutes.TeamsForUser = api.BaseRoutes.User.PathPrefix("/teams").Subrouter()

--- a/api4/bot.go
+++ b/api4/bot.go
@@ -15,6 +15,7 @@ func (api *API) InitBot() {
 	api.BaseRoutes.Bot.Handle("", api.ApiSessionRequired(getBot)).Methods("GET")
 	api.BaseRoutes.Bots.Handle("", api.ApiSessionRequired(getBots)).Methods("GET")
 	api.BaseRoutes.Bot.Handle("/disable", api.ApiSessionRequired(disableBot)).Methods("POST")
+	api.BaseRoutes.Bot.Handle("/assign/{user_id:[A-Za-z0-9]+}", api.ApiSessionRequired(assignBot)).Methods("POST")
 }
 
 func createBot(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -45,11 +46,11 @@ func createBot(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func patchBot(c *Context, w http.ResponseWriter, r *http.Request) {
-	c.RequireUserId()
+	c.RequireBotUserId()
 	if c.Err != nil {
 		return
 	}
-	botUserId := c.Params.UserId
+	botUserId := c.Params.BotUserId
 
 	botPatch := model.BotPatchFromJson(r.Body)
 	if botPatch == nil {
@@ -72,11 +73,11 @@ func patchBot(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getBot(c *Context, w http.ResponseWriter, r *http.Request) {
-	c.RequireUserId()
+	c.RequireBotUserId()
 	if c.Err != nil {
 		return
 	}
-	botUserId := c.Params.UserId
+	botUserId := c.Params.BotUserId
 
 	includeDeleted := r.URL.Query().Get("include_deleted") == "true"
 
@@ -146,11 +147,11 @@ func getBots(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func disableBot(c *Context, w http.ResponseWriter, r *http.Request) {
-	c.RequireUserId()
+	c.RequireBotUserId()
 	if c.Err != nil {
 		return
 	}
-	botUserId := c.Params.UserId
+	botUserId := c.Params.BotUserId
 
 	if err := c.App.SessionHasPermissionToManageBot(c.App.Session, botUserId); err != nil {
 		c.Err = err
@@ -158,6 +159,29 @@ func disableBot(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	bot, err := c.App.UpdateBotActive(botUserId, false)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	w.Write(bot.ToJson())
+}
+
+func assignBot(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireUserId()
+	c.RequireBotUserId()
+	if c.Err != nil {
+		return
+	}
+	botUserId := c.Params.BotUserId
+	userId := c.Params.UserId
+
+	if err := c.App.SessionHasPermissionToManageBot(c.App.Session, botUserId); err != nil {
+		c.Err = err
+		return
+	}
+
+	bot, err := c.App.UpdateBotOwner(botUserId, userId)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/bot.go
+++ b/api4/bot.go
@@ -112,6 +112,7 @@ func getBot(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func getBots(c *Context, w http.ResponseWriter, r *http.Request) {
 	includeDeleted := r.URL.Query().Get("include_deleted") == "true"
+	onlyOrphaned := r.URL.Query().Get("only_orphaned") == "true"
 
 	var creatorId string
 	if c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_READ_OTHERS_BOTS) {
@@ -130,6 +131,7 @@ func getBots(c *Context, w http.ResponseWriter, r *http.Request) {
 		PerPage:        c.Params.PerPage,
 		CreatorId:      creatorId,
 		IncludeDeleted: includeDeleted,
+		OnlyOrphaned:   onlyOrphaned,
 	})
 	if err != nil {
 		c.Err = err

--- a/api4/bot_test.go
+++ b/api4/bot_test.go
@@ -798,7 +798,7 @@ func TestAssignBot(t *testing.T) {
 		th.LoginBasic()
 	})
 
-	t.Run("deligated user assign bot", func(t *testing.T) {
+	t.Run("delegated user assign bot", func(t *testing.T) {
 		defer th.RestoreDefaultRolePermissions(th.SaveDefaultRolePermissions())
 
 		th.AddPermissionToRole(model.PERMISSION_CREATE_BOT.Id, model.SYSTEM_USER_ROLE_ID)

--- a/app/bot.go
+++ b/app/bot.go
@@ -44,7 +44,7 @@ func (a *App) PatchBot(botUserId string, botPatch *model.BotPatch) (*model.Bot, 
 	user.Username = patchedUser.Username
 	user.Email = patchedUser.Email
 	user.FirstName = patchedUser.FirstName
-	if result := <-a.Srv.Store.User().Update(user, true); result.Err != nil {
+	if result = <-a.Srv.Store.User().Update(user, true); result.Err != nil {
 		return nil, result.Err
 	}
 
@@ -125,4 +125,21 @@ func (a *App) PermanentDeleteBot(botUserId string) *model.AppError {
 	}
 
 	return nil
+}
+
+// UpdateBotOwner changes a bot's owner to the given value
+func (a *App) UpdateBotOwner(botUserId, newOwnerId string) (*model.Bot, *model.AppError) {
+	result := <-a.Srv.Store.Bot().Get(botUserId, true)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	bot := result.Data.(*model.Bot)
+
+	bot.CreatorId = newOwnerId
+
+	if result = <-a.Srv.Store.Bot().Update(bot); result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.(*model.Bot), nil
 }

--- a/app/bot.go
+++ b/app/bot.go
@@ -68,7 +68,7 @@ func (a *App) GetBot(botUserId string, includeDeleted bool) (*model.Bot, *model.
 
 // GetBots returns the requested page of bots.
 func (a *App) GetBots(options *model.BotGetOptions) (model.BotList, *model.AppError) {
-	result := <-a.Srv.Store.Bot().GetAll(options.Page*options.PerPage, options.PerPage, options.CreatorId, options.IncludeDeleted)
+	result := <-a.Srv.Store.Bot().GetAll(options)
 	if result.Err != nil {
 		return nil, result.Err
 	}

--- a/model/bot.go
+++ b/model/bot.go
@@ -43,6 +43,7 @@ type BotPatch struct {
 type BotGetOptions struct {
 	CreatorId      string
 	IncludeDeleted bool
+	OnlyOrphaned   bool
 	Page           int
 	PerPage        int
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -154,8 +154,8 @@ func (c *Client4) GetBotsRoute() string {
 	return fmt.Sprintf("/bots")
 }
 
-func (c *Client4) GetBotRoute(userId string) string {
-	return fmt.Sprintf("%s/%s", c.GetBotsRoute(), userId)
+func (c *Client4) GetBotRoute(botUserId string) string {
+	return fmt.Sprintf("%s/%s", c.GetBotsRoute(), botUserId)
 }
 
 func (c *Client4) GetTeamsRoute() string {
@@ -1415,6 +1415,16 @@ func (c *Client4) GetBotsOrphaned(page, perPage int, etag string) ([]*Bot, *Resp
 // DisableBot disables the given bot in the system.
 func (c *Client4) DisableBot(userId string) (*Bot, *Response) {
 	r, err := c.doApiPostBytes(c.GetBotRoute(userId)+"/disable", nil)
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	return BotFromJson(r.Body), BuildResponse(r)
+}
+
+// AssignBot assigns the given bot to the given user
+func (c *Client4) AssignBot(botUserId, newOwnerId string) (*Bot, *Response) {
+	r, err := c.doApiPostBytes(c.GetBotRoute(botUserId)+"/assign/"+newOwnerId, nil)
 	if err != nil {
 		return nil, BuildErrorResponse(r, err)
 	}

--- a/model/client4.go
+++ b/model/client4.go
@@ -1401,6 +1401,17 @@ func (c *Client4) GetBotsIncludeDeleted(page, perPage int, etag string) ([]*Bot,
 	return BotListFromJson(r.Body), BuildResponse(r)
 }
 
+// GetBotsOrphaned fetches the given page of bots, only including orphanded bots.
+func (c *Client4) GetBotsOrphaned(page, perPage int, etag string) ([]*Bot, *Response) {
+	query := fmt.Sprintf("?page=%v&per_page=%v&only_orphaned=true", page, perPage)
+	r, err := c.DoApiGet(c.GetBotsRoute()+query, etag)
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	return BotListFromJson(r.Body), BuildResponse(r)
+}
+
 // DisableBot disables the given bot in the system.
 func (c *Client4) DisableBot(userId string) (*Bot, *Response) {
 	r, err := c.doApiPostBytes(c.GetBotRoute(userId)+"/disable", nil)

--- a/store/store.go
+++ b/store/store.go
@@ -290,7 +290,7 @@ type UserStore interface {
 
 type BotStore interface {
 	Get(userId string, includeDeleted bool) StoreChannel
-	GetAll(page, perPage int, creatorId string, includeDeleted bool) StoreChannel
+	GetAll(options *model.BotGetOptions) StoreChannel
 	Save(bot *model.Bot) StoreChannel
 	Update(bot *model.Bot) StoreChannel
 	PermanentDelete(userId string) StoreChannel

--- a/store/storetest/mocks/BotStore.go
+++ b/store/storetest/mocks/BotStore.go
@@ -29,13 +29,13 @@ func (_m *BotStore) Get(userId string, includeDeleted bool) store.StoreChannel {
 	return r0
 }
 
-// GetAll provides a mock function with given fields: page, perPage, creatorId, includeDeleted
-func (_m *BotStore) GetAll(page int, perPage int, creatorId string, includeDeleted bool) store.StoreChannel {
-	ret := _m.Called(page, perPage, creatorId, includeDeleted)
+// GetAll provides a mock function with given fields: options
+func (_m *BotStore) GetAll(options *model.BotGetOptions) store.StoreChannel {
+	ret := _m.Called(options)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(int, int, string, bool) store.StoreChannel); ok {
-		r0 = rf(page, perPage, creatorId, includeDeleted)
+	if rf, ok := ret.Get(0).(func(*model.BotGetOptions) store.StoreChannel); ok {
+		r0 = rf(options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/web/context.go
+++ b/web/context.go
@@ -563,3 +563,14 @@ func (c *Context) RequireSyncableType() *Context {
 	}
 	return c
 }
+
+func (c *Context) RequireBotUserId() *Context {
+	if c.Err != nil {
+		return c
+	}
+
+	if len(c.Params.BotUserId) != 26 {
+		c.SetInvalidUrlParam("bot_user_id")
+	}
+	return c
+}

--- a/web/params.go
+++ b/web/params.go
@@ -58,6 +58,7 @@ type Params struct {
 	RemoteId       string
 	SyncableId     string
 	SyncableType   model.GroupSyncableType
+	BotUserId      string
 }
 
 func ParamsFromRequest(r *http.Request) *Params {
@@ -226,5 +227,10 @@ func ParamsFromRequest(r *http.Request) *Params {
 			params.SyncableType = model.GroupSyncableTypeChannel
 		}
 	}
+
+	if val, ok := props["bot_user_id"]; ok {
+		params.BotUserId = val
+	}
+
 	return params
 }


### PR DESCRIPTION
Adds a parameter to get bots to specify that you only want the orphaned entries. This will allow an admin to find bots that need to be taken care of.
Also adds the new route `/assign` which allows users with permissions to assign bots to themselves or others. 

Future:
- Change "CreatorId" to "OwnerId" as the value may no longer be the creator.