### PR TITLE
MM-15796 Migrate "Session.GetSessionsWithActiveDeviceIds" to Sync by default

### DIFF
--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -14,7 +14,6 @@ import (
 	"github.com/mattermost/go-i18n/i18n"
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
-	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
@@ -405,18 +404,7 @@ func (a *App) SendAckToPushProxy(ack *model.PushNotificationAck) error {
 }
 
 func (a *App) getMobileAppSessions(userId string) ([]*model.Session, *model.AppError) {
-	sessionChan := make(chan store.StoreResult, 1)
-	go func() {
-		data, err := a.Srv.Store.Session().GetSessionsWithActiveDeviceIds(userId)
-		sessionChan <- store.StoreResult{Data: data, Err: err}
-		close(sessionChan)
-	}()
-
-	r := <-sessionChan
-	if r.Err != nil {
-		return nil, r.Err
-	}
-	return r.Data.([]*model.Session), nil
+	return a.Srv.Store.Session().GetSessionsWithActiveDeviceIds(userId)
 }
 
 func ShouldSendPushNotification(user *model.User, channelNotifyProps model.StringMap, wasMentioned bool, status *model.Status, post *model.Post) bool {

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/go-i18n/i18n"
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/store"
 	"github.com/mattermost/mattermost-server/utils"
 )
 
@@ -404,11 +405,18 @@ func (a *App) SendAckToPushProxy(ack *model.PushNotificationAck) error {
 }
 
 func (a *App) getMobileAppSessions(userId string) ([]*model.Session, *model.AppError) {
-	result := <-a.Srv.Store.Session().GetSessionsWithActiveDeviceIds(userId)
-	if result.Err != nil {
-		return nil, result.Err
+	sessionChan := make(chan store.StoreResult, 1)
+	go func() {
+		data, err := a.Srv.Store.Session().GetSessionsWithActiveDeviceIds(userId)
+		sessionChan <- store.StoreResult{Data: data, Err: err}
+		close(sessionChan)
+	}()
+
+	r := <-sessionChan
+	if r.Err != nil {
+		return nil, r.Err
 	}
-	return result.Data.([]*model.Session), nil
+	return r.Data.([]*model.Session), nil
 }
 
 func ShouldSendPushNotification(user *model.User, channelNotifyProps model.StringMap, wasMentioned bool, status *model.Status, post *model.Post) bool {

--- a/store/sqlstore/session_store.go
+++ b/store/sqlstore/session_store.go
@@ -136,17 +136,24 @@ func (me SqlSessionStore) GetSessions(userId string) store.StoreChannel {
 	})
 }
 
-func (me SqlSessionStore) GetSessionsWithActiveDeviceIds(userId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		var sessions []*model.Session
+func (me SqlSessionStore) GetSessionsWithActiveDeviceIds(userId string) ([]*model.Session, *model.AppError) {
+	query :=
+		`SELECT * 
+		FROM 
+			Sessions 
+		WHERE 
+			UserId = :UserId AND 
+			ExpiresAt != 0 AND 
+			:ExpiresAt <= ExpiresAt AND 
+			DeviceId != ''`
 
-		if _, err := me.GetReplica().Select(&sessions, "SELECT * FROM Sessions WHERE UserId = :UserId AND ExpiresAt != 0 AND :ExpiresAt <= ExpiresAt AND DeviceId != ''", map[string]interface{}{"UserId": userId, "ExpiresAt": model.GetMillis()}); err != nil {
-			result.Err = model.NewAppError("SqlSessionStore.GetActiveSessionsWithDeviceIds", "store.sql_session.get_sessions.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
+	var sessions []*model.Session
 
-			result.Data = sessions
-		}
-	})
+	_, err := me.GetReplica().Select(&sessions, query, map[string]interface{}{"UserId": userId, "ExpiresAt": model.GetMillis()})
+	if err != nil {
+		return nil, model.NewAppError("SqlSessionStore.GetActiveSessionsWithDeviceIds", "store.sql_session.get_sessions.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	return sessions, nil
 }
 
 func (me SqlSessionStore) Remove(sessionIdOrToken string) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -315,7 +315,7 @@ type SessionStore interface {
 	Save(session *model.Session) StoreChannel
 	Get(sessionIdOrToken string) StoreChannel
 	GetSessions(userId string) StoreChannel
-	GetSessionsWithActiveDeviceIds(userId string) StoreChannel
+	GetSessionsWithActiveDeviceIds(userId string) ([]*model.Session, *model.AppError)
 	Remove(sessionIdOrToken string) StoreChannel
 	RemoveAllSessions() StoreChannel
 	PermanentDeleteSessionsByUser(teamId string) StoreChannel

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -74,19 +74,28 @@ func (_m *SessionStore) GetSessions(userId string) store.StoreChannel {
 }
 
 // GetSessionsWithActiveDeviceIds provides a mock function with given fields: userId
-func (_m *SessionStore) GetSessionsWithActiveDeviceIds(userId string) store.StoreChannel {
+func (_m *SessionStore) GetSessionsWithActiveDeviceIds(userId string) ([]*model.Session, *model.AppError) {
 	ret := _m.Called(userId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 []*model.Session
+	if rf, ok := ret.Get(0).(func(string) []*model.Session); ok {
 		r0 = rf(userId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.Session)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(userId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // PermanentDeleteSessionsByUser provides a mock function with given fields: teamId

--- a/store/storetest/session_store.go
+++ b/store/storetest/session_store.go
@@ -87,10 +87,10 @@ func testSessionGetWithDeviceId(t *testing.T, ss store.Store) {
 	s3.DeviceId = model.NewId()
 	store.Must(ss.Session().Save(&s3))
 
-	if rs1 := (<-ss.Session().GetSessionsWithActiveDeviceIds(s1.UserId)); rs1.Err != nil {
-		t.Fatal(rs1.Err)
+	if data, err := ss.Session().GetSessionsWithActiveDeviceIds(s1.UserId); err != nil {
+		t.Fatal(err)
 	} else {
-		if len(rs1.Data.([]*model.Session)) != 1 {
+		if len(data) != 1 {
 			t.Fatal("should match len")
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request migrates the `GetSessionsWithActiveDeviceIds` in the `Session` store to use Sync by default. I followed the instructions laid out in the issue description and updated all necessary files.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Resolves #10936