### PR TITLE
[GH-10866] Preferrence.Save - Remove preference length return arg

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1056,7 +1056,7 @@ func (a *App) AddDirectChannels(teamId string, user *model.User) *model.AppError
 		}
 	}
 
-	if _, err := a.Srv.Store.Preference().Save(&preferences); err != nil {
+	if err := a.Srv.Store.Preference().Save(&preferences); err != nil {
 		return model.NewAppError("AddDirectChannels", "api.user.add_direct_channels_and_forget.failed.error", map[string]interface{}{"UserId": user.Id, "TeamId": teamId, "Error": err.Error()}, "", http.StatusInternalServerError)
 	}
 

--- a/app/command_expand_collapse.go
+++ b/app/command_expand_collapse.go
@@ -68,7 +68,7 @@ func (a *App) setCollapsePreference(args *model.CommandArgs, isCollapse bool) *m
 		Value:    strconv.FormatBool(isCollapse),
 	}
 
-	if _, err := a.Srv.Store.Preference().Save(&model.Preferences{pref}); err != nil {
+	if err := a.Srv.Store.Preference().Save(&model.Preferences{pref}); err != nil {
 		return &model.CommandResponse{Text: args.T("api.command_expand_collapse.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 

--- a/app/email_batching_test.go
+++ b/app/email_batching_test.go
@@ -115,14 +115,13 @@ func TestCheckPendingNotifications(t *testing.T) {
 	channelMember.LastViewedAt = 9999999
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
 
-	count, err := th.App.Srv.Store.Preference().Save(&model.Preferences{{
+	err = th.App.Srv.Store.Preference().Save(&model.Preferences{{
 		UserId:   th.BasicUser.Id,
 		Category: model.PREFERENCE_CATEGORY_NOTIFICATIONS,
 		Name:     model.PREFERENCE_NAME_EMAIL_INTERVAL,
 		Value:    "60",
 	}})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	// test that notifications aren't sent before interval
 	job.checkPendingNotifications(time.Unix(10001, 0), func(string, []*batchedNotification) {})
@@ -258,14 +257,13 @@ func TestCheckPendingNotificationsCantParseInterval(t *testing.T) {
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
 
 	// preference value is not an integer, so we'll fall back to the default 15min value
-	count, err := th.App.Srv.Store.Preference().Save(&model.Preferences{{
+	err = th.App.Srv.Store.Preference().Save(&model.Preferences{{
 		UserId:   th.BasicUser.Id,
 		Category: model.PREFERENCE_CATEGORY_NOTIFICATIONS,
 		Name:     model.PREFERENCE_NAME_EMAIL_INTERVAL,
 		Value:    "notAnIntegerValue",
 	}})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	job.pendingNotifications[th.BasicUser.Id] = []*batchedNotification{
 		{

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -80,9 +80,8 @@ func TestExportUserChannels(t *testing.T) {
 	}
 	var preferences model.Preferences
 	preferences = append(preferences, preference)
-	count, err := th.App.Srv.Store.Preference().Save(&preferences)
+	err := th.App.Srv.Store.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	th.App.UpdateChannelMemberNotifyProps(notifyProps, channel.Id, user.Id)
 	exportData, err := th.App.buildUserChannelMemberships(user.Id, team.Id)

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -636,7 +636,7 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 	}
 
 	if len(preferences) > 0 {
-		if _, err := a.Srv.Store.Preference().Save(&preferences); err != nil {
+		if err := a.Srv.Store.Preference().Save(&preferences); err != nil {
 			return model.NewAppError("BulkImport", "app.import.import_user.save_preferences.error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
@@ -721,7 +721,7 @@ func (a *App) ImportUserTeams(user *model.User, data *[]UserTeamImportData) *mod
 	}
 
 	if len(teamThemePreferences) > 0 {
-		if _, err := a.Srv.Store.Preference().Save(&teamThemePreferences); err != nil {
+		if err := a.Srv.Store.Preference().Save(&teamThemePreferences); err != nil {
 			return model.NewAppError("BulkImport", "app.import.import_user_teams.save_preferences.error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
@@ -818,7 +818,7 @@ func (a *App) ImportUserChannels(user *model.User, team *model.Team, teamMember 
 	}
 
 	if len(preferences) > 0 {
-		if _, err := a.Srv.Store.Preference().Save(&preferences); err != nil {
+		if err := a.Srv.Store.Preference().Save(&preferences); err != nil {
 			return model.NewAppError("BulkImport", "app.import.import_user_channels.save_preferences.error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
@@ -1024,7 +1024,7 @@ func (a *App) ImportPost(data *PostImportData, dryRun bool) *model.AppError {
 		}
 
 		if len(preferences) > 0 {
-			if _, err := a.Srv.Store.Preference().Save(&preferences); err != nil {
+			if err := a.Srv.Store.Preference().Save(&preferences); err != nil {
 				return model.NewAppError("BulkImport", "app.import.import_post.save_preferences.error", nil, err.Error(), http.StatusInternalServerError)
 			}
 		}
@@ -1129,7 +1129,7 @@ func (a *App) ImportDirectChannel(data *DirectChannelImportData, dryRun bool) *m
 		}
 	}
 
-	if _, err := a.Srv.Store.Preference().Save(&preferences); err != nil {
+	if err := a.Srv.Store.Preference().Save(&preferences); err != nil {
 		err.StatusCode = http.StatusBadRequest
 		return err
 	}
@@ -1248,7 +1248,7 @@ func (a *App) ImportDirectPost(data *DirectPostImportData, dryRun bool) *model.A
 		}
 
 		if len(preferences) > 0 {
-			if _, err := a.Srv.Store.Preference().Save(&preferences); err != nil {
+			if err := a.Srv.Store.Preference().Save(&preferences); err != nil {
 				return model.NewAppError("BulkImport", "app.import.import_direct_post.save_preferences.error", nil, err.Error(), http.StatusInternalServerError)
 			}
 		}

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -186,7 +186,7 @@ func (a *App) AllowOAuthAppAccessToUser(userId string, authRequest *model.Author
 		Value:    authRequest.Scope,
 	}
 
-	if _, err = a.Srv.Store.Preference().Save(&model.Preferences{authorizedApp}); err != nil {
+	if err = a.Srv.Store.Preference().Save(&model.Preferences{authorizedApp}); err != nil {
 		mlog.Error(err.Error())
 		return authRequest.RedirectUri + "?error=server_error&state=" + authRequest.State, nil
 	}

--- a/app/preference.go
+++ b/app/preference.go
@@ -48,7 +48,7 @@ func (a *App) UpdatePreferences(userId string, preferences model.Preferences) *m
 		}
 	}
 
-	if _, err := a.Srv.Store.Preference().Save(&preferences); err != nil {
+	if err := a.Srv.Store.Preference().Save(&preferences); err != nil {
 		err.StatusCode = http.StatusBadRequest
 		return err
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -310,7 +310,7 @@ func (a *App) createUser(user *model.User) (*model.User, *model.AppError) {
 	}
 
 	pref := model.Preference{UserId: ruser.Id, Category: model.PREFERENCE_CATEGORY_TUTORIAL_STEPS, Name: ruser.Id, Value: "0"}
-	if _, err := a.Srv.Store.Preference().Save(&model.Preferences{pref}); err != nil {
+	if err := a.Srv.Store.Preference().Save(&model.Preferences{pref}); err != nil {
 		mlog.Error(fmt.Sprintf("Encountered error saving tutorial preference, err=%v", err.Message))
 	}
 

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -54,25 +54,25 @@ func (s SqlPreferenceStore) DeleteUnusedFeatures() {
 	s.GetMaster().Exec(sql, queryParams)
 }
 
-func (s SqlPreferenceStore) Save(preferences *model.Preferences) (int, *model.AppError) {
+func (s SqlPreferenceStore) Save(preferences *model.Preferences) *model.AppError {
 	// wrap in a transaction so that if one fails, everything fails
 	transaction, err := s.GetMaster().Begin()
 	if err != nil {
-		return 0, model.NewAppError("SqlPreferenceStore.Save", "store.sql_preference.save.open_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return model.NewAppError("SqlPreferenceStore.Save", "store.sql_preference.save.open_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	defer finalizeTransaction(transaction)
 	for _, preference := range *preferences {
 		if upsertResult := s.save(transaction, &preference); upsertResult.Err != nil {
-			return 0, upsertResult.Err
+			return upsertResult.Err
 		}
 	}
 
 	if err := transaction.Commit(); err != nil {
 		// don't need to rollback here since the transaction is already closed
-		return 0, model.NewAppError("SqlPreferenceStore.Save", "store.sql_preference.save.commit_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return model.NewAppError("SqlPreferenceStore.Save", "store.sql_preference.save.commit_transaction.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
-	return len(*preferences), nil
+	return nil
 }
 
 func (s SqlPreferenceStore) save(transaction *gorp.Transaction, preference *model.Preference) store.StoreResult {

--- a/store/sqlstore/preference_store_test.go
+++ b/store/sqlstore/preference_store_test.go
@@ -52,9 +52,8 @@ func TestDeleteUnusedFeatures(t *testing.T) {
 			},
 		}
 
-		count, err := ss.Preference().Save(&features)
+		err := ss.Preference().Save(&features)
 		require.Nil(t, err)
-		require.Equal(t, 4, count)
 
 		ss.Preference().(*SqlPreferenceStore).DeleteUnusedFeatures()
 

--- a/store/store.go
+++ b/store/store.go
@@ -428,7 +428,7 @@ type CommandWebhookStore interface {
 }
 
 type PreferenceStore interface {
-	Save(preferences *model.Preferences) (int, *model.AppError)
+	Save(preferences *model.Preferences) *model.AppError
 	GetCategory(userId string, category string) (model.Preferences, *model.AppError)
 	Get(userId string, category string, name string) (*model.Preference, *model.AppError)
 	GetAll(userId string) StoreChannel

--- a/store/storetest/mocks/PreferenceStore.go
+++ b/store/storetest/mocks/PreferenceStore.go
@@ -183,24 +183,17 @@ func (_m *PreferenceStore) PermanentDeleteByUser(userId string) *model.AppError 
 }
 
 // Save provides a mock function with given fields: preferences
-func (_m *PreferenceStore) Save(preferences *model.Preferences) (int, *model.AppError) {
+func (_m *PreferenceStore) Save(preferences *model.Preferences) *model.AppError {
 	ret := _m.Called(preferences)
 
-	var r0 int
-	if rf, ok := ret.Get(0).(func(*model.Preferences) int); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(*model.Preferences) *model.AppError); ok {
 		r0 = rf(preferences)
 	} else {
-		r0 = ret.Get(0).(int)
-	}
-
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(*model.Preferences) *model.AppError); ok {
-		r1 = rf(preferences)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 
-	return r0, r1
+	return r0
 }

--- a/store/storetest/oauth_store.go
+++ b/store/storetest/oauth_store.go
@@ -335,9 +335,8 @@ func testOAuthGetAuthorizedApps(t *testing.T, ss store.Store) {
 	p.Category = model.PREFERENCE_CATEGORY_AUTHORIZED_OAUTH_APP
 	p.Name = a1.Id
 	p.Value = "true"
-	count, err := ss.Preference().Save(&model.Preferences{p})
+	err := ss.Preference().Save(&model.Preferences{p})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	if result := <-ss.OAuth().GetAuthorizedApps(a1.CreatorId, 0, 1000); result.Err != nil {
 		t.Fatal(result.Err)
@@ -363,9 +362,8 @@ func testOAuthGetAccessDataByUserForApp(t *testing.T, ss store.Store) {
 	p.Category = model.PREFERENCE_CATEGORY_AUTHORIZED_OAUTH_APP
 	p.Name = a1.Id
 	p.Value = "true"
-	count, err := ss.Preference().Save(&model.Preferences{p})
+	err := ss.Preference().Save(&model.Preferences{p})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	if result := <-ss.OAuth().GetAuthorizedApps(a1.CreatorId, 0, 1000); result.Err != nil {
 		t.Fatal(result.Err)

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -1393,9 +1393,8 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 		},
 	}
 
-	count, err := ss.Preference().Save(&preferences)
+	err = ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r2 := (<-ss.Post().GetFlaggedPostsForTeam(o1.UserId, c1.TeamId, 0, 2)).Data.(*model.PostList)
 
@@ -1412,9 +1411,8 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 		},
 	}
 
-	count, err = ss.Preference().Save(&preferences)
+	err = ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r3 := (<-ss.Post().GetFlaggedPostsForTeam(o1.UserId, c1.TeamId, 0, 1)).Data.(*model.PostList)
 
@@ -1449,9 +1447,8 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 		},
 	}
 
-	count, err = ss.Preference().Save(&preferences)
+	err = ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r4 = (<-ss.Post().GetFlaggedPostsForTeam(o1.UserId, c1.TeamId, 0, 2)).Data.(*model.PostList)
 
@@ -1467,9 +1464,8 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 			Value:    "true",
 		},
 	}
-	count, err = ss.Preference().Save(&preferences)
+	err = ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r4 = (<-ss.Post().GetFlaggedPostsForTeam(o1.UserId, c1.TeamId, 0, 2)).Data.(*model.PostList)
 
@@ -1491,9 +1487,8 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 			Value:    "true",
 		},
 	}
-	count, err = ss.Preference().Save(&preferences)
+	err = ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r4 = (<-ss.Post().GetFlaggedPostsForTeam(o1.UserId, c1.TeamId, 0, 10)).Data.(*model.PostList)
 
@@ -1543,9 +1538,8 @@ func testPostStoreGetFlaggedPosts(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err := ss.Preference().Save(&preferences)
+	err := ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r2 := (<-ss.Post().GetFlaggedPosts(o1.UserId, 0, 2)).Data.(*model.PostList)
 
@@ -1562,9 +1556,8 @@ func testPostStoreGetFlaggedPosts(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err = ss.Preference().Save(&preferences)
+	err = ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r3 := (<-ss.Post().GetFlaggedPosts(o1.UserId, 0, 1)).Data.(*model.PostList)
 
@@ -1599,9 +1592,8 @@ func testPostStoreGetFlaggedPosts(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err = ss.Preference().Save(&preferences)
+	err = ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r4 = (<-ss.Post().GetFlaggedPosts(o1.UserId, 0, 2)).Data.(*model.PostList)
 
@@ -1654,9 +1646,8 @@ func testPostStoreGetFlaggedPostsForChannel(t *testing.T, ss store.Store) {
 		Value:    "true",
 	}
 
-	count, err := ss.Preference().Save(&model.Preferences{preference})
+	err := ss.Preference().Save(&model.Preferences{preference})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r = (<-ss.Post().GetFlaggedPostsForChannel(o1.UserId, o1.ChannelId, 0, 10)).Data.(*model.PostList)
 
@@ -1665,14 +1656,12 @@ func testPostStoreGetFlaggedPostsForChannel(t *testing.T, ss store.Store) {
 	}
 
 	preference.Name = o2.Id
-	count, err = ss.Preference().Save(&model.Preferences{preference})
+	err = ss.Preference().Save(&model.Preferences{preference})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	preference.Name = o3.Id
-	count, err = ss.Preference().Save(&model.Preferences{preference})
+	err = ss.Preference().Save(&model.Preferences{preference})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r = (<-ss.Post().GetFlaggedPostsForChannel(o1.UserId, o1.ChannelId, 0, 1)).Data.(*model.PostList)
 
@@ -1699,9 +1688,8 @@ func testPostStoreGetFlaggedPostsForChannel(t *testing.T, ss store.Store) {
 	}
 
 	preference.Name = o4.Id
-	count, err = ss.Preference().Save(&model.Preferences{preference})
+	err = ss.Preference().Save(&model.Preferences{preference})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	r = (<-ss.Post().GetFlaggedPostsForChannel(o1.UserId, o4.ChannelId, 0, 10)).Data.(*model.PostList)
 

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -43,9 +43,7 @@ func testPreferenceSave(t *testing.T, ss store.Store) {
 			Value:    "value1b",
 		},
 	}
-	if count, err := ss.Preference().Save(&preferences); count != 2 {
-		t.Fatal("got incorrect number of rows saved")
-	} else if err != nil {
+	if err := ss.Preference().Save(&preferences); err != nil {
 		t.Fatal("saving preference returned error")
 	}
 
@@ -57,9 +55,7 @@ func testPreferenceSave(t *testing.T, ss store.Store) {
 
 	preferences[0].Value = "value2a"
 	preferences[1].Value = "value2b"
-	if count, err := ss.Preference().Save(&preferences); count != 2 {
-		t.Fatal("got incorrect number of rows saved")
-	} else if err != nil {
+	if err := ss.Preference().Save(&preferences); err != nil {
 		t.Fatal("saving preference returned error")
 	}
 
@@ -98,9 +94,8 @@ func testPreferenceGet(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err := ss.Preference().Save(&preferences)
+	err := ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 4, count)
 
 	if data, err := ss.Preference().Get(userId, category, name); err != nil {
 		t.Fatal(err)
@@ -145,9 +140,8 @@ func testPreferenceGetCategory(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err := ss.Preference().Save(&preferences)
+	err := ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 4, count)
 
 	if preferencesByCategory, err := ss.Preference().GetCategory(userId, category); err != nil {
 		t.Fatal(err)
@@ -196,9 +190,8 @@ func testPreferenceGetAll(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err := ss.Preference().Save(&preferences)
+	err := ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 4, count)
 
 	if result := <-ss.Preference().GetAll(userId); result.Err != nil {
 		t.Fatal(result.Err)
@@ -244,9 +237,8 @@ func testPreferenceDeleteByUser(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err := ss.Preference().Save(&preferences)
+	err := ss.Preference().Save(&preferences)
 	require.Nil(t, err)
-	require.Equal(t, 4, count)
 
 	if err := ss.Preference().PermanentDeleteByUser(userId); err != nil {
 		t.Fatal(err)
@@ -294,9 +286,8 @@ func testIsFeatureEnabled(t *testing.T, ss store.Store) {
 		},
 	}
 
-	count, err := ss.Preference().Save(&features)
+	err := ss.Preference().Save(&features)
 	require.Nil(t, err)
-	require.Equal(t, 5, count)
 
 	if result := <-ss.Preference().IsFeatureEnabled(feature1, userId); result.Err != nil {
 		t.Fatal(result.Err)
@@ -333,9 +324,8 @@ func testPreferenceDelete(t *testing.T, ss store.Store) {
 		Value:    "value1a",
 	}
 
-	count, err := ss.Preference().Save(&model.Preferences{preference})
+	err := ss.Preference().Save(&model.Preferences{preference})
 	require.Nil(t, err)
-	require.Equal(t, 1, count)
 
 	if prefs := store.Must(ss.Preference().GetAll(preference.UserId)).(model.Preferences); len([]model.Preference(prefs)) != 1 {
 		t.Fatal("should've returned 1 preference")
@@ -368,9 +358,8 @@ func testPreferenceDeleteCategory(t *testing.T, ss store.Store) {
 		Value:    "value1a",
 	}
 
-	count, err := ss.Preference().Save(&model.Preferences{preference1, preference2})
+	err := ss.Preference().Save(&model.Preferences{preference1, preference2})
 	require.Nil(t, err)
-	require.Equal(t, 2, count)
 
 	if prefs := store.Must(ss.Preference().GetAll(userId)).(model.Preferences); len([]model.Preference(prefs)) != 2 {
 		t.Fatal("should've returned 2 preferences")
@@ -405,9 +394,8 @@ func testPreferenceDeleteCategoryAndName(t *testing.T, ss store.Store) {
 		Value:    "value1a",
 	}
 
-	count, err := ss.Preference().Save(&model.Preferences{preference1, preference2})
+	err := ss.Preference().Save(&model.Preferences{preference1, preference2})
 	require.Nil(t, err)
-	require.Equal(t, 2, count)
 
 	if prefs := store.Must(ss.Preference().GetAll(userId)).(model.Preferences); len([]model.Preference(prefs)) != 1 {
 		t.Fatal("should've returned 1 preference")
@@ -455,9 +443,8 @@ func testPreferenceCleanupFlagsBatch(t *testing.T, ss store.Store) {
 		Value:    "true",
 	}
 
-	count, err := ss.Preference().Save(&model.Preferences{preference1, preference2})
+	err := ss.Preference().Save(&model.Preferences{preference1, preference2})
 	require.Nil(t, err)
-	require.Equal(t, 2, count)
 
 	_, err = ss.Preference().CleanupFlagsBatch(10000)
 	assert.Nil(t, err)


### PR DESCRIPTION

#### Summary
Removes preference length return argument from Preference.Save function

#### Ticket Link

Discussed in #10866 
