### PR TITLE
MM-15367 Do not try to render web app 404 error page when web server is disabled

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -132,11 +132,14 @@ func (a *App) HTMLTemplates() *template.Template {
 }
 
 func (a *App) Handle404(w http.ResponseWriter, r *http.Request) {
-	err := model.NewAppError("Handle404", "api.context.404.app_error", nil, "", http.StatusNotFound)
-
 	mlog.Debug(fmt.Sprintf("%v: code=404 ip=%v", r.URL.Path, utils.GetIpAddress(r)))
 
-	utils.RenderWebAppError(a.Config(), w, r, err, a.AsymmetricSigningKey())
+	if *a.Config().ServiceSettings.WebserverMode == "disabled" {
+		http.NotFound(w, r)
+		return
+	}
+
+	utils.RenderWebAppError(a.Config(), w, r, model.NewAppError("Handle404", "api.context.404.app_error", nil, "", http.StatusNotFound), a.AsymmetricSigningKey())
 }
 
 func (a *App) getSystemInstallDate() (int64, *model.AppError) {

--- a/web/web.go
+++ b/web/web.go
@@ -68,6 +68,8 @@ func Handle404(config configservice.ConfigService, w http.ResponseWriter, r *htt
 		w.WriteHeader(err.StatusCode)
 		err.DetailedError = "There doesn't appear to be an api call for the url='" + r.URL.Path + "'.  Typo? are you missing a team_id or user_id as part of the url?"
 		w.Write([]byte(err.ToJson()))
+	} else if *config.Config().ServiceSettings.WebserverMode == "disabled" {
+		http.NotFound(w, r)
 	} else {
 		utils.RenderWebAppError(config.Config(), w, r, err, config.AsymmetricSigningKey())
 	}


### PR DESCRIPTION
#### Summary
When the web server is disabled just default 404 instead of trying to render the 404 page in the web app. This fixes an infinite redirect loop.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15367