### PR TITLE
[MM-13799] Ignoring database timeout during migration database upgrade to version 5.10.0

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	VERSION_5_10_0           = "5.10.0"
 	VERSION_5_9_0            = "5.9.0"
 	VERSION_5_8_0            = "5.8.0"
 	VERSION_5_7_0            = "5.7.0"
@@ -575,8 +576,14 @@ func UpgradeDatabaseToVersion59(sqlStore SqlStore) {
 }
 
 func UpgradeDatabaseToVersion510(sqlStore SqlStore) {
-	// if shouldPerformUpgrade(sqlStore, VERSION_5_9_0, VERSION_5_10_0) {
-
-	// 	saveSchemaVersion(sqlStore, VERSION_5_10_0)
-	// }
+	if shouldPerformUpgrade(sqlStore, VERSION_5_9_0, VERSION_5_10_0) {
+		if sqlStore.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+			sqlStore.GetMaster().Exec("SELECT pg_sleep(1000)")
+			sqlStore.GetMaster().Exec("SET statement_timeout TO 0")
+		} else if sqlStore.DriverName() == model.DATABASE_DRIVER_MYSQL {
+			sqlStore.GetMaster().Exec("SET SLEEP(1000)")
+			sqlStore.GetMaster().Exec("SET SESSION wait_timeout = 2147483")
+		}
+		saveSchemaVersion(sqlStore, VERSION_5_10_0)
+	}
 }


### PR DESCRIPTION
#### Summary
- Enable the 5.10.0 version
- Check the database driver used by the sqlStore and execute SQL statement that (1) sleep for 1000 seconds and (2) ignoring the timeout according to the DB. 
- We can set the timeout to 0 for PostgreSQL while for MySQL we can just set it to the maximum timeout value. 

#### Ticket Link
Fixes #10327 
Jira ticket: [MM-13799](https://mattermost.atlassian.net/browse/MM-13799)

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
