### PR TITLE
remove reference from jenkins

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,3 @@
-codecov:
-  ci:
-    - build.mattermost.com
-  notify:
-    require_ci_to_pass: yes
-
 coverage:
   status:
     project:


### PR DESCRIPTION
#### Summary
Removing the reference from our jenkins because some jobs run protected like the master branch, so I have my doubts if this is not the issue we are having

This is an experiment :-)