### PR TITLE
MM-15569 Fixes failing test on TestGetPostsForChannelAroundLastUnread

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -148,7 +148,7 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	etag := ""
 
 	if since > 0 {
-		list, err = c.App.GetPostsSince(channelId, since, app.MAX_LIMIT_POSTS_SINCE)
+		list, err = c.App.GetPostsSince(channelId, since)
 	} else if len(afterPost) > 0 {
 		etag = c.App.GetPostsEtag(channelId)
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1747,17 +1747,17 @@ func TestGetPostsForChannelAroundLastUnread(t *testing.T) {
 		t.Fatal("Should return 12 posts only since there's no unread post")
 	}
 
+	// get the first system post generated before the created posts above
+	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post1.Id, 0, 2, "")
+	CheckNoError(t, resp)
+	systemPostId1 := posts.Order[1]
+
 	// Set channel member's last viewed before post1.
 	channelMember, err = th.App.Srv.Store.Channel().GetMember(channelId, userId)
 	require.Nil(t, err)
 	channelMember.LastViewedAt = post1.CreateAt - 1
 	store.Must(th.App.Srv.Store.Channel().UpdateMember(channelMember))
 	th.App.Srv.Store.Post().InvalidateLastPostTimeCache(channelId)
-
-	// get the first system post generated before the created posts above
-	posts, resp = Client.GetPostsBefore(th.BasicChannel.Id, post1.Id, 0, 2, "")
-	CheckNoError(t, resp)
-	systemPostId1 := posts.Order[1]
 
 	posts, resp = Client.GetPostsAroundLastUnread(userId, channelId, 3, 3)
 	CheckNoError(t, resp)

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -465,7 +465,7 @@ func (api *PluginAPI) GetPost(postId string) (*model.Post, *model.AppError) {
 }
 
 func (api *PluginAPI) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
