### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ You may be licensed to use source code to create compiled versions not produced 
 1. Under the Free Software Foundation’s GNU AGPL v.3.0, subject to the exceptions outlined in this policy; or
 2. Under a commercial license available from Mattermost, Inc. by contacting commercial@mattermost.com
 
-You are licensed to use the source code in Admin Tools and Configuration Files (templates/, config/, model/,
+You are licensed to use the source code in Admin Tools and Configuration Files (templates/, config/default.json, model/,
 plugin/ and all subdirectories thereof) under the Apache License v2.0.
 
 We promise that we will not enforce the copyleft provisions in AGPL v3.0 against you if your application (a) does not


### PR DESCRIPTION
Previously, the `config/` folder contained data files for default.json and timezones.json and was licensed under Apache 2.0. However, in the past month, we have repurposed the config folder, which will autogenerate the config file in an upcoming release.

To account for the restructuring of the config folder, `config/` is no longer considered to be licensed with Apache 2.0.

In the near term, we'll keep `config/default.json` licensed under Apache 2.0 for compatibility with previous releases, which this PR accomplishes.

Later, we'll remove `config/default.json` from the Apache 2.0 license list, once `default.json` is replaced with the full auto-generation of the config file.
