### PR TITLE
MM-14721 - Add an identifier for compliance exports when a message is posted by a bot account

### DIFF
--- a/model/channel_member_history_result.go
+++ b/model/channel_member_history_result.go
@@ -12,4 +12,5 @@ type ChannelMemberHistoryResult struct {
 	// these two fields are never set in the database - when we SELECT, we join on Users to get them
 	UserEmail string `db:"Email"`
 	Username  string
+	IsBot     bool
 }

--- a/model/message_export.go
+++ b/model/message_export.go
@@ -16,6 +16,7 @@ type MessageExport struct {
 	UserId    *string
 	UserEmail *string
 	Username  *string
+	IsBot     bool
 
 	PostId         *string
 	PostCreateAt   *int64

--- a/store/sqlstore/channel_member_history_store.go
+++ b/store/sqlstore/channel_member_history_store.go
@@ -112,9 +112,11 @@ func (s SqlChannelMemberHistoryStore) getFromChannelMemberHistoryTable(startTime
 			SELECT
 				cmh.*,
 				u.Email,
-				u.Username
+				u.Username,
+			    Bots.UserId IS NOT NULL AS IsBot
 			FROM ChannelMemberHistory cmh
 			INNER JOIN Users u ON cmh.UserId = u.Id
+			LEFT JOIN Bots ON Bots.UserId = u.Id
 			WHERE cmh.ChannelId = :ChannelId
 			AND cmh.JoinTime <= :EndTime
 			AND (cmh.LeaveTime IS NULL OR cmh.LeaveTime >= :StartTime)
@@ -135,9 +137,12 @@ func (s SqlChannelMemberHistoryStore) getFromChannelMembersTable(startTime int64
 			ch.ChannelId,
 			ch.UserId,
 			u.Email,
-			u.Username
+			u.Username,
+		    Bots.UserId IS NOT NULL AS IsBot
+
 		FROM ChannelMembers AS ch
 		INNER JOIN Users AS u ON ch.UserId = u.id
+		LEFT JOIN Bots ON Bots.UserId = u.Id
 		WHERE ch.ChannelId = :ChannelId`
 
 	params := map[string]interface{}{"ChannelId": channelId}

--- a/templates/globalrelay_compliance_export.html
+++ b/templates/globalrelay_compliance_export.html
@@ -71,6 +71,7 @@
 <table class="participants">
     <tr>
         <th class="username">Username<br></th>
+        <th class="usertype">UserType<br></th>
         <th class="email">Email</th>
         <th class="joined">Joined</th>
         <th class="left">Left</th>

--- a/templates/globalrelay_compliance_export_message.html
+++ b/templates/globalrelay_compliance_export_message.html
@@ -2,6 +2,7 @@
 <li class="message">
     <span class="sent_time">{{.Props.SentTime}}</span>
     <span class="username">@{{.Props.Username}}</span>
+    <span class="usertype">{{.Props.UserType}}</span>
     <span class="email">({{.Props.Email}}):</span>
     <span class="message">{{.Props.Message}}</span>
 </li>

--- a/templates/globalrelay_compliance_export_participant_row.html
+++ b/templates/globalrelay_compliance_export_participant_row.html
@@ -1,6 +1,7 @@
 {{define "globalrelay_compliance_export_participant_row"}}
 <tr>
     <td class="username">@{{.Props.Username}}</td>
+    <td class="usertype">{{.Props.UserType}}</td>
     <td class="email">{{.Props.Email}}</td>
     <td class="joined">{{.Props.Joined}}</td>
     <td class="left">{{.Props.Left}}</td>


### PR DESCRIPTION
Added new field 'UserType' to compliance export. Right now supports 'bot' and 'user'

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-14721
Related enterprise PR: https://github.com/mattermost/enterprise/pull/437