### PR TITLE
sqlstore/team: Updates maximum length of AllowedDomains to 1000 characters.

### DIFF
--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -143,7 +143,7 @@ func NewSqlTeamStore(sqlStore SqlStore) store.TeamStore {
 		table.ColMap("Description").SetMaxSize(255)
 		table.ColMap("Email").SetMaxSize(128)
 		table.ColMap("CompanyName").SetMaxSize(64)
-		table.ColMap("AllowedDomains").SetMaxSize(500)
+		table.ColMap("AllowedDomains").SetMaxSize(1000)
 		table.ColMap("InviteId").SetMaxSize(32)
 
 		tablem := db.AddTableWithName(teamMember{}, "TeamMembers").SetKeys(false, "TeamId", "UserId")


### PR DESCRIPTION
#### Summary
We have several different e-mail domains for a team and recently ran
into a length issue while adding an additional one. I did a little bit
of searching and it looks like the only limit is in the ORM mapping
code (here). The column data type seems to be TEXT.
