### PR TITLE
MM-14243: Remove any unused PERMANENT_DELETE_USER permission

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -125,7 +125,6 @@ func TestDoAdvancedPermissionsMigration(t *testing.T) {
 			model.PERMISSION_JOIN_PUBLIC_TEAMS.Id,
 			model.PERMISSION_CREATE_DIRECT_CHANNEL.Id,
 			model.PERMISSION_CREATE_GROUP_CHANNEL.Id,
-			model.PERMISSION_PERMANENT_DELETE_USER.Id,
 			model.PERMISSION_CREATE_TEAM.Id,
 		},
 		"system_post_all": []string{
@@ -306,7 +305,6 @@ func TestDoAdvancedPermissionsMigration(t *testing.T) {
 			model.PERMISSION_JOIN_PUBLIC_TEAMS.Id,
 			model.PERMISSION_CREATE_DIRECT_CHANNEL.Id,
 			model.PERMISSION_CREATE_GROUP_CHANNEL.Id,
-			model.PERMISSION_PERMANENT_DELETE_USER.Id,
 			model.PERMISSION_CREATE_TEAM.Id,
 		},
 		"system_post_all": []string{
@@ -582,7 +580,6 @@ func TestDoEmojisPermissionsMigration(t *testing.T) {
 		model.PERMISSION_JOIN_PUBLIC_TEAMS.Id,
 		model.PERMISSION_CREATE_DIRECT_CHANNEL.Id,
 		model.PERMISSION_CREATE_GROUP_CHANNEL.Id,
-		model.PERMISSION_PERMANENT_DELETE_USER.Id,
 		model.PERMISSION_CREATE_TEAM.Id,
 		model.PERMISSION_CREATE_EMOJIS.Id,
 		model.PERMISSION_DELETE_EMOJIS.Id,

--- a/app/permissions_migrations.go
+++ b/app/permissions_migrations.go
@@ -18,6 +18,7 @@ const (
 	MIGRATION_KEY_EMOJI_PERMISSIONS_SPLIT        = "emoji_permissions_split"
 	MIGRATION_KEY_WEBHOOK_PERMISSIONS_SPLIT      = "webhook_permissions_split"
 	MIGRATION_KEY_LIST_JOIN_PUBLIC_PRIVATE_TEAMS = "list_join_public_private_teams"
+	MIGRATION_KEY_REMOVE_PERMANENT_DELETE_USER   = "remove_permanent_delete_user"
 
 	PERMISSION_MANAGE_SYSTEM                   = "manage_system"
 	PERMISSION_MANAGE_EMOJIS                   = "manage_emojis"
@@ -35,6 +36,7 @@ const (
 	PERMISSION_LIST_PRIVATE_TEAMS              = "list_private_teams"
 	PERMISSION_JOIN_PUBLIC_TEAMS               = "join_public_teams"
 	PERMISSION_JOIN_PRIVATE_TEAMS              = "join_private_teams"
+	PERMISSION_PERMANENT_DELETE_USER           = "permanent_delete_user"
 )
 
 func isRole(role string) func(string, map[string]bool) bool {
@@ -173,6 +175,15 @@ func getListJoinPublicPrivateTeamsPermissionsMigration() permissionsMap {
 	}
 }
 
+func removePermanentDeleteUserMigration() permissionsMap {
+	return permissionsMap{
+		permissionTransformation{
+			On:     permissionExists(PERMISSION_PERMANENT_DELETE_USER),
+			Remove: []string{PERMISSION_PERMANENT_DELETE_USER},
+		},
+	}
+}
+
 // DoPermissionsMigrations execute all the permissions migrations need by the current version.
 func (a *App) DoPermissionsMigrations() *model.AppError {
 	PermissionsMigrations := []struct {
@@ -182,6 +193,7 @@ func (a *App) DoPermissionsMigrations() *model.AppError {
 		{Key: MIGRATION_KEY_EMOJI_PERMISSIONS_SPLIT, Migration: getEmojisPermissionsSplitMigration},
 		{Key: MIGRATION_KEY_WEBHOOK_PERMISSIONS_SPLIT, Migration: getWebhooksPermissionsSplitMigration},
 		{Key: MIGRATION_KEY_LIST_JOIN_PUBLIC_PRIVATE_TEAMS, Migration: getListJoinPublicPrivateTeamsPermissionsMigration},
+		{Key: MIGRATION_KEY_REMOVE_PERMANENT_DELETE_USER, Migration: removePermanentDeleteUserMigration},
 	}
 
 	for _, migration := range PermissionsMigrations {

--- a/model/permission.go
+++ b/model/permission.go
@@ -286,6 +286,7 @@ func initializePermissions() {
 		"authentication.permissions.remove_others_reactions.description",
 		PERMISSION_SCOPE_CHANNEL,
 	}
+	// DEPRECATED
 	PERMISSION_PERMANENT_DELETE_USER = &Permission{
 		"permanent_delete_user",
 		"authentication.permissions.permanent_delete_user.name",
@@ -304,12 +305,14 @@ func initializePermissions() {
 		"authentication.permissions.get_public_link.description",
 		PERMISSION_SCOPE_SYSTEM,
 	}
+	// DEPRECATED
 	PERMISSION_MANAGE_WEBHOOKS = &Permission{
 		"manage_webhooks",
 		"authentication.permissions.manage_webhooks.name",
 		"authentication.permissions.manage_webhooks.description",
 		PERMISSION_SCOPE_TEAM,
 	}
+	// DEPRECATED
 	PERMISSION_MANAGE_OTHERS_WEBHOOKS = &Permission{
 		"manage_others_webhooks",
 		"authentication.permissions.manage_others_webhooks.name",
@@ -352,12 +355,14 @@ func initializePermissions() {
 		"authentication.permissions.manage_system_wide_oauth.description",
 		PERMISSION_SCOPE_SYSTEM,
 	}
+	// DEPRECATED
 	PERMISSION_MANAGE_EMOJIS = &Permission{
 		"manage_emojis",
 		"authentication.permissions.manage_emojis.name",
 		"authentication.permissions.manage_emojis.description",
 		PERMISSION_SCOPE_TEAM,
 	}
+	// DEPRECATED
 	PERMISSION_MANAGE_OTHERS_EMOJIS = &Permission{
 		"manage_others_emojis",
 		"authentication.permissions.manage_others_emojis.name",

--- a/model/role.go
+++ b/model/role.go
@@ -268,7 +268,6 @@ func MakeDefaultRoles() map[string]*Role {
 			PERMISSION_JOIN_PUBLIC_TEAMS.Id,
 			PERMISSION_CREATE_DIRECT_CHANNEL.Id,
 			PERMISSION_CREATE_GROUP_CHANNEL.Id,
-			PERMISSION_PERMANENT_DELETE_USER.Id,
 		},
 		SchemeManaged: true,
 		BuiltIn:       true,


### PR DESCRIPTION
#### Summary
Remove any unused PERMANENT_DELETE_USER permission. I maintain the definition
of the permission (marked as deprecated) because is need for the migrations,
because any posible permission that can be in the store, must be in the list of
permissions (and during the migration the permission will be there)


#### Ticket Link
[MM-14243](https://mattermost.atlassian.net/browse/MM-14243)