### PR TITLE
[MM-15799] Migrate "Session.PermanentDeleteSessionsByUser" to Sync by default

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1415,8 +1415,8 @@ func (a *App) PermanentDeleteUser(user *model.User) *model.AppError {
 		return err
 	}
 
-	if result := <-a.Srv.Store.Session().PermanentDeleteSessionsByUser(user.Id); result.Err != nil {
-		return result.Err
+	if err := a.Srv.Store.Session().PermanentDeleteSessionsByUser(user.Id); err != nil {
+		return err
 	}
 
 	if result := <-a.Srv.Store.UserAccessToken().DeleteAllForUser(user.Id); result.Err != nil {

--- a/store/sqlstore/session_store.go
+++ b/store/sqlstore/session_store.go
@@ -167,13 +167,13 @@ func (me SqlSessionStore) RemoveAllSessions() store.StoreChannel {
 	})
 }
 
-func (me SqlSessionStore) PermanentDeleteSessionsByUser(userId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		_, err := me.GetMaster().Exec("DELETE FROM Sessions WHERE UserId = :UserId", map[string]interface{}{"UserId": userId})
-		if err != nil {
-			result.Err = model.NewAppError("SqlSessionStore.RemoveAllSessionsForUser", "store.sql_session.permanent_delete_sessions_by_user.app_error", nil, "id="+userId+", err="+err.Error(), http.StatusInternalServerError)
-		}
-	})
+func (me SqlSessionStore) PermanentDeleteSessionsByUser(userId string) *model.AppError {
+	_, err := me.GetMaster().Exec("DELETE FROM Sessions WHERE UserId = :UserId", map[string]interface{}{"UserId": userId})
+	if err != nil {
+		return model.NewAppError("SqlSessionStore.RemoveAllSessionsForUser", "store.sql_session.permanent_delete_sessions_by_user.app_error", nil, "id="+userId+", err="+err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
 }
 
 func (me SqlSessionStore) UpdateLastActivityAt(sessionId string, time int64) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -318,7 +318,7 @@ type SessionStore interface {
 	GetSessionsWithActiveDeviceIds(userId string) ([]*model.Session, *model.AppError)
 	Remove(sessionIdOrToken string) StoreChannel
 	RemoveAllSessions() StoreChannel
-	PermanentDeleteSessionsByUser(teamId string) StoreChannel
+	PermanentDeleteSessionsByUser(teamId string) *model.AppError
 	UpdateLastActivityAt(sessionId string, time int64) StoreChannel
 	UpdateRoles(userId string, roles string) StoreChannel
 	UpdateDeviceId(id string, deviceId string, expiresAt int64) StoreChannel

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -108,15 +108,15 @@ func (_m *SessionStore) GetSessionsWithActiveDeviceIds(userId string) ([]*model.
 }
 
 // PermanentDeleteSessionsByUser provides a mock function with given fields: teamId
-func (_m *SessionStore) PermanentDeleteSessionsByUser(teamId string) store.StoreChannel {
+func (_m *SessionStore) PermanentDeleteSessionsByUser(teamId string) *model.AppError {
 	ret := _m.Called(teamId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string) *model.AppError); ok {
 		r0 = rf(teamId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 

--- a/store/storetest/session_store.go
+++ b/store/storetest/session_store.go
@@ -168,8 +168,8 @@ func testSessionRemoveByUser(t *testing.T, ss store.Store) {
 		}
 	}
 
-	err = ss.Session().PermanentDeleteSessionsByUser(s1.UserId)
-	require.Nil(t, err)
+	deleteErr := ss.Session().PermanentDeleteSessionsByUser(s1.UserId)
+	require.Nil(t, deleteErr)
 
 	if _, err := ss.Session().Get(s1.Id); err == nil {
 		t.Fatal("should have been removed")

--- a/store/storetest/session_store.go
+++ b/store/storetest/session_store.go
@@ -168,7 +168,7 @@ func testSessionRemoveByUser(t *testing.T, ss store.Store) {
 		}
 	}
 
-	store.Must(ss.Session().PermanentDeleteSessionsByUser(s1.UserId))
+	require.Nil(t, ss.Session().PermanentDeleteSessionsByUser(s1.UserId))
 
 	if _, err := ss.Session().Get(s1.Id); err == nil {
 		t.Fatal("should have been removed")

--- a/store/storetest/session_store.go
+++ b/store/storetest/session_store.go
@@ -168,7 +168,8 @@ func testSessionRemoveByUser(t *testing.T, ss store.Store) {
 		}
 	}
 
-	require.Nil(t, ss.Session().PermanentDeleteSessionsByUser(s1.UserId))
+	err = ss.Session().PermanentDeleteSessionsByUser(s1.UserId)
+	require.Nil(t, err)
 
 	if _, err := ss.Session().Get(s1.Id); err == nil {
 		t.Fatal("should have been removed")


### PR DESCRIPTION
#### Summary
Migrate the `PermanentDeleteSessionsByUser` method from the `Preference` store to Sync by
default.

#### Ticket Link

 Fixes #10933 