### PR TITLE
MM-14560 Changed local image proxy to be off by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -415,7 +415,7 @@
         "PluginStates": {}
     },
     "ImageProxySettings": {
-        "Enable": true,
+        "Enable": false,
         "ImageProxyType": "local",
         "RemoteImageProxyURL": "",
         "RemoteImageProxyOptions": ""

--- a/model/config.go
+++ b/model/config.go
@@ -2168,7 +2168,11 @@ type ImageProxySettings struct {
 
 func (ips *ImageProxySettings) SetDefaults(ss ServiceSettings) {
 	if ips.Enable == nil {
-		ips.Enable = NewBool(true)
+		if ss.DEPRECATED_DO_NOT_USE_ImageProxyType == nil || *ss.DEPRECATED_DO_NOT_USE_ImageProxyType == "" {
+			ips.Enable = NewBool(false)
+		} else {
+			ips.Enable = NewBool(true)
+		}
 	}
 
 	if ips.ImageProxyType == nil {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -601,7 +601,7 @@ func TestImageProxySettingsSetDefaults(t *testing.T) {
 		ips := ImageProxySettings{}
 		ips.SetDefaults(ServiceSettings{})
 
-		assert.Equal(t, true, *ips.Enable)
+		assert.Equal(t, false, *ips.Enable)
 		assert.Equal(t, IMAGE_PROXY_TYPE_LOCAL, *ips.ImageProxyType)
 		assert.Equal(t, "", *ips.RemoteImageProxyURL)
 		assert.Equal(t, "", *ips.RemoteImageProxyOptions)


### PR DESCRIPTION
This is being disabled by default due to concerns about breaking image previews and integration icons for links on the local network. 

Note that it's also being cherry-picked onto 5.8.1 as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14560

#### Checklist
- Added or updated unit tests (required for all new features)
