### PR TITLE
[MM-14779] Investigate flaky TestExportGMandDMChannels

### DIFF
--- a/app/export_test.go
+++ b/app/export_test.go
@@ -354,7 +354,7 @@ func TestExportGMandDMChannels(t *testing.T) {
 	channels = result.Data.([]*model.DirectChannelForExport)
 
 	// Adding some deteminism so its possible to assert on slice index
-	sort.Slice(channels, func(i, j int) bool { return channels[i].CreateAt > channels[j].CreateAt })
+	sort.Slice(channels, func(i, j int) bool { return channels[i].Type > channels[j].Type })
 	assert.Equal(t, 2, len(channels))
 	assert.ElementsMatch(t, []string{th1.BasicUser.Username, user1.Username, user2.Username}, *channels[0].Members)
 	assert.ElementsMatch(t, []string{th1.BasicUser.Username, th1.BasicUser2.Username}, *channels[1].Members)

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -254,7 +254,7 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 		UserId:    me.BasicUser.Id,
 		ChannelId: channel.Id,
 		Message:   "message_" + id,
-		CreateAt:  model.GetMillis() - 1000,
+		CreateAt:  model.GetMillis() - 100000,
 	}
 
 	utils.DisableDebugLogForTest()

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -254,7 +254,7 @@ func (me *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 		UserId:    me.BasicUser.Id,
 		ChannelId: channel.Id,
 		Message:   "message_" + id,
-		CreateAt:  model.GetMillis() - 10000,
+		CreateAt:  model.GetMillis() - 1000,
 	}
 
 	utils.DisableDebugLogForTest()


### PR DESCRIPTION
#### Summary
While testing direct and group channels export, the tests relied on `CreateAt` for sorting and it was expected that it would never collide and the order the channels were created would not be the same.
It turns out that is not impossible for channels and posts to be created in unit tests in an non-deterministic manner as it's using milliseconds for `CreateAt`.
This PR does two things: 

1) Change the flaky test to use something more deterministic for that scenario by sorting on `Type` (G, D)
2) Chages the `CreatePost` helper method to use nanoseconds as milliseconds proved a bit too optimistic

Ideally, we'd change those helper methods to allow for some more determinism. In the case of a post for example, the helper method could accept a message prefix so that sorting on message could be possible.

#### Ticket Link
[MM-14779](https://mattermost.atlassian.net/browse/MM-14779)