### PR TITLE
MM-13996 Properly get image dimensions for OpenGraph images using secure_url

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -169,15 +169,26 @@ func (a *App) getImagesForPost(post *model.Post, imageURLs []string, isNewPost b
 
 		case model.POST_EMBED_OPENGRAPH:
 			for _, image := range embed.Data.(*opengraph.OpenGraph).Images {
+				var imageURL string
+				if image.SecureURL != "" {
+					imageURL = image.SecureURL
+				} else if image.URL != "" {
+					imageURL = image.URL
+				}
+
+				if imageURL == "" {
+					continue
+				}
+
 				if image.Width != 0 || image.Height != 0 {
 					// The site has already told us the image dimensions
-					images[image.URL] = &model.PostImage{
+					images[imageURL] = &model.PostImage{
 						Width:  int(image.Width),
 						Height: int(image.Height),
 					}
 				} else {
 					// The site did not specify its image dimensions
-					imageURLs = append(imageURLs, image.URL)
+					imageURLs = append(imageURLs, imageURL)
 				}
 			}
 		}


### PR DESCRIPTION
For images in the OpenGraph metadata, we only looked for the `url` field, but we should've also been looking for the `secure_url` field for sites that defined it. We also set the `secure_url` field when proxying OpenGraph images as well, so we were not properly giving image dimensions for OpenGraph images.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13996

#### Checklist
- Added or updated unit tests (required for all new features)