### PR TITLE
MM-13997 Prioritize images over OpenGraph metadata when requesting metadata

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -353,7 +353,7 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 		// /api/v4/image requires authentication, so bypass the API by hitting the proxy directly
 		body, contentType, err = a.ImageProxy.GetImageDirect(a.ImageProxy.GetUnproxiedImageURL(request.URL.String()))
 	} else {
-		request.Header.Add("Accept", "text/html, image/*")
+		request.Header.Add("Accept", "image/*, text/html")
 
 		client := a.HTTPService.MakeClient(false)
 		client.Timeout = time.Duration(*a.Config().ExperimentalSettings.LinkMetadataTimeoutMilliseconds) * time.Millisecond


### PR DESCRIPTION
Some websites such as giphy serve both HTML or an image for a given link. By switching the order, we prioritize receiving images instead of HTML that might contain OpenGraph metadata.

The reason we need this is that when we're loading metadata for a given link, we don't care if the link is in a Markdown image or if it's just a raw link in the post. Unless we start to differentiate the two (which requires some changes around how we store this metadata), we need to pick one or the other to use here. Since we can show previews for plain images, but we can't render OpenGraph as a Markdown image, I've picked to prefer images.

I didn't add a test for this since there's no built-in utility in Go for doing content negotiation, and any such unit test would be pointless anyway with a mocked server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13997