### PR TITLE
add ParentId index to posts db table

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -81,6 +81,7 @@ func (s *SqlPostStore) CreateIndexesIfNotExists() {
 	s.CreateIndexIfNotExists("idx_posts_channel_id", "Posts", "ChannelId")
 	s.CreateIndexIfNotExists("idx_posts_root_id", "Posts", "RootId")
 	s.CreateIndexIfNotExists("idx_posts_user_id", "Posts", "UserId")
+	s.CreateIndexIfNotExists("idx_posts_parent_id", "Posts", "ParentId")
 	s.CreateIndexIfNotExists("idx_posts_is_pinned", "Posts", "IsPinned")
 
 	s.CreateCompositeIndexIfNotExists("idx_posts_channel_id_update_at", "Posts", []string{"ChannelId", "UpdateAt"})


### PR DESCRIPTION
#### Summary
When you run `mattermost  export` you should have all needed indexes
Obviously it will be very slow without index by field "ParentId" in the table "Posts"

#### Checklist
- [x] Touches critical sections of the codebase (auth, upgrade, etc.)
