### PR TITLE
Add plugin API method to upload other plugins

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -627,7 +627,7 @@ func (api *PluginAPI) SendMail(to, subject, htmlBody string) *model.AppError {
 // Plugin Section
 
 func (api *PluginAPI) UploadPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError) {
-	return nil, api.app.InstallPlugin(file, replace)
+	return api.app.InstallPlugin(file, replace)
 }
 
 func (api *PluginAPI) GetPlugins() ([]*model.Manifest, *model.AppError) {

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -624,6 +625,10 @@ func (api *PluginAPI) SendMail(to, subject, htmlBody string) *model.AppError {
 }
 
 // Plugin Section
+
+func (api *PluginAPI) UploadPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError) {
+	return nil, api.app.InstallPlugin(file, replace)
+}
 
 func (api *PluginAPI) GetPlugins() ([]*model.Manifest, *model.AppError) {
 	plugins, err := api.app.GetPlugins()

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -4,6 +4,8 @@
 package plugin
 
 import (
+	"io"
+
 	plugin "github.com/hashicorp/go-plugin"
 	"github.com/mattermost/mattermost-server/model"
 )
@@ -428,6 +430,11 @@ type API interface {
 	OpenInteractiveDialog(dialog model.OpenDialogRequest) *model.AppError
 
 	// Plugin Section
+
+	// UploadPlugin uploads a plugin compressed in a .tar.gz file.
+	//
+	// Minimum server version: 5.12
+	UploadPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError)
 
 	// GetPlugins will return a list of plugin manifests for currently active plugins.
 	//

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -8,6 +8,7 @@ package plugin
 
 import (
 	"fmt"
+	"io"
 	"log"
 
 	"github.com/mattermost/mattermost-server/mlog"
@@ -3316,6 +3317,36 @@ func (s *apiRPCServer) OpenInteractiveDialog(args *Z_OpenInteractiveDialogArgs, 
 		returns.A = hook.OpenInteractiveDialog(args.A)
 	} else {
 		return encodableError(fmt.Errorf("API OpenInteractiveDialog called but not implemented."))
+	}
+	return nil
+}
+
+type Z_UploadPluginArgs struct {
+	A io.Reader
+	B bool
+}
+
+type Z_UploadPluginReturns struct {
+	A *model.Manifest
+	B *model.AppError
+}
+
+func (g *apiRPCClient) UploadPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError) {
+	_args := &Z_UploadPluginArgs{file, replace}
+	_returns := &Z_UploadPluginReturns{}
+	if err := g.client.Call("Plugin.UploadPlugin", _args, _returns); err != nil {
+		log.Printf("RPC call to UploadPlugin API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) UploadPlugin(args *Z_UploadPluginArgs, returns *Z_UploadPluginReturns) error {
+	if hook, ok := s.impl.(interface {
+		UploadPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.UploadPlugin(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API UploadPlugin called but not implemented."))
 	}
 	return nil
 }

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -4,6 +4,7 @@
 
 package plugintest
 
+import io "io"
 import mock "github.com/stretchr/testify/mock"
 import model "github.com/mattermost/mattermost-server/model"
 
@@ -2677,6 +2678,31 @@ func (_m *API) UploadFile(data []byte, channelId string, filename string) (*mode
 	var r1 *model.AppError
 	if rf, ok := ret.Get(1).(func([]byte, string, string) *model.AppError); ok {
 		r1 = rf(data, channelId, filename)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
+// UploadPlugin provides a mock function with given fields: file, replace
+func (_m *API) UploadPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError) {
+	ret := _m.Called(file, replace)
+
+	var r0 *model.Manifest
+	if rf, ok := ret.Get(0).(func(io.Reader, bool) *model.Manifest); ok {
+		r0 = rf(file, replace)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Manifest)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(io.Reader, bool) *model.AppError); ok {
+		r1 = rf(file, replace)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds a `UploadPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError)` method to the plugin API.

#### Other designs

- I have considered calling the method `InstallPlugin()`, but this indicates that the plugin in running after the method call, what is not the case. `EnablePlugin()` needs to be called after this method to enable it. 2/5
- I considered removing the `replace` parameter, but I would like to keep the flexibility for plugin devs. 3/5
- I did consider adding a unit test for this. But this requires a bundled plugin and it seams to me that getting this done takes more time then it's worth the effort. 1/5

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10289
