### PR TITLE
[MM-8421] Special PR to have parseImages return nil when format is tiff

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -517,5 +517,10 @@ func parseImages(body io.Reader) (*model.PostImage, error) {
 		image.FrameCount = frameCount
 	}
 
+	// Make image information nil when the format is tiff
+	if format == "tiff" {
+		image = nil
+	}
+
 	return image, nil
 }

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -1995,11 +1995,7 @@ func TestParseImages(t *testing.T) {
 		},
 		"tiff": {
 			FileName: "test.tiff",
-			Expected: &model.PostImage{
-				Width:  701,
-				Height: 701,
-				Format: "tiff",
-			},
+			Expected: (*model.PostImage)(nil),
 		},
 		"not an image": {
 			FileName:    "README.md",


### PR DESCRIPTION
#### Summary
Adds a special case to `parseImages in app/post_metadata.go` so that format returns nil when the `DecodeConfig` is tiff. This prevents empty boxes/previews from appearing for tiff image links since most browsers can't render them.

#### Ticket Link
Special additional PR for the [webapp PR ](https://github.com/mattermost/mattermost-webapp/pull/2333)for the [ticket](https://github.com/mattermost/mattermost-server/issues/8092)

