### PR TITLE
MM-13104: forbid bot login

### DIFF
--- a/app/authentication.go
+++ b/app/authentication.go
@@ -130,6 +130,10 @@ func (a *App) CheckUserPreflightAuthenticationCriteria(user *model.User, mfaToke
 		return err
 	}
 
+	if err := checkUserNotBot(user); err != nil {
+		return err
+	}
+
 	if err := checkUserLoginAttempts(user, *a.Config().ServiceSettings.MaximumLoginAttempts); err != nil {
 		return err
 	}
@@ -174,6 +178,13 @@ func checkUserLoginAttempts(user *model.User, max int) *model.AppError {
 func checkUserNotDisabled(user *model.User) *model.AppError {
 	if user.DeleteAt > 0 {
 		return model.NewAppError("Login", "api.user.login.inactive.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
+	}
+	return nil
+}
+
+func checkUserNotBot(user *model.User) *model.AppError {
+	if user.IsBot {
+		return model.NewAppError("Login", "api.user.login.bot_login_forbidden.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
 	}
 	return nil
 }

--- a/app/login.go
+++ b/app/login.go
@@ -57,6 +57,11 @@ func (a *App) AuthenticateUserForLogin(id, loginId, password, mfaToken string, l
 	// then trust the proxy and cert that the correct user is supplied and allow
 	// them access
 	if *a.Config().ExperimentalSettings.ClientSideCertEnable && *a.Config().ExperimentalSettings.ClientSideCertCheck == model.CLIENT_SIDE_CERT_CHECK_PRIMARY_AUTH {
+		// Unless the user is a bot.
+		if err := checkUserNotBot(user); err != nil {
+			return nil, err
+		}
+
 		return user, nil
 	}
 

--- a/app/login.go
+++ b/app/login.go
@@ -58,7 +58,7 @@ func (a *App) AuthenticateUserForLogin(id, loginId, password, mfaToken string, l
 	// them access
 	if *a.Config().ExperimentalSettings.ClientSideCertEnable && *a.Config().ExperimentalSettings.ClientSideCertCheck == model.CLIENT_SIDE_CERT_CHECK_PRIMARY_AUTH {
 		// Unless the user is a bot.
-		if err := checkUserNotBot(user); err != nil {
+		if err = checkUserNotBot(user); err != nil {
 			return nil, err
 		}
 

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -552,6 +552,13 @@ func (a *App) LoginByOAuth(service string, userData io.Reader, teamId string) (*
 			return nil, err
 		}
 	} else {
+		// OAuth doesn't run through CheckUserPreflightAuthenticationCriteria, so prevent bot login
+		// here manually. Technically, the auth data above will fail to match a bot in the first
+		// place, but explicit is always better.
+		if user.IsBot {
+			return nil, model.NewAppError("loginByOAuth", "api.user.login_by_oauth.bot_login_forbidden.app_error", nil, "", http.StatusForbidden)
+		}
+
 		if err = a.UpdateOAuthUserAttrs(bytes.NewReader(buf.Bytes()), user, provider, service); err != nil {
 			return nil, err
 		}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2259,6 +2259,10 @@
     "translation": "This user account does not use AD/LDAP"
   },
   {
+    "id": "api.user.login.bot_login_forbidden.app_error",
+    "translation": "Bot login is forbidden"
+  },
+  {
     "id": "api.user.login.blank_pwd.app_error",
     "translation": "Password field must not be blank"
   },
@@ -2285,6 +2289,10 @@
   {
     "id": "api.user.login.use_auth_service.app_error",
     "translation": "Please sign in using {{.AuthService}}"
+  },
+  {
+    "id": "api.user.login_by_oauth.bot_login_forbidden.app_error",
+    "translation": "Bot login is forbidden"
   },
   {
     "id": "api.user.login_by_oauth.not_available.app_error",


### PR DESCRIPTION
#### Summary
User accounts corresponding to bots should not be allowed to login. In practice, this is already impossible as we don't give bots the necessary AuthData, but add some explicit checks and coverage around this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13104

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates