### PR TITLE
[MM-15767] Limit exposure of any information about the user status on login failure

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1240,10 +1240,13 @@ func sendPasswordReset(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func login(c *Context, w http.ResponseWriter, r *http.Request) {
-	// For hardened mode, translate all login errors to generic. MFA error being an exception, since it's required for
-	// the login flow itself.
+	// Translate all login errors to generic. MFA error being an exception, since it's required for the login flow itself
 	defer func() {
-		if *c.App.Config().ServiceSettings.ExperimentalEnableHardenedMode && c.Err != nil && c.Err.Id != "mfa.validate_token.authenticate.app_error" {
+		if c.Err != nil &&
+			c.Err.Id != "mfa.validate_token.authenticate.app_error" &&
+			c.Err.Id != "api.user.login.blank_pwd.app_error" &&
+			c.Err.Id != "api.user.login.bot_login_forbidden.app_error" &&
+			c.Err.Id != "api.user.login.client_side_cert.certificate.app_error" {
 			c.Err = model.NewAppError("login", "api.user.login.invalid_credentials", nil, "", http.StatusUnauthorized)
 		}
 	}()

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2655,7 +2655,7 @@ func TestLogin(t *testing.T) {
 
 	t.Run("unknown user", func(t *testing.T) {
 		_, resp := th.Client.Login("unknown", th.BasicUser.Password)
-		CheckErrorMessage(t, resp, "store.sql_user.get_for_login.app_error")
+		CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	})
 
 	t.Run("valid login", func(t *testing.T) {
@@ -2764,7 +2764,7 @@ func TestCBALogin(t *testing.T) {
 			th.Client.Logout()
 			th.Client.HttpHeader["X-SSL-Client-Cert-Subject-DN"] = "C=US, ST=Maryland, L=Pasadena, O=Brent Baccala, OU=FreeSoft, CN=www.freesoft.org/emailAddress=mis_match" + th.BasicUser.Email
 			_, resp := th.Client.Login(th.BasicUser.Email, "")
-			CheckBadRequestStatus(t, resp)
+			CheckUnauthorizedStatus(t, resp)
 		})
 
 		t.Run("successful cba login", func(t *testing.T) {
@@ -4114,28 +4114,41 @@ func TestLoginLockout(t *testing.T) {
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableMultifactorAuthentication = true })
 
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
-	CheckErrorMessage(t, resp, "api.user.check_user_password.invalid.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
-	CheckErrorMessage(t, resp, "api.user.check_user_password.invalid.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
-	CheckErrorMessage(t, resp, "api.user.check_user_password.invalid.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
-	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
-	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
+
+	//Check if lock is active
+	_, resp = th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 
 	// Fake user has MFA enabled
 	if result := <-th.Server.Store.User().UpdateMfaActive(th.BasicUser2.Id, true); result.Err != nil {
 		t.Fatal(result.Err)
 	}
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
-	CheckErrorMessage(t, resp, "api.user.check_user_mfa.bad_code.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
-	CheckErrorMessage(t, resp, "api.user.check_user_mfa.bad_code.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
-	CheckErrorMessage(t, resp, "api.user.check_user_mfa.bad_code.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
-	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
-	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
+
+	// Fake user has MFA disabled
+	if result := <-th.Server.Store.User().UpdateMfaActive(th.BasicUser2.Id, false); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+
+	//Check if lock is active
+	_, resp = th.Client.Login(th.BasicUser2.Email, th.BasicUser2.Password)
+	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials")
 }


### PR DESCRIPTION
#### Summary
Currently we indicate if a user account exists, if the password was incorrect or the wrong authentication method used. This PR uses the previous existent code used for the hardened mode to obfuscate the error message before sent back to the client, with the following exceptions:

- Invalid MFA Token
- Blank password
- Bot Login is forbidden
- Client Certificate error

The error messages above don't expose any additional information, and communicate that something was invalid before any specific user is valdiated.

**ToDo:** The error message might need additional UX work.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15767