### PR TITLE
MM-14488: Autogenerate mention_keys on creation if mention_keys aren't provided

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -446,6 +446,8 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 				user.AddNotifyProp(model.MENTION_KEYS_NOTIFY_PROP, *data.NotifyProps.MentionKeys)
 				hasNotifyPropsChanged = true
 			}
+		} else {
+			user.UpdateMentionKeysFromUsername("")
 		}
 	}
 

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -1443,7 +1443,7 @@ func TestImportUserDefaultNotifyProps(t *testing.T) {
 	assert.Equal(t, "false", val)
 
 	// Check all the other notify props are set to their default values.
-	comparisonUser := model.User{}
+	comparisonUser := model.User{Username: user.Username}
 	comparisonUser.SetDefaultNotifications()
 
 	for key, expectedValue := range comparisonUser.NotifyProps {


### PR DESCRIPTION
#### Summary
Autogenerate mention_keys on creation if mention_keys aren't provided

#### Ticket Link
[MM-14488](https://mattermost.atlassian.net/browse/MM-14488)

#### Checklist
- [x] Added or updated unit tests (required for all new features)