### PR TITLE
Fixing emojis and webhooks permissions split

### DIFF
--- a/cmd/mattermost/commands/init.go
+++ b/cmd/mattermost/commands/init.go
@@ -26,6 +26,7 @@ func InitDBCommandContextCobra(command *cobra.Command) (*app.App, error) {
 	a.InitPlugins(*a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
 	a.DoAdvancedPermissionsMigration()
 	a.DoEmojisPermissionsMigration()
+	a.DoPermissionsMigrations()
 
 	return a, nil
 }

--- a/model/permission.go
+++ b/model/permission.go
@@ -46,12 +46,16 @@ var PERMISSION_REMOVE_OTHERS_REACTIONS *Permission
 var PERMISSION_PERMANENT_DELETE_USER *Permission
 var PERMISSION_UPLOAD_FILE *Permission
 var PERMISSION_GET_PUBLIC_LINK *Permission
+var PERMISSION_MANAGE_WEBHOOKS *Permission
+var PERMISSION_MANAGE_OTHERS_WEBHOOKS *Permission
 var PERMISSION_MANAGE_INCOMING_WEBHOOKS *Permission
 var PERMISSION_MANAGE_OUTGOING_WEBHOOKS *Permission
 var PERMISSION_MANAGE_OTHERS_INCOMING_WEBHOOKS *Permission
 var PERMISSION_MANAGE_OTHERS_OUTGOING_WEBHOOKS *Permission
 var PERMISSION_MANAGE_OAUTH *Permission
 var PERMISSION_MANAGE_SYSTEM_WIDE_OAUTH *Permission
+var PERMISSION_MANAGE_EMOJIS *Permission
+var PERMISSION_MANAGE_OTHERS_EMOJIS *Permission
 var PERMISSION_CREATE_EMOJIS *Permission
 var PERMISSION_DELETE_EMOJIS *Permission
 var PERMISSION_DELETE_OTHERS_EMOJIS *Permission
@@ -272,6 +276,18 @@ func initializePermissions() {
 		"authentication.permissions.get_public_link.description",
 		PERMISSION_SCOPE_SYSTEM,
 	}
+	PERMISSION_MANAGE_WEBHOOKS = &Permission{
+		"manage_webhooks",
+		"authentication.permissions.manage_webhooks.name",
+		"authentication.permissions.manage_webhooks.description",
+		PERMISSION_SCOPE_TEAM,
+	}
+	PERMISSION_MANAGE_OTHERS_WEBHOOKS = &Permission{
+		"manage_others_webhooks",
+		"authentication.permissions.manage_others_webhooks.name",
+		"authentication.permissions.manage_others_webhooks.description",
+		PERMISSION_SCOPE_TEAM,
+	}
 	PERMISSION_MANAGE_INCOMING_WEBHOOKS = &Permission{
 		"manage_incoming_webhooks",
 		"authentication.permissions.manage_incoming_webhooks.name",
@@ -307,6 +323,18 @@ func initializePermissions() {
 		"authentication.permissions.manage_system_wide_oauth.name",
 		"authentication.permissions.manage_system_wide_oauth.description",
 		PERMISSION_SCOPE_SYSTEM,
+	}
+	PERMISSION_MANAGE_EMOJIS = &Permission{
+		"manage_emojis",
+		"authentication.permissions.manage_emojis.name",
+		"authentication.permissions.manage_emojis.description",
+		PERMISSION_SCOPE_TEAM,
+	}
+	PERMISSION_MANAGE_OTHERS_EMOJIS = &Permission{
+		"manage_others_emojis",
+		"authentication.permissions.manage_others_emojis.name",
+		"authentication.permissions.manage_others_emojis.description",
+		PERMISSION_SCOPE_TEAM,
 	}
 	PERMISSION_CREATE_EMOJIS = &Permission{
 		"create_emojis",
@@ -490,12 +518,16 @@ func initializePermissions() {
 		PERMISSION_PERMANENT_DELETE_USER,
 		PERMISSION_UPLOAD_FILE,
 		PERMISSION_GET_PUBLIC_LINK,
+		PERMISSION_MANAGE_WEBHOOKS,
+		PERMISSION_MANAGE_OTHERS_WEBHOOKS,
 		PERMISSION_MANAGE_INCOMING_WEBHOOKS,
 		PERMISSION_MANAGE_OUTGOING_WEBHOOKS,
 		PERMISSION_MANAGE_OTHERS_INCOMING_WEBHOOKS,
 		PERMISSION_MANAGE_OTHERS_OUTGOING_WEBHOOKS,
 		PERMISSION_MANAGE_OAUTH,
 		PERMISSION_MANAGE_SYSTEM_WIDE_OAUTH,
+		PERMISSION_MANAGE_EMOJIS,
+		PERMISSION_MANAGE_OTHERS_EMOJIS,
 		PERMISSION_CREATE_EMOJIS,
 		PERMISSION_DELETE_EMOJIS,
 		PERMISSION_DELETE_OTHERS_EMOJIS,


### PR DESCRIPTION
#### Summary
Fixing emojis and webhooks permissions split. The old permission is need to be
able to save multiple migrations at one shot, so in need the old permissions as
valid values in the roles model.

#### Ticket Link
[MM-11101](https://mattermost.atlassian.net/browse/MM-11101)