### PR TITLE
[MM-14375] Skip tutorial steps for sysadmin, user-1 and user-2 from generated sample data

### DIFF
--- a/cmd/mattermost/commands/sampledata.go
+++ b/cmd/mattermost/commands/sampledata.go
@@ -399,15 +399,18 @@ func createUser(idx int, teamMemberships int, channelMemberships int, teamsAndCh
 		nickname = fake.Company()
 	}
 
-	// Half of users skip tutorial
+	// sysadmin, user-1 and user-2 users skip tutorial steps
+	// Other half of users also skip tutorial steps
 	tutorialStep := "999"
-	switch rand.Intn(6) {
-	case 1:
-		tutorialStep = "1"
-	case 2:
-		tutorialStep = "2"
-	case 3:
-		tutorialStep = "3"
+	if idx > 2 {
+		switch rand.Intn(6) {
+		case 1:
+			tutorialStep = "1"
+		case 2:
+			tutorialStep = "2"
+		case 3:
+			tutorialStep = "3"
+		}
 	}
 
 	teams := []app.UserTeamImportData{}


### PR DESCRIPTION
#### Summary
Skip tutorial steps for sysadmin, user-1 and user-2 from generated sample data
- to prevent flaky E2E tests when using these users due to tutorial icons and tooltips covering some of the target elements.

#### Ticket Link
Jira ticket: [MM-14375](https://mattermost.atlassian.net/browse/MM-14375)
