### PR TITLE
MM-13817: Increase the time limit of tokens existency from 24h to 48h

### DIFF
--- a/model/token.go
+++ b/model/token.go
@@ -7,7 +7,7 @@ import "net/http"
 
 const (
 	TOKEN_SIZE            = 64
-	MAX_TOKEN_EXIPRY_TIME = 1000 * 60 * 60 * 24 // 24 hour
+	MAX_TOKEN_EXIPRY_TIME = 1000 * 60 * 60 * 48 // 48 hour
 	TOKEN_TYPE_OAUTH      = "oauth"
 )
 


### PR DESCRIPTION
#### Summary
Increase the time limit of tokens existency from 24h to 48h.

How this works? Every hour is run a cleanup of exiting tokens, removing any
token older than 24 hours. For now we have 4 kind of tokens. One for Oauth
(without explicit expiration, but with a 30 minutes cookie expiration), a
verify email (without explicit expiration), invitations with explicit
expiration after 48h, and password recovery with explicit expiration after 1
hour. Every token is removed after 24 hours. If we change the limit of the
cleanup to 48h, we will see that email verification, oauth tokens, and
invitations start to work during 48 hours (I’m not sure about the OAuth,
because I didn’t investigate properly the cookie expiration implications).

#### Ticket Link
[MM-13817](https://mattermost.atlassian.net/browse/MM-13817)