### PR TITLE
[MM-14768] Add a custom JSON Marshaler to the group_constrained fields

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -5,7 +5,6 @@ package model
 
 import (
 	"crypto/sha1"
-	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -52,7 +51,7 @@ type Channel struct {
 	CreatorId        string                 `json:"creator_id"`
 	SchemeId         *string                `json:"scheme_id"`
 	Props            map[string]interface{} `json:"props" db:"-"`
-	GroupConstrained sql.NullBool           `json:"group_constrained"`
+	GroupConstrained JsonNullBool           `json:"group_constrained"`
 }
 
 type ChannelWithTeamData struct {

--- a/model/channel.go
+++ b/model/channel.go
@@ -51,7 +51,7 @@ type Channel struct {
 	CreatorId        string                 `json:"creator_id"`
 	SchemeId         *string                `json:"scheme_id"`
 	Props            map[string]interface{} `json:"props" db:"-"`
-	GroupConstrained JsonNullBool           `json:"group_constrained"`
+	GroupConstrained NullBool               `json:"group_constrained"`
 }
 
 type ChannelWithTeamData struct {

--- a/model/team.go
+++ b/model/team.go
@@ -26,22 +26,22 @@ const (
 )
 
 type Team struct {
-	Id                 string       `json:"id"`
-	CreateAt           int64        `json:"create_at"`
-	UpdateAt           int64        `json:"update_at"`
-	DeleteAt           int64        `json:"delete_at"`
-	DisplayName        string       `json:"display_name"`
-	Name               string       `json:"name"`
-	Description        string       `json:"description"`
-	Email              string       `json:"email"`
-	Type               string       `json:"type"`
-	CompanyName        string       `json:"company_name"`
-	AllowedDomains     string       `json:"allowed_domains"`
-	InviteId           string       `json:"invite_id"`
-	AllowOpenInvite    bool         `json:"allow_open_invite"`
-	LastTeamIconUpdate int64        `json:"last_team_icon_update,omitempty"`
-	SchemeId           *string      `json:"scheme_id"`
-	GroupConstrained   JsonNullBool `json:"group_constrained"`
+	Id                 string   `json:"id"`
+	CreateAt           int64    `json:"create_at"`
+	UpdateAt           int64    `json:"update_at"`
+	DeleteAt           int64    `json:"delete_at"`
+	DisplayName        string   `json:"display_name"`
+	Name               string   `json:"name"`
+	Description        string   `json:"description"`
+	Email              string   `json:"email"`
+	Type               string   `json:"type"`
+	CompanyName        string   `json:"company_name"`
+	AllowedDomains     string   `json:"allowed_domains"`
+	InviteId           string   `json:"invite_id"`
+	AllowOpenInvite    bool     `json:"allow_open_invite"`
+	LastTeamIconUpdate int64    `json:"last_team_icon_update,omitempty"`
+	SchemeId           *string  `json:"scheme_id"`
+	GroupConstrained   NullBool `json:"group_constrained"`
 }
 
 type TeamPatch struct {

--- a/model/team.go
+++ b/model/team.go
@@ -4,7 +4,6 @@
 package model
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -42,7 +41,7 @@ type Team struct {
 	AllowOpenInvite    bool         `json:"allow_open_invite"`
 	LastTeamIconUpdate int64        `json:"last_team_icon_update,omitempty"`
 	SchemeId           *string      `json:"scheme_id"`
-	GroupConstrained   sql.NullBool `json:"group_constrained"`
+	GroupConstrained   JsonNullBool `json:"group_constrained"`
 }
 
 type TeamPatch struct {

--- a/model/utils.go
+++ b/model/utils.go
@@ -6,6 +6,7 @@ package model
 import (
 	"bytes"
 	"crypto/rand"
+	"database/sql"
 	"encoding/base32"
 	"encoding/json"
 	"fmt"
@@ -586,4 +587,30 @@ func GetPreferredTimezone(timezone StringMap) string {
 	}
 
 	return timezone["manualTimezone"]
+}
+
+type JsonNullBool struct {
+	sql.NullBool
+}
+
+func (jnb *JsonNullBool) MarshalJSON() ([]byte, error) {
+	if jnb.Valid {
+		return json.Marshal(jnb.Bool)
+	} else {
+		return json.Marshal(nil)
+	}
+}
+
+func (jnb *JsonNullBool) UnmarshalJSON(data []byte) error {
+	var b *bool
+	if err := json.Unmarshal(data, &b); err != nil {
+		return err
+	}
+	if b != nil {
+		jnb.Valid = true
+		jnb.Bool = *b
+	} else {
+		jnb.Valid = false
+	}
+	return nil
 }

--- a/model/utils.go
+++ b/model/utils.go
@@ -597,7 +597,7 @@ func (nb NullBool) MarshalJSON() ([]byte, error) {
 	if nb.Valid {
 		return json.Marshal(nb.Bool)
 	} else {
-		return json.Marshal(nil)
+		return json.Marshal(false)
 	}
 }
 

--- a/model/utils.go
+++ b/model/utils.go
@@ -589,28 +589,28 @@ func GetPreferredTimezone(timezone StringMap) string {
 	return timezone["manualTimezone"]
 }
 
-type JsonNullBool struct {
+type NullBool struct {
 	sql.NullBool
 }
 
-func (jnb *JsonNullBool) MarshalJSON() ([]byte, error) {
-	if jnb.Valid {
-		return json.Marshal(jnb.Bool)
+func (nb NullBool) MarshalJSON() ([]byte, error) {
+	if nb.Valid {
+		return json.Marshal(nb.Bool)
 	} else {
 		return json.Marshal(nil)
 	}
 }
 
-func (jnb *JsonNullBool) UnmarshalJSON(data []byte) error {
+func (nb *NullBool) UnmarshalJSON(data []byte) error {
 	var b *bool
 	if err := json.Unmarshal(data, &b); err != nil {
 		return err
 	}
 	if b != nil {
-		jnb.Valid = true
-		jnb.Bool = *b
+		nb.Valid = true
+		nb.Bool = *b
 	} else {
-		jnb.Valid = false
+		nb.Valid = false
 	}
 	return nil
 }

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -738,7 +738,13 @@ func TestNullBoolMarshal(t *testing.T) {
 			Name: "Not valid and value true",
 			Valid: false,
 			Bool: true,
-			Result: "null",
+			Result: "false",
+		},
+		{
+			Name: "Not valid and value false",
+			Valid: false,
+			Bool: false,
+			Result: "false",
 		},
 		{
 			Name: "Valid and value true",
@@ -818,13 +824,13 @@ func TestNullBoolMarshalType(t *testing.T) {
 			Name: "Not valid and value false",
 			Valid: false,
 			Bool: false,
-			Result: "{\"active\":null}",
+			Result: "{\"active\":false}",
 		},
 		{
 			Name: "Not valid and value true",
 			Valid: false,
 			Bool: true,
-			Result: "{\"active\":null}",
+			Result: "{\"active\":false}",
 		},
 		{
 			Name: "Valid and value true",

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -724,3 +724,83 @@ func checkNowhereNil(t *testing.T, name string, value interface{}) bool {
 		return true
 	}
 }
+
+func TestJsonNullBoolMarshaler(t *testing.T) {
+	testCases := []struct{
+		Name   string
+		Valid  bool
+		Bool   bool
+		Result string
+	}{
+		{
+			Name: "Not valid and value true",
+			Valid: false,
+			Bool: true,
+			Result: "null",
+		},
+		{
+			Name: "Valid and value true",
+			Valid: true,
+			Bool: true,
+			Result: "true",
+		},
+		{
+			Name: "Valid and value false",
+			Valid: true,
+			Bool: false,
+			Result: "false",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			jnb := JsonNullBool{}
+			jnb.Valid = tc.Valid
+			jnb.Bool = tc.Bool
+			res, err := jnb.MarshalJSON()
+			require.Nil(t, err)
+			require.Equal(t, tc.Result, string(res))
+		})
+	}
+}
+
+func TestJsonNullBoolUnmarshal(t *testing.T) {
+	testCases := []struct{
+		Name      string
+		JsonInput string
+		Valid     bool
+		Bool      bool
+	}{
+		{
+			Name: "Null input",
+			JsonInput: "null",
+			Valid: false,
+			Bool: false,
+		},
+		{
+			Name: "True input",
+			JsonInput: "true",
+			Valid: true,
+			Bool: true,
+		},
+		{
+			Name: "False input",
+			JsonInput: "false",
+			Valid: true,
+			Bool: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			expectedJnb := JsonNullBool{}
+			expectedJnb.Valid = tc.Valid
+			expectedJnb.Bool = tc.Bool
+
+			jnb := JsonNullBool{}
+			err := jnb.UnmarshalJSON([]byte(tc.JsonInput))
+			require.Nil(t, err)
+			require.Equal(t, expectedJnb, jnb)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
The ticket's bug was a result of the `team`s being rendered with the `sql.NullBool` plain format (this is, `{ "Bool": bool, "Valid": bool }`) and the frontend sending that as part of the patch, which expects a plain `bool` in the `group_constrained` field.

The PR adds a custom type to be used instead of `sql.NullBool` to modify the JSON rendering methods and avoid the missmatch between the `team` and `channel` models and their patches.

#### Ticket Link
[MM-14768](https://mattermost.atlassian.net/browse/MM-14768)
