### PR TITLE
MM-14334 Allow plugin setting help text to contain Markdown

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -55,6 +55,9 @@ type PluginSetting struct {
 	// The help text to display to the user.
 	HelpText string `json:"help_text" yaml:"help_text"`
 
+	// Whether or not the help text includes markdown.
+	HelpTextMarkdown bool `json:"help_text_markdown" yaml:"help_text_markdown"`
+
 	// The help text to display alongside the "Regenerate" button for settings of the "generated" type.
 	RegenerateHelpText string `json:"regenerate_help_text,omitempty" yaml:"regenerate_help_text,omitempty"`
 


### PR DESCRIPTION
This adds a `help_text_markdown` setting to the plugin setting schema that works the same as the setting with the same name used for non-plugin settings in the system console.

This won't have any visible effect until https://github.com/mattermost/mattermost-webapp/pull/2467 is merged.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14334