### PR TITLE
[MM-14502] Add experimental flag to enable click-to-reply

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -43,6 +43,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 
 	// This setting is only temporary, so keep using the old setting name for the mobile and web apps
 	props["ExperimentalEnablePostMetadata"] = strconv.FormatBool(!*c.ExperimentalSettings.DisablePostMetadata)
+	props["ExperimentalEnableClickToReply"] = strconv.FormatBool(*c.ExperimentalSettings.EnableClickToReply)
 
 	if *c.ServiceSettings.ExperimentalChannelOrganization || *c.ServiceSettings.ExperimentalGroupUnreadChannels != model.GROUP_UNREAD_CHANNELS_DISABLED {
 		props["ExperimentalChannelOrganization"] = strconv.FormatBool(true)

--- a/config/default.json
+++ b/config/default.json
@@ -360,7 +360,8 @@
         "ClientSideCertCheck": "secondary",
         "DisablePostMetadata": false,
         "LinkMetadataTimeoutMilliseconds": 5000,
-        "RestrictSystemAdmin": false
+        "RestrictSystemAdmin": false,
+        "EnableClickToReply": false
     },
     "AnalyticsSettings": {
         "MaxUsersForStatistics": 2500

--- a/model/config.go
+++ b/model/config.go
@@ -712,6 +712,7 @@ type ExperimentalSettings struct {
 	ClientSideCertEnable            *bool
 	ClientSideCertCheck             *string
 	DisablePostMetadata             *bool
+	EnableClickToReply              *bool
 	LinkMetadataTimeoutMilliseconds *int64
 	RestrictSystemAdmin             *bool
 }
@@ -727,6 +728,10 @@ func (s *ExperimentalSettings) SetDefaults() {
 
 	if s.DisablePostMetadata == nil {
 		s.DisablePostMetadata = NewBool(false)
+	}
+
+	if s.EnableClickToReply == nil {
+		s.EnableClickToReply = NewBool(false)
 	}
 
 	if s.LinkMetadataTimeoutMilliseconds == nil {


### PR DESCRIPTION
#### Summary
Adds an experimental feature flag to enable/disable click-to-reply feature ([See video](https://youtu.be/uzUFp-1iLQA)). Can be merged, but depends on webapp PR I'll be submitting.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14502

#### Checklist
N/A
