### PR TITLE
Removed confusing and obsolete comment

### DIFF
--- a/app/authorization.go
+++ b/app/authorization.go
@@ -20,7 +20,6 @@ func (a *App) SessionHasPermissionTo(session model.Session, permission *model.Pe
 	return a.RolesGrantPermission(session.GetUserRoles(), permission.Id)
 }
 
-/// DO NOT USE: LEGACY
 func (a *App) SessionHasPermissionToTeam(session model.Session, teamId string, permission *model.Permission) bool {
 	if teamId == "" {
 		return false


### PR DESCRIPTION
#### Summary
This comment was introduced by @crspeller refering to a function without `*App`
scope, and to be replaced with the `*App` scoped version (in this commit:
4491b5ecdfad96959f9a9ab32a5f127bbfa7eac5).  Some time later @ccbrown removed
the function but not the comment itself (here:
816a30397da6ceff836d8723233dc5cdbda70871), and now looks like the legacy
function is the current valid function.