### PR TITLE
MM-14416: Adds new fields to Channels and Teams for use by LDAP groups removals.

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -391,7 +391,7 @@ func TestPatchTeam(t *testing.T) {
 	patch.CompanyName = model.NewString("Other company name")
 	patch.InviteId = model.NewString("inviteid1")
 	patch.AllowOpenInvite = model.NewBool(true)
-	patch.IsGroupConstrained = model.NewBool(true)
+	patch.GroupConstrained = model.NewBool(true)
 
 	rteam, resp := Client.PatchTeam(team.Id, patch)
 	CheckNoError(t, resp)
@@ -411,8 +411,8 @@ func TestPatchTeam(t *testing.T) {
 	if !rteam.AllowOpenInvite {
 		t.Fatal("AllowOpenInvite did not update properly")
 	}
-	if !rteam.IsGroupConstrained {
-		t.Fatal("IsGroupConstrained did not update properly")
+	if !rteam.GroupConstrained {
+		t.Fatal("GroupConstrained did not update properly")
 	}
 
 	_, resp = Client.PatchTeam("junk", patch)

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -391,6 +391,7 @@ func TestPatchTeam(t *testing.T) {
 	patch.CompanyName = model.NewString("Other company name")
 	patch.InviteId = model.NewString("inviteid1")
 	patch.AllowOpenInvite = model.NewBool(true)
+	patch.IsGroupConstrained = model.NewBool(true)
 
 	rteam, resp := Client.PatchTeam(team.Id, patch)
 	CheckNoError(t, resp)
@@ -409,6 +410,9 @@ func TestPatchTeam(t *testing.T) {
 	}
 	if !rteam.AllowOpenInvite {
 		t.Fatal("AllowOpenInvite did not update properly")
+	}
+	if !rteam.IsGroupConstrained {
+		t.Fatal("IsGroupConstrained did not update properly")
 	}
 
 	_, resp = Client.PatchTeam("junk", patch)

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -391,7 +391,6 @@ func TestPatchTeam(t *testing.T) {
 	patch.CompanyName = model.NewString("Other company name")
 	patch.InviteId = model.NewString("inviteid1")
 	patch.AllowOpenInvite = model.NewBool(true)
-	patch.GroupConstrained = model.NewBool(true)
 
 	rteam, resp := Client.PatchTeam(team.Id, patch)
 	CheckNoError(t, resp)
@@ -410,9 +409,6 @@ func TestPatchTeam(t *testing.T) {
 	}
 	if !rteam.AllowOpenInvite {
 		t.Fatal("AllowOpenInvite did not update properly")
-	}
-	if !rteam.GroupConstrained {
-		t.Fatal("GroupConstrained did not update properly")
 	}
 
 	_, resp = Client.PatchTeam("junk", patch)

--- a/model/channel.go
+++ b/model/channel.go
@@ -51,7 +51,7 @@ type Channel struct {
 	CreatorId          string                 `json:"creator_id"`
 	SchemeId           *string                `json:"scheme_id"`
 	Props              map[string]interface{} `json:"props" db:"-"`
-	IsGroupConstrained bool                   `json:"is_group_constrained"`
+	GroupConstrained bool                   `json:"group_constrained"`
 }
 
 type ChannelWithTeamData struct {
@@ -66,7 +66,7 @@ type ChannelPatch struct {
 	Name               *string `json:"name"`
 	Header             *string `json:"header"`
 	Purpose            *string `json:"purpose"`
-	IsGroupConstrained *bool   `json:"is_group_constrained"`
+	GroupConstrained *bool   `json:"group_constrained"`
 }
 
 type ChannelForExport struct {
@@ -184,8 +184,8 @@ func (o *Channel) Patch(patch *ChannelPatch) {
 		o.Purpose = *patch.Purpose
 	}
 
-	if patch.IsGroupConstrained != nil {
-		o.IsGroupConstrained = *patch.IsGroupConstrained
+	if patch.GroupConstrained != nil {
+		o.GroupConstrained = *patch.GroupConstrained
 	}
 }
 

--- a/model/channel.go
+++ b/model/channel.go
@@ -35,22 +35,22 @@ const (
 )
 
 type Channel struct {
-	Id                 string                 `json:"id"`
-	CreateAt           int64                  `json:"create_at"`
-	UpdateAt           int64                  `json:"update_at"`
-	DeleteAt           int64                  `json:"delete_at"`
-	TeamId             string                 `json:"team_id"`
-	Type               string                 `json:"type"`
-	DisplayName        string                 `json:"display_name"`
-	Name               string                 `json:"name"`
-	Header             string                 `json:"header"`
-	Purpose            string                 `json:"purpose"`
-	LastPostAt         int64                  `json:"last_post_at"`
-	TotalMsgCount      int64                  `json:"total_msg_count"`
-	ExtraUpdateAt      int64                  `json:"extra_update_at"`
-	CreatorId          string                 `json:"creator_id"`
-	SchemeId           *string                `json:"scheme_id"`
-	Props              map[string]interface{} `json:"props" db:"-"`
+	Id               string                 `json:"id"`
+	CreateAt         int64                  `json:"create_at"`
+	UpdateAt         int64                  `json:"update_at"`
+	DeleteAt         int64                  `json:"delete_at"`
+	TeamId           string                 `json:"team_id"`
+	Type             string                 `json:"type"`
+	DisplayName      string                 `json:"display_name"`
+	Name             string                 `json:"name"`
+	Header           string                 `json:"header"`
+	Purpose          string                 `json:"purpose"`
+	LastPostAt       int64                  `json:"last_post_at"`
+	TotalMsgCount    int64                  `json:"total_msg_count"`
+	ExtraUpdateAt    int64                  `json:"extra_update_at"`
+	CreatorId        string                 `json:"creator_id"`
+	SchemeId         *string                `json:"scheme_id"`
+	Props            map[string]interface{} `json:"props" db:"-"`
 	GroupConstrained bool                   `json:"group_constrained"`
 }
 
@@ -62,10 +62,10 @@ type ChannelWithTeamData struct {
 }
 
 type ChannelPatch struct {
-	DisplayName        *string `json:"display_name"`
-	Name               *string `json:"name"`
-	Header             *string `json:"header"`
-	Purpose            *string `json:"purpose"`
+	DisplayName      *string `json:"display_name"`
+	Name             *string `json:"name"`
+	Header           *string `json:"header"`
+	Purpose          *string `json:"purpose"`
 	GroupConstrained *bool   `json:"group_constrained"`
 }
 

--- a/model/channel.go
+++ b/model/channel.go
@@ -35,22 +35,23 @@ const (
 )
 
 type Channel struct {
-	Id            string                 `json:"id"`
-	CreateAt      int64                  `json:"create_at"`
-	UpdateAt      int64                  `json:"update_at"`
-	DeleteAt      int64                  `json:"delete_at"`
-	TeamId        string                 `json:"team_id"`
-	Type          string                 `json:"type"`
-	DisplayName   string                 `json:"display_name"`
-	Name          string                 `json:"name"`
-	Header        string                 `json:"header"`
-	Purpose       string                 `json:"purpose"`
-	LastPostAt    int64                  `json:"last_post_at"`
-	TotalMsgCount int64                  `json:"total_msg_count"`
-	ExtraUpdateAt int64                  `json:"extra_update_at"`
-	CreatorId     string                 `json:"creator_id"`
-	SchemeId      *string                `json:"scheme_id"`
-	Props         map[string]interface{} `json:"props" db:"-"`
+	Id                 string                 `json:"id"`
+	CreateAt           int64                  `json:"create_at"`
+	UpdateAt           int64                  `json:"update_at"`
+	DeleteAt           int64                  `json:"delete_at"`
+	TeamId             string                 `json:"team_id"`
+	Type               string                 `json:"type"`
+	DisplayName        string                 `json:"display_name"`
+	Name               string                 `json:"name"`
+	Header             string                 `json:"header"`
+	Purpose            string                 `json:"purpose"`
+	LastPostAt         int64                  `json:"last_post_at"`
+	TotalMsgCount      int64                  `json:"total_msg_count"`
+	ExtraUpdateAt      int64                  `json:"extra_update_at"`
+	CreatorId          string                 `json:"creator_id"`
+	SchemeId           *string                `json:"scheme_id"`
+	Props              map[string]interface{} `json:"props" db:"-"`
+	IsGroupConstrained bool                   `json:"is_group_constrained"`
 }
 
 type ChannelWithTeamData struct {
@@ -61,10 +62,11 @@ type ChannelWithTeamData struct {
 }
 
 type ChannelPatch struct {
-	DisplayName *string `json:"display_name"`
-	Name        *string `json:"name"`
-	Header      *string `json:"header"`
-	Purpose     *string `json:"purpose"`
+	DisplayName        *string `json:"display_name"`
+	Name               *string `json:"name"`
+	Header             *string `json:"header"`
+	Purpose            *string `json:"purpose"`
+	IsGroupConstrained *bool   `json:"is_group_constrained"`
 }
 
 type ChannelForExport struct {
@@ -180,6 +182,10 @@ func (o *Channel) Patch(patch *ChannelPatch) {
 
 	if patch.Purpose != nil {
 		o.Purpose = *patch.Purpose
+	}
+
+	if patch.IsGroupConstrained != nil {
+		o.IsGroupConstrained = *patch.IsGroupConstrained
 	}
 }
 

--- a/model/channel.go
+++ b/model/channel.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"crypto/sha1"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -51,7 +52,7 @@ type Channel struct {
 	CreatorId        string                 `json:"creator_id"`
 	SchemeId         *string                `json:"scheme_id"`
 	Props            map[string]interface{} `json:"props" db:"-"`
-	GroupConstrained bool                   `json:"group_constrained"`
+	GroupConstrained sql.NullBool           `json:"group_constrained"`
 }
 
 type ChannelWithTeamData struct {
@@ -185,7 +186,7 @@ func (o *Channel) Patch(patch *ChannelPatch) {
 	}
 
 	if patch.GroupConstrained != nil {
-		o.GroupConstrained = *patch.GroupConstrained
+		o.GroupConstrained.Bool = *patch.GroupConstrained
 	}
 }
 

--- a/model/channel_test.go
+++ b/model/channel_test.go
@@ -42,6 +42,7 @@ func TestChannelPatch(t *testing.T) {
 	*p.DisplayName = NewId()
 	*p.Header = NewId()
 	*p.Purpose = NewId()
+	*p.IsGroupConstrained = true
 
 	o := Channel{Id: NewId(), Name: NewId()}
 	o.Patch(p)
@@ -56,6 +57,9 @@ func TestChannelPatch(t *testing.T) {
 		t.Fatal("do not match")
 	}
 	if *p.Purpose != o.Purpose {
+		t.Fatal("do not match")
+	}
+	if *p.IsGroupConstrained != o.IsGroupConstrained {
 		t.Fatal("do not match")
 	}
 }

--- a/model/channel_test.go
+++ b/model/channel_test.go
@@ -42,7 +42,7 @@ func TestChannelPatch(t *testing.T) {
 	*p.DisplayName = NewId()
 	*p.Header = NewId()
 	*p.Purpose = NewId()
-	*p.IsGroupConstrained = true
+	*p.GroupConstrained = true
 
 	o := Channel{Id: NewId(), Name: NewId()}
 	o.Patch(p)
@@ -59,7 +59,7 @@ func TestChannelPatch(t *testing.T) {
 	if *p.Purpose != o.Purpose {
 		t.Fatal("do not match")
 	}
-	if *p.IsGroupConstrained != o.IsGroupConstrained {
+	if *p.GroupConstrained != o.GroupConstrained {
 		t.Fatal("do not match")
 	}
 }

--- a/model/channel_test.go
+++ b/model/channel_test.go
@@ -37,7 +37,7 @@ func TestChannelCopy(t *testing.T) {
 }
 
 func TestChannelPatch(t *testing.T) {
-	p := &ChannelPatch{Name: new(string), DisplayName: new(string), Header: new(string), Purpose: new(string)}
+	p := &ChannelPatch{Name: new(string), DisplayName: new(string), Header: new(string), Purpose: new(string), GroupConstrained: new(bool)}
 	*p.Name = NewId()
 	*p.DisplayName = NewId()
 	*p.Header = NewId()
@@ -59,8 +59,8 @@ func TestChannelPatch(t *testing.T) {
 	if *p.Purpose != o.Purpose {
 		t.Fatal("do not match")
 	}
-	if *p.GroupConstrained != o.GroupConstrained {
-		t.Fatal("do not match")
+	if *p.GroupConstrained != o.GroupConstrained.Bool {
+		t.Fatalf("expected %v got %v", *p.GroupConstrained, o.GroupConstrained.Bool)
 	}
 }
 

--- a/model/team.go
+++ b/model/team.go
@@ -41,7 +41,7 @@ type Team struct {
 	AllowOpenInvite    bool    `json:"allow_open_invite"`
 	LastTeamIconUpdate int64   `json:"last_team_icon_update,omitempty"`
 	SchemeId           *string `json:"scheme_id"`
-	IsGroupConstrained bool    `json:"is_group_constrained"`
+	GroupConstrained bool    `json:"group_constrained"`
 }
 
 type TeamPatch struct {
@@ -51,7 +51,7 @@ type TeamPatch struct {
 	AllowedDomains     *string `json:"allowed_domains"`
 	InviteId           *string `json:"invite_id"`
 	AllowOpenInvite    *bool   `json:"allow_open_invite"`
-	IsGroupConstrained *bool   `json:"is_group_constrained"`
+	GroupConstrained *bool   `json:"group_constrained"`
 }
 
 type TeamForExport struct {
@@ -276,8 +276,8 @@ func (t *Team) Patch(patch *TeamPatch) {
 		t.AllowOpenInvite = *patch.AllowOpenInvite
 	}
 
-	if patch.IsGroupConstrained != nil {
-		t.IsGroupConstrained = *patch.IsGroupConstrained
+	if patch.GroupConstrained != nil {
+		t.GroupConstrained = *patch.GroupConstrained
 	}
 }
 

--- a/model/team.go
+++ b/model/team.go
@@ -41,16 +41,16 @@ type Team struct {
 	AllowOpenInvite    bool    `json:"allow_open_invite"`
 	LastTeamIconUpdate int64   `json:"last_team_icon_update,omitempty"`
 	SchemeId           *string `json:"scheme_id"`
-	GroupConstrained bool    `json:"group_constrained"`
+	GroupConstrained   bool    `json:"group_constrained"`
 }
 
 type TeamPatch struct {
-	DisplayName        *string `json:"display_name"`
-	Description        *string `json:"description"`
-	CompanyName        *string `json:"company_name"`
-	AllowedDomains     *string `json:"allowed_domains"`
-	InviteId           *string `json:"invite_id"`
-	AllowOpenInvite    *bool   `json:"allow_open_invite"`
+	DisplayName      *string `json:"display_name"`
+	Description      *string `json:"description"`
+	CompanyName      *string `json:"company_name"`
+	AllowedDomains   *string `json:"allowed_domains"`
+	InviteId         *string `json:"invite_id"`
+	AllowOpenInvite  *bool   `json:"allow_open_invite"`
 	GroupConstrained *bool   `json:"group_constrained"`
 }
 

--- a/model/team.go
+++ b/model/team.go
@@ -41,15 +41,17 @@ type Team struct {
 	AllowOpenInvite    bool    `json:"allow_open_invite"`
 	LastTeamIconUpdate int64   `json:"last_team_icon_update,omitempty"`
 	SchemeId           *string `json:"scheme_id"`
+	IsGroupConstrained bool    `json:"is_group_constrained"`
 }
 
 type TeamPatch struct {
-	DisplayName     *string `json:"display_name"`
-	Description     *string `json:"description"`
-	CompanyName     *string `json:"company_name"`
-	AllowedDomains  *string `json:"allowed_domains"`
-	InviteId        *string `json:"invite_id"`
-	AllowOpenInvite *bool   `json:"allow_open_invite"`
+	DisplayName        *string `json:"display_name"`
+	Description        *string `json:"description"`
+	CompanyName        *string `json:"company_name"`
+	AllowedDomains     *string `json:"allowed_domains"`
+	InviteId           *string `json:"invite_id"`
+	AllowOpenInvite    *bool   `json:"allow_open_invite"`
+	IsGroupConstrained *bool   `json:"is_group_constrained"`
 }
 
 type TeamForExport struct {
@@ -272,6 +274,10 @@ func (t *Team) Patch(patch *TeamPatch) {
 
 	if patch.AllowOpenInvite != nil {
 		t.AllowOpenInvite = *patch.AllowOpenInvite
+	}
+
+	if patch.IsGroupConstrained != nil {
+		t.IsGroupConstrained = *patch.IsGroupConstrained
 	}
 }
 

--- a/model/team.go
+++ b/model/team.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,22 +27,22 @@ const (
 )
 
 type Team struct {
-	Id                 string  `json:"id"`
-	CreateAt           int64   `json:"create_at"`
-	UpdateAt           int64   `json:"update_at"`
-	DeleteAt           int64   `json:"delete_at"`
-	DisplayName        string  `json:"display_name"`
-	Name               string  `json:"name"`
-	Description        string  `json:"description"`
-	Email              string  `json:"email"`
-	Type               string  `json:"type"`
-	CompanyName        string  `json:"company_name"`
-	AllowedDomains     string  `json:"allowed_domains"`
-	InviteId           string  `json:"invite_id"`
-	AllowOpenInvite    bool    `json:"allow_open_invite"`
-	LastTeamIconUpdate int64   `json:"last_team_icon_update,omitempty"`
-	SchemeId           *string `json:"scheme_id"`
-	GroupConstrained   bool    `json:"group_constrained"`
+	Id                 string       `json:"id"`
+	CreateAt           int64        `json:"create_at"`
+	UpdateAt           int64        `json:"update_at"`
+	DeleteAt           int64        `json:"delete_at"`
+	DisplayName        string       `json:"display_name"`
+	Name               string       `json:"name"`
+	Description        string       `json:"description"`
+	Email              string       `json:"email"`
+	Type               string       `json:"type"`
+	CompanyName        string       `json:"company_name"`
+	AllowedDomains     string       `json:"allowed_domains"`
+	InviteId           string       `json:"invite_id"`
+	AllowOpenInvite    bool         `json:"allow_open_invite"`
+	LastTeamIconUpdate int64        `json:"last_team_icon_update,omitempty"`
+	SchemeId           *string      `json:"scheme_id"`
+	GroupConstrained   sql.NullBool `json:"group_constrained"`
 }
 
 type TeamPatch struct {
@@ -277,7 +278,7 @@ func (t *Team) Patch(patch *TeamPatch) {
 	}
 
 	if patch.GroupConstrained != nil {
-		t.GroupConstrained = *patch.GroupConstrained
+		t.GroupConstrained.Bool = *patch.GroupConstrained
 	}
 }
 

--- a/model/team_test.go
+++ b/model/team_test.go
@@ -130,3 +130,48 @@ func TestCleanTeamName(t *testing.T) {
 		t.Fatal("didn't clean name properly")
 	}
 }
+
+func TestTeamPatch(t *testing.T) {
+	p := &TeamPatch{
+		DisplayName:      new(string),
+		Description:      new(string),
+		CompanyName:      new(string),
+		AllowedDomains:   new(string),
+		InviteId:         new(string),
+		AllowOpenInvite:  new(bool),
+		GroupConstrained: new(bool),
+	}
+
+	*p.DisplayName = NewId()
+	*p.Description = NewId()
+	*p.CompanyName = NewId()
+	*p.AllowedDomains = NewId()
+	*p.InviteId = NewId()
+	*p.AllowOpenInvite = true
+	*p.GroupConstrained = true
+
+	o := Team{Id: NewId()}
+	o.Patch(p)
+
+	if *p.DisplayName != o.DisplayName {
+		t.Fatal("DisplayName did not update")
+	}
+	if *p.Description != o.Description {
+		t.Fatal("Description did not update")
+	}
+	if *p.CompanyName != o.CompanyName {
+		t.Fatal("CompanyName did not update")
+	}
+	if *p.AllowedDomains != o.AllowedDomains {
+		t.Fatal("AllowedDomains did not update")
+	}
+	if *p.InviteId != o.InviteId {
+		t.Fatal("InviteId did not update")
+	}
+	if *p.AllowOpenInvite != o.AllowOpenInvite {
+		t.Fatal("AllowOpenInvite did not update")
+	}
+	if *p.GroupConstrained != o.GroupConstrained {
+		t.Fatal("GroupConstrained did not update")
+	}
+}

--- a/model/team_test.go
+++ b/model/team_test.go
@@ -171,7 +171,7 @@ func TestTeamPatch(t *testing.T) {
 	if *p.AllowOpenInvite != o.AllowOpenInvite {
 		t.Fatal("AllowOpenInvite did not update")
 	}
-	if *p.GroupConstrained != o.GroupConstrained {
-		t.Fatal("GroupConstrained did not update")
+	if *p.GroupConstrained != o.GroupConstrained.Bool {
+		t.Fatalf("expected %v got %v", *p.GroupConstrained, o.GroupConstrained.Bool)
 	}
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -634,8 +634,8 @@ func UpgradeDatabaseToVersion510(sqlStore SqlStore) {
 		}
 	}
 
-	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "IsGroupConstrained", "tinyint(1)", "boolean")
-	sqlStore.CreateColumnIfNotExistsNoDefault("Teams", "IsGroupConstrained", "tinyint(1)", "boolean")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "GroupConstrained", "tinyint(1)", "boolean")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Teams", "GroupConstrained", "tinyint(1)", "boolean")
 
 	// 	saveSchemaVersion(sqlStore, VERSION_5_10_0)
 	// }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -634,6 +634,9 @@ func UpgradeDatabaseToVersion510(sqlStore SqlStore) {
 		}
 	}
 
+	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "IsGroupConstrained", "tinyint(1)", "boolean")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Teams", "IsGroupConstrained", "tinyint(1)", "boolean")
+
 	// 	saveSchemaVersion(sqlStore, VERSION_5_10_0)
 	// }
 }


### PR DESCRIPTION
#### Summary
Adds new field on `Team` and `Channel` for use by LDAP groups removals.

Originally I was planning to call the new fields `LimitMembershipToGroups` and then I thought `GroupConstrained` seems to capture the intent but I'm open to other ideas or opinions. I'm 0/5.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14416

#### Checklist
- [x] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
- [ ] Has enterprise changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-server/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, upgrade, etc.)