### PR TITLE
Fix out of range error if Search Replicas < Replicas in Config Parsing

### DIFF
--- a/config/utils.go
+++ b/config/utils.go
@@ -51,7 +51,7 @@ func desanitize(actual, target *model.Config) {
 		target.SqlSettings.DataSourceReplicas[i] = actual.SqlSettings.DataSourceReplicas[i]
 	}
 
-	target.SqlSettings.DataSourceSearchReplicas = make([]string, len(actual.SqlSettings.DataSourceReplicas))
+	target.SqlSettings.DataSourceSearchReplicas = make([]string, len(actual.SqlSettings.DataSourceSearchReplicas))
 	for i := range target.SqlSettings.DataSourceSearchReplicas {
 		target.SqlSettings.DataSourceSearchReplicas[i] = actual.SqlSettings.DataSourceSearchReplicas[i]
 	}


### PR DESCRIPTION
#### Summary
This fixes a bug that the config desanitize can crash if the amount of `DataSourceReplicas` is higher than `DataSourceSearchReplicas`, causing a out of range panic.

FYI @lieut-data 