### PR TITLE
MM-15202 Preventing failed plugins webapp components from being served.

### DIFF
--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -82,7 +82,10 @@ func (env *Environment) Available() ([]*model.BundleInfo, error) {
 func (env *Environment) Active() []*model.BundleInfo {
 	activePlugins := []*model.BundleInfo{}
 	env.activePlugins.Range(func(key, value interface{}) bool {
-		activePlugins = append(activePlugins, value.(activePlugin).BundleInfo)
+		plugin := value.(activePlugin)
+		if plugin.State == model.PluginStateRunning {
+			activePlugins = append(activePlugins, plugin.BundleInfo)
+		}
 
 		return true
 	})


### PR DESCRIPTION
Changes the active plugin to only return "active" plugins that are actually running. This prevents /api/v4/plugins/webapp from returning plugins that have failed to start.

This isn't ideal, the proper solution to this would be to restore the semantics of env.activePlugins to be only plugins that are truly active or make the name more clear. Ticket for that investigation: https://mattermost.atlassian.net/browse/MM-15831

Ticket: https://mattermost.atlassian.net/browse/MM-15202