### PR TITLE
MM-15328 Fix panic in markdown link parsing

### DIFF
--- a/utils/markdown/autolink.go
+++ b/utils/markdown/autolink.go
@@ -78,6 +78,10 @@ func parseURLAutolink(data string, position int) (Range, bool) {
 		start -= 1
 	}
 
+	if start < 0 || position >= len(data) {
+		return Range{}, false
+	}
+
 	// Ensure that the URL scheme is allowed and that at least one character after the scheme is valid.
 	scheme := data[start:position]
 	if !isSchemeAllowed(scheme) || !isValidHostCharacter(data[position+3:]) {

--- a/utils/markdown/autolink_test.go
+++ b/utils/markdown/autolink_test.go
@@ -130,6 +130,18 @@ func TestParseURLAutolink(t *testing.T) {
 			Position:    14,
 			Expected:    "http://example.com",
 		},
+		{
+			Description: "bad link protocol",
+			Input:       "://///",
+			Position:    0,
+			Expected:    "",
+		},
+		{
+			Description: "position greater than input length",
+			Input:       "there is no colon",
+			Position:    1000,
+			Expected:    "",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
#### Summary
Fix panic in markdown link parsing by making sure we're not accessing a slice out of its bounds.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15328
