### PR TITLE
MM-14145: The config store Set will now Save automatically

### DIFF
--- a/app/admin.go
+++ b/app/admin.go
@@ -168,7 +168,6 @@ func (a *App) SaveConfig(newCfg *model.Config, sendConfigChangeClusterMessage bo
 		return model.NewAppError("saveConfig", "app.save_config.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
-	a.PersistConfig()
 	if a.Metrics != nil {
 		if *a.Config().MetricsSettings.Enable {
 			a.Metrics.StartServer()

--- a/app/config.go
+++ b/app/config.go
@@ -56,12 +56,6 @@ func (a *App) UpdateConfig(f func(*model.Config)) {
 	a.Srv.UpdateConfig(f)
 }
 
-func (a *App) PersistConfig() {
-	if err := a.Srv.configStore.Save(); err != nil {
-		mlog.Error("Failed to persist config", mlog.Err(err))
-	}
-}
-
 func (s *Server) ReloadConfig() error {
 	debug.FreeOSMemory()
 	if err := s.configStore.Load(); err != nil {

--- a/app/saml.go
+++ b/app/saml.go
@@ -65,7 +65,6 @@ func (a *App) AddSamlPublicCertificate(fileData *multipart.FileHeader) *model.Ap
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
-	a.PersistConfig()
 
 	return nil
 }
@@ -83,7 +82,6 @@ func (a *App) AddSamlPrivateCertificate(fileData *multipart.FileHeader) *model.A
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
-	a.PersistConfig()
 
 	return nil
 }
@@ -101,7 +99,6 @@ func (a *App) AddSamlIdpCertificate(fileData *multipart.FileHeader) *model.AppEr
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
-	a.PersistConfig()
 
 	return nil
 }
@@ -134,7 +131,6 @@ func (a *App) RemoveSamlPublicCertificate() *model.AppError {
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
-	a.PersistConfig()
 
 	return nil
 }
@@ -153,7 +149,6 @@ func (a *App) RemoveSamlPrivateCertificate() *model.AppError {
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
-	a.PersistConfig()
 
 	return nil
 }
@@ -172,7 +167,6 @@ func (a *App) RemoveSamlIdpCertificate() *model.AppError {
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
-	a.PersistConfig()
 
 	return nil
 }

--- a/cmd/mattermost/commands/config.go
+++ b/cmd/mattermost/commands/config.go
@@ -226,9 +226,6 @@ func configSetCmdF(command *cobra.Command, args []string) error {
 
 	f := updateConfigValue(configSetting, newVal, oldConfig, newConfig)
 	f(newConfig)
-	if _, err := configStore.Set(newConfig); err != nil {
-		return errors.Wrap(err, "failed to set config")
-	}
 
 	// UpdateConfig above would have already fixed these invalid locales, but we check again
 	// in the context of an explicit change to these parameters to avoid saving the fixed
@@ -237,7 +234,9 @@ func configSetCmdF(command *cobra.Command, args []string) error {
 		return errors.New("Invalid locale configuration")
 	}
 
-	configStore.Save()
+	if _, err := configStore.Set(newConfig); err != nil {
+		return errors.Wrap(err, "failed to set config")
+	}
 
 	return nil
 }

--- a/config/database.go
+++ b/config/database.go
@@ -111,9 +111,10 @@ func parseDSN(dsn string) (string, string, error) {
 	return scheme, dsn, nil
 }
 
-// Set replaces the current configuration in its entirety, without updating the backing store.
+// Set replaces the current configuration in its entirety and updates the backing store.
 func (ds *DatabaseStore) Set(newCfg *model.Config) (*model.Config, error) {
-	return ds.commonStore.set(newCfg, nil)
+	return ds.commonStore.set(newCfg, nil, ds.persist)
+
 }
 
 // persist writes the configuration to the configured database.

--- a/config/database.go
+++ b/config/database.go
@@ -193,14 +193,6 @@ func (ds *DatabaseStore) Load() (err error) {
 	return ds.commonStore.load(ioutil.NopCloser(bytes.NewReader(configurationData)), needsSave, ds.persist)
 }
 
-// Save writes the current configuration to the backing store.
-func (ds *DatabaseStore) Save() error {
-	ds.configLock.RLock()
-	defer ds.configLock.RUnlock()
-
-	return ds.persist(ds.config)
-}
-
 // String returns the path to the database backing the config, masking the password.
 func (ds *DatabaseStore) String() string {
 	u, _ := url.Parse(ds.originalDsn)

--- a/config/database_test.go
+++ b/config/database_test.go
@@ -436,21 +436,8 @@ func TestDatabaseStoreSave(t *testing.T) {
 		},
 	}
 
-	t.Run("set without save", func(t *testing.T) {
+	t.Run("set with automatic save", func(t *testing.T) {
 		_, err = ds.Set(newCfg)
-		require.NoError(t, err)
-
-		err = ds.Load()
-		require.NoError(t, err)
-
-		assert.Equal(t, "http://minimal", *ds.Get().ServiceSettings.SiteURL)
-	})
-
-	t.Run("set with save", func(t *testing.T) {
-		_, err = ds.Set(newCfg)
-		require.NoError(t, err)
-
-		err = ds.Save()
 		require.NoError(t, err)
 
 		err = ds.Load()

--- a/config/database_test.go
+++ b/config/database_test.go
@@ -272,7 +272,6 @@ func TestDatabaseStoreSet(t *testing.T) {
 		_, tearDown := setupConfigDatabase(t, minimalConfig)
 		defer tearDown()
 
-		sqlSettings := mainHelper.GetSqlSettings()
 		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
 		defer ds.Close()

--- a/config/database_test.go
+++ b/config/database_test.go
@@ -268,6 +268,30 @@ func TestDatabaseStoreSet(t *testing.T) {
 		assert.Equal(t, "http://new", *ds.Get().ServiceSettings.SiteURL)
 	})
 
+	t.Run("set with automatic save", func(t *testing.T) {
+		_, tearDown := setupConfigDatabase(t, minimalConfig)
+		defer tearDown()
+
+		sqlSettings := mainHelper.GetSqlSettings()
+		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
+		require.NoError(t, err)
+		defer ds.Close()
+
+		newCfg := &model.Config{
+			ServiceSettings: model.ServiceSettings{
+				SiteURL: sToP("http://new"),
+			},
+		}
+
+		_, err = ds.Set(newCfg)
+		require.NoError(t, err)
+
+		err = ds.Load()
+		require.NoError(t, err)
+
+		assert.Equal(t, "http://new", *ds.Get().ServiceSettings.SiteURL)
+	})
+
 	t.Run("persist failed", func(t *testing.T) {
 		t.Skip("skipping persistence test inside Set")
 		_, tearDown := setupConfigDatabase(t, emptyConfig)
@@ -418,32 +442,6 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatal("callback should have been called when config loaded")
 		}
-	})
-}
-
-func TestDatabaseStoreSave(t *testing.T) {
-	_, tearDown := setupConfigDatabase(t, minimalConfig)
-	defer tearDown()
-
-	sqlSettings := mainHelper.GetSqlSettings()
-	ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
-	require.NoError(t, err)
-	defer ds.Close()
-
-	newCfg := &model.Config{
-		ServiceSettings: model.ServiceSettings{
-			SiteURL: sToP("http://new"),
-		},
-	}
-
-	t.Run("set with automatic save", func(t *testing.T) {
-		_, err = ds.Set(newCfg)
-		require.NoError(t, err)
-
-		err = ds.Load()
-		require.NoError(t, err)
-
-		assert.Equal(t, "http://new", *ds.Get().ServiceSettings.SiteURL)
 	})
 }
 

--- a/config/file.go
+++ b/config/file.go
@@ -86,7 +86,7 @@ func resolveConfigFilePath(path string) (string, error) {
 	return "", fmt.Errorf("failed to find config file %s", path)
 }
 
-// Set replaces the current configuration in its entirety, without updating the backing store.
+// Set replaces the current configuration in its entirety and updates the backing store.
 func (fs *FileStore) Set(newCfg *model.Config) (*model.Config, error) {
 	return fs.commonStore.set(newCfg, func(cfg *model.Config) error {
 		if *fs.config.ClusterSettings.Enable && *fs.config.ClusterSettings.ReadOnlyConfig {
@@ -94,7 +94,8 @@ func (fs *FileStore) Set(newCfg *model.Config) (*model.Config, error) {
 		}
 
 		return nil
-	})
+	},
+		fs.persist)
 }
 
 // persist writes the configuration to the configured file.

--- a/config/file.go
+++ b/config/file.go
@@ -94,8 +94,7 @@ func (fs *FileStore) Set(newCfg *model.Config) (*model.Config, error) {
 		}
 
 		return nil
-	},
-		fs.persist)
+	}, fs.persist)
 }
 
 // persist writes the configuration to the configured file.
