### PR TITLE
MM-15006: Returning informative errors on config validation

### DIFF
--- a/api4/config.go
+++ b/api4/config.go
@@ -95,7 +95,13 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err := c.App.SaveConfig(cfg, true)
+	err := cfg.IsValid()
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	err = c.App.SaveConfig(cfg, true)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -111,6 +111,16 @@ func TestUpdateConfig(t *testing.T) {
 
 	require.Equal(t, SiteName, cfg.TeamSettings.SiteName, "It should update the SiteName")
 
+	t.Run("Should fail with validation error if invalid config setting is passed", func(t *testing.T) {
+		//Revert the change
+		badcfg := cfg.Clone()
+		badcfg.PasswordSettings.MinimumLength = model.NewInt(4)
+		badcfg.PasswordSettings.MinimumLength = model.NewInt(4)
+		_, resp = th.SystemAdminClient.UpdateConfig(badcfg)
+		CheckBadRequestStatus(t, resp)
+		CheckErrorMessage(t, resp, "model.config.is_valid.password_length.app_error")
+	})
+
 	t.Run("Should not be able to modify PluginSettings.EnableUploads", func(t *testing.T) {
 		oldEnableUploads := *th.App.Config().PluginSettings.EnableUploads
 		*cfg.PluginSettings.EnableUploads = !oldEnableUploads


### PR DESCRIPTION
#### Summary
With the new config, any config save failing because invalid configuration
fields is returning a 500 error with the same error. This happens because the
code in app config "flat" any error other than `ErrReadOnlyConfiguration`. My
solution is to validate the config in the Api, but now is validating the config
twice for this api endpoint (not a big deal)

#### Ticket Link
[MM-15006](https://mattermost.atlassian.net/browse/MM-15006)