### PR TITLE
Fix panic when replying to posts

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -310,11 +310,9 @@ func (a *App) getMentionedUsersFromDirectChannel(mentionedUserIds map[string]boo
 
 // Get a active and mentioned users from all channels
 func (a *App) getMentionedUsersFromOtherChannels(post *model.Post, m *ExplicitMentions, profileMap map[string]*model.User, mentionedUserIds map[string]bool, team *model.Team,
-	parentPostList *model.PostList, channel *model.Channel, sender *model.User, channelMemberNotifyPropsMap map[string]model.StringMap, allActivityPushUserIds []string) ([]string, map[string]bool, map[string]model.StringMap, error) {
+	parentPostList *model.PostList, channel *model.Channel, sender *model.User, channelMemberNotifyPropsMap map[string]model.StringMap, allActivityPushUserIds []string, threadMentionedUserIds map[string]string) ([]string, map[string]bool, map[string]model.StringMap, map[string]string, error) {
 	// Add an implicit mention when a user is added to a channel
 	// even if the user has set 'username mentions' to false in account settings.
-	var threadMentionedUserIds map[string]string
-
 	if post.Type == model.POST_ADD_TO_CHANNEL {
 		val := post.Props[model.POST_PROPS_ADDED_USER_ID]
 		if val != nil {
@@ -356,7 +354,7 @@ func (a *App) getMentionedUsersFromOtherChannels(post *model.Post, m *ExplicitMe
 			if channel.IsGroupConstrained() {
 				nonMemberIDs, err := a.FilterNonGroupChannelMembers(channelMentions.IDs(), channel)
 				if err != nil {
-					return nil, nil, nil, err
+					return nil, nil, nil, nil, err
 				}
 
 				outOfChannelMentions = channelMentions.FilterWithoutID(nonMemberIDs)
@@ -382,7 +380,7 @@ func (a *App) getMentionedUsersFromOtherChannels(post *model.Post, m *ExplicitMe
 			allActivityPushUserIds = append(allActivityPushUserIds, profile.Id)
 		}
 	}
-	return allActivityPushUserIds, mentionedUserIds, channelMemberNotifyPropsMap, nil
+	return allActivityPushUserIds, mentionedUserIds, channelMemberNotifyPropsMap, threadMentionedUserIds, nil
 }
 
 // Send Push Notifications based on mentioned or active users
@@ -513,7 +511,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 		mentionedUserIds, hereNotification, channelNotification, allNotification = m.MentionedUserIds, m.HereMentioned, m.ChannelMentioned, m.AllMentioned
 
 		var err error
-		allActivityPushUserIds, mentionedUserIds, channelMemberNotifyPropsMap, err = a.getMentionedUsersFromOtherChannels(post, m, profileMap, mentionedUserIds, team, parentPostList, channel, sender, channelMemberNotifyPropsMap, allActivityPushUserIds)
+		allActivityPushUserIds, mentionedUserIds, channelMemberNotifyPropsMap, threadMentionedUserIds, err = a.getMentionedUsersFromOtherChannels(post, m, profileMap, mentionedUserIds, team, parentPostList, channel, sender, channelMemberNotifyPropsMap, allActivityPushUserIds, threadMentionedUserIds)
 		if err != nil {
 			return nil, err
 		}

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -83,6 +83,22 @@ func TestSendNotifications(t *testing.T) {
 	mentions, err2 = th.App.SendNotifications(post1, th.BasicTeam, th.BasicChannel, th.BasicUser, nil)
 	assert.Nil(t, err2)
 	assert.Len(t, mentions, 0)
+
+	post4, err := th.App.CreatePostMissingChannel(&model.Post{
+		UserId:    th.BasicUser2.Id,
+		ChannelId: dm.Id,
+		RootId:    post3.Id,
+		Message:   "reply message",
+	}, true)
+	postList := model.NewPostList()
+	postList.AddOrder(post3.Id)
+	postList.AddOrder(post4.Id)
+	postList.AddPost(post3)
+	postList.AddPost(post4)
+	mentions, err2 = th.App.SendNotifications(post4, th.BasicTeam, dm, th.BasicUser2, postList)
+	assert.Nil(t, err2)
+	assert.Len(t, mentions, 1)
+
 }
 
 func TestGetExplicitMentions(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR #10492 introduced a server panic by not initializing the `threadMentionedUserIds` var, in this PR we send the already existing var to the function and we also return it so push notifications are actually sent to the users.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-15698