### PR TITLE
[MM-14576] Add GetBundlePath method to Plugin API

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -99,8 +99,13 @@ func (api *PluginAPI) SavePluginConfig(pluginConfig map[string]interface{}) *mod
 	return api.app.SaveConfig(cfg, true)
 }
 
-func (api *PluginAPI) GetBundlePath() string {
-	return filepath.Join(*api.GetConfig().PluginSettings.Directory, api.manifest.Id)
+func (api *PluginAPI) GetBundlePath() (string, error) {
+	bundlePath, err := filepath.Abs(filepath.Join(*api.GetConfig().PluginSettings.Directory, api.manifest.Id))
+	if err != nil {
+		return "", err
+	}
+
+	return bundlePath, err
 }
 
 func (api *PluginAPI) GetLicense() *model.License {

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/mlog"
@@ -96,6 +97,10 @@ func (api *PluginAPI) SavePluginConfig(pluginConfig map[string]interface{}) *mod
 	cfg := api.app.GetSanitizedConfig()
 	cfg.PluginSettings.Plugins[api.manifest.Id] = pluginConfig
 	return api.app.SaveConfig(cfg, true)
+}
+
+func (api *PluginAPI) GetBundlePath() string {
+	return filepath.Join(*api.GetConfig().PluginSettings.Directory, api.manifest.Id)
 }
 
 func (api *PluginAPI) GetLicense() *model.License {

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -44,6 +44,11 @@ type API interface {
 	// Minimum server version: 5.6
 	SavePluginConfig(config map[string]interface{}) *model.AppError
 
+	// GetBundlePath returns the path where the plugin's bundle was unpacked.
+	//
+	// Minimum server version: 5.10
+	GetBundlePath() string
+
 	// GetLicense returns the current license used by the Mattermost server. Returns nil if the
 	// the server does not have a license.
 	//

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -44,10 +44,10 @@ type API interface {
 	// Minimum server version: 5.6
 	SavePluginConfig(config map[string]interface{}) *model.AppError
 
-	// GetBundlePath returns the path where the plugin's bundle was unpacked.
+	// GetBundlePath returns the absolute path where the plugin's bundle was unpacked.
 	//
 	// Minimum server version: 5.10
-	GetBundlePath() string
+	GetBundlePath() (string, error)
 
 	// GetLicense returns the current license used by the Mattermost server. Returns nil if the
 	// the server does not have a license.

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -44,7 +44,7 @@ type API interface {
 	// Minimum server version: 5.6
 	SavePluginConfig(config map[string]interface{}) *model.AppError
 
-	// GetLicense returns the current license used by the Mattermoset server. Returns nil if the
+	// GetLicense returns the current license used by the Mattermost server. Returns nil if the
 	// the server does not have a license.
 	//
 	// Minimum server version: 5.10

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -671,6 +671,33 @@ func (s *apiRPCServer) SavePluginConfig(args *Z_SavePluginConfigArgs, returns *Z
 	return nil
 }
 
+type Z_GetBundlePathArgs struct {
+}
+
+type Z_GetBundlePathReturns struct {
+	A string
+}
+
+func (g *apiRPCClient) GetBundlePath() string {
+	_args := &Z_GetBundlePathArgs{}
+	_returns := &Z_GetBundlePathReturns{}
+	if err := g.client.Call("Plugin.GetBundlePath", _args, _returns); err != nil {
+		log.Printf("RPC call to GetBundlePath API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) GetBundlePath(args *Z_GetBundlePathArgs, returns *Z_GetBundlePathReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetBundlePath() string
+	}); ok {
+		returns.A = hook.GetBundlePath()
+	} else {
+		return encodableError(fmt.Errorf("API GetBundlePath called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetLicenseArgs struct {
 }
 

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -676,22 +676,23 @@ type Z_GetBundlePathArgs struct {
 
 type Z_GetBundlePathReturns struct {
 	A string
+	B error
 }
 
-func (g *apiRPCClient) GetBundlePath() string {
+func (g *apiRPCClient) GetBundlePath() (string, error) {
 	_args := &Z_GetBundlePathArgs{}
 	_returns := &Z_GetBundlePathReturns{}
 	if err := g.client.Call("Plugin.GetBundlePath", _args, _returns); err != nil {
 		log.Printf("RPC call to GetBundlePath API failed: %s", err.Error())
 	}
-	return _returns.A
+	return _returns.A, _returns.B
 }
 
 func (s *apiRPCServer) GetBundlePath(args *Z_GetBundlePathArgs, returns *Z_GetBundlePathReturns) error {
 	if hook, ok := s.impl.(interface {
-		GetBundlePath() string
+		GetBundlePath() (string, error)
 	}); ok {
-		returns.A = hook.GetBundlePath()
+		returns.A, returns.B = hook.GetBundlePath()
 	} else {
 		return encodableError(fmt.Errorf("API GetBundlePath called but not implemented."))
 	}

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -445,6 +445,20 @@ func (_m *API) GetBots(options *model.BotGetOptions) ([]*model.Bot, *model.AppEr
 	return r0, r1
 }
 
+// GetBundlePath provides a mock function with given fields:
+func (_m *API) GetBundlePath() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // GetChannel provides a mock function with given fields: channelId
 func (_m *API) GetChannel(channelId string) (*model.Channel, *model.AppError) {
 	ret := _m.Called(channelId)
@@ -1699,13 +1713,13 @@ func (_m *API) GetUserStatusesByIds(userIds []string) ([]*model.Status, *model.A
 	return r0, r1
 }
 
-// GetUsers provides a mock function with given fields: _a0
-func (_m *API) GetUsers(_a0 *model.UserGetOptions) ([]*model.User, *model.AppError) {
-	ret := _m.Called(_a0)
+// GetUsers provides a mock function with given fields: options
+func (_m *API) GetUsers(options *model.UserGetOptions) ([]*model.User, *model.AppError) {
+	ret := _m.Called(options)
 
 	var r0 []*model.User
 	if rf, ok := ret.Get(0).(func(*model.UserGetOptions) []*model.User); ok {
-		r0 = rf(_a0)
+		r0 = rf(options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.User)
@@ -1714,7 +1728,7 @@ func (_m *API) GetUsers(_a0 *model.UserGetOptions) ([]*model.User, *model.AppErr
 
 	var r1 *model.AppError
 	if rf, ok := ret.Get(1).(func(*model.UserGetOptions) *model.AppError); ok {
-		r1 = rf(_a0)
+		r1 = rf(options)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -446,7 +446,7 @@ func (_m *API) GetBots(options *model.BotGetOptions) ([]*model.Bot, *model.AppEr
 }
 
 // GetBundlePath provides a mock function with given fields:
-func (_m *API) GetBundlePath() string {
+func (_m *API) GetBundlePath() (string, error) {
 	ret := _m.Called()
 
 	var r0 string
@@ -456,7 +456,14 @@ func (_m *API) GetBundlePath() string {
 		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetChannel provides a mock function with given fields: channelId


### PR DESCRIPTION
#### Summary
This PR adds a `GetBundlePath() string` method to the Plugin API. This will return the path where the plugin bundle was unpacked.

By default the plugin directory is `./plugins`. Hence the returned path will most likely be relative e.g. `plugins/com.github.matterpoll.matterpoll`. Currently this should not cause problems, because the plugin working directory is the same as the servers one. If we want to change this to an absolute path, the signature for the method has to be `GetBundlePath() (string, error)` because [`filepath.Abs()`](https://golang.org/pkg/path/filepath/#Abs) can error. Or is there a smarter solution?

If someone wants test for this changes, just request them.

cc @kaakaa

#### Ticket Link
Fixes #10448 