### PR TITLE
MM-13740 Add additional plugin APIs for NPS plugin

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -98,8 +98,20 @@ func (api *PluginAPI) SavePluginConfig(pluginConfig map[string]interface{}) *mod
 	return api.app.SaveConfig(cfg, true)
 }
 
+func (api *PluginAPI) GetLicense() *model.License {
+	return api.app.License()
+}
+
 func (api *PluginAPI) GetServerVersion() string {
 	return model.CurrentVersion
+}
+
+func (api *PluginAPI) GetSystemInstallDate() (int64, *model.AppError) {
+	return api.app.getSystemInstallDate()
+}
+
+func (api *PluginAPI) GetDiagnosticId() string {
+	return api.app.DiagnosticId()
 }
 
 func (api *PluginAPI) CreateTeam(team *model.Team) (*model.Team, *model.AppError) {

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -44,10 +44,26 @@ type API interface {
 	// Minimum server version: 5.6
 	SavePluginConfig(config map[string]interface{}) *model.AppError
 
+	// GetLicense returns the current license used by the Mattermoset server. Returns nil if the
+	// the server does not have a license.
+	//
+	// Minimum server version: 5.10
+	GetLicense() *model.License
+
 	// GetServerVersion return the current Mattermost server version
 	//
 	// Minimum server version: 5.4
 	GetServerVersion() string
+
+	// GetSystemInstallDate returns the time that Mattermost was first installed and ran.
+	//
+	// Minimum server version: 5.10
+	GetSystemInstallDate() (int64, *model.AppError)
+
+	// GetDiagnosticId returns a unique identifier used by the server for diagnostic reports.
+	//
+	// Minimum server version: 5.10
+	GetDiagnosticId() string
 
 	// CreateUser creates a user.
 	CreateUser(user *model.User) (*model.User, *model.AppError)

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -671,6 +671,33 @@ func (s *apiRPCServer) SavePluginConfig(args *Z_SavePluginConfigArgs, returns *Z
 	return nil
 }
 
+type Z_GetLicenseArgs struct {
+}
+
+type Z_GetLicenseReturns struct {
+	A *model.License
+}
+
+func (g *apiRPCClient) GetLicense() *model.License {
+	_args := &Z_GetLicenseArgs{}
+	_returns := &Z_GetLicenseReturns{}
+	if err := g.client.Call("Plugin.GetLicense", _args, _returns); err != nil {
+		log.Printf("RPC call to GetLicense API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) GetLicense(args *Z_GetLicenseArgs, returns *Z_GetLicenseReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetLicense() *model.License
+	}); ok {
+		returns.A = hook.GetLicense()
+	} else {
+		return encodableError(fmt.Errorf("API GetLicense called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetServerVersionArgs struct {
 }
 
@@ -694,6 +721,61 @@ func (s *apiRPCServer) GetServerVersion(args *Z_GetServerVersionArgs, returns *Z
 		returns.A = hook.GetServerVersion()
 	} else {
 		return encodableError(fmt.Errorf("API GetServerVersion called but not implemented."))
+	}
+	return nil
+}
+
+type Z_GetSystemInstallDateArgs struct {
+}
+
+type Z_GetSystemInstallDateReturns struct {
+	A int64
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetSystemInstallDate() (int64, *model.AppError) {
+	_args := &Z_GetSystemInstallDateArgs{}
+	_returns := &Z_GetSystemInstallDateReturns{}
+	if err := g.client.Call("Plugin.GetSystemInstallDate", _args, _returns); err != nil {
+		log.Printf("RPC call to GetSystemInstallDate API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetSystemInstallDate(args *Z_GetSystemInstallDateArgs, returns *Z_GetSystemInstallDateReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetSystemInstallDate() (int64, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetSystemInstallDate()
+	} else {
+		return encodableError(fmt.Errorf("API GetSystemInstallDate called but not implemented."))
+	}
+	return nil
+}
+
+type Z_GetDiagnosticIdArgs struct {
+}
+
+type Z_GetDiagnosticIdReturns struct {
+	A string
+}
+
+func (g *apiRPCClient) GetDiagnosticId() string {
+	_args := &Z_GetDiagnosticIdArgs{}
+	_returns := &Z_GetDiagnosticIdReturns{}
+	if err := g.client.Call("Plugin.GetDiagnosticId", _args, _returns); err != nil {
+		log.Printf("RPC call to GetDiagnosticId API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) GetDiagnosticId(args *Z_GetDiagnosticIdArgs, returns *Z_GetDiagnosticIdReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetDiagnosticId() string
+	}); ok {
+		returns.A = hook.GetDiagnosticId()
+	} else {
+		return encodableError(fmt.Errorf("API GetDiagnosticId called but not implemented."))
 	}
 	return nil
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -294,6 +294,11 @@ func (_m *API) DeleteChannelMember(channelId string, userId string) *model.AppEr
 	return r0
 }
 
+// DeleteEphemeralPost provides a mock function with given fields: userId, post
+func (_m *API) DeleteEphemeralPost(userId string, post *model.Post) {
+	_m.Called(userId, post)
+}
+
 // DeletePost provides a mock function with given fields: postId
 func (_m *API) DeletePost(postId string) *model.AppError {
 	ret := _m.Called(postId)
@@ -681,6 +686,20 @@ func (_m *API) GetConfig() *model.Config {
 	return r0
 }
 
+// GetDiagnosticId provides a mock function with given fields:
+func (_m *API) GetDiagnosticId() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetDirectChannel provides a mock function with given fields: userId1, userId2
 func (_m *API) GetDirectChannel(userId1 string, userId2 string) (*model.Channel, *model.AppError) {
 	ret := _m.Called(userId1, userId2)
@@ -934,6 +953,22 @@ func (_m *API) GetLDAPUserAttributes(userId string, attributes []string) (map[st
 	}
 
 	return r0, r1
+}
+
+// GetLicense provides a mock function with given fields:
+func (_m *API) GetLicense() *model.License {
+	ret := _m.Called()
+
+	var r0 *model.License
+	if rf, ok := ret.Get(0).(func() *model.License); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.License)
+		}
+	}
+
+	return r0
 }
 
 // GetPluginConfig provides a mock function with given fields:
@@ -1257,6 +1292,29 @@ func (_m *API) GetSession(sessionId string) (*model.Session, *model.AppError) {
 	var r1 *model.AppError
 	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
 		r1 = rf(sessionId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetSystemInstallDate provides a mock function with given fields:
+func (_m *API) GetSystemInstallDate() (int64, *model.AppError) {
+	ret := _m.Called()
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func() int64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
@@ -2240,35 +2298,6 @@ func (_m *API) SendEphemeralPost(userId string, post *model.Post) *model.Post {
 	return r0
 }
 
-// UpdateEphemeralPost provides a mock function with given fields: userId, post
-func (_m *API) UpdateEphemeralPost(userId string, post *model.Post) *model.Post {
-	ret := _m.Called(userId, post)
-
-	var r0 *model.Post
-	if rf, ok := ret.Get(0).(func(string, *model.Post) *model.Post); ok {
-		r0 = rf(userId, post)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.Post)
-		}
-	}
-
-	return r0
-}
-
-// DeleteEphemeralPost provides a mock function with given fields: userId, post
-func (_m *API) DeleteEphemeralPost(userId string, post *model.Post) {
-	ret := _m.Called(userId, post)
-
-	if rf, ok := ret.Get(0).(func(string, *model.Post) *model.Post); ok {
-		_ = rf(userId, post)
-	} else {
-		if ret.Get(0) != nil {
-			_ = ret.Get(0).(*model.Post)
-		}
-	}
-}
-
 // SendMail provides a mock function with given fields: to, subject, htmlBody
 func (_m *API) SendMail(to string, subject string, htmlBody string) *model.AppError {
 	ret := _m.Called(to, subject, htmlBody)
@@ -2429,6 +2458,22 @@ func (_m *API) UpdateChannelMemberRoles(channelId string, userId string, newRole
 	}
 
 	return r0, r1
+}
+
+// UpdateEphemeralPost provides a mock function with given fields: userId, post
+func (_m *API) UpdateEphemeralPost(userId string, post *model.Post) *model.Post {
+	ret := _m.Called(userId, post)
+
+	var r0 *model.Post
+	if rf, ok := ret.Get(0).(func(string, *model.Post) *model.Post); ok {
+		r0 = rf(userId, post)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Post)
+		}
+	}
+
+	return r0
 }
 
 // UpdatePost provides a mock function with given fields: post


### PR DESCRIPTION
Exposes these fields so that we can include the following information with NPS results:
- Server version
- Server install date
- Server diagnostics ID
- License ID
- License SKU

Let me know if there's anywhere else that I should be documenting these plugin APIs or if this is sufficient.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13740