### PR TITLE
[MM-15303] Migrate "Preference.DeleteCategory" to Sync by default

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -945,8 +945,8 @@ func (a *App) LeaveTeam(team *model.Team, user *model.User, requestorId string) 
 	}
 
 	// delete the preferences that set the last channel used in the team and other team specific preferences
-	if result := <-a.Srv.Store.Preference().DeleteCategory(user.Id, team.Id); result.Err != nil {
-		return result.Err
+	if err := a.Srv.Store.Preference().DeleteCategory(user.Id, team.Id); err != nil {
+		return err
 	}
 
 	a.ClearSessionCacheForUser(user.Id)

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -261,17 +261,19 @@ func (s SqlPreferenceStore) Delete(userId, category, name string) store.StoreCha
 	})
 }
 
-func (s SqlPreferenceStore) DeleteCategory(userId string, category string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if _, err := s.GetMaster().Exec(
-			`DELETE FROM
-				Preferences
-			WHERE
-				UserId = :UserId
-				AND Category = :Category`, map[string]interface{}{"UserId": userId, "Category": category}); err != nil {
-			result.Err = model.NewAppError("SqlPreferenceStore.DeleteCategory", "store.sql_preference.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
-		}
-	})
+func (s SqlPreferenceStore) DeleteCategory(userId string, category string) *model.AppError {
+	_, err := s.GetMaster().Exec(
+		`DELETE FROM
+			Preferences
+		WHERE
+			UserId = :UserId
+			AND Category = :Category`, map[string]interface{}{"UserId": userId, "Category": category})
+
+	if err != nil {
+		return model.NewAppError("SqlPreferenceStore.DeleteCategory", "store.sql_preference.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
 }
 
 func (s SqlPreferenceStore) DeleteCategoryAndName(category string, name string) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -433,7 +433,7 @@ type PreferenceStore interface {
 	Get(userId string, category string, name string) (*model.Preference, *model.AppError)
 	GetAll(userId string) StoreChannel
 	Delete(userId, category, name string) StoreChannel
-	DeleteCategory(userId string, category string) StoreChannel
+	DeleteCategory(userId string, category string) *model.AppError
 	DeleteCategoryAndName(category string, name string) StoreChannel
 	PermanentDeleteByUser(userId string) *model.AppError
 	IsFeatureEnabled(feature, userId string) StoreChannel

--- a/store/storetest/mocks/PreferenceStore.go
+++ b/store/storetest/mocks/PreferenceStore.go
@@ -53,15 +53,15 @@ func (_m *PreferenceStore) Delete(userId string, category string, name string) s
 }
 
 // DeleteCategory provides a mock function with given fields: userId, category
-func (_m *PreferenceStore) DeleteCategory(userId string, category string) store.StoreChannel {
+func (_m *PreferenceStore) DeleteCategory(userId string, category string) *model.AppError {
 	ret := _m.Called(userId, category)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string) *model.AppError); ok {
 		r0 = rf(userId, category)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -357,8 +357,8 @@ func testPreferenceDeleteCategory(t *testing.T, ss store.Store) {
 		t.Fatal("should've returned 2 preferences")
 	}
 
-	if result := <-ss.Preference().DeleteCategory(userId, category); result.Err != nil {
-		t.Fatal(result.Err)
+	if err := ss.Preference().DeleteCategory(userId, category); err != nil {
+		t.Fatal(err)
 	}
 
 	if prefs := store.Must(ss.Preference().GetAll(userId)).(model.Preferences); len([]model.Preference(prefs)) != 0 {


### PR DESCRIPTION
#### Summary
Migrate the `DeleteCategory` method from the `Preference` store to Sync by
default.

#### Ticket Link

 Fixes #10714 
