### PR TITLE
Let stale bot ignore pr further in the lifecycle

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,7 +8,10 @@ daysUntilStale: 14
 daysUntilClose: false
 
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: Lifecycle/frozen
+exemptLabels:
+  - Lifecycle/2:inactive
+  - Lifecycle/3:orphaned
+  - Lifecycle/frozen
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: true

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,7 +7,7 @@ daysUntilStale: 14
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
 daysUntilClose: false
 
-# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+# Issues or Pull Requests with these labels will be ignored by the stale bot. Set to `[]` to disable.
 exemptLabels:
   - Lifecycle/2:inactive
   - Lifecycle/3:orphaned


### PR DESCRIPTION
#### Summary
Stale bot should ignore PR's that are further in the life cycle. These are the ones, we have to check manually.

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-server/pull/10143
