### PR TITLE
[MM-15836] Fix redirect after OAuth login

### DIFF
--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -530,7 +530,11 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		c.App.Session = *session
 
-		redirectUrl = c.GetSiteURLHeader()
+		if _, ok := props["redirect_to"]; ok {
+			redirectUrl = props["redirect_to"]
+		} else {
+			redirectUrl = c.GetSiteURLHeader()
+		}
 	}
 
 	if action == model.OAUTH_ACTION_MOBILE {


### PR DESCRIPTION
#### Summary
This fixes the `redirect_to` value being ignored after logging in via OAuth.

#### Ticket Link
fixes #10943