### PR TITLE
Use gzip for API responses [MM-11426]

### DIFF
--- a/api4/handlers.go
+++ b/api4/handlers.go
@@ -6,6 +6,7 @@ package api4
 import (
 	"net/http"
 
+	"github.com/NYTimes/gziphandler"
 	"github.com/mattermost/mattermost-server/web"
 )
 
@@ -14,7 +15,7 @@ type Context = web.Context
 // ApiHandler provides a handler for API endpoints which do not require the user to be logged in order for access to be
 // granted.
 func (api *API) ApiHandler(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &web.Handler{
+	handler := &web.Handler{
 		GetGlobalAppOptions: api.GetGlobalAppOptions,
 		HandleFunc:          h,
 		RequireSession:      false,
@@ -22,12 +23,16 @@ func (api *API) ApiHandler(h func(*Context, http.ResponseWriter, *http.Request))
 		RequireMfa:          false,
 		IsStatic:            false,
 	}
+	if *api.ConfigService.Config().ServiceSettings.WebserverMode == "gzip" {
+		return gziphandler.GzipHandler(handler)
+	}
+	return handler
 }
 
 // ApiSessionRequired provides a handler for API endpoints which require the user to be logged in in order for access to
 // be granted.
 func (api *API) ApiSessionRequired(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &web.Handler{
+	handler := &web.Handler{
 		GetGlobalAppOptions: api.GetGlobalAppOptions,
 		HandleFunc:          h,
 		RequireSession:      true,
@@ -35,13 +40,18 @@ func (api *API) ApiSessionRequired(h func(*Context, http.ResponseWriter, *http.R
 		RequireMfa:          true,
 		IsStatic:            false,
 	}
+	if *api.ConfigService.Config().ServiceSettings.WebserverMode == "gzip" {
+		return gziphandler.GzipHandler(handler)
+	}
+	return handler
+
 }
 
 // ApiSessionRequiredMfa provides a handler for API endpoints which require a logged-in user session  but when accessed,
 // if MFA is enabled, the MFA process is not yet complete, and therefore the requirement to have completed the MFA
 // authentication must be waived.
 func (api *API) ApiSessionRequiredMfa(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &web.Handler{
+	handler := &web.Handler{
 		GetGlobalAppOptions: api.GetGlobalAppOptions,
 		HandleFunc:          h,
 		RequireSession:      true,
@@ -49,13 +59,18 @@ func (api *API) ApiSessionRequiredMfa(h func(*Context, http.ResponseWriter, *htt
 		RequireMfa:          false,
 		IsStatic:            false,
 	}
+	if *api.ConfigService.Config().ServiceSettings.WebserverMode == "gzip" {
+		return gziphandler.GzipHandler(handler)
+	}
+	return handler
+
 }
 
 // ApiHandlerTrustRequester provides a handler for API endpoints which do not require the user to be logged in and are
 // allowed to be requested directly rather than via javascript/XMLHttpRequest, such as site branding images or the
 // websocket.
 func (api *API) ApiHandlerTrustRequester(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &web.Handler{
+	handler := &web.Handler{
 		GetGlobalAppOptions: api.GetGlobalAppOptions,
 		HandleFunc:          h,
 		RequireSession:      false,
@@ -63,12 +78,17 @@ func (api *API) ApiHandlerTrustRequester(h func(*Context, http.ResponseWriter, *
 		RequireMfa:          false,
 		IsStatic:            false,
 	}
+	if *api.ConfigService.Config().ServiceSettings.WebserverMode == "gzip" {
+		return gziphandler.GzipHandler(handler)
+	}
+	return handler
+
 }
 
 // ApiSessionRequiredTrustRequester provides a handler for API endpoints which do require the user to be logged in and
 // are allowed to be requested directly rather than via javascript/XMLHttpRequest, such as emoji or file uploads.
 func (api *API) ApiSessionRequiredTrustRequester(h func(*Context, http.ResponseWriter, *http.Request)) http.Handler {
-	return &web.Handler{
+	handler := &web.Handler{
 		GetGlobalAppOptions: api.GetGlobalAppOptions,
 		HandleFunc:          h,
 		RequireSession:      true,
@@ -76,4 +96,9 @@ func (api *API) ApiSessionRequiredTrustRequester(h func(*Context, http.ResponseW
 		RequireMfa:          true,
 		IsStatic:            false,
 	}
+	if *api.ConfigService.Config().ServiceSettings.WebserverMode == "gzip" {
+		return gziphandler.GzipHandler(handler)
+	}
+	return handler
+
 }

--- a/api4/handlers_test.go
+++ b/api4/handlers_test.go
@@ -1,0 +1,86 @@
+package api4
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
+func handlerForGzip(c *Context, w http.ResponseWriter, r *http.Request) {
+	// gziphandler default requires body size greater than 1400 bytes
+	const body = "aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc"
+	io.WriteString(w, body)
+}
+
+func TestApiHandlerWithGzip(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	WebserverMode := *th.App.Config().ServiceSettings.WebserverMode
+
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = WebserverMode })
+	}()
+
+	// WebserverMode = "gzip"
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "gzip" })
+
+	api := Init(th.Server, th.Server.AppOptions, th.Server.Router)
+
+	handler := api.ApiHandler(handlerForGzip)
+
+	// No specified "Accept-Encoding" in req
+	resp1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest("GET", "/api/v4/test", nil)
+
+	handler.ServeHTTP(resp1, req1)
+	header := resp1.Header().Get("Content-Encoding")
+
+	if header != "" {
+		t.Errorf("Expected no Content-Encoding, but got %q", header)
+	}
+
+	resp2 := httptest.NewRecorder()
+
+	// Specify qzip as option for "Accept-Encoding"
+	req2 := httptest.NewRequest("GET", "/api/v4/test", nil)
+	req2.Header.Set("Accept-Encoding", "gzip")
+
+	handler.ServeHTTP(resp2, req2)
+	header = resp2.Header().Get("Content-Encoding")
+	if header != "gzip" {
+		t.Errorf("Expected Content-Encoding=gzip, got %q", header)
+	}
+	// WebserverMode = "nogzip"
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "nogzip" })
+
+	// Api config gets updated, but handler's doesn't - need to refresh it
+	handler = api.ApiHandler(handlerForGzip)
+
+	// No specified "Accept-Encoding" in req
+	resp3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest("GET", "/api/v4/test", nil)
+
+	handler.ServeHTTP(resp3, req3)
+	header = resp3.Header().Get("Content-Encoding")
+
+	if header != "" {
+		t.Errorf("Expected no Content-Encoding, but got %q", header)
+	}
+
+	resp4 := httptest.NewRecorder()
+
+	// No specified "Accept-Encoding" in req
+	req4 := httptest.NewRequest("GET", "/api/v4/test", nil)
+	req4.Header.Set("Accept-Encoding", "gzip")
+
+	handler.ServeHTTP(resp4, req4)
+
+	header = resp4.Header().Get("Content-Encoding")
+	if header != "" {
+		t.Errorf("Expected no Content-Encoding, as WebserverMode == nogzip, but got %q", header)
+	}
+}

--- a/api4/handlers_test.go
+++ b/api4/handlers_test.go
@@ -16,11 +16,13 @@ func handlerForGzip(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Write(body[:])
 }
 
-func testAPIHandlerGzipMode(t *testing.T, name string, h http.Handler) {
+func testAPIHandlerGzipMode(t *testing.T, name string, h http.Handler, token string) {
 	t.Run("Handler: "+name+" No Accept-Encoding", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/api/v4/test", nil)
+		req.Header.Set(model.HEADER_AUTH, "Bearer "+token)
 		h.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Equal(t, "", resp.Header().Get("Content-Encoding"))
 	})
 
@@ -28,16 +30,22 @@ func testAPIHandlerGzipMode(t *testing.T, name string, h http.Handler) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/api/v4/test", nil)
 		req.Header.Set("Accept-Encoding", "gzip")
+		req.Header.Set(model.HEADER_AUTH, "Bearer "+token)
+
 		h.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Equal(t, "gzip", resp.Header().Get("Content-Encoding"))
 	})
 }
 
-func testAPIHandlerNoGzipMode(t *testing.T, name string, h http.Handler) {
+func testAPIHandlerNoGzipMode(t *testing.T, name string, h http.Handler, token string) {
 	t.Run("Handler: "+name+" No Accept-Encoding", func(t *testing.T) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/api/v4/test", nil)
+		req.Header.Set(model.HEADER_AUTH, "Bearer "+token)
+
 		h.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Equal(t, "", resp.Header().Get("Content-Encoding"))
 	})
 
@@ -45,7 +53,10 @@ func testAPIHandlerNoGzipMode(t *testing.T, name string, h http.Handler) {
 		resp := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/api/v4/test", nil)
 		req.Header.Set("Accept-Encoding", "gzip")
+		req.Header.Set(model.HEADER_AUTH, "Bearer "+token)
+
 		h.ServeHTTP(resp, req)
+		assert.Equal(t, http.StatusOK, resp.Code)
 		assert.Equal(t, "", resp.Header().Get("Content-Encoding"))
 	})
 }
@@ -55,25 +66,25 @@ func TestAPIHandlersWithGzip(t *testing.T) {
 	defer th.TearDown()
 
 	api := Init(th.Server, th.Server.AppOptions, th.Server.Router)
+	session, _ := th.App.GetSession(th.Client.AuthToken)
 
 	t.Run("with WebserverMode == \"gzip\"", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "gzip" })
 
-		testAPIHandlerGzipMode(t, "ApiHandler", api.ApiHandler(handlerForGzip))
-		testAPIHandlerGzipMode(t, "ApiSessionRequired", api.ApiSessionRequired(handlerForGzip))
-		testAPIHandlerGzipMode(t, "ApiSessionRequiredMfa", api.ApiSessionRequiredMfa(handlerForGzip))
-		testAPIHandlerGzipMode(t, "ApiHandlerTrustRequester", api.ApiHandlerTrustRequester(handlerForGzip))
-		testAPIHandlerGzipMode(t, "ApiSessionRequiredTrustRequester", api.ApiSessionRequiredTrustRequester(handlerForGzip))
+		testAPIHandlerGzipMode(t, "ApiHandler", api.ApiHandler(handlerForGzip), "")
+		testAPIHandlerGzipMode(t, "ApiSessionRequired", api.ApiSessionRequired(handlerForGzip), session.Token)
+		testAPIHandlerGzipMode(t, "ApiSessionRequiredMfa", api.ApiSessionRequiredMfa(handlerForGzip), session.Token)
+		testAPIHandlerGzipMode(t, "ApiHandlerTrustRequester", api.ApiHandlerTrustRequester(handlerForGzip), "")
+		testAPIHandlerGzipMode(t, "ApiSessionRequiredTrustRequester", api.ApiSessionRequiredTrustRequester(handlerForGzip), session.Token)
 	})
 
 	t.Run("with WebserverMode == \"nogzip\"", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "nogzip" })
 
