### PR TITLE
made the Restore and Delete store method to be sync

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -585,11 +585,7 @@ func (a *App) postChannelPrivacyMessage(user *model.User, channel *model.Channel
 }
 
 func (a *App) RestoreChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
-	result := <-a.Srv.Store.Channel().Restore(channel.Id, model.GetMillis())
-	if result.Err != nil {
-		return nil, result.Err
-	}
-	return channel, nil
+	return a.Srv.Store.Channel().Restore(channel.Id, model.GetMillis())
 }
 
 func (a *App) PatchChannel(channel *model.Channel, patch *model.ChannelPatch, userId string) (*model.Channel, *model.AppError) {
@@ -873,8 +869,8 @@ func (a *App) DeleteChannel(channel *model.Channel, userId string) *model.AppErr
 
 	deleteAt := model.GetMillis()
 
-	if dresult := <-a.Srv.Store.Channel().Delete(channel.Id, deleteAt); dresult.Err != nil {
-		return dresult.Err
+	if _, err := a.Srv.Store.Channel().Delete(channel.Id, deleteAt); err != nil {
+		return err
 	}
 	a.InvalidateCacheForChannel(channel)
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -585,7 +585,10 @@ func (a *App) postChannelPrivacyMessage(user *model.User, channel *model.Channel
 }
 
 func (a *App) RestoreChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
-	return a.Srv.Store.Channel().Restore(channel.Id, model.GetMillis())
+	if err := a.Srv.Store.Channel().Restore(channel.Id, model.GetMillis()); err != nil {
+		return nil, err
+	}
+	return channel, nil
 }
 
 func (a *App) PatchChannel(channel *model.Channel, patch *model.ChannelPatch, userId string) (*model.Channel, *model.AppError) {
@@ -869,7 +872,7 @@ func (a *App) DeleteChannel(channel *model.Channel, userId string) *model.AppErr
 
 	deleteAt := model.GetMillis()
 
-	if _, err := a.Srv.Store.Channel().Delete(channel.Id, deleteAt); err != nil {
+	if err := a.Srv.Store.Channel().Delete(channel.Id, deleteAt); err != nil {
 		return err
 	}
 	a.InvalidateCacheForChannel(channel)

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -475,7 +475,7 @@ func restoreChannelsCmdF(command *cobra.Command, args []string) error {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
 			continue
 		}
-		if _, err := a.Srv.Store.Channel().SetDeleteAt(channel.Id, 0, model.GetMillis()); err != nil {
+		if err := a.Srv.Store.Channel().SetDeleteAt(channel.Id, 0, model.GetMillis()); err != nil {
 			CommandPrintErrorln("Unable to restore channel '" + args[i] + "'")
 		}
 	}

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -313,8 +313,8 @@ func archiveChannelsCmdF(command *cobra.Command, args []string) error {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
 			continue
 		}
-		if result := <-a.Srv.Store.Channel().Delete(channel.Id, model.GetMillis()); result.Err != nil {
-			CommandPrintErrorln("Unable to archive channel '" + channel.Name + "' error: " + result.Err.Error())
+		if _, err := a.Srv.Store.Channel().Delete(channel.Id, model.GetMillis()); err != nil {
+			CommandPrintErrorln("Unable to archive channel '" + channel.Name + "' error: " + err.Error())
 		}
 	}
 
@@ -475,7 +475,7 @@ func restoreChannelsCmdF(command *cobra.Command, args []string) error {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
 			continue
 		}
-		if result := <-a.Srv.Store.Channel().SetDeleteAt(channel.Id, 0, model.GetMillis()); result.Err != nil {
+		if _, err := a.Srv.Store.Channel().SetDeleteAt(channel.Id, 0, model.GetMillis()); err != nil {
 			CommandPrintErrorln("Unable to restore channel '" + args[i] + "'")
 		}
 	}

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -313,7 +313,7 @@ func archiveChannelsCmdF(command *cobra.Command, args []string) error {
 			CommandPrintErrorln("Unable to find channel '" + args[i] + "'")
 			continue
 		}
-		if _, err := a.Srv.Store.Channel().Delete(channel.Id, model.GetMillis()); err != nil {
+		if err := a.Srv.Store.Channel().Delete(channel.Id, model.GetMillis()); err != nil {
 			CommandPrintErrorln("Unable to archive channel '" + channel.Name + "' error: " + err.Error())
 		}
 	}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -769,21 +769,13 @@ func (s SqlChannelStore) get(id string, master bool, allowFromCache bool) (*mode
 }
 
 // Delete records the given deleted timestamp to the channel in question.
-func (s SqlChannelStore) Delete(channelId string, time int64) (*model.Channel, *model.AppError) {
-	err := s.SetDeleteAt(channelId, time, time)
-	if err != nil {
-		return nil, err
-	}
-	return s.Get(channelId, false)
+func (s SqlChannelStore) Delete(channelId string, time int64) *model.AppError {
+	return s.SetDeleteAt(channelId, time, time)
 }
 
 // Restore reverts a previous deleted timestamp from the channel in question.
-func (s SqlChannelStore) Restore(channelId string, time int64) (*model.Channel, *model.AppError) {
-	err := s.SetDeleteAt(channelId, 0, time)
-	if err != nil {
-		return nil, err
-	}
-	return s.Get(channelId, false)
+func (s SqlChannelStore) Restore(channelId string, time int64) *model.AppError {
+	return s.SetDeleteAt(channelId, 0, time)
 }
 
 // SetDeleteAt records the given deleted and updated timestamp to the channel in question.

--- a/store/store.go
+++ b/store/store.go
@@ -139,7 +139,7 @@ type ChannelStore interface {
 	GetFromMaster(id string) (*model.Channel, *model.AppError)
 	Delete(channelId string, time int64) (*model.Channel, *model.AppError)
 	Restore(channelId string, time int64) (*model.Channel, *model.AppError)
-	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) (*model.Channel, *model.AppError)
+	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) *model.AppError
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	PermanentDelete(channelId string) StoreChannel
 	GetByName(team_id string, name string, allowFromCache bool) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -137,9 +137,9 @@ type ChannelStore interface {
 	InvalidateChannel(id string)
 	InvalidateChannelByName(teamId, name string)
 	GetFromMaster(id string) (*model.Channel, *model.AppError)
-	Delete(channelId string, time int64) StoreChannel
-	Restore(channelId string, time int64) StoreChannel
-	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) StoreChannel
+	Delete(channelId string, time int64) (*model.Channel, *model.AppError)
+	Restore(channelId string, time int64)  (*model.Channel, *model.AppError)
+	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) (*model.Channel, *model.AppError)
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	PermanentDelete(channelId string) StoreChannel
 	GetByName(team_id string, name string, allowFromCache bool) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -137,8 +137,8 @@ type ChannelStore interface {
 	InvalidateChannel(id string)
 	InvalidateChannelByName(teamId, name string)
 	GetFromMaster(id string) (*model.Channel, *model.AppError)
-	Delete(channelId string, time int64) (*model.Channel, *model.AppError)
-	Restore(channelId string, time int64) (*model.Channel, *model.AppError)
+	Delete(channelId string, time int64) *model.AppError
+	Restore(channelId string, time int64) *model.AppError
 	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) *model.AppError
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	PermanentDelete(channelId string) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -138,7 +138,7 @@ type ChannelStore interface {
 	InvalidateChannelByName(teamId, name string)
 	GetFromMaster(id string) (*model.Channel, *model.AppError)
 	Delete(channelId string, time int64) (*model.Channel, *model.AppError)
-	Restore(channelId string, time int64)  (*model.Channel, *model.AppError)
+	Restore(channelId string, time int64) (*model.Channel, *model.AppError)
 	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) (*model.Channel, *model.AppError)
 	PermanentDeleteByTeam(teamId string) StoreChannel
 	PermanentDelete(channelId string) StoreChannel

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -656,7 +656,7 @@ func testChannelStoreGetByName(t *testing.T, ss store.Store) {
 	require.NotNil(t, result.Err, "Missing id should have failed")
 
 	err := ss.Channel().Delete(channelID, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	result = <-ss.Channel().GetByName(o1.TeamId, o1.Name, false)
 	require.NotNil(t, result.Err, "Deleted channel should not be returned by GetByName()")
@@ -705,10 +705,10 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 	}
 
 	err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	err = ss.Channel().Delete(o2.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	r := <-ss.Channel().GetByNames(o1.TeamId, []string{o1.Name}, false)
 	require.Nil(t, r.Err)
@@ -725,7 +725,7 @@ func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o1, -1))
 	now := model.GetMillis()
 	err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 	o1.DeleteAt = now
 	o1.UpdateAt = now
 
@@ -750,7 +750,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 	err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	cresult := <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -790,7 +790,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o3, -1))
 	err = ss.Channel().Delete(o3.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	cresult = <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -1080,7 +1080,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	c2.DeleteAt = model.GetMillis()
 	c2.UpdateAt = c2.DeleteAt
 	err = ss.Channel().Delete(c2.Id, c2.DeleteAt)
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	c3 := model.Channel{}
 	c3.TeamId = t2.Id
@@ -1229,7 +1229,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	}
 	store.Must(ss.Channel().Save(&o7, -1))
 	err := ss.Channel().Delete(o7.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	t.Run("both o3 and o6 listed in more channels", func(t *testing.T) {
 		result := <-ss.Channel().GetMoreChannels(teamId, userId, 0, 100)
@@ -1316,7 +1316,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
 	err := ss.Channel().Delete(o5.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	t.Run("both o1 and o4 listed in public channels", func(t *testing.T) {
 		cresult := <-ss.Channel().GetPublicChannelsForTeam(teamId, 0, 100)
@@ -1409,7 +1409,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	}
 	store.Must(ss.Channel().Save(&oc5, -1))
 	err := ss.Channel().Delete(oc5.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	t.Run("only oc1 and oc4, among others, should be found as a public channel in the team", func(t *testing.T) {
 		result := <-ss.Channel().GetPublicChannelsByIdsForTeam(teamId, []string{oc1.Id, oc2.Id, model.NewId(), pc3.Id, oc4.Id})
@@ -2002,7 +2002,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o10.DeleteAt = model.GetMillis()
 	o10.UpdateAt = o10.DeleteAt
 	err := ss.Channel().Delete(o10.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	t.Run("three public channels matching 'ChannelA', but already a member of one and one deleted", func(t *testing.T) {
 		result := <-ss.Channel().SearchMore(m1.UserId, teamId, "ChannelA")
@@ -2181,7 +2181,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
 	err := ss.Channel().Delete(o13.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	testCases := []struct {
 		Description     string
@@ -2373,7 +2373,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
 	err = ss.Channel().Delete(o13.Id, o13.DeleteAt)
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	testCases := []struct {
 		Description     string
@@ -2472,7 +2472,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	store.Must(ss.Channel().SaveMember(&m3))
 
 	err := ss.Channel().SetDeleteAt(o3.Id, 100, 100)
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
@@ -2634,13 +2634,13 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	}
 
 	err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 	err = ss.Channel().Delete(o2.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 	err = ss.Channel().Delete(p3.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 	err = ss.Channel().Delete(d4.Id, model.GetMillis())
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
 		t.Fatal(result.Err.Error())
@@ -2998,7 +2998,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	o1.UpdateAt = model.GetMillis()
 
 	e := ss.Channel().Delete(o1.Id, o1.DeleteAt)
-	require.Nil(t, e, "Channel must have been deleted")
+	require.Nil(t, e, "channel should have been deleted")
 
 	t.Run("o1 still listed in public channels when marked as deleted", func(t *testing.T) {
 		result := <-ss.Channel().SearchInTeam(teamId, "", true)
@@ -3423,7 +3423,7 @@ func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, ss stor
 
 	o1.DeleteAt = 1
 	err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
-	require.Nil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "channel should have been deleted")
 
 	r1 := <-ss.Channel().GetAllDirectChannelsForExportAfter(10000, strings.Repeat("0", 26))
 	assert.Nil(t, r1.Err)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -529,16 +529,16 @@ func testChannelStoreRestore(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
-	if r := <-ss.Channel().Delete(o1.Id, model.GetMillis()); r.Err != nil {
-		t.Fatal(r.Err)
+	if _, err := ss.Channel().Delete(o1.Id, model.GetMillis()); err != nil {
+		t.Fatal(err)
 	}
 
 	if c, _ := ss.Channel().Get(o1.Id, false); c.DeleteAt == 0 {
 		t.Fatal("should have been deleted")
 	}
 
-	if r := <-ss.Channel().Restore(o1.Id, model.GetMillis()); r.Err != nil {
-		t.Fatal(r.Err)
+	if _, err := ss.Channel().Restore(o1.Id, model.GetMillis()); err != nil {
+		t.Fatal(err)
 	}
 
 	if c, _ := ss.Channel().Get(o1.Id, false); c.DeleteAt != 0 {
@@ -588,16 +588,16 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&m2))
 
-	if r := <-ss.Channel().Delete(o1.Id, model.GetMillis()); r.Err != nil {
-		t.Fatal(r.Err)
+	if _, err := ss.Channel().Delete(o1.Id, model.GetMillis()); err != nil {
+		t.Fatal(err)
 	}
 
 	if c, _ := ss.Channel().Get(o1.Id, false); c.DeleteAt == 0 {
 		t.Fatal("should have been deleted")
 	}
 
-	if r := <-ss.Channel().Delete(o3.Id, model.GetMillis()); r.Err != nil {
-		t.Fatal(r.Err)
+	if _, err := ss.Channel().Delete(o3.Id, model.GetMillis()); err != nil {
+		t.Fatal(err)
 	}
 
 	cresult := <-ss.Channel().GetChannels(o1.TeamId, m1.UserId, false)
@@ -655,7 +655,9 @@ func testChannelStoreGetByName(t *testing.T, ss store.Store) {
 	result = <-ss.Channel().GetByName(o1.TeamId, "", false)
 	require.NotNil(t, result.Err, "Missing id should have failed")
 
-	store.Must(ss.Channel().Delete(channelID, model.GetMillis()))
+	_, err := ss.Channel().Delete(channelID, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
+
 	result = <-ss.Channel().GetByName(o1.TeamId, o1.Name, false)
 	require.NotNil(t, result.Err, "Deleted channel should not be returned by GetByName()")
 }
@@ -702,8 +704,11 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 		assert.Equal(t, tc.ExpectedIds, ids, "tc %v", index)
 	}
 
-	store.Must(ss.Channel().Delete(o1.Id, model.GetMillis()))
-	store.Must(ss.Channel().Delete(o2.Id, model.GetMillis()))
+	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
+
+	_, err = ss.Channel().Delete(o2.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	r := <-ss.Channel().GetByNames(o1.TeamId, []string{o1.Name}, false)
 	require.Nil(t, r.Err)
@@ -719,7 +724,8 @@ func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 	now := model.GetMillis()
-	store.Must(ss.Channel().Delete(o1.Id, now))
+	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 	o1.DeleteAt = now
 	o1.UpdateAt = now
 
@@ -743,7 +749,8 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
-	store.Must(ss.Channel().Delete(o1.Id, model.GetMillis()))
+	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	cresult := <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -782,7 +789,8 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o3, -1))
-	store.Must(ss.Channel().SetDeleteAt(o3.Id, model.GetMillis(), model.GetMillis()))
+	_, err = ss.Channel().Delete(o3.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	cresult = <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -1071,7 +1079,8 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	store.Must(ss.Channel().Save(&c2, -1))
 	c2.DeleteAt = model.GetMillis()
 	c2.UpdateAt = c2.DeleteAt
-	store.Must(ss.Channel().Delete(c2.Id, c2.DeleteAt))
+	_, err = ss.Channel().Delete(c2.Id, c2.DeleteAt)
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	c3 := model.Channel{}
 	c3.TeamId = t2.Id
@@ -1219,7 +1228,8 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o7, -1))
-	store.Must(ss.Channel().Delete(o7.Id, model.GetMillis()))
+	_, err := ss.Channel().Delete(o7.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	t.Run("both o3 and o6 listed in more channels", func(t *testing.T) {
 		result := <-ss.Channel().GetMoreChannels(teamId, userId, 0, 100)
@@ -1305,7 +1315,8 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
-	store.Must(ss.Channel().Delete(o5.Id, model.GetMillis()))
+	_, err := ss.Channel().Delete(o5.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	t.Run("both o1 and o4 listed in public channels", func(t *testing.T) {
 		cresult := <-ss.Channel().GetPublicChannelsForTeam(teamId, 0, 100)
@@ -1397,7 +1408,8 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&oc5, -1))
-	store.Must(ss.Channel().Delete(oc5.Id, model.GetMillis()))
+	_, err := ss.Channel().Delete(oc5.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	t.Run("only oc1 and oc4, among others, should be found as a public channel in the team", func(t *testing.T) {
 		result := <-ss.Channel().GetPublicChannelsByIdsForTeam(teamId, []string{oc1.Id, oc2.Id, model.NewId(), pc3.Id, oc4.Id})
@@ -1989,7 +2001,8 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o10, -1))
 	o10.DeleteAt = model.GetMillis()
 	o10.UpdateAt = o10.DeleteAt
-	store.Must(ss.Channel().Delete(o10.Id, o10.DeleteAt))
+	_, err := ss.Channel().Delete(o10.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	t.Run("three public channels matching 'ChannelA', but already a member of one and one deleted", func(t *testing.T) {
 		result := <-ss.Channel().SearchMore(m1.UserId, teamId, "ChannelA")
@@ -2167,7 +2180,8 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o13, -1))
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
-	store.Must(ss.Channel().Delete(o13.Id, o13.DeleteAt))
+	_, err := ss.Channel().Delete(o13.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	testCases := []struct {
 		Description     string
@@ -2358,7 +2372,8 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o13, -1))
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
-	store.Must(ss.Channel().Delete(o13.Id, o13.DeleteAt))
+	_, err = ss.Channel().Delete(o13.Id, o13.DeleteAt)
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	testCases := []struct {
 		Description     string
@@ -2456,7 +2471,8 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&m3))
 
-	store.Must(ss.Channel().SetDeleteAt(o3.Id, 100, 100))
+	_, err := ss.Channel().SetDeleteAt(o3.Id,100, 100)
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
@@ -2617,10 +2633,14 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 		directStartCount = result.Data.(int64)
 	}
 
-	store.Must(ss.Channel().Delete(o1.Id, model.GetMillis()))
-	store.Must(ss.Channel().Delete(o2.Id, model.GetMillis()))
-	store.Must(ss.Channel().Delete(p3.Id, model.GetMillis()))
-	store.Must(ss.Channel().Delete(d4.Id, model.GetMillis()))
+	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
+	_, err = ss.Channel().Delete(o2.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
+	_, err = ss.Channel().Delete(p3.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
+	_, err = ss.Channel().Delete(d4.Id, model.GetMillis())
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
 		t.Fatal(result.Err.Error())
@@ -2976,7 +2996,9 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 
 	o1.DeleteAt = model.GetMillis()
 	o1.UpdateAt = model.GetMillis()
-	store.Must(ss.Channel().Delete(o1.Id, o1.DeleteAt))
+
+	_, error := ss.Channel().Delete(o1.Id, o1.DeleteAt)
+	require.NotNil(t, error, "Channel must have been deleted")
 
 	t.Run("o1 still listed in public channels when marked as deleted", func(t *testing.T) {
 		result := <-ss.Channel().SearchInTeam(teamId, "", true)
@@ -3397,11 +3419,11 @@ func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, ss stor
 	m2.UserId = u2.Id
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 
-	result := <-ss.Channel().SaveDirectChannel(&o1, &m1, &m2)
+	_ = <-ss.Channel().SaveDirectChannel(&o1, &m1, &m2)
 
 	o1.DeleteAt = 1
-	result = <-ss.Channel().SetDeleteAt(o1.Id, 1, 1)
-	assert.Nil(t, result.Err)
+	_, err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
+	require.NotNil(t, err, "Channel must have been deleted")
 
 	r1 := <-ss.Channel().GetAllDirectChannelsForExportAfter(10000, strings.Repeat("0", 26))
 	assert.Nil(t, r1.Err)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -656,7 +656,7 @@ func testChannelStoreGetByName(t *testing.T, ss store.Store) {
 	require.NotNil(t, result.Err, "Missing id should have failed")
 
 	_, err := ss.Channel().Delete(channelID, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	result = <-ss.Channel().GetByName(o1.TeamId, o1.Name, false)
 	require.NotNil(t, result.Err, "Deleted channel should not be returned by GetByName()")
@@ -705,10 +705,10 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 	}
 
 	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	_, err = ss.Channel().Delete(o2.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	r := <-ss.Channel().GetByNames(o1.TeamId, []string{o1.Name}, false)
 	require.Nil(t, r.Err)
@@ -725,7 +725,7 @@ func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o1, -1))
 	now := model.GetMillis()
 	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 	o1.DeleteAt = now
 	o1.UpdateAt = now
 
@@ -750,7 +750,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	cresult := <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -790,7 +790,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o3, -1))
 	_, err = ss.Channel().Delete(o3.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	cresult = <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
 	if cresult.Err != nil {
@@ -1080,7 +1080,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	c2.DeleteAt = model.GetMillis()
 	c2.UpdateAt = c2.DeleteAt
 	_, err = ss.Channel().Delete(c2.Id, c2.DeleteAt)
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	c3 := model.Channel{}
 	c3.TeamId = t2.Id
@@ -1229,7 +1229,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	}
 	store.Must(ss.Channel().Save(&o7, -1))
 	_, err := ss.Channel().Delete(o7.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("both o3 and o6 listed in more channels", func(t *testing.T) {
 		result := <-ss.Channel().GetMoreChannels(teamId, userId, 0, 100)
@@ -1316,7 +1316,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
 	_, err := ss.Channel().Delete(o5.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("both o1 and o4 listed in public channels", func(t *testing.T) {
 		cresult := <-ss.Channel().GetPublicChannelsForTeam(teamId, 0, 100)
@@ -1409,7 +1409,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	}
 	store.Must(ss.Channel().Save(&oc5, -1))
 	_, err := ss.Channel().Delete(oc5.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("only oc1 and oc4, among others, should be found as a public channel in the team", func(t *testing.T) {
 		result := <-ss.Channel().GetPublicChannelsByIdsForTeam(teamId, []string{oc1.Id, oc2.Id, model.NewId(), pc3.Id, oc4.Id})
@@ -2002,7 +2002,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o10.DeleteAt = model.GetMillis()
 	o10.UpdateAt = o10.DeleteAt
 	_, err := ss.Channel().Delete(o10.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("three public channels matching 'ChannelA', but already a member of one and one deleted", func(t *testing.T) {
 		result := <-ss.Channel().SearchMore(m1.UserId, teamId, "ChannelA")
@@ -2181,7 +2181,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
 	_, err := ss.Channel().Delete(o13.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	testCases := []struct {
 		Description     string
@@ -2373,7 +2373,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
 	_, err = ss.Channel().Delete(o13.Id, o13.DeleteAt)
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	testCases := []struct {
 		Description     string
@@ -2472,7 +2472,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	store.Must(ss.Channel().SaveMember(&m3))
 
 	_, err := ss.Channel().SetDeleteAt(o3.Id, 100, 100)
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
@@ -2634,13 +2634,13 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	}
 
 	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 	_, err = ss.Channel().Delete(o2.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 	_, err = ss.Channel().Delete(p3.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 	_, err = ss.Channel().Delete(d4.Id, model.GetMillis())
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
 		t.Fatal(result.Err.Error())
@@ -2997,8 +2997,8 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	o1.DeleteAt = model.GetMillis()
 	o1.UpdateAt = model.GetMillis()
 
-	_, error := ss.Channel().Delete(o1.Id, o1.DeleteAt)
-	require.NotNil(t, error, "Channel must have been deleted")
+	_, e := ss.Channel().Delete(o1.Id, o1.DeleteAt)
+	require.Nil(t, e, "Channel must have been deleted")
 
 	t.Run("o1 still listed in public channels when marked as deleted", func(t *testing.T) {
 		result := <-ss.Channel().SearchInTeam(teamId, "", true)
@@ -3423,7 +3423,7 @@ func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, ss stor
 
 	o1.DeleteAt = 1
 	_, err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
-	require.NotNil(t, err, "Channel must have been deleted")
+	require.Nil(t, err, "Channel must have been deleted")
 
 	r1 := <-ss.Channel().GetAllDirectChannelsForExportAfter(10000, strings.Repeat("0", 26))
 	assert.Nil(t, r1.Err)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -529,7 +529,7 @@ func testChannelStoreRestore(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
-	if _, err := ss.Channel().Delete(o1.Id, model.GetMillis()); err != nil {
+	if err := ss.Channel().Delete(o1.Id, model.GetMillis()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -537,7 +537,7 @@ func testChannelStoreRestore(t *testing.T, ss store.Store) {
 		t.Fatal("should have been deleted")
 	}
 
-	if _, err := ss.Channel().Restore(o1.Id, model.GetMillis()); err != nil {
+	if err := ss.Channel().Restore(o1.Id, model.GetMillis()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -588,7 +588,7 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	m2.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&m2))
 
-	if _, err := ss.Channel().Delete(o1.Id, model.GetMillis()); err != nil {
+	if err := ss.Channel().Delete(o1.Id, model.GetMillis()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -596,7 +596,7 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 		t.Fatal("should have been deleted")
 	}
 
-	if _, err := ss.Channel().Delete(o3.Id, model.GetMillis()); err != nil {
+	if err := ss.Channel().Delete(o3.Id, model.GetMillis()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -655,7 +655,7 @@ func testChannelStoreGetByName(t *testing.T, ss store.Store) {
 	result = <-ss.Channel().GetByName(o1.TeamId, "", false)
 	require.NotNil(t, result.Err, "Missing id should have failed")
 
-	_, err := ss.Channel().Delete(channelID, model.GetMillis())
+	err := ss.Channel().Delete(channelID, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	result = <-ss.Channel().GetByName(o1.TeamId, o1.Name, false)
@@ -704,10 +704,10 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 		assert.Equal(t, tc.ExpectedIds, ids, "tc %v", index)
 	}
 
-	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	err := ss.Channel().Delete(o1.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
-	_, err = ss.Channel().Delete(o2.Id, model.GetMillis())
+	err = ss.Channel().Delete(o2.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	r := <-ss.Channel().GetByNames(o1.TeamId, []string{o1.Name}, false)
@@ -724,7 +724,7 @@ func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 	now := model.GetMillis()
-	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	err := ss.Channel().Delete(o1.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 	o1.DeleteAt = now
 	o1.UpdateAt = now
@@ -749,7 +749,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
-	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	err := ss.Channel().Delete(o1.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	cresult := <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
@@ -789,7 +789,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o3.Name = "zz" + model.NewId() + "b"
 	o3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o3, -1))
-	_, err = ss.Channel().Delete(o3.Id, model.GetMillis())
+	err = ss.Channel().Delete(o3.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	cresult = <-ss.Channel().GetDeleted(o1.TeamId, 0, 100)
@@ -1079,7 +1079,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	store.Must(ss.Channel().Save(&c2, -1))
 	c2.DeleteAt = model.GetMillis()
 	c2.UpdateAt = c2.DeleteAt
-	_, err = ss.Channel().Delete(c2.Id, c2.DeleteAt)
+	err = ss.Channel().Delete(c2.Id, c2.DeleteAt)
 	require.Nil(t, err, "Channel must have been deleted")
 
 	c3 := model.Channel{}
@@ -1228,7 +1228,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o7, -1))
-	_, err := ss.Channel().Delete(o7.Id, model.GetMillis())
+	err := ss.Channel().Delete(o7.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("both o3 and o6 listed in more channels", func(t *testing.T) {
@@ -1315,7 +1315,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
-	_, err := ss.Channel().Delete(o5.Id, model.GetMillis())
+	err := ss.Channel().Delete(o5.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("both o1 and o4 listed in public channels", func(t *testing.T) {
@@ -1408,7 +1408,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&oc5, -1))
-	_, err := ss.Channel().Delete(oc5.Id, model.GetMillis())
+	err := ss.Channel().Delete(oc5.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("only oc1 and oc4, among others, should be found as a public channel in the team", func(t *testing.T) {
@@ -2001,7 +2001,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o10, -1))
 	o10.DeleteAt = model.GetMillis()
 	o10.UpdateAt = o10.DeleteAt
-	_, err := ss.Channel().Delete(o10.Id, model.GetMillis())
+	err := ss.Channel().Delete(o10.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	t.Run("three public channels matching 'ChannelA', but already a member of one and one deleted", func(t *testing.T) {
@@ -2180,7 +2180,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o13, -1))
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
-	_, err := ss.Channel().Delete(o13.Id, model.GetMillis())
+	err := ss.Channel().Delete(o13.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	testCases := []struct {
@@ -2372,7 +2372,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().Save(&o13, -1))
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
-	_, err = ss.Channel().Delete(o13.Id, o13.DeleteAt)
+	err = ss.Channel().Delete(o13.Id, o13.DeleteAt)
 	require.Nil(t, err, "Channel must have been deleted")
 
 	testCases := []struct {
@@ -2633,13 +2633,13 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 		directStartCount = result.Data.(int64)
 	}
 
-	_, err := ss.Channel().Delete(o1.Id, model.GetMillis())
+	err := ss.Channel().Delete(o1.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
-	_, err = ss.Channel().Delete(o2.Id, model.GetMillis())
+	err = ss.Channel().Delete(o2.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
-	_, err = ss.Channel().Delete(p3.Id, model.GetMillis())
+	err = ss.Channel().Delete(p3.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
-	_, err = ss.Channel().Delete(d4.Id, model.GetMillis())
+	err = ss.Channel().Delete(d4.Id, model.GetMillis())
 	require.Nil(t, err, "Channel must have been deleted")
 
 	if result := <-ss.Channel().AnalyticsDeletedTypeCount("", "O"); result.Err != nil {
@@ -2997,7 +2997,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	o1.DeleteAt = model.GetMillis()
 	o1.UpdateAt = model.GetMillis()
 
-	_, e := ss.Channel().Delete(o1.Id, o1.DeleteAt)
+	e := ss.Channel().Delete(o1.Id, o1.DeleteAt)
 	require.Nil(t, e, "Channel must have been deleted")
 
 	t.Run("o1 still listed in public channels when marked as deleted", func(t *testing.T) {

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -2471,7 +2471,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&m3))
 
-	_, err := ss.Channel().SetDeleteAt(o3.Id,100, 100)
+	_, err := ss.Channel().SetDeleteAt(o3.Id, 100, 100)
 	require.NotNil(t, err, "Channel must have been deleted")
 
 	o4 := model.Channel{}

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -2471,7 +2471,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	m3.NotifyProps = model.GetDefaultChannelNotifyProps()
 	store.Must(ss.Channel().SaveMember(&m3))
 
-	_, err := ss.Channel().SetDeleteAt(o3.Id, 100, 100)
+	err := ss.Channel().SetDeleteAt(o3.Id, 100, 100)
 	require.Nil(t, err, "Channel must have been deleted")
 
 	o4 := model.Channel{}
@@ -3422,7 +3422,7 @@ func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, ss stor
 	_ = <-ss.Channel().SaveDirectChannel(&o1, &m1, &m2)
 
 	o1.DeleteAt = 1
-	_, err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
+	err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
 	require.Nil(t, err, "Channel must have been deleted")
 
 	r1 := <-ss.Channel().GetAllDirectChannelsForExportAfter(10000, strings.Repeat("0", 26))

--- a/store/storetest/group_supplier.go
+++ b/store/storetest/group_supplier.go
@@ -1169,7 +1169,7 @@ func testPendingAutoAddChannelMembers(t *testing.T, ss store.Store) {
 	require.Len(t, res.Data, 1)
 
 	// No result if Channel deleted
-	_, err := ss.Channel().Delete(channel.Id, model.GetMillis())
+	err := ss.Channel().Delete(channel.Id, model.GetMillis())
 	require.Nil(t, err)
 	res = <-ss.Group().ChannelMembersToAdd(0)
 	require.Nil(t, res.Err)
@@ -1177,7 +1177,7 @@ func testPendingAutoAddChannelMembers(t *testing.T, ss store.Store) {
 
 	// reset state of channel and verify
 	channel.DeleteAt = 0
-	_, err := ss.Channel().Update(channel)
+	_, err = ss.Channel().Update(channel)
 	require.Nil(t, err)
 	res = <-ss.Group().ChannelMembersToAdd(0)
 	require.Nil(t, res.Err)

--- a/store/storetest/group_supplier.go
+++ b/store/storetest/group_supplier.go
@@ -1169,8 +1169,8 @@ func testPendingAutoAddChannelMembers(t *testing.T, ss store.Store) {
 	require.Len(t, res.Data, 1)
 
 	// No result if Channel deleted
-	res = <-ss.Channel().Delete(channel.Id, model.GetMillis())
-	require.Nil(t, res.Err)
+	_, err := ss.Channel().Delete(channel.Id, model.GetMillis())
+	require.Nil(t, err)
 	res = <-ss.Group().ChannelMembersToAdd(0)
 	require.Nil(t, res.Err)
 	require.Len(t, res.Data, 0)

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -115,19 +115,28 @@ func (_m *ChannelStore) CreateDirectChannel(userId string, otherUserId string) s
 }
 
 // Delete provides a mock function with given fields: channelId, time
-func (_m *ChannelStore) Delete(channelId string, time int64) store.StoreChannel {
+func (_m *ChannelStore) Delete(channelId string, time int64) (*model.Channel, *model.AppError) {
 	ret := _m.Called(channelId, time)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+	var r0 *model.Channel
+	if rf, ok := ret.Get(0).(func(string, int64) *model.Channel); ok {
 		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Channel)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
+		r1 = rf(channelId, time)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // Get provides a mock function with given fields: id, allowFromCache
@@ -922,19 +931,28 @@ func (_m *ChannelStore) ResetAllChannelSchemes() store.StoreChannel {
 }
 
 // Restore provides a mock function with given fields: channelId, time
-func (_m *ChannelStore) Restore(channelId string, time int64) store.StoreChannel {
+func (_m *ChannelStore) Restore(channelId string, time int64) (*model.Channel, *model.AppError) {
 	ret := _m.Called(channelId, time)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+	var r0 *model.Channel
+	if rf, ok := ret.Get(0).(func(string, int64) *model.Channel); ok {
 		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Channel)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
+		r1 = rf(channelId, time)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // Save provides a mock function with given fields: channel, maxChannelsPerTeam
@@ -1034,19 +1052,28 @@ func (_m *ChannelStore) SearchMore(userId string, teamId string, term string) st
 }
 
 // SetDeleteAt provides a mock function with given fields: channelId, deleteAt, updateAt
-func (_m *ChannelStore) SetDeleteAt(channelId string, deleteAt int64, updateAt int64) store.StoreChannel {
+func (_m *ChannelStore) SetDeleteAt(channelId string, deleteAt int64, updateAt int64) (*model.Channel, *model.AppError) {
 	ret := _m.Called(channelId, deleteAt, updateAt)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64, int64) store.StoreChannel); ok {
+	var r0 *model.Channel
+	if rf, ok := ret.Get(0).(func(string, int64, int64) *model.Channel); ok {
 		r0 = rf(channelId, deleteAt, updateAt)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Channel)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64, int64) *model.AppError); ok {
+		r1 = rf(channelId, deleteAt, updateAt)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // Update provides a mock function with given fields: channel

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -1052,28 +1052,19 @@ func (_m *ChannelStore) SearchMore(userId string, teamId string, term string) st
 }
 
 // SetDeleteAt provides a mock function with given fields: channelId, deleteAt, updateAt
-func (_m *ChannelStore) SetDeleteAt(channelId string, deleteAt int64, updateAt int64) (*model.Channel, *model.AppError) {
+func (_m *ChannelStore) SetDeleteAt(channelId string, deleteAt int64, updateAt int64) *model.AppError {
 	ret := _m.Called(channelId, deleteAt, updateAt)
 
-	var r0 *model.Channel
-	if rf, ok := ret.Get(0).(func(string, int64, int64) *model.Channel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, int64, int64) *model.AppError); ok {
 		r0 = rf(channelId, deleteAt, updateAt)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.Channel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, int64, int64) *model.AppError); ok {
-		r1 = rf(channelId, deleteAt, updateAt)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
-	}
-
-	return r0, r1
+	return r0
 }
 
 // Update provides a mock function with given fields: channel

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -115,28 +115,19 @@ func (_m *ChannelStore) CreateDirectChannel(userId string, otherUserId string) s
 }
 
 // Delete provides a mock function with given fields: channelId, time
-func (_m *ChannelStore) Delete(channelId string, time int64) (*model.Channel, *model.AppError) {
+func (_m *ChannelStore) Delete(channelId string, time int64) *model.AppError {
 	ret := _m.Called(channelId, time)
 
-	var r0 *model.Channel
-	if rf, ok := ret.Get(0).(func(string, int64) *model.Channel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, int64) *model.AppError); ok {
 		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.Channel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
-		r1 = rf(channelId, time)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
-	}
-
-	return r0, r1
+	return r0
 }
 
 // Get provides a mock function with given fields: id, allowFromCache
@@ -931,28 +922,19 @@ func (_m *ChannelStore) ResetAllChannelSchemes() store.StoreChannel {
 }
 
 // Restore provides a mock function with given fields: channelId, time
-func (_m *ChannelStore) Restore(channelId string, time int64) (*model.Channel, *model.AppError) {
+func (_m *ChannelStore) Restore(channelId string, time int64) *model.AppError {
 	ret := _m.Called(channelId, time)
 
-	var r0 *model.Channel
-	if rf, ok := ret.Get(0).(func(string, int64) *model.Channel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, int64) *model.AppError); ok {
 		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.Channel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
-		r1 = rf(channelId, time)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
-	}
-
-	return r0, r1
+	return r0
 }
 
 // Save provides a mock function with given fields: channel, maxChannelsPerTeam

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -2073,7 +2073,7 @@ func testPostStoreGetDirectPostParentsForExportAfterDeleted(t *testing.T, ss sto
 	<-ss.Channel().SaveDirectChannel(&o1, &m1, &m2)
 
 	o1.DeleteAt = 1
-	_, err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
+	err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
 	assert.Nil(t, err)
 
 	p1 := &model.Post{}

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -899,7 +899,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	c3.Name = "zz" + model.NewId() + "b"
 	c3.Type = model.CHANNEL_OPEN
 	c3 = (<-ss.Channel().Save(c3, -1)).Data.(*model.Channel)
-	<-ss.Channel().Delete(c3.Id, model.GetMillis())
+	ss.Channel().Delete(c3.Id, model.GetMillis())
 
 	m3 := model.ChannelMember{}
 	m3.ChannelId = c3.Id
@@ -2073,8 +2073,8 @@ func testPostStoreGetDirectPostParentsForExportAfterDeleted(t *testing.T, ss sto
 	<-ss.Channel().SaveDirectChannel(&o1, &m1, &m2)
 
 	o1.DeleteAt = 1
-	result := <-ss.Channel().SetDeleteAt(o1.Id, 1, 1)
-	assert.Nil(t, result.Err)
+	_, err := ss.Channel().SetDeleteAt(o1.Id, 1, 1)
+	assert.Nil(t, err)
 
 	p1 := &model.Post{}
 	p1.ChannelId = o1.Id


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Makes the store method Restore and Delete Channel sync

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10765
