### PR TITLE
Fixed MM-14627, was incorrectly removing props from updated post

### DIFF
--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -36,7 +36,7 @@ func (a *App) DoPostAction(postId, actionId, userId, selectedOption string) (str
 
 func (a *App) DoPostActionWithCookie(postId, actionId, userId, selectedOption string, cookie *model.PostActionCookie) (string, *model.AppError) {
 	// the prop values that we need to retain/clear in replacement message to match the original
-	remove := []string{"override_username", "override_icon_url"}
+	remove := []string{}
 	retain := map[string]interface{}{}
 	datasource := ""
 
@@ -94,8 +94,8 @@ func (a *App) DoPostActionWithCookie(postId, actionId, userId, selectedOption st
 		upstreamRequest.Context = action.Integration.Context
 		datasource = action.DataSource
 
-		retainPropKeys := []string{"override_username", "override_icon_url"}
-		for _, key := range retainPropKeys {
+		// Set override_username, override_icon_ur to what they were before.
+		for _, key := range model.PostActionRetainPropKeys {
 			value, ok := post.Props[key]
 			if ok {
 				retain[key] = value

--- a/app/integration_action_test.go
+++ b/app/integration_action_test.go
@@ -90,7 +90,7 @@ func TestPostAction(t *testing.T) {
 		}
 		assert.Equal(t, "foo", request.Context["s"])
 		assert.EqualValues(t, 3, request.Context["n"])
-		fmt.Fprintf(w, `{"post": {"message": "updated"}, "ephemeral_text": "foo"}`)
+		fmt.Fprintf(w, `{"update": {"message": "updated"}, "ephemeral_text": "foo"}`)
 	}))
 	defer ts.Close()
 
@@ -308,6 +308,82 @@ func TestPostAction(t *testing.T) {
 
 	_, err = th.App.DoPostAction(postSubpath.Id, attachmentsSubpath[0].Actions[0].Id, th.BasicUser.Id, "")
 	require.Nil(t, err)
+}
+
+func TestPostActionProps(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost 127.0.0.1"
+	})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := model.PostActionIntegrationRequestFromJson(r.Body)
+		assert.NotNil(t, request)
+
+		fmt.Fprintf(w, `{
+			"update": {
+				"message": "updated",
+				"props": {
+					"override_username":"new_override_user",
+					"override_icon_url":"new_override_icon",
+					"A":"AA"
+				}
+			},
+			"ephemeral_text": "foo"
+		}`)
+	}))
+	defer ts.Close()
+
+	interactivePost := model.Post{
+		Message:       "Interactive post",
+		ChannelId:     th.BasicChannel.Id,
+		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+		UserId:        th.BasicUser.Id,
+		Props: model.StringInterface{
+			"attachments": []*model.SlackAttachment{
+				{
+					Text: "hello",
+					Actions: []*model.PostAction{
+						{
+							Integration: &model.PostActionIntegration{
+								Context: model.StringInterface{
+									"s": "foo",
+									"n": 3,
+								},
+								URL: ts.URL,
+							},
+							Name:       "action",
+							Type:       "some_type",
+							DataSource: "some_source",
+						},
+					},
+				},
+			},
+			"override_icon_url": "old_override_icon",
+			"B":                 "BB",
+		},
+	}
+
+	post, err := th.App.CreatePostAsUser(&interactivePost, "")
+	require.Nil(t, err)
+	attachments, ok := post.Props["attachments"].([]*model.SlackAttachment)
+	require.True(t, ok)
+
+	clientTriggerId, err := th.App.DoPostAction(post.Id, attachments[0].Actions[0].Id, th.BasicUser.Id, "")
+	require.Nil(t, err)
+	assert.True(t, len(clientTriggerId) == 26)
+
+	pchan := th.App.Srv.Store.Post().GetSingle(post.Id)
+	result := <-pchan
+	require.Nil(t, result.Err)
+	newPost := result.Data.(*model.Post)
+
+	assert.Nil(t, newPost.Props["B"])
+	assert.Nil(t, newPost.Props["override_username"])
+	assert.Equal(t, "AA", newPost.Props["A"])
+	assert.Equal(t, "old_override_icon", newPost.Props["override_icon_url"])
 }
 
 func TestSubmitInteractiveDialog(t *testing.T) {

--- a/app/integration_action_test.go
+++ b/app/integration_action_test.go
@@ -90,7 +90,7 @@ func TestPostAction(t *testing.T) {
 		}
 		assert.Equal(t, "foo", request.Context["s"])
 		assert.EqualValues(t, 3, request.Context["n"])
-		fmt.Fprintf(w, `{"update": {"message": "updated"}, "ephemeral_text": "foo"}`)
+		fmt.Fprintf(w, `{"post": {"message": "updated"}, "ephemeral_text": "foo"}`)
 	}))
 	defer ts.Close()
 

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -26,6 +26,8 @@ const (
 	INTERACTIVE_DIALOG_TRIGGER_TIMEOUT_MILLISECONDS = 3000
 )
 
+var PostActionRetainPropKeys = []string{"override_username", "override_icon_url"}
+
 type DoPostActionRequest struct {
 	SelectedOption string `json:"selected_option,omitempty"`
 	Cookie         string `json:"cookie,omitempty"`
@@ -327,10 +329,9 @@ func AddPostActionCookies(o *Post, secret []byte) *Post {
 	p := o.Clone()
 
 	// retainedProps carry over their value from the old post, including no value
-	retainPropKeys := []string{"override_username", "override_icon_url"}
 	retainProps := map[string]interface{}{}
 	removeProps := []string{}
-	for _, key := range retainPropKeys {
+	for _, key := range PostActionRetainPropKeys {
 		value, ok := p.Props[key]
 		if ok {
 			retainProps[key] = value


### PR DESCRIPTION
#### Summary
- Fixed the wrong initialization of `remove`
- Consolidated the list of properties to retain in `model.PostActionRetainPropKeys`
- Added a test

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14627