-		testAPIHandlerNoGzipMode(t, "ApiHandler", api.ApiHandler(handlerForGzip))
-		testAPIHandlerNoGzipMode(t, "ApiSessionRequired", api.ApiSessionRequired(handlerForGzip))
-		testAPIHandlerNoGzipMode(t, "ApiSessionRequiredMfa", api.ApiSessionRequiredMfa(handlerForGzip))
-		testAPIHandlerNoGzipMode(t, "ApiHandlerTrustRequester", api.ApiHandlerTrustRequester(handlerForGzip))
-		testAPIHandlerNoGzipMode(t, "ApiSessionRequiredTrustRequester", api.ApiSessionRequiredTrustRequester(handlerForGzip))
-
+		testAPIHandlerNoGzipMode(t, "ApiHandler", api.ApiHandler(handlerForGzip), "")
+		testAPIHandlerNoGzipMode(t, "ApiSessionRequired", api.ApiSessionRequired(handlerForGzip), session.Token)
+		testAPIHandlerNoGzipMode(t, "ApiSessionRequiredMfa", api.ApiSessionRequiredMfa(handlerForGzip), session.Token)
+		testAPIHandlerNoGzipMode(t, "ApiHandlerTrustRequester", api.ApiHandlerTrustRequester(handlerForGzip), "")
+		testAPIHandlerNoGzipMode(t, "ApiSessionRequiredTrustRequester", api.ApiSessionRequiredTrustRequester(handlerForGzip), session.Token)
 	})
 }

