### PR TITLE
Trim leading and trailing spaces for search terms

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-server/app"
@@ -709,7 +710,7 @@ func searchUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 func autocompleteUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	channelId := r.URL.Query().Get("in_channel")
 	teamId := r.URL.Query().Get("in_team")
-	name := r.URL.Query().Get("name")
+	name := strings.TrimSpace(r.URL.Query().Get("name"))
 	limitStr := r.URL.Query().Get("limit")
 	limit, _ := strconv.Atoi(limitStr)
 	if limitStr == "" {

--- a/model/channel_search.go
+++ b/model/channel_search.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const CHANNEL_SEARCH_DEFAULT_LIMIT = 50
@@ -26,5 +27,8 @@ func (c *ChannelSearch) ToJson() string {
 func ChannelSearchFromJson(data io.Reader) *ChannelSearch {
 	var cs *ChannelSearch
 	json.NewDecoder(data).Decode(&cs)
+
+	cs.Term = strings.TrimSpace(cs.Term)
+
 	return cs
 }

--- a/model/channel_search_test.go
+++ b/model/channel_search_test.go
@@ -16,4 +16,12 @@ func TestChannelSearchJson(t *testing.T) {
 	if channelSearch.Term != rchannelSearch.Term {
 		t.Fatal("Terms do not match")
 	}
+
+	channelSearchWithSpaces := ChannelSearch{Term: " a string "}
+	jsonWithSpaces := channelSearchWithSpaces.ToJson()
+	rchannelSearchWithSpaces := ChannelSearchFromJson(strings.NewReader(jsonWithSpaces))
+
+	if !strings.EqualFold(rchannelSearchWithSpaces.Term, "a string") {
+		t.Fatal("Terms should not have leading or trailing spaces")
+	}
 }

--- a/model/post.go
+++ b/model/post.go
@@ -378,6 +378,11 @@ func SearchParameterFromJson(data io.Reader) *SearchParameter {
 		return nil
 	}
 
+	if searchParam.Terms != nil {
+		terms := strings.TrimSpace(*searchParam.Terms)
+		searchParam.Terms = &terms
+	}
+
 	return &searchParam
 }
 

--- a/model/post_test.go
+++ b/model/post_test.go
@@ -530,3 +530,15 @@ func BenchmarkRewriteImageURLs(b *testing.B) {
 		})
 	}
 }
+
+func TestSearchParameterFromJson(t *testing.T) {
+	terms := " a string "
+	searchParameter := SearchParameter{
+		Terms: &terms,
+	}
+	json := searchParameter.SearchParameterToJson()
+	result := SearchParameterFromJson(strings.NewReader(json))
+	if !strings.EqualFold(*result.Terms, "a string") {
+		t.Fatal("Term should not have leading or trailing spaces")
+	}
+}

--- a/model/user_search.go
+++ b/model/user_search.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"io"
+	"strings"
 )
 
 const USER_SEARCH_MAX_LIMIT = 1000
@@ -39,6 +40,8 @@ func UserSearchFromJson(data io.Reader) *UserSearch {
 	if us.Limit == 0 {
 		us.Limit = USER_SEARCH_DEFAULT_LIMIT
 	}
+
+	us.Term = strings.TrimSpace(us.Term)
 
 	return us
 }

--- a/model/user_search_test.go
+++ b/model/user_search_test.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -15,5 +16,13 @@ func TestUserSearchJson(t *testing.T) {
 
 	if userSearch.Term != ruserSearch.Term {
 		t.Fatal("Terms do not match")
+	}
+
+	userSearchWithSpaces := UserSearch{Term: " a string ", TeamId: NewId()}
+	jsonWithSpaces := userSearchWithSpaces.ToJson()
+	ruserSearchWithSpaces := UserSearchFromJson(bytes.NewReader(jsonWithSpaces))
+
+	if !strings.EqualFold(ruserSearchWithSpaces.Term, "a string") {
+		t.Fatal("Term should not have leading or trailing spaces")
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR trims leading and trailing spaces for search terms when searching for posts, users and autocomplete users

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-15703