### PR TITLE
skip TestUserLoginMFAFlow/WithCorrectMFA as it fails at random

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -4,12 +4,13 @@
 package api4
 
 import (
-	"github.com/dgryski/dgoogauth"
 	"net/http"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dgryski/dgoogauth"
 
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
@@ -1305,13 +1306,13 @@ func TestDeleteUser(t *testing.T) {
 	selfDeleteUser := th.CreateUser()
 	th.Client.Login(selfDeleteUser.Email, selfDeleteUser.Password)
 
-	th.App.UpdateConfig(func(c *model.Config){
+	th.App.UpdateConfig(func(c *model.Config) {
 		*c.TeamSettings.EnableUserDeactivation = false
 	})
 	_, resp = th.Client.DeleteUser(selfDeleteUser.Id)
 	CheckUnauthorizedStatus(t, resp)
 
-	th.App.UpdateConfig(func(c *model.Config){
+	th.App.UpdateConfig(func(c *model.Config) {
 		*c.TeamSettings.EnableUserDeactivation = true
 	})
 	_, resp = th.Client.DeleteUser(selfDeleteUser.Id)
@@ -1850,7 +1851,7 @@ func TestCheckUserMfa(t *testing.T) {
 		t.Fatal("should be false - mfa not active")
 	}
 
-	th.App.UpdateConfig(func (c *model.Config){
+	th.App.UpdateConfig(func(c *model.Config) {
 		*c.ServiceSettings.DisableLegacyMFA = true
 	})
 
@@ -1862,7 +1863,7 @@ func TestUserLoginMFAFlow(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
-	th.App.UpdateConfig(func (c *model.Config){
+	th.App.UpdateConfig(func(c *model.Config) {
 		*c.ServiceSettings.DisableLegacyMFA = true
 		*c.ServiceSettings.EnableMultifactorAuthentication = true
 	})
@@ -1870,7 +1871,7 @@ func TestUserLoginMFAFlow(t *testing.T) {
 	secret, err := th.App.GenerateMfaSecret(th.BasicUser.Id)
 	assert.Nil(t, err)
 
-	t.Run("WithoutMFA", func (t *testing.T){
+	t.Run("WithoutMFA", func(t *testing.T) {
 		_, resp := th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
 		CheckNoError(t, resp)
 	})
@@ -1884,7 +1885,7 @@ func TestUserLoginMFAFlow(t *testing.T) {
 		t.Fatal(result.Err)
 	}
 
-	t.Run("WithInvalidMFA", func (t *testing.T){
+	t.Run("WithInvalidMFA", func(t *testing.T) {
 		user, resp := th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
 		CheckErrorMessage(t, resp, "mfa.validate_token.authenticate.app_error")
 		assert.Nil(t, user)
@@ -1904,8 +1905,9 @@ func TestUserLoginMFAFlow(t *testing.T) {
 		assert.Nil(t, user)
 	})
 
-	t.Run("WithCorrectMFA", func (t *testing.T){
-		code := dgoogauth.ComputeCode(secret.Secret, time.Now().UTC().Unix() / 30)
+	t.Run("WithCorrectMFA", func(t *testing.T) {
+		t.Skip("Skipping test that fails randomly.")
+		code := dgoogauth.ComputeCode(secret.Secret, time.Now().UTC().Unix()/30)
 
 		user, resp := th.Client.LoginWithMFA(th.BasicUser.Email, th.BasicUser.Password, strconv.Itoa(code))
 		CheckNoError(t, resp)


### PR DESCRIPTION
#### Summary
`TestUserLoginMFAFlow/WithCorrectMFA` seems to be brittle. If you run `while go test -run 'TestUserLoginMFAFlow'; do echo "PASSED"; done`, it will eventually fail with:
```
--- FAIL: TestUserLoginMFAFlow (2.63s)
    --- FAIL: TestUserLoginMFAFlow/WithCorrectMFA (0.09s)
        user_test.go:1911: Expected no error, got ": Error trying to authenticate MFA token, "
```

I suspect it wraps over the TOTP token timeout, generating the code right before and trying to verify it right after. Skipping for now until we can circle back on this one.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)