### PR TITLE
[MM-14930] Add 'few' and 'many' language plural translations

### DIFF
--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -627,6 +627,8 @@
     "id": "api.command_groupmsg.invalid_user.app_error",
     "translation": {
       "one": "Nie można znaleźć użytkownika: {{.Users}}",
+      "few": "Nie można znaleźć użytkowników: {{.Users}}",
+      "many": "Nie można znaleźć użytkowników: {{.Users}}",
       "other": "Nie można znaleźć użytkowników: {{.Users}}"
     }
   },
@@ -1034,6 +1036,8 @@
     "id": "api.email_batching.send_batched_email_notification.body_text",
     "translation": {
       "one": "Masz nowe powiadomienie.",
+      "few": "Masz {{.Count}} nowe powiadomienia.",
+      "many": "Masz {{.Count}} nowe powiadomienia.",
       "other": "Masz {{.Count}} nowe powiadomienia."
     }
   },
@@ -1041,6 +1045,8 @@
     "id": "api.email_batching.send_batched_email_notification.subject",
     "translation": {
       "one": "Nowe powiadomienie [{{.SiteName}}] z {{.Month}} {{.Day}}, {{.Year}}",
+      "few": "Nowe powiadomienia [{{.SiteName}}] z {{.Month}} {{.Day}}, {{.Year}}",
+      "many": "Nowe powiadomienia [{{.SiteName}}] z {{.Month}} {{.Day}}, {{.Year}}",
       "other": "Nowe powiadomienia [{{.SiteName}}] z {{.Month}} {{.Day}}, {{.Year}}"
     }
   },
@@ -1484,6 +1490,8 @@
     "id": "api.post.get_message_for_notification.files_sent",
     "translation": {
       "one": "{{.Count}} plik wysłany: {{.Filenames}}",
+      "few": "Wysłano {{.Count}} pliki: {{.Filenames}}",
+      "many": "Wysłano {{.Count}} pliki: {{.Filenames}}",
       "other": "Wysłano {{.Count}} pliki: {{.Filenames}}"
     }
   },
@@ -1491,6 +1499,8 @@
     "id": "api.post.get_message_for_notification.images_sent",
     "translation": {
       "one": "{{.Count}} plik wysłany: {{.Filenames}}",
+      "few": "Wysłano {{.Count}} plików: {{.Filenames}}",
+      "many": "Wysłano {{.Count}} plików: {{.Filenames}}",
       "other": "Wysłano {{.Count}} plików: {{.Filenames}}"
     }
   },

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -627,6 +627,7 @@
     "id": "api.command_groupmsg.invalid_user.app_error",
     "translation": {
       "one": "În imposibilitatea de a găsi utilizatorul: {{.Users}}",
+      "few": "În imposibilitatea de a găsi utilizatorii: {{.Users}}",
       "other": "În imposibilitatea de a găsi utilizatorii: {{.Users}}"
     }
   },
@@ -1034,6 +1035,7 @@
     "id": "api.email_batching.send_batched_email_notification.body_text",
     "translation": {
       "one": "Ai o nouă notificare.",
+      "few": "Ai {{.Count}} notificări noi.",
       "other": "Ai {{.Count}} notificări noi."
     }
   },
@@ -1041,6 +1043,7 @@
     "id": "api.email_batching.send_batched_email_notification.subject",
     "translation": {
       "one": "[{{.SiteName}}] Notificare nouă pentru {{.Month}} {{.Day}}, {{.Year}}",
+      "few": "[{{.SiteName}}] Notificări noi pentru {{.Month}} {{.Day}}, {{.Year}}",
       "other": "[{{.SiteName}}] Notificări noi pentru {{.Month}} {{.Day}}, {{.Year}}"
     }
   },
@@ -1484,6 +1487,7 @@
     "id": "api.post.get_message_for_notification.files_sent",
     "translation": {
       "one": "{{.Count}} fișier trimis: {{.Filenames}}",
+      "few": "{{.Count}} fișiere trimise: {{.Filenames}}",
       "other": "{{.Count}} fișiere trimise: {{.Filenames}}"
     }
   },
@@ -1491,6 +1495,7 @@
     "id": "api.post.get_message_for_notification.images_sent",
     "translation": {
       "one": "{{.Count}} imagine trimisă: {{.Filenames}}",
+      "few": "{{.Count}} imagini trimise: {{.Filenames}}",
       "other": "{{.Count}} imagini trimise: {{.Filenames}}"
     }
   },

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -627,6 +627,8 @@
     "id": "api.command_groupmsg.invalid_user.app_error",
     "translation": {
       "one": "Не удалось найти пользователя: {{.Users}}",
+      "few": "Не удалось найти пользователей: {{.Users}}",
+      "many": "Не удалось найти пользователей: {{.Users}}",
       "other": "Не удалось найти пользователей: {{.Users}}"
     }
   },
@@ -1034,6 +1036,8 @@
     "id": "api.email_batching.send_batched_email_notification.body_text",
     "translation": {
       "one": "У вас есть новое уведомление.",
+      "few": "У вас есть {{.Count}} уведомление.",
+      "many": "У вас есть {{.Count}} уведомление.",
       "other": "У вас есть {{.Count}} уведомление."
     }
   },
