### PR TITLE
[MM-15300] Migrate "Preference.PermanentDeleteByUser" to Sync by default

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1435,8 +1435,8 @@ func (a *App) PermanentDeleteUser(user *model.User) *model.AppError {
 		return err
 	}
 
-	if result := <-a.Srv.Store.Preference().PermanentDeleteByUser(user.Id); result.Err != nil {
-		return result.Err
+	if err := a.Srv.Store.Preference().PermanentDeleteByUser(user.Id); err != nil {
+		return err
 	}
 
 	if result := <-a.Srv.Store.Channel().PermanentDeleteMembersByUser(user.Id); result.Err != nil {

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -216,13 +216,16 @@ func (s SqlPreferenceStore) GetAll(userId string) store.StoreChannel {
 	})
 }
 
-func (s SqlPreferenceStore) PermanentDeleteByUser(userId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if _, err := s.GetMaster().Exec(
-			`DELETE FROM Preferences WHERE UserId = :UserId`, map[string]interface{}{"UserId": userId}); err != nil {
-			result.Err = model.NewAppError("SqlPreferenceStore.Delete", "store.sql_preference.permanent_delete_by_user.app_error", nil, err.Error(), http.StatusInternalServerError)
-		}
-	})
+func (s SqlPreferenceStore) PermanentDeleteByUser(userId string) *model.AppError {
+	if _, err := s.GetMaster().Exec(
+		`DELETE FROM 
+			Preferences 
+		WHERE 
+			UserId = :UserId`, map[string]interface{}{"UserId": userId}); err != nil {
+		return model.NewAppError("SqlPreferenceStore.Delete", "store.sql_preference.permanent_delete_by_user.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
 }
 
 func (s SqlPreferenceStore) IsFeatureEnabled(feature, userId string) store.StoreChannel {

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -217,11 +217,13 @@ func (s SqlPreferenceStore) GetAll(userId string) store.StoreChannel {
 }
 
 func (s SqlPreferenceStore) PermanentDeleteByUser(userId string) *model.AppError {
-	if _, err := s.GetMaster().Exec(
+	query :=
 		`DELETE FROM 
 			Preferences 
 		WHERE 
-			UserId = :UserId`, map[string]interface{}{"UserId": userId}); err != nil {
+			UserId = :UserId`
+
+	if _, err := s.GetMaster().Exec(query, map[string]interface{}{"UserId": userId}); err != nil {
 		return model.NewAppError("SqlPreferenceStore.Delete", "store.sql_preference.permanent_delete_by_user.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -435,7 +435,7 @@ type PreferenceStore interface {
 	Delete(userId, category, name string) StoreChannel
 	DeleteCategory(userId string, category string) StoreChannel
 	DeleteCategoryAndName(category string, name string) StoreChannel
-	PermanentDeleteByUser(userId string) StoreChannel
+	PermanentDeleteByUser(userId string) *model.AppError
 	IsFeatureEnabled(feature, userId string) StoreChannel
 	CleanupFlagsBatch(limit int64) StoreChannel
 }

--- a/store/storetest/mocks/PreferenceStore.go
+++ b/store/storetest/mocks/PreferenceStore.go
@@ -160,15 +160,15 @@ func (_m *PreferenceStore) IsFeatureEnabled(feature string, userId string) store
 }
 
 // PermanentDeleteByUser provides a mock function with given fields: userId
-func (_m *PreferenceStore) PermanentDeleteByUser(userId string) store.StoreChannel {
+func (_m *PreferenceStore) PermanentDeleteByUser(userId string) *model.AppError {
 	ret := _m.Called(userId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string) *model.AppError); ok {
 		r0 = rf(userId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -235,8 +235,8 @@ func testPreferenceDeleteByUser(t *testing.T, ss store.Store) {
 
 	store.Must(ss.Preference().Save(&preferences))
 
-	if result := <-ss.Preference().PermanentDeleteByUser(userId); result.Err != nil {
-		t.Fatal(result.Err)
+	if err := ss.Preference().PermanentDeleteByUser(userId); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
#### Summary

This PR migrates PermanentDeleteByUser in the Preference store to use a synchronous call by default.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/10717

