### PR TITLE
Add unread API for scrolling overhaul

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -233,7 +233,7 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 	if len(etag) > 0 {
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 	}
-	w.Write([]byte(c.App.PostListWithProxyAddedToImageURLs(postList).ToJson()))
+	w.Write([]byte(clientPostList.ToJson()))
 }
 
 func getFlaggedPostsForUser(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/post.go
+++ b/api4/post.go
@@ -21,8 +21,9 @@ func (api *API) InitPost() {
 	api.BaseRoutes.Post.Handle("/thread", api.ApiSessionRequired(getPostThread)).Methods("GET")
 	api.BaseRoutes.Post.Handle("/files/info", api.ApiSessionRequired(getFileInfosForPost)).Methods("GET")
 	api.BaseRoutes.PostsForChannel.Handle("", api.ApiSessionRequired(getPostsForChannel)).Methods("GET")
-	api.BaseRoutes.PostsForChannel.Handle("/unread", api.ApiSessionRequired(getPostsForChannelAroundLastUnread)).Methods("GET")
 	api.BaseRoutes.PostsForUser.Handle("/flagged", api.ApiSessionRequired(getFlaggedPostsForUser)).Methods("GET")
+
+	api.BaseRoutes.ChannelForUser.Handle("/posts/unread", api.ApiSessionRequired(getPostsForChannelAroundLastUnread)).Methods("GET")
 
 	api.BaseRoutes.Team.Handle("/posts/search", api.ApiSessionRequired(searchPosts)).Methods("POST")
 	api.BaseRoutes.Post.Handle("", api.ApiSessionRequired(updatePost)).Methods("PUT")
@@ -175,8 +176,14 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *http.Request) {
-	c.RequireChannelId()
+	c.RequireUserId().RequireChannelId()
 	if c.Err != nil {
+		return
+	}
+
+	userId := c.Params.UserId
+	if !c.App.SessionHasPermissionToUser(c.Session, userId) {
+		c.SetPermissionError(model.PERMISSION_EDIT_OTHER_USERS)
 		return
 	}
 
@@ -186,7 +193,7 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 		return
 	}
 
-	postList, err := c.App.GetPostsForChannelAroundLastUnread(channelId, c.Session.UserId)
+	postList, err := c.App.GetPostsForChannelAroundLastUnread(channelId, userId, c.Params.LimitBefore, c.Params.LimitAfter)
 	if err != nil {
 		c.Err = err
 		return
@@ -200,7 +207,7 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 			return
 		}
 
-		postList, err = c.App.GetPostsPage(channelId, app.PAGE_DEFAULT, app.PER_PAGE_DEFAULT)
+		postList, err = c.App.GetPostsPage(channelId, app.PAGE_DEFAULT, c.Params.LimitBefore)
 	}
 
 	if len(etag) > 0 {

--- a/api4/post.go
+++ b/api4/post.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -20,6 +21,7 @@ func (api *API) InitPost() {
 	api.BaseRoutes.Post.Handle("/thread", api.ApiSessionRequired(getPostThread)).Methods("GET")
 	api.BaseRoutes.Post.Handle("/files/info", api.ApiSessionRequired(getFileInfosForPost)).Methods("GET")
 	api.BaseRoutes.PostsForChannel.Handle("", api.ApiSessionRequired(getPostsForChannel)).Methods("GET")
+	api.BaseRoutes.PostsForChannel.Handle("/unread", api.ApiSessionRequired(getPostsForChannelAroundLastUnread)).Methods("GET")
 	api.BaseRoutes.PostsForUser.Handle("/flagged", api.ApiSessionRequired(getFlaggedPostsForUser)).Methods("GET")
 
 	api.BaseRoutes.Team.Handle("/posts/search", api.ApiSessionRequired(searchPosts)).Methods("POST")
@@ -133,7 +135,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	etag := ""
 
 	if since > 0 {
-		list, err = c.App.GetPostsSince(c.Params.ChannelId, since)
+		list, err = c.App.GetPostsSince(c.Params.ChannelId, since, app.MAX_LIMIT_POSTS_SINCE)
 	} else if len(afterPost) > 0 {
 		etag = c.App.GetPostsEtag(c.Params.ChannelId)
 
@@ -170,6 +172,41 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write([]byte(c.App.PreparePostListForClient(list).ToJson()))
+}
+
+func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	channelId := c.Params.ChannelId
+	if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_READ_CHANNEL) {
+		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
+		return
+	}
+
+	postList, err := c.App.GetPostsForChannelAroundLastUnread(channelId, c.Session.UserId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	etag := ""
+	if len(postList.Order) == 0 {
+		etag = c.App.GetPostsEtag(channelId)
+
+		if c.HandleEtag(etag, "Get Posts", w, r) {
+			return
+		}
+
+		postList, err = c.App.GetPostsPage(channelId, app.PAGE_DEFAULT, app.PER_PAGE_DEFAULT)
+	}
+
+	if len(etag) > 0 {
+		w.Header().Set(model.HEADER_ETAG_SERVER, etag)
+	}
+	w.Write([]byte(c.App.PostListWithProxyAddedToImageURLs(postList).ToJson()))
 }
 
 func getFlaggedPostsForUser(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/post.go
+++ b/api4/post.go
@@ -112,12 +112,20 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	afterPost := r.URL.Query().Get("after")
-	beforePost := r.URL.Query().Get("before")
-	sinceString := r.URL.Query().Get("since")
+	if len(afterPost) > 0 && len(afterPost) != 26 {
+		c.SetInvalidParam("after")
+		return
+	}
 
+	beforePost := r.URL.Query().Get("before")
+	if len(beforePost) > 0 && len(beforePost) != 26 {
+		c.SetInvalidParam("before")
+		return
+	}
+
+	sinceString := r.URL.Query().Get("since")
 	var since int64
 	var parseError error
-
 	if len(sinceString) > 0 {
 		since, parseError = strconv.ParseInt(sinceString, 10, 64)
 		if parseError != nil {
@@ -126,7 +134,11 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if !c.App.SessionHasPermissionToChannel(c.App.Session, c.Params.ChannelId, model.PERMISSION_READ_CHANNEL) {
+	channelId := c.Params.ChannelId
+	page := c.Params.Page
+	perPage := c.Params.PerPage
+
+	if !c.App.SessionHasPermissionToChannel(c.App.Session, channelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -136,31 +148,31 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	etag := ""
 
 	if since > 0 {
-		list, err = c.App.GetPostsSince(c.Params.ChannelId, since, app.MAX_LIMIT_POSTS_SINCE)
+		list, err = c.App.GetPostsSince(channelId, since, app.MAX_LIMIT_POSTS_SINCE)
 	} else if len(afterPost) > 0 {
-		etag = c.App.GetPostsEtag(c.Params.ChannelId)
+		etag = c.App.GetPostsEtag(channelId)
 
 		if c.HandleEtag(etag, "Get Posts After", w, r) {
 			return
 		}
 
-		list, err = c.App.GetPostsAfterPost(c.Params.ChannelId, afterPost, c.Params.Page, c.Params.PerPage)
+		list, err = c.App.GetPostsAfterPost(channelId, afterPost, page, perPage)
 	} else if len(beforePost) > 0 {
-		etag = c.App.GetPostsEtag(c.Params.ChannelId)
+		etag = c.App.GetPostsEtag(channelId)
 
 		if c.HandleEtag(etag, "Get Posts Before", w, r) {
 			return
 		}
 
-		list, err = c.App.GetPostsBeforePost(c.Params.ChannelId, beforePost, c.Params.Page, c.Params.PerPage)
+		list, err = c.App.GetPostsBeforePost(channelId, beforePost, page, perPage)
 	} else {
-		etag = c.App.GetPostsEtag(c.Params.ChannelId)
+		etag = c.App.GetPostsEtag(channelId)
 
 		if c.HandleEtag(etag, "Get Posts", w, r) {
 			return
 		}
 
-		list, err = c.App.GetPostsPage(c.Params.ChannelId, c.Params.Page, c.Params.PerPage)
+		list, err = c.App.GetPostsPage(channelId, page, perPage)
 	}
 
 	if err != nil {
@@ -172,7 +184,10 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 	}
 
-	w.Write([]byte(c.App.PreparePostListForClient(list).ToJson()))
+	c.App.AddCursorIdsForPostList(list, afterPost, beforePost, since, page, perPage)
+	clientPostList := c.App.PreparePostListForClient(list)
+
+	w.Write([]byte(clientPostList.ToJson()))
 }
 
 func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -182,13 +197,13 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 	}
 
 	userId := c.Params.UserId
-	if !c.App.SessionHasPermissionToUser(c.Session, userId) {
+	if !c.App.SessionHasPermissionToUser(c.App.Session, userId) {
 		c.SetPermissionError(model.PERMISSION_EDIT_OTHER_USERS)
 		return
 	}
 
 	channelId := c.Params.ChannelId
-	if !c.App.SessionHasPermissionToChannel(c.Session, channelId, model.PERMISSION_READ_CHANNEL) {
+	if !c.App.SessionHasPermissionToChannel(c.App.Session, channelId, model.PERMISSION_READ_CHANNEL) {
 		c.SetPermissionError(model.PERMISSION_READ_CHANNEL)
 		return
 	}
@@ -209,6 +224,11 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 
 		postList, err = c.App.GetPostsPage(channelId, app.PAGE_DEFAULT, c.Params.LimitBefore)
 	}
+
+	postList.NextPostId = c.App.GetNextPostIdFromPostList(postList)
+	postList.PrevPostId = c.App.GetPrevPostIdFromPostList(postList)
+
+	clientPostList := c.App.PreparePostListForClient(postList)
 
 	if len(etag) > 0 {
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
 	"github.com/mattermost/mattermost-server/utils/testutils"
 )
@@ -1271,6 +1272,165 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 
 	if len(posts.Posts) != 0 {
 		t.Fatal("should have no posts")
+	}
+}
+
+func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	Client := th.Client
+	userId := th.BasicUser.Id
+	channelId := th.BasicChannel.Id
+
+	post := &model.Post{}
+	post.ChannelId = channelId
+	post.UserId = userId
+
+	// create 100 posts (1-100), and marked 41st post as the last before post
+	var lastBeforePostId string
+	for i := 1; i <= 100; i++ {
+		post.Id = ""
+		post.Message = "zz" + model.NewId() + "a"
+		post.CreateAt = int64(i) * 2
+
+		if i == 41 {
+			lastBeforePost := store.Must(th.App.Srv.Store.Post().Save(post)).(*model.Post)
+			lastBeforePostId = lastBeforePost.Id
+		} else {
+			store.Must(th.App.Srv.Store.Post().Save(post))
+		}
+	}
+
+	// All returned posts are all read by the user, since it's created by the user itself.
+	posts, resp := Client.GetPostsAroundLastUnread(userId, channelId, 10, 20)
+	CheckNoError(t, resp)
+
+	if len(posts.Order) != 10 {
+		t.Fatal("Should return 10 posts only since there's no unread post")
+	}
+
+	// Set channel member's last viewed to 0.
+	// All returned posts are latest posts as if all previous posts were already read by the user.
+	channelMember := store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember.LastViewedAt = 0
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 20, 40)
+	CheckNoError(t, resp)
+
+	if len(posts.Order) != 20 {
+		t.Fatal("Should return 20 posts only since there's no unread post")
+	}
+
+	// create next 10 posts (101-110), and marked 101st as the last unread post
+	var lastUnreadPostId string
+	var lastUnreadPostCreateAt int64
+	for i := 101; i <= 110; i++ {
+		post.Id = ""
+		post.Message = "zz" + model.NewId() + "a"
+		post.CreateAt = int64(i) * 2
+
+		if i == 101 {
+			lastUnreadPost := store.Must(th.App.Srv.Store.Post().Save(post)).(*model.Post)
+			lastUnreadPostId = lastUnreadPost.Id
+			lastUnreadPostCreateAt = lastUnreadPost.CreateAt
+		} else {
+			store.Must(th.App.Srv.Store.Post().Save(post))
+		}
+	}
+
+	since := lastUnreadPostCreateAt - 1
+	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember.LastViewedAt = since
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 60, 60)
+	CheckNoError(t, resp)
+
+	// should return 70 + 2 posts (system_join_channel and initial post)
+	if len(posts.Order) != 72 {
+		t.Fatal("Should return 70 posts")
+	}
+
+	for i, postId := range posts.Order {
+		post = posts.Posts[postId]
+		if i < 12 {
+			if post.CreateAt < channelMember.LastViewedAt {
+				t.Fatal("Should be unread post")
+			}
+		}
+
+		if i == 11 {
+			if post.Id != lastUnreadPostId {
+				t.Fatal("Should match the last unread post")
+			}
+		}
+
+		if i == 71 {
+			if post.Id != lastBeforePostId {
+				t.Fatal("Should match the last unread post")
+			}
+		}
+	}
+
+	// create next 100 posts (111-210), and marked 160th post as the recent unread post
+	var recentUnreadPostId string
+	for i := 111; i <= 210; i++ {
+		post.Id = ""
+		post.Message = "zz" + model.NewId() + "a"
+		post.CreateAt = int64(i) * 2
+		if i == 160 {
+			recentUnreadPost := store.Must(th.App.Srv.Store.Post().Save(post)).(*model.Post)
+			recentUnreadPostId = recentUnreadPost.Id
+		} else {
+			store.Must(th.App.Srv.Store.Post().Save(post))
+		}
+	}
+
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 60, 60)
+	CheckNoError(t, resp)
+
+	if len(posts.Order) != 120 {
+		t.Fatal("Should return 120 posts")
+	}
+
+	for i, postId := range posts.Order {
+		post = posts.Posts[postId]
+
+		// the 1st post should match the recent unread post
+		if i == 0 {
+			if post.Id != recentUnreadPostId {
+				t.Fatal("Should match recent unread post")
+			}
+		}
+
+		// 0 - 59th posts should be all unread posts
+		if i < 60 {
+			if post.CreateAt < channelMember.LastViewedAt {
+				t.Fatal("Should be unread post")
+			}
+		}
+
+		// 60th - 120th posts should be all read posts
+		if i >= 60 {
+			if post.CreateAt > channelMember.LastViewedAt {
+				t.Fatal("Should be read post")
+			}
+		}
+
+		// index 59 or 60th post should equal to last unread post
+		if i == 59 {
+			if post.Id != lastUnreadPostId {
+				t.Fatal("Should match the last unread post")
+			}
+		}
+
+		// index 119 or 120th post should equal to last before post
+		if i == 119 {
+			if post.Id != lastBeforePostId {
+				t.Fatal("Should match the last before post")
+			}
+		}
 	}
 }
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -912,6 +912,13 @@ func TestGetPostsForChannel(t *testing.T) {
 		t.Log(posts.Posts)
 		t.Fatal("should return 2 posts")
 	}
