### PR TITLE
MM-14082 Don't print warnings when saving duplicate metadata

### DIFF
--- a/store/sqlstore/link_metadata_store.go
+++ b/store/sqlstore/link_metadata_store.go
@@ -45,7 +45,7 @@ func (s SqlLinkMetadataStore) Save(metadata *model.LinkMetadata) store.StoreChan
 		metadata.PreSave()
 
 		err := s.GetMaster().Insert(metadata)
-		if err != nil {
+		if err != nil && !IsUniqueConstraintError(err, []string{"PRIMARY", "linkmetadata_pkey"}) {
 			result.Err = model.NewAppError("SqlLinkMetadataStore.Save", "store.sql_link_metadata.save.app_error", nil, "url="+metadata.URL+", "+err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/store/storetest/link_metadata_store.go
+++ b/store/storetest/link_metadata_store.go
@@ -108,7 +108,7 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 
 		result := <-ss.LinkMetadata().Save(metadata)
 		require.Nil(t, result.Err)
-		assert.Equal(t, result.Data.(*model.LinkMetadata).Data, &model.PostImage{})
+		assert.Equal(t, &model.PostImage{}, result.Data.(*model.LinkMetadata).Data)
 
 		metadata.Data = &model.PostImage{Height: 10, Width: 20}
 
@@ -119,7 +119,7 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 		// Should return the original result, not the duplicate one
 		result = <-ss.LinkMetadata().Get(metadata.URL, metadata.Timestamp)
 		require.Nil(t, result.Err)
-		assert.Equal(t, result.Data.(*model.LinkMetadata).Data, &model.PostImage{})
+		assert.Equal(t, &model.PostImage{}, result.Data.(*model.LinkMetadata).Data)
 	})
 }
 

--- a/store/storetest/link_metadata_store.go
+++ b/store/storetest/link_metadata_store.go
@@ -98,7 +98,7 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 		assert.Equal(t, *metadata, *result.Data.(*model.LinkMetadata))
 	})
 
-	t.Run("should fail to save with duplicate URL and timestamp", func(t *testing.T) {
+	t.Run("should not save with duplicate URL and timestamp, but should not return an error", func(t *testing.T) {
 		metadata := &model.LinkMetadata{
 			URL:       "http://example.com",
 			Timestamp: getNextLinkMetadataTimestamp(),
@@ -108,10 +108,18 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 
 		result := <-ss.LinkMetadata().Save(metadata)
 		require.Nil(t, result.Err)
+		assert.Equal(t, result.Data.(*model.LinkMetadata).Data, &model.PostImage{})
+
+		metadata.Data = &model.PostImage{Height: 10, Width: 20}
 
 		result = <-ss.LinkMetadata().Save(metadata)
+		require.Nil(t, result.Err)
+		assert.Equal(t, result.Data.(*model.LinkMetadata).Data, &model.PostImage{Height: 10, Width: 20})
 
-		assert.NotNil(t, result.Err)
+		// Should return the original result, not the duplicate one
+		result = <-ss.LinkMetadata().Get(metadata.URL, metadata.Timestamp)
+		require.Nil(t, result.Err)
+		assert.Equal(t, result.Data.(*model.LinkMetadata).Data, &model.PostImage{})
 	})
 }
 


### PR DESCRIPTION
Attempting to save duplicate metadata is harmless and just means that multiple threads are trying to get metadata for a link at the same time. This generally won't happen, but the Zoom plugin seems to make a post and then edit it quickly, so it was causing this to happen frequently.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14082

#### Checklist
- Added or updated unit tests (required for all new features)