--- a/api4/handlers_test.go
+++ b/api4/handlers_test.go
@@ -66,7 +66,6 @@ func TestAPIHandlersWithGzip(t *testing.T) {
 		testAPIHandlerGzipMode(t, "ApiSessionRequiredTrustRequester", api.ApiSessionRequiredTrustRequester(handlerForGzip))
 	})
 
-	// WebserverMode = "nogzip"
 	t.Run("with WebserverMode == \"nogzip\"", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "nogzip" })
 

--- a/api4/handlers_test.go
+++ b/api4/handlers_test.go
@@ -1,86 +1,80 @@
 package api4
 
 import (
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/mattermost/mattermost-server/model"
 )
 
 func handlerForGzip(c *Context, w http.ResponseWriter, r *http.Request) {
 	// gziphandler default requires body size greater than 1400 bytes
-	const body = "aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc aaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbcccaaabbbccc"
-	io.WriteString(w, body)
+	var body [1400]byte
+	w.Write(body[:])
 }
 
-func TestApiHandlerWithGzip(t *testing.T) {
+func testAPIHandlerGzipMode(t *testing.T, name string, h http.Handler) {
+	t.Run("Handler: "+name+" No Accept-Encoding", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v4/test", nil)
+		h.ServeHTTP(resp, req)
+		assert.Equal(t, "", resp.Header().Get("Content-Encoding"))
+	})
+
+	t.Run("Handler: "+name+" With Accept-Encoding", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v4/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		h.ServeHTTP(resp, req)
+		assert.Equal(t, "gzip", resp.Header().Get("Content-Encoding"))
+	})
+}
+
+func testAPIHandlerNoGzipMode(t *testing.T, name string, h http.Handler) {
+	t.Run("Handler: "+name+" No Accept-Encoding", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v4/test", nil)
+		h.ServeHTTP(resp, req)
+		assert.Equal(t, "", resp.Header().Get("Content-Encoding"))
+	})
+
+	t.Run("Handler: "+name+" With Accept-Encoding", func(t *testing.T) {
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v4/test", nil)
+		req.Header.Set("Accept-Encoding", "gzip")
+		h.ServeHTTP(resp, req)
+		assert.Equal(t, "", resp.Header().Get("Content-Encoding"))
+	})
+}
+
+func TestAPIHandlersWithGzip(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 
-	WebserverMode := *th.App.Config().ServiceSettings.WebserverMode
-
-	defer func() {
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = WebserverMode })
-	}()
-
-	// WebserverMode = "gzip"
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "gzip" })
-
 	api := Init(th.Server, th.Server.AppOptions, th.Server.Router)
 
