### PR TITLE
[MM-15803] Migrate "Session.AnalyticsSessionCount" to Sync by default

### DIFF
--- a/app/analytics.go
+++ b/app/analytics.go
@@ -206,7 +206,7 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 			close(commandChan)
 		}()
 
-		sessionChan := a.Srv.Store.Session().AnalyticsSessionCount()
+		sessionCount, sessionErr := a.Srv.Store.Session().AnalyticsSessionCount()
 
 		var fileChan store.StoreChannel
 		var hashtagChan store.StoreChannel
@@ -253,11 +253,10 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 		}
 		rows[4].Value = float64(r.Data.(int64))
 
-		r = <-sessionChan
-		if r.Err != nil {
-			return nil, r.Err
+		if sessionErr != nil {
+			return nil, sessionErr
 		}
-		rows[5].Value = float64(r.Data.(int64))
+		rows[5].Value = float64(sessionCount)
 
 		return rows, nil
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -322,7 +322,7 @@ type SessionStore interface {
 	UpdateLastActivityAt(sessionId string, time int64) StoreChannel
 	UpdateRoles(userId string, roles string) StoreChannel
 	UpdateDeviceId(id string, deviceId string, expiresAt int64) StoreChannel
-	AnalyticsSessionCount() StoreChannel
+	AnalyticsSessionCount() (int64, *model.AppError)
 	Cleanup(expiryTime int64, batchSize int64)
 }
 

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -14,19 +14,26 @@ type SessionStore struct {
 }
 
 // AnalyticsSessionCount provides a mock function with given fields:
-func (_m *SessionStore) AnalyticsSessionCount() store.StoreChannel {
+func (_m *SessionStore) AnalyticsSessionCount() (int64, *model.AppError) {
 	ret := _m.Called()
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+	var r0 int64
+	if rf, ok := ret.Get(0).(func() int64); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
 		}
 	}
 
-	return r0
+	return r0, r1
 }
 
 // Cleanup provides a mock function with given fields: expiryTime, batchSize

--- a/store/storetest/session_store.go
+++ b/store/storetest/session_store.go
@@ -245,10 +245,10 @@ func testSessionCount(t *testing.T, ss store.Store) {
 	s1.ExpiresAt = model.GetMillis() + 100000
 	store.Must(ss.Session().Save(&s1))
 
-	if r1 := <-ss.Session().AnalyticsSessionCount(); r1.Err != nil {
-		t.Fatal(r1.Err)
+	if count, err := ss.Session().AnalyticsSessionCount(); err != nil {
+		t.Fatal(err)
 	} else {
-		if r1.Data.(int64) == 0 {
+		if count == 0 {
 			t.Fatal("should have at least 1 session")
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request migrates the AnalyticsSessionCount in the Session store to use Sync by default. I followed the instructions laid out in the issue description and updated all necessary files.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #10929