### PR TITLE
[MM-14254] Add elasticsearch initialisation to the cmd

### DIFF
--- a/cmd/mattermost/commands/init.go
+++ b/cmd/mattermost/commands/init.go
@@ -35,7 +35,10 @@ func InitDBCommandContext(configDSN string) (*app.App, error) {
 	}
 	model.AppErrorInit(utils.T)
 
-	s, err := app.NewServer(app.Config(configDSN, false))
+	s, err := app.NewServer(
+		app.Config(configDSN, false),
+		app.StartElasticsearch,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Summary
This PR adds Elasticsearch to the initialisation of the `Server` when running a command. This will allow the commands to update Elasticsearch indexes when required (e.g. creating a public channel in EE).

#### Ticket Link
[MM-14254](https://mattermost.atlassian.net/browse/MM-14254)

#### Checklist
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
