### PR TITLE
MM-14723: Add CreateBotAccounts to client.go

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -23,6 +23,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["ExperimentalPrimaryTeam"] = *c.TeamSettings.ExperimentalPrimaryTeam
 	props["ExperimentalViewArchivedChannels"] = strconv.FormatBool(*c.TeamSettings.ExperimentalViewArchivedChannels)
 
+	props["CreateBotAccounts"] = strconv.FormatBool(*c.ServiceSettings.CreateBotAccounts)
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(*c.ServiceSettings.EnableOAuthServiceProvider)
 	props["GoogleDeveloperKey"] = *c.ServiceSettings.GoogleDeveloperKey
 	props["EnableIncomingWebhooks"] = strconv.FormatBool(*c.ServiceSettings.EnableIncomingWebhooks)
@@ -197,6 +198,8 @@ func GenerateLimitedClientConfig(c *model.Config, diagnosticId string, license *
 	props["BuildHash"] = model.BuildHash
 	props["BuildHashEnterprise"] = model.BuildHashEnterprise
 	props["BuildEnterpriseReady"] = model.BuildEnterpriseReady
+
+	props["CreateBotAccounts"] = strconv.FormatBool(*c.ServiceSettings.CreateBotAccounts)
 
 	props["SiteName"] = *c.TeamSettings.SiteName
 	props["WebsocketURL"] = strings.TrimRight(*c.ServiceSettings.WebsocketURL, "/")


### PR DESCRIPTION
#### Summary
This PR allows the CreateBotAccounts flag under ServiceSettings to be used outside of the System Console. This is needed for the PR [#2751 in webapp](https://github.com/mattermost/mattermost-webapp/pull/2751) to allow for conditional rendering based on the status of the flag. 

#### Ticket Link
#10776 
