### PR TITLE
[MM-15126] Adding terms of service to the login response

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1192,6 +1192,17 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.LogAuditWithUserId(user.Id, "success")
 
+	userTermsOfService, err := c.App.GetUserTermsOfService(user.Id)
+	if err != nil && err.StatusCode != http.StatusNotFound {
+		c.Err = err
+		return
+	}
+
+	if userTermsOfService != nil {
+		user.TermsOfServiceId = userTermsOfService.TermsOfServiceId
+		user.TermsOfServiceCreateAt = userTermsOfService.CreateAt
+	}
+
 	c.App.Session = *session
 
 	user.Sanitize(map[string]bool{})

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2649,6 +2649,26 @@ func TestLogin(t *testing.T) {
 		_, resp = th.Client.Login(botUser.Email, "password")
 		CheckErrorMessage(t, resp, "api.user.login.bot_login_forbidden.app_error")
 	})
+
+	t.Run("login with terms_of_service set", func(t *testing.T) {
+		termsOfService, err := th.App.CreateTermsOfService("terms of service", th.BasicUser.Id)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		success, resp := th.Client.RegisterTermsOfServiceAction(th.BasicUser.Id, termsOfService.Id, true)
+		CheckNoError(t, resp)
+		assert.True(t, *success)
+
+		userTermsOfService, resp := th.Client.GetUserTermsOfService(th.BasicUser.Id, "")
+		CheckNoError(t, resp)
+
+		user, resp := th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+		CheckNoError(t, resp)
+		assert.Equal(t, user.Id, th.BasicUser.Id)
+		assert.Equal(t, user.TermsOfServiceId, userTermsOfService.TermsOfServiceId)
+		assert.Equal(t, user.TermsOfServiceCreateAt, userTermsOfService.CreateAt)
+	})
 }
 
 func TestCBALogin(t *testing.T) {


### PR DESCRIPTION
#### Summary
Login response was not including the state of the ToS, so even when they were accepted, the client would still show them to the user to accept.

#### Ticket Link
[MM-15126](https://mattermost.atlassian.net/browse/MM-15126)
