### PR TITLE
MM-11828: Lists of key:values are sent to system console settings #10342

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -25,6 +25,14 @@ type PluginOption struct {
 	Value string `json:"value" yaml:"value"`
 }
 
+type ListEntry struct {
+	// The key for this entry in the list/array
+	Key string `json:"key" yaml:"key"`
+
+	// The value for this entry in the list/array
+	Value string `json:"value" yaml:"value"`
+}
+
 type PluginSetting struct {
 	// The key that the setting will be assigned to in the configuration file.
 	Key string `json:"key" yaml:"key"`
@@ -50,6 +58,8 @@ type PluginSetting struct {
 	// "longtext" will result in a multi line string that can be typed in manually.
 	//
 	// "username" will result in a text setting that will autocomplete to a username.
+	//
+	// "key_value_list" will result in an array or 'map' of key:value strings that can be edited by the user.
 	Type string `json:"type" yaml:"type"`
 
 	// The help text to display to the user.
@@ -67,6 +77,10 @@ type PluginSetting struct {
 	// For "radio" or "dropdown" settings, this is the list of pre-defined options that the user can choose
 	// from.
 	Options []*PluginOption `json:"options,omitempty" yaml:"options,omitempty"`
+
+	// For the "key_value_list" setting, this is the list of currently defined key:value pairs,
+	// which can be modified by the user.
+	KeyValueList []*ListEntry `json:"key_value_list,omitempty" yaml:"key_value_list,omitempty"`
 }
 
 type PluginSettingsSchema struct {

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -95,6 +95,25 @@ func TestManifestUnmarshal(t *testing.T) {
 					},
 					Default: "thedefault",
 				},
+				&PluginSetting{
+					Key:                "alistsetting",
+					DisplayName:        "Key:Value pairs",
+					Type:               "key_value_list",
+					HelpText:           "thehelptext",
+					RegenerateHelpText: "theregeneratehelptext",
+					Placeholder:        "theplaceholder",
+					KeyValueList: []*ListEntry{
+						&ListEntry{
+							Key:   "Key1",
+							Value: "Value1",
+						},
+						&ListEntry{
+							Key:   "Key2",
+							Value: "Value2 'with' \"quotes\"",
+						},
+					},
+					Default: "default not very relevant for list setting",
+				},
 			},
 		},
 	}
@@ -125,6 +144,19 @@ settings_schema:
               - display_name: theoptiondisplayname
                 value: thevalue
           default: thedefault
+        - key: alistsetting
+          display_name: Key:Value pairs
+          type: key_value_list
+          help_text: thehelptext
+          regenerate_help_text: theregeneratehelptext
+          placeholder: theplaceholder
+          key_value_list:
+              - key: Key1
+                value: Value1
+              - key: Key2
+                value: Value2 'with' "quotes"
+          default: default not very relevant for list setting
+        
 `), &yamlResult))
 	assert.Equal(t, expected, yamlResult)
 
@@ -161,6 +193,25 @@ settings_schema:
 					}
 				],
 				"default": "thedefault"
+			},
+			{
+				"key": "alistsetting",
+				"display_name": "Key:Value pairs",
+				"type": "key_value_list",
+				"help_text": "thehelptext",
+				"regenerate_help_text": "theregeneratehelptext",
+				"placeholder": "theplaceholder",
+				"key_value_list": [
+					{
+						"key": "Key1",
+						"value": "Value1"
+					},
+					{
+						"key": "Key2",
+						"value": "Value2 'with' \"quotes\""
+					}
+				],
+				"default": "default not very relevant for list setting"
 			}
 		]
     }
@@ -238,6 +289,24 @@ func TestManifestJson(t *testing.T) {
 					},
 					Default: "thedefault",
 				},
+				&PluginSetting{
+					Key:                "alistsetting",
+					DisplayName:        "Key:Value pairs",
+					Type:               "key_value_list",
+					HelpText:           "thehelptext",
+					RegenerateHelpText: "theregeneratehelptext",
+					Placeholder:        "theplaceholder",
+					KeyValueList: []*ListEntry{
+						&ListEntry{
+							Key:   "Key1",
+							Value: "Value1",
+						},
+						&ListEntry{
+							Key:   "Key2",
+							Value: "Value2",
+						},
+					},
+				},
 			},
 		},
 	}
@@ -304,6 +373,24 @@ func TestManifestClientManifest(t *testing.T) {
 						},
 					},
 					Default: "thedefault",
+				},
+				&PluginSetting{
+					Key:                "alistsetting",
+					DisplayName:        "Key:Value pairs",
+					Type:               "key_value_list",
+					HelpText:           "thehelptext",
+					RegenerateHelpText: "theregeneratehelptext",
+					Placeholder:        "theplaceholder",
+					KeyValueList: []*ListEntry{
+						&ListEntry{
+							Key:   "Key1",
+							Value: "Value1",
+						},
+						&ListEntry{
+							Key:   "Key2",
+							Value: "Value2",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
#### Summary
We can now send a "key_value_list" Type in the PluginSetting struct. Each
key and value are strings. This satisfies what is needed by
https://github.com/mattermost/mattermost-plugin-autolink/.  Tests were
updated.

However, this won't satisfy any plugin that needs a more complicated
list of arbitrary structs. Eg.: {string, bool}, {string, int}, {string,
int, bool}, or even nested structs.

An alternative is to serialize a `map[string]interface{}`, and then the
plugin author would have to deal with the type switches needed to turn
that into a usable struct/map. The problem with that is the System
Console Settings react component will have to find some UI that would
adapt to display (and edit!) arbitrary structs. That seems like a
complicated option.

I propose as a first version we allow key:value pairs of strings, and
see if anyone really needs something more complicated. Then we can add
those as needed.

#### Next steps:

* developer documentation needs to be updated to reflect the new
"key_value_list" Type. I can do that once we settle on the solution.

* the schema_admin_settings react component in the webapp (I think)
needs to be updated. Eg., a good UI for displaying and editing the
list needs to be designed.

WIP, needs feedback. I went back and forth between naming it "list"
or "map" but settled on "key_value_list" to be precise and not to
confuse with Go's builtin map.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-11828
#10342 

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] Has UI changes