### PR TITLE
MM-15835: correct errors and content types for oauth api calls

### DIFF
--- a/app/oauth.go
+++ b/app/oauth.go
@@ -246,7 +246,7 @@ func (a *App) GetOAuthAccessTokenForCodeFlow(clientId, grantType, redirectUri, c
 		var authData *model.AuthData
 		result := <-a.Srv.Store.OAuth().GetAuthData(code)
 		if result.Err != nil {
-			return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.expired_code.app_error", nil, "", http.StatusInternalServerError)
+			return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.expired_code.app_error", nil, "", http.StatusBadRequest)
 		}
 		authData = result.Data.(*model.AuthData)
 
@@ -267,7 +267,7 @@ func (a *App) GetOAuthAccessTokenForCodeFlow(clientId, grantType, redirectUri, c
 
 		result = <-a.Srv.Store.OAuth().GetPreviousAccessData(user.Id, clientId)
 		if result.Err != nil {
-			return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.internal.app_error", nil, "", http.StatusInternalServerError)
+			return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.internal.app_error", nil, "", http.StatusBadRequest)
 		}
 
 		if result.Data != nil {

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -195,7 +195,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			c.Err.IsOAuth = false
 		}
 
-		if IsApiCall(c.App, r) || IsWebhookCall(c.App, r) || len(r.Header.Get("X-Mobile-App")) > 0 {
+		if IsApiCall(c.App, r) || IsWebhookCall(c.App, r) || IsOAuthApiCall(c.App, r) || len(r.Header.Get("X-Mobile-App")) > 0 {
 			w.WriteHeader(c.Err.StatusCode)
 			w.Write([]byte(c.Err.ToJson()))
 		} else {

--- a/web/web.go
+++ b/web/web.go
@@ -89,13 +89,11 @@ func IsWebhookCall(a *app.App, r *http.Request) bool {
 func IsOAuthApiCall(config configservice.ConfigService, r *http.Request) bool {
 	subpath, _ := utils.GetSubpathFromConfig(config.Config())
 
-	// To avoid the /oauth/authorize page on get
-	if r.Method == "GET" {
-		return false
+	if r.Method == "POST" && r.URL.Path == path.Join(subpath, "oauth", "authorize") {
+		return true
 	}
 
 	if r.URL.Path == path.Join(subpath, "oauth", "apps", "authorized") ||
-		r.URL.Path == path.Join(subpath, "oauth", "authorize") ||
 		r.URL.Path == path.Join(subpath, "oauth", "deauthorize") ||
 		r.URL.Path == path.Join(subpath, "oauth", "access_token") {
 		return true

--- a/web/web.go
+++ b/web/web.go
@@ -86,6 +86,23 @@ func IsWebhookCall(a *app.App, r *http.Request) bool {
 	return strings.HasPrefix(r.URL.Path, path.Join(subpath, "hooks")+"/")
 }
 
+func IsOAuthApiCall(config configservice.ConfigService, r *http.Request) bool {
+	subpath, _ := utils.GetSubpathFromConfig(config.Config())
+
+	// To avoid the /oauth/authorize page on get
+	if r.Method == "GET" {
+		return false
+	}
+
+	if r.URL.Path == path.Join(subpath, "oauth", "apps", "authorized") ||
+		r.URL.Path == path.Join(subpath, "oauth", "authorize") ||
+		r.URL.Path == path.Join(subpath, "oauth", "deauthorize") ||
+		r.URL.Path == path.Join(subpath, "oauth", "access_token") {
+		return true
+	}
+	return false
+}
+
 func ReturnStatusOK(w http.ResponseWriter) {
 	m := make(map[string]string)
 	m[model.STATUS] = model.STATUS_OK


### PR DESCRIPTION
#### Summary
Returning json responses for errors on oauth API endpoints, and returning 4xx
errors instead of 500 error when is something that could happend because the
user input.

#### Ticket Link
[MM-15835](https://mattermost.atlassian.net/browse/MM-15835)