### PR TITLE
[MM-15304] Migrate "Preference.DeleteCategoryAndName" to Sync by default

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -766,8 +766,8 @@ func (a *App) DeletePost(postId, deleteByID string) (*model.Post, *model.AppErro
 }
 
 func (a *App) DeleteFlaggedPosts(postId string) {
-	if result := <-a.Srv.Store.Preference().DeleteCategoryAndName(model.PREFERENCE_CATEGORY_FLAGGED_POST, postId); result.Err != nil {
-		mlog.Warn(fmt.Sprintf("Unable to delete flagged post preference when deleting post, err=%v", result.Err))
+	if err := a.Srv.Store.Preference().DeleteCategoryAndName(model.PREFERENCE_CATEGORY_FLAGGED_POST, postId); err != nil {
+		mlog.Warn(fmt.Sprintf("Unable to delete flagged post preference when deleting post, err=%v", err))
 		return
 	}
 }

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -274,17 +274,19 @@ func (s SqlPreferenceStore) DeleteCategory(userId string, category string) store
 	})
 }
 
-func (s SqlPreferenceStore) DeleteCategoryAndName(category string, name string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if _, err := s.GetMaster().Exec(
-			`DELETE FROM
-				Preferences
-			WHERE
-				Name = :Name
-				AND Category = :Category`, map[string]interface{}{"Name": name, "Category": category}); err != nil {
-			result.Err = model.NewAppError("SqlPreferenceStore.DeleteCategoryAndName", "store.sql_preference.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
-		}
-	})
+func (s SqlPreferenceStore) DeleteCategoryAndName(category string, name string) *model.AppError {
+	_, err := s.GetMaster().Exec(
+		`DELETE FROM
+			Preferences
+		WHERE
+			Name = :Name
+			AND Category = :Category`, map[string]interface{}{"Name": name, "Category": category})
+
+	if err != nil {
+		return model.NewAppError("SqlPreferenceStore.DeleteCategoryAndName", "store.sql_preference.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
 }
 
 func (s SqlPreferenceStore) CleanupFlagsBatch(limit int64) (int64, *model.AppError) {

--- a/store/store.go
+++ b/store/store.go
@@ -434,7 +434,7 @@ type PreferenceStore interface {
 	GetAll(userId string) StoreChannel
 	Delete(userId, category, name string) StoreChannel
 	DeleteCategory(userId string, category string) StoreChannel
-	DeleteCategoryAndName(category string, name string) StoreChannel
+	DeleteCategoryAndName(category string, name string) *model.AppError
 	PermanentDeleteByUser(userId string) *model.AppError
 	IsFeatureEnabled(feature, userId string) StoreChannel
 	CleanupFlagsBatch(limit int64) (int64, *model.AppError)

--- a/store/storetest/mocks/PreferenceStore.go
+++ b/store/storetest/mocks/PreferenceStore.go
@@ -69,15 +69,15 @@ func (_m *PreferenceStore) DeleteCategory(userId string, category string) store.
 }
 
 // DeleteCategoryAndName provides a mock function with given fields: category, name
-func (_m *PreferenceStore) DeleteCategoryAndName(category string, name string) store.StoreChannel {
+func (_m *PreferenceStore) DeleteCategoryAndName(category string, name string) *model.AppError {
 	ret := _m.Called(category, name)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string) *model.AppError); ok {
 		r0 = rf(category, name)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -396,8 +396,8 @@ func testPreferenceDeleteCategoryAndName(t *testing.T, ss store.Store) {
 		t.Fatal("should've returned 1 preference")
 	}
 
-	if result := <-ss.Preference().DeleteCategoryAndName(category, name); result.Err != nil {
-		t.Fatal(result.Err)
+	if err := ss.Preference().DeleteCategoryAndName(category, name); err != nil {
+		t.Fatal(err)
 	}
 
 	if prefs := store.Must(ss.Preference().GetAll(userId)).(model.Preferences); len([]model.Preference(prefs)) != 0 {


### PR DESCRIPTION
#### Summary
Migrate the `DeleteCategoryAndName` method from the `Preference` store to Sync by
default.

#### Ticket Link

 Fixes #10713 