### PR TITLE
[MM-14361] Initialise the translations before loading the config store

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -169,10 +169,8 @@ func NewServer(options ...Option) (*Server, error) {
 
 	s.ImageProxy = imageproxy.MakeImageProxy(s, s.HTTPService)
 
-	if utils.T == nil {
-		if err := utils.TranslationsPreInit(); err != nil {
-			return nil, errors.Wrapf(err, "unable to load Mattermost translation files")
-		}
+	if err := utils.TranslationsPreInit(); err != nil {
+		return nil, errors.Wrapf(err, "unable to load Mattermost translation files")
 	}
 
 	err := s.RunOldAppInitalization()

--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -14,8 +14,10 @@ import (
 	"github.com/mattermost/mattermost-server/config"
 	"github.com/mattermost/mattermost-server/manualtesting"
 	"github.com/mattermost/mattermost-server/mlog"
+	"github.com/mattermost/mattermost-server/utils"
 	"github.com/mattermost/mattermost-server/web"
 	"github.com/mattermost/mattermost-server/wsapi"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -42,6 +44,9 @@ func serverCmdF(command *cobra.Command, args []string) error {
 
 	interruptChan := make(chan os.Signal, 1)
 
+	if err = utils.TranslationsPreInit(); err != nil {
+		return errors.Wrapf(err, "unable to load Mattermost translation files")
+	}
 	configStore, err := config.NewStore(configDSN, !disableConfigWatch)
 	if err != nil {
 		return err

--- a/utils/i18n.go
+++ b/utils/i18n.go
@@ -21,9 +21,13 @@ var TDefault i18n.TranslateFunc
 var locales map[string]string = make(map[string]string)
 var settings model.LocalizationSettings
 
-// this functions loads translations from filesystem
-// and assign english while loading server config
+// this functions loads translations from filesystem if they are not
+// loaded already and assigns english while loading server config
 func TranslationsPreInit() error {
+	if T != nil {
+		return nil
+	}
+
 	// Set T even if we fail to load the translations. Lots of shutdown handling code will
 	// segfault trying to handle the error, and the untranslated IDs are strictly better.
 	T = TfuncWithFallback("en")


### PR DESCRIPTION
#### Summary
Adds a check to `TranslationsPreInit` so it only loads the translations if they are not already, and add a call to it when starting through the server command before loading the config, avoiding the default locales being applied.

#### Ticket Link
[MM-14361](https://mattermost.atlassian.net/browse/MM-14361)

#### Checklist
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)
