### PR TITLE
[MM-15301] Migrate "Preference.IsFeatureEnabled" to Sync by default

### DIFF
--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -224,21 +224,20 @@ func (s SqlPreferenceStore) PermanentDeleteByUser(userId string) *model.AppError
 	return nil
 }
 
-func (s SqlPreferenceStore) IsFeatureEnabled(feature, userId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if value, err := s.GetReplica().SelectStr(`SELECT
-				value
-			FROM
-				Preferences
-			WHERE
-				UserId = :UserId
-				AND Category = :Category
-				AND Name = :Name`, map[string]interface{}{"UserId": userId, "Category": model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS, "Name": store.FEATURE_TOGGLE_PREFIX + feature}); err != nil {
-			result.Err = model.NewAppError("SqlPreferenceStore.IsFeatureEnabled", "store.sql_preference.is_feature_enabled.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-			result.Data = value == "true"
-		}
-	})
+func (s SqlPreferenceStore) IsFeatureEnabled(feature, userId string) (bool, *model.AppError) {
+	query :=
+		`SELECT value FROM Preferences
+		WHERE
+			UserId = :UserId
+			AND Category = :Category
+			AND Name = :Name`
+
+	value, err := s.GetReplica().SelectStr(query, map[string]interface{}{"UserId": userId, "Category": model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS, "Name": store.FEATURE_TOGGLE_PREFIX + feature})
+	if err != nil {
+		return false, model.NewAppError("SqlPreferenceStore.IsFeatureEnabled", "store.sql_preference.is_feature_enabled.app_error", nil, err.Error(), http.StatusInternalServerError)
+	} else {
+		return value == "true", nil
+	}
 }
 
 func (s SqlPreferenceStore) Delete(userId, category, name string) store.StoreChannel {

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -235,9 +235,8 @@ func (s SqlPreferenceStore) IsFeatureEnabled(feature, userId string) (bool, *mod
 	value, err := s.GetReplica().SelectStr(query, map[string]interface{}{"UserId": userId, "Category": model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS, "Name": store.FEATURE_TOGGLE_PREFIX + feature})
 	if err != nil {
 		return false, model.NewAppError("SqlPreferenceStore.IsFeatureEnabled", "store.sql_preference.is_feature_enabled.app_error", nil, err.Error(), http.StatusInternalServerError)
-	} else {
-		return value == "true", nil
 	}
+	return value == "true", nil
 }
 
 func (s SqlPreferenceStore) Delete(userId, category, name string) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -436,7 +436,7 @@ type PreferenceStore interface {
 	DeleteCategory(userId string, category string) StoreChannel
 	DeleteCategoryAndName(category string, name string) StoreChannel
 	PermanentDeleteByUser(userId string) *model.AppError
-	IsFeatureEnabled(feature, userId string) StoreChannel
+	IsFeatureEnabled(feature, userId string) (bool, *model.AppError)
 	CleanupFlagsBatch(limit int64) (int64, *model.AppError)
 }
 

--- a/store/storetest/mocks/PreferenceStore.go
+++ b/store/storetest/mocks/PreferenceStore.go
@@ -151,19 +151,26 @@ func (_m *PreferenceStore) GetCategory(userId string, category string) (model.Pr
 }
 
 // IsFeatureEnabled provides a mock function with given fields: feature, userId
-func (_m *PreferenceStore) IsFeatureEnabled(feature string, userId string) store.StoreChannel {
+func (_m *PreferenceStore) IsFeatureEnabled(feature string, userId string) (bool, *model.AppError) {
 	ret := _m.Called(feature, userId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string) bool); ok {
 		r0 = rf(feature, userId)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, string) *model.AppError); ok {
+		r1 = rf(feature, userId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
 		}
 	}
 
-	return r0
+	return r0, r1
 }
 
 // PermanentDeleteByUser provides a mock function with given fields: userId

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -4,8 +4,9 @@
 package storetest
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 
@@ -298,29 +299,29 @@ func testIsFeatureEnabled(t *testing.T, ss store.Store) {
 	require.Nil(t, err)
 	require.Equal(t, 5, count)
 
-	if result := <-ss.Preference().IsFeatureEnabled(feature1, userId); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); !data {
+	if data, err := ss.Preference().IsFeatureEnabled(feature1, userId); err != nil {
+		t.Fatal(err)
+	} else if !data {
 		t.Fatalf("got incorrect setting for feature1, %v=%v", true, data)
 	}
 
-	if result := <-ss.Preference().IsFeatureEnabled(feature2, userId); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); data {
+	if data, err := ss.Preference().IsFeatureEnabled(feature2, userId); err != nil {
+		t.Fatal(err)
+	} else if data {
 		t.Fatalf("got incorrect setting for feature2, %v=%v", false, data)
 	}
 
 	// make sure we get false if something different than "true" or "false" has been saved to database
-	if result := <-ss.Preference().IsFeatureEnabled(feature3, userId); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); data {
+	if data, err := ss.Preference().IsFeatureEnabled(feature3, userId); err != nil {
+		t.Fatal(err)
+	} else if data {
 		t.Fatalf("got incorrect setting for feature3, %v=%v", false, data)
 	}
 
 	// make sure false is returned if a non-existent feature is queried
-	if result := <-ss.Preference().IsFeatureEnabled("someOtherFeature", userId); result.Err != nil {
-		t.Fatal(result.Err)
-	} else if data := result.Data.(bool); data {
+	if data, err := ss.Preference().IsFeatureEnabled("someOtherFeature", userId); err != nil {
+		t.Fatal(err)
+	} else if data {
 		t.Fatalf("got incorrect setting for non-existent feature 'someOtherFeature', %v=%v", false, data)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request migrates the IsFeatureEnabled in the Preference store to use Sync by default. I followed the instructions laid out in the issue description. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/10716