### PR TITLE
Make CSRF Logging less verbose if not enforced

### DIFF
--- a/app/plugin_requests.go
+++ b/app/plugin_requests.go
@@ -87,9 +87,14 @@ func (a *App) servePluginRequest(w http.ResponseWriter, r *http.Request, handler
 			}
 
 			// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
-			if !*a.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement && r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML && !csrfCheckPassed {
-				a.Log.Warn("CSRF Check failed for request - Please migrate your plugin to either send a CSRF Header or Form Field, XMLHttpRequest is deprecated")
-				csrfCheckPassed = true
+			if r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML && !csrfCheckPassed {
+				csrfErrorMessage := "CSRF Check failed for request - Please migrate your plugin to either send a CSRF Header or Form Field, XMLHttpRequest is deprecated"
+				if *a.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement {
+					a.Log.Warn(csrfErrorMessage)
+				} else {
+					a.Log.Debug(csrfErrorMessage)
+					csrfCheckPassed = true
+				}
 			}
 		} else {
 			csrfCheckPassed = true

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -98,10 +98,15 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			csrfHeader := r.Header.Get(model.HEADER_CSRF_TOKEN)
 			if csrfHeader == session.GetCSRF() {
 				csrfCheckPassed = true
-			} else if !*c.App.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement && r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML {
+			} else if r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML {
 				// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
-				c.Log.Warn("CSRF Header check failed for request - Please upgrade your web application or custom app to set a CSRF Header")
-				csrfCheckPassed = true
+				csrfErrorMessage := "CSRF Header check failed for request - Please upgrade your web application or custom app to set a CSRF Header"
+				if *c.App.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement {
+					c.Log.Warn(csrfErrorMessage)
+				} else {
+					c.Log.Debug(csrfErrorMessage)
+					csrfCheckPassed = true
+				}
 			}
 
 			if !csrfCheckPassed {


### PR DESCRIPTION
#### Summary
This PR makes the logging of the in [MM-10346](https://mattermost.atlassian.net/projects/MM/issues/MM-10346) introduced CSRF token implementation less verbose unless it's actually enforced. If it's not enforced, the warning message is only printed in LogDebug. If it's enforced, the LogWarn is used.