### PR TITLE
MM-14415: Removes 'CanLeave' field.

### DIFF
--- a/api4/group_test.go
+++ b/api4/group_test.go
@@ -139,8 +139,7 @@ func TestLinkGroupTeam(t *testing.T) {
 	assert.Nil(t, err)
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	_, response := th.Client.LinkGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
@@ -171,8 +170,7 @@ func TestLinkGroupChannel(t *testing.T) {
 	assert.Nil(t, err)
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	_, response := th.Client.LinkGroupSyncable(g.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
@@ -202,8 +200,7 @@ func TestUnlinkGroupTeam(t *testing.T) {
 	assert.Nil(t, err)
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	th.App.SetLicense(model.NewTestLicense("ldap"))
@@ -240,8 +237,7 @@ func TestUnlinkGroupChannel(t *testing.T) {
 	assert.Nil(t, err)
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	th.App.SetLicense(model.NewTestLicense("ldap"))
@@ -286,8 +282,7 @@ func TestGetGroupTeam(t *testing.T) {
 	th.App.SetLicense(model.NewTestLicense("ldap"))
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	_, response = th.SystemAdminClient.LinkGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
@@ -300,7 +295,6 @@ func TestGetGroupTeam(t *testing.T) {
 	assert.Equal(t, g.Id, groupSyncable.GroupId)
 	assert.Equal(t, th.BasicTeam.Id, groupSyncable.SyncableId)
 	assert.Equal(t, *patch.AutoAdd, groupSyncable.AutoAdd)
-	// assert.Equal(t, *patch.CanLeave, groupSyncable.CanLeave) // TODO: Re-add this test in phase 2 of LDAP groups sync.
 
 	_, response = th.SystemAdminClient.GetGroupSyncable(model.NewId(), th.BasicTeam.Id, model.GroupSyncableTypeTeam, "")
 	CheckNotFoundStatus(t, response)
@@ -342,8 +336,7 @@ func TestGetGroupChannel(t *testing.T) {
 	th.App.SetLicense(model.NewTestLicense("ldap"))
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	_, response = th.SystemAdminClient.LinkGroupSyncable(g.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
@@ -356,7 +349,6 @@ func TestGetGroupChannel(t *testing.T) {
 	assert.Equal(t, g.Id, groupSyncable.GroupId)
 	assert.Equal(t, th.BasicChannel.Id, groupSyncable.SyncableId)
 	assert.Equal(t, *patch.AutoAdd, groupSyncable.AutoAdd)
-	// assert.Equal(t, *patch.CanLeave, groupSyncable.CanLeave) // TODO: Re-add this test in phase 2 of LDAP groups sync.
 
 	_, response = th.SystemAdminClient.GetGroupSyncable(model.NewId(), th.BasicChannel.Id, model.GroupSyncableTypeChannel, "")
 	CheckNotFoundStatus(t, response)
@@ -392,8 +384,7 @@ func TestGetGroupTeams(t *testing.T) {
 	th.App.SetLicense(model.NewTestLicense("ldap"))
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	for i := 0; i < 10; i++ {
@@ -442,8 +433,7 @@ func TestGetGroupChannels(t *testing.T) {
 	th.App.SetLicense(model.NewTestLicense("ldap"))
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	for i := 0; i < 10; i++ {
@@ -490,8 +480,7 @@ func TestPatchGroupTeam(t *testing.T) {
 	assert.Nil(t, err)
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	th.App.SetLicense(model.NewTestLicense("ldap"))
@@ -499,7 +488,6 @@ func TestPatchGroupTeam(t *testing.T) {
 	groupSyncable, response := th.SystemAdminClient.LinkGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
 	assert.Equal(t, http.StatusCreated, response.StatusCode)
 	assert.NotNil(t, groupSyncable)
-	// assert.True(t, groupSyncable.CanLeave) // TODO: Re-add this test in phase 2 of LDAP groups sync.
 	assert.True(t, groupSyncable.AutoAdd)
 
 	_, response = th.Client.PatchGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
@@ -521,15 +509,9 @@ func TestPatchGroupTeam(t *testing.T) {
 	assert.Equal(t, th.BasicTeam.Id, groupSyncable.SyncableId)
 	assert.Equal(t, model.GroupSyncableTypeTeam, groupSyncable.Type)
 
-	// TODO: Re-add this test in phase 2 of LDAP groups sync.
-	// patch.CanLeave = model.NewBool(false)
-	// _, response = th.SystemAdminClient.PatchGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
-	// CheckBadRequestStatus(t, response)
-
 	patch.AutoAdd = model.NewBool(true)
 	groupSyncable, response = th.SystemAdminClient.PatchGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
 	CheckOKStatus(t, response)
-	assert.False(t, groupSyncable.CanLeave)
 
 	_, response = th.SystemAdminClient.PatchGroupSyncable(model.NewId(), th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
 	CheckNotFoundStatus(t, response)
@@ -563,8 +545,7 @@ func TestPatchGroupChannel(t *testing.T) {
 	assert.Nil(t, err)
 
 	patch := &model.GroupSyncablePatch{
-		CanLeave: model.NewBool(true),
-		AutoAdd:  model.NewBool(true),
+		AutoAdd: model.NewBool(true),
 	}
 
 	th.App.SetLicense(model.NewTestLicense("ldap"))
@@ -572,7 +553,6 @@ func TestPatchGroupChannel(t *testing.T) {
 	groupSyncable, response := th.SystemAdminClient.LinkGroupSyncable(g.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
 	assert.Equal(t, http.StatusCreated, response.StatusCode)
 	assert.NotNil(t, groupSyncable)
-	// assert.True(t, groupSyncable.CanLeave) // TODO: Re-add this test in phase 2 of LDAP groups sync.
 	assert.True(t, groupSyncable.AutoAdd)
 
 	_, response = th.Client.PatchGroupSyncable(g.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
@@ -594,15 +574,9 @@ func TestPatchGroupChannel(t *testing.T) {
 	assert.Equal(t, th.BasicChannel.Id, groupSyncable.SyncableId)
 	assert.Equal(t, model.GroupSyncableTypeChannel, groupSyncable.Type)
 
-	// TODO: Re-add this test in phase 2 of LDAP groups sync.
-	// patch.CanLeave = model.NewBool(false)
-	// _, response = th.SystemAdminClient.PatchGroupSyncable(g.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
-	// CheckBadRequestStatus(t, response)
-
 	patch.AutoAdd = model.NewBool(true)
 	groupSyncable, response = th.SystemAdminClient.PatchGroupSyncable(g.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
 	CheckOKStatus(t, response)
-	assert.False(t, groupSyncable.CanLeave)
 
 	_, response = th.SystemAdminClient.PatchGroupSyncable(model.NewId(), th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
 	CheckNotFoundStatus(t, response)

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -137,7 +137,6 @@ func TestCreateGroupSyncable(t *testing.T) {
 	group := th.CreateGroup()
 	groupSyncable := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: th.BasicTeam.Id,
 		Type:       model.GroupSyncableTypeTeam,
@@ -158,7 +157,6 @@ func TestGetGroupSyncable(t *testing.T) {
 	group := th.CreateGroup()
 	groupSyncable := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: th.BasicTeam.Id,
 		Type:       model.GroupSyncableTypeTeam,
@@ -181,7 +179,6 @@ func TestGetGroupSyncables(t *testing.T) {
 	// Create a group team
 	groupSyncable := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: th.BasicTeam.Id,
 		Type:       model.GroupSyncableTypeTeam,
@@ -203,7 +200,6 @@ func TestDeleteGroupSyncable(t *testing.T) {
 	group := th.CreateGroup()
 	groupChannel := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: th.BasicChannel.Id,
 		Type:       model.GroupSyncableTypeChannel,

--- a/app/syncables_test.go
+++ b/app/syncables_test.go
@@ -71,7 +71,6 @@ func TestPopulateSyncablesSince(t *testing.T) {
 	}
 
 	_, err = th.App.CreateGroupSyncable(&model.GroupSyncable{
-		CanLeave:   true,
 		AutoAdd:    true,
 		GroupId:    gleeGroup.Id,
 		SyncableId: practiceChannel.Id,
@@ -82,7 +81,6 @@ func TestPopulateSyncablesSince(t *testing.T) {
 	}
 
 	scienceTeamGroupSyncable, err := th.App.CreateGroupSyncable(&model.GroupSyncable{
-		CanLeave:   true,
 		AutoAdd:    false,
 		GroupId:    scienceGroup.Id,
 		SyncableId: nerdsTeam.Id,
@@ -93,7 +91,6 @@ func TestPopulateSyncablesSince(t *testing.T) {
 	}
 
 	scienceChannelGroupSyncable, err := th.App.CreateGroupSyncable(&model.GroupSyncable{
-		CanLeave:   true,
 		AutoAdd:    false,
 		GroupId:    scienceGroup.Id,
 		SyncableId: experimentsChannel.Id,
@@ -290,7 +287,6 @@ func TestPopulateSyncablesSince(t *testing.T) {
 	}
 
 	// the channel syncable is updated
-	scienceChannelGroupSyncable.CanLeave = false
 	scienceChannelGroupSyncable, err = th.App.UpdateGroupSyncable(scienceChannelGroupSyncable)
 	if err != nil {
 		t.Errorf("error updating group syncable: %s", err.Error())

--- a/model/group_syncable.go
+++ b/model/group_syncable.go
@@ -29,7 +29,6 @@ type GroupSyncable struct {
 	// TeamId.
 	SyncableId string `db:"-" json:"-"`
 
-	CanLeave bool              `db:"-" json:"can_leave"`
 	AutoAdd  bool              `json:"auto_add"`
 	CreateAt int64             `json:"create_at"`
 	DeleteAt int64             `json:"delete_at"`
@@ -51,10 +50,6 @@ func (syncable *GroupSyncable) IsValid() *AppError {
 	if !IsValidId(syncable.SyncableId) {
 		return NewAppError("GroupSyncable.SyncableIsValid", "model.group_syncable.syncable_id.app_error", nil, "", http.StatusBadRequest)
 	}
-	// TODO: Add this validation check for phase 2 of LDAP group sync.
-	// if syncable.AutoAdd == false && syncable.CanLeave == false {
-	// 	return NewAppError("GroupSyncable.SyncableIsValid", "model.group_syncable.invalid_state", nil, "", http.StatusBadRequest)
-	// }
 	return nil
 }
 
@@ -74,8 +69,6 @@ func (syncable *GroupSyncable) UnmarshalJSON(b []byte) error {
 			syncable.Type = GroupSyncableTypeChannel
 		case "group_id":
 			syncable.GroupId = value.(string)
-		case "can_leave":
-			syncable.CanLeave = value.(bool)
 		case "auto_add":
 			syncable.AutoAdd = value.(bool)
 		default:
@@ -130,15 +123,10 @@ func (syncable *GroupSyncable) MarshalJSON() ([]byte, error) {
 }
 
 type GroupSyncablePatch struct {
-	CanLeave *bool `json:"can_leave"`
-	AutoAdd  *bool `json:"auto_add"`
+	AutoAdd *bool `json:"auto_add"`
 }
 
 func (syncable *GroupSyncable) Patch(patch *GroupSyncablePatch) {
-	// TODO: Add this validation check for phase 2 of LDAP group sync.
-	// if patch.CanLeave != nil {
-	// 	syncable.CanLeave = *patch.CanLeave
-	// }
 	if patch.AutoAdd != nil {
 		syncable.AutoAdd = *patch.AutoAdd
 	}

--- a/store/sqlstore/group_supplier.go
+++ b/store/sqlstore/group_supplier.go
@@ -470,7 +470,6 @@ func (s *SqlSupplier) getGroupSyncable(groupID string, syncableID string, syncab
 		groupTeam := result.(*groupTeam)
 		groupSyncable.SyncableId = groupTeam.TeamId
 		groupSyncable.GroupId = groupTeam.GroupId
-		groupSyncable.CanLeave = groupTeam.CanLeave
 		groupSyncable.AutoAdd = groupTeam.AutoAdd
 		groupSyncable.CreateAt = groupTeam.CreateAt
 		groupSyncable.DeleteAt = groupTeam.DeleteAt
@@ -480,7 +479,6 @@ func (s *SqlSupplier) getGroupSyncable(groupID string, syncableID string, syncab
 		groupChannel := result.(*groupChannel)
 		groupSyncable.SyncableId = groupChannel.ChannelId
 		groupSyncable.GroupId = groupChannel.GroupId
-		groupSyncable.CanLeave = groupChannel.CanLeave
 		groupSyncable.AutoAdd = groupChannel.AutoAdd
 		groupSyncable.CreateAt = groupChannel.CreateAt
 		groupSyncable.DeleteAt = groupChannel.DeleteAt
@@ -527,7 +525,6 @@ func (s *SqlSupplier) GroupGetAllGroupSyncablesByGroup(ctx context.Context, grou
 			groupSyncable := &model.GroupSyncable{
 				SyncableId:      result.TeamId,
 				GroupId:         result.GroupId,
-				CanLeave:        result.CanLeave,
 				AutoAdd:         result.AutoAdd,
 				CreateAt:        result.CreateAt,
 				DeleteAt:        result.DeleteAt,
@@ -564,7 +561,6 @@ func (s *SqlSupplier) GroupGetAllGroupSyncablesByGroup(ctx context.Context, grou
 			groupSyncable := &model.GroupSyncable{
 				SyncableId:         result.ChannelId,
 				GroupId:            result.GroupId,
-				CanLeave:           result.CanLeave,
 				AutoAdd:            result.AutoAdd,
 				CreateAt:           result.CreateAt,
 				DeleteAt:           result.DeleteAt,

--- a/store/storetest/group_supplier.go
+++ b/store/storetest/group_supplier.go
@@ -618,22 +618,10 @@ func testCreateGroupSyncable(t *testing.T, ss store.Store) {
 	// Invalid GroupID
 	res2 := <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
 		GroupId:    "x",
-		CanLeave:   true,
 		SyncableId: string(model.NewId()),
 		Type:       model.GroupSyncableTypeTeam,
 	})
 	assert.Equal(t, res2.Err.Id, "model.group_syncable.group_id.app_error")
-
-	// TODO: Add this validation test in phase 2 of LDAP groups sync.
-	// Invalid CanLeave/AutoAdd combo (both false)
-	// res3 := <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
-	// 	GroupId:    model.NewId(),
-	// 	CanLeave:   false,
-	// 	AutoAdd:    false,
-	// 	SyncableId: string(model.NewId()),
-	// 	Type:       model.GroupSyncableTypeTeam,
-	// })
-	// assert.Equal(t, res3.Err.Id, "model.group_syncable.invalid_state")
 
 	// Create Group
 	g1 := &model.Group{
@@ -664,7 +652,6 @@ func testCreateGroupSyncable(t *testing.T, ss store.Store) {
 	// New GroupSyncable, happy path
 	gt1 := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: string(team.Id),
 		Type:       model.GroupSyncableTypeTeam,
@@ -674,7 +661,6 @@ func testCreateGroupSyncable(t *testing.T, ss store.Store) {
 	d1 := res6.Data.(*model.GroupSyncable)
 	assert.Equal(t, gt1.SyncableId, d1.SyncableId)
 	assert.Equal(t, gt1.GroupId, d1.GroupId)
-	assert.Equal(t, gt1.CanLeave, d1.CanLeave)
 	assert.Equal(t, gt1.AutoAdd, d1.AutoAdd)
 	assert.NotZero(t, d1.CreateAt)
 	assert.Zero(t, d1.DeleteAt)
@@ -711,7 +697,6 @@ func testGetGroupSyncable(t *testing.T, ss store.Store) {
 	// Create GroupSyncable
 	gt1 := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: string(team.Id),
 		Type:       model.GroupSyncableTypeTeam,
@@ -726,7 +711,6 @@ func testGetGroupSyncable(t *testing.T, ss store.Store) {
 	dgt := res4.Data.(*model.GroupSyncable)
 	assert.Equal(t, gt1.GroupId, dgt.GroupId)
 	assert.Equal(t, gt1.SyncableId, dgt.SyncableId)
-	// assert.Equal(t, gt1.CanLeave, dgt.CanLeave) // TODO: Re-add this test in phase 2 of LDAP groups sync.
 	assert.Equal(t, gt1.AutoAdd, dgt.AutoAdd)
 	assert.NotZero(t, gt1.CreateAt)
 	assert.NotZero(t, gt1.UpdateAt)
@@ -770,7 +754,6 @@ func testGetAllGroupSyncablesByGroup(t *testing.T, ss store.Store) {
 		// create groupteam
 		res3 := <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
 			GroupId:    group.Id,
-			CanLeave:   true,
 			SyncableId: string(team.Id),
 			Type:       model.GroupSyncableTypeTeam,
 		})
@@ -825,7 +808,6 @@ func testUpdateGroupSyncable(t *testing.T, ss store.Store) {
 	// New GroupSyncable, happy path
 	gt1 := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: string(team.Id),
 		Type:       model.GroupSyncableTypeTeam,
@@ -835,25 +817,15 @@ func testUpdateGroupSyncable(t *testing.T, ss store.Store) {
 	d1 := res6.Data.(*model.GroupSyncable)
 
 	// Update existing group team
-	gt1.CanLeave = false
 	gt1.AutoAdd = true
 	res7 := <-ss.Group().UpdateGroupSyncable(gt1)
 	assert.Nil(t, res7.Err)
 	d2 := res7.Data.(*model.GroupSyncable)
-	assert.False(t, d2.CanLeave)
 	assert.True(t, d2.AutoAdd)
-
-	// TODO: Add this validation check test in phase 2 of LDAP groups sync.
-	// Update to invalid state
-	// gt1.AutoAdd = false
-	// gt1.CanLeave = false
-	// res8 := <-ss.Group().UpdateGroupSyncable(gt1)
-	// assert.Equal(t, res8.Err.Id, "model.group_syncable.invalid_state")
 
 	// Non-existent Group
 	gt2 := &model.GroupSyncable{
 		GroupId:    model.NewId(),
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: string(team.Id),
 		Type:       model.GroupSyncableTypeTeam,
@@ -864,7 +836,6 @@ func testUpdateGroupSyncable(t *testing.T, ss store.Store) {
 	// Non-existent Team
 	gt3 := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: string(model.NewId()),
 		Type:       model.GroupSyncableTypeTeam,
@@ -876,7 +847,6 @@ func testUpdateGroupSyncable(t *testing.T, ss store.Store) {
 	origCreateAt := d1.CreateAt
 	d1.CreateAt = model.GetMillis()
 	d1.AutoAdd = true
-	d1.CanLeave = true
 	res11 := <-ss.Group().UpdateGroupSyncable(d1)
 	assert.Nil(t, res11.Err)
 	d3 := res11.Data.(*model.GroupSyncable)
@@ -925,7 +895,6 @@ func testDeleteGroupSyncable(t *testing.T, ss store.Store) {
 	// Create GroupSyncable
 	gt1 := &model.GroupSyncable{
 		GroupId:    group.Id,
-		CanLeave:   true,
 		AutoAdd:    false,
 		SyncableId: string(team.Id),
 		Type:       model.GroupSyncableTypeTeam,
@@ -949,7 +918,6 @@ func testDeleteGroupSyncable(t *testing.T, ss store.Store) {
 	assert.NotZero(t, d1.DeleteAt)
 	assert.Equal(t, d1.GroupId, groupTeam.GroupId)
 	assert.Equal(t, d1.SyncableId, groupTeam.SyncableId)
-	// assert.Equal(t, d1.CanLeave, groupTeam.CanLeave) // TODO: Re-add this test in phase 2 of LDAP groups sync.
 	assert.Equal(t, d1.AutoAdd, groupTeam.AutoAdd)
 	assert.Equal(t, d1.CreateAt, groupTeam.CreateAt)
 	assert.Condition(t, func() bool { return d1.UpdateAt > groupTeam.UpdateAt })
@@ -1002,7 +970,6 @@ func testPendingAutoAddTeamMembers(t *testing.T, ss store.Store) {
 	// Create GroupTeam
 	res = <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
 		AutoAdd:    true,
-		CanLeave:   true,
 		SyncableId: team.Id,
 		Type:       model.GroupSyncableTypeTeam,
 		GroupId:    group.Id,
@@ -1034,7 +1001,6 @@ func testPendingAutoAddTeamMembers(t *testing.T, ss store.Store) {
 
 	pristineSyncable := *syncable
 
-	syncable.CanLeave = false
 	res = <-ss.Group().UpdateGroupSyncable(syncable)
 	assert.Nil(t, res.Err)
 
@@ -1053,7 +1019,6 @@ func testPendingAutoAddTeamMembers(t *testing.T, ss store.Store) {
 
 	// Only includes if auto-add
 	syncable.AutoAdd = false
-	syncable.CanLeave = true // have to update this or the model isn't valid
 	res = <-ss.Group().UpdateGroupSyncable(syncable)
 	assert.Nil(t, res.Err)
 	res = <-ss.Group().PendingAutoAddTeamMembers(0)
@@ -1173,7 +1138,6 @@ func testPendingAutoAddChannelMembers(t *testing.T, ss store.Store) {
 	// Create GroupChannel
 	res = <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
 		AutoAdd:    true,
-		CanLeave:   true,
 		SyncableId: channel.Id,
 		Type:       model.GroupSyncableTypeChannel,
 		GroupId:    group.Id,
@@ -1205,7 +1169,6 @@ func testPendingAutoAddChannelMembers(t *testing.T, ss store.Store) {
 
 	pristineSyncable := *syncable
 
-	syncable.CanLeave = false
 	res = <-ss.Group().UpdateGroupSyncable(syncable)
 	assert.Nil(t, res.Err)
 
@@ -1224,7 +1187,6 @@ func testPendingAutoAddChannelMembers(t *testing.T, ss store.Store) {
 
 	// Only includes if auto-add
 	syncable.AutoAdd = false
-	syncable.CanLeave = true // have to update this or the model isn't valid
 	res = <-ss.Group().UpdateGroupSyncable(syncable)
 	assert.Nil(t, res.Err)
 	res = <-ss.Group().PendingAutoAddChannelMembers(0)


### PR DESCRIPTION
#### Summary
Removes 'CanLeave' field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14415

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)