### PR TITLE
[MM-14313] Use LogAudit for Active/Deactive Action

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -877,7 +877,7 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 	}
 
-	c.LogAuditWithUserId(user.Id, fmt.Sprintf("active=%v", active))
+	c.LogAudit(fmt.Sprintf("user_id=%s active=%v", user.Id, active))
 	if isSelfDeactive {
 		c.App.Srv.Go(func() {
 			if err = c.App.SendDeactivateAccountEmail(user.Email, user.Locale, c.App.GetSiteURL()); err != nil {


### PR DESCRIPTION
#### Summary
In order to avoid leaking the admin session, log the modification in the current users audit log and refer to the user ID in the extra data.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14313
