### PR TITLE
MM-14620 Specify parameter name for PluginAPI.GetUsers

### DIFF
--- a/plugin/api.go
+++ b/plugin/api.go
@@ -74,7 +74,7 @@ type API interface {
 	// GetUsers a list of users based on search options.
 	//
 	// Minimum server version: 5.10
-	GetUsers(*model.UserGetOptions) ([]*model.User, *model.AppError)
+	GetUsers(options *model.UserGetOptions) ([]*model.User, *model.AppError)
 
 	// GetUser gets a user.
 	GetUser(userId string) (*model.User, *model.AppError)

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -846,8 +846,8 @@ type Z_GetUsersReturns struct {
 	B *model.AppError
 }
 
-func (g *apiRPCClient) GetUsers(*model.UserGetOptions) ([]*model.User, *model.AppError) {
-	_args := &Z_GetUsersArgs{}
+func (g *apiRPCClient) GetUsers(options *model.UserGetOptions) ([]*model.User, *model.AppError) {
+	_args := &Z_GetUsersArgs{options}
 	_returns := &Z_GetUsersReturns{}
 	if err := g.client.Call("Plugin.GetUsers", _args, _returns); err != nil {
 		log.Printf("RPC call to GetUsers API failed: %s", err.Error())
@@ -857,7 +857,7 @@ func (g *apiRPCClient) GetUsers(*model.UserGetOptions) ([]*model.User, *model.Ap
 
 func (s *apiRPCServer) GetUsers(args *Z_GetUsersArgs, returns *Z_GetUsersReturns) error {
 	if hook, ok := s.impl.(interface {
-		GetUsers(*model.UserGetOptions) ([]*model.User, *model.AppError)
+		GetUsers(options *model.UserGetOptions) ([]*model.User, *model.AppError)
 	}); ok {
 		returns.A, returns.B = hook.GetUsers(args.A)
 	} else {


### PR DESCRIPTION
This is to fix the generated code so that it actually passes arguments correctly. If you look at the diff, the client-side call doesn't actually pass any values for the unnamed parameter.

I also filed https://mattermost.atlassian.net/browse/MM-14621 in case we want to actually fix the generator code.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14620