### PR TITLE
[MM-14568] Activate Legacy MFA for release 5.9 by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -74,7 +74,7 @@
         "ExperimentalChannelOrganization": false,
         "EnableAPITeamDeletion": false,
         "ExperimentalEnableHardenedMode": false,
-        "DisableLegacyMFA": true,
+        "DisableLegacyMFA": false,
         "EnableEmailInvitations": false,
         "ExperimentalLdapGroupSync": false,
         "ExperimentalStrictCSRFEnforcement": false


### PR DESCRIPTION
#### Summary
To avoid breaking outdated mobile versions with the deactivation of the legacy MFA mechanism, we will enable it in version 5.9 by default. The activation by default will be postponed to 5.10.

Needs to be cherry-picked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14568
