### PR TITLE
MM-14037 Ensure deprecated image proxy settings are read correctly

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -278,9 +278,9 @@ type ServiceSettings struct {
 	ExperimentalEnableDefaultChannelLeaveJoinMessages *bool
 	ExperimentalGroupUnreadChannels                   *string
 	ExperimentalChannelOrganization                   *bool
-	DEPRECATED_DO_NOT_USE_ImageProxyType              *string `json:"ImageProxyType"`    // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_ImageProxyURL               *string `json:"ImageProxyURL"`     // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_ImageProxyOptions           *string `json:"ImageProxyOptions"` // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_ImageProxyType              *string `json:"ImageProxyType" mapstructure:"ImageProxyType"`       // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_ImageProxyURL               *string `json:"ImageProxyURL" mapstructure:"ImageProxyURL"`         // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_ImageProxyOptions           *string `json:"ImageProxyOptions" mapstructure:"ImageProxyOptions"` // This field is deprecated and must not be used.
 	EnableAPITeamDeletion                             *bool
 	ExperimentalEnableHardenedMode                    *bool
 	ExperimentalStrictCSRFEnforcement                 *bool

--- a/utils/config_test.go
+++ b/utils/config_test.go
@@ -109,6 +109,25 @@ func TestReadConfig_PluginSettings(t *testing.T) {
 		}, *config.PluginSettings.PluginStates["jira"])
 	}
 }
+func TestReadConfig_ImageProxySettings(t *testing.T) {
+	TranslationsPreInit()
+
+	t.Run("deprecated settings should still be read properly", func(t *testing.T) {
+		config, _, err := ReadConfig(bytes.NewReader([]byte(`{
+			"ServiceSettings": {
+				"ImageProxyType": "OldImageProxyType",
+				"ImageProxyURL": "OldImageProxyURL",
+				"ImageProxyOptions": "OldImageProxyOptions"
+			}
+		}`)), false)
+
+		require.Nil(t, err)
+
+		assert.Equal(t, model.NewString("OldImageProxyType"), config.ServiceSettings.DEPRECATED_DO_NOT_USE_ImageProxyType)
+		assert.Equal(t, model.NewString("OldImageProxyURL"), config.ServiceSettings.DEPRECATED_DO_NOT_USE_ImageProxyURL)
+		assert.Equal(t, model.NewString("OldImageProxyOptions"), config.ServiceSettings.DEPRECATED_DO_NOT_USE_ImageProxyOptions)
+	})
+}
 
 func TestConfigFromEnviroVars(t *testing.T) {
 	TranslationsPreInit()


### PR DESCRIPTION
When moving these settings, I renamed the fields which caused the library responsible for loading the config to not load the old ones. I thought the `json` struct tags would help the library find the old fields, but it turned out that the mapstructure library needed its own struct tags.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14037

#### Checklist
- Added or updated unit tests (required for all new features)