### PR TITLE
MM-14811: Accepts Server rather than App in account migration interfa…

### DIFF
--- a/app/enterprise.go
+++ b/app/enterprise.go
@@ -11,9 +11,9 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
-var accountMigrationInterface func(*App) einterfaces.AccountMigrationInterface
+var accountMigrationInterface func(*Server) einterfaces.AccountMigrationInterface
 
-func RegisterAccountMigrationInterface(f func(*App) einterfaces.AccountMigrationInterface) {
+func RegisterAccountMigrationInterface(f func(*Server) einterfaces.AccountMigrationInterface) {
 	accountMigrationInterface = f
 }
 
@@ -109,7 +109,7 @@ func RegisterSamlInterface(f func(*App) einterfaces.SamlInterface) {
 
 func (s *Server) initEnterprise() {
 	if accountMigrationInterface != nil {
-		s.AccountMigration = accountMigrationInterface(s.FakeApp())
+		s.AccountMigration = accountMigrationInterface(s)
 	}
 	if complianceInterface != nil {
 		s.Compliance = complianceInterface(s.FakeApp())


### PR DESCRIPTION
…ce registration.

#### Summary

Accepts Server rather than App in account migration interface registration.

There is an argument to be made that all of the `(*App).Register*Interface` methods should have the same signature for consistency. I think they should. 0/5 on whether that should be in this bug fix PR or as a separate story.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-14811

#### Enterprise change

https://github.com/mattermost/enterprise/pull/416