### PR TITLE
[MM-13610] Fix Login Hooks for SAML

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -65,27 +65,6 @@ func (a *App) AuthenticateUserForLogin(id, loginId, password, mfaToken string, l
 		return nil, err
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		var rejectionReason string
-		pluginContext := a.PluginContext()
-		pluginsEnvironment.RunMultiPluginHook(func(hooks plugin.Hooks) bool {
-			rejectionReason = hooks.UserWillLogIn(pluginContext, user)
-			return rejectionReason == ""
-		}, plugin.UserWillLogInId)
-
-		if rejectionReason != "" {
-			return nil, model.NewAppError("AuthenticateUserForLogin", "Login rejected by plugin: "+rejectionReason, nil, "", http.StatusBadRequest)
-		}
-
-		a.Srv.Go(func() {
-			pluginContext := a.PluginContext()
-			pluginsEnvironment.RunMultiPluginHook(func(hooks plugin.Hooks) bool {
-				hooks.UserHasLoggedIn(pluginContext, user)
-				return true
-			}, plugin.UserHasLoggedInId)
-		})
-	}
-
 	return user, nil
 }
 
@@ -126,6 +105,20 @@ func (a *App) GetUserForLogin(id, loginId string) (*model.User, *model.AppError)
 }
 
 func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId string) (*model.Session, *model.AppError) {
+
+	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
+		var rejectionReason string
+		pluginContext := a.PluginContext()
+		pluginsEnvironment.RunMultiPluginHook(func(hooks plugin.Hooks) bool {
+			rejectionReason = hooks.UserWillLogIn(pluginContext, user)
+			return rejectionReason == ""
+		}, plugin.UserWillLogInId)
+
+		if rejectionReason != "" {
+			return nil, model.NewAppError("DoLogin", "Login rejected by plugin: "+rejectionReason, nil, "", http.StatusBadRequest)
+		}
+	}
+
 	session := &model.Session{UserId: user.Id, Roles: user.GetRawRoles(), DeviceId: deviceId, IsOAuth: false}
 	session.GenerateCSRF()
 	maxAge := *a.Config().ServiceSettings.SessionLengthWebInDays * 60 * 60 * 24
@@ -202,6 +195,16 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 	http.SetCookie(w, sessionCookie)
 	http.SetCookie(w, userCookie)
 	http.SetCookie(w, csrfCookie)
+
+	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
+		a.Srv.Go(func() {
+			pluginContext := a.PluginContext()
+			pluginsEnvironment.RunMultiPluginHook(func(hooks plugin.Hooks) bool {
+				hooks.UserHasLoggedIn(pluginContext, user)
+				return true
+			}, plugin.UserHasLoggedInId)
+		})
+	}
 
 	return session, nil
 }

--- a/app/login.go
+++ b/app/login.go
@@ -105,7 +105,6 @@ func (a *App) GetUserForLogin(id, loginId string) (*model.User, *model.AppError)
 }
 
 func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, deviceId string) (*model.Session, *model.AppError) {
-
 	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
 		var rejectionReason string
 		pluginContext := a.PluginContext()

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -7,9 +7,12 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -706,14 +709,12 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	`}, th.App, th.App.NewPluginAPI)
 	defer tearDown()
 
-	user, err := th.App.AuthenticateUserForLogin("", th.BasicUser.Email, "hunter2", "", false)
+	r := &http.Request{}
+	w := httptest.NewRecorder()
+	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	if user != nil {
-		t.Errorf("Expected nil, got %+v", user)
-	}
-
-	if err == nil {
-		t.Errorf("Expected err, got nil")
+	if !strings.HasPrefix(err.Id, "Login rejected by plugin") {
+		t.Errorf("Expected Login rejected by plugin, got %s", err.Id)
 	}
 }
 
@@ -751,14 +752,16 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 	`}, th.App, th.App.NewPluginAPI)
 	defer tearDown()
 
-	user, err := th.App.AuthenticateUserForLogin("", th.BasicUser.Email, "hunter2", "", false)
-
-	if user == nil {
-		t.Errorf("Expected user object, got nil")
-	}
+	r := &http.Request{}
+	w := httptest.NewRecorder()
+	session, err := th.App.DoLogin(w, r, th.BasicUser, "")
 
 	if err != nil {
 		t.Errorf("Expected nil, got %s", err)
+	}
+
+	if session.UserId != th.BasicUser.Id {
+		t.Errorf("Expected %s, got %s", th.BasicUser.Id, session.UserId)
 	}
 }
 
@@ -797,11 +800,9 @@ func TestUserHasLoggedIn(t *testing.T) {
 	`}, th.App, th.App.NewPluginAPI)
 	defer tearDown()
 
-	user, err := th.App.AuthenticateUserForLogin("", th.BasicUser.Email, "hunter2", "", false)
-
-	if user == nil {
-		t.Errorf("Expected user object, got nil")
-	}
+	r := &http.Request{}
+	w := httptest.NewRecorder()
+	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
 	if err != nil {
 		t.Errorf("Expected nil, got %s", err)
@@ -809,7 +810,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	user, _ = th.App.GetUser(th.BasicUser.Id)
+	user, _ := th.App.GetUser(th.BasicUser.Id)
 
 	if user.FirstName != "plugin-callback-success" {
 		t.Errorf("Expected firstname overwrite, got default")


### PR DESCRIPTION
#### Summary
The SAML authentication flow returns an error from the normal login flow and continues from a dedicated `completeSaml` handler. Since the login hooks were executed in a section that was skipped by SAML, they were never invoked that way. This PR moves the hook execution to the `DoLogin` flow which is invoked by all 3 login flows:

1. `completeOAuth` - `oauth.go:521`
2. `login` - `user.go:1144`
3. `completeSaml` - `saml.go:129`

Since that's the only place where we invoke `App.CreateSession`, it should cover all authentication flows.

FYI @lindalumitchell 

#### Ticket Link
https://mattermost.atlassian.net/projects/MM/issues/MM-13610