### PR TITLE
explicitly configure DisableLegacyMFA for TestCheckUserMfa

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1811,6 +1811,10 @@ func TestCheckUserMfa(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
+	th.App.UpdateConfig(func(c *model.Config) {
+		*c.ServiceSettings.DisableLegacyMFA = false
+	})
+
 	required, resp := th.Client.CheckUserMfa(th.BasicUser.Email)
 	CheckNoError(t, resp)
 


### PR DESCRIPTION
#### Summary
In `master`, unit tests are run with a config generated from `*model.Config.SetDefaults`, which has `DisableLegacyMFA` defaulting to be `false`. This value is distinct from `default.json` so as to avoid breaking existing servers that upgrade their configurations, but in release-5.9 we run tests against `default.json` copied as `config.json`. This particular test didn't make the preconditions for `DisableLegacyMFA` explicit and thus failed to pass on release-5.9.

Medium term, we should eliminate `default.json` altogether and encode this business logic exclusively in `*model.Config.SetDefaults`.

#### Ticket Link
N/A

#### Checklist
- [x] Added or updated unit tests (required for all new features)