### PR TITLE
MM-14582 Support desktop-app-driven user-status updates

### DIFF
--- a/api4/status.go
+++ b/api4/status.go
@@ -84,13 +84,19 @@ func updateUserStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.App.DisableAutoResponder(c.Params.UserId, c.IsSystemAdmin())
 	}
 
+	// allow overiding the manual status updates with 'manual' query string
+	manual := true
+	if r.FormValue("manual") == "false" {
+		manual = false
+	}
+
 	switch status.Status {
 	case "online":
-		c.App.SetStatusOnline(c.Params.UserId, true)
+		c.App.SetStatusOnline(c.Params.UserId, manual)
 	case "offline":
-		c.App.SetStatusOffline(c.Params.UserId, true)
+		c.App.SetStatusOffline(c.Params.UserId, manual)
 	case "away":
-		c.App.SetStatusAwayIfNeeded(c.Params.UserId, true)
+		c.App.SetStatusAwayIfNeeded(c.Params.UserId, manual)
 	case "dnd":
 		c.App.SetStatusDoNotDisturb(c.Params.UserId)
 	default:


### PR DESCRIPTION
#### Summary
This PR adds support for setting a users's status without the manual=true option to prevent the requested status change from sticking until cleared. This change is a part of the Desktop App feature allowing a users status to remain `online` while they are using their computer, even when the Desktop App is in the background.

Specifically, a query string is added to the endpoint (`?manual={false}`) for the server to dynamically handle setting a manual status or not.

This PR is part of several related PR's:
Desktop: [PR 945](https://github.com/mattermost/desktop/pull/945)
Webapp: [PR 2466](https://github.com/mattermost/mattermost-webapp/pull/2466)
Redux: [PR 795](https://github.com/mattermost/mattermost-redux/pull/795)
Server: This PR

#### Ticket Link
[MM-14582](https://mattermost.atlassian.net/browse/MM-14582), supports: [MM-7970](https://mattermost.atlassian.net/browse/MM-7970)

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Added or updated unit tests (required for all new features)
- [ ] Added API documentation (required for all new APIs)
- [ ] All new/modified APIs include changes to the drivers
