### PR TITLE
[MM-14233] Check whether self-deactivation is enabled in delete handler

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -791,6 +791,12 @@ func deleteUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if EnableUserDeactivation flag is disabled the user cannot deactivate himself.
+	if c.Params.UserId == c.App.Session.UserId && !*c.App.Config().TeamSettings.EnableUserDeactivation && !c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.Err = model.NewAppError("deleteUser", "api.user.update_active.not_enable.app_error", nil, "userId="+c.Params.UserId, http.StatusUnauthorized)
+		return
+	}
+
 	user, err := c.App.GetUser(userId)
 	if err != nil {
 		c.Err = err

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1300,6 +1300,21 @@ func TestDeleteUser(t *testing.T) {
 
 	_, resp = th.Client.DeleteUser(testUser.Id)
 	CheckNoError(t, resp)
+
+	selfDeleteUser := th.CreateUser()
+	th.Client.Login(selfDeleteUser.Email, selfDeleteUser.Password)
+
+	th.App.UpdateConfig(func(c *model.Config){
+		*c.TeamSettings.EnableUserDeactivation = false
+	})
+	_, resp = th.Client.DeleteUser(selfDeleteUser.Id)
+	CheckUnauthorizedStatus(t, resp)
+
+	th.App.UpdateConfig(func(c *model.Config){
+		*c.TeamSettings.EnableUserDeactivation = true
+	})
+	_, resp = th.Client.DeleteUser(selfDeleteUser.Id)
+	CheckNoError(t, resp)
 }
 
 func TestUpdateUserRoles(t *testing.T) {


### PR DESCRIPTION
#### Summary
Currently it's possible for users to disable themselves using the delete handler, this PR checks whether it's enabled and returns a 401 error otherwise. System admins are unaffected by this change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14233

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