@@ -1041,6 +1045,8 @@
     "id": "api.email_batching.send_batched_email_notification.subject",
     "translation": {
       "one": "[{{.SiteName}}] Новое уведомление за {{.Day}} {{.Month}}, {{.Year}}",
+      "few": "[{{.SiteName}}] Новые уведомления за {{.Day}} {{.Month}}, {{.Year}}",
+      "many": "[{{.SiteName}}] Новые уведомления за {{.Day}} {{.Month}}, {{.Year}}",
       "other": "[{{.SiteName}}] Новые уведомления за {{.Day}} {{.Month}}, {{.Year}}"
     }
   },
@@ -1484,14 +1490,18 @@
     "id": "api.post.get_message_for_notification.files_sent",
     "translation": {
       "one": "{{.Count}} файл отправлен: {{.Filenames}}{{.Count}} файлов отправлено: {{.Filenames}}",
-      "other": ""
+      "few": "{{.Count}} файл отправлен: {{.Filenames}}{{.Count}} файлов отправлено: {{.Filenames}}",
+      "many": "{{.Count}} файл отправлен: {{.Filenames}}{{.Count}} файлов отправлено: {{.Filenames}}",
+      "other": "{{.Count}} файл отправлен: {{.Filenames}}{{.Count}} файлов отправлено: {{.Filenames}}"
     }
   },
   {
     "id": "api.post.get_message_for_notification.images_sent",
     "translation": {
       "one": "{{.Count}} изображение отправлено: {{.Filenames}}{{.Count}} изображений отправлено: {{.Filenames}}",
-      "other": ""
+      "few": "{{.Count}} изображение отправлено: {{.Filenames}}{{.Count}} изображений отправлено: {{.Filenames}}",
+      "many": "{{.Count}} изображение отправлено: {{.Filenames}}{{.Count}} изображений отправлено: {{.Filenames}}",
+      "other": "{{.Count}} изображение отправлено: {{.Filenames}}{{.Count}} изображений отправлено: {{.Filenames}}"
     }
   },
   {

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -627,7 +627,9 @@
     "id": "api.command_groupmsg.invalid_user.app_error",
     "translation": {
       "one": "Не вдалося знайти користувача: {{.Users}}Не вдалося знайти користувачів: {{.Users}}",
-      "other": ""
+      "few": "Не вдалося знайти користувача: {{.Users}}Не вдалося знайти користувачів: {{.Users}}",
+      "many": "Не вдалося знайти користувача: {{.Users}}Не вдалося знайти користувачів: {{.Users}}",
+      "other": "Не вдалося знайти користувача: {{.Users}}Не вдалося знайти користувачів: {{.Users}}"
     }
   },
   {
@@ -1034,6 +1036,8 @@
     "id": "api.email_batching.send_batched_email_notification.body_text",
     "translation": {
       "one": "Ви отримали нове повідомлення.У вас є {{.Count}} нові сповіщення.",
+      "few": "У вас є {{.Count}} нові сповіщення.",
+      "many": "У вас є {{.Count}} нові сповіщення.",
       "other": "У вас є {{.Count}} нові сповіщення."
     }
   },
@@ -1041,6 +1045,8 @@
     "id": "api.email_batching.send_batched_email_notification.subject",
     "translation": {
       "one": "[{{.SiteName}}] Нове повідомлення для {{.Month}} {{.Day}}, {{.Year}}",
+      "few": "[{{.SiteName}}] Нові сповіщення для {{.Month}} {{.Day}}, {{.Year}}",
+      "many": "[{{.SiteName}}] Нові сповіщення для {{.Month}} {{.Day}}, {{.Year}}",
       "other": "[{{.SiteName}}] Нові сповіщення для {{.Month}} {{.Day}}, {{.Year}}"
     }
   },
@@ -1484,6 +1490,8 @@
     "id": "api.post.get_message_for_notification.files_sent",
     "translation": {
       "one": "Файл {{.Count}} відправлений: {{.Filenames}}Файли {{.Count}} відправлені: {{.Filenames}}",
+      "few": "Файл {{.Count}} відправлений: {{.Filenames}}Файли {{.Count}} відправлені: {{.Filenames}}",
+      "many": "Файл {{.Count}} відправлений: {{.Filenames}}Файли {{.Count}} відправлені: {{.Filenames}}",
       "other": "Файл {{.Count}} відправлений: {{.Filenames}}Файли {{.Count}} відправлені: {{.Filenames}}"
     }
   },
@@ -1491,6 +1499,8 @@
     "id": "api.post.get_message_for_notification.images_sent",
     "translation": {
       "one": "{{.Count}} зображення надіслано: {{.Filenames}}{{.Count}} відправлені зображення: {{.Filenames}}",
+      "few": "{{.Count}} зображення надіслано: {{.Filenames}}{{.Count}} відправлені зображення: {{.Filenames}}",
+      "many": "{{.Count}} зображення надіслано: {{.Filenames}}{{.Count}} відправлені зображення: {{.Filenames}}",
       "other": "{{.Count}} зображення надіслано: {{.Filenames}}{{.Count}} відправлені зображення: {{.Filenames}}"
     }
   },


### PR DESCRIPTION
This change adds new plural translations to certain languages.
These languages had plural options beyond the standard 'one' and
'other' definitions that most languages have. This resolves an
issue where these missing plural lookups would often result in
partially-translated messages.

Fixes https://mattermost.atlassian.net/browse/MM-14930