### PR TITLE
MM-15128 change openDialog to allow dialogs with no elements

### DIFF
--- a/api4/integration_action.go
+++ b/api4/integration_action.go
@@ -79,11 +79,6 @@ func openDialog(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if dialog.Dialog.Elements == nil || len(dialog.Dialog.Elements) == 0 {
-		c.SetInvalidParam("dialog.elements")
-		return
-	}
-
 	if err := c.App.OpenInteractiveDialog(dialog); err != nil {
 		c.Err = err
 		return

--- a/api4/integration_action_test.go
+++ b/api4/integration_action_test.go
@@ -142,16 +142,16 @@ func TestOpenDialog(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 	assert.False(t, pass)
 
-	// At least one element is required
+	// Should pass with no elements
 	request.URL = "http://localhost:8065"
 	request.Dialog.Elements = nil
 	pass, resp = Client.OpenInteractiveDialog(request)
-	CheckBadRequestStatus(t, resp)
-	assert.False(t, pass)
+	CheckNoError(t, resp)
+	assert.True(t, pass)
 	request.Dialog.Elements = []model.DialogElement{}
 	pass, resp = Client.OpenInteractiveDialog(request)
-	CheckBadRequestStatus(t, resp)
-	assert.False(t, pass)
+	CheckNoError(t, resp)
+	assert.True(t, pass)
 }
 
 func TestSubmitDialog(t *testing.T) {


### PR DESCRIPTION


#### Summary
This pull request is to add support for interactive dialogs with no elements (#10686). As far as I know, the small change here should be enough to add support on the server side. As for the web app, we still need to modify the InteractiveDialog component to not require elements. While my experience with react is limited, I think the change needed is to simply drop the .isRequired tag for the array of elements in that component and add proper checks/test cases. Also, as @hanzei said in #10686 we probably need an integration test as well.

If I am missing the scope of the problem, I'll gladly go back and rework the solution 👍. 

#### Ticket Link
Addresses #10686
