### PR TITLE
Add support for tracing in LDAP

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -1642,6 +1642,8 @@ type LdapSettings struct {
 	LoginButtonColor       *string
 	LoginButtonBorderColor *string
 	LoginButtonTextColor   *string
+
+	Trace *bool
 }
 
 func (s *LdapSettings) SetDefaults() {
@@ -1758,6 +1760,10 @@ func (s *LdapSettings) SetDefaults() {
 
 	if s.LoginButtonTextColor == nil {
 		s.LoginButtonTextColor = NewString("#2389D7")
+	}
+
+	if s.Trace == nil {
+		s.Trace = NewBool(false)
 	}
 }
 


### PR DESCRIPTION
#### Summary
Add support for tracing in LDAP. It adds a setting in the `LdapSettings` to
enable debug mode in the ldap client library. Asked by Paul Rothrock.

Enterprise PR: mattermost/enterprise#439