### PR TITLE
Revert "MM-14845: Fix Update and Patch channel for private channels. …

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -120,12 +120,6 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Since the `team_user` role can have PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES out of the box, we must additionally check membership for private channels.
-		if _, memberErr := c.App.GetChannelMember(channel.Id, c.App.Session.UserId); memberErr != nil {
-			c.Err = model.NewAppError("updateChannel", "api.channel.patch_update_channel.forbidden.app_error", nil, "", http.StatusForbidden)
-			return
-		}
-
 	case model.CHANNEL_GROUP, model.CHANNEL_DIRECT:
 		// Modifying the header is not linked to any specific permission for group/dm channels, so just check for membership.
 		if _, err := c.App.GetChannelMember(channel.Id, c.App.Session.UserId); err != nil {
@@ -260,12 +254,6 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	case model.CHANNEL_PRIVATE:
 		if !c.App.SessionHasPermissionToChannel(c.App.Session, c.Params.ChannelId, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES) {
 			c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES)
-			return
-		}
-
-		// Since the `team_user` role can have PERMISSION_MANAGE_PRIVATE_CHANNEL_PROPERTIES out of the box, we must additionally check membership for private channels.
-		if _, memberErr := c.App.GetChannelMember(c.Params.ChannelId, c.App.Session.UserId); memberErr != nil {
-			c.Err = model.NewAppError("patchChannel", "api.channel.patch_update_channel.forbidden.app_error", nil, "", http.StatusForbidden)
 			return
 		}
 

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -212,10 +212,6 @@ func TestUpdateChannel(t *testing.T) {
 		t.Fatal("Update failed for Purpose in private channel")
 	}
 
-	// Updating a private channel requires permission *and* membership, so this should fail.
-	_, resp = th.SystemAdminClient.UpdateChannel(private)
-	CheckForbiddenStatus(t, resp)
-
 	//Non existing channel
 	channel1 := &model.Channel{DisplayName: "Test API Name for apiv4", Name: GenerateTestChannelName(), Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	_, resp = Client.UpdateChannel(channel1)
@@ -325,15 +321,8 @@ func TestPatchChannel(t *testing.T) {
 	_, resp = th.SystemAdminClient.PatchChannel(th.BasicChannel.Id, patch)
 	CheckNoError(t, resp)
 
-	Client.Logout()
-	Client.Login(th.BasicUser.Username, th.BasicUser.Password)
-
-	_, resp = th.Client.PatchChannel(th.BasicPrivateChannel.Id, patch)
-	CheckNoError(t, resp)
-
-	// Patching a private channel requires permission *and* membership, so this should fail.
 	_, resp = th.SystemAdminClient.PatchChannel(th.BasicPrivateChannel.Id, patch)
-	CheckForbiddenStatus(t, resp)
+	CheckNoError(t, resp)
 
 	// Test updating the header of someone else's GM channel.
 	user1 := th.CreateUser()


### PR DESCRIPTION
This reverts the original, hacky fix from master (the only branch where it got merged already).

The correct fix is in the other PR you guys already reviewed.