### PR TITLE
Migrate "Post.GetParentsForExportAfter" to Sync by default #10965

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -332,13 +332,11 @@ func (a *App) buildUserNotifyProps(notifyProps model.StringMap) *UserNotifyProps
 func (a *App) ExportAllPosts(writer io.Writer) *model.AppError {
 	afterId := strings.Repeat("0", 26)
 	for {
-		result := <-a.Srv.Store.Post().GetParentsForExportAfter(1000, afterId)
+		posts, err := a.Srv.Store.Post().GetParentsForExportAfter(1000, afterId)
 
-		if result.Err != nil {
-			return result.Err
+		if err != nil {
+			return err
 		}
-
-		posts := result.Data.([]*model.PostForExport)
 
 		if len(posts) == 0 {
 			break

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1266,10 +1266,9 @@ func (s *SqlPostStore) GetMaxPostSize() int {
 	return s.maxPostSizeCached
 }
 
-func (s *SqlPostStore) GetParentsForExportAfter(limit int, afterId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		var posts []*model.PostForExport
-		_, err1 := s.GetSearchReplica().Select(&posts, `
+func (s *SqlPostStore) GetParentsForExportAfter(limit int, afterId string) ([]*model.PostForExport, *model.AppError) {
+	var posts []*model.PostForExport
+	_, err := s.GetSearchReplica().Select(&posts, `
                 SELECT
                     p1.*,
                     Users.Username as Username,
@@ -1293,14 +1292,13 @@ func (s *SqlPostStore) GetParentsForExportAfter(limit int, afterId string) store
                     p1.Id
                 LIMIT
                     :Limit`,
-			map[string]interface{}{"Limit": limit, "AfterId": afterId})
+		map[string]interface{}{"Limit": limit, "AfterId": afterId})
 
-		if err1 != nil {
-			result.Err = model.NewAppError("SqlPostStore.GetAllAfterForExport", "store.sql_post.get_posts.app_error", nil, err1.Error(), http.StatusInternalServerError)
-		} else {
-			result.Data = posts
-		}
-	})
+	if err != nil {
+		return nil, model.NewAppError("SqlPostStore.GetAllAfterForExport", "store.sql_post.get_posts.app_error",
+			nil, err.Error(), http.StatusInternalServerError)
+	}
+	return posts, nil
 }
 
 func (s *SqlPostStore) GetRepliesForExport(parentId string) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -238,7 +238,7 @@ type PostStore interface {
 	PermanentDeleteBatch(endTime int64, limit int64) StoreChannel
 	GetOldest() StoreChannel
 	GetMaxPostSize() int
-	GetParentsForExportAfter(limit int, afterId string) StoreChannel
+	GetParentsForExportAfter(limit int, afterId string) ([]*model.PostForExport, *model.AppError)
 	GetRepliesForExport(parentId string) StoreChannel
 	GetDirectPostParentsForExportAfter(limit int, afterId string) ([]*model.DirectPostForExport, *model.AppError)
 }

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -243,19 +243,28 @@ func (_m *PostStore) GetOldest() store.StoreChannel {
 }
 
 // GetParentsForExportAfter provides a mock function with given fields: limit, afterId
-func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) store.StoreChannel {
+func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) ([]*model.PostForExport, *model.AppError) {
 	ret := _m.Called(limit, afterId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(int, string) store.StoreChannel); ok {
+	var r0 []*model.PostForExport
+	if rf, ok := ret.Get(0).(func(int, string) []*model.PostForExport); ok {
 		r0 = rf(limit, afterId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.PostForExport)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
+		r1 = rf(channelId, time)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetPosts provides a mock function with given fields: channelId, offset, limit, allowFromCache

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -257,7 +257,7 @@ func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) ([]*mod
 
 	var r1 *model.AppError
 	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
-		r1 = rf(channelId, time)
+		r1 = rf(limit, afterId)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -256,7 +256,7 @@ func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) ([]*mod
 	}
 
 	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
+	if rf, ok := ret.Get(1).(func(int64, string) *model.AppError); ok {
 		r1 = rf(limit, afterId)
 	} else {
 		if ret.Get(1) != nil {

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -256,7 +256,7 @@ func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) ([]*mod
 	}
 
 	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(int64, string) *model.AppError); ok {
+	if rf, ok := ret.Get(1).(func(int, string) *model.AppError); ok {
 		r1 = rf(limit, afterId)
 	} else {
 		if ret.Get(1) != nil {

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -2107,12 +2107,11 @@ func testPostStoreGetParentsForExportAfter(t *testing.T, ss store.Store) {
 	p1.CreateAt = 1000
 	p1 = (<-ss.Post().Save(p1)).Data.(*model.Post)
 
-	r1 := <-ss.Post().GetParentsForExportAfter(10000, strings.Repeat("0", 26))
-	assert.Nil(t, r1.Err)
-	d1 := r1.Data.([]*model.PostForExport)
+	posts, err := ss.Post().GetParentsForExportAfter(10000, strings.Repeat("0", 26))
+	assert.Nil(t, err)
 
 	found := false
-	for _, p := range d1 {
+	for _, p := range posts {
 		if p.Id == p1.Id {
 			found = true
 			assert.Equal(t, p.Id, p1.Id)


### PR DESCRIPTION
Summary
Migrate `Post.GetParentsForExportAfter` in `store/sqlstore/post_store.go` to Sync by default removing the `return.Do` wrapper.

Ticket Link
Fixes #10965