### PR TITLE
MM-15302 Don't get post embeds with link previews disabled

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -127,7 +127,7 @@ func (a *App) getEmbedForPost(post *model.Post, firstLink string, isNewPost bool
 		}, nil
 	}
 
-	if firstLink == "" {
+	if firstLink == "" || !*a.Config().ServiceSettings.EnableLinkPreviews {
 		return nil, nil
 	}
 
@@ -145,7 +145,7 @@ func (a *App) getEmbedForPost(post *model.Post, firstLink string, isNewPost bool
 	}
 
 	if image != nil {
-		// Note that we're not passing the image info here since they'll be part of the PostMetadata.Images field
+		// Note that we're not passing the image info here since it'll be part of the PostMetadata.Images field
 		return &model.PostEmbed{
 			Type: model.POST_EMBED_IMAGE,
 			URL:  firstLink,

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -66,6 +66,7 @@ func TestPreparePostForClient(t *testing.T) {
 		th := Setup(t).InitBasic()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableLinkPreviews = true
 			*cfg.ImageProxySettings.Enable = false
 			*cfg.ExperimentalSettings.DisablePostMetadata = false
 		})
@@ -420,6 +421,7 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 		th := Setup(t).InitBasic()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableLinkPreviews = true
 			*cfg.ServiceSettings.SiteURL = "http://mymattermost.com"
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
@@ -518,6 +520,7 @@ func TestGetEmbedForPost(t *testing.T) {
 			t.Fatal("Invalid path", r.URL.Path)
 		}
 	}))
+	defer server.Close()
 
 	ogURL := server.URL + "/index.html"
 	imageURL := server.URL + "/image.png"


### PR DESCRIPTION
Without post metadata, the server doesn't request information on pasted links if EnableLinkPreviews is false, but when the server has post metadata enabled currently, it ignores EnableLinkPreviews even though the client won't show anything for them. This makes it respect that setting by not making those requests when it doesn't need to.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15032
