### PR TITLE
[MM-11832] show that a plugin requires a configuration key

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -92,7 +92,7 @@ func (a *App) SyncPluginsActiveState() {
 
 			// Activate plugin if enabled
 			if pluginEnabled {
-				updatedManifest, activated, err := pluginsEnvironment.Activate(pluginId)
+				updatedManifest, activated, err := pluginsEnvironment.Activate(pluginId, a.Config())
 				if err != nil {
 					plugin.WrapLogger(a.Log).Error("Unable to activate plugin", mlog.Err(err))
 					continue

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -39,7 +39,7 @@ func setupPluginApiTest(t *testing.T, pluginCode string, pluginManifest string, 
 	compileGo(t, pluginCode, backend)
 
 	ioutil.WriteFile(filepath.Join(pluginDir, pluginId, "plugin.json"), []byte(pluginManifest), 0600)
-	manifest, activated, reterr := env.Activate(pluginId)
+	manifest, activated, reterr := env.Activate(pluginId, app.Config())
 	require.Nil(t, reterr)
 	require.NotNil(t, manifest)
 	require.True(t, activated)
@@ -594,7 +594,7 @@ func TestPluginAPIGetPlugins(t *testing.T) {
 		compileGo(t, pluginCode, backend)
 
 		ioutil.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(fmt.Sprintf(`{"id": "%s", "server": {"executable": "backend.exe"}}`, pluginID)), 0600)
-		manifest, activated, reterr := env.Activate(pluginID)
+		manifest, activated, reterr := env.Activate(pluginID, th.App.Config)
 
 		require.Nil(t, reterr)
 		require.NotNil(t, manifest)

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -594,7 +594,7 @@ func TestPluginAPIGetPlugins(t *testing.T) {
 		compileGo(t, pluginCode, backend)
 
 		ioutil.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(fmt.Sprintf(`{"id": "%s", "server": {"executable": "backend.exe"}}`, pluginID)), 0600)
-		manifest, activated, reterr := env.Activate(pluginID, th.App.Config)
+		manifest, activated, reterr := env.Activate(pluginID, th.App.Config())
 
 		require.Nil(t, reterr)
 		require.NotNil(t, manifest)

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -56,7 +56,7 @@ func SetAppEnvironmentWithPlugins(t *testing.T, pluginCode []string, app *App, a
 		compileGo(t, code, backend)
 
 		ioutil.WriteFile(filepath.Join(pluginDir, pluginId, "plugin.json"), []byte(`{"id": "`+pluginId+`", "backend": {"executable": "backend.exe"}}`), 0600)
-		_, _, activationErr := env.Activate(pluginId)
+		_, _, activationErr := env.Activate(pluginId, app.Config())
 		pluginIds = append(pluginIds, pluginId)
 		activationErrors = append(activationErrors, activationErr)
 	}

--- a/model/manifest.go
+++ b/model/manifest.go
@@ -319,10 +319,7 @@ func (m *Manifest) MeetMinServerVersion(serverVersion string) (bool, error) {
 }
 
 func (m *Manifest) ValidatePluginConfig(config map[string]interface{}) error {
-	if m.SettingsSchema == nil {
-		return fmt.Errorf(`Validation error could not find SettingsSchema for plugin manifest of [%s]`, m.Id)
-	}
-	if m.SettingsSchema.Settings == nil {
+	if m.SettingsSchema == nil || m.SettingsSchema.Settings == nil {
 		return nil // no Settings therefore no required Keys
 	}
 	if config == nil || len(config) < 1 {

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -724,17 +724,14 @@ func TestValidatePluginConfig(t *testing.T) {
 				"someKey": "someData"
 			}
 		}`
-	var manifest Manifest
-	r := strings.NewReader(ManifestString)
-	err := json.NewDecoder(r).Decode(&manifest)
-	require.Nil(t, err)
+	manifest := ManifestFromJson(strings.NewReader(ManifestString))
 	var ConfigString = `{
  "someKey": true,
  "someOtherKey": 5
 	}`
 	var configPass map[string]interface{}
-	r = strings.NewReader(ConfigString)
-	err = json.NewDecoder(r).Decode(&configPass)
+	r := strings.NewReader(ConfigString)
+	err := json.NewDecoder(r).Decode(&configPass)
 	require.Nil(t, err)
 	ConfigString = `{
 		"someKey": true
@@ -767,11 +764,8 @@ func TestValidatePluginConfig(t *testing.T) {
 		     "props": {
 					 "someKey": "someData"
 		     }
-		   }`
-	var manifestMissingSettings Manifest
-	r = strings.NewReader(ManifestString)
-	err = json.NewDecoder(r).Decode(&manifestMissingSettings)
-	require.Nil(t, err)
+			 }`
+	manifestMissingSettings := ManifestFromJson(strings.NewReader(ManifestString))
 	ManifestString = `
 	   {
 		     "id": "com.mycompany.myplugin",
@@ -792,11 +786,8 @@ func TestValidatePluginConfig(t *testing.T) {
 		     "props": {
 					 "someKey": "someData"
 		     }
-		   }`
-	var manifestMissingSettingsSchema Manifest
-	r = strings.NewReader(ManifestString)
-	err = json.NewDecoder(r).Decode(&manifestMissingSettingsSchema)
-	require.Nil(t, err)
+			 }`
+	manifestMissingSettingsSchema := ManifestFromJson(strings.NewReader(ManifestString))
 	ManifestString = `
 	{
 			"id": "com.mycompany.myplugin",
@@ -844,10 +835,7 @@ func TestValidatePluginConfig(t *testing.T) {
 				"someKey": "someData"
 			}
 		}`
-	var manifestNoRequiredKeys Manifest
-	r = strings.NewReader(ManifestString)
-	err = json.NewDecoder(r).Decode(&manifestNoRequiredKeys)
-	require.Nil(t, err)
+	manifestNoRequiredKeys := ManifestFromJson(strings.NewReader(ManifestString))
 	testCases := []struct {
 		Description string
 		Manifest    *Manifest
@@ -856,37 +844,37 @@ func TestValidatePluginConfig(t *testing.T) {
 	}{
 		{
 			"passing configuration with 2 required keys",
-			&manifest,
+			manifest,
 			configPass,
 			nil,
 		},
 		{
 			"failing configuration with 2 required keys of which one is missing",
-			&manifest,
+			manifest,
 			configMissingKey,
 			NewConfigError(manifest.Id, []string{"someOtherKey"}),
 		},
 		{
 			"passing with Settings within SettingsSchema of manifest is missing, therefore no required keys",
-			&manifestMissingSettings,
+			manifestMissingSettings,
 			configPass,
 			nil,
 		},
 		{
 			"passing when missing SettingsSchema of manifest since no keys are required",
-			&manifestMissingSettingsSchema,
+			manifestMissingSettingsSchema,
 			configPass,
 			nil,
 		},
 		{
 			"passing with missing plugin config where no required keys are configured in manifest",
-			&manifestNoRequiredKeys,
+			manifestNoRequiredKeys,
 			nil,
 			nil,
 		},
 		{
 			"failing with missing plugin config where 2 required keys are configured in manifest",
-			&manifest,
+			manifest,
 			nil,
 			NewConfigError(manifest.Id, []string{"someKey", "someOtherKey"}),
 		},

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -5,7 +5,6 @@ package model
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -874,10 +873,10 @@ func TestValidatePluginConfig(t *testing.T) {
 			nil,
 		},
 		{
-			"failing due to missing SettingsSchema of manifest is missing",
+			"passing when missing SettingsSchema of manifest since no keys are required",
 			&manifestMissingSettingsSchema,
 			configPass,
-			fmt.Errorf(`Validation error could not find SettingsSchema for plugin manifest of [%s]`, manifestMissingSettings.Id),
+			nil,
 		},
 		{
 			"passing with missing plugin config where no required keys are configured in manifest",

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -128,7 +128,7 @@ func (env *Environment) Statuses() (model.PluginStatuses, error) {
 	return pluginStatuses, nil
 }
 
-func (env *Environment) Activate(id string) (manifest *model.Manifest, activated bool, reterr error) {
+func (env *Environment) Activate(id string, config *model.Config) (manifest *model.Manifest, activated bool, reterr error) {
 	// Check if we are already active
 	if _, ok := env.activePlugins.Load(id); ok {
 		return nil, false, nil
@@ -169,6 +169,10 @@ func (env *Environment) Activate(id string) (manifest *model.Manifest, activated
 		if !fulfilled {
 			return nil, false, fmt.Errorf("plugin requires Mattermost %v: %v", pluginInfo.Manifest.MinServerVersion, id)
 		}
+	}
+
+	if err := pluginInfo.Manifest.ValidatePluginConfig(config.PluginSettings.Plugins[id]); err != nil {
+		return pluginInfo.Manifest, false, err
 	}
 
 	componentActivated := false


### PR DESCRIPTION
#### Summary
When a plugin configuration is first loaded or is changed the configuration of the plugin is verified for required values against the schema defined in the plugin manifest and as a result logged within the server log

#### Ticket Link
[MM-11832](https://mattermost.atlassian.net/browse/MM-11832)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ x] Touches critical sections of the codebase (auth, upgrade, etc.)
