### PR TITLE
MM-14310: Add new build type field to config and diagnostics.

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -686,6 +686,7 @@ func (a *App) trackServer() {
 		"version":          model.CurrentVersion,
 		"database_type":    *a.Config().SqlSettings.DriverName,
 		"operating_system": runtime.GOOS,
+		"build_type":       *a.Config().ServiceSettings.BuildType,
 	}
 
 	if scr := <-a.Srv.Store.User().AnalyticsGetSystemAdminCount(); scr.Err == nil {

--- a/config/default.json
+++ b/config/default.json
@@ -36,6 +36,7 @@
         "EnableMultifactorAuthentication": false,
         "EnforceMultifactorAuthentication": false,
         "EnableUserAccessTokens": false,
+        "BuildType": "custom",
         "AllowCorsFrom": "",
         "CorsExposedHeaders": "",
         "CorsAllowCredentials": false,

--- a/model/config.go
+++ b/model/config.go
@@ -96,6 +96,7 @@ const (
 	SERVICE_SETTINGS_DEFAULT_LISTEN_AND_ADDRESS = ":8065"
 	SERVICE_SETTINGS_DEFAULT_GFYCAT_API_KEY     = "2_KtH_W5"
 	SERVICE_SETTINGS_DEFAULT_GFYCAT_API_SECRET  = "3wLVZPiswc3DnaiaFoLkDvB4X0IV6CpMkj4tf2inJRsBY6-FnkT08zGmppWFgeof"
+	SERVICE_SETTINGS_DEFAULT_BUILD_TYPE         = "custom"
 
 	TEAM_SETTINGS_DEFAULT_SITE_NAME                = "Mattermost"
 	TEAM_SETTINGS_DEFAULT_MAX_USERS_PER_TEAM       = 50
@@ -243,6 +244,7 @@ type ServiceSettings struct {
 	EnableMultifactorAuthentication                   *bool
 	EnforceMultifactorAuthentication                  *bool
 	EnableUserAccessTokens                            *bool
+	BuildType                                         *string
 	AllowCorsFrom                                     *string
 	CorsExposedHeaders                                *string
 	CorsAllowCredentials                              *bool
@@ -507,6 +509,10 @@ func (s *ServiceSettings) SetDefaults() {
 
 	if s.WebsocketSecurePort == nil {
 		s.WebsocketSecurePort = NewInt(443)
+	}
+
+	if s.BuildType == nil {
+		s.BuildType = NewString(SERVICE_SETTINGS_DEFAULT_BUILD_TYPE)
 	}
 
 	if s.AllowCorsFrom == nil {


### PR DESCRIPTION
#### Summary
This PR adds a new config field to the ServiceSettings section called BuildType. This is to allow us to record in telemetry whether the server is: a standard install, a docker install, a puppet install, etc.

The choice of the config file for this is to balance simplicity with quality of data. Although people could edit this, we expect very few will, so it will have a minimal data quality impact. However, it's extremely simple to add a new config field and for packers to set it appropriately when building a package, which makes ease of adoption as simple as possible.

The default value is "custom" and will be set to something else by Jenkins when making releases (and further set by downstream packagers to a value appropriate to that package).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14310