### PR TITLE
Migrate Post.GetOldest to Sync by default

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1169,16 +1169,14 @@ func (s *SqlPostStore) PermanentDeleteBatch(endTime int64, limit int64) (int64, 
 	return rowsAffected, nil
 }
 
-func (s *SqlPostStore) GetOldest() store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		var post model.Post
-		err := s.GetReplica().SelectOne(&post, "SELECT * FROM Posts ORDER BY CreateAt LIMIT 1")
-		if err != nil {
-			result.Err = model.NewAppError("SqlPostStore.GetOldest", "store.sql_post.get.app_error", nil, err.Error(), http.StatusNotFound)
-		}
+func (s *SqlPostStore) GetOldest() (*model.Post, *model.AppError) {
+	var post model.Post
+	err := s.GetReplica().SelectOne(&post, "SELECT * FROM Posts ORDER BY CreateAt LIMIT 1")
+	if err != nil {
+		return nil, model.NewAppError("SqlPostStore.GetOldest", "store.sql_post.get.app_error", nil, err.Error(), http.StatusNotFound)
+	}
 
-		result.Data = &post
-	})
+	return &post, nil
 }
 
 func (s *SqlPostStore) determineMaxPostSize() int {

--- a/store/store.go
+++ b/store/store.go
@@ -236,7 +236,7 @@ type PostStore interface {
 	GetPostsByIds(postIds []string) ([]*model.Post, *model.AppError)
 	GetPostsBatchForIndexing(startTime int64, endTime int64, limit int) ([]*model.PostForIndexing, *model.AppError)
 	PermanentDeleteBatch(endTime int64, limit int64) (int64, *model.AppError)
-	GetOldest() StoreChannel
+	GetOldest() (*model.Post, *model.AppError)
 	GetMaxPostSize() int
 	GetParentsForExportAfter(limit int, afterId string) ([]*model.PostForExport, *model.AppError)
 	GetRepliesForExport(parentId string) ([]*model.ReplyForExport, *model.AppError)

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -254,19 +254,28 @@ func (_m *PostStore) GetMaxPostSize() int {
 }
 
 // GetOldest provides a mock function with given fields:
-func (_m *PostStore) GetOldest() store.StoreChannel {
+func (_m *PostStore) GetOldest() (*model.Post, *model.AppError) {
 	ret := _m.Called()
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+	var r0 *model.Post
+	if rf, ok := ret.Get(0).(func() *model.Post); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Post)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetParentsForExportAfter provides a mock function with given fields: limit, afterId

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -2073,8 +2073,9 @@ func testPostStoreGetOldest(t *testing.T, ss store.Store) {
 	o2.CreateAt = 1
 	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetOldest()).Data.(*model.Post)
+	r1, err := ss.Post().GetOldest()
 
+	require.NoError(t, err)
 	assert.EqualValues(t, o2.Id, r1.Id)
 }
 

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -2075,7 +2075,7 @@ func testPostStoreGetOldest(t *testing.T, ss store.Store) {
 
 	r1, err := ss.Post().GetOldest()
 
-	require.NoError(t, err)
+	require.Nil(t, err)
 	assert.EqualValues(t, o2.Id, r1.Id)
 }
 


### PR DESCRIPTION
#### Summary
This PR migrates method "Post.GetOldest" to Sync by default.
#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/10966
