### PR TITLE
MM-14052: fix subpath yet again

### DIFF
--- a/utils/subpath_test.go
+++ b/utils/subpath_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -117,7 +118,7 @@ func TestUpdateAssetsSubpath(t *testing.T) {
 				baseManifestJson,
 				"/",
 				nil,
-				resetRootHtml,
+				baseRootHtml,
 				baseCss,
 				baseManifestJson,
 			},
@@ -137,7 +138,11 @@ func TestUpdateAssetsSubpath(t *testing.T) {
 
 				contents, err := ioutil.ReadFile(filepath.Join(tempDir, model.CLIENT_DIR, "root.html"))
 				require.NoError(t, err)
-				require.Equal(t, testCase.ExpectedRootHTML, string(contents))
+
+				// Rewrite the expected and contents for simpler diffs when failed.
+				expectedRootHTML := strings.Replace(testCase.ExpectedRootHTML, ">", ">\n", -1)
+				contentsStr := strings.Replace(string(contents), ">", ">\n", -1)
+				require.Equal(t, expectedRootHTML, contentsStr)
 
 				contents, err = ioutil.ReadFile(filepath.Join(tempDir, model.CLIENT_DIR, "main.css"))
 				require.NoError(t, err)

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -77,7 +77,10 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Instruct the browser not to display us in an iframe unless is the same origin for anti-clickjacking
 		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		// Set content security policy. This is also specified in the root.html of the webapp in a meta tag.
-		w.Header().Set("Content-Security-Policy", "frame-ancestors 'self'; script-src 'self' cdn.segment.com/analytics.js/")
+		w.Header().Set("Content-Security-Policy", fmt.Sprintf(
+			"frame-ancestors 'self'; script-src 'self' cdn.segment.com/analytics.js/%s",
+			utils.GetSubpathScriptHash(subpath),
+		))
 	} else {
 		// All api response bodies will be JSON formatted by default
 		w.Header().Set("Content-Type", "application/json")

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -6,7 +6,6 @@ package web
 import (
 	"net/http"
 	"net/http/httptest"
-	"path"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -252,7 +251,7 @@ func TestHandlerServeCSPHeader(t *testing.T) {
 		defer th.TearDown()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			*cfg.ServiceSettings.SiteURL = path.Join(*cfg.ServiceSettings.SiteURL, "/subpath/")
+			*cfg.ServiceSettings.SiteURL = *cfg.ServiceSettings.SiteURL + "/subpath"
 		})
 
 		web := New(th.Server, th.Server.AppOptions, th.Server.Router)
@@ -270,6 +269,6 @@ func TestHandlerServeCSPHeader(t *testing.T) {
 		response := httptest.NewRecorder()
 		handler.ServeHTTP(response, request)
 		assert.Equal(t, 200, response.Code)
-		assert.Contains(t, response.Header()["Content-Security-Policy"], "frame-ancestors 'self'; script-src 'self' cdn.segment.com/analytics.js/ 'sha256-FM9ZedAgORGblKMijevDdC2WMIirVsuXHcqSXpq3Gg0='")
+		assert.Contains(t, response.Header()["Content-Security-Policy"], "frame-ancestors 'self'; script-src 'self' cdn.segment.com/analytics.js/ 'sha256-tPOjw+tkVs9axL78ZwGtYl975dtyPHB6LYKAO2R3gR4='")
 	})
 }


### PR DESCRIPTION
#### Summary
The server now emits a `script-src` CSP directive that overrides the `root.html` rewrite. Fix this by emitting the requisite `sha-256` hash server-side as well as rewriting `root.html`. We can't remove the `root.html` rewrite, since the assets may be on a CDN instead and we use the same code path to rewrite them (on demand).

Prior to this change, going from `/` -> `/subpath` -> `/` would leave changes in `root.html`: the `Content-Security-Policy` header would still have the `sha-256` hash, and the inline script would still override the `publicPath` but to the default subpath value. To avoid sending down a `sha-256` hash server-side when no subpath is required, change this to fully strip out the subpath changes. This is the only unit test change to the existing subpath tests, as the existing coverage proves the algorithm still works. I separately added unit tests to assert the CSP header emitted by the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14052

#### Checklist
- [x] Added or updated unit tests (required for all new features)