### PR TITLE
Adds license check to teams and channels that include GroupConstrained

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -69,6 +69,11 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if channel.GroupConstrained != nil && (c.App.License() == nil || !*c.App.License().Features.LDAPGroups) {
+		c.Err = model.NewAppError("Api4.createChannel", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
 	sc, err := c.App.CreateChannelWithUser(channel, c.App.Session.UserId)
 	if err != nil {
 		c.Err = err
@@ -141,6 +146,11 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewAppError("updateChannel", "api.channel.update_channel.tried.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}, "", http.StatusBadRequest)
 			return
 		}
+	}
+
+	if channel.GroupConstrained != nil && (c.App.License() == nil || !*c.App.License().Features.LDAPGroups) {
+		c.Err = model.NewAppError("Api4.updateChannel", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
 	}
 
 	oldChannel.Header = channel.Header
@@ -261,6 +271,11 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	default:
 		c.Err = model.NewAppError("patchChannel", "api.channel.patch_update_channel.forbidden.app_error", nil, "", http.StatusForbidden)
+		return
+	}
+
+	if patch.GroupConstrained != nil && (c.App.License() == nil || !*c.App.License().Features.LDAPGroups) {
+		c.Err = model.NewAppError("Api4.patchChannel", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -139,6 +139,17 @@ func TestCreateChannel(t *testing.T) {
 			t.Fatal("wrong status code")
 		}
 	}
+
+	// Test GroupConstrained flag
+	groupConstrainedChannel := &model.Channel{DisplayName: "Test API Name", Name: GenerateTestChannelName(), Type: model.CHANNEL_OPEN, TeamId: team.Id, GroupConstrained: model.NewBool(true)}
+	_, resp = Client.CreateChannel(groupConstrainedChannel)
+	CheckNotImplementedStatus(t, resp)
+
+	th.App.SetLicense(model.NewTestLicense("ldap"))
+
+	_, resp = Client.CreateChannel(groupConstrainedChannel)
+	CheckNoError(t, resp)
+	CheckCreatedStatus(t, resp)
 }
 
 func TestUpdateChannel(t *testing.T) {
@@ -172,6 +183,19 @@ func TestUpdateChannel(t *testing.T) {
 	if newChannel.Purpose != channel.Purpose {
 		t.Fatal("Update failed for Purpose")
 	}
+
+	// Test GroupConstrained flag
+	channel.GroupConstrained = model.NewBool(true)
+	_, resp = Client.UpdateChannel(channel)
+	CheckNotImplementedStatus(t, resp)
+
+	th.App.SetLicense(model.NewTestLicense("ldap"))
+
+	_, resp = Client.UpdateChannel(channel)
+	CheckNoError(t, resp)
+	CheckOKStatus(t, resp)
+
+	th.App.SetLicense(nil)
 
 	//Update a private channel
 	private.DisplayName = "My new display name for private channel"
@@ -276,6 +300,20 @@ func TestPatchChannel(t *testing.T) {
 	if channel.Name != oldName {
 		t.Fatal("should not have updated")
 	}
+
+	// Test GroupConstrained flag
+	patch.GroupConstrained = model.NewBool(true)
+	_, resp = Client.PatchChannel(th.BasicChannel.Id, patch)
+	CheckNotImplementedStatus(t, resp)
+
+	th.App.SetLicense(model.NewTestLicense("ldap"))
+
+	_, resp = Client.PatchChannel(th.BasicChannel.Id, patch)
+	CheckNoError(t, resp)
+	CheckOKStatus(t, resp)
+
+	th.App.SetLicense(nil)
+	patch.GroupConstrained = nil
 
 	_, resp = Client.PatchChannel("junk", patch)
 	CheckBadRequestStatus(t, resp)

--- a/api4/team.go
+++ b/api4/team.go
@@ -71,6 +71,11 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if team.GroupConstrained != nil && (c.App.License() == nil || !*c.App.License().Features.LDAPGroups) {
+		c.Err = model.NewAppError("Api4.createTeam", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
 	rteam, err := c.App.CreateTeamWithUser(team, c.App.Session.UserId)
 	if err != nil {
 		c.Err = err
@@ -149,6 +154,11 @@ func updateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if team.GroupConstrained != nil && (c.App.License() == nil || !*c.App.License().Features.LDAPGroups) {
+		c.Err = model.NewAppError("Api4.updateTeam", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
+		return
+	}
+
 	updatedTeam, err := c.App.UpdateTeam(team)
 	if err != nil {
 		c.Err = err
@@ -174,6 +184,11 @@ func patchTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if !c.App.SessionHasPermissionToTeam(c.App.Session, c.Params.TeamId, model.PERMISSION_MANAGE_TEAM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_TEAM)
+		return
+	}
+
+	if team.GroupConstrained != nil && (c.App.License() == nil || !*c.App.License().Features.LDAPGroups) {
+		c.Err = model.NewAppError("Api4.patchTeam", "api.ldap_groups.license_error", nil, "", http.StatusNotImplemented)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
If a `channel` or `team` has the `group_constrained` flag set for the create, update or patch endpoints, this PR checks that the license exists and rejects the request if it doesn't.

#### Ticket Link
[MM-14640](https://mattermost.atlassian.net/browse/MM-14640) and [MM-14641](https://mattermost.atlassian.net/browse/MM-14641)
