### PR TITLE
[MM-13816] Fix MFA prompt not being shown for hardened mode

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1109,9 +1109,10 @@ func sendPasswordReset(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func login(c *Context, w http.ResponseWriter, r *http.Request) {
-	// For hardened mode, translate all login errors to generic.
+	// For hardened mode, translate all login errors to generic. MFA error being an exception, since it's required for
+	// the login flow itself.
 	defer func() {
-		if *c.App.Config().ServiceSettings.ExperimentalEnableHardenedMode && c.Err != nil {
+		if *c.App.Config().ServiceSettings.ExperimentalEnableHardenedMode && c.Err != nil && c.Err.Id != "mfa.validate_token.authenticate.app_error" {
 			c.Err = model.NewAppError("login", "api.user.login.invalid_credentials", nil, "", http.StatusUnauthorized)
 		}
 	}()


### PR DESCRIPTION
#### Summary
After the recent MFA refactor, we use an error-based flow to check whether a MFA token was required or not. Since we are obfuscating all errors before returning them to the client, this resulted in the MFA prompt never be shown.

This PR adds an exception to the error that is returned with a correct credential pair, but missing MFA token.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-13816