-	handler := api.ApiHandler(handlerForGzip)
+	t.Run("with WebserverMode == \"gzip\"", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "gzip" })
 
-	// No specified "Accept-Encoding" in req
-	resp1 := httptest.NewRecorder()
-	req1 := httptest.NewRequest("GET", "/api/v4/test", nil)
+		testAPIHandlerGzipMode(t, "ApiHandler", api.ApiHandler(handlerForGzip))
+		testAPIHandlerGzipMode(t, "ApiSessionRequired", api.ApiSessionRequired(handlerForGzip))
+		testAPIHandlerGzipMode(t, "ApiSessionRequiredMfa", api.ApiSessionRequiredMfa(handlerForGzip))
+		testAPIHandlerGzipMode(t, "ApiHandlerTrustRequester", api.ApiHandlerTrustRequester(handlerForGzip))
+		testAPIHandlerGzipMode(t, "ApiSessionRequiredTrustRequester", api.ApiSessionRequiredTrustRequester(handlerForGzip))
+	})
 
-	handler.ServeHTTP(resp1, req1)
-	header := resp1.Header().Get("Content-Encoding")
-
-	if header != "" {
-		t.Errorf("Expected no Content-Encoding, but got %q", header)
-	}
-
-	resp2 := httptest.NewRecorder()
-
-	// Specify qzip as option for "Accept-Encoding"
-	req2 := httptest.NewRequest("GET", "/api/v4/test", nil)
-	req2.Header.Set("Accept-Encoding", "gzip")
-
-	handler.ServeHTTP(resp2, req2)
-	header = resp2.Header().Get("Content-Encoding")
-	if header != "gzip" {
-		t.Errorf("Expected Content-Encoding=gzip, got %q", header)
-	}
 	// WebserverMode = "nogzip"
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "nogzip" })
+	t.Run("with WebserverMode == \"nogzip\"", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.WebserverMode = "nogzip" })
 
