### PR TITLE
[MM-11142] Console logging should be human readable during developmen…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,8 @@ run-server: start-docker ## Starts the server.
 	@echo Running mattermost for development
 
 	mkdir -p $(BUILD_WEBAPP_DIR)/dist/files
-	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) --disableconfigwatch &
+	$(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) --disableconfigwatch | \
+	    $(GO) run $(GOFLAGS) $(GO_LINKER_FLAGS) $(PLATFORM_FILES) logs --logrus &
 
 debug-server: start-docker
 	mkdir -p $(BUILD_WEBAPP_DIR)/dist/files


### PR DESCRIPTION
#### Summary
This PR sets the default console logging for developers as 'not json' -- i.e., human readable. But because developers may have changed it, I didn't want to just clobber their setting every time they started the server. So I had to check whether or not we were loading from the default config file. To do this, I had to add a flag to the commonStore struct (common.go), and add a function to the Store interface (store.go) to allow the NewServer function (server.go) to query whether or not this was the first time the config settings had been loaded. It's messy, but I couldn't think of another way to not clobber the developer's settings. Happy to see if there's another way of doing this while respecting previous settings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11142
GH-10349

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
