### PR TITLE
MM-14847 Fixing prepackaged plugin build process.

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -65,7 +65,7 @@ endif
 
 	@# Download prepackaged plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
-		curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | awk -F\" '/browser_download_url/ { system("cd $(DIST_PATH)/prepackaged_plugins; curl -O " $$4) }';\
+		curl -s https://api.github.com/repos/mattermost/$$plugin_package/releases/latest | awk -F\" '/browser_download_url/ { system("cd $(DIST_PATH)/prepackaged_plugins; curl -OL " $$4) }';\
 	done
 
 	@# ----- PLATFORM SPECIFIC -----


### PR DESCRIPTION
#### Summary
Fixing prepackaged plugins by adding -L to curl command to follow redirects. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14847