### PR TITLE
[MM-14699] Add MimeType to Emoji

### DIFF
--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -147,7 +147,7 @@ func TestCreateEmoji(t *testing.T) {
 
 	_, resp = Client.CreateEmoji(emoji, make([]byte, 100), "image.gif")
 	CheckBadRequestStatus(t, resp)
-	CheckErrorMessage(t, resp, "api.emoji.upload.image.app_error")
+	CheckErrorMessage(t, resp, "api.emoji.create.decode.app_error")
 
 	// try to create an emoji as another user
 	emoji = &model.Emoji{

--- a/app/emoji.go
+++ b/app/emoji.go
@@ -74,6 +74,9 @@ func (a *App) CreateEmoji(sessionUserId string, emoji *model.Emoji, multiPartIma
 	defer imageFile.Close()
 
 	imageBytes, err := ioutil.ReadAll(imageFile)
+	if err != nil {
+		return nil, model.NewAppError("createEmoji", "api.emoji.create.read.app_error", nil, "", http.StatusBadRequest)
+	}
 	_, imageType, err := image.DecodeConfig(bytes.NewReader(imageBytes))
 	if err != nil {
 		return nil, model.NewAppError("createEmoji", "api.emoji.create.decode.app_error", nil, err.Error(), http.StatusBadRequest)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1097,6 +1097,10 @@
     "translation": "Unable to create the emoji. An error occurred when trying to open the attached image."
   },
   {
+    "id": "api.emoji.create.read.app_error",
+    "translation": "Unable to read image file for emoji."
+  },
+  {
     "id": "api.emoji.disabled.app_error",
     "translation": "Custom emoji have been disabled by the system admin."
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1089,6 +1089,14 @@
     "translation": "Unable to create emoji. Image must be less than 1 MB in size."
   },
   {
+    "id": "api.emoji.create.decode.app_error",
+    "translation": "Unable to decode image file for emoji."
+  },
+  {
+    "id": "api.emoji.create.open.app_error",
+    "translation": "Unable to create the emoji. An error occurred when trying to open the attached image."
+  },
+  {
     "id": "api.emoji.disabled.app_error",
     "translation": "Custom emoji have been disabled by the system admin."
   },
@@ -4497,6 +4505,10 @@
   {
     "id": "model.emoji.name.app_error",
     "translation": "Name must be 1 to 64 lowercase alphanumeric characters"
+  },
+  {
+    "id": "model.emoji.mime_type.app_error",
+    "translation": "Invalid emoji MIME type"
   },
   {
     "id": "model.emoji.update_at.app_error",

--- a/model/emoji_test.go
+++ b/model/emoji_test.go
@@ -18,6 +18,7 @@ func TestEmojiIsValid(t *testing.T) {
 		DeleteAt:  0,
 		CreatorId: NewId(),
 		Name:      "name",
+		MimeType:  "image/png",
 	}
 
 	if err := emoji.IsValid(); err != nil {
@@ -60,4 +61,17 @@ func TestEmojiIsValid(t *testing.T) {
 
 	emoji.Name = "croissant"
 	require.NotNil(t, emoji.IsValid())
+
+	emoji.Name = "name-"
+	emoji.MimeType = ""
+	require.NotNil(t, emoji.IsValid())
+
+	emoji.MimeType = "application/octet-stream"
+	require.NotNil(t, emoji.IsValid())
+
+	emoji.MimeType = "image/gif"
+	require.Nil(t, emoji.IsValid())
+
+	emoji.MimeType = "image/jpeg"
+	require.Nil(t, emoji.IsValid())
 }

--- a/store/sqlstore/emoji_store.go
+++ b/store/sqlstore/emoji_store.go
@@ -37,6 +37,7 @@ func NewSqlEmojiStore(sqlStore SqlStore, metrics einterfaces.MetricsInterface) s
 		table.ColMap("Id").SetMaxSize(26)
 		table.ColMap("CreatorId").SetMaxSize(26)
 		table.ColMap("Name").SetMaxSize(64)
+		table.ColMap("MimeType").SetMaxSize(256)
 
 		table.SetUniqueTogether("Name", "DeleteAt")
 	}


### PR DESCRIPTION
#### Summary
On iOS, custom GIF emoji's do not animate unless the cached file extension is `.gif`. Since the URL to get the custom emoji image from the server does not contain any information regarding the type, the mobile app does not know the type of image until the image is fetched. However, the app requires knowledge of this type prior to making the get request as the file path with extension is determined prior to the request and used in RNFetchBlob's `config`, which then uses that file path to save the image automagically on success of the request. With this change, the response from getting the custom emoji will include a MIME type which the mobile app can then use to create a correct file path prior to sending the request to get the image.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14699