### PR TITLE
[MM-14235] Use LogAudit instead of LogAuditWithUser when logging user modification changes

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -829,7 +829,7 @@ func updateUserRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.LogAuditWithUserId(c.Params.UserId, "roles="+newRoles)
+	c.LogAudit(fmt.Sprintf("user=%s roles=%s", c.Params.UserId, newRoles))
 	ReturnStatusOK(w)
 }
 
@@ -905,7 +905,7 @@ func updateUserAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.LogAuditWithUserId(c.Params.UserId, fmt.Sprintf("updated user auth to service=%v", user.AuthService))
+	c.LogAudit(fmt.Sprintf("updated user %s auth to service=%v", c.Params.UserId, user.AuthService))
 	w.Write([]byte(user.ToJson()))
 }
 


### PR DESCRIPTION
#### Summary
This PR changes two invocations of LogAuditWithUser to LogAudit to avoid the situation that admin action audit entries are leaked to the user audit log. The user that is modified is now stored in the extra data itself.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14235