+	// "since" query to return empty NextPostId and PrevPostId
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
 
 	found := make([]bool, 2)
 	for _, p := range posts.Posts {
@@ -946,6 +953,97 @@ func TestGetPostsForChannel(t *testing.T) {
 
 	_, resp = th.SystemAdminClient.GetPostsForChannel(th.BasicChannel.Id, 0, 60, "")
 	CheckNoError(t, resp)
+
+	// more tests for next_post_id, prev_post_id, and order
+	// There are 12 posts composed of first 2 system messages and 10 created posts
+	Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+	th.CreatePost() // post6
+	post7 := th.CreatePost()
+	post8 := th.CreatePost()
+	th.CreatePost() // post9
+	post10 := th.CreatePost()
+
+	// get the system post IDs posted before the created posts above
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post1.Id, 0, 2, "")
+	systemPostId1 := posts.Order[1]
+
+	// similar to '/posts'
+	posts, resp = Client.GetPostsForChannel(th.BasicChannel.Id, 0, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 12 || posts.Order[0] != post10.Id || posts.Order[11] != systemPostId1 {
+		t.Fatal("should return 12 posts and match order")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+
+	// similar to '/posts?per_page=3'
+	posts, resp = Client.GetPostsForChannel(th.BasicChannel.Id, 0, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post10.Id || posts.Order[2] != post8.Id {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != post7.Id {
+		t.Fatal("should return post7.Id as PrevPostId")
+	}
+
+	// similar to '/posts?per_page=3&page=1'
+	posts, resp = Client.GetPostsForChannel(th.BasicChannel.Id, 1, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post7.Id || posts.Order[2] != post5.Id {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post8.Id {
+		t.Fatal("should return post8.Id as NextPostId")
+	}
+	if posts.PrevPostId != post4.Id {
+		t.Fatal("should return post4.Id as PrevPostId")
+	}
+
+	// similar to '/posts?per_page=3&page=2'
+	posts, resp = Client.GetPostsForChannel(th.BasicChannel.Id, 2, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post4.Id || posts.Order[2] != post2.Id {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post5.Id {
+		t.Fatal("should return post5.Id as NextPostId")
+	}
+	if posts.PrevPostId != post1.Id {
+		t.Fatal("should return post1.Id as PrevPostId")
+	}
+
+	// similar to '/posts?per_page=3&page=3'
+	posts, resp = Client.GetPostsForChannel(th.BasicChannel.Id, 3, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post1.Id || posts.Order[2] != systemPostId1 {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post2.Id {
+		t.Fatal("should return post2.Id as NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+
+	// similar to '/posts?per_page=3&page=4'
+	posts, resp = Client.GetPostsForChannel(th.BasicChannel.Id, 4, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 0 {
+		t.Fatal("should return 0 post")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
 }
 
 func TestGetFlaggedPostsForUser(t *testing.T) {
@@ -1191,7 +1289,7 @@ func TestGetFlaggedPostsForUser(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
-func TestGetPostsAfterAndBefore(t *testing.T) {
+func TestGetPostsBefore(t *testing.T) {
 	th := Setup().InitBasic()
 	defer th.TearDown()
 	Client := th.Client
@@ -1224,24 +1322,208 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 		}
 	}
 
-	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post3.Id, 1, 1, "")
+	if posts.NextPostId != post3.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should match empty PrevPostId")
+	}
+
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post4.Id, 1, 1, "")
 	CheckNoError(t, resp)
 
 	if len(posts.Posts) != 1 {
 		t.Fatal("too many posts returned")
 	}
-
-	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, "junk", 1, 1, "")
-	CheckNoError(t, resp)
-
-	if len(posts.Posts) != 0 {
-		t.Fatal("should have no posts")
+	if posts.Order[0] != post2.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post3.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PrevPostId != post1.Id {
+		t.Fatal("should match PrevPostId")
 	}
 
-	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post3.Id, 0, 100, "")
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, "junk", 1, 1, "")
+	CheckBadRequestStatus(t, resp)
+
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post5.Id, 0, 3, "")
 	CheckNoError(t, resp)
 
-	found = make([]bool, 2)
+	if len(posts.Posts) != 3 {
+		t.Fatal("should match length of posts returned")
+	}
+	if posts.Order[0] != post4.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.Order[2] != post2.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post5.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PrevPostId != post1.Id {
+		t.Fatal("should match PrevPostId")
+	}
+
+	// get the system post IDs posted before the created posts above
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post1.Id, 0, 2, "")
+	CheckNoError(t, resp)
+	systemPostId2 := posts.Order[0]
+	systemPostId1 := posts.Order[1]
+
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post5.Id, 1, 3, "")
+	CheckNoError(t, resp)
+
+	if len(posts.Posts) != 3 {
+		t.Fatal("should match length of posts returned")
+	}
+	if posts.Order[0] != post1.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.Order[1] != systemPostId2 {
+		t.Fatal("should match returned post")
+	}
+	if posts.Order[2] != systemPostId1 {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post2.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return empty PrevPostId")
+	}
+
+	// more tests for next_post_id, prev_post_id, and order
+	// There are 12 posts composed of first 2 system messages and 10 created posts
+	post6 := th.CreatePost()
+	th.CreatePost() // post7
+	post8 := th.CreatePost()
+	post9 := th.CreatePost()
+	th.CreatePost() // post10
+
+	// similar to '/posts?before=post9'
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post9.Id, 0, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 10 || posts.Order[0] != post8.Id || posts.Order[9] != systemPostId1 {
+		t.Fatal("should return 10 posts and match order")
+	}
+	if posts.NextPostId != post9.Id {
+		t.Fatal("should return post9.Id as NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+
+	// similar to '/posts?before=post9&per_page=3'
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post9.Id, 0, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post8.Id || posts.Order[2] != post6.Id {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post9.Id {
+		t.Fatal("should return post9.Id as NextPostId")
+	}
+	if posts.PrevPostId != post5.Id {
+		t.Fatal("should return post5.Id as PrevPostId")
+	}
+
+	// similar to '/posts?before=post9&per_page=3&page=1'
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post9.Id, 1, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post5.Id || posts.Order[2] != post3.Id {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post6.Id {
+		t.Fatal("should return post6.Id as NextPostId")
+	}
+	if posts.PrevPostId != post2.Id {
+		t.Fatal("should return post2.Id as PrevPostId")
+	}
+
+	// similar to '/posts?before=post9&per_page=3&page=2'
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post9.Id, 2, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post2.Id || posts.Order[2] != systemPostId2 {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post3.Id {
+		t.Fatal("should return post3.Id as NextPostId")
+	}
+	if posts.PrevPostId != systemPostId1 {
+		t.Fatal("should return systemPostId1 as PrevPostId")
+	}
+
+	// similar to '/posts?before=post1&per_page=3'
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post1.Id, 0, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 2 || posts.Order[0] != systemPostId2 || posts.Order[1] != systemPostId1 {
+		t.Fatal("should return 2 posts and match order")
+	}
+	if posts.NextPostId != post1.Id {
+		t.Fatal("should return post1.Id as NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+
+	// similar to '/posts?before=systemPostId1'
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, systemPostId1, 0, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 0 {
+		t.Fatal("should return 0 post")
+	}
+	if posts.NextPostId != systemPostId1 {
+		t.Fatal("should return systemPostId1 as NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+
+	// similar to '/posts?before=systemPostId1&per_page=60&page=1'
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, systemPostId1, 1, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 0 {
+		t.Fatal("should return 0 post")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+
+	// similar to '/posts?before=non-existent-post'
+	nonExistentPostId := model.NewId()
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, nonExistentPostId, 0, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 0 {
+		t.Fatal("should return 0 post")
+	}
+	if posts.NextPostId != nonExistentPostId {
+		t.Fatal("should return nonExistentPostId as NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+}
+
+func TestGetPostsAfter(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+	Client := th.Client
+
+	post1 := th.CreatePost()
+	post2 := th.CreatePost()
+	post3 := th.CreatePost()
+	post4 := th.CreatePost()
+	post5 := th.CreatePost()
+
+	posts, resp := Client.GetPostsAfter(th.BasicChannel.Id, post3.Id, 0, 100, "")
+	CheckNoError(t, resp)
+
+	found := make([]bool, 2)
 	for _, p := range posts.Posts {
 		if p.Id == post4.Id {
 			found[0] = true
@@ -1260,18 +1542,165 @@ func TestGetPostsAfterAndBefore(t *testing.T) {
 		}
 	}
 
-	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post3.Id, 1, 1, "")
+	if posts.NextPostId != "" {
+		t.Fatal("should match empty NextPostId")
+	}
+	if posts.PrevPostId != post3.Id {
+		t.Fatal("should match PrevPostId")
+	}
+
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post2.Id, 1, 1, "")
 	CheckNoError(t, resp)
 
 	if len(posts.Posts) != 1 {
 		t.Fatal("too many posts returned")
 	}
+	if posts.Order[0] != post4.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post5.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PrevPostId != post3.Id {
+		t.Fatal("should match PrevPostId")
+	}
 
 	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, "junk", 1, 1, "")
+	CheckBadRequestStatus(t, resp)
+
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post1.Id, 0, 3, "")
 	CheckNoError(t, resp)
 
-	if len(posts.Posts) != 0 {
-		t.Fatal("should have no posts")
+	if len(posts.Posts) != 3 {
+		t.Fatal("should match length of posts returned")
+	}
+	if posts.Order[0] != post4.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.Order[2] != post2.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != post5.Id {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PrevPostId != post1.Id {
+		t.Fatal("should match PrevPostId")
+	}
+
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post1.Id, 1, 3, "")
+	CheckNoError(t, resp)
+
+	if len(posts.Posts) != 1 {
+		t.Fatal("should match length of posts returned")
+	}
+	if posts.Order[0] != post5.Id {
+		t.Fatal("should match returned post")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should match NextPostId")
+	}
+	if posts.PrevPostId != post4.Id {
+		t.Fatal("should match PrevPostId")
+	}
+
+	// more tests for next_post_id, prev_post_id, and order
+	// There are 12 posts composed of first 2 system messages and 10 created posts
+	post6 := th.CreatePost()
+	th.CreatePost() // post7
+	post8 := th.CreatePost()
+	post9 := th.CreatePost()
+	post10 := th.CreatePost()
+
+	// similar to '/posts?after=post2'
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post2.Id, 0, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 8 || posts.Order[0] != post10.Id || posts.Order[7] != post3.Id {
+		t.Fatal("should return 8 posts and match order")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != post2.Id {
+		t.Fatal("should return post2.Id as PrevPostId")
+	}
+
+	// similar to '/posts?after=post2&per_page=3'
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post2.Id, 0, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post5.Id || posts.Order[2] != post3.Id {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post6.Id {
+		t.Fatal("should return post6.Id as NextPostId")
+	}
+	if posts.PrevPostId != post2.Id {
+		t.Fatal("should return post2.Id as PrevPostId")
+	}
+
+	// similar to '/posts?after=post2&per_page=3&page=1'
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post2.Id, 1, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 3 || posts.Order[0] != post8.Id || posts.Order[2] != post6.Id {
+		t.Fatal("should return 3 posts and match order")
+	}
+	if posts.NextPostId != post9.Id {
+		t.Fatal("should return post9.Id as NextPostId")
+	}
+	if posts.PrevPostId != post5.Id {
+		t.Fatal("should return post5.Id as PrevPostId")
+	}
+
+	// similar to '/posts?after=post2&per_page=3&page=2'
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post2.Id, 2, 3, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 2 || posts.Order[0] != post10.Id || posts.Order[1] != post9.Id {
+		t.Fatal("should return 2 posts and match order")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != post8.Id {
+		t.Fatal("should return post8.Id as PrevPostId")
+	}
+
+	// similar to '/posts?after=post10'
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post10.Id, 0, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 0 {
+		t.Fatal("should return 0 post")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != post10.Id {
+		t.Fatal("should return post10.Id as PrevPostId")
+	}
+
+	// similar to '/posts?after=post10&page=1'
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, post10.Id, 1, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 0 {
+		t.Fatal("should return 0 post")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
+	}
+
+	// similar to '/posts?after=non-existent-post'
+	nonExistentPostId := model.NewId()
+	posts, resp = Client.GetPostsAfter(th.BasicChannel.Id, nonExistentPostId, 0, 60, "")
+	CheckNoError(t, resp)
+	if len(posts.Order) != 0 {
+		t.Fatal("should return 0 post")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != nonExistentPostId {
+		t.Fatal("should return nonExistentPostId as PrevPostId")
 	}
 }
 
@@ -1282,31 +1711,24 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	userId := th.BasicUser.Id
 	channelId := th.BasicChannel.Id
 
-	post := &model.Post{}
-	post.ChannelId = channelId
-	post.UserId = userId
-
-	// create 100 posts (1-100), and marked 41st post as the last before post
-	var lastBeforePostId string
-	for i := 1; i <= 100; i++ {
-		post.Id = ""
-		post.Message = "zz" + model.NewId() + "a"
-		post.CreateAt = int64(i) * 2
-
-		if i == 41 {
-			lastBeforePost := store.Must(th.App.Srv.Store.Post().Save(post)).(*model.Post)
-			lastBeforePostId = lastBeforePost.Id
-		} else {
-			store.Must(th.App.Srv.Store.Post().Save(post))
-		}
-	}
+	// 12 posts = 2 systems posts + 10 created posts below
+	post1 := th.CreatePost()
+	post2 := th.CreatePost()
+	post3 := th.CreatePost()
+	post4 := th.CreatePost()
+	th.CreatePost() // post5
+	post6 := th.CreatePost()
+	post7 := th.CreatePost()
+	post8 := th.CreatePost()
+	post9 := th.CreatePost()
+	post10 := th.CreatePost()
 
 	// All returned posts are all read by the user, since it's created by the user itself.
-	posts, resp := Client.GetPostsAroundLastUnread(userId, channelId, 10, 20)
+	posts, resp := Client.GetPostsAroundLastUnread(userId, channelId, 20, 20)
 	CheckNoError(t, resp)
 
-	if len(posts.Order) != 10 {
-		t.Fatal("Should return 10 posts only since there's no unread post")
+	if len(posts.Order) != 12 {
+		t.Fatal("Should return 12 posts only since there's no unread post")
 	}
 
 	// Set channel member's last viewed to 0.
@@ -1314,123 +1736,94 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	channelMember := store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
 	channelMember.LastViewedAt = 0
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
 
-	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 20, 40)
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 20, 20)
 	CheckNoError(t, resp)
 
-	if len(posts.Order) != 20 {
-		t.Fatal("Should return 20 posts only since there's no unread post")
+	if len(posts.Order) != 12 {
+		t.Fatal("Should return 12 posts only since there's no unread post")
 	}
 
-	// create next 10 posts (101-110), and marked 101st as the last unread post
-	var lastUnreadPostId string
-	var lastUnreadPostCreateAt int64
-	for i := 101; i <= 110; i++ {
-		post.Id = ""
-		post.Message = "zz" + model.NewId() + "a"
-		post.CreateAt = int64(i) * 2
-
-		if i == 101 {
-			lastUnreadPost := store.Must(th.App.Srv.Store.Post().Save(post)).(*model.Post)
-			lastUnreadPostId = lastUnreadPost.Id
-			lastUnreadPostCreateAt = lastUnreadPost.CreateAt
-		} else {
-			store.Must(th.App.Srv.Store.Post().Save(post))
-		}
-	}
-
-	since := lastUnreadPostCreateAt - 1
+	// Set channel member's last viewed before post1.
 	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
-	channelMember.LastViewedAt = since
+	channelMember.LastViewedAt = post1.CreateAt - 1
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
 
-	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 60, 60)
+	// get the first system post generated before the created posts above
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post1.Id, 0, 2, "")
+	CheckNoError(t, resp)
+	systemPostId1 := posts.Order[1]
+
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 3, 3)
 	CheckNoError(t, resp)
 
-	// should return 70 + 2 posts (system_join_channel and initial post)
-	if len(posts.Order) != 72 {
-		t.Fatal("Should return 70 posts")
+	if len(posts.Order) != 5 || posts.Order[0] != post3.Id || posts.Order[4] != systemPostId1 {
+		t.Fatal("Should return 5 posts and match order")
+	}
+	if posts.NextPostId != post4.Id {
+		t.Fatal("should return post4.Id as NextPostId")
+	}
+	if posts.PrevPostId != "" {
+		t.Fatal("should return an empty PrevPostId")
 	}
 
-	for i, postId := range posts.Order {
-		post = posts.Posts[postId]
-		if i < 12 {
-			if post.CreateAt < channelMember.LastViewedAt {
-				t.Fatal("Should be unread post")
-			}
-		}
+	// Set channel member's last viewed before post6.
+	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember.LastViewedAt = post6.CreateAt - 1
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
 
-		if i == 11 {
-			if post.Id != lastUnreadPostId {
-				t.Fatal("Should match the last unread post")
-			}
-		}
-
-		if i == 71 {
-			if post.Id != lastBeforePostId {
-				t.Fatal("Should match the last unread post")
-			}
-		}
-	}
-
-	// create next 100 posts (111-210), and marked 160th post as the recent unread post
-	var recentUnreadPostId string
-	for i := 111; i <= 210; i++ {
-		post.Id = ""
-		post.Message = "zz" + model.NewId() + "a"
-		post.CreateAt = int64(i) * 2
-		if i == 160 {
-			recentUnreadPost := store.Must(th.App.Srv.Store.Post().Save(post)).(*model.Post)
-			recentUnreadPostId = recentUnreadPost.Id
-		} else {
-			store.Must(th.App.Srv.Store.Post().Save(post))
-		}
-	}
-
-	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 60, 60)
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 3, 3)
 	CheckNoError(t, resp)
 
-	if len(posts.Order) != 120 {
-		t.Fatal("Should return 120 posts")
+	if len(posts.Order) != 6 || posts.Order[0] != post8.Id || posts.Order[5] != post3.Id {
+		t.Fatal("Should return 6 posts and match order")
+	}
+	if posts.NextPostId != post9.Id {
+		t.Fatal("should return post8.Id as NextPostId")
+	}
+	if posts.PrevPostId != post2.Id {
+		t.Fatal("should return post2.Id as PrevPostId")
 	}
 
-	for i, postId := range posts.Order {
-		post = posts.Posts[postId]
+	// Set channel member's last viewed before post10.
+	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember.LastViewedAt = post10.CreateAt - 1
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
 
-		// the 1st post should match the recent unread post
-		if i == 0 {
-			if post.Id != recentUnreadPostId {
-				t.Fatal("Should match recent unread post")
-			}
-		}
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 3, 3)
+	CheckNoError(t, resp)
 
-		// 0 - 59th posts should be all unread posts
-		if i < 60 {
-			if post.CreateAt < channelMember.LastViewedAt {
-				t.Fatal("Should be unread post")
-			}
-		}
+	if len(posts.Order) != 4 || posts.Order[0] != post10.Id || posts.Order[3] != post7.Id {
+		t.Fatal("Should return 4 posts and match order")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != post6.Id {
+		t.Fatal("should return post6.Id as PrevPostId")
+	}
 
-		// 60th - 120th posts should be all read posts
-		if i >= 60 {
-			if post.CreateAt > channelMember.LastViewedAt {
-				t.Fatal("Should be read post")
-			}
-		}
+	// Set channel member's last viewed equal to post10.
+	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember.LastViewedAt = post10.CreateAt
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
 
-		// index 59 or 60th post should equal to last unread post
-		if i == 59 {
-			if post.Id != lastUnreadPostId {
-				t.Fatal("Should match the last unread post")
-			}
-		}
+	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 3, 3)
+	CheckNoError(t, resp)
 
-		// index 119 or 120th post should equal to last before post
-		if i == 119 {
-			if post.Id != lastBeforePostId {
-				t.Fatal("Should match the last before post")
-			}
-		}
+	if len(posts.Order) != 3 || posts.Order[0] != post10.Id || posts.Order[2] != post8.Id {
+		t.Fatal("Should return 3 posts and match order")
+	}
+	if posts.NextPostId != "" {
+		t.Fatal("should return an empty NextPostId")
+	}
+	if posts.PrevPostId != post7.Id {
+		t.Fatal("should return post7.Id as PrevPostId")
 	}
 }
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/app"
 	"github.com/mattermost/mattermost-server/model"
@@ -1733,7 +1734,8 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 
 	// Set channel member's last viewed to 0.
 	// All returned posts are latest posts as if all previous posts were already read by the user.
-	channelMember := store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember, err := th.App.Srv.Store.Channel().GetMember(channelId, userId)
+	require.Nil(t, err)
 	channelMember.LastViewedAt = 0
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
 	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
@@ -1745,16 +1747,17 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 		t.Fatal("Should return 12 posts only since there's no unread post")
 	}
 
-	// Set channel member's last viewed before post1.
-	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
-	channelMember.LastViewedAt = post1.CreateAt - 1
-	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
-	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
-
 	// get the first system post generated before the created posts above
 	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post1.Id, 0, 2, "")
 	CheckNoError(t, resp)
 	systemPostId1 := posts.Order[1]
+
+	// Set channel member's last viewed before post1.
+	channelMember, err = th.App.Srv.Store.Channel().GetMember(channelId, userId)
+	require.Nil(t, err)
+	channelMember.LastViewedAt = post1.CreateAt - 1
+	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
+	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
 
 	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 3, 3)
 	CheckNoError(t, resp)
@@ -1770,7 +1773,8 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	}
 
 	// Set channel member's last viewed before post6.
-	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember, err = th.App.Srv.Store.Channel().GetMember(channelId, userId)
+	require.Nil(t, err)
 	channelMember.LastViewedAt = post6.CreateAt - 1
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
 	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
@@ -1789,7 +1793,8 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	}
 
 	// Set channel member's last viewed before post10.
-	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember, err = th.App.Srv.Store.Channel().GetMember(channelId, userId)
+	require.Nil(t, err)
 	channelMember.LastViewedAt = post10.CreateAt - 1
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
 	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
@@ -1808,7 +1813,8 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 	}
 
 	// Set channel member's last viewed equal to post10.
-	channelMember = store.Must(th.App.Srv.Store.Channel().GetMember(channelId, userId)).(*model.ChannelMember)
+	channelMember, err = th.App.Srv.Store.Channel().GetMember(channelId, userId)
+	require.Nil(t, err)
 	channelMember.LastViewedAt = post10.CreateAt
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
 	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -465,7 +465,7 @@ func (api *PluginAPI) GetPost(postId string) (*model.Post, *model.AppError) {
 }
 
 func (api *PluginAPI) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
-	return api.app.GetPostsSince(channelId, time)
+	return api.app.GetPostsSince(channelId, time, MAX_LIMIT_POSTS_SINCE)
 }
 
 func (api *PluginAPI) GetPostsAfter(channelId, postId string, page, perPage int) (*model.PostList, *model.AppError) {

--- a/app/post.go
+++ b/app/post.go
@@ -719,6 +719,102 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 	return result.Data.(*model.PostList), nil
 }
 
+func (a *App) GetPostAfterTime(channelId string, time int64) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostAfterTime(channelId, time)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.(*model.Post), nil
+}
+
+func (a *App) GetPostBeforeTime(channelId string, time int64) (*model.Post, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostBeforeTime(channelId, time)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+
+	return result.Data.(*model.Post), nil
+}
+
+func (a *App) GetNextPostIdFromPostList(postList *model.PostList) string {
+	if len(postList.Order) > 0 {
+		firstPostId := postList.Order[0]
+		firstPost := postList.Posts[firstPostId]
+		nextPost, err := a.GetPostAfterTime(firstPost.ChannelId, firstPost.CreateAt)
+		if err != nil {
+			mlog.Error("GetNextPostIdFromPostList: failed in getting next post", mlog.Any("err", err))
+		}
+
+		if nextPost != nil {
+			return nextPost.Id
+		}
+	}
+
+	return ""
+}
+
+func (a *App) GetPrevPostIdFromPostList(postList *model.PostList) string {
+	if len(postList.Order) > 0 {
+		lastPostId := postList.Order[len(postList.Order)-1]
+		lastPost := postList.Posts[lastPostId]
+		previousPost, err := a.GetPostBeforeTime(lastPost.ChannelId, lastPost.CreateAt)
+		if err != nil {
+			mlog.Error("GetPrevPostIdFromPostList: failed in getting previous post", mlog.Any("err", err))
+		}
+
+		if previousPost != nil {
+			return previousPost.Id
+		}
+	}
+
+	return ""
+}
+
+// AddCursorIdsForPostList adds NextPostId and PrevPostId as cursor to the PostList.
+// The conditional blocks ensure that it sets those cursor IDs immediately as afterPost, beforePost or empty,
+// and only query to database whenever necessary.
+func (a *App) AddCursorIdsForPostList(originalList *model.PostList, afterPost, beforePost string, since int64, page, perPage int) {
+	prevPostIdSet := false
+	prevPostId := ""
+	nextPostIdSet := false
+	nextPostId := ""
+
+	if since > 0 { // "since" query to return empty NextPostId and PrevPostId
+		nextPostIdSet = true
+		prevPostIdSet = true
+	} else if afterPost != "" {
+		if page == 0 {
+			prevPostId = afterPost
+			prevPostIdSet = true
+		}
+
+		if len(originalList.Order) < perPage {
+			nextPostIdSet = true
+		}
+	} else if beforePost != "" {
+		if page == 0 {
+			nextPostId = beforePost
+			nextPostIdSet = true
+		}
+
+		if len(originalList.Order) < perPage {
+			prevPostIdSet = true
+		}
+	}
+
+	if !nextPostIdSet {
+		nextPostId = a.GetNextPostIdFromPostList(originalList)
+	}
+
+	if !prevPostIdSet {
+		prevPostId = a.GetPrevPostIdFromPostList(originalList)
+	}
+
+	originalList.NextPostId = nextPostId
+	originalList.PrevPostId = prevPostId
+}
+
 func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string, limitBefore, limitAfter int) (*model.PostList, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError

--- a/app/post.go
+++ b/app/post.go
@@ -22,7 +22,6 @@ const (
 	PENDING_POST_IDS_CACHE_TTL  = 30 * time.Second
 	MAX_LIMIT_POSTS_SINCE       = 1000
 	PAGE_DEFAULT                = 0
-	PER_PAGE_DEFAULT            = 60
 )
 
 func (a *App) CreatePostAsUser(post *model.Post, currentSessionId string) (*model.Post, *model.AppError) {
@@ -720,7 +719,7 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 	return result.Data.(*model.PostList), nil
 }
 
-func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string) (*model.PostList, *model.AppError) {
+func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string, limitBefore, limitAfter int) (*model.PostList, *model.AppError) {
 	var member *model.ChannelMember
 	var err *model.AppError
 	if member, err = a.GetChannelMember(channelId, userId); err != nil {
@@ -730,7 +729,7 @@ func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string) (*mod
 	}
 
 	var postListSince *model.PostList
-	if postListSince, err = a.GetPostsSince(channelId, member.LastViewedAt, PER_PAGE_DEFAULT); err != nil {
+	if postListSince, err = a.GetPostsSince(channelId, member.LastViewedAt, limitAfter); err != nil {
 		return nil, err
 	} else if len(postListSince.Order) == 0 {
 		return model.NewPostList(), nil
@@ -739,7 +738,7 @@ func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string) (*mod
 	var lastUnreadPostId = postListSince.Order[len(postListSince.Order)-1]
 	var postListBefore *model.PostList
 	if lastUnreadPostId != "" {
-		if postListBefore, err = a.GetPostsBeforePost(channelId, lastUnreadPostId, PAGE_DEFAULT, PER_PAGE_DEFAULT); err != nil {
+		if postListBefore, err = a.GetPostsBeforePost(channelId, lastUnreadPostId, PAGE_DEFAULT, limitBefore); err != nil {
 			return nil, err
 		}
 	}

--- a/app/post.go
+++ b/app/post.go
@@ -20,6 +20,9 @@ import (
 const (
 	PENDING_POST_IDS_CACHE_SIZE = 25000
 	PENDING_POST_IDS_CACHE_TTL  = 30 * time.Second
+	MAX_LIMIT_POSTS_SINCE       = 1000
+	PAGE_DEFAULT                = 0
+	PER_PAGE_DEFAULT            = 60
 )
 
 func (a *App) CreatePostAsUser(post *model.Post, currentSessionId string) (*model.Post, *model.AppError) {
@@ -614,8 +617,8 @@ func (a *App) GetPostsEtag(channelId string) string {
 	return (<-a.Srv.Store.Post().GetEtag(channelId, true)).Data.(string)
 }
 
-func (a *App) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
-	result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, true)
+func (a *App) GetPostsSince(channelId string, time int64, limit int) (*model.PostList, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, limit, true)
 	if result.Err != nil {
 		return nil, result.Err
 	}
@@ -715,6 +718,38 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 		return nil, result.Err
 	}
 	return result.Data.(*model.PostList), nil
+}
+
+func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string) (*model.PostList, *model.AppError) {
+	var member *model.ChannelMember
+	var err *model.AppError
+	if member, err = a.GetChannelMember(channelId, userId); err != nil {
+		return nil, err
+	} else if member.LastViewedAt == 0 {
+		return model.NewPostList(), nil
+	}
+
+	var postListSince *model.PostList
+	if postListSince, err = a.GetPostsSince(channelId, member.LastViewedAt, PER_PAGE_DEFAULT); err != nil {
+		return nil, err
+	} else if len(postListSince.Order) == 0 {
+		return model.NewPostList(), nil
+	}
+
+	var lastUnreadPostId = postListSince.Order[len(postListSince.Order)-1]
+	var postListBefore *model.PostList
+	if lastUnreadPostId != "" {
+		if postListBefore, err = a.GetPostsBeforePost(channelId, lastUnreadPostId, PAGE_DEFAULT, PER_PAGE_DEFAULT); err != nil {
+			return nil, err
+		}
+	}
+
+	if postListBefore != nil {
+		postListSince.Extend(postListBefore)
+	}
+
+	postListSince.SortByCreateAt()
+	return postListSince, nil
 }
 
 func (a *App) DeletePost(postId, deleteByID string) (*model.Post, *model.AppError) {

--- a/app/post.go
+++ b/app/post.go
@@ -743,7 +743,7 @@ func (a *App) GetNextPostIdFromPostList(postList *model.PostList) string {
 		firstPost := postList.Posts[firstPostId]
 		nextPost, err := a.GetPostAfterTime(firstPost.ChannelId, firstPost.CreateAt)
 		if err != nil {
-			mlog.Error("GetNextPostIdFromPostList: failed in getting next post", mlog.Any("err", err))
+			mlog.Warn("GetNextPostIdFromPostList: failed in getting next post", mlog.Err(err))
 		}
 
 		if nextPost != nil {
@@ -760,7 +760,7 @@ func (a *App) GetPrevPostIdFromPostList(postList *model.PostList) string {
 		lastPost := postList.Posts[lastPostId]
 		previousPost, err := a.GetPostBeforeTime(lastPost.ChannelId, lastPost.CreateAt)
 		if err != nil {
-			mlog.Error("GetPrevPostIdFromPostList: failed in getting previous post", mlog.Any("err", err))
+			mlog.Warn("GetPrevPostIdFromPostList: failed in getting previous post", mlog.Err(err))
 		}
 
 		if previousPost != nil {
@@ -831,7 +831,7 @@ func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string, limit
 		return model.NewPostList(), nil
 	}
 
-	var lastUnreadPostId = postListSince.Order[len(postListSince.Order)-1]
+	var lastUnreadPostId = postListSince.Order[0]
 	var postListBefore *model.PostList
 	if lastUnreadPostId != "" {
 		if postListBefore, err = a.GetPostsBeforePost(channelId, lastUnreadPostId, PAGE_DEFAULT, limitBefore); err != nil {

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -40,8 +40,10 @@ func (a *App) InitPostMetadata() {
 
 func (a *App) PreparePostListForClient(originalList *model.PostList) *model.PostList {
 	list := &model.PostList{
-		Posts: make(map[string]*model.Post, len(originalList.Posts)),
-		Order: originalList.Order, // Note that this uses the original Order array, so it isn't a deep copy
+		Posts:      make(map[string]*model.Post, len(originalList.Posts)),
+		Order:      originalList.Order,
+		NextPostId: originalList.NextPostId,
+		PrevPostId: originalList.PrevPostId,
 	}
 
 	for id, originalPost := range originalList.Posts {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6015,6 +6015,10 @@
     "translation": "Unable to get the parent post for the channel"
   },
   {
+    "id": "store.sql_post.get_post_around.get.app_error",
+    "translation": "Unable to get post around time bound"
+  },
+  {
     "id": "store.sql_post.get_posts.app_error",
     "translation": "Limit exceeded for paging"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -2431,8 +2431,9 @@ func (c *Client4) GetPostsBefore(channelId, postId string, page, perPage int, et
 }
 
 // GetPostsAroundLastUnread gets a list of posts around last unread post by a user in a channel.
-func (c *Client4) GetPostsAroundLastUnread(channelId string) (*PostList, *Response) {
-	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts/unread", ""); err != nil {
+func (c *Client4) GetPostsAroundLastUnread(userId, channelId string, limitBefore, limitAfter int) (*PostList, *Response) {
+	query := fmt.Sprintf("?limit_before=%v&limit_after=%v", limitBefore, limitAfter)
+	if r, err := c.DoApiGet(c.GetUserRoute(userId)+c.GetChannelRoute(channelId)+"/posts/unread"+query, ""); err != nil {
 		return nil, BuildErrorResponse(r, err)
 	} else {
 		defer closeBody(r)

--- a/model/client4.go
+++ b/model/client4.go
@@ -2430,6 +2430,16 @@ func (c *Client4) GetPostsBefore(channelId, postId string, page, perPage int, et
 	return PostListFromJson(r.Body), BuildResponse(r)
 }
 
+// GetPostsAroundLastUnread gets a list of posts around last unread post by a user in a channel.
+func (c *Client4) GetPostsAroundLastUnread(channelId string) (*PostList, *Response) {
+	if r, err := c.DoApiGet(c.GetChannelRoute(channelId)+"/posts/unread", ""); err != nil {
+		return nil, BuildErrorResponse(r, err)
+	} else {
+		defer closeBody(r)
+		return PostListFromJson(r.Body), BuildResponse(r)
+	}
+}
+
 // SearchPosts returns any posts with matching terms string.
 func (c *Client4) SearchPosts(teamId string, terms string, isOrSearch bool) (*PostList, *Response) {
 	params := SearchParameter{

--- a/model/post_list.go
+++ b/model/post_list.go
@@ -10,14 +10,18 @@ import (
 )
 
 type PostList struct {
-	Order []string         `json:"order"`
-	Posts map[string]*Post `json:"posts"`
+	Order      []string         `json:"order"`
+	Posts      map[string]*Post `json:"posts"`
+	NextPostId string           `json:"next_post_id"`
+	PrevPostId string           `json:"prev_post_id"`
 }
 
 func NewPostList() *PostList {
 	return &PostList{
-		Order: make([]string, 0),
-		Posts: make(map[string]*Post),
+		Order:      make([]string, 0),
+		Posts:      make(map[string]*Post),
+		NextPostId: "",
+		PrevPostId: "",
 	}
 }
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -4,6 +4,7 @@
 package sqlstore
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -711,6 +712,50 @@ func (s *SqlPostStore) getPostsAround(channelId string, postId string, numPosts 
 
 			result.Data = list
 		}
+	})
+}
+
+func (s *SqlPostStore) GetPostBeforeTime(channelId string, time int64) store.StoreChannel {
+	return s.getPostAroundTime(channelId, time, true)
+}
+
+func (s *SqlPostStore) GetPostAfterTime(channelId string, time int64) store.StoreChannel {
+	return s.getPostAroundTime(channelId, time, false)
+}
+
+func (s *SqlPostStore) getPostAroundTime(channelId string, time int64, before bool) store.StoreChannel {
+	return store.Do(func(result *store.StoreResult) {
+		var direction string
+		var sort string
+		if before {
+			direction = "<"
+			sort = "DESC"
+		} else {
+			direction = ">"
+			sort = "ASC"
+		}
+
+		var post *model.Post
+		err := s.GetReplica().SelectOne(
+			&post,
+			`SELECT
+				*
+			FROM
+				Posts
+			WHERE
+				CreateAt `+direction+` :Time
+				AND ChannelId = :ChannelId
+				AND DeleteAt = 0
+			ORDER BY CreateAt `+sort+`
+			LIMIT 1`,
+			map[string]interface{}{"ChannelId": channelId, "Time": time})
+		if err != nil {
+			if err != sql.ErrNoRows {
+				result.Err = model.NewAppError("SqlPostStore.getPostAroundTime", "store.sql_post.get_post_around.get.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)
+			}
+		}
+
+		result.Data = post
 	})
 }
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -548,7 +548,7 @@ func (s *SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFr
 	})
 }
 
-func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
+func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if allowFromCache {
 			// If the last post in the channel's time is less than or equal to the time we are getting posts since,
@@ -580,7 +580,7 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 			WHERE
 			    (UpdateAt > :Time
 			        AND ChannelId = :ChannelId)
-			LIMIT 1000)
+			LIMIT :Limit)
 			UNION
 			(SELECT
 			    *
@@ -596,9 +596,9 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 			    WHERE
 			        UpdateAt > :Time
 			            AND ChannelId = :ChannelId
-			    LIMIT 1000) temp_tab))
+			    LIMIT :Limit) temp_tab))
 			ORDER BY CreateAt DESC`,
-			map[string]interface{}{"ChannelId": channelId, "Time": time})
+			map[string]interface{}{"ChannelId": channelId, "Time": time, "Limit": limit})
 
 		if err != nil {
 			result.Err = model.NewAppError("SqlPostStore.GetPostsSince", "store.sql_post.get_posts_since.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -371,7 +371,7 @@ func (s *SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 func (s *SqlPostStore) GetEtag(channelId string, allowFromCache bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if allowFromCache {
-			if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok {
+			if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) > 0 {
 				if s.metrics != nil {
 					s.metrics.IncrementMemCacheHitCounter("Last Post Time")
 				}

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -371,7 +371,7 @@ func (s *SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 func (s *SqlPostStore) GetEtag(channelId string, allowFromCache bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if allowFromCache {
-			if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) > 0 {
+			if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok {
 				if s.metrics != nil {
 					s.metrics.IncrementMemCacheHitCounter("Last Post Time")
 				}
@@ -581,7 +581,7 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, al
 			WHERE
 			    (UpdateAt > :Time
 			        AND ChannelId = :ChannelId)
-			LIMIT :Limit)
+			LIMIT 1000)
 			UNION
 			(SELECT
 			    *
@@ -597,8 +597,8 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, al
 			    WHERE
 			        UpdateAt > :Time
 			            AND ChannelId = :ChannelId
-			    LIMIT :Limit) temp_tab))
-			ORDER BY CreateAt DESC`,
+			    LIMIT 1000) temp_tab))
+			ORDER BY CreateAt ASC LIMIT :Limit`,
 			map[string]interface{}{"ChannelId": channelId, "Time": time, "Limit": limit})
 
 		if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -223,7 +223,7 @@ type PostStore interface {
 	GetFlaggedPostsForChannel(userId, channelId string, offset int, limit int) StoreChannel
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
-	GetPostsSince(channelId string, time int64, allowFromCache bool) StoreChannel
+	GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) StoreChannel
 	GetEtag(channelId string, allowFromCache bool) StoreChannel
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -224,6 +224,8 @@ type PostStore interface {
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) StoreChannel
+	GetPostAfterTime(channelId string, time int64) StoreChannel
+	GetPostBeforeTime(channelId string, time int64) StoreChannel
 	GetEtag(channelId string, allowFromCache bool) StoreChannel
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -322,13 +322,13 @@ func (_m *PostStore) GetPostsCreatedAt(channelId string, time int64) store.Store
 	return r0
 }
 
-// GetPostsSince provides a mock function with given fields: channelId, time, allowFromCache
-func (_m *PostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
+// GetPostsSince provides a mock function with given fields: channelId, time, limit, allowFromCache
+func (_m *PostStore) GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(channelId, time, allowFromCache)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64, bool) store.StoreChannel); ok {
-		r0 = rf(channelId, time, allowFromCache)
+	if rf, ok := ret.Get(0).(func(string, int64, int, bool) store.StoreChannel); ok {
+		r0 = rf(channelId, time, limit, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -226,6 +226,38 @@ func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) store.S
 	return r0
 }
 
+// GetPostAfterTime provides a mock function with given fields: channelId, time
+func (_m *PostStore) GetPostAfterTime(channelId string, time int64) store.StoreChannel {
+	ret := _m.Called(channelId, time)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+		r0 = rf(channelId, time)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
+// GetPostBeforeTime provides a mock function with given fields: channelId, time
+func (_m *PostStore) GetPostBeforeTime(channelId string, time int64) store.StoreChannel {
+	ret := _m.Called(channelId, time)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+		r0 = rf(channelId, time)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
+}
+
 // GetPosts provides a mock function with given fields: channelId, offset, limit, allowFromCache
 func (_m *PostStore) GetPosts(channelId string, offset int, limit int, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(channelId, offset, limit, allowFromCache)

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -33,6 +33,7 @@ func TestPostStore(t *testing.T, ss store.Store, s SqlSupplier) {
 	t.Run("GetPostsWithDetails", func(t *testing.T) { testPostStoreGetPostsWithDetails(t, ss) })
 	t.Run("GetPostsBeforeAfter", func(t *testing.T) { testPostStoreGetPostsBeforeAfter(t, ss) })
 	t.Run("GetPostsSince", func(t *testing.T) { testPostStoreGetPostsSince(t, ss) })
+	t.Run("GetPostBeforeAfter", func(t *testing.T) { testPostStoreGetPostBeforeAfter(t, ss) })
 	t.Run("Search", func(t *testing.T) { testPostStoreSearch(t, ss) })
 	t.Run("UserCountsWithPostsByDay", func(t *testing.T) { testUserCountsWithPostsByDay(t, ss) })
 	t.Run("PostCountsByDay", func(t *testing.T) { testPostCountsByDay(t, ss) })
@@ -866,6 +867,96 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 
 	if len(r2.Order) != 0 {
 		t.Fatal("wrong size ", len(r2.Posts))
+	}
+}
+
+func testPostStoreGetPostBeforeAfter(t *testing.T, ss store.Store) {
+	channelId := model.NewId()
+
+	o0 := &model.Post{}
+	o0.ChannelId = channelId
+	o0.UserId = model.NewId()
+	o0.Message = "zz" + model.NewId() + "b"
+	o0 = (<-ss.Post().Save(o0)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o1 := &model.Post{}
+	o1.ChannelId = channelId
+	o1.Type = model.POST_JOIN_CHANNEL
+	o1.UserId = model.NewId()
+	o1.Message = "system_join_channel message"
+	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o0a := &model.Post{}
+	o0a.ChannelId = channelId
+	o0a.UserId = model.NewId()
+	o0a.Message = "zz" + model.NewId() + "b"
+	o0a.ParentId = o1.Id
+	o0a.RootId = o1.Id
+	o0a = (<-ss.Post().Save(o0a)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o0b := &model.Post{}
+	o0b.ChannelId = channelId
+	o0b.UserId = model.NewId()
+	o0b.Message = "deleted message"
+	o0b.ParentId = o1.Id
+	o0b.RootId = o1.Id
+	o0b.DeleteAt = 1
+	o0b = (<-ss.Post().Save(o0b)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	otherChannlPost := &model.Post{}
+	otherChannlPost.ChannelId = model.NewId()
+	otherChannlPost.UserId = model.NewId()
+	otherChannlPost.Message = "zz" + model.NewId() + "b"
+	otherChannlPost = (<-ss.Post().Save(otherChannlPost)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o2 := &model.Post{}
+	o2.ChannelId = channelId
+	o2.UserId = model.NewId()
+	o2.Message = "zz" + model.NewId() + "b"
+	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	time.Sleep(2 * time.Millisecond)
+
+	o2a := &model.Post{}
+	o2a.ChannelId = channelId
+	o2a.UserId = model.NewId()
+	o2a.Message = "zz" + model.NewId() + "b"
+	o2a.ParentId = o2.Id
+	o2a.RootId = o2.Id
+	o2a = (<-ss.Post().Save(o2a)).Data.(*model.Post)
+
+	r1 := (<-ss.Post().GetPostBeforeTime(channelId, o0a.CreateAt))
+	if r1.Data.(*model.Post).Id != o1.Id || r1.Err != nil {
+		t.Fatal("should return before post o1")
+	}
+
+	r1 = (<-ss.Post().GetPostAfterTime(channelId, o0b.CreateAt))
+	if r1.Data.(*model.Post).Id != o2.Id || r1.Err != nil {
+		t.Fatal("should return before post o2")
+	}
+
+	r2 := (<-ss.Post().GetPostBeforeTime(channelId, o0.CreateAt))
+	if r2.Data.(*model.Post) != nil || r2.Err != nil {
+		t.Fatal("should return no post")
+	}
+
+	r2 = (<-ss.Post().GetPostAfterTime(channelId, o0.CreateAt))
+	if r2.Data.(*model.Post).Id != o1.Id || r2.Err != nil {
+		t.Fatal("should return before post o1")
+	}
+
+	r3 := (<-ss.Post().GetPostBeforeTime(channelId, o2a.CreateAt))
+	if r3.Data.(*model.Post).Id != o2.Id || r2.Err != nil {
+		t.Fatal("should return before post o2")
+	}
+
+	r3 = (<-ss.Post().GetPostAfterTime(channelId, o2a.CreateAt))
+	if r3.Data.(*model.Post) != nil || r3.Err != nil {
+		t.Fatal("should return no post")
 	}
 }
 

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -836,7 +836,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o5.RootId = o4.Id
 	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, false)).Data.(*model.PostList)
+	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, 1000, false)).Data.(*model.PostList)
 
 	if r1.Order[0] != o5.Id {
 		t.Fatal("invalid order")
@@ -862,7 +862,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 		t.Fatal("Missing parent")
 	}
 
-	r2 := (<-ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, true)).Data.(*model.PostList)
+	r2 := (<-ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, 1000, true)).Data.(*model.PostList)
 
 	if len(r2.Order) != 0 {
 		t.Fatal("wrong size ", len(r2.Posts))

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -839,19 +839,19 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 
 	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, 1000, false)).Data.(*model.PostList)
 
-	if r1.Order[0] != o5.Id {
+	if r1.Order[5] != o5.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[1] != o4.Id {
+	if r1.Order[4] != o4.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[2] != o3.Id {
+	if r1.Order[3] != o3.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[3] != o2a.Id {
+	if r1.Order[2] != o2a.Id {
 		t.Fatal("invalid order")
 	}
 

--- a/web/params.go
+++ b/web/params.go
@@ -18,6 +18,8 @@ const (
 	PER_PAGE_MAXIMUM      = 200
 	LOGS_PER_PAGE_DEFAULT = 10000
 	LOGS_PER_PAGE_MAXIMUM = 10000
+	LIMIT_DEFAULT         = 60
+	LIMIT_MAXIMUM         = 200
 )
 
 type Params struct {
@@ -66,6 +68,8 @@ type Params struct {
 	NotAssociatedToChannel string
 	Paginate               *bool
 	IncludeMemberCount     bool
+	LimitAfter             int
+	LimitBefore            int
 }
 
 func ParamsFromRequest(r *http.Request) *Params {
@@ -258,6 +262,22 @@ func ParamsFromRequest(r *http.Request) *Params {
 
 	if val, err := strconv.ParseBool(query.Get("include_member_count")); err == nil {
 		params.IncludeMemberCount = val
+	}
+
+	if val, err := strconv.Atoi(query.Get("limit_after")); err != nil || val < 0 {
+		params.LimitAfter = LIMIT_DEFAULT
+	} else if val > LIMIT_MAXIMUM {
+		params.LimitAfter = LIMIT_MAXIMUM
+	} else {
+		params.LimitAfter = val
+	}
+
+	if val, err := strconv.Atoi(query.Get("limit_before")); err != nil || val < 0 {
+		params.LimitBefore = LIMIT_DEFAULT
+	} else if val > LIMIT_MAXIMUM {
+		params.LimitBefore = LIMIT_MAXIMUM
+	} else {
+		params.LimitBefore = val
 	}
 
 	return params


### PR DESCRIPTION
#### Summary
Add unread API `GET /users/{user_id:[A-Za-z0-9]+}/channels/{channel_id:[A-Za-z0-9]+}/posts/unread` to get into the last unread post when viewing a channel.

This PR includes approved commits from [post-list-improvements](https://github.com/mattermost/mattermost-server/compare/post-list-improvements) branch, with the last commit of fixing merge conflicts.

#### Ticket Link
Jira tickets:
- [MM-11210](https://mattermost.atlassian.net/browse/MM-11210) -> [Add API GET 'api/v4/channels/{channel_id:[A-Za-z0-9]+}/posts/unread' for scrolling overhaul](https://github.com/mattermost/mattermost-server/pull/9108)
- [MM-11528](https://mattermost.atlassian.net/browse/MM-11528), [MM-11583](https://mattermost.atlassian.net/browse/MM-11583) -> [Add userId to in the "posts/unread" path and update test with time delay to fix intermittent failure](https://github.com/mattermost/mattermost-server/pull/9229)
- [MM-11876](https://mattermost.atlassian.net/browse/MM-11876) -> [Add cursor to posts list such as next_post_id and previous_post_id](https://github.com/mattermost/mattermost-server/pull/9707)
- [MM-12753](https://mattermost.atlassian.net/browse/MM-12753) -> [Fix missing message when using unread API](https://github.com/mattermost/mattermost-server/pull/10233)

