### PR TITLE
Update .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
+trim_trailing_whitespace = true
 
 [*.go]
 indent_style = tab
@@ -23,9 +24,14 @@ indent_size = 2
 [webapp/i18n/**.json]
 indent_size = 2
 
-[Makefile]
+[Makefile,*.mk]
 indent_style = tab
 
 [*.scss]
 indent_style = space
 indent_size = 4
+
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,21 +15,11 @@ indent_style = tab
 indent_style = space
 indent_size = 4
 
-[webapp/package.json]
-indent_size = 2
-
 [i18n/**.json]
-indent_size = 2
-
-[webapp/i18n/**.json]
 indent_size = 2
 
 [Makefile,*.mk]
 indent_style = tab
-
-[*.scss]
-indent_style = space
-indent_size = 4
 
 [*.md]
 indent_style = space


### PR DESCRIPTION
Makes some changes that were suggested when I added an editorconfig to the NPS plugin so that we're consistent on trailing whitespace, all Makefiles, and Markdown files.