### PR TITLE
MM-15310 and MM-15311: Making server channel name validation more restrictive

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -269,7 +269,7 @@ func TestPatchChannel(t *testing.T) {
 		Header:      new(string),
 		Purpose:     new(string),
 	}
-	*patch.Name = model.NewId()
+	*patch.Name = model.NewId()[0:10]
 	*patch.DisplayName = model.NewId()
 	*patch.Header = model.NewId()
 	*patch.Purpose = model.NewId()
@@ -2535,7 +2535,7 @@ func TestUpdateChannelScheme(t *testing.T) {
 
 	channel, resp := th.SystemAdminClient.CreateChannel(&model.Channel{
 		DisplayName: "Name",
-		Name:        "z-z-" + model.NewId() + "a",
+		Name:        "z-z-" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      team.Id,
 	})

--- a/api4/commands_test.go
+++ b/api4/commands_test.go
@@ -274,11 +274,11 @@ func TestLeaveCommands(t *testing.T) {
 	team := th.BasicTeam
 	user2 := th.BasicUser2
 
-	channel1 := &model.Channel{DisplayName: "AA", Name: "aa" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel1 := &model.Channel{DisplayName: "AA", Name: "aa" + model.NewId()[0:10] + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).(*model.Channel)
 	Client.Must(Client.AddChannelMember(channel1.Id, th.BasicUser.Id))
 
-	channel2 := &model.Channel{DisplayName: "BB", Name: "bb" + model.NewId() + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
+	channel2 := &model.Channel{DisplayName: "BB", Name: "bb" + model.NewId()[0:10] + "a", Type: model.CHANNEL_PRIVATE, TeamId: team.Id}
 	channel2 = Client.Must(Client.CreateChannel(channel2)).(*model.Channel)
 	Client.Must(Client.AddChannelMember(channel2.Id, th.BasicUser.Id))
 	Client.Must(Client.AddChannelMember(channel2.Id, user2.Id))

--- a/api4/commands_test.go
+++ b/api4/commands_test.go
@@ -115,14 +115,14 @@ func testJoinCommands(t *testing.T, alias string) {
 	team := th.BasicTeam
 	user2 := th.BasicUser2
 
-	channel0 := &model.Channel{DisplayName: "00", Name: "00" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel0 := &model.Channel{DisplayName: "00", Name: "00" + model.NewId()[0:10] + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel0 = Client.Must(Client.CreateChannel(channel0)).(*model.Channel)
 
-	channel1 := &model.Channel{DisplayName: "AA", Name: "aa" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel1 := &model.Channel{DisplayName: "AA", Name: "aa" + model.NewId()[0:10] + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel1 = Client.Must(Client.CreateChannel(channel1)).(*model.Channel)
 	Client.Must(Client.RemoveUserFromChannel(channel1.Id, th.BasicUser.Id))
 
-	channel2 := &model.Channel{DisplayName: "BB", Name: "bb" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
+	channel2 := &model.Channel{DisplayName: "BB", Name: "bb" + model.NewId()[0:10] + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	channel2 = Client.Must(Client.CreateChannel(channel2)).(*model.Channel)
 	Client.Must(Client.RemoveUserFromChannel(channel2.Id, th.BasicUser.Id))
 

--- a/api4/scheme_test.go
+++ b/api4/scheme_test.go
@@ -397,7 +397,7 @@ func TestGetChannelsForScheme(t *testing.T) {
 	channel1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "A Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 
@@ -421,7 +421,7 @@ func TestGetChannelsForScheme(t *testing.T) {
 	channel2 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "B Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		SchemeId:    &scheme1.Id,
 	}
@@ -694,7 +694,7 @@ func TestDeleteScheme(t *testing.T) {
 		res := <-th.App.Srv.Store.Channel().Save(&model.Channel{
 			TeamId:      model.NewId(),
 			DisplayName: model.NewId(),
-			Name:        model.NewId(),
+			Name:        model.NewId()[0:10],
 			Type:        model.CHANNEL_OPEN,
 			SchemeId:    &s1.Id,
 		}, -1)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -3930,7 +3930,7 @@ func TestGetUsersByStatus(t *testing.T) {
 
 	channel, err := th.App.CreateChannel(&model.Channel{
 		DisplayName: "dn_" + model.NewId(),
-		Name:        "name_" + model.NewId(),
+		Name:        "name_" + model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      team.Id,
 		CreatorId:   model.NewId(),

--- a/api4/user_viewmembers_test.go
+++ b/api4/user_viewmembers_test.go
@@ -31,11 +31,11 @@ func TestApiResctrictedViewMembers(t *testing.T) {
 	team2, err := th.App.CreateTeam(&model.Team{DisplayName: "dn_" + model.NewId(), Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN})
 	require.Nil(t, err)
 
-	channel1, err := th.App.CreateChannel(&model.Channel{DisplayName: "dn_" + model.NewId(), Name: "name_" + model.NewId(), Type: model.CHANNEL_OPEN, TeamId: team1.Id, CreatorId: model.NewId()}, false)
+	channel1, err := th.App.CreateChannel(&model.Channel{DisplayName: "dn_" + model.NewId(), Name: "name_" + model.NewId()[0:10], Type: model.CHANNEL_OPEN, TeamId: team1.Id, CreatorId: model.NewId()}, false)
 	require.Nil(t, err)
-	channel2, err := th.App.CreateChannel(&model.Channel{DisplayName: "dn_" + model.NewId(), Name: "name_" + model.NewId(), Type: model.CHANNEL_OPEN, TeamId: team1.Id, CreatorId: model.NewId()}, false)
+	channel2, err := th.App.CreateChannel(&model.Channel{DisplayName: "dn_" + model.NewId(), Name: "name_" + model.NewId()[0:10], Type: model.CHANNEL_OPEN, TeamId: team1.Id, CreatorId: model.NewId()}, false)
 	require.Nil(t, err)
-	channel3, err := th.App.CreateChannel(&model.Channel{DisplayName: "dn_" + model.NewId(), Name: "name_" + model.NewId(), Type: model.CHANNEL_OPEN, TeamId: team2.Id, CreatorId: model.NewId()}, false)
+	channel3, err := th.App.CreateChannel(&model.Channel{DisplayName: "dn_" + model.NewId(), Name: "name_" + model.NewId()[0:10], Type: model.CHANNEL_OPEN, TeamId: team2.Id, CreatorId: model.NewId()}, false)
 	require.Nil(t, err)
 
 	th.LinkUserToTeam(user1, team1)

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -143,7 +143,7 @@ func TestMoveChannel(t *testing.T) {
 	// Test moving a channel with no members.
 	channel3 := &model.Channel{
 		DisplayName: "dn_" + model.NewId(),
-		Name:        "name_" + model.NewId(),
+		Name:        "name_" + model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      sourceTeam.Id,
 		CreatorId:   th.BasicUser.Id,

--- a/app/command_join_test.go
+++ b/app/command_join_test.go
@@ -42,7 +42,7 @@ func TestJoinCommandForExistingChannel(t *testing.T) {
 
 	channel2, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "AA",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,
@@ -71,7 +71,7 @@ func TestJoinCommandWithTilde(t *testing.T) {
 
 	channel2, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "AA",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,
@@ -96,7 +96,7 @@ func TestJoinCommandPermissions(t *testing.T) {
 
 	channel2, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "AA",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,
@@ -131,7 +131,7 @@ func TestJoinCommandPermissions(t *testing.T) {
 	// Try a private channel *without* permission.
 	channel3, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "BB",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_PRIVATE,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,

--- a/app/command_leave_test.go
+++ b/app/command_leave_test.go
@@ -20,7 +20,7 @@ func TestLeaveProviderDoCommand(t *testing.T) {
 
 	publicChannel, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "AA",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,
@@ -28,7 +28,7 @@ func TestLeaveProviderDoCommand(t *testing.T) {
 
 	privateChannel, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "BB",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,

--- a/app/command_mute_test.go
+++ b/app/command_mute_test.go
@@ -80,7 +80,7 @@ func TestMuteCommandSpecificChannel(t *testing.T) {
 	channel1 := th.BasicChannel
 	channel2, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "AA",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,
@@ -125,7 +125,7 @@ func TestMuteCommandNotMember(t *testing.T) {
 	channel1 := th.BasicChannel
 	channel2, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "AA",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,

--- a/app/command_remove_test.go
+++ b/app/command_remove_test.go
@@ -19,7 +19,7 @@ func TestRemoveProviderDoCommand(t *testing.T) {
 
 	publicChannel, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "AA",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,
@@ -27,7 +27,7 @@ func TestRemoveProviderDoCommand(t *testing.T) {
 
 	privateChannel, _ := th.App.CreateChannel(&model.Channel{
 		DisplayName: "BB",
-		Name:        "aa" + model.NewId() + "a",
+		Name:        "aa" + model.NewId()[0:10] + "a",
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      th.BasicTeam.Id,
 		CreatorId:   th.BasicUser.Id,

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -196,7 +196,7 @@ func (me *TestHelper) createChannel(team *model.Team, channelType string) *model
 
 	channel := &model.Channel{
 		DisplayName: "dn_" + id,
-		Name:        "name_" + id,
+		Name:        "name_" + id[0:10],
 		Type:        channelType,
 		TeamId:      team.Id,
 		CreatorId:   me.BasicUser.Id,
@@ -219,7 +219,7 @@ func (me *TestHelper) createChannelWithAnotherUser(team *model.Team, channelType
 
 	channel := &model.Channel{
 		DisplayName: "dn_" + id,
-		Name:        "name_" + id,
+		Name:        "name_" + id[0:10],
 		Type:        channelType,
 		TeamId:      team.Id,
 		CreatorId:   userId,

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -1022,7 +1022,7 @@ func TestImportImportUser(t *testing.T) {
 		t.Fatalf("Failed to get team from database.")
 	}
 
-	channelName := model.NewId()
+	channelName := model.NewId()[0:10]
 	th.App.ImportChannel(&ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,
@@ -1103,7 +1103,7 @@ func TestImportImportUser(t *testing.T) {
 			Name: &teamName,
 			Channels: &[]UserChannelImportData{
 				{
-					Name: ptrStr(model.NewId()),
+					Name: ptrStr(model.NewId()[0:10]),
 				},
 			},
 		},
@@ -1191,7 +1191,7 @@ func TestImportImportUser(t *testing.T) {
 			Name: &teamName,
 			Channels: &[]UserChannelImportData{
 				{
-					Name: ptrStr(model.NewId()),
+					Name: ptrStr(model.NewId()[0:10]),
 				},
 			},
 		},
@@ -1569,7 +1569,7 @@ func TestImportImportUser(t *testing.T) {
 
 	channelData := &ChannelImportData{
 		Team:        &teamName,
-		Name:        ptrStr(model.NewId()),
+		Name:        ptrStr(model.NewId()[0:10]),
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 		Header:      ptrStr("Channe Header"),
@@ -1777,7 +1777,7 @@ func TestImportImportPost(t *testing.T) {
 	}
 
 	// Create a Channel.
-	channelName := model.NewId()
+	channelName := model.NewId()[0:10]
 	th.App.ImportChannel(&ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,
@@ -2783,7 +2783,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	}
 
 	// Create a Channel.
-	channelName := model.NewId()
+	channelName := model.NewId()[0:10]
 	th.App.ImportChannel(&ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -184,7 +184,7 @@ func TestImportBulkImport(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCustomEmoji = true })
 
 	teamName := model.NewId()
-	channelName := model.NewId()
+	channelName := model.NewId()[0:10]
 	username := model.NewId()
 	username2 := model.NewId()
 	username3 := model.NewId()

--- a/app/syncables_test.go
+++ b/app/syncables_test.go
@@ -34,7 +34,7 @@ func TestCreateDefaultMemberships(t *testing.T) {
 	practiceChannel, err := th.App.CreateChannel(&model.Channel{
 		TeamId:      singersTeam.Id,
 		DisplayName: "Practices",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}, false)
 	if err != nil {
@@ -44,7 +44,7 @@ func TestCreateDefaultMemberships(t *testing.T) {
 	experimentsChannel, err := th.App.CreateChannel(&model.Channel{
 		TeamId:      singersTeam.Id,
 		DisplayName: "Experiments",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}, false)
 	if err != nil {

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -432,7 +432,7 @@ func TestGetUsersByStatus(t *testing.T) {
 	team := th.CreateTeam()
 	channel, err := th.App.CreateChannel(&model.Channel{
 		DisplayName: "dn_" + model.NewId(),
-		Name:        "name_" + model.NewId(),
+		Name:        "name_" + model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		TeamId:      team.Id,
 		CreatorId:   model.NewId(),

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -112,7 +112,7 @@ func TestCreateChannel(t *testing.T) {
 	defer th.TearDown()
 
 	id := model.NewId()
-	name := "name" + id
+	name := "name" + id[0:10]
 
 	th.CheckCommand(t, "channel", "create", "--display_name", name, "--team", th.BasicTeam.Name, "--name", name)
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4091,8 +4091,8 @@
     "translation": "Invalid username"
   },
   {
-    "id": "model.channel.is_valid.2_or_more.app_error",
-    "translation": "Name must be 2 or more lowercase alphanumeric characters"
+    "id": "model.channel.is_valid.between_2_and_22.app_error",
+    "translation": "Name must be between 2 and 22 lowercase alphanumeric characters"
   },
   {
     "id": "model.channel.is_valid.create_at.app_error",
@@ -4113,6 +4113,10 @@
   {
     "id": "model.channel.is_valid.id.app_error",
     "translation": "Invalid Id"
+  },
+  {
+    "id": "model.channel.is_valid.invalid_channel_name.app_error",
+    "translation": "Invalid channel name"
   },
   {
     "id": "model.channel.is_valid.purpose.app_error",

--- a/model/channel.go
+++ b/model/channel.go
@@ -131,8 +131,12 @@ func (o *Channel) IsValid() *AppError {
 		return NewAppError("Channel.IsValid", "model.channel.is_valid.display_name.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
-	if !IsValidChannelIdentifier(o.Name) {
-		return NewAppError("Channel.IsValid", "model.channel.is_valid.2_or_more.app_error", nil, "id="+o.Id, http.StatusBadRequest)
+	if (o.Type == CHANNEL_OPEN || o.Type == CHANNEL_PRIVATE) && !IsValidChannelIdentifier(o.Name) {
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.between_2_and_22.app_error", nil, "id="+o.Id, http.StatusBadRequest)
+	}
+
+	if (o.Type == CHANNEL_GROUP || o.Type == CHANNEL_DIRECT) && !IsValidGroupOrDirectChannelIdentifier(o.Name) {
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.invalid_channel_name.app_error", nil, "id="+o.Id, http.StatusBadRequest)
 	}
 
 	if !(o.Type == CHANNEL_OPEN || o.Type == CHANNEL_PRIVATE || o.Type == CHANNEL_DIRECT || o.Type == CHANNEL_GROUP) {

--- a/model/utils.go
+++ b/model/utils.go
@@ -360,6 +360,28 @@ func IsValidChannelIdentifier(s string) bool {
 		return false
 	}
 
+	if len(s) > CHANNEL_NAME_UI_MAX_LENGTH {
+		return false
+	}
+
+	multipleHyphens := regexp.MustCompile("-{2,}")
+	if multipleHyphens.MatchString(s) {
+		return false
+	}
+
+	return true
+}
+
+func IsValidGroupOrDirectChannelIdentifier(s string) bool {
+
+	if !IsValidAlphaNumHyphenUnderscore(s, true) {
+		return false
+	}
+
+	if len(s) < CHANNEL_NAME_MIN_LENGTH {
+		return false
+	}
+
 	return true
 }
 

--- a/model/utils.go
+++ b/model/utils.go
@@ -350,8 +350,9 @@ var reservedName = []string{
 	"help",
 }
 
-func IsValidChannelIdentifier(s string) bool {
+var multipleHyphensRegexp = regexp.MustCompile("-{2,}")
 
+func IsValidChannelIdentifier(s string) bool {
 	if !IsValidAlphaNumHyphenUnderscore(s, true) {
 		return false
 	}
@@ -364,8 +365,7 @@ func IsValidChannelIdentifier(s string) bool {
 		return false
 	}
 
-	multipleHyphens := regexp.MustCompile("-{2,}")
-	if multipleHyphens.MatchString(s) {
+	if multipleHyphensRegexp.MatchString(s) {
 		return false
 	}
 
@@ -373,7 +373,6 @@ func IsValidChannelIdentifier(s string) bool {
 }
 
 func IsValidGroupOrDirectChannelIdentifier(s string) bool {
-
 	if !IsValidAlphaNumHyphenUnderscore(s, true) {
 		return false
 	}

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -767,3 +767,121 @@ func checkNowhereNil(t *testing.T, name string, value interface{}) bool {
 		return true
 	}
 }
+
+func TestIsValidChannelIdentifier(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name        string
+		ChannelName string
+		Expected    bool
+	}{
+		{
+			"Valid channel name",
+			"channel-10_valid",
+			true,
+		},
+		{
+			"Very Long name",
+			"this-name-have-more-than-22-characters-in-it-so-it-must-fail",
+			false,
+		},
+		{
+			"Very short name",
+			"a",
+			false,
+		},
+		{
+			"Not valid characters",
+			"channel-with-no-simple-characters-$",
+			false,
+		},
+		{
+			"With spaces",
+			"channel name with spaces",
+			false,
+		},
+		{
+			"Channel with multiple hyphens",
+			"channel--name",
+			false,
+		},
+		{
+			"Channel starting with hyphen",
+			"-channel",
+			false,
+		},
+		{
+			"Channel ending with hyphen",
+			"channel-",
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, testCase.Expected, IsValidChannelIdentifier(testCase.ChannelName))
+		})
+	}
+}
+
+func TestIsValidGroupOrDirectChannelIdentifier(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name        string
+		ChannelName string
+		Expected    bool
+	}{
+		{
+			"Valid channel name",
+			"channel-10_valid",
+			true,
+		},
+		{
+			"Very Long name",
+			"this-name-have-more-than-22-characters-in-it-so-it-must-fail",
+			true,
+		},
+		{
+			"Very short name",
+			"a",
+			false,
+		},
+		{
+			"Not valid characters",
+			"channel-with-no-simple-characters-$",
+			false,
+		},
+		{
+			"With spaces",
+			"channel name with spaces",
+			false,
+		},
+		{
+			"Channel with multiple hyphens",
+			"channel--name",
+			true,
+		},
+		{
+			"Channel starting with hyphen",
+			"-channel",
+			false,
+		},
+		{
+			"Channel ending with hyphen",
+			"channel-",
+			false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, testCase.Expected, IsValidGroupOrDirectChannelIdentifier(testCase.ChannelName))
+		})
+	}
+}

--- a/store/storetest/channel_member_history_store.go
+++ b/store/storetest/channel_member_history_store.go
@@ -26,7 +26,7 @@ func testLogJoinEvent(t *testing.T, ss store.Store) {
 	channel := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Display " + model.NewId(),
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	channel = *store.Must(ss.Channel().Save(&channel, -1)).(*model.Channel)
@@ -49,7 +49,7 @@ func testLogLeaveEvent(t *testing.T, ss store.Store) {
 	channel := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Display " + model.NewId(),
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	channel = *store.Must(ss.Channel().Save(&channel, -1)).(*model.Channel)
@@ -75,7 +75,7 @@ func testGetUsersInChannelAtChannelMemberHistory(t *testing.T, ss store.Store) {
 	channel := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Display " + model.NewId(),
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	channel = *store.Must(ss.Channel().Save(&channel, -1)).(*model.Channel)
@@ -158,7 +158,7 @@ func testGetUsersInChannelAtChannelMembers(t *testing.T, ss store.Store) {
 	channel := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Display " + model.NewId(),
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	channel = *store.Must(ss.Channel().Save(&channel, -1)).(*model.Channel)
@@ -260,7 +260,7 @@ func testPermanentDeleteBatch(t *testing.T, ss store.Store) {
 	channel := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Display " + model.NewId(),
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	channel = *store.Must(ss.Channel().Save(&channel, -1)).(*model.Channel)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -94,7 +94,7 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 
 	if err := (<-ss.Channel().Save(&o1, -1)).Err; err != nil {
@@ -237,14 +237,14 @@ func testChannelStoreUpdate(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Name"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
@@ -288,13 +288,13 @@ func testGetChannelUnread(t *testing.T, ss store.Store) {
 	notifyPropsModel := model.GetDefaultChannelNotifyProps()
 
 	// Setup Channel 1
-	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Downtown", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
+	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId()[0:10], DisplayName: "Downtown", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
 	store.Must(ss.Channel().Save(c1, -1))
 	cm1 := &model.ChannelMember{ChannelId: c1.Id, UserId: m1.UserId, NotifyProps: notifyPropsModel, MsgCount: 90}
 	store.Must(ss.Channel().SaveMember(cm1))
 
 	// Setup Channel 2
-	c2 := &model.Channel{TeamId: m2.TeamId, Name: model.NewId(), DisplayName: "Cultural", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
+	c2 := &model.Channel{TeamId: m2.TeamId, Name: model.NewId()[0:10], DisplayName: "Cultural", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
 	store.Must(ss.Channel().Save(c2, -1))
 	cm2 := &model.ChannelMember{ChannelId: c2.Id, UserId: m2.UserId, NotifyProps: notifyPropsModel, MsgCount: 90, MentionCount: 5}
 	store.Must(ss.Channel().SaveMember(cm2))
@@ -350,7 +350,7 @@ func testChannelStoreGet(t *testing.T, ss store.Store, s SqlSupplier) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -381,7 +381,7 @@ func testChannelStoreGet(t *testing.T, ss store.Store, s SqlSupplier) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Direct Name"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_DIRECT
 
 	m1 := model.ChannelMember{}
@@ -438,7 +438,7 @@ func testChannelStoreGetChannelsByIds(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "aa" + model.NewId() + "b"
+	o1.Name = "aa" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -457,7 +457,7 @@ func testChannelStoreGetChannelsByIds(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Direct Name"
-	o2.Name = "bb" + model.NewId() + "b"
+	o2.Name = "bb" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_DIRECT
 
 	m1 := model.ChannelMember{}
@@ -506,7 +506,7 @@ func testChannelStoreGetForPost(t *testing.T, ss store.Store) {
 	o1 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
@@ -527,7 +527,7 @@ func testChannelStoreRestore(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -553,28 +553,28 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
 	o3 := model.Channel{}
 	o3.TeamId = o1.TeamId
 	o3.DisplayName = "Channel3"
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = "zz" + model.NewId()[0:10] + "b"
 	o3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o3, -1))
 
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
 	o4.DisplayName = "Channel4"
-	o4.Name = "zz" + model.NewId() + "b"
+	o4.Name = "zz" + model.NewId()[0:10] + "b"
 	o4.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o4, -1))
 
@@ -637,7 +637,7 @@ func testChannelStoreGetByName(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -668,7 +668,7 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -676,7 +676,7 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      o1.TeamId,
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o2, -1))
@@ -722,7 +722,7 @@ func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 	now := model.GetMillis()
@@ -748,7 +748,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 	err := ss.Channel().Delete(o1.Id, model.GetMillis())
@@ -771,7 +771,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
@@ -788,7 +788,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o3 := model.Channel{}
 	o3.TeamId = o1.TeamId
 	o3.DisplayName = "Channel3"
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = "zz" + model.NewId()[0:10] + "b"
 	o3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o3, -1))
 	err = ss.Channel().Delete(o3.Id, model.GetMillis())
@@ -830,7 +830,7 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = model.NewId()
 	c1.DisplayName = "NameName"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
 
@@ -914,7 +914,7 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = model.NewId()
 	c1.DisplayName = "NameName"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
 
@@ -974,14 +974,14 @@ func testChannelStoreGetChannels(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -1069,14 +1069,14 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1" + model.NewId()
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c1, -1))
 
 	c2 := model.Channel{}
 	c2.TeamId = t1.Id
 	c2.DisplayName = "Channel2" + model.NewId()
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = "zz" + model.NewId()[0:10] + "b"
 	c2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c2, -1))
 	c2.DeleteAt = model.GetMillis()
@@ -1087,7 +1087,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	c3 := model.Channel{}
 	c3.TeamId = t2.Id
 	c3.DisplayName = "Channel3" + model.NewId()
-	c3.Name = "zz" + model.NewId() + "b"
+	c3.Name = "zz" + model.NewId()[0:10] + "b"
 	c3.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&c3, -1))
 
@@ -1099,7 +1099,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	c5 := model.Channel{}
 	c5.Name = model.GetGroupNameFromUserIds(userIds)
 	c5.DisplayName = "GroupChannel" + model.NewId()
-	c5.Name = "zz" + model.NewId() + "b"
+	c5.Name = "zz" + model.NewId()[0:10] + "b"
 	c5.Type = model.CHANNEL_GROUP
 	store.Must(ss.Channel().Save(&c5, -1))
 
@@ -1140,7 +1140,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -1161,7 +1161,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      otherTeamId,
 		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o2, -1))
@@ -1177,7 +1177,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o3, -1))
@@ -1186,7 +1186,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelB",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o4, -1))
@@ -1195,7 +1195,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelC",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
@@ -1217,7 +1217,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o6 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelD",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o6, -1))
@@ -1227,7 +1227,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o7 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelD",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o7, -1))
@@ -1272,7 +1272,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -1281,7 +1281,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "OpenChannel1Team2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o2, -1))
@@ -1290,7 +1290,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "PrivateChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o3, -1))
@@ -1305,7 +1305,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel2Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o4, -1))
@@ -1314,7 +1314,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel3Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
@@ -1359,7 +1359,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&oc1, -1))
@@ -1368,7 +1368,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc2 := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "OpenChannel2TeamOther",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&oc2, -1))
@@ -1377,7 +1377,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	pc3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "PrivateChannel3Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&pc3, -1))
@@ -1398,7 +1398,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel4Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&oc4, -1))
@@ -1407,7 +1407,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel4Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&oc5, -1))
@@ -1431,14 +1431,14 @@ func testChannelStoreGetChannelCounts(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -1484,14 +1484,14 @@ func testChannelStoreGetMembersForUser(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = t1.Id
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
@@ -1528,14 +1528,14 @@ func testChannelStoreGetMembersForUserWithPagination(t *testing.T, ss store.Stor
 	o1 := model.Channel{}
 	o1.TeamId = t1.Id
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
@@ -1565,7 +1565,7 @@ func testChannelStoreUpdateLastViewedAt(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	o1.TotalMsgCount = 25
 	o1.LastPostAt = 12345
@@ -1580,7 +1580,7 @@ func testChannelStoreUpdateLastViewedAt(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel1"
-	o2.Name = "zz" + model.NewId() + "c"
+	o2.Name = "zz" + model.NewId()[0:10] + "c"
 	o2.Type = model.CHANNEL_OPEN
 	o2.TotalMsgCount = 26
 	o2.LastPostAt = 123456
@@ -1625,7 +1625,7 @@ func testChannelStoreIncrementMentionCount(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	o1.TotalMsgCount = 25
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -1663,7 +1663,7 @@ func testUpdateChannelMember(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: model.NewId(),
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(c1, -1))
@@ -1692,7 +1692,7 @@ func testGetMember(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: model.NewId(),
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(c1, -1))
@@ -1700,7 +1700,7 @@ func testGetMember(t *testing.T, ss store.Store) {
 	c2 := &model.Channel{
 		TeamId:      c1.TeamId,
 		DisplayName: model.NewId(),
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(c2, -1))
@@ -1768,7 +1768,7 @@ func testChannelStoreGetMemberForPost(t *testing.T, ss store.Store) {
 	o1 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
@@ -1801,7 +1801,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 	c1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&c1, -1))
@@ -1809,7 +1809,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 	c2 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&c2, -1))
@@ -1904,7 +1904,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -1926,7 +1926,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      otherTeamId,
 		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o2, -1))
@@ -1941,7 +1941,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o3, -1))
@@ -1949,7 +1949,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelB",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o4, -1))
@@ -1957,7 +1957,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelC",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
@@ -2059,7 +2059,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -2067,7 +2067,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      otherTeamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o2, -1))
@@ -2096,7 +2096,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA (alternate)",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o3, -1))
@@ -2104,7 +2104,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel B",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o4, -1))
@@ -2112,7 +2112,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel C",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
@@ -2177,7 +2177,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o13 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA (deleted)",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o13, -1))
@@ -2251,7 +2251,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -2259,7 +2259,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      t2.Id,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o2, -1))
@@ -2288,7 +2288,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "ChannelA (alternate)",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o3, -1))
@@ -2296,7 +2296,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "ChannelB",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o4, -1))
@@ -2304,7 +2304,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "ChannelC",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	store.Must(ss.Channel().Save(&o5, -1))
@@ -2369,7 +2369,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o13 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "ChannelA (deleted)",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o13, -1))
@@ -2438,7 +2438,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "ChannelA"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -2451,7 +2451,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
@@ -2464,7 +2464,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	o3 := model.Channel{}
 	o3.TeamId = o1.TeamId
 	o3.DisplayName = "ChannelA"
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = "zz" + model.NewId()[0:10] + "b"
 	o3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o3, -1))
 
@@ -2480,7 +2480,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
 	o4.DisplayName = "ChannelA"
-	o4.Name = "zz" + model.NewId() + "b"
+	o4.Name = "zz" + model.NewId()[0:10] + "b"
 	o4.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&o4, -1))
 
@@ -2493,7 +2493,7 @@ func testChannelStoreAutocompleteInTeamForSearch(t *testing.T, ss store.Store, s
 	o5 := model.Channel{}
 	o5.TeamId = o1.TeamId
 	o5.DisplayName = "ChannelC"
-	o5.Name = "zz" + model.NewId() + "b"
+	o5.Name = "zz" + model.NewId()[0:10] + "b"
 	o5.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&o5, -1))
 
@@ -2535,7 +2535,7 @@ func testChannelStoreGetMembersByIds(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "ChannelA"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
@@ -2578,21 +2578,21 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "ChannelA"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o1, -1))
 
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
 	p3 := model.Channel{}
 	p3.TeamId = model.NewId()
 	p3.DisplayName = "Channel3"
-	p3.Name = "zz" + model.NewId() + "b"
+	p3.Name = "zz" + model.NewId()[0:10] + "b"
 	p3.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&p3, -1))
 
@@ -2674,7 +2674,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	o1 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
@@ -2694,7 +2694,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	o2 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
@@ -2715,7 +2715,7 @@ func testChannelStoreMaxChannelsPerTeam(t *testing.T, ss store.Store) {
 	channel := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Channel",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	result := <-ss.Channel().Save(channel, 0)
@@ -2752,7 +2752,7 @@ func testChannelStoreGetChannelsByScheme(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		SchemeId:    &s1.Id,
 	}
@@ -2760,7 +2760,7 @@ func testChannelStoreGetChannelsByScheme(t *testing.T, ss store.Store) {
 	c2 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		SchemeId:    &s1.Id,
 	}
@@ -2768,7 +2768,7 @@ func testChannelStoreGetChannelsByScheme(t *testing.T, ss store.Store) {
 	c3 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 
@@ -2800,7 +2800,7 @@ func testChannelStoreMigrateChannelMembers(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		SchemeId:    &s1,
 	}
@@ -2880,7 +2880,7 @@ func testResetAllChannelSchemes(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		SchemeId:    &s1.Id,
 	}
@@ -2888,7 +2888,7 @@ func testResetAllChannelSchemes(t *testing.T, ss store.Store) {
 	c2 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		SchemeId:    &s1.Id,
 	}
@@ -2913,7 +2913,7 @@ func testChannelStoreClearAllCustomRoleAssignments(t *testing.T, ss store.Store)
 	c := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 
@@ -2977,7 +2977,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Open Channel",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o1, -1))
@@ -2986,7 +2986,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	o2 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Open Channel 2",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	store.Must(ss.Channel().Save(&o2, -1))
@@ -3042,7 +3042,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 		Id:          model.NewId(),
 		TeamId:      teamId,
 		DisplayName: "Open Channel 3",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 
@@ -3097,7 +3097,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Open Channel 4",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 
@@ -3136,7 +3136,7 @@ func testChannelStoreGetAllChannelsForExportAfter(t *testing.T, ss store.Store) 
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c1, -1))
 
@@ -3168,14 +3168,14 @@ func testChannelStoreGetChannelMembersForExport(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c1, -1))
 
 	c2 := model.Channel{}
 	c2.TeamId = model.NewId()
 	c2.DisplayName = "Channel2"
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = "zz" + model.NewId()[0:10] + "b"
 	c2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c2, -1))
 
@@ -3221,7 +3221,7 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c1, -1))
 
@@ -3287,7 +3287,7 @@ func testChannelStoreExportAllDirectChannels(t *testing.T, ss store.Store, s Sql
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name" + model.NewId()
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_DIRECT
 
 	userIds := []string{model.NewId(), model.NewId(), model.NewId()}
@@ -3295,7 +3295,7 @@ func testChannelStoreExportAllDirectChannels(t *testing.T, ss store.Store, s Sql
 	o2 := model.Channel{}
 	o2.Name = model.GetGroupNameFromUserIds(userIds)
 	o2.DisplayName = "GroupChannel" + model.NewId()
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_GROUP
 	store.Must(ss.Channel().Save(&o2, -1))
 
@@ -3340,20 +3340,20 @@ func testChannelStoreExportAllDirectChannelsExcludePrivateAndPublic(t *testing.T
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "The Direct Channel" + model.NewId()
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_DIRECT
 
 	o2 := model.Channel{}
 	o2.TeamId = teamId
 	o2.DisplayName = "Channel2" + model.NewId()
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = "zz" + model.NewId()[0:10] + "b"
 	o2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&o2, -1))
 
 	o3 := model.Channel{}
 	o3.TeamId = teamId
 	o3.DisplayName = "Channel3" + model.NewId()
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = "zz" + model.NewId()[0:10] + "b"
 	o3.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(&o3, -1))
 
@@ -3397,7 +3397,7 @@ func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, ss stor
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Different Name" + model.NewId()
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_DIRECT
 
 	u1 := &model.User{}
@@ -3442,7 +3442,7 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 	// Set up all the objects needed
 	c1 := &model.Channel{}
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(c1, -1))
 
@@ -3450,7 +3450,7 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 
 	c2 := &model.Channel{}
 	c2.DisplayName = "Channel2"
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = "zz" + model.NewId()[0:10] + "b"
 	c2.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(c2, -1))
 
@@ -3459,19 +3459,19 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 
 	c3 := &model.Channel{}
 	c3.DisplayName = "Channel3"
-	c3.Name = "zz" + model.NewId() + "b"
+	c3.Name = "zz" + model.NewId()[0:10] + "b"
 	c3.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(c3, -1))
 
 	c4 := &model.Channel{}
 	c4.DisplayName = "Channel4"
-	c4.Name = "zz" + model.NewId() + "b"
+	c4.Name = "zz" + model.NewId()[0:10] + "b"
 	c4.Type = model.CHANNEL_PRIVATE
 	store.Must(ss.Channel().Save(c4, -1))
 
 	c5 := &model.Channel{}
 	c5.DisplayName = "Channel5"
-	c5.Name = "zz" + model.NewId() + "b"
+	c5.Name = "zz" + model.NewId()[0:10] + "b"
 	c5.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(c5, -1))
 
@@ -3479,7 +3479,7 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 
 	c6 := &model.Channel{}
 	c6.DisplayName = "Channel6"
-	c6.Name = "zz" + model.NewId() + "b"
+	c6.Name = "zz" + model.NewId()[0:10] + "b"
 	c6.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(c6, -1))
 

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -88,7 +88,7 @@ func testComplianceExport(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel2"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
@@ -188,7 +188,7 @@ func testComplianceExportDirectMessages(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel2"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
@@ -280,7 +280,7 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 	// need a public channel
 	channel := &model.Channel{
 		TeamId:      team.Id,
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		DisplayName: "Public Channel",
 		Type:        model.CHANNEL_OPEN,
 	}
@@ -375,7 +375,7 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 	// need a private channel
 	channel := &model.Channel{
 		TeamId:      team.Id,
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		DisplayName: "Private Channel",
 		Type:        model.CHANNEL_PRIVATE,
 	}
@@ -556,7 +556,7 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 	// can't create a group channel directly, because importing app creates an import cycle, so we have to fake it
 	groupMessageChannel := &model.Channel{
 		TeamId: team.Id,
-		Name:   model.NewId(),
+		Name:   model.NewId()[0:10],
 		Type:   model.CHANNEL_GROUP,
 	}
 	groupMessageChannel = store.Must(ss.Channel().Save(groupMessageChannel, -1)).(*model.Channel)

--- a/store/storetest/group_supplier.go
+++ b/store/storetest/group_supplier.go
@@ -1087,7 +1087,7 @@ func testPendingAutoAddChannelMembers(t *testing.T, ss store.Store) {
 	channel := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "A Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN, // Query does not look at type so this shouldn't matter.
 	}
 	res = <-ss.Channel().Save(channel, 9999)
@@ -1452,7 +1452,7 @@ func pendingMemberRemovalsDataSetup(t *testing.T, ss store.Store) *removalsData 
 	channelConstrained := &model.Channel{
 		TeamId:           model.NewId(),
 		DisplayName:      "A Name",
-		Name:             model.NewId(),
+		Name:             model.NewId()[0:10],
 		Type:             model.CHANNEL_PRIVATE,
 		GroupConstrained: model.NewBool(true),
 	}
@@ -1463,7 +1463,7 @@ func pendingMemberRemovalsDataSetup(t *testing.T, ss store.Store) *removalsData 
 	channelUnconstrained := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "A Name",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	res = <-ss.Channel().Save(channelUnconstrained, 9999)
@@ -1566,7 +1566,7 @@ func testGetGroupsByChannel(t *testing.T, ss store.Store) {
 	channel1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Channel1",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	res := <-ss.Channel().Save(channel1, 9999)
@@ -1607,7 +1607,7 @@ func testGetGroupsByChannel(t *testing.T, ss store.Store) {
 	channel2 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Channel2",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}
 	res = <-ss.Channel().Save(channel2, 9999)
@@ -1978,7 +1978,7 @@ func testGetGroups(t *testing.T, ss store.Store) {
 	channel1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Channel1",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	res := <-ss.Channel().Save(channel1, 9999)
@@ -2033,7 +2033,7 @@ func testGetGroups(t *testing.T, ss store.Store) {
 	channel2 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Channel2",
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	res = <-ss.Channel().Save(channel2, 9999)

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -69,7 +69,7 @@ func testPostStoreSave(t *testing.T, ss store.Store) {
 }
 
 func testPostStoreSaveChannelMsgCounts(t *testing.T, ss store.Store) {
-	c1 := &model.Channel{Name: model.NewId(), DisplayName: "posttestchannel", Type: model.CHANNEL_OPEN}
+	c1 := &model.Channel{Name: model.NewId()[0:10], DisplayName: "posttestchannel", Type: model.CHANNEL_OPEN}
 	res := <-ss.Channel().Save(c1, 1000000)
 	require.Nil(t, res.Err)
 
@@ -876,7 +876,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = teamId
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = (<-ss.Channel().Save(c1, -1)).Data.(*model.Channel)
 
@@ -889,14 +889,14 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	c2 := &model.Channel{}
 	c2.TeamId = teamId
 	c2.DisplayName = "Channel1"
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = "zz" + model.NewId()[0:10] + "b"
 	c2.Type = model.CHANNEL_OPEN
 	c2 = (<-ss.Channel().Save(c2, -1)).Data.(*model.Channel)
 
 	c3 := &model.Channel{}
 	c3.TeamId = teamId
 	c3.DisplayName = "Channel1"
-	c3.Name = "zz" + model.NewId() + "b"
+	c3.Name = "zz" + model.NewId()[0:10] + "b"
 	c3.Type = model.CHANNEL_OPEN
 	c3 = (<-ss.Channel().Save(c3, -1)).Data.(*model.Channel)
 	ss.Channel().Delete(c3.Id, model.GetMillis())
@@ -1083,7 +1083,7 @@ func testUserCountsWithPostsByDay(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel2"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
@@ -1142,7 +1142,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel2"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
@@ -1203,7 +1203,7 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 	c1 := &model.Channel{}
 	c1.TeamId = model.NewId()
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = store.Must(ss.Channel().Save(c1, -1)).(*model.Channel)
 
@@ -1238,7 +1238,7 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 
 	c2 := &model.Channel{}
 	c2.DisplayName = "DMChannel1"
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = "zz" + model.NewId()[0:10] + "b"
 	c2.Type = model.CHANNEL_DIRECT
 
 	m1 := &model.ChannelMember{}
@@ -1744,14 +1744,14 @@ func testPostStoreGetPostsBatchForIndexing(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = model.NewId()
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	c1 = (<-ss.Channel().Save(c1, -1)).Data.(*model.Channel)
 
 	c2 := &model.Channel{}
 	c2.TeamId = model.NewId()
 	c2.DisplayName = "Channel2"
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = "zz" + model.NewId()[0:10] + "b"
 	c2.Type = model.CHANNEL_OPEN
 	c2 = (<-ss.Channel().Save(c2, -1)).Data.(*model.Channel)
 
@@ -1888,7 +1888,7 @@ func testPostStoreGetParentsForExportAfter(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c1, -1))
 
@@ -1935,7 +1935,7 @@ func testPostStoreGetRepliesForExport(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = "zz" + model.NewId()[0:10] + "b"
 	c1.Type = model.CHANNEL_OPEN
 	store.Must(ss.Channel().Save(&c1, -1))
 
@@ -1994,7 +1994,7 @@ func testPostStoreGetDirectPostParentsForExportAfter(t *testing.T, ss store.Stor
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_DIRECT
 
 	u1 := &model.User{}
@@ -2044,7 +2044,7 @@ func testPostStoreGetDirectPostParentsForExportAfterDeleted(t *testing.T, ss sto
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_DIRECT
 
 	u1 := &model.User{}
@@ -2108,7 +2108,7 @@ func testPostStoreGetDirectPostParentsForExportAfterBatched(t *testing.T, ss sto
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = "zz" + model.NewId()[0:10] + "b"
 	o1.Type = model.CHANNEL_DIRECT
 
 	var postIds []string

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -453,7 +453,7 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	c5 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: model.NewId(),
-		Name:        model.NewId(),
+		Name:        model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 		SchemeId:    &d5.Id,
 	}

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -1212,9 +1212,9 @@ func testGetChannelUnreadsForAllTeams(t *testing.T, ss store.Store) {
 	store.Must(ss.Team().SaveMember(m1, -1))
 	store.Must(ss.Team().SaveMember(m2, -1))
 
-	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
+	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId()[0:10], DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
 	store.Must(ss.Channel().Save(c1, -1))
-	c2 := &model.Channel{TeamId: m2.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
+	c2 := &model.Channel{TeamId: m2.TeamId, Name: model.NewId()[0:10], DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
 	store.Must(ss.Channel().Save(c2, -1))
 
 	cm1 := &model.ChannelMember{ChannelId: c1.Id, UserId: m1.UserId, NotifyProps: model.GetDefaultChannelNotifyProps(), MsgCount: 90}
@@ -1275,9 +1275,9 @@ func testGetChannelUnreadsForTeam(t *testing.T, ss store.Store) {
 	m1 := &model.TeamMember{TeamId: teamId1, UserId: uid}
 	store.Must(ss.Team().SaveMember(m1, -1))
 
-	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
+	c1 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId()[0:10], DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
 	store.Must(ss.Channel().Save(c1, -1))
-	c2 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId(), DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
+	c2 := &model.Channel{TeamId: m1.TeamId, Name: model.NewId()[0:10], DisplayName: "Town Square", Type: model.CHANNEL_OPEN, TotalMsgCount: 100}
 	store.Must(ss.Channel().Save(c2, -1))
 
 	cm1 := &model.ChannelMember{ChannelId: c1.Id, UserId: m1.UserId, NotifyProps: model.GetDefaultChannelNotifyProps(), MsgCount: 90}

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -681,14 +681,14 @@ func testUserStoreGetProfilesInChannel(t *testing.T, ss store.Store) {
 	c1 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in channel",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
 	c2 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in private",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}, -1)).(*model.Channel)
 
@@ -769,14 +769,14 @@ func testUserStoreGetProfilesInChannelByStatus(t *testing.T, ss store.Store) {
 	c1 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in channel",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
 	c2 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in private",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}, -1)).(*model.Channel)
 
@@ -912,14 +912,14 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, ss store.Store) {
 	c1 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in channel",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
 	c2 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in private",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}, -1)).(*model.Channel)
 
@@ -1019,14 +1019,14 @@ func testUserStoreGetProfilesNotInChannel(t *testing.T, ss store.Store) {
 	c1 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in channel",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 
 	c2 := store.Must(ss.Channel().Save(&model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Profiles in private",
-		Name:        "profiles-" + model.NewId(),
+		Name:        "profiles-" + model.NewId()[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}, -1)).(*model.Channel)
 
@@ -1646,13 +1646,13 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = teamId
 	c1.DisplayName = "Unread Messages"
-	c1.Name = "unread-messages-" + model.NewId()
+	c1.Name = "unread-messages-" + model.NewId()[0:6]
 	c1.Type = model.CHANNEL_OPEN
 
 	c2 := model.Channel{}
 	c2.TeamId = teamId
 	c2.DisplayName = "Unread Direct"
-	c2.Name = "unread-direct-" + model.NewId()
+	c2.Name = "unread-direct-" + model.NewId()[0:6]
 	c2.Type = model.CHANNEL_DIRECT
 
 	u1 := &model.User{}
@@ -2335,7 +2335,7 @@ func testUserStoreSearchNotInChannel(t *testing.T, ss store.Store) {
 	c1 := model.Channel{
 		TeamId:      tid,
 		DisplayName: "NameName",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
@@ -2343,7 +2343,7 @@ func testUserStoreSearchNotInChannel(t *testing.T, ss store.Store) {
 	c2 := model.Channel{
 		TeamId:      tid,
 		DisplayName: "NameName",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	c2 = *store.Must(ss.Channel().Save(&c2, -1)).(*model.Channel)
@@ -2549,7 +2549,7 @@ func testUserStoreSearchInChannel(t *testing.T, ss store.Store) {
 	c1 := model.Channel{
 		TeamId:      tid,
 		DisplayName: "NameName",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	c1 = *store.Must(ss.Channel().Save(&c1, -1)).(*model.Channel)
@@ -2557,7 +2557,7 @@ func testUserStoreSearchInChannel(t *testing.T, ss store.Store) {
 	c2 := model.Channel{
 		TeamId:      tid,
 		DisplayName: "NameName",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        "zz" + model.NewId()[0:10] + "b",
 		Type:        model.CHANNEL_OPEN,
 	}
 	c2 = *store.Must(ss.Channel().Save(&c2, -1)).(*model.Channel)
@@ -3412,15 +3412,15 @@ func testUserStoreGetUsersBatchForIndexing(t *testing.T, ss store.Store) {
 	})
 	require.Nil(t, err)
 	cPub1 := store.Must(ss.Channel().Save(&model.Channel{
-		Name: model.NewId(),
+		Name: model.NewId()[0:10],
 		Type: model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 	cPub2 := store.Must(ss.Channel().Save(&model.Channel{
-		Name: model.NewId(),
+		Name: model.NewId()[0:10],
 		Type: model.CHANNEL_OPEN,
 	}, -1)).(*model.Channel)
 	cPriv := store.Must(ss.Channel().Save(&model.Channel{
-		Name: model.NewId(),
+		Name: model.NewId()[0:10],
 		Type: model.CHANNEL_PRIVATE,
 	}, -1)).(*model.Channel)
 
@@ -3651,7 +3651,7 @@ func testUserStoreGetChannelGroupUsers(t *testing.T, ss store.Store) {
 	id := model.NewId()
 	res := <-ss.Channel().Save(&model.Channel{
 		DisplayName: "dn_" + id,
-		Name:        "n-" + id,
+		Name:        "n-" + id[0:10],
 		Type:        model.CHANNEL_PRIVATE,
 	}, 999)
 	require.Nil(t, res.Err)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -110,7 +110,7 @@ func (th *TestHelper) InitBasic() *TestHelper {
 
 	th.App.JoinUserToTeam(team, user, "")
 
-	channel, _ := th.App.CreateChannel(&model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId() + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id, CreatorId: user.Id}, true)
+	channel, _ := th.App.CreateChannel(&model.Channel{DisplayName: "Test API Name", Name: "zz" + model.NewId()[0:10] + "a", Type: model.CHANNEL_OPEN, TeamId: team.Id, CreatorId: user.Id}, true)
 
 	th.BasicUser = user
 	th.BasicChannel = channel

--- a/web/webhook_test.go
+++ b/web/webhook_test.go
@@ -200,7 +200,7 @@ func TestIncomingWebhook(t *testing.T) {
 	})
 
 	t.Run("ChannelLockedWebhook", func(t *testing.T) {
-		channel, err := th.App.CreateChannel(&model.Channel{TeamId: th.BasicTeam.Id, Name: model.NewId(), DisplayName: model.NewId(), Type: model.CHANNEL_OPEN, CreatorId: th.BasicUser.Id}, true)
+		channel, err := th.App.CreateChannel(&model.Channel{TeamId: th.BasicTeam.Id, Name: model.NewId()[0:10], DisplayName: model.NewId(), Type: model.CHANNEL_OPEN, CreatorId: th.BasicUser.Id}, true)
 		require.Nil(t, err)
 
 		hook, err := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, &model.IncomingWebhook{ChannelId: th.BasicChannel.Id, ChannelLocked: true})


### PR DESCRIPTION
#### Summary
Making server channel name validation more restrictive, verifiying multiple
hyphens are not allowed and the max size used is the same in the backend and in
the frontend (22 characters).

#### Ticket Link
[MM-15310](https://mattermost.atlassian.net/browse/MM-15310)
[MM-15311](https://mattermost.atlassian.net/browse/MM-15311)