### PR TITLE
MM-14246 - Plugin framework: support transactional semantics with KV Store

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -662,7 +662,7 @@ func (api *PluginAPI) KVSet(key string, value []byte) *model.AppError {
 	return api.app.SetPluginKey(api.id, key, value)
 }
 
-func (api *PluginAPI) KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError {
+func (api *PluginAPI) KVCompareAndSet(key string, oldValue, newValue []byte) (bool, *model.AppError) {
 	return api.app.CompareAndSetPluginKey(api.id, key, oldValue, newValue)
 }
 

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -662,6 +662,10 @@ func (api *PluginAPI) KVSet(key string, value []byte) *model.AppError {
 	return api.app.SetPluginKey(api.id, key, value)
 }
 
+func (api *PluginAPI) KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError {
+	return api.app.CompareAndSetPluginKey(api.id, key, oldValue, newValue)
+}
+
 func (api *PluginAPI) KVSetWithExpiry(key string, value []byte, expireInSeconds int64) *model.AppError {
 	return api.app.SetPluginKeyWithExpiry(api.id, key, value, expireInSeconds)
 }

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -687,18 +687,38 @@ func TestPluginAPIKVCompareAndSet(t *testing.T) {
 			expectedValue2 := []byte("value2")
 			expectedValue3 := []byte("value3")
 
+			// Attempt update using an incorrect old value
+			updated, err := api.KVCompareAndSet(expectedKey, expectedValue2, expectedValue1)
+			require.Nil(t, err)
+			require.False(t, updated)
+
 			// Make sure no key is already created
 			value, err := api.KVGet(expectedKey)
 			require.Nil(t, err)
 			require.Nil(t, value)
 
-			require.Nil(t, api.KVSet(expectedKey, expectedValue1))
+			// Insert using nil old value
+			updated, err = api.KVCompareAndSet(expectedKey, nil, expectedValue1)
+			require.Nil(t, err)
+			require.True(t, updated)
+
+			// Get inserted value
+			value, err = api.KVGet(expectedKey)
+			require.Nil(t, err)
+			require.Equal(t, expectedValue1, value)
+
+			// Attempt to insert again using nil old value
+			updated, err = api.KVCompareAndSet(expectedKey, nil, expectedValue2)
+			require.Nil(t, err)
+			require.False(t, updated)
+
+			// Get old value to assert nothing has changed
 			value, err = api.KVGet(expectedKey)
 			require.Nil(t, err)
 			require.Equal(t, expectedValue1, value)
 
 			// Update using correct old value
-			updated, err := api.KVCompareAndSet(expectedKey, expectedValue1, expectedValue2)
+			updated, err = api.KVCompareAndSet(expectedKey, expectedValue1, expectedValue2)
 			require.Nil(t, err)
 			require.True(t, updated)
 

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -12,7 +12,6 @@ import (
 	"image/color"
 	"image/png"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -699,37 +698,36 @@ func TestPluginAPIKVCompareAndSet(t *testing.T) {
 			require.Equal(t, expectedValue1, value)
 
 			// Update using correct old value
-			require.Nil(t, api.KVCompareAndSet(expectedKey, expectedValue1, expectedValue2))
+			updated, err := api.KVCompareAndSet(expectedKey, expectedValue1, expectedValue2)
+			require.Nil(t, err)
+			require.True(t, updated)
 
 			value, err = api.KVGet(expectedKey)
 			require.Nil(t, err)
 			require.Equal(t, expectedValue2, value)
 
 			// Update using incorrect old value
-			err = api.KVCompareAndSet(expectedKey, []byte("incorrect"), expectedValue3)
-			require.NotNil(t, err)
-			require.Contains(t, err.Error(), "no rows were affected")
-			require.Equal(t, err.StatusCode, http.StatusNotModified)
+			updated, err = api.KVCompareAndSet(expectedKey, []byte("incorrect"), expectedValue3)
+			require.Nil(t, err)
+			require.False(t, updated)
 
 			value, err = api.KVGet(expectedKey)
 			require.Nil(t, err)
 			require.Equal(t, expectedValue2, value)
 
 			// Update using nil old value
-			err = api.KVCompareAndSet(expectedKey, nil, expectedValue3)
-			require.NotNil(t, err)
-			require.Contains(t, err.Error(), "no rows were affected")
-			require.Equal(t, err.StatusCode, http.StatusNotModified)
+			updated, err = api.KVCompareAndSet(expectedKey, nil, expectedValue3)
+			require.Nil(t, err)
+			require.False(t, updated)
 
 			value, err = api.KVGet(expectedKey)
 			require.Nil(t, err)
 			require.Equal(t, expectedValue2, value)
 
 			// Update using empty old value
-			err = api.KVCompareAndSet(expectedKey, expectedValueEmpty, expectedValue3)
-			require.NotNil(t, err)
-			require.Contains(t, err.Error(), "no rows were affected")
-			require.Equal(t, err.StatusCode, http.StatusNotModified)
+			updated, err = api.KVCompareAndSet(expectedKey, expectedValueEmpty, expectedValue3)
+			require.Nil(t, err)
+			require.False(t, updated)
 
 			value, err = api.KVGet(expectedKey)
 			require.Nil(t, err)

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -54,9 +54,9 @@ func (a *App) CompareAndSetPluginKey(pluginId string, key string, oldValue, newV
 		Value:    newValue,
 	}
 
-	updated, err := a.Srv.Store.Plugin().CompareAndUpdate(kv, oldValue)
+	updated, err := a.Srv.Store.Plugin().CompareAndSet(kv, oldValue)
 	if err != nil {
-		mlog.Error("Failed to update plugin key value", mlog.String("plugin_id", pluginId), mlog.String("key", key), mlog.Err(err))
+		mlog.Error("Failed to compare and set plugin key value", mlog.String("plugin_id", pluginId), mlog.String("key", key), mlog.Err(err))
 		return updated, err
 	}
 

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -141,13 +141,17 @@ func TestPluginKeyValueStoreCompareAndUpdate(t *testing.T) {
 	assert.Equal(t, []byte("test"), ret)
 
 	// Test updating using correct old value
-	assert.Nil(t, th.App.CompareAndSetPluginKey(pluginId, "key", []byte("test"), []byte("test2")))
+	updated, err := th.App.CompareAndSetPluginKey(pluginId, "key", []byte("test"), []byte("test2"))
+	assert.Nil(t, err)
+	assert.True(t, updated)
 	ret, err = th.App.GetPluginKey(pluginId, "key")
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("test2"), ret)
 
 	// Test updating using incorrect old value
-	assert.NotNil(t, th.App.CompareAndSetPluginKey(pluginId, "key", []byte("oldvalue"), []byte("test3")))
+	updated, err = th.App.CompareAndSetPluginKey(pluginId, "key", []byte("oldvalue"), []byte("test3"))
+	assert.Nil(t, err)
+	assert.False(t, updated)
 	ret, err = th.App.GetPluginKey(pluginId, "key")
 	assert.Nil(t, err)
 	assert.Equal(t, []byte("test2"), ret)

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -125,6 +125,34 @@ func TestPluginKeyValueStore(t *testing.T) {
 	assert.Equal(t, []string{"key", "key3", "key4", hashedKey2}, list)
 }
 
+func TestPluginKeyValueStoreCompareAndUpdate(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	pluginId := "testpluginid"
+
+	defer func() {
+		assert.Nil(t, th.App.DeletePluginKey(pluginId, "key"))
+	}()
+
+	assert.Nil(t, th.App.SetPluginKey(pluginId, "key", []byte("test")))
+	ret, err := th.App.GetPluginKey(pluginId, "key")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("test"), ret)
+
+	// Test updating using correct old value
+	assert.Nil(t, th.App.CompareAndSetPluginKey(pluginId, "key", []byte("test"), []byte("test2")))
+	ret, err = th.App.GetPluginKey(pluginId, "key")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("test2"), ret)
+
+	// Test updating using incorrect old value
+	assert.NotNil(t, th.App.CompareAndSetPluginKey(pluginId, "key", []byte("oldvalue"), []byte("test3")))
+	ret, err = th.App.GetPluginKey(pluginId, "key")
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("test2"), ret)
+}
+
 func TestServePluginRequest(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -459,11 +459,12 @@ type API interface {
 	// KVSet will store a key-value pair, unique per plugin.
 	KVSet(key string, value []byte) *model.AppError
 
-	// KVCompareAndSet will update a key-value pair, unique per plugin,
-	// to the given new value if the current value == the old value.
+	// KVCompareAndSet will update a key-value pair,
+	// unique per plugin, to the given new value if the current value == the old value.
+	// Inserts a new key if oldValue == nil.
 	// Returns (false, err) if DB error occurred
-	// Returns (false, nil) if current value != old value
-	// Returns (true, nil) if current value == old value
+	// Returns (false, nil) if current value != old value or key already exists when inserting
+	// Returns (true, nil) if current value == old value or new key is inserted
 	//
 	// Minimum server version: 5.12
 	KVCompareAndSet(key string, oldValue, newValue []byte) (bool, *model.AppError)

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -461,9 +461,12 @@ type API interface {
 
 	// KVCompareAndSet will update a key-value pair, unique per plugin,
 	// to the given new value if the current value == the old value.
+	// Returns (false, err) if DB error occurred
+	// Returns (false, nil) if current value != old value
+	// Returns (true, nil) if current value == old value
 	//
 	// Minimum server version: 5.12
-	KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError
+	KVCompareAndSet(key string, oldValue, newValue []byte) (bool, *model.AppError)
 
 	// KVSet will store a key-value pair, unique per plugin with an expiry time
 	//

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -459,6 +459,12 @@ type API interface {
 	// KVSet will store a key-value pair, unique per plugin.
 	KVSet(key string, value []byte) *model.AppError
 
+	// KVCompareAndSet will update a key-value pair, unique per plugin,
+	// to the given new value if the current value == the old value.
+	//
+	// Minimum server version: 5.12
+	KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError
+
 	// KVSet will store a key-value pair, unique per plugin with an expiry time
 	//
 	// Minimum server version: 5.6

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -3497,23 +3497,24 @@ type Z_KVCompareAndSetArgs struct {
 }
 
 type Z_KVCompareAndSetReturns struct {
-	A *model.AppError
+	A bool
+	B *model.AppError
 }
 
-func (g *apiRPCClient) KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError {
+func (g *apiRPCClient) KVCompareAndSet(key string, oldValue, newValue []byte) (bool, *model.AppError) {
 	_args := &Z_KVCompareAndSetArgs{key, oldValue, newValue}
 	_returns := &Z_KVCompareAndSetReturns{}
 	if err := g.client.Call("Plugin.KVCompareAndSet", _args, _returns); err != nil {
 		log.Printf("RPC call to KVCompareAndSet API failed: %s", err.Error())
 	}
-	return _returns.A
+	return _returns.A, _returns.B
 }
 
 func (s *apiRPCServer) KVCompareAndSet(args *Z_KVCompareAndSetArgs, returns *Z_KVCompareAndSetReturns) error {
 	if hook, ok := s.impl.(interface {
-		KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError
+		KVCompareAndSet(key string, oldValue, newValue []byte) (bool, *model.AppError)
 	}); ok {
-		returns.A = hook.KVCompareAndSet(args.A, args.B, args.C)
+		returns.A, returns.B = hook.KVCompareAndSet(args.A, args.B, args.C)
 	} else {
 		return encodableError(fmt.Errorf("API KVCompareAndSet called but not implemented."))
 	}

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -3490,6 +3490,36 @@ func (s *apiRPCServer) KVSet(args *Z_KVSetArgs, returns *Z_KVSetReturns) error {
 	return nil
 }
 
+type Z_KVCompareAndSetArgs struct {
+	A string
+	B []byte
+	C []byte
+}
+
+type Z_KVCompareAndSetReturns struct {
+	A *model.AppError
+}
+
+func (g *apiRPCClient) KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError {
+	_args := &Z_KVCompareAndSetArgs{key, oldValue, newValue}
+	_returns := &Z_KVCompareAndSetReturns{}
+	if err := g.client.Call("Plugin.KVCompareAndSet", _args, _returns); err != nil {
+		log.Printf("RPC call to KVCompareAndSet API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) KVCompareAndSet(args *Z_KVCompareAndSetArgs, returns *Z_KVCompareAndSetReturns) error {
+	if hook, ok := s.impl.(interface {
+		KVCompareAndSet(key string, oldValue, newValue []byte) *model.AppError
+	}); ok {
+		returns.A = hook.KVCompareAndSet(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("API KVCompareAndSet called but not implemented."))
+	}
+	return nil
+}
+
 type Z_KVSetWithExpiryArgs struct {
 	A string
 	B []byte

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1863,19 +1863,26 @@ func (_m *API) HasPermissionToTeam(userId string, teamId string, permission *mod
 }
 
 // KVCompareAndSet provides a mock function with given fields: key, oldValue, newValue
-func (_m *API) KVCompareAndSet(key string, oldValue []byte, newValue []byte) *model.AppError {
+func (_m *API) KVCompareAndSet(key string, oldValue []byte, newValue []byte) (bool, *model.AppError) {
 	ret := _m.Called(key, oldValue, newValue)
 
-	var r0 *model.AppError
-	if rf, ok := ret.Get(0).(func(string, []byte, []byte) *model.AppError); ok {
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, []byte, []byte) bool); ok {
 		r0 = rf(key, oldValue, newValue)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.AppError)
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, []byte, []byte) *model.AppError); ok {
+		r1 = rf(key, oldValue, newValue)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
 		}
 	}
 
-	return r0
+	return r0, r1
 }
 
 // KVDelete provides a mock function with given fields: key

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1862,6 +1862,22 @@ func (_m *API) HasPermissionToTeam(userId string, teamId string, permission *mod
 	return r0
 }
 
+// KVCompareAndSet provides a mock function with given fields: key, oldValue, newValue
+func (_m *API) KVCompareAndSet(key string, oldValue []byte, newValue []byte) *model.AppError {
+	ret := _m.Called(key, oldValue, newValue)
+
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, []byte, []byte) *model.AppError); ok {
+		r0 = rf(key, oldValue, newValue)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
+		}
+	}
+
+	return r0
+}
+
 // KVDelete provides a mock function with given fields: key
 func (_m *API) KVDelete(key string) *model.AppError {
 	ret := _m.Called(key)

--- a/store/sqlstore/plugin_store.go
+++ b/store/sqlstore/plugin_store.go
@@ -85,7 +85,7 @@ func (ps SqlPluginStore) CompareAndSet(kv *model.PluginKeyValue, oldValue []byte
 			if IsUniqueConstraintError(err, []string{"PRIMARY", "PluginId", "Key", "PKey"}) {
 				return false, nil
 			} else {
-				return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
+				return false, model.NewAppError("SqlPluginStore.CompareAndSet", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}
 		}
 	} else {
@@ -100,12 +100,12 @@ func (ps SqlPluginStore) CompareAndSet(kv *model.PluginKeyValue, oldValue []byte
 			},
 		)
 		if err != nil {
-			return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return false, model.NewAppError("SqlPluginStore.CompareAndSet", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 
 		if rowsAffected, err := updateResult.RowsAffected(); err != nil {
 			// Failed to update
-			return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return false, model.NewAppError("SqlPluginStore.CompareAndSet", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
 		} else if rowsAffected == 0 {
 			// No rows were affected by the update, where condition was not satisfied,
 			// return false, but no error.

--- a/store/sqlstore/plugin_store.go
+++ b/store/sqlstore/plugin_store.go
@@ -71,31 +71,46 @@ func (ps SqlPluginStore) SaveOrUpdate(kv *model.PluginKeyValue) store.StoreChann
 	})
 }
 
-func (ps SqlPluginStore) CompareAndUpdate(kv *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError) {
+func (ps SqlPluginStore) CompareAndSet(kv *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError) {
 	if err := kv.IsValid(); err != nil {
 		return false, err
 	}
 
-	updateResult, err := ps.GetMaster().Exec(
-		`UPDATE PluginKeyValueStore SET PValue = :New WHERE PluginId = :PluginId AND PKey = :Key AND PValue = :Old`,
-		map[string]interface{}{
-			"PluginId": kv.PluginId,
-			"Key":      kv.Key,
-			"Old":      oldValue,
-			"New":      kv.Value,
-		},
-	)
-	if err != nil {
-		return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
-	}
+	if oldValue == nil {
+		// Insert if oldValue is nil
+		if err := ps.GetMaster().Insert(kv); err != nil {
+			// If the error is from unique constraints violation, it's the result of a
+			// race condition, return false and no error. Otherwise we have a real error and
+			// need to return it.
+			if IsUniqueConstraintError(err, []string{"PRIMARY", "PluginId", "Key", "PKey"}) {
+				return false, nil
+			} else {
+				return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
+		}
+	} else {
+		// Update if oldValue is not nil
+		updateResult, err := ps.GetMaster().Exec(
+			`UPDATE PluginKeyValueStore SET PValue = :New WHERE PluginId = :PluginId AND PKey = :Key AND PValue = :Old`,
+			map[string]interface{}{
+				"PluginId": kv.PluginId,
+				"Key":      kv.Key,
+				"Old":      oldValue,
+				"New":      kv.Value,
+			},
+		)
+		if err != nil {
+			return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
 
-	if rowsAffected, err := updateResult.RowsAffected(); err != nil {
-		// Failed to update
-		return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
-	} else if rowsAffected == 0 {
-		// No rows were affected by the update, where condition was not satisfied,
-		// return false, but no error.
-		return false, nil
+		if rowsAffected, err := updateResult.RowsAffected(); err != nil {
+			// Failed to update
+			return false, model.NewAppError("SqlPluginStore.CompareAndUpdate", "store.sql_plugin_store.save.app_error", nil, err.Error(), http.StatusInternalServerError)
+		} else if rowsAffected == 0 {
+			// No rows were affected by the update, where condition was not satisfied,
+			// return false, but no error.
+			return false, nil
+		}
 	}
 
 	return true, nil

--- a/store/store.go
+++ b/store/store.go
@@ -524,6 +524,7 @@ type UserAccessTokenStore interface {
 
 type PluginStore interface {
 	SaveOrUpdate(keyVal *model.PluginKeyValue) StoreChannel
+	CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) StoreChannel
 	Get(pluginId, key string) StoreChannel
 	Delete(pluginId, key string) StoreChannel
 	DeleteAllForPlugin(PluginId string) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -524,7 +524,7 @@ type UserAccessTokenStore interface {
 
 type PluginStore interface {
 	SaveOrUpdate(keyVal *model.PluginKeyValue) StoreChannel
-	CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError)
+	CompareAndSet(keyVal *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError)
 	Get(pluginId, key string) StoreChannel
 	Delete(pluginId, key string) StoreChannel
 	DeleteAllForPlugin(PluginId string) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -524,7 +524,7 @@ type UserAccessTokenStore interface {
 
 type PluginStore interface {
 	SaveOrUpdate(keyVal *model.PluginKeyValue) StoreChannel
-	CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) StoreChannel
+	CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError)
 	Get(pluginId, key string) StoreChannel
 	Delete(pluginId, key string) StoreChannel
 	DeleteAllForPlugin(PluginId string) StoreChannel

--- a/store/storetest/mocks/PluginStore.go
+++ b/store/storetest/mocks/PluginStore.go
@@ -14,19 +14,26 @@ type PluginStore struct {
 }
 
 // CompareAndUpdate provides a mock function with given fields: keyVal, oldValue
-func (_m *PluginStore) CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) store.StoreChannel {
+func (_m *PluginStore) CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError) {
 	ret := _m.Called(keyVal, oldValue)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(*model.PluginKeyValue, []byte) store.StoreChannel); ok {
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(*model.PluginKeyValue, []byte) bool); ok {
 		r0 = rf(keyVal, oldValue)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(*model.PluginKeyValue, []byte) *model.AppError); ok {
+		r1 = rf(keyVal, oldValue)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
 		}
 	}
 
-	return r0
+	return r0, r1
 }
 
 // Delete provides a mock function with given fields: pluginId, key

--- a/store/storetest/mocks/PluginStore.go
+++ b/store/storetest/mocks/PluginStore.go
@@ -13,8 +13,8 @@ type PluginStore struct {
 	mock.Mock
 }
 
-// CompareAndUpdate provides a mock function with given fields: keyVal, oldValue
-func (_m *PluginStore) CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError) {
+// CompareAndSet provides a mock function with given fields: keyVal, oldValue
+func (_m *PluginStore) CompareAndSet(keyVal *model.PluginKeyValue, oldValue []byte) (bool, *model.AppError) {
 	ret := _m.Called(keyVal, oldValue)
 
 	var r0 bool

--- a/store/storetest/mocks/PluginStore.go
+++ b/store/storetest/mocks/PluginStore.go
@@ -13,6 +13,22 @@ type PluginStore struct {
 	mock.Mock
 }
 
+// CompareAndUpdate provides a mock function with given fields: keyVal, oldValue
+func (_m *PluginStore) CompareAndUpdate(keyVal *model.PluginKeyValue, oldValue []byte) store.StoreChannel {
+	ret := _m.Called(keyVal, oldValue)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(*model.PluginKeyValue, []byte) store.StoreChannel); ok {
+		r0 = rf(keyVal, oldValue)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // Delete provides a mock function with given fields: pluginId, key
 func (_m *PluginStore) Delete(pluginId string, key string) store.StoreChannel {
 	ret := _m.Called(pluginId, key)


### PR DESCRIPTION
#### Summary
Adding transactions semantics to KV store

- Added `KVCompareAndSet(key string, old []byte, new []byte)` to PluginAPI
- Added `CompareAndSet(kv *model.PluginKeyValue, oldValue []byte)` to `PluginStore`
- Added unit tests for `KVCompareAndSet`, `CompareAndSetPluginKey`

Other design considerations:
1. Update `model.PluginKeyValue` struct to include `OldValue []byte` field.
- Decided against it because `PluginKeyValue` struct is used to fetch a kv pair. Don't think it'll be  _clean_  to have a field on that struct called `OldValue`  which has no meaning when fetching a kv pair.

2. Create a new struct `model.UpsertPluginKeyValue` for `PluginStore.SaveOrUpdate(keyVal *model.UpsertPluginKeyValue)`
```
type UpsertPluginKeyValue struct {
	*PluginKeyValue

	// Used to update a key-value pair 
	// if the current value == the old value.
	OldValue []byte
}
```
- Decided against it as it would've made `SaveOrUpdate` really complicated.

3. Update `SaveOrUpdate(kv *model.PluginKeyValue)` to handle all, insert, update, conditional update. Initially my plan was to move forward with this but working through it decided against it as it would've made `SaveOrUpdate` really complicated. So went with a new `CompareAndUpdate(kv *model.PluginKeyValue, oldValue []byte)` api on `PluginStore`.

<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes:
GH: https://github.com/mattermost/mattermost-server/issues/10410
JIRA: https://mattermost.atlassian.net/browse/MM-14246
