### PR TITLE
MM-15777 Preventing bad email configuration from failing personal access token creation

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -256,8 +256,11 @@ func (a *App) CreateUserAccessToken(token *model.UserAccessToken) (*model.UserAc
 	}
 	token = result.Data.(*model.UserAccessToken)
 
-	if err := a.SendUserAccessTokenAddedEmail(user.Email, user.Locale, a.GetSiteURL()); err != nil {
-		return nil, err
+	// Don't send emails to bot users.
+	if !user.IsBot {
+		if err := a.SendUserAccessTokenAddedEmail(user.Email, user.Locale, a.GetSiteURL()); err != nil {
+			a.Log.Error("Unable to send user access token added email", mlog.Err(err), mlog.String("user_id", user.Id))
+		}
 	}
 
 	return token, nil


### PR DESCRIPTION
#### Summary
- Skips email sending when creating personal access tokens for bot users.
- Logs an error instead of returning an error when failing to send email confirming bot token creation.
- This prevents the bot creation page skipping the access token screen when the email configuration in the Mattermost server is incorrect. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15777