### PR TITLE
[MM-13694] Sets a default value for SiteName if empty

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4367,6 +4367,10 @@
     "translation": "Site name must be less than or equal to {{.MaxLength}} characters."
   },
   {
+    "id": "model.config.is_valid.sitename_empty.app_error",
+    "translation": "Site name cannot be empty."
+  },
+  {
     "id": "model.config.is_valid.sql_conn_max_lifetime_milliseconds.app_error",
     "translation": "Invalid connection maximum lifetime for SQL settings. Must be a non-negative number."
   },

--- a/model/config.go
+++ b/model/config.go
@@ -1389,7 +1389,7 @@ type TeamSettings struct {
 
 func (s *TeamSettings) SetDefaults() {
 
-	if s.SiteName == nil {
+	if s.SiteName == nil || *s.SiteName == "" {
 		s.SiteName = NewString(TEAM_SETTINGS_DEFAULT_SITE_NAME)
 	}
 
@@ -2388,6 +2388,10 @@ func (ts *TeamSettings) isValid() *AppError {
 
 	if !(*ts.TeammateNameDisplay == SHOW_FULLNAME || *ts.TeammateNameDisplay == SHOW_NICKNAME_FULLNAME || *ts.TeammateNameDisplay == SHOW_USERNAME) {
 		return NewAppError("Config.IsValid", "model.config.is_valid.teammate_name_display.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if len(*ts.SiteName) == 0 {
+		return NewAppError("Config.IsValid", "model.config.is_valid.sitename_empty.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if len(*ts.SiteName) > SITENAME_MAX_LENGTH {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -55,6 +55,19 @@ func TestConfigDefaults(t *testing.T) {
 	})
 }
 
+func TestConfigEmptySiteName(t *testing.T) {
+	c1 := Config{
+		TeamSettings: TeamSettings{
+			SiteName: NewString(""),
+		},
+	}
+	c1.SetDefaults()
+
+	if *c1.TeamSettings.SiteName != TEAM_SETTINGS_DEFAULT_SITE_NAME {
+		t.Fatal("TeamSettings.SiteName should default to " + TEAM_SETTINGS_DEFAULT_SITE_NAME)
+	}
+}
+
 func TestConfigDefaultFileSettingsDirectory(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()
@@ -111,6 +124,18 @@ func TestConfigDefaultServiceSettingsExperimentalGroupUnreadChannels(t *testing.
 
 	if *c1.ServiceSettings.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED {
 		t.Fatal("ServiceSettings.ExperimentalGroupUnreadChannels should set false to 'disabled'")
+	}
+}
+
+func TestTeamSettingsIsValidSiteNameEmpty(t *testing.T) {
+	c1 := Config{}
+	c1.SetDefaults()
+	c1.TeamSettings.SiteName = NewString("")
+
+	// should fail fast because ts.SiteName is not set
+	err := c1.TeamSettings.isValid()
+	if err == nil {
+		t.Fatal("TeamSettings validation should fail with an empty SiteName")
 	}
 }
 


### PR DESCRIPTION
#### Summary
This PR updates the config defaults so if the `SiteName` field is blank in `TeamSettings`, it is set to a default value.

#### Ticket Link
[MM-13694](https://mattermost.atlassian.net/browse/MM-13694)

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [x] Has UI changes
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
