### PR TITLE
[MM-14381] Fix brittle MFA Login Successful Test

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2083,7 +2083,7 @@ func TestUserLoginMFAFlow(t *testing.T) {
 
 		code := dgoogauth.ComputeCode(secret3.Secret, time.Now().UTC().Unix()/30)
 
-		user, resp := th.Client.LoginWithMFA(th.BasicUser.Email, th.BasicUser.Password, strconv.Itoa(code))
+		user, resp := th.Client.LoginWithMFA(th.BasicUser.Email, th.BasicUser.Password, fmt.Sprintf("%06d", code))
 		CheckNoError(t, resp)
 		assert.NotNil(t, user)
 	})

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -4,6 +4,7 @@
 package api4
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -2036,7 +2037,6 @@ func TestUserLoginMFAFlow(t *testing.T) {
 	})
 
 	t.Run("WithInvalidMFA", func(t *testing.T) {
-
 		secret, err := th.App.GenerateMfaSecret(th.BasicUser.Id)
 		assert.Nil(t, err)
 
@@ -2069,7 +2069,7 @@ func TestUserLoginMFAFlow(t *testing.T) {
 	})
 
 	t.Run("WithCorrectMFA", func(t *testing.T) {
-		secret3, err := th.App.GenerateMfaSecret(th.BasicUser.Id)
+		secret, err := th.App.GenerateMfaSecret(th.BasicUser.Id)
 		assert.Nil(t, err)
 
 		// Fake user has MFA enabled
@@ -2077,11 +2077,11 @@ func TestUserLoginMFAFlow(t *testing.T) {
 			t.Fatal(result.Err)
 		}
 
-		if result := <-th.Server.Store.User().UpdateMfaSecret(th.BasicUser.Id, secret3.Secret); result.Err != nil {
+		if result := <-th.Server.Store.User().UpdateMfaSecret(th.BasicUser.Id, secret.Secret); result.Err != nil {
 			t.Fatal(result.Err)
 		}
 
-		code := dgoogauth.ComputeCode(secret3.Secret, time.Now().UTC().Unix()/30)
+		code := dgoogauth.ComputeCode(secret.Secret, time.Now().UTC().Unix()/30)
 
 		user, resp := th.Client.LoginWithMFA(th.BasicUser.Email, th.BasicUser.Password, fmt.Sprintf("%06d", code))
 		CheckNoError(t, resp)


### PR DESCRIPTION
#### Summary
The PR fixes the brittle `TestUserLoginMFAFlow/WithCorrectMFA` test. It was validated using:
`SECONDS=0; while go test ./... -run 'TestUserLoginMFAFlow/WithCorrectMFA'; do echo "PASSED - $SECONDS seconds elapsed"; done` with a runtime 1000s+ without any failures.

Since this is no guarantee, @lieut-data since you were able to replicate the races locally I'd appreciate a second test on your machine eventually to make sure that we don't introduce an unstable test once again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-14381
