### PR TITLE
MM-14590: Adds license check to LDAP test and LDAP sync API endpoints.

### DIFF
--- a/api4/ldap.go
+++ b/api4/ldap.go
@@ -33,6 +33,11 @@ func (api *API) InitLdap() {
 }
 
 func syncLdap(c *Context, w http.ResponseWriter, r *http.Request) {
+	if c.App.License() == nil || !*c.App.License().Features.LDAP {
+		c.Err = model.NewAppError("Api4.syncLdap", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
 	if !c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_MANAGE_SYSTEM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return
@@ -44,6 +49,11 @@ func syncLdap(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func testLdap(c *Context, w http.ResponseWriter, r *http.Request) {
+	if c.App.License() == nil || !*c.App.License().Features.LDAP {
+		c.Err = model.NewAppError("Api4.testLdap", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
 	if !c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_MANAGE_SYSTEM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return

--- a/api4/ldap_test.go
+++ b/api4/ldap_test.go
@@ -5,11 +5,15 @@ package api4
 
 import (
 	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
 )
 
 func TestTestLdap(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
+
+	th.App.SetLicense(model.NewTestLicense("ldap_groups"))
 
 	_, resp := th.Client.TestLdap()
 	CheckForbiddenStatus(t, resp)
@@ -21,6 +25,8 @@ func TestTestLdap(t *testing.T) {
 func TestSyncLdap(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
+
+	th.App.SetLicense(model.NewTestLicense("ldap_groups"))
 
 	_, resp := th.SystemAdminClient.SyncLdap()
 	CheckNoError(t, resp)

--- a/api4/ldap_test.go
+++ b/api4/ldap_test.go
@@ -6,6 +6,8 @@ package api4
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -13,22 +15,36 @@ func TestTestLdap(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
+	_, resp := th.SystemAdminClient.TestLdap()
+	CheckNotImplementedStatus(t, resp)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, "api.ldap_groups.license_error", resp.Error.Id)
+
 	th.App.SetLicense(model.NewTestLicense("ldap_groups"))
 
-	_, resp := th.Client.TestLdap()
+	_, resp = th.Client.TestLdap()
 	CheckForbiddenStatus(t, resp)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, "api.context.permissions.app_error", resp.Error.Id)
 
 	_, resp = th.SystemAdminClient.TestLdap()
 	CheckNotImplementedStatus(t, resp)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, "ent.ldap.disabled.app_error", resp.Error.Id)
 }
 
 func TestSyncLdap(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
+	_, resp := th.SystemAdminClient.SyncLdap()
+	CheckNotImplementedStatus(t, resp)
+	require.NotNil(t, resp.Error)
+	require.Equal(t, "api.ldap_groups.license_error", resp.Error.Id)
+
 	th.App.SetLicense(model.NewTestLicense("ldap_groups"))
 
-	_, resp := th.SystemAdminClient.SyncLdap()
+	_, resp = th.SystemAdminClient.SyncLdap()
 	CheckNoError(t, resp)
 
 	_, resp = th.Client.SyncLdap()


### PR DESCRIPTION
#### Summary

Adds license check to LDAP test and LDAP sync API endpoints.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-14590