### PR TITLE
MM-11634 - Fixed 'Download apps' link

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -342,7 +342,7 @@
         "LoginButtonTextColor": ""
     },
     "NativeAppSettings": {
-        "AppDownloadLink": "https://about.mattermost.com/downloads/",
+        "AppDownloadLink": "https://mattermost.com/download/#mattermostApps",
         "AndroidAppDownloadLink": "https://about.mattermost.com/mattermost-android-app/",
         "IosAppDownloadLink": "https://about.mattermost.com/mattermost-ios-app/"
     },

--- a/model/config.go
+++ b/model/config.go
@@ -137,7 +137,7 @@ const (
 	SAML_SETTINGS_DEFAULT_LOCALE_ATTRIBUTE     = ""
 	SAML_SETTINGS_DEFAULT_POSITION_ATTRIBUTE   = ""
 
-	NATIVEAPP_SETTINGS_DEFAULT_APP_DOWNLOAD_LINK         = "https://about.mattermost.com/downloads/"
+	NATIVEAPP_SETTINGS_DEFAULT_APP_DOWNLOAD_LINK         = "https://mattermost.com/download/#mattermostApps"
 	NATIVEAPP_SETTINGS_DEFAULT_ANDROID_APP_DOWNLOAD_LINK = "https://about.mattermost.com/mattermost-android-app/"
 	NATIVEAPP_SETTINGS_DEFAULT_IOS_APP_DOWNLOAD_LINK     = "https://about.mattermost.com/mattermost-ios-app/"
 

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -309,7 +309,7 @@
         "LoginButtonTextColor": ""
     },
     "NativeAppSettings": {
-        "AppDownloadLink": "https://about.mattermost.com/downloads/",
+        "AppDownloadLink": "https://mattermost.com/download/#mattermostApps",
         "AndroidAppDownloadLink": "https://about.mattermost.com/mattermost-android-app/",
         "IosAppDownloadLink": "https://about.mattermost.com/mattermost-ios-app/"
     },


### PR DESCRIPTION
#### Summary
Currently when clicking on the app icons in the tutorial or selecting the option to "Download Apps" in the main menu, another tab is opened taking you to the downloads page but the first thing you see is the server download and you need to scroll down to find the apps.

Expected:
Link should take you directly to the apps section of the download page. Link: https://about.mattermost.com/download/#mattermostApps

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-11634
