### PR TITLE
[MM-14300] Return 400 if a post is created with a child post as root

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -189,6 +189,11 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 			return nil, model.NewAppError("createPost", "api.post.create_post.channel_root_id.app_error", nil, "", http.StatusInternalServerError)
 		}
 
+		rootPost := parentPostList.Posts[post.RootId]
+		if len(rootPost.RootId) > 0 {
+			return nil, model.NewAppError("createPost", "api.post.create_post.root_id.app_error", nil, "", http.StatusBadRequest)
+		}
+
 		if post.ParentId == "" {
 			post.ParentId = post.RootId
 		}

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -342,6 +342,59 @@ func TestPostReplyToPostWhereRootPosterLeftChannel(t *testing.T) {
 	}
 }
 
+func TestPostAttachPostToChildPost(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	channel := th.BasicChannel
+	user := th.BasicUser
+	rootPost := th.BasicPost
+
+	replyPost1 := model.Post{
+		Message:       "reply one",
+		ChannelId:     channel.Id,
+		RootId:        rootPost.Id,
+		ParentId:      rootPost.Id,
+		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		UserId:        user.Id,
+		CreateAt:      0,
+	}
+
+	res1, err := th.App.CreatePostAsUser(&replyPost1, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replyPost2 := model.Post{
+		Message:       "reply two",
+		ChannelId:     channel.Id,
+		RootId:        res1.Id,
+		ParentId:      res1.Id,
+		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		UserId:        user.Id,
+		CreateAt:      0,
+	}
+
+	_, err = th.App.CreatePostAsUser(&replyPost2, false)
+	if err.StatusCode != http.StatusBadRequest {
+		t.Fatal(fmt.Sprintf("Expected BadRequest error, got %v", err))
+	}
+
+	replyPost3 := model.Post{
+		Message:       "reply three",
+		ChannelId:     channel.Id,
+		RootId:        rootPost.Id,
+		ParentId:      rootPost.Id,
+		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		UserId:        user.Id,
+		CreateAt:      0,
+	}
+
+	if _, err := th.App.CreatePostAsUser(&replyPost3, false); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPostChannelMentions(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()


### PR DESCRIPTION
#### Summary
This PR checks that the `root_id` of a new `Post` is the root of the thread, and returns a `400 Bad Request` if it's not.

#### Ticket Link
[MM-14300](https://mattermost.atlassian.net/browse/MM-14300)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
