### PR TITLE
MM-15706: disable PluginHealthCheck_RPCPingFail test

### DIFF
--- a/plugin/health_check_test.go
+++ b/plugin/health_check_test.go
@@ -20,7 +20,7 @@ func TestPluginHealthCheck(t *testing.T) {
 	for name, f := range map[string]func(*testing.T){
 		"PluginHealthCheck_Success":                 testPluginHealthCheck_Success,
 		"PluginHealthCheck_PluginPanicProcessCheck": testPluginHealthCheck_PluginPanicProcessCheck,
-		"PluginHealthCheck_RPCPingFail":             testPluginHealthCheck_RPCPingFail,
+		// "PluginHealthCheck_RPCPingFail":             testPluginHealthCheck_RPCPingFail,
 	} {
 		t.Run(name, f)
 	}


### PR DESCRIPTION
#### Summary
Temporarily disabled the PluginHealthCheck_RPCPingFail test, filed a follow-up ticket https://mattermost.atlassian.net/browse/MM-15870. cc @mickmister 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15706