@@ -151,14 +150,6 @@ func (fs *FileStore) Load() (err error) {
 	}()
 
 	return fs.commonStore.load(f, needsSave, fs.persist)
-}
-
-// Save writes the current configuration to the backing store.
-func (fs *FileStore) Save() error {
-	fs.configLock.Lock()
-	defer fs.configLock.Unlock()
-
-	return fs.persist(fs.config)
 }
 
 // startWatcher starts a watcher to monitor for external config file changes.

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -615,21 +615,8 @@ func TestFileStoreSave(t *testing.T) {
 		},
 	}
 
-	t.Run("set without save", func(t *testing.T) {
+	t.Run("set with automatic save", func(t *testing.T) {
 		_, err = fs.Set(newCfg)
-		require.NoError(t, err)
-
-		err = fs.Load()
-		require.NoError(t, err)
-
-		assert.Equal(t, "http://minimal", *fs.Get().ServiceSettings.SiteURL)
-	})
-
-	t.Run("set with save", func(t *testing.T) {
-		_, err = fs.Set(newCfg)
-		require.NoError(t, err)
-
-		err = fs.Save()
 		require.NoError(t, err)
 
 		err = fs.Load()

--- a/config/memory.go
+++ b/config/memory.go
@@ -87,11 +87,6 @@ func (ms *memoryStore) Load() (err error) {
 	return nil
 }
 
-// Save does nothing, as there is no backing store.
-func (ms *memoryStore) Save() error {
-	return nil
-}
-
 // String returns a hard-coded description, as there is no backing store.
 func (ms *memoryStore) String() string {
 	return "mock://"

--- a/config/store.go
+++ b/config/store.go
@@ -26,9 +26,6 @@ type Store interface {
 	// Load updates the current configuration from the backing store, possibly initializing.
 	Load() (err error)
 
-	// Save writes the current configuration to the backing store.
-	Save() error
-
 	// AddListener adds a callback function to invoke when the configuration is modified.
 	AddListener(listener Listener) string
 

--- a/config/store.go
+++ b/config/store.go
@@ -20,7 +20,7 @@ type Store interface {
 	// GetEnvironmentOverrides fetches the configuration fields overridden by environment variables.
 	GetEnvironmentOverrides() map[string]interface{}
 
-	// Set replaces the current configuration in its entirety, without updating the backing store.
+	// Set replaces the current configuration in its entirety and updates the backing store.
 	Set(*model.Config) (*model.Config, error)
 
 	// Load updates the current configuration from the backing store, possibly initializing.


### PR DESCRIPTION
#### Summary
When UpdateConfig (and configStore.Set) is called in admin.go and
config.go, commonStore.Set now takes a store-specific persist function.
It uses that persist function to save the configuration automatically.

Removed: Now callers do not have to call configStore.Save or
app.PersistConfig, and those functions have been removed.

Possible downside: this means a "failed to persist config" error can now
be thrown during a app.UpdateConfig or commonStore.Set call. But
considering application code never really sets a config without saving
it (except in the test cases, which were testing that -- see below), it
seems fine to group these responsibilities.

Also removed: tests for 'set without save'. Since that can not happen
anymore, the tests are not needed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14145
#10338

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