-	// Api config gets updated, but handler's doesn't - need to refresh it
-	handler = api.ApiHandler(handlerForGzip)
+		testAPIHandlerNoGzipMode(t, "ApiHandler", api.ApiHandler(handlerForGzip))
+		testAPIHandlerNoGzipMode(t, "ApiSessionRequired", api.ApiSessionRequired(handlerForGzip))
+		testAPIHandlerNoGzipMode(t, "ApiSessionRequiredMfa", api.ApiSessionRequiredMfa(handlerForGzip))
+		testAPIHandlerNoGzipMode(t, "ApiHandlerTrustRequester", api.ApiHandlerTrustRequester(handlerForGzip))
+		testAPIHandlerNoGzipMode(t, "ApiSessionRequiredTrustRequester", api.ApiSessionRequiredTrustRequester(handlerForGzip))
 
-	// No specified "Accept-Encoding" in req
-	resp3 := httptest.NewRecorder()
-	req3 := httptest.NewRequest("GET", "/api/v4/test", nil)
-
-	handler.ServeHTTP(resp3, req3)
-	header = resp3.Header().Get("Content-Encoding")
-
-	if header != "" {
-		t.Errorf("Expected no Content-Encoding, but got %q", header)
-	}
-
-	resp4 := httptest.NewRecorder()
-
-	// No specified "Accept-Encoding" in req
-	req4 := httptest.NewRequest("GET", "/api/v4/test", nil)
-	req4.Header.Set("Accept-Encoding", "gzip")
-
-	handler.ServeHTTP(resp4, req4)
-
-	header = resp4.Header().Get("Content-Encoding")
-	if header != "" {
-		t.Errorf("Expected no Content-Encoding, as WebserverMode == nogzip, but got %q", header)
-	}
+	})
 }


### PR DESCRIPTION
#### Summary

- Update `api4/handlers` to use gziphandler wrapper if server configured to
use gzip
- Add test to ensure `Content-Encoding="gzip"` header is set  if `WebserverMode=="gzip"` and `Accept-Encoding="gzip"` present in http request

I only added a single test to `ApiHandler` method as logic is the same in other methods. Happy to extend unit tests to the other 4 if necessary however. 

The `NewHandler` method in `web/handlers.go` appears to be used only in the webhook, so also not covered by the scope of the issue summary. 

I did not include changes to web and mobile apps - this would be separate repos/PRs I assume. 

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10325

