### PR TITLE
MM-14795 Added "from_webhook" to protected props in DoPostAction

### DIFF
--- a/app/integration_action_test.go
+++ b/app/integration_action_test.go
@@ -328,6 +328,7 @@ func TestPostActionProps(t *testing.T) {
 				"has_reactions": true,
 				"is_pinned": false,
 				"props": {
+					"from_webhook":true,
 					"override_username":"new_override_user",
 					"override_icon_url":"new_override_icon",
 					"A":"AA"
@@ -366,6 +367,7 @@ func TestPostActionProps(t *testing.T) {
 				},
 			},
 			"override_icon_url": "old_override_icon",
+			"from_webhook":      false,
 			"B":                 "BB",
 		},
 	}
@@ -390,6 +392,7 @@ func TestPostActionProps(t *testing.T) {
 	assert.Nil(t, newPost.Props["override_username"])
 	assert.Equal(t, "AA", newPost.Props["A"])
 	assert.Equal(t, "old_override_icon", newPost.Props["override_icon_url"])
+	assert.Equal(t, false, newPost.Props["from_webhook"])
 }
 
 func TestSubmitInteractiveDialog(t *testing.T) {

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -26,7 +26,7 @@ const (
 	INTERACTIVE_DIALOG_TRIGGER_TIMEOUT_MILLISECONDS = 3000
 )
 
-var PostActionRetainPropKeys = []string{"override_username", "override_icon_url"}
+var PostActionRetainPropKeys = []string{"from_webhook", "override_username", "override_icon_url"}
 
 type DoPostActionRequest struct {
 	SelectedOption string `json:"selected_option,omitempty"`


### PR DESCRIPTION
Per @hanzei's request
- https://github.com/mattermost/mattermost-server/pull/10546#issuecomment-481997493
- https://mattermost.atlassian.net/browse/MM-14795
