### PR TITLE
Adding Content-Type header to the OAuth complete endpoint

### DIFF
--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -538,6 +538,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	http.Redirect(w, r, redirectUrl, http.StatusTemporaryRedirect)
 }
 


### PR DESCRIPTION
#### Summary
Adding `text/html` Content-Type header instead of `application/json` to the OAuth complete endpoint.

#### Ticket Link
[MM-15752](https://mattermost.atlassian.net/browse/MM-15752)