### PR TITLE
Adds the endpoints and store logic to get groups by team and by channel

### DIFF
--- a/api4/group.go
+++ b/api4/group.go
@@ -55,6 +55,14 @@ func (api *API) InitGroup() {
 	// GET /api/v4/groups/:group_id/members?page=0&per_page=100
 	api.BaseRoutes.Groups.Handle("/{group_id:[A-Za-z0-9]+}/members",
 		api.ApiSessionRequired(getGroupMembers)).Methods("GET")
+
+	// GET /api/v4/channels/:channel_id/groups?page=0&per_page=100
+	api.BaseRoutes.Channels.Handle("/{channel_id:[A-Za-z0-9]+}/groups",
+		api.ApiSessionRequired(getGroupsByChannel)).Methods("GET")
+
+	// GET /api/v4/teams/:team_id/groups?page=0&per_page=100
+	api.BaseRoutes.Teams.Handle("/{team_id:[A-Za-z0-9]+}/groups",
+		api.ApiSessionRequired(getGroupsByTeam)).Methods("GET")
 }
 
 func getGroup(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -426,6 +434,68 @@ func getGroupMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 	})
 	if marshalErr != nil {
 		c.Err = model.NewAppError("Api4.getGroupMembers", "api.marshal_error", nil, marshalErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(b)
+}
+
+func getGroupsByChannel(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	if c.App.License() == nil || !*c.App.License().Features.LDAPGroups {
+		c.Err = model.NewAppError("Api4.getGroupsByChannel", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if !c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	groups, err := c.App.GetGroupsByChannel(c.Params.ChannelId, c.Params.Page, c.Params.PerPage)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	b, marshalErr := json.Marshal(groups)
+	if marshalErr != nil {
+		c.Err = model.NewAppError("Api4.getGroupsByChannel", "api.marshal_error", nil, marshalErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(b)
+}
+
+func getGroupsByTeam(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireTeamId()
+	if c.Err != nil {
+		return
+	}
+
+	if c.App.License() == nil || !*c.App.License().Features.LDAPGroups {
+		c.Err = model.NewAppError("Api4.getGroupsByTeam", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
+	if !c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_MANAGE_SYSTEM) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	groups, err := c.App.GetGroupsByTeam(c.Params.TeamId, c.Params.Page, c.Params.PerPage)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	b, marshalErr := json.Marshal(groups)
+	if marshalErr != nil {
+		c.Err = model.NewAppError("Api4.getGroupsByTeam", "api.marshal_error", nil, marshalErr.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/app/group.go
+++ b/app/group.go
@@ -164,3 +164,19 @@ func (a *App) ChannelMembersToRemove() ([]*model.ChannelMember, *model.AppError)
 	}
 	return result.Data.([]*model.ChannelMember), nil
 }
+
+func (a *App) GetGroupsByChannel(channelId string, page, perPage int) ([]*model.Group, *model.AppError) {
+	result := <-a.Srv.Store.Group().GetGroupsByChannel(channelId, page, perPage)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	return result.Data.([]*model.Group), nil
+}
+
+func (a *App) GetGroupsByTeam(teamId string, page, perPage int) ([]*model.Group, *model.AppError) {
+	result := <-a.Srv.Store.Group().GetGroupsByTeam(teamId, page, perPage)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	return result.Data.([]*model.Group), nil
+}

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -197,3 +197,55 @@ func TestDeleteGroupSyncable(t *testing.T) {
 	require.NotNil(t, err)
 	require.Nil(t, gs)
 }
+
+func TestGetGroupsByChannel(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	group := th.CreateGroup()
+
+	// Create a group channel
+	groupSyncable := &model.GroupSyncable{
+		GroupId:    group.Id,
+		AutoAdd:    false,
+		SyncableId: th.BasicChannel.Id,
+		Type:       model.GroupSyncableTypeChannel,
+	}
+
+	gs, err := th.App.CreateGroupSyncable(groupSyncable)
+	require.Nil(t, err)
+	require.NotNil(t, gs)
+
+	groups, err := th.App.GetGroupsByChannel(th.BasicChannel.Id, 0, 60)
+	require.Nil(t, err)
+	require.ElementsMatch(t, []*model.Group{group}, groups)
+
+	groups, err = th.App.GetGroupsByChannel(model.NewId(), 0, 60)
+	require.Nil(t, err)
+	require.Empty(t, groups)
+}
+
+func TestGetGroupsByTeam(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	group := th.CreateGroup()
+
+	// Create a group team
+	groupSyncable := &model.GroupSyncable{
+		GroupId:    group.Id,
+		AutoAdd:    false,
+		SyncableId: th.BasicTeam.Id,
+		Type:       model.GroupSyncableTypeTeam,
+	}
+
+	gs, err := th.App.CreateGroupSyncable(groupSyncable)
+	require.Nil(t, err)
+	require.NotNil(t, gs)
+
+	groups, err := th.App.GetGroupsByTeam(th.BasicTeam.Id, 0, 60)
+	require.Nil(t, err)
+	require.ElementsMatch(t, []*model.Group{group}, groups)
+
+	groups, err = th.App.GetGroupsByTeam(model.NewId(), 0, 60)
+	require.Nil(t, err)
+	require.Empty(t, groups)
+}

--- a/model/client4.go
+++ b/model/client4.go
@@ -3290,6 +3290,30 @@ func (c *Client4) UnlinkLdapGroup(dn string) (*Group, *Response) {
 	return GroupFromJson(r.Body), BuildResponse(r)
 }
 
+// GetLdapGroupsByChannel retrieves the Mattermost Groups associated with a given channel
+func (c *Client4) GetGroupsByChannel(channelId string, page, perPage int) ([]*Group, *Response) {
+	path := fmt.Sprintf("%s/groups?page=%v&per_page=%v", c.GetChannelRoute(channelId), page, perPage)
+	r, appErr := c.DoApiGet(path, "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
+	}
+	defer closeBody(r)
+
+	return GroupsFromJson(r.Body), BuildResponse(r)
+}
+
+// GetLdapGroupsByTeam retrieves the Mattermost Groups associated with a given team
+func (c *Client4) GetGroupsByTeam(teamId string, page, perPage int) ([]*Group, *Response) {
+	path := fmt.Sprintf("%s/groups?page=%v&per_page=%v", c.GetTeamRoute(teamId), page, perPage)
+	r, appErr := c.DoApiGet(path, "")
+	if appErr != nil {
+		return nil, BuildErrorResponse(r, appErr)
+	}
+	defer closeBody(r)
+
+	return GroupsFromJson(r.Body), BuildResponse(r)
+}
+
 // Audits Section
 
 // GetAudits returns a list of audits for the whole system.

--- a/store/layered_store.go
+++ b/store/layered_store.go
@@ -477,3 +477,15 @@ func (s *LayeredGroupStore) ChannelMembersToRemove() StoreChannel {
 		return supplier.ChannelMembersToRemove(s.TmpContext)
 	})
 }
+
+func (s *LayeredGroupStore) GetGroupsByChannel(channelId string, page, perPage int) StoreChannel {
+	return s.RunQuery(func(supplier LayeredStoreSupplier) *LayeredStoreSupplierResult {
+		return supplier.GetGroupsByChannel(s.TmpContext, channelId, page, perPage)
+	})
+}
+
+func (s *LayeredGroupStore) GetGroupsByTeam(teamId string, page, perPage int) StoreChannel {
+	return s.RunQuery(func(supplier LayeredStoreSupplier) *LayeredStoreSupplierResult {
+		return supplier.GetGroupsByTeam(s.TmpContext, teamId, page, perPage)
+	})
+}

--- a/store/layered_store_supplier.go
+++ b/store/layered_store_supplier.go
@@ -73,4 +73,7 @@ type LayeredStoreSupplier interface {
 
 	TeamMembersToRemove(ctx context.Context, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
 	ChannelMembersToRemove(ctx context.Context, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
+
+	GetGroupsByChannel(ctx context.Context, channelId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
+	GetGroupsByTeam(ctx context.Context, teamId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult
 }

--- a/store/local_cache_supplier_groups.go
+++ b/store/local_cache_supplier_groups.go
@@ -108,3 +108,13 @@ func (s *LocalCacheSupplier) TeamMembersToRemove(ctx context.Context, hints ...L
 func (s *LocalCacheSupplier) ChannelMembersToRemove(ctx context.Context, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
 	return s.Next().ChannelMembersToRemove(ctx, hints...)
 }
+
+func (s *LocalCacheSupplier) GetGroupsByChannel(ctx context.Context, channelId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
+	// TODO: Redis caching.
+	return s.Next().GetGroupsByChannel(ctx, channelId, page, perPage, hints...)
+}
+
+func (s *LocalCacheSupplier) GetGroupsByTeam(ctx context.Context, teamId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
+	// TODO: Redis caching.
+	return s.Next().GetGroupsByTeam(ctx, teamId, page, perPage, hints...)
+}

--- a/store/local_cache_supplier_groups.go
+++ b/store/local_cache_supplier_groups.go
@@ -110,11 +110,9 @@ func (s *LocalCacheSupplier) ChannelMembersToRemove(ctx context.Context, hints .
 }
 
 func (s *LocalCacheSupplier) GetGroupsByChannel(ctx context.Context, channelId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
-	// TODO: Redis caching.
 	return s.Next().GetGroupsByChannel(ctx, channelId, page, perPage, hints...)
 }
 
 func (s *LocalCacheSupplier) GetGroupsByTeam(ctx context.Context, teamId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
-	// TODO: Redis caching.
 	return s.Next().GetGroupsByTeam(ctx, teamId, page, perPage, hints...)
 }

--- a/store/redis_supplier_groups.go
+++ b/store/redis_supplier_groups.go
@@ -108,3 +108,13 @@ func (s *RedisSupplier) ChannelMembersToRemove(ctx context.Context, hints ...Lay
 	// TODO: Redis caching.
 	return s.Next().ChannelMembersToRemove(ctx, hints...)
 }
+
+func (s *RedisSupplier) GetGroupsByChannel(ctx context.Context, channelId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
+	// TODO: Redis caching.
+	return s.Next().GetGroupsByChannel(ctx, channelId, page, perPage, hints...)
+}
+
+func (s *RedisSupplier) GetGroupsByTeam(ctx context.Context, teamId string, page, perPage int, hints ...LayeredStoreHint) *LayeredStoreSupplierResult {
+	// TODO: Redis caching.
+	return s.Next().GetGroupsByTeam(ctx, teamId, page, perPage, hints...)
+}

--- a/store/store.go
+++ b/store/store.go
@@ -585,6 +585,9 @@ type GroupStore interface {
 
 	TeamMembersToRemove() StoreChannel
 	ChannelMembersToRemove() StoreChannel
+
+	GetGroupsByChannel(channelId string, page, perPage int) StoreChannel
+	GetGroupsByTeam(teamId string, page, perPage int) StoreChannel
 }
 
 type LinkMetadataStore interface {

--- a/store/storetest/group_supplier.go
+++ b/store/storetest/group_supplier.go
@@ -1525,7 +1525,7 @@ func testGetGroupsByChannel(t *testing.T, ss store.Store) {
 
 	// Create Groups 1 and 2
 	res = <-ss.Group().Create(&model.Group{
-		Name:        "Group1",
+		Name:        model.NewId(),
 		DisplayName: "group-1",
 		RemoteId:    model.NewId(),
 		Source:      model.GroupSourceLdap,
@@ -1534,7 +1534,7 @@ func testGetGroupsByChannel(t *testing.T, ss store.Store) {
 	group1 := res.Data.(*model.Group)
 
 	res = <-ss.Group().Create(&model.Group{
-		Name:        "Group2",
+		Name:        model.NewId(),
 		DisplayName: "group-2",
 		RemoteId:    model.NewId(),
 		Source:      model.GroupSourceLdap,
@@ -1566,7 +1566,7 @@ func testGetGroupsByChannel(t *testing.T, ss store.Store) {
 
 	// Create Group3
 	res = <-ss.Group().Create(&model.Group{
-		Name:        "Group3",
+		Name:        model.NewId(),
 		DisplayName: "group-3",
 		RemoteId:    model.NewId(),
 		Source:      model.GroupSourceLdap,
@@ -1654,7 +1654,7 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 
 	// Create Groups 1 and 2
 	res = <-ss.Group().Create(&model.Group{
-		Name:        "Group1",
+		Name:        model.NewId(),
 		DisplayName: "group-1",
 		RemoteId:    model.NewId(),
 		Source:      model.GroupSourceLdap,
@@ -1663,7 +1663,7 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 	group1 := res.Data.(*model.Group)
 
 	res = <-ss.Group().Create(&model.Group{
-		Name:        "Group2",
+		Name:        model.NewId(),
 		DisplayName: "group-2",
 		RemoteId:    model.NewId(),
 		Source:      model.GroupSourceLdap,
@@ -1699,7 +1699,7 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 
 	// Create Group3
 	res = <-ss.Group().Create(&model.Group{
-		Name:        "Group3",
+		Name:        model.NewId(),
 		DisplayName: "group-3",
 		RemoteId:    model.NewId(),
 		Source:      model.GroupSourceLdap,

--- a/store/storetest/group_supplier.go
+++ b/store/storetest/group_supplier.go
@@ -36,6 +36,9 @@ func TestGroupStore(t *testing.T, ss store.Store) {
 
 	t.Run("TeamMembersToRemove", func(t *testing.T) { testPendingTeamMemberRemovals(t, ss) })
 	t.Run("ChannelMembersToRemove", func(t *testing.T) { testPendingChannelMemberRemovals(t, ss) })
+
+	t.Run("GetGroupsByChannel", func(t *testing.T) { testGetGroupsByChannel(t, ss) })
+	t.Run("GetGroupsByTeam", func(t *testing.T) { testGetGroupsByTeam(t, ss) })
 }
 
 func testGroupStoreCreate(t *testing.T, ss store.Store) {
@@ -1505,5 +1508,263 @@ func pendingMemberRemovalsDataSetup(t *testing.T, ss store.Store) *removalsData 
 		ConstrainedTeam:      teamConstrained,
 		UnconstrainedTeam:    teamUnconstrained,
 		Group:                group,
+	}
+}
+
+func testGetGroupsByChannel(t *testing.T, ss store.Store) {
+	// Create Channel1
+	channel1 := &model.Channel{
+		TeamId:      model.NewId(),
+		DisplayName: "Channel1",
+		Name:        model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}
+	res := <-ss.Channel().Save(channel1, 9999)
+	require.Nil(t, res.Err)
+	channel1 = res.Data.(*model.Channel)
+
+	// Create Groups 1 and 2
+	res = <-ss.Group().Create(&model.Group{
+		Name:        "Group1",
+		DisplayName: "group-1",
+		RemoteId:    model.NewId(),
+		Source:      model.GroupSourceLdap,
+	})
+	require.Nil(t, res.Err)
+	group1 := res.Data.(*model.Group)
+
+	res = <-ss.Group().Create(&model.Group{
+		Name:        "Group2",
+		DisplayName: "group-2",
+		RemoteId:    model.NewId(),
+		Source:      model.GroupSourceLdap,
+	})
+	require.Nil(t, res.Err)
+	group2 := res.Data.(*model.Group)
+
+	// And associate them with Channel1
+	for _, g := range []*model.Group{group1, group2} {
+		res = <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
+			AutoAdd:    true,
+			SyncableId: channel1.Id,
+			Type:       model.GroupSyncableTypeChannel,
+			GroupId:    g.Id,
+		})
+		require.Nil(t, res.Err)
+	}
+
+	// Create Channel2
+	channel2 := &model.Channel{
+		TeamId:      model.NewId(),
+		DisplayName: "Channel2",
+		Name:        model.NewId(),
+		Type:        model.CHANNEL_OPEN,
+	}
+	res = <-ss.Channel().Save(channel2, 9999)
+	require.Nil(t, res.Err)
+	channel2 = res.Data.(*model.Channel)
+
+	// Create Group3
+	res = <-ss.Group().Create(&model.Group{
+		Name:        "Group3",
+		DisplayName: "group-3",
+		RemoteId:    model.NewId(),
+		Source:      model.GroupSourceLdap,
+	})
+	require.Nil(t, res.Err)
+	group3 := res.Data.(*model.Group)
+
+	// And associate it to Channel2
+	res = <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
+		AutoAdd:    true,
+		SyncableId: channel2.Id,
+		Type:       model.GroupSyncableTypeChannel,
+		GroupId:    group3.Id,
+	})
+	require.Nil(t, res.Err)
+
+	testCases := []struct {
+		Name      string
+		ChannelId string
+		Page      int
+		PerPage   int
+		Result    []*model.Group
+	}{
+		{
+			Name:      "Get the two Groups for Channel1",
+			ChannelId: channel1.Id,
+			Page:      0,
+			PerPage:   60,
+			Result:    []*model.Group{group1, group2},
+		},
+		{
+			Name:      "Get first Group for Channel1 with page 0 with 1 element",
+			ChannelId: channel1.Id,
+			Page:      0,
+			PerPage:   1,
+			Result:    []*model.Group{group1},
+		},
+		{
+			Name:      "Get second Group for Channel1 with page 1 with 1 element",
+			ChannelId: channel1.Id,
+			Page:      1,
+			PerPage:   1,
+			Result:    []*model.Group{group2},
+		},
+		{
+			Name:      "Get third Group for Channel2",
+			ChannelId: channel2.Id,
+			Page:      0,
+			PerPage:   60,
+			Result:    []*model.Group{group3},
+		},
+		{
+			Name:      "Get empty Groups for a fake id",
+			ChannelId: model.NewId(),
+			Page:      0,
+			PerPage:   60,
+			Result:    []*model.Group{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := <-ss.Group().GetGroupsByChannel(tc.ChannelId, tc.Page, tc.PerPage)
+			require.Nil(t, res.Err)
+			require.ElementsMatch(t, tc.Result, res.Data.([]*model.Group))
+		})
+	}
+}
+
+func testGetGroupsByTeam(t *testing.T, ss store.Store) {
+	// Create Team1
+	team1 := &model.Team{
+		DisplayName:     "Team1",
+		Description:     model.NewId(),
+		CompanyName:     model.NewId(),
+		AllowOpenInvite: false,
+		InviteId:        model.NewId(),
+		Name:            model.NewId(),
+		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
+		Type:            model.TEAM_OPEN,
+	}
+	res := <-ss.Team().Save(team1)
+	require.Nil(t, res.Err)
+	team1 = res.Data.(*model.Team)
+
+	// Create Groups 1 and 2
+	res = <-ss.Group().Create(&model.Group{
+		Name:        "Group1",
+		DisplayName: "group-1",
+		RemoteId:    model.NewId(),
+		Source:      model.GroupSourceLdap,
+	})
+	require.Nil(t, res.Err)
+	group1 := res.Data.(*model.Group)
+
+	res = <-ss.Group().Create(&model.Group{
+		Name:        "Group2",
+		DisplayName: "group-2",
+		RemoteId:    model.NewId(),
+		Source:      model.GroupSourceLdap,
+	})
+	require.Nil(t, res.Err)
+	group2 := res.Data.(*model.Group)
+
+	// And associate them with Team1
+	for _, g := range []*model.Group{group1, group2} {
+		res = <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
+			AutoAdd:    true,
+			SyncableId: team1.Id,
+			Type:       model.GroupSyncableTypeTeam,
+			GroupId:    g.Id,
+		})
+		require.Nil(t, res.Err)
+	}
+
+	// Create Team2
+	team2 := &model.Team{
+		DisplayName:     "Team2",
+		Description:     model.NewId(),
+		CompanyName:     model.NewId(),
+		AllowOpenInvite: false,
+		InviteId:        model.NewId(),
+		Name:            model.NewId(),
+		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
+		Type:            model.TEAM_INVITE,
+	}
+	res = <-ss.Team().Save(team2)
+	require.Nil(t, res.Err)
+	team2 = res.Data.(*model.Team)
+
+	// Create Group3
+	res = <-ss.Group().Create(&model.Group{
+		Name:        "Group3",
+		DisplayName: "group-3",
+		RemoteId:    model.NewId(),
+		Source:      model.GroupSourceLdap,
+	})
+	require.Nil(t, res.Err)
+	group3 := res.Data.(*model.Group)
+
+	// And associate it to Team2
+	res = <-ss.Group().CreateGroupSyncable(&model.GroupSyncable{
+		AutoAdd:    true,
+		SyncableId: team2.Id,
+		Type:       model.GroupSyncableTypeTeam,
+		GroupId:    group3.Id,
+	})
+	require.Nil(t, res.Err)
+
+	testCases := []struct {
+		Name    string
+		TeamId  string
+		Page    int
+		PerPage int
+		Result  []*model.Group
+	}{
+		{
+			Name:    "Get the two Groups for Team1",
+			TeamId:  team1.Id,
+			Page:    0,
+			PerPage: 60,
+			Result:  []*model.Group{group1, group2},
+		},
+		{
+			Name:    "Get first Group for Team1 with page 0 with 1 element",
+			TeamId:  team1.Id,
+			Page:    0,
+			PerPage: 1,
+			Result:  []*model.Group{group1},
+		},
+		{
+			Name:    "Get second Group for Team1 with page 1 with 1 element",
+			TeamId:  team1.Id,
+			Page:    1,
+			PerPage: 1,
+			Result:  []*model.Group{group2},
+		},
+		{
+			Name:    "Get third Group for Team2",
+			TeamId:  team2.Id,
+			Page:    0,
+			PerPage: 60,
+			Result:  []*model.Group{group3},
+		},
+		{
+			Name:    "Get empty Groups for a fake id",
+			TeamId:  model.NewId(),
+			Page:    0,
+			PerPage: 60,
+			Result:  []*model.Group{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			res := <-ss.Group().GetGroupsByTeam(tc.TeamId, tc.Page, tc.PerPage)
+			require.Nil(t, res.Err)
+			require.ElementsMatch(t, tc.Result, res.Data.([]*model.Group))
+		})
 	}
 }

--- a/store/storetest/mocks/GroupStore.go
+++ b/store/storetest/mocks/GroupStore.go
@@ -189,6 +189,38 @@ func (_m *GroupStore) GetGroupSyncable(groupID string, syncableID string, syncab
 	return r0
 }
 
+// GetGroupsByChannel provides a mock function with given fields: channelId, page, perPage
+func (_m *GroupStore) GetGroupsByChannel(channelId string, page int, perPage int) store.StoreChannel {
+	ret := _m.Called(channelId, page, perPage)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, int, int) store.StoreChannel); ok {
+		r0 = rf(channelId, page, perPage)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+// GetGroupsByTeam provides a mock function with given fields: teamId, page, perPage
+func (_m *GroupStore) GetGroupsByTeam(teamId string, page int, perPage int) store.StoreChannel {
+	ret := _m.Called(teamId, page, perPage)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, int, int) store.StoreChannel); ok {
+		r0 = rf(teamId, page, perPage)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetMemberCount provides a mock function with given fields: groupID
 func (_m *GroupStore) GetMemberCount(groupID string) store.StoreChannel {
 	ret := _m.Called(groupID)

--- a/store/storetest/mocks/LayeredStoreDatabaseLayer.go
+++ b/store/storetest/mocks/LayeredStoreDatabaseLayer.go
@@ -184,6 +184,52 @@ func (_m *LayeredStoreDatabaseLayer) FileInfo() store.FileInfoStore {
 	return r0
 }
 
+// GetGroupsByChannel provides a mock function with given fields: ctx, channelId, page, perPage, hints
+func (_m *LayeredStoreDatabaseLayer) GetGroupsByChannel(ctx context.Context, channelId string, page int, perPage int, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
+	_va := make([]interface{}, len(hints))
+	for _i := range hints {
+		_va[_i] = hints[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, channelId, page, perPage)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *store.LayeredStoreSupplierResult
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult); ok {
+		r0 = rf(ctx, channelId, page, perPage, hints...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*store.LayeredStoreSupplierResult)
+		}
+	}
+
+	return r0
+}
+
+// GetGroupsByTeam provides a mock function with given fields: ctx, teamId, page, perPage, hints
+func (_m *LayeredStoreDatabaseLayer) GetGroupsByTeam(ctx context.Context, teamId string, page int, perPage int, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
+	_va := make([]interface{}, len(hints))
+	for _i := range hints {
+		_va[_i] = hints[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, teamId, page, perPage)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *store.LayeredStoreSupplierResult
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult); ok {
+		r0 = rf(ctx, teamId, page, perPage, hints...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*store.LayeredStoreSupplierResult)
+		}
+	}
+
+	return r0
+}
+
 // Group provides a mock function with given fields:
 func (_m *LayeredStoreDatabaseLayer) Group() store.GroupStore {
 	ret := _m.Called()

--- a/store/storetest/mocks/LayeredStoreSupplier.go
+++ b/store/storetest/mocks/LayeredStoreSupplier.go
@@ -14,6 +14,52 @@ type LayeredStoreSupplier struct {
 	mock.Mock
 }
 
+// GetGroupsByChannel provides a mock function with given fields: ctx, channelId, page, perPage, hints
+func (_m *LayeredStoreSupplier) GetGroupsByChannel(ctx context.Context, channelId string, page int, perPage int, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
+	_va := make([]interface{}, len(hints))
+	for _i := range hints {
+		_va[_i] = hints[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, channelId, page, perPage)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *store.LayeredStoreSupplierResult
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult); ok {
+		r0 = rf(ctx, channelId, page, perPage, hints...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*store.LayeredStoreSupplierResult)
+		}
+	}
+
+	return r0
+}
+
+// GetGroupsByTeam provides a mock function with given fields: ctx, teamId, page, perPage, hints
+func (_m *LayeredStoreSupplier) GetGroupsByTeam(ctx context.Context, teamId string, page int, perPage int, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
+	_va := make([]interface{}, len(hints))
+	for _i := range hints {
+		_va[_i] = hints[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, teamId, page, perPage)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *store.LayeredStoreSupplierResult
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int, ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult); ok {
+		r0 = rf(ctx, teamId, page, perPage, hints...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*store.LayeredStoreSupplierResult)
+		}
+	}
+
+	return r0
+}
+
 // GroupCreate provides a mock function with given fields: ctx, group, hints
 func (_m *LayeredStoreSupplier) GroupCreate(ctx context.Context, group *model.Group, hints ...store.LayeredStoreHint) *store.LayeredStoreSupplierResult {
 	_va := make([]interface{}, len(hints))


### PR DESCRIPTION
#### Summary
Adds the endpoints and store logic to retrieve groups by team and by channel

API changes [documented in this PR](https://github.com/mattermost/mattermost-api-reference/pull/433).

#### Ticket Link
[MM-14645](https://mattermost.atlassian.net/browse/MM-14645) and [MM-14646](https://mattermost.atlassian.net/browse/MM-14646)