### PR TITLE
Avoid panic from reading CSRF of nil session pointer

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -106,17 +106,19 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// CSRF Check
 		if tokenLocation == app.TokenLocationCookie && h.RequireSession && !h.TrustRequester && r.Method != "GET" {
-			csrfHeader := r.Header.Get(model.HEADER_CSRF_TOKEN)
-			if csrfHeader == session.GetCSRF() {
-				csrfCheckPassed = true
-			} else if r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML {
-				// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
-				csrfErrorMessage := "CSRF Header check failed for request - Please upgrade your web application or custom app to set a CSRF Header"
-				if *c.App.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement {
-					c.Log.Warn(csrfErrorMessage)
-				} else {
-					c.Log.Debug(csrfErrorMessage)
+			if session != nil {
+				csrfHeader := r.Header.Get(model.HEADER_CSRF_TOKEN)
+				if csrfHeader == session.GetCSRF() {
 					csrfCheckPassed = true
+				} else if r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML {
+					// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
+					csrfErrorMessage := "CSRF Header check failed for request - Please upgrade your web application or custom app to set a CSRF Header"
+					if *c.App.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement {
+						c.Log.Warn(csrfErrorMessage)
+					} else {
+						c.Log.Debug(csrfErrorMessage)
+						csrfCheckPassed = true
+					}
 				}
 			}
 

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -3,7 +3,6 @@
 
 package web
 
-import "C"
 import (
 	"fmt"
 	"net/http"

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -125,22 +125,20 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// CSRF Check
 		if c.Err == nil && tokenLocation == app.TokenLocationCookie && h.RequireSession && !h.TrustRequester && r.Method != "GET" {
-			if session != nil {
-				csrfHeader := r.Header.Get(model.HEADER_CSRF_TOKEN)
-				if csrfHeader == session.GetCSRF() {
+			csrfHeader := r.Header.Get(model.HEADER_CSRF_TOKEN)
+			if csrfHeader == session.GetCSRF() {
+				csrfCheckPassed = true
+			} else if r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML {
+				// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
+				csrfErrorMessage := "CSRF Header check failed for request - Please upgrade your web application or custom app to set a CSRF Header"
+				if *c.App.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement {
+					c.Log.Warn(csrfErrorMessage)
+				} else {
+					c.Log.Debug(csrfErrorMessage)
 					csrfCheckPassed = true
-				} else if r.Header.Get(model.HEADER_REQUESTED_WITH) == model.HEADER_REQUESTED_WITH_XML {
-					// ToDo(DSchalla) 2019/01/04: Remove after deprecation period and only allow CSRF Header (MM-13657)
-					csrfErrorMessage := "CSRF Header check failed for request - Please upgrade your web application or custom app to set a CSRF Header"
-					if *c.App.Config().ServiceSettings.ExperimentalStrictCSRFEnforcement {
-						c.Log.Warn(csrfErrorMessage)
-					} else {
-						c.Log.Debug(csrfErrorMessage)
-						csrfCheckPassed = true
-					}
 				}
 			}
-
+			
 			if !csrfCheckPassed {
 				token = ""
 				c.App.Session = model.Session{}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -3,6 +3,7 @@
 
 package web
 
+import "C"
 import (
 	"fmt"
 	"net/http"
@@ -102,10 +103,29 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if len(token) != 0 {
 		session, err := c.App.GetSession(token)
+		if err != nil {
+			c.Log.Info("Invalid session", mlog.Err(err))
+			if err.StatusCode == http.StatusInternalServerError {
+				c.Err = err
+			} else if h.RequireSession {
+				c.RemoveSessionCookie(w, r)
+				c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token, http.StatusUnauthorized)
+			}
+		} else if !session.IsOAuth && tokenLocation == app.TokenLocationQueryString {
+			c.Err = model.NewAppError("ServeHTTP", "api.context.token_provided.app_error", nil, "token="+token, http.StatusUnauthorized)
+		} else {
+			c.App.Session = *session
+		}
+
+		// Rate limit by UserID
+		if c.App.Srv.RateLimiter != nil && c.App.Srv.RateLimiter.UserIdRateLimit(c.App.Session.UserId, w) {
+			return
+		}
+
 		csrfCheckPassed := false
 
 		// CSRF Check
-		if tokenLocation == app.TokenLocationCookie && h.RequireSession && !h.TrustRequester && r.Method != "GET" {
+		if c.Err == nil && tokenLocation == app.TokenLocationCookie && h.RequireSession && !h.TrustRequester && r.Method != "GET" {
 			if session != nil {
 				csrfHeader := r.Header.Get(model.HEADER_CSRF_TOKEN)
 				if csrfHeader == session.GetCSRF() {
@@ -124,31 +144,8 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			if !csrfCheckPassed {
 				token = ""
-				session = nil
+				c.App.Session = model.Session{}
 				c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token+" Appears to be a CSRF attempt", http.StatusUnauthorized)
-			}
-		} else {
-			csrfCheckPassed = true
-		}
-
-		if csrfCheckPassed {
-			if err != nil {
-				c.Log.Info("Invalid session", mlog.Err(err))
-				if err.StatusCode == http.StatusInternalServerError {
-					c.Err = err
-				} else if h.RequireSession {
-					c.RemoveSessionCookie(w, r)
-					c.Err = model.NewAppError("ServeHTTP", "api.context.session_expired.app_error", nil, "token="+token, http.StatusUnauthorized)
-				}
-			} else if !session.IsOAuth && tokenLocation == app.TokenLocationQueryString {
-				c.Err = model.NewAppError("ServeHTTP", "api.context.token_provided.app_error", nil, "token="+token, http.StatusUnauthorized)
-			} else {
-				c.App.Session = *session
-			}
-
-			// Rate limit by UserID
-			if c.App.Srv.RateLimiter != nil && c.App.Srv.RateLimiter.UserIdRateLimit(c.App.Session.UserId, w) {
-				return
 			}
 		}
 	}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -138,7 +138,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					csrfCheckPassed = true
 				}
 			}
-			
+
 			if !csrfCheckPassed {
 				token = ""
 				c.App.Session = model.Session{}


### PR DESCRIPTION
#### Summary
In `web/handlers.go:104` we are receiving the session from the token, but actually don't verify if it's returning `nil` resulting in a panic when `GetCSRF()` is executed, since the error is never checked. This PR moves the session validation before the CSRF check component, which now is only executed after the session was validated and only executed if currently no error was set for the request.