-	return api.app.GetPostsSince(channelId, time, MAX_LIMIT_POSTS_SINCE)
+	return api.app.GetPostsSince(channelId, time)
 }
 
 func (api *PluginAPI) GetPostsAfter(channelId, postId string, page, perPage int) (*model.PostList, *model.AppError) {

--- a/app/post.go
+++ b/app/post.go
@@ -617,7 +617,10 @@ func (a *App) GetPostsSince(channelId string, time int64, limit int) (*model.Pos
 	if result.Err != nil {
 		return nil, result.Err
 	}
-	return result.Data.(*model.PostList), nil
+	postList := result.Data.(*model.PostList)
+	postList.SortByCreateAt()
+
+	return postList, nil
 }
 
 func (a *App) GetSinglePost(postId string) (*model.Post, *model.AppError) {
@@ -722,7 +725,7 @@ func (a *App) GetNextPostIdFromPostList(postList *model.PostList) string {
 		firstPost := postList.Posts[firstPostId]
 		nextPost, err := a.GetPostAfterTime(firstPost.ChannelId, firstPost.CreateAt)
 		if err != nil {
-			mlog.Error("GetNextPostIdFromPostList: failed in getting next post", mlog.Any("err", err))
+			mlog.Warn("GetNextPostIdFromPostList: failed in getting next post", mlog.Err(err))
 		}
 
 		if nextPost != nil {
@@ -739,7 +742,7 @@ func (a *App) GetPrevPostIdFromPostList(postList *model.PostList) string {
 		lastPost := postList.Posts[lastPostId]
 		previousPost, err := a.GetPostBeforeTime(lastPost.ChannelId, lastPost.CreateAt)
 		if err != nil {
-			mlog.Error("GetPrevPostIdFromPostList: failed in getting previous post", mlog.Any("err", err))
+			mlog.Warn("GetPrevPostIdFromPostList: failed in getting previous post", mlog.Err(err))
 		}
 
 		if previousPost != nil {

--- a/app/post.go
+++ b/app/post.go
@@ -698,21 +698,11 @@ func (a *App) GetPostsAroundPost(postId, channelId string, offset, limit int, be
 }
 
 func (a *App) GetPostAfterTime(channelId string, time int64) (*model.Post, *model.AppError) {
-	result := <-a.Srv.Store.Post().GetPostAfterTime(channelId, time)
-	if result.Err != nil {
-		return nil, result.Err
-	}
-
-	return result.Data.(*model.Post), nil
+	return a.Srv.Store.Post().GetPostAfterTime(channelId, time)
 }
 
 func (a *App) GetPostBeforeTime(channelId string, time int64) (*model.Post, *model.AppError) {
-	result := <-a.Srv.Store.Post().GetPostBeforeTime(channelId, time)
-	if result.Err != nil {
-		return nil, result.Err
-	}
-
-	return result.Data.(*model.Post), nil
+	return a.Srv.Store.Post().GetPostBeforeTime(channelId, time)
 }
 
 func (a *App) GetNextPostIdFromPostList(postList *model.PostList) string {

--- a/app/post.go
+++ b/app/post.go
@@ -18,10 +18,9 @@ import (
 )
 
 const (
-	MAX_LIMIT_POSTS_SINCE       = 1000
-	PAGE_DEFAULT                = 0
 	PENDING_POST_IDS_CACHE_SIZE = 25000
 	PENDING_POST_IDS_CACHE_TTL  = 30 * time.Second
+	PAGE_DEFAULT                = 0
 )
 
 func (a *App) CreatePostAsUser(post *model.Post, currentSessionId string) (*model.Post, *model.AppError) {
@@ -612,15 +611,12 @@ func (a *App) GetPostsEtag(channelId string) string {
 	return a.Srv.Store.Post().GetEtag(channelId, true)
 }
 
-func (a *App) GetPostsSince(channelId string, time int64, limit int) (*model.PostList, *model.AppError) {
-	result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, limit, true)
+func (a *App) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
+	result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, true)
 	if result.Err != nil {
 		return nil, result.Err
 	}
-	postList := result.Data.(*model.PostList)
-	postList.SortByCreateAt()
-
-	return postList, nil
+	return result.Data.(*model.PostList), nil
 }
 
 func (a *App) GetSinglePost(postId string) (*model.Post, *model.AppError) {
@@ -806,27 +802,29 @@ func (a *App) GetPostsForChannelAroundLastUnread(channelId, userId string, limit
 		return model.NewPostList(), nil
 	}
 
-	var postListSince *model.PostList
-	if postListSince, err = a.GetPostsSince(channelId, member.LastViewedAt, limitAfter); err != nil {
+	lastUnreadPost, err := a.GetPostAfterTime(channelId, member.LastViewedAt)
+	if err != nil {
 		return nil, err
-	} else if len(postListSince.Order) == 0 {
+	} else if lastUnreadPost == nil {
 		return model.NewPostList(), nil
 	}
 
-	var lastUnreadPostId = postListSince.Order[len(postListSince.Order)-1]
-	var postListBefore *model.PostList
-	if lastUnreadPostId != "" {
-		if postListBefore, err = a.GetPostsBeforePost(channelId, lastUnreadPostId, PAGE_DEFAULT, limitBefore); err != nil {
-			return nil, err
-		}
+	var postList *model.PostList
+	if postList, err = a.GetPostsBeforePost(channelId, lastUnreadPost.Id, PAGE_DEFAULT, limitBefore); err != nil {
+		return nil, err
 	}
 
-	if postListBefore != nil {
-		postListSince.Extend(postListBefore)
+	if postListAfter, err := a.GetPostsAfterPost(channelId, lastUnreadPost.Id, PAGE_DEFAULT, limitAfter-1); err != nil {
+		return nil, err
+	} else if postListAfter != nil {
+		postList.Extend(postListAfter)
 	}
 
-	postListSince.SortByCreateAt()
-	return postListSince, nil
+	postList.AddPost(lastUnreadPost)
+	postList.AddOrder(lastUnreadPost.Id)
+
+	postList.SortByCreateAt()
+	return postList, nil
 }
 
 func (a *App) DeletePost(postId, deleteByID string) (*model.Post, *model.AppError) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6091,6 +6091,10 @@
     "translation": "Unable to get the parent post for the channel"
   },
   {
+    "id": "store.sql_post.get_post_around.get.app_error",
+    "translation": "Unable to get post around time bound"
+  },
+  {
     "id": "store.sql_post.get_posts.app_error",
     "translation": "Limit exceeded for paging"
   },

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -334,7 +334,7 @@ func (s *SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 
 func (s *SqlPostStore) GetEtag(channelId string, allowFromCache bool) string {
 	if allowFromCache {
-		if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok {
+		if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) > 0 {
 			if s.metrics != nil {
 				s.metrics.IncrementMemCacheHitCounter("Last Post Time")
 			}

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -507,7 +507,7 @@ func (s *SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFr
 	return list, err
 }
 
-func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) store.StoreChannel {
+func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 		if allowFromCache {
 			// If the last post in the channel's time is less than or equal to the time we are getting posts since,
@@ -556,8 +556,8 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, al
 			        UpdateAt > :Time
 			            AND ChannelId = :ChannelId
 				LIMIT 1000) temp_tab))
-			ORDER BY CreateAt ASC LIMIT :Limit`,
-			map[string]interface{}{"ChannelId": channelId, "Time": time, "Limit": limit})
+			ORDER BY CreateAt DESC`,
+			map[string]interface{}{"ChannelId": channelId, "Time": time})
 
 		if err != nil {
 			result.Err = model.NewAppError("SqlPostStore.GetPostsSince", "store.sql_post.get_posts_since.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -334,7 +334,7 @@ func (s *SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 
 func (s *SqlPostStore) GetEtag(channelId string, allowFromCache bool) string {
 	if allowFromCache {
-		if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) > 0 {
+		if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok {
 			if s.metrics != nil {
 				s.metrics.IncrementMemCacheHitCounter("Last Post Time")
 			}
@@ -539,7 +539,7 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, al
 			WHERE
 			    (UpdateAt > :Time
 			        AND ChannelId = :ChannelId)
-			LIMIT :Limit)
+			LIMIT 1000)
 			UNION
 			(SELECT
 			    *
@@ -555,8 +555,8 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, limit int, al
 			    WHERE
 			        UpdateAt > :Time
 			            AND ChannelId = :ChannelId
-			    LIMIT :Limit) temp_tab))
-			ORDER BY CreateAt DESC`,
+				LIMIT 1000) temp_tab))
+			ORDER BY CreateAt ASC LIMIT :Limit`,
 			map[string]interface{}{"ChannelId": channelId, "Time": time, "Limit": limit})
 
 		if err != nil {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -678,48 +678,46 @@ func (s *SqlPostStore) getPostsAround(channelId string, postId string, limit int
 	})
 }
 
-func (s *SqlPostStore) GetPostBeforeTime(channelId string, time int64) store.StoreChannel {
+func (s *SqlPostStore) GetPostBeforeTime(channelId string, time int64) (*model.Post, *model.AppError) {
 	return s.getPostAroundTime(channelId, time, true)
 }
 
-func (s *SqlPostStore) GetPostAfterTime(channelId string, time int64) store.StoreChannel {
+func (s *SqlPostStore) GetPostAfterTime(channelId string, time int64) (*model.Post, *model.AppError) {
 	return s.getPostAroundTime(channelId, time, false)
 }
 
-func (s *SqlPostStore) getPostAroundTime(channelId string, time int64, before bool) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		var direction string
-		var sort string
-		if before {
-			direction = "<"
-			sort = "DESC"
-		} else {
-			direction = ">"
-			sort = "ASC"
-		}
+func (s *SqlPostStore) getPostAroundTime(channelId string, time int64, before bool) (*model.Post, *model.AppError) {
+	var direction string
+	var sort string
+	if before {
+		direction = "<"
+		sort = "DESC"
+	} else {
+		direction = ">"
+		sort = "ASC"
+	}
 
-		var post *model.Post
-		err := s.GetReplica().SelectOne(
-			&post,
-			`SELECT
-				*
-			FROM
-				Posts
-			WHERE
-				CreateAt `+direction+` :Time
-				AND ChannelId = :ChannelId
-				AND DeleteAt = 0
-			ORDER BY CreateAt `+sort+`
-			LIMIT 1`,
-			map[string]interface{}{"ChannelId": channelId, "Time": time})
-		if err != nil {
-			if err != sql.ErrNoRows {
-				result.Err = model.NewAppError("SqlPostStore.getPostAroundTime", "store.sql_post.get_post_around.get.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)
-			}
+	var post *model.Post
+	err := s.GetReplica().SelectOne(
+		&post,
+		`SELECT
+			*
+		FROM
+			Posts
+		WHERE
+			CreateAt `+direction+` :Time
+			AND ChannelId = :ChannelId
+			AND DeleteAt = 0
+		ORDER BY CreateAt `+sort+`
+		LIMIT 1`,
+		map[string]interface{}{"ChannelId": channelId, "Time": time})
+	if err != nil {
+		if err != sql.ErrNoRows {
+			return nil, model.NewAppError("SqlPostStore.getPostAroundTime", "store.sql_post.get_post_around.get.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)
 		}
+	}
 
-		result.Data = post
-	})
+	return post, nil
 }
 
 func (s *SqlPostStore) getRootPosts(channelId string, offset int, limit int) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -224,8 +224,8 @@ type PostStore interface {
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsSince(channelId string, time int64, allowFromCache bool) StoreChannel
-	GetPostAfterTime(channelId string, time int64) StoreChannel
-	GetPostBeforeTime(channelId string, time int64) StoreChannel
+	GetPostAfterTime(channelId string, time int64) (*model.Post, *model.AppError)
+	GetPostBeforeTime(channelId string, time int64) (*model.Post, *model.AppError)
 	GetEtag(channelId string, allowFromCache bool) string
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/store.go
+++ b/store/store.go
@@ -223,7 +223,7 @@ type PostStore interface {
 	GetFlaggedPostsForChannel(userId, channelId string, offset int, limit int) StoreChannel
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) StoreChannel
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) StoreChannel
-	GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) StoreChannel
+	GetPostsSince(channelId string, time int64, allowFromCache bool) StoreChannel
 	GetPostAfterTime(channelId string, time int64) StoreChannel
 	GetPostBeforeTime(channelId string, time int64) StoreChannel
 	GetEtag(channelId string, allowFromCache bool) string

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -259,35 +259,53 @@ func (_m *PostStore) GetParentsForExportAfter(limit int, afterId string) store.S
 }
 
 // GetPostAfterTime provides a mock function with given fields: channelId, time
-func (_m *PostStore) GetPostAfterTime(channelId string, time int64) store.StoreChannel {
+func (_m *PostStore) GetPostAfterTime(channelId string, time int64) (*model.Post, *model.AppError) {
 	ret := _m.Called(channelId, time)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+	var r0 *model.Post
+	if rf, ok := ret.Get(0).(func(string, int64) *model.Post); ok {
 		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Post)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
+		r1 = rf(channelId, time)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetPostBeforeTime provides a mock function with given fields: channelId, time
-func (_m *PostStore) GetPostBeforeTime(channelId string, time int64) store.StoreChannel {
+func (_m *PostStore) GetPostBeforeTime(channelId string, time int64) (*model.Post, *model.AppError) {
 	ret := _m.Called(channelId, time)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64) store.StoreChannel); ok {
+	var r0 *model.Post
+	if rf, ok := ret.Get(0).(func(string, int64) *model.Post); ok {
 		r0 = rf(channelId, time)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Post)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64) *model.AppError); ok {
+		r1 = rf(channelId, time)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetPosts provides a mock function with given fields: channelId, offset, limit, allowFromCache

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -395,13 +395,13 @@ func (_m *PostStore) GetPostsCreatedAt(channelId string, time int64) store.Store
 	return r0
 }
 
-// GetPostsSince provides a mock function with given fields: channelId, time, limit, allowFromCache
-func (_m *PostStore) GetPostsSince(channelId string, time int64, limit int, allowFromCache bool) store.StoreChannel {
+// GetPostsSince provides a mock function with given fields: channelId, time, allowFromCache
+func (_m *PostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
 	ret := _m.Called(channelId, time, allowFromCache)
 
 	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64, int, bool) store.StoreChannel); ok {
-		r0 = rf(channelId, time, limit, allowFromCache)
+	if rf, ok := ret.Get(0).(func(string, int64, bool) store.StoreChannel); ok {
+		r0 = rf(channelId, time, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(store.StoreChannel)

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -954,21 +954,21 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o5.RootId = o4.Id
 	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, 1000, false)).Data.(*model.PostList)
+	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, false)).Data.(*model.PostList)
 
-	if r1.Order[5] != o5.Id {
+	if r1.Order[0] != o5.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[4] != o4.Id {
+	if r1.Order[1] != o4.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[3] != o3.Id {
+	if r1.Order[2] != o3.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[2] != o2a.Id {
+	if r1.Order[3] != o2a.Id {
 		t.Fatal("invalid order")
 	}
 
@@ -980,7 +980,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 		t.Fatal("Missing parent")
 	}
 
-	r2 := (<-ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, 1000, true)).Data.(*model.PostList)
+	r2 := (<-ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, true)).Data.(*model.PostList)
 
 	if len(r2.Order) != 0 {
 		t.Fatal("wrong size ", len(r2.Posts))

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -956,19 +956,19 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 
 	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, 1000, false)).Data.(*model.PostList)
 
-	if r1.Order[0] != o5.Id {
+	if r1.Order[5] != o5.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[1] != o4.Id {
+	if r1.Order[4] != o4.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[2] != o3.Id {
+	if r1.Order[3] != o3.Id {
 		t.Fatal("invalid order")
 	}
 
-	if r1.Order[3] != o2a.Id {
+	if r1.Order[2] != o2a.Id {
 		t.Fatal("invalid order")
 	}
 

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -1046,33 +1046,33 @@ func testPostStoreGetPostBeforeAfter(t *testing.T, ss store.Store) {
 	o2a.RootId = o2.Id
 	o2a = (<-ss.Post().Save(o2a)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetPostBeforeTime(channelId, o0a.CreateAt))
-	if r1.Data.(*model.Post).Id != o1.Id || r1.Err != nil {
+	r1, err := ss.Post().GetPostBeforeTime(channelId, o0a.CreateAt)
+	if r1.Id != o1.Id || err != nil {
 		t.Fatal("should return before post o1")
 	}
 
-	r1 = (<-ss.Post().GetPostAfterTime(channelId, o0b.CreateAt))
-	if r1.Data.(*model.Post).Id != o2.Id || r1.Err != nil {
+	r1, err = ss.Post().GetPostAfterTime(channelId, o0b.CreateAt)
+	if r1.Id != o2.Id || err != nil {
 		t.Fatal("should return before post o2")
 	}
 
-	r2 := (<-ss.Post().GetPostBeforeTime(channelId, o0.CreateAt))
-	if r2.Data.(*model.Post) != nil || r2.Err != nil {
+	r2, err := ss.Post().GetPostBeforeTime(channelId, o0.CreateAt)
+	if r2 != nil || err != nil {
 		t.Fatal("should return no post")
 	}
 
-	r2 = (<-ss.Post().GetPostAfterTime(channelId, o0.CreateAt))
-	if r2.Data.(*model.Post).Id != o1.Id || r2.Err != nil {
+	r2, err = ss.Post().GetPostAfterTime(channelId, o0.CreateAt)
+	if r2.Id != o1.Id || err != nil {
 		t.Fatal("should return before post o1")
 	}
 
-	r3 := (<-ss.Post().GetPostBeforeTime(channelId, o2a.CreateAt))
-	if r3.Data.(*model.Post).Id != o2.Id || r2.Err != nil {
+	r3, err := ss.Post().GetPostBeforeTime(channelId, o2a.CreateAt)
+	if r3.Id != o2.Id || err != nil {
 		t.Fatal("should return before post o2")
 	}
 
-	r3 = (<-ss.Post().GetPostAfterTime(channelId, o2a.CreateAt))
-	if r3.Data.(*model.Post) != nil || r3.Err != nil {
+	r3, err = ss.Post().GetPostAfterTime(channelId, o2a.CreateAt)
+	if r3 != nil || err != nil {
 		t.Fatal("should return no post")
 	}
 }


### PR DESCRIPTION
#### Summary
This PR intends to finalize unread API so the 'post-list-improvements' branch could finally submitted against master.
It includes:
- fix to failing TestGetPostsForChannelAroundLastUnread
- reverts unnecessary change to GetPostsSince - https://github.com/mattermost/mattermost-server/pull/11039/commits/15fb9a4238a568a05bb3a0a874c59169224fd2aa
- migrate the new functions - GetPostAfterTime and GetPostBeforeTime - to sync by default - https://github.com/mattermost/mattermost-server/pull/11039/commits/ce3540428fb137bafbf3a69949e16a53a28c297e

This PR was originally submitted as https://github.com/mattermost/mattermost-server/pull/10861.  However, I messed up that PR and `unread-posts-api` branch.

I copied over the comments made by HH.  Sorry for inconvenience in reviewing this PR.

#### Ticket Link
Jira ticket: [MM-15569](https://mattermost.atlassian.net/browse/MM-15569)
