### PR TITLE
[MM-14573] Toggle DisableLegacyMFA to true by default

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -74,7 +74,7 @@
         "ExperimentalChannelOrganization": false,
         "EnableAPITeamDeletion": false,
         "ExperimentalEnableHardenedMode": false,
-        "DisableLegacyMFA": false,
+        "DisableLegacyMFA": true,
         "EnableEmailInvitations": false,
         "ExperimentalLdapGroupSync": false,
         "ExperimentalStrictCSRFEnforcement": false


### PR DESCRIPTION
#### Summary
This pull request changes the DisableLegacyMFA flag back to true after reverting it to false for 5.9 - The effect will be that new installations will disable the legacy MFA endpoint by default, while existing installations will keep it enabled by default.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14573