### PR TITLE
MM-15632 DeleteEphemeralMessage to accept a `postId string`

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -447,8 +447,8 @@ func (api *PluginAPI) UpdateEphemeralPost(userId string, post *model.Post) *mode
 	return api.app.UpdateEphemeralPost(userId, post)
 }
 
-func (api *PluginAPI) DeleteEphemeralPost(userId string, post *model.Post) {
-	api.app.DeleteEphemeralPost(userId, post)
+func (api *PluginAPI) DeleteEphemeralPost(userId, postId string) {
+	api.app.DeleteEphemeralPost(userId, postId)
 }
 
 func (api *PluginAPI) DeletePost(postId string) *model.AppError {

--- a/app/post.go
+++ b/app/post.go
@@ -440,12 +440,13 @@ func (a *App) UpdateEphemeralPost(userId string, post *model.Post) *model.Post {
 func (a *App) DeleteEphemeralPost(userId, postId string) {
 	post := &model.Post{
 		Id:       postId,
+		UserId:   userId,
 		Type:     model.POST_EPHEMERAL,
 		DeleteAt: model.GetMillis(),
 		UpdateAt: model.GetMillis(),
 	}
 
-	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", post.ChannelId, userId, nil)
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", "", userId, nil)
 	message.Add("post", post.ToJson())
 	a.Publish(message)
 }

--- a/app/post.go
+++ b/app/post.go
@@ -437,16 +437,17 @@ func (a *App) UpdateEphemeralPost(userId string, post *model.Post) *model.Post {
 	return post
 }
 
-func (a *App) DeleteEphemeralPost(userId string, post *model.Post) *model.Post {
-	post.Type = model.POST_EPHEMERAL
-	post.DeleteAt = model.GetMillis()
-	post.UpdateAt = post.DeleteAt
-	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", post.ChannelId, userId, nil)
+func (a *App) DeleteEphemeralPost(userId, postId string) {
+	post := &model.Post{
+		Id:       postId,
+		Type:     model.POST_EPHEMERAL,
+		DeleteAt: model.GetMillis(),
+		UpdateAt: model.GetMillis(),
+	}
 
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", post.ChannelId, userId, nil)
 	message.Add("post", post.ToJson())
 	a.Publish(message)
-
-	return post
 }
 
 func (a *App) UpdatePost(post *model.Post, safeUpdate bool) (*model.Post, *model.AppError) {

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -314,7 +314,7 @@ type API interface {
 
 	// DeleteEphemeralPost deletes an ephemeral message previously sent to the user.
 	// EXPERIMENTAL: This API is experimental and can be changed without advance notice.
-	DeleteEphemeralPost(userId string, post *model.Post)
+	DeleteEphemeralPost(userId, postId string)
 
 	// DeletePost deletes a post.
 	DeletePost(postId string) *model.AppError

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2643,14 +2643,14 @@ func (s *apiRPCServer) UpdateEphemeralPost(args *Z_UpdateEphemeralPostArgs, retu
 
 type Z_DeleteEphemeralPostArgs struct {
 	A string
-	B *model.Post
+	B string
 }
 
 type Z_DeleteEphemeralPostReturns struct {
 }
 
-func (g *apiRPCClient) DeleteEphemeralPost(userId string, post *model.Post) {
-	_args := &Z_DeleteEphemeralPostArgs{userId, post}
+func (g *apiRPCClient) DeleteEphemeralPost(userId, postId string) {
+	_args := &Z_DeleteEphemeralPostArgs{userId, postId}
 	_returns := &Z_DeleteEphemeralPostReturns{}
 	if err := g.client.Call("Plugin.DeleteEphemeralPost", _args, _returns); err != nil {
 		log.Printf("RPC call to DeleteEphemeralPost API failed: %s", err.Error())
@@ -2660,7 +2660,7 @@ func (g *apiRPCClient) DeleteEphemeralPost(userId string, post *model.Post) {
 
 func (s *apiRPCServer) DeleteEphemeralPost(args *Z_DeleteEphemeralPostArgs, returns *Z_DeleteEphemeralPostReturns) error {
 	if hook, ok := s.impl.(interface {
-		DeleteEphemeralPost(userId string, post *model.Post)
+		DeleteEphemeralPost(userId, postId string)
 	}); ok {
 		hook.DeleteEphemeralPost(args.A, args.B)
 	} else {

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -294,9 +294,9 @@ func (_m *API) DeleteChannelMember(channelId string, userId string) *model.AppEr
 	return r0
 }
 
-// DeleteEphemeralPost provides a mock function with given fields: userId, post
-func (_m *API) DeleteEphemeralPost(userId string, post *model.Post) {
-	_m.Called(userId, post)
+// DeleteEphemeralPost provides a mock function with given fields: userId, postId
+func (_m *API) DeleteEphemeralPost(userId string, postId string) {
+	_m.Called(userId, postId)
 }
 
 // DeletePost provides a mock function with given fields: postId


### PR DESCRIPTION
#### Summary
Before it was accepting `post *model.Post`, and returning one.

This is a breaking change for the giphy plugin and any other that rely
on the API. cc @scottleedavis 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15632