### PR TITLE
[MM-14890] Logs endpoint always returns an empty line

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -198,6 +198,9 @@ func TestGetLogs(t *testing.T) {
 		t.Log(len(logs))
 		t.Fatal("wrong length")
 	}
+	for i := 10; i < 20; i++ {
+		assert.Containsf(t, logs[i-10], fmt.Sprintf(`"msg":"%d"`, i), "Log line doesn't contain correct message")
+	}
 
 	logs, resp = th.SystemAdminClient.GetLogs(1, 10)
 	CheckNoError(t, resp)

--- a/app/admin.go
+++ b/app/admin.go
@@ -61,7 +61,7 @@ func (a *App) GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 		var newLine = []byte{'\n'}
 		var lineCount int
 		const searchPos = -1
-		lineEndPos, err := file.Seek(0, io.SeekEnd)
+		lineEndPos, err := file.Seek(-1, io.SeekEnd) // we skip the last byte of the file, since it's \n
 		if err != nil {
 			return nil, model.NewAppError("getLogs", "api.admin.file_read_error", nil, err.Error(), http.StatusInternalServerError)
 		}

--- a/app/admin.go
+++ b/app/admin.go
@@ -66,7 +66,8 @@ func (a *App) GetLogsSkipSend(page, perPage int) ([]string, *model.AppError) {
 		var endOffset int64 = 0
 
 		// if the file exists and it's last byte is '\n' - skip it
-		if stat, err := os.Stat(logFile); err == nil && stat != nil {
+		var stat os.FileInfo
+		if stat, err = os.Stat(logFile); err == nil {
 			if _, err = file.ReadAt(b, stat.Size()-1); err == nil && b[0] == newLine[0] {
 				endOffset = -1
 			}


### PR DESCRIPTION
#### Summary

Fix new line being returned in logs, improved the test of GetLogs by actually checking the contents

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/10558

