### PR TITLE
Adding missing Order to postList in Post().Get()

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -299,6 +299,7 @@ func (s *SqlPostStore) Get(id string) (*model.PostList, *model.AppError) {
 
 	for _, p := range posts {
 		pl.AddPost(p)
+		pl.AddOrder(p.Id)
 	}
 
 	return pl, nil


### PR DESCRIPTION
#### Summary
Adds postIds to the PostList.Order slice to make sure it can be sorted.
#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/11006
