### PR TITLE
[MM-11287] Add support for plus sign and period/dot in custom URL schemes (#9155)

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2866,7 +2866,7 @@ func (mes *MessageExportSettings) isValid(fs FileSettings) *AppError {
 
 func (ds *DisplaySettings) isValid() *AppError {
 	if len(ds.CustomUrlSchemes) != 0 {
-		validProtocolPattern := regexp.MustCompile(`(?i)^\s*[a-z][a-z0-9-]*\s*$`)
+		validProtocolPattern := regexp.MustCompile(`(?i)^\s*[a-z][a-z0-9-]*([+.][a-z]+)?\s*$`)
 
 		for _, scheme := range ds.CustomUrlSchemes {
 			if !validProtocolPattern.MatchString(scheme) {

--- a/model/config.go
+++ b/model/config.go
@@ -2866,7 +2866,7 @@ func (mes *MessageExportSettings) isValid(fs FileSettings) *AppError {
 
 func (ds *DisplaySettings) isValid() *AppError {
 	if len(ds.CustomUrlSchemes) != 0 {
-		validProtocolPattern := regexp.MustCompile(`(?i)^\s*[a-z][a-z0-9-]*([+.][a-z]+)?\s*$`)
+		validProtocolPattern := regexp.MustCompile(`(?i)^\s*[A-Za-z][A-Za-z0-9.+-]*\s*$`)
 
 		for _, scheme := range ds.CustomUrlSchemes {
 			if !validProtocolPattern.MatchString(scheme) {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -509,7 +509,7 @@ func TestDisplaySettingsIsValidCustomUrlSchemes(t *testing.T) {
 		{
 			name:  "containing period",
 			value: []string{"iris.beep"},
-			valid: false, // should technically be true, but client doesn't support it
+			valid: true,
 		},
 		{
 			name:  "containing hyphen",
@@ -519,7 +519,7 @@ func TestDisplaySettingsIsValidCustomUrlSchemes(t *testing.T) {
 		{
 			name:  "containing plus",
 			value: []string{"coap+tcp", "coap+ws"},
-			valid: false, // should technically be true, but client doesn't support it
+			valid: true,
 		},
 		{
 			name:  "starting with number",


### PR DESCRIPTION
Fixes https://github.com/mattermost/mattermost-server/issues/9155

Add functionality to allow `+` and `.` in custom URL schemes, in System Console > Customization > Posts > Custom URL Schemes (in addition to hyphen)

[Jira ticket](https://mattermost.atlassian.net/browse/MM-11287)

Related PR:
* https://github.com/mattermost/marked/pull/11
* https://github.com/mattermost/commonmark.js/pull/7