### PR TITLE
MM-15956: consistent params for config migrate

### DIFF
--- a/cmd/mattermost/commands/config.go
+++ b/cmd/mattermost/commands/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/mattermost/mattermost-server/config"
+	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils"
 	"github.com/mattermost/viper"
@@ -69,19 +70,16 @@ var ConfigSetCmd = &cobra.Command{
 }
 
 var MigrateConfigCmd = &cobra.Command{
-	Use:     "migrate",
+	Use:     "migrate [from_config] [to_config]",
 	Short:   "Migrate existing config between backends",
 	Long:    "Migrate a file-based configuration to (or from) a database-based configuration. Point the Mattermost server at the target configuration to start using it",
-	Example: `config migrate --from=path/to/config.json --to="postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"`,
+	Example: `config migrate path/to/config.json "postgres://mmuser:mostest@dockerhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"`,
+	Args:    cobra.ExactArgs(2),
 	RunE:    configMigrateCmdF,
 }
 
 func init() {
 	ConfigSubpathCmd.Flags().String("path", "", "Optional subpath; defaults to value in SiteURL")
-	MigrateConfigCmd.Flags().String("from", "", "Config from which to migrate")
-	MigrateConfigCmd.Flags().String("to", "", "Config to which to migrate")
-	MigrateConfigCmd.MarkFlagRequired("to")
-
 	ConfigShowCmd.Flags().Bool("json", false, "Output the configuration as JSON.")
 
 	ConfigCmd.AddCommand(
@@ -249,28 +247,19 @@ func configSetCmdF(command *cobra.Command, args []string) error {
 }
 
 func configMigrateCmdF(command *cobra.Command, args []string) error {
-	// Parse source config; defaults to global --config unless overwritten by --from
-	from, err := command.Flags().GetString("from")
-	if err != nil {
-		return errors.Wrap(err, "failed reading source config parameter")
-	}
-	if from == "" {
-		from = viper.GetString("config")
-	}
-
-	// Parse destination config store - MarkFlagRequired handles errors here
-	to, _ := command.Flags().GetString("to")
+	from := args[0]
+	to := args[1]
 
 	// Get source config store - invalid config will throw error here
 	fromConfigStore, err := config.NewStore(from, false)
 	if err != nil {
-		return errors.Wrap(err, "failed to read --from config")
+		return errors.Wrapf(err, "failed to access config %s", from)
 	}
 
 	// Get destination config store
 	toConfigStore, err := config.NewStore(to, false)
 	if err != nil {
-		return errors.Wrap(err, "failed to read --to config")
+		return errors.Wrapf(err, "failed to access config %s", to)
 	}
 
 	// Copy config from source to destination
@@ -278,6 +267,8 @@ func configMigrateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to migrate config")
 	}
+
+	mlog.Info("Successfully migrated config.")
 
 	return nil
 }

--- a/cmd/mattermost/commands/config_test.go
+++ b/cmd/mattermost/commands/config_test.go
@@ -476,24 +476,24 @@ func TestConfigMigrate(t *testing.T) {
 	defer ds.Close()
 	defer fs.Close()
 
-	t.Run("Should error without --to parameter", func(t *testing.T) {
-		assert.Error(t, th.RunCommand(t, "config", "migrate", "--from", fileDSN))
+	t.Run("Should error with too few parameters", func(t *testing.T) {
+		assert.Error(t, th.RunCommand(t, "config", "migrate", fileDSN))
 	})
 
-	t.Run("Should work passing the --to and the --from", func(t *testing.T) {
-		assert.NoError(t, th.RunCommand(t, "config", "migrate", "--from", fileDSN, "--to", sqlDSN))
+	t.Run("Should error with too many parameters", func(t *testing.T) {
+		assert.Error(t, th.RunCommand(t, "config", "migrate", fileDSN, sqlDSN, "reallyfast"))
 	})
 
-	t.Run("Should work passing --to and no --from (taking the default config file)", func(t *testing.T) {
-		assert.NoError(t, th.RunCommand(t, "config", "migrate", "--to", sqlDSN))
+	t.Run("Should work passing two parameters", func(t *testing.T) {
+		assert.NoError(t, th.RunCommand(t, "config", "migrate", fileDSN, sqlDSN))
 	})
 
-	t.Run("Should fail passing an invalid --to", func(t *testing.T) {
-		assert.Error(t, th.RunCommand(t, "config", "migrate", "--from", fileDSN, "--to", "mysql://asd"))
+	t.Run("Should fail passing an invalid target", func(t *testing.T) {
+		assert.Error(t, th.RunCommand(t, "config", "migrate", fileDSN, "mysql://asd"))
 	})
 
-	t.Run("Should fail passing an invalid --from", func(t *testing.T) {
-		assert.Error(t, th.RunCommand(t, "config", "migrate", "--from", "invalid/path", "--to", sqlDSN))
+	t.Run("Should fail passing an invalid source", func(t *testing.T) {
+		assert.Error(t, th.RunCommand(t, "config", "migrate", "invalid/path", sqlDSN))
 	})
 }
 


### PR DESCRIPTION
#### Summary
This changes the syntax of the config migrate command from:

    mattermost config migrate --from <from config> --to <to config>

to:

    mattermost config migrate <from config> <to config>

making it more consistent with our other CLI commands.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15956