### PR TITLE
[MM-15841] Store: Migrate "Post.Save" to Sync by default

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -395,12 +395,16 @@ func (me *TestHelper) CreateMessagePostWithClient(client *model.Client4, channel
 }
 
 func (me *TestHelper) CreateMessagePostNoClient(channel *model.Channel, message string, createAtTime int64) *model.Post {
-	post := store.Must(me.App.Srv.Store.Post().Save(&model.Post{
+	post, err := me.App.Srv.Store.Post().Save(&model.Post{
 		UserId:    me.BasicUser.Id,
 		ChannelId: channel.Id,
 		Message:   message,
 		CreateAt:  createAtTime,
-	})).(*model.Post)
+	})
+
+	if err != nil {
+		panic(err)
+	}
 
 	return post
 }

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -892,8 +892,8 @@ func (a *App) ImportReply(data *ReplyImportData, post *model.Post, teamId string
 	}
 
 	if reply.Id == "" {
-		if result := <-a.Srv.Store.Post().Save(reply); result.Err != nil {
-			return result.Err
+		if _, err := a.Srv.Store.Post().Save(reply); err != nil {
+			return err
 		}
 	} else {
 		if _, err := a.Srv.Store.Post().Overwrite(reply); err != nil {
@@ -992,8 +992,8 @@ func (a *App) ImportPost(data *PostImportData, dryRun bool) *model.AppError {
 	}
 
 	if post.Id == "" {
-		if result := <-a.Srv.Store.Post().Save(post); result.Err != nil {
-			return result.Err
+		if _, err := a.Srv.Store.Post().Save(post); err != nil {
+			return err
 		}
 	} else {
 		if _, err := a.Srv.Store.Post().Overwrite(post); err != nil {
@@ -1215,8 +1215,8 @@ func (a *App) ImportDirectPost(data *DirectPostImportData, dryRun bool) *model.A
 	}
 
 	if post.Id == "" {
-		if result := <-a.Srv.Store.Post().Save(post); result.Err != nil {
-			return result.Err
+		if _, err := a.Srv.Store.Post().Save(post); err != nil {
+			return err
 		}
 	} else {
 		if _, err := a.Srv.Store.Post().Overwrite(post); err != nil {

--- a/app/post.go
+++ b/app/post.go
@@ -213,7 +213,7 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 
 	post.Hashtags, _ = model.ParseHashtags(post.Message)
 
-	if err := a.FillInPostProps(post, channel); err != nil {
+	if err = a.FillInPostProps(post, channel); err != nil {
 		return nil, err
 	}
 
@@ -255,11 +255,10 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 		}
 	}
 
-	result := <-a.Srv.Store.Post().Save(post)
-	if result.Err != nil {
-		return nil, result.Err
+	rpost, err := a.Srv.Store.Post().Save(post)
+	if err != nil {
+		return nil, err
 	}
-	rpost := result.Data.(*model.Post)
 
 	// Update the mapping from pending post id to the actual post id, for any clients that
 	// might be duplicating requests.
@@ -278,7 +277,7 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 	esInterface := a.Elasticsearch
 	if esInterface != nil && *a.Config().ElasticsearchSettings.EnableIndexing {
 		a.Srv.Go(func() {
-			if err := esInterface.IndexPost(rpost, channel.TeamId); err != nil {
+			if err = esInterface.IndexPost(rpost, channel.TeamId); err != nil {
 				mlog.Error("Encountered error indexing post", mlog.String("post_id", post.Id), mlog.Err(err))
 			}
 		})
@@ -289,8 +288,8 @@ func (a *App) CreatePost(post *model.Post, channel *model.Channel, triggerWebhoo
 	}
 
 	if len(post.FileIds) > 0 {
-		if err := a.attachFilesToPost(post); err != nil {
-			mlog.Error("Encountered error attaching files to post", mlog.String("post_id", post.Id), mlog.Any("file_ids", post.FileIds), mlog.Err(result.Err))
+		if err = a.attachFilesToPost(post); err != nil {
+			mlog.Error("Encountered error attaching files to post", mlog.String("post_id", post.Id), mlog.Any("file_ids", post.FileIds), mlog.Err(err))
 		}
 
 		if a.Metrics != nil {

--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -758,7 +758,8 @@ func (a *App) OldImportPost(post *model.Post) string {
 		post.RootId = firstPostId
 		post.ParentId = firstPostId
 
-		if result := <-a.Srv.Store.Post().Save(post); result.Err != nil {
+		_, err := a.Srv.Store.Post().Save(post)
+		if err != nil {
 			mlog.Debug(fmt.Sprintf("Error saving post. user=%v, message=%v", post.UserId, post.Message))
 		}
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -114,18 +114,18 @@ func (s *SqlPostStore) Save(post *model.Post) (*model.Post, *model.AppError) {
 		post.Type != model.POST_ADD_TO_CHANNEL && post.Type != model.POST_REMOVE_FROM_CHANNEL &&
 		post.Type != model.POST_ADD_TO_TEAM && post.Type != model.POST_REMOVE_FROM_TEAM {
 		if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = GREATEST(:LastPostAt, LastPostAt), TotalMsgCount = TotalMsgCount + 1 WHERE Id = :ChannelId", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId}); err != nil {
-			mlog.Error(fmt.Sprintf("Update Channel LastPostAt: %v", err.Error()))
+			mlog.Error(fmt.Sprintf("Error updating Channel LastPostAt: %v", err.Error()))
 		}
 	} else {
 		// don't update TotalMsgCount for unimportant messages so that the channel isn't marked as unread
 		if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = :LastPostAt WHERE Id = :ChannelId AND LastPostAt < :LastPostAt", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId}); err != nil {
-			mlog.Error(fmt.Sprintf("Update Channel LastPostAt: %v", err.Error()))
+			mlog.Error(fmt.Sprintf("Error updating Channel LastPostAt: %v", err.Error()))
 		}
 	}
 
 	if len(post.RootId) > 0 {
 		if _, err := s.GetMaster().Exec("UPDATE Posts SET UpdateAt = :UpdateAt WHERE Id = :RootId", map[string]interface{}{"UpdateAt": time, "RootId": post.RootId}); err != nil {
-			mlog.Error(fmt.Sprintf("Update Post UpdateAt: %v", err.Error()))
+			mlog.Error(fmt.Sprintf("Error updating Post UpdateAt: %v", err.Error()))
 		}
 	}
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -114,18 +114,18 @@ func (s *SqlPostStore) Save(post *model.Post) (*model.Post, *model.AppError) {
 		post.Type != model.POST_ADD_TO_CHANNEL && post.Type != model.POST_REMOVE_FROM_CHANNEL &&
 		post.Type != model.POST_ADD_TO_TEAM && post.Type != model.POST_REMOVE_FROM_TEAM {
 		if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = GREATEST(:LastPostAt, LastPostAt), TotalMsgCount = TotalMsgCount + 1 WHERE Id = :ChannelId", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId}); err != nil {
-			return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
+			mlog.Error(fmt.Sprintf("Update Channel LastPostAt: %v", err.Error()))
 		}
 	} else {
 		// don't update TotalMsgCount for unimportant messages so that the channel isn't marked as unread
 		if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = :LastPostAt WHERE Id = :ChannelId AND LastPostAt < :LastPostAt", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId}); err != nil {
-			return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
+			mlog.Error(fmt.Sprintf("Update Channel LastPostAt: %v", err.Error()))
 		}
 	}
 
 	if len(post.RootId) > 0 {
 		if _, err := s.GetMaster().Exec("UPDATE Posts SET UpdateAt = :UpdateAt WHERE Id = :RootId", map[string]interface{}{"UpdateAt": time, "RootId": post.RootId}); err != nil {
-			return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
+			mlog.Error(fmt.Sprintf("Update Post UpdateAt: %v", err.Error()))
 		}
 	}
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -90,43 +90,46 @@ func (s *SqlPostStore) CreateIndexesIfNotExists() {
 	s.CreateFullTextIndexIfNotExists("idx_posts_hashtags_txt", "Posts", "Hashtags")
 }
 
-func (s *SqlPostStore) Save(post *model.Post) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if len(post.Id) > 0 {
-			result.Err = model.NewAppError("SqlPostStore.Save", "store.sql_post.save.existing.app_error", nil, "id="+post.Id, http.StatusBadRequest)
-			return
+func (s *SqlPostStore) Save(post *model.Post) (*model.Post, *model.AppError) {
+	if len(post.Id) > 0 {
+		return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.existing.app_error", nil, "id="+post.Id, http.StatusBadRequest)
+	}
+
+	maxPostSize := s.GetMaxPostSize()
+
+	post.PreSave()
+	if err := post.IsValid(maxPostSize); err != nil {
+		return nil, err
+	}
+
+	if err := s.GetMaster().Insert(post); err != nil {
+		return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
+	}
+
+	time := post.UpdateAt
+
+	if post.Type != model.POST_JOIN_LEAVE && post.Type != model.POST_ADD_REMOVE &&
+		post.Type != model.POST_JOIN_CHANNEL && post.Type != model.POST_LEAVE_CHANNEL &&
+		post.Type != model.POST_JOIN_TEAM && post.Type != model.POST_LEAVE_TEAM &&
+		post.Type != model.POST_ADD_TO_CHANNEL && post.Type != model.POST_REMOVE_FROM_CHANNEL &&
+		post.Type != model.POST_ADD_TO_TEAM && post.Type != model.POST_REMOVE_FROM_TEAM {
+		if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = GREATEST(:LastPostAt, LastPostAt), TotalMsgCount = TotalMsgCount + 1 WHERE Id = :ChannelId", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId}); err != nil {
+			return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
 		}
-
-		maxPostSize := s.GetMaxPostSize()
-
-		post.PreSave()
-		if result.Err = post.IsValid(maxPostSize); result.Err != nil {
-			return
+	} else {
+		// don't update TotalMsgCount for unimportant messages so that the channel isn't marked as unread
+		if _, err := s.GetMaster().Exec("UPDATE Channels SET LastPostAt = :LastPostAt WHERE Id = :ChannelId AND LastPostAt < :LastPostAt", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId}); err != nil {
+			return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
 		}
+	}
 
-		if err := s.GetMaster().Insert(post); err != nil {
-			result.Err = model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
-		} else {
-			time := post.UpdateAt
-
-			if post.Type != model.POST_JOIN_LEAVE && post.Type != model.POST_ADD_REMOVE &&
-				post.Type != model.POST_JOIN_CHANNEL && post.Type != model.POST_LEAVE_CHANNEL &&
-				post.Type != model.POST_JOIN_TEAM && post.Type != model.POST_LEAVE_TEAM &&
-				post.Type != model.POST_ADD_TO_CHANNEL && post.Type != model.POST_REMOVE_FROM_CHANNEL &&
-				post.Type != model.POST_ADD_TO_TEAM && post.Type != model.POST_REMOVE_FROM_TEAM {
-				s.GetMaster().Exec("UPDATE Channels SET LastPostAt = GREATEST(:LastPostAt, LastPostAt), TotalMsgCount = TotalMsgCount + 1 WHERE Id = :ChannelId", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId})
-			} else {
-				// don't update TotalMsgCount for unimportant messages so that the channel isn't marked as unread
-				s.GetMaster().Exec("UPDATE Channels SET LastPostAt = :LastPostAt WHERE Id = :ChannelId AND LastPostAt < :LastPostAt", map[string]interface{}{"LastPostAt": time, "ChannelId": post.ChannelId})
-			}
-
-			if len(post.RootId) > 0 {
-				s.GetMaster().Exec("UPDATE Posts SET UpdateAt = :UpdateAt WHERE Id = :RootId", map[string]interface{}{"UpdateAt": time, "RootId": post.RootId})
-			}
-
-			result.Data = post
+	if len(post.RootId) > 0 {
+		if _, err := s.GetMaster().Exec("UPDATE Posts SET UpdateAt = :UpdateAt WHERE Id = :RootId", map[string]interface{}{"UpdateAt": time, "RootId": post.RootId}); err != nil {
+			return nil, model.NewAppError("SqlPostStore.Save", "store.sql_post.save.app_error", nil, "id="+post.Id+", "+err.Error(), http.StatusInternalServerError)
 		}
-	})
+	}
+
+	return post, nil
 }
 
 func (s *SqlPostStore) Update(newPost *model.Post, oldPost *model.Post) (*model.Post, *model.AppError) {

--- a/store/store.go
+++ b/store/store.go
@@ -210,7 +210,7 @@ type ChannelMemberHistoryStore interface {
 }
 
 type PostStore interface {
-	Save(post *model.Post) StoreChannel
+	Save(post *model.Post) (*model.Post, *model.AppError)
 	Update(newPost *model.Post, oldPost *model.Post) (*model.Post, *model.AppError)
 	Get(id string) (*model.PostList, *model.AppError)
 	GetSingle(id string) (*model.Post, *model.AppError)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -524,11 +524,12 @@ func testChannelStoreGetForPost(t *testing.T, ss store.Store) {
 	o1, err := ss.Channel().Save(ch, -1)
 	require.Nil(t, err)
 
-	p1 := store.Must(ss.Post().Save(&model.Post{
+	p1, err := ss.Post().Save(&model.Post{
 		UserId:    model.NewId(),
 		ChannelId: o1.Id,
 		Message:   "test",
-	})).(*model.Post)
+	})
+	require.Nil(t, err)
 
 	if r1 := <-ss.Channel().GetForPost(p1.Id); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -1871,11 +1872,12 @@ func testChannelStoreGetMemberForPost(t *testing.T, ss store.Store) {
 		NotifyProps: model.GetDefaultChannelNotifyProps(),
 	})).(*model.ChannelMember)
 
-	p1 := store.Must(ss.Post().Save(&model.Post{
+	p1, err := ss.Post().Save(&model.Post{
 		UserId:    model.NewId(),
 		ChannelId: o1.Id,
 		Message:   "test",
-	})).(*model.Post)
+	})
+	require.Nil(t, err)
 
 	if r1 := <-ss.Channel().GetMemberForPost(p1.Id, m1.UserId); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -2836,12 +2838,12 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	o1, err := ss.Channel().Save(ch1, -1)
 	require.Nil(t, err)
 
-	p1 := store.Must(ss.Post().Save(&model.Post{
+	p1, err := ss.Post().Save(&model.Post{
 		UserId:    model.NewId(),
 		ChannelId: o1.Id,
 		Message:   "test",
 		IsPinned:  true,
-	})).(*model.Post)
+	})
 
 	if r1 := <-ss.Channel().GetPinnedPosts(o1.Id); r1.Err != nil {
 		t.Fatal(r1.Err)
@@ -2859,11 +2861,12 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	o2, err := ss.Channel().Save(ch2, -1)
 	require.Nil(t, err)
 
-	store.Must(ss.Post().Save(&model.Post{
+	_, err = ss.Post().Save(&model.Post{
 		UserId:    model.NewId(),
 		ChannelId: o2.Id,
 		Message:   "test",
-	}))
+	})
+	require.Nil(t, err)
 
 	if r2 := <-ss.Channel().GetPinnedPosts(o2.Id); r2.Err != nil {
 		t.Fatal(r2.Err)

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -115,6 +115,7 @@ func testComplianceExport(t *testing.T, ss store.Store) {
 	o2.CreateAt = o1.CreateAt + 20
 	o2.Message = "zz" + model.NewId() + "b"
 	_, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o2a := &model.Post{}
 	o2a.ChannelId = c1.Id

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -98,28 +98,31 @@ func testComplianceExport(t *testing.T, ss store.Store) {
 	o1.UserId = u1.Id
 	o1.CreateAt = model.GetMillis()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = store.Must(ss.Post().Save(o1)).(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o1a := &model.Post{}
 	o1a.ChannelId = c1.Id
 	o1a.UserId = u1.Id
 	o1a.CreateAt = o1.CreateAt + 10
 	o1a.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_, err = ss.Post().Save(o1a)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u1.Id
 	o2.CreateAt = o1.CreateAt + 20
 	o2.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o2)).(*model.Post)
+	_, err = ss.Post().Save(o2)
 
 	o2a := &model.Post{}
 	o2a.ChannelId = c1.Id
 	o2a.UserId = u2.Id
 	o2a.CreateAt = o1.CreateAt + 30
 	o2a.Message = "zz" + model.NewId() + "b"
-	o2a = store.Must(ss.Post().Save(o2a)).(*model.Post)
+	o2a, err = ss.Post().Save(o2a)
+	require.Nil(t, err)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -201,35 +204,40 @@ func testComplianceExportDirectMessages(t *testing.T, ss store.Store) {
 	o1.UserId = u1.Id
 	o1.CreateAt = model.GetMillis()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = store.Must(ss.Post().Save(o1)).(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o1a := &model.Post{}
 	o1a.ChannelId = c1.Id
 	o1a.UserId = u1.Id
 	o1a.CreateAt = o1.CreateAt + 10
 	o1a.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_, err = ss.Post().Save(o1a)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
 	o2.UserId = u1.Id
 	o2.CreateAt = o1.CreateAt + 20
 	o2.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o2)).(*model.Post)
+	_, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o2a := &model.Post{}
 	o2a.ChannelId = c1.Id
 	o2a.UserId = u2.Id
 	o2a.CreateAt = o1.CreateAt + 30
 	o2a.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o2a)).(*model.Post)
+	_, err = ss.Post().Save(o2a)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = cDM.Id
 	o3.UserId = u1.Id
 	o3.CreateAt = o1.CreateAt + 40
 	o3.Message = "zz" + model.NewId() + "b"
-	o3 = store.Must(ss.Post().Save(o3)).(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -296,7 +304,8 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 		CreateAt:  startTime,
 		Message:   "zz" + model.NewId() + "a",
 	}
-	post1 = store.Must(ss.Post().Save(post1)).(*model.Post)
+	post1, err = ss.Post().Save(post1)
+	require.Nil(t, err)
 
 	post2 := &model.Post{
 		ChannelId: channel.Id,
@@ -304,7 +313,8 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 		CreateAt:  startTime + 10,
 		Message:   "zz" + model.NewId() + "b",
 	}
-	post2 = store.Must(ss.Post().Save(post2)).(*model.Post)
+	post2, err = ss.Post().Save(post2)
+	require.Nil(t, err)
 
 	// fetch the message exports for both posts that user1 sent
 	messageExportMap := map[string]model.MessageExport{}
@@ -392,7 +402,8 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 		CreateAt:  startTime,
 		Message:   "zz" + model.NewId() + "a",
 	}
-	post1 = store.Must(ss.Post().Save(post1)).(*model.Post)
+	post1, err = ss.Post().Save(post1)
+	require.Nil(t, err)
 
 	post2 := &model.Post{
 		ChannelId: channel.Id,
@@ -400,7 +411,8 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 		CreateAt:  startTime + 10,
 		Message:   "zz" + model.NewId() + "b",
 	}
-	post2 = store.Must(ss.Post().Save(post2)).(*model.Post)
+	post2, err = ss.Post().Save(post2)
+	require.Nil(t, err)
 
 	// fetch the message exports for both posts that user1 sent
 	messageExportMap := map[string]model.MessageExport{}
@@ -484,7 +496,8 @@ func testMessageExportDirectMessageChannel(t *testing.T, ss store.Store) {
 		CreateAt:  startTime + 20,
 		Message:   "zz" + model.NewId() + "c",
 	}
-	post = store.Must(ss.Post().Save(post)).(*model.Post)
+	post, err = ss.Post().Save(post)
+	require.Nil(t, err)
 
 	// fetch the message export for the post that user1 sent
 	messageExportMap := map[string]model.MessageExport{}
@@ -573,7 +586,8 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 		CreateAt:  startTime + 20,
 		Message:   "zz" + model.NewId() + "c",
 	}
-	post = store.Must(ss.Post().Save(post)).(*model.Post)
+	post, err = ss.Post().Save(post)
+	require.Nil(t, err)
 
 	// fetch the message export for the post that user1 sent
 	messageExportMap := map[string]model.MessageExport{}

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -605,19 +605,28 @@ func (_m *PostStore) PermanentDeleteByUser(userId string) *model.AppError {
 }
 
 // Save provides a mock function with given fields: post
-func (_m *PostStore) Save(post *model.Post) store.StoreChannel {
+func (_m *PostStore) Save(post *model.Post) (*model.Post, *model.AppError) {
 	ret := _m.Called(post)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(*model.Post) store.StoreChannel); ok {
+	var r0 *model.Post
+	if rf, ok := ret.Get(0).(func(*model.Post) *model.Post); ok {
 		r0 = rf(post)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Post)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(*model.Post) *model.AppError); ok {
+		r1 = rf(post)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // Search provides a mock function with given fields: teamId, userId, params

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -2126,7 +2126,7 @@ func testPostStorePermanentDeleteBatch(t *testing.T, ss store.Store) {
 	o3, err = ss.Post().Save(o3)
 	require.Nil(t, err)
 
-	_, err := ss.Post().PermanentDeleteBatch(2000, 1000)
+	_, err = ss.Post().PermanentDeleteBatch(2000, 1000)
 	require.Nil(t, err)
 
 	if _, err := ss.Post().Get(o1.Id); err == nil {

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -59,11 +59,11 @@ func testPostStoreSave(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
 
-	if err := (<-ss.Post().Save(&o1)).Err; err != nil {
+	if _, err := ss.Post().Save(&o1); err != nil {
 		t.Fatal("couldn't save item", err)
 	}
 
-	if err := (<-ss.Post().Save(&o1)).Err; err == nil {
+	if _, err := ss.Post().Save(&o1); err == nil {
 		t.Fatal("shouldn't be able to update from save")
 	}
 }
@@ -78,7 +78,8 @@ func testPostStoreSaveChannelMsgCounts(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
 
-	require.Nil(t, (<-ss.Post().Save(&o1)).Err)
+	_, err = ss.Post().Save(&o1)
+	require.Nil(t, err)
 
 	c1, err = ss.Channel().Get(c1.Id, false)
 	require.Nil(t, err)
@@ -86,11 +87,13 @@ func testPostStoreSaveChannelMsgCounts(t *testing.T, ss store.Store) {
 
 	o1.Id = ""
 	o1.Type = model.POST_ADD_TO_TEAM
-	require.Nil(t, (<-ss.Post().Save(&o1)).Err)
+	_, err = ss.Post().Save(&o1)
+	require.Nil(t, err)
 
 	o1.Id = ""
 	o1.Type = model.POST_REMOVE_FROM_TEAM
-	require.Nil(t, (<-ss.Post().Save(&o1)).Err)
+	_, err = ss.Post().Save(&o1)
+	require.Nil(t, err)
 
 	c1, err = ss.Channel().Get(c1.Id, false)
 	require.Nil(t, err)
@@ -103,7 +106,8 @@ func testPostStoreSaveChannelMsgCounts(t *testing.T, ss store.Store) {
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.CreateAt = int64(7)
-	require.Nil(t, (<-ss.Post().Save(&o2)).Err)
+	_, err = ss.Post().Save(&o2)
+	require.Nil(t, err)
 
 	c1, err = ss.Channel().Get(c1.Id, false)
 	require.Nil(t, err)
@@ -121,7 +125,8 @@ func testPostStoreGet(t *testing.T, ss store.Store) {
 		t.Fatal("Invalid Etag")
 	}
 
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	etag2 := ss.Post().GetEtag(o1.ChannelId, false)
 	if strings.Index(etag2, fmt.Sprintf("%v.%v", model.CurrentVersion, o1.UpdateAt)) != 0 {
@@ -151,7 +156,8 @@ func testPostStoreGetSingle(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
 
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	if post, err := ss.Post().GetSingle(o1.Id); err != nil {
 		t.Fatal(err)
@@ -183,7 +189,8 @@ func testGetEtagCache(t *testing.T, ss store.Store) {
 		t.Fatal("Invalid Etag")
 	}
 
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	// We have not invalidated the cache so this should be the same as above
 	etag3 := ss.Post().GetEtag(o1.ChannelId, true)
@@ -205,7 +212,8 @@ func testPostStoreUpdate(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -213,13 +221,15 @@ func testPostStoreUpdate(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "CCCCCCCCC"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = o1.ChannelId
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "QQQQQQQQQQ"
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	r1, err := ss.Post().Get(o1.Id)
 	if err != nil {
@@ -292,12 +302,13 @@ func testPostStoreUpdate(t *testing.T, ss store.Store) {
 		t.Fatal("Failed to update/get")
 	}
 
-	o4 := store.Must(ss.Post().Save(&model.Post{
+	o4, err := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 		Message:   model.NewId(),
 		Filenames: []string{"test"},
-	})).(*model.Post)
+	})
+	require.Nil(t, err)
 
 	r4, err := ss.Post().Get(o4.Id)
 	if err != nil {
@@ -337,7 +348,8 @@ func testPostStoreDelete(t *testing.T, ss store.Store) {
 		t.Fatal("Invalid Etag")
 	}
 
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	if r1, err := ss.Post().Get(o1.Id); err != nil {
 		t.Fatal(err)
@@ -374,7 +386,8 @@ func testPostStoreDelete1Level(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -382,7 +395,8 @@ func testPostStoreDelete1Level(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	if err := ss.Post().Delete(o1.Id, model.GetMillis(), ""); err != nil {
 		t.Fatal(err)
@@ -402,7 +416,8 @@ func testPostStoreDelete2Level(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -410,7 +425,8 @@ func testPostStoreDelete2Level(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = o1.ChannelId
@@ -418,13 +434,15 @@ func testPostStoreDelete2Level(t *testing.T, ss store.Store) {
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.ParentId = o2.Id
 	o3.RootId = o1.Id
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	o4 := &model.Post{}
 	o4.ChannelId = model.NewId()
 	o4.UserId = model.NewId()
 	o4.Message = "zz" + model.NewId() + "b"
-	o4 = (<-ss.Post().Save(o4)).Data.(*model.Post)
+	o4, err = ss.Post().Save(o4)
+	require.Nil(t, err)
 
 	if err := ss.Post().Delete(o1.Id, model.GetMillis(), ""); err != nil {
 		t.Fatal(err)
@@ -452,7 +470,8 @@ func testPostStorePermDelete1Level(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -460,13 +479,15 @@ func testPostStorePermDelete1Level(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = model.NewId()
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "b"
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	if err2 := ss.Post().PermanentDeleteByUser(o2.UserId); err2 != nil {
 		t.Fatal(err2)
@@ -494,7 +515,8 @@ func testPostStorePermDelete1Level2(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -502,13 +524,15 @@ func testPostStorePermDelete1Level2(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = model.NewId()
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "b"
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	if err2 := ss.Post().PermanentDeleteByUser(o1.UserId); err2 != nil {
 		t.Fatal(err2)
@@ -532,7 +556,8 @@ func testPostStoreGetWithChildren(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -540,7 +565,8 @@ func testPostStoreGetWithChildren(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = o1.ChannelId
@@ -548,7 +574,8 @@ func testPostStoreGetWithChildren(t *testing.T, ss store.Store) {
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.ParentId = o2.Id
 	o3.RootId = o1.Id
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	pl, err := ss.Post().Get(o1.Id)
 	if err != nil {
@@ -591,7 +618,8 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o2 := &model.Post{}
@@ -600,7 +628,8 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	_ = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	_, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o2a := &model.Post{}
@@ -609,7 +638,8 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	o2a.Message = "zz" + model.NewId() + "b"
 	o2a.ParentId = o1.Id
 	o2a.RootId = o1.Id
-	o2a = (<-ss.Post().Save(o2a)).Data.(*model.Post)
+	o2a, err = ss.Post().Save(o2a)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o3 := &model.Post{}
@@ -618,14 +648,16 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.ParentId = o1.Id
 	o3.RootId = o1.Id
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o4 := &model.Post{}
 	o4.ChannelId = o1.ChannelId
 	o4.UserId = model.NewId()
 	o4.Message = "zz" + model.NewId() + "b"
-	o4 = (<-ss.Post().Save(o4)).Data.(*model.Post)
+	o4, err = ss.Post().Save(o4)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o5 := &model.Post{}
@@ -634,7 +666,8 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	o5.Message = "zz" + model.NewId() + "b"
 	o5.ParentId = o4.Id
 	o5.RootId = o4.Id
-	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
+	o5, err = ss.Post().Save(o5)
+	require.Nil(t, err)
 
 	r1, err := ss.Post().GetPosts(o1.ChannelId, 0, 4, false)
 	require.Nil(t, err)
@@ -691,13 +724,15 @@ func testPostStoreGetPostsWithDetails(t *testing.T, ss store.Store) {
 	}
 
 	// Run once to fill cache
-	ss.Post().GetPosts(o1.ChannelId, 0, 30, true)
+	_, err = ss.Post().GetPosts(o1.ChannelId, 0, 30, true)
+	require.Nil(t, err)
 
 	o6 := &model.Post{}
 	o6.ChannelId = o1.ChannelId
 	o6.UserId = model.NewId()
 	o6.Message = "zz" + model.NewId() + "b"
-	_ = (<-ss.Post().Save(o6)).Data.(*model.Post)
+	_, err = ss.Post().Save(o6)
+	require.Nil(t, err)
 
 	// Should only be 6 since we hit the cache
 	r3, err := ss.Post().GetPosts(o1.ChannelId, 0, 30, true)
@@ -719,11 +754,12 @@ func testPostStoreGetPostsBeforeAfter(t *testing.T, ss store.Store) {
 
 		var posts []*model.Post
 		for i := 0; i < 10; i++ {
-			post := store.Must(ss.Post().Save(&model.Post{
+			post, err := ss.Post().Save(&model.Post{
 				ChannelId: channelId,
 				UserId:    userId,
 				Message:   "message",
-			})).(*model.Post)
+			})
+			require.Nil(t, err)
 
 			posts = append(posts, post)
 
@@ -808,52 +844,58 @@ func testPostStoreGetPostsBeforeAfter(t *testing.T, ss store.Store) {
 		// post5
 		// post6 (in response to post2)
 
-		post1 := store.Must(ss.Post().Save(&model.Post{
+		post1, err := ss.Post().Save(&model.Post{
 			ChannelId: channelId,
 			UserId:    userId,
 			Message:   "message",
-		})).(*model.Post)
+		})
+		require.Nil(t, err)
 		time.Sleep(time.Millisecond)
 
-		post2 := store.Must(ss.Post().Save(&model.Post{
+		post2, err := ss.Post().Save(&model.Post{
 			ChannelId: channelId,
 			UserId:    userId,
 			Message:   "message",
-		})).(*model.Post)
+		})
+		require.Nil(t, err)
 		time.Sleep(time.Millisecond)
 
-		post3 := store.Must(ss.Post().Save(&model.Post{
+		post3, err := ss.Post().Save(&model.Post{
 			ChannelId: channelId,
 			UserId:    userId,
 			ParentId:  post1.Id,
 			RootId:    post1.Id,
 			Message:   "message",
-		})).(*model.Post)
+		})
+		require.Nil(t, err)
 		time.Sleep(time.Millisecond)
 
-		post4 := store.Must(ss.Post().Save(&model.Post{
+		post4, err := ss.Post().Save(&model.Post{
 			ChannelId: channelId,
 			UserId:    userId,
 			RootId:    post2.Id,
 			ParentId:  post2.Id,
 			Message:   "message",
-		})).(*model.Post)
+		})
+		require.Nil(t, err)
 		time.Sleep(time.Millisecond)
 
-		post5 := store.Must(ss.Post().Save(&model.Post{
+		post5, err := ss.Post().Save(&model.Post{
 			ChannelId: channelId,
 			UserId:    userId,
 			Message:   "message",
-		})).(*model.Post)
+		})
+		require.Nil(t, err)
 		time.Sleep(time.Millisecond)
 
-		post6 := store.Must(ss.Post().Save(&model.Post{
+		post6, err := ss.Post().Save(&model.Post{
 			ChannelId: channelId,
 			UserId:    userId,
 			ParentId:  post2.Id,
 			RootId:    post2.Id,
 			Message:   "message",
-		})).(*model.Post)
+		})
+		require.Nil(t, err)
 
 		// Adding a post to a thread changes the UpdateAt timestamp of the parent post
 		post1.UpdateAt = post3.UpdateAt
@@ -893,14 +935,16 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o0.ChannelId = model.NewId()
 	o0.UserId = model.NewId()
 	o0.Message = "zz" + model.NewId() + "b"
-	_ = (<-ss.Post().Save(o0)).Data.(*model.Post)
+	_, err := ss.Post().Save(o0)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o1 := &model.Post{}
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o2 := &model.Post{}
@@ -909,7 +953,8 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	_ = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	_, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o2a := &model.Post{}
@@ -918,7 +963,8 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o2a.Message = "zz" + model.NewId() + "b"
 	o2a.ParentId = o1.Id
 	o2a.RootId = o1.Id
-	o2a = (<-ss.Post().Save(o2a)).Data.(*model.Post)
+	o2a, err = ss.Post().Save(o2a)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o3 := &model.Post{}
@@ -927,14 +973,16 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.ParentId = o1.Id
 	o3.RootId = o1.Id
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o4 := &model.Post{}
 	o4.ChannelId = o1.ChannelId
 	o4.UserId = model.NewId()
 	o4.Message = "zz" + model.NewId() + "b"
-	o4 = (<-ss.Post().Save(o4)).Data.(*model.Post)
+	o4, err = ss.Post().Save(o4)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o5 := &model.Post{}
@@ -943,7 +991,8 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o5.Message = "zz" + model.NewId() + "b"
 	o5.ParentId = o4.Id
 	o5.RootId = o4.Id
-	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
+	o5, err = ss.Post().Save(o5)
+	require.Nil(t, err)
 
 	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, false)).Data.(*model.PostList)
 
@@ -1021,57 +1070,66 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	o1.ChannelId = c1.Id
 	o1.UserId = model.NewId()
 	o1.Message = "corey mattermost new york"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o1a := &model.Post{}
 	o1a.ChannelId = c1.Id
 	o1a.UserId = model.NewId()
 	o1a.Message = "corey mattermost new york"
 	o1a.Type = model.POST_JOIN_CHANNEL
-	_ = (<-ss.Post().Save(o1a)).Data.(*model.Post)
+	_, err = ss.Post().Save(o1a)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
 	o2.UserId = model.NewId()
 	o2.Message = "New Jersey is where John is from"
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = c2.Id
 	o3.UserId = model.NewId()
 	o3.Message = "New Jersey is where John is from corey new york"
-	_ = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	_, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	o4 := &model.Post{}
 	o4.ChannelId = c1.Id
 	o4.UserId = model.NewId()
 	o4.Hashtags = "#hashtag"
 	o4.Message = "(message)blargh"
-	o4 = (<-ss.Post().Save(o4)).Data.(*model.Post)
+	o4, err = ss.Post().Save(o4)
+	require.Nil(t, err)
 
 	o5 := &model.Post{}
 	o5.ChannelId = c1.Id
 	o5.UserId = model.NewId()
 	o5.Hashtags = "#secret #howdy"
-	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
+	o5, err = ss.Post().Save(o5)
+	require.Nil(t, err)
 
 	o6 := &model.Post{}
 	o6.ChannelId = c3.Id
 	o6.UserId = model.NewId()
 	o6.Hashtags = "#hashtag"
-	o6 = (<-ss.Post().Save(o6)).Data.(*model.Post)
+	o6, err = ss.Post().Save(o6)
+	require.Nil(t, err)
 
 	o7 := &model.Post{}
 	o7.ChannelId = c3.Id
 	o7.UserId = model.NewId()
 	o7.Message = "New Jersey is where John is from corey new york"
-	o7 = (<-ss.Post().Save(o7)).Data.(*model.Post)
+	o7, err = ss.Post().Save(o7)
+	require.Nil(t, err)
 
 	o8 := &model.Post{}
 	o8.ChannelId = c3.Id
 	o8.UserId = model.NewId()
 	o8.Message = "Deleted"
-	o8 = (<-ss.Post().Save(o8)).Data.(*model.Post)
+	o8, err = ss.Post().Save(o8)
+	require.Nil(t, err)
 
 	tt := []struct {
 		name                     string
@@ -1203,28 +1261,32 @@ func testUserCountsWithPostsByDay(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.CreateAt = utils.MillisFromTime(utils.Yesterday())
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = store.Must(ss.Post().Save(o1)).(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o1a := &model.Post{}
 	o1a.ChannelId = c1.Id
 	o1a.UserId = model.NewId()
 	o1a.CreateAt = o1.CreateAt
 	o1a.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_, err = ss.Post().Save(o1a)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
 	o2.UserId = model.NewId()
 	o2.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24)
 	o2.Message = "zz" + model.NewId() + "b"
-	o2 = store.Must(ss.Post().Save(o2)).(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o2a := &model.Post{}
 	o2a.ChannelId = c1.Id
 	o2a.UserId = o2.UserId
 	o2a.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24)
 	o2a.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o2a)).(*model.Post)
+	_, err = ss.Post().Save(o2a)
+	require.Nil(t, err)
 
 	if r1, err := ss.Post().AnalyticsUserCountsWithPostsByDay(t1.Id); err != nil {
 		t.Fatal(err)
@@ -1263,28 +1325,32 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.CreateAt = utils.MillisFromTime(utils.Yesterday())
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = store.Must(ss.Post().Save(o1)).(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o1a := &model.Post{}
 	o1a.ChannelId = c1.Id
 	o1a.UserId = model.NewId()
 	o1a.CreateAt = o1.CreateAt
 	o1a.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o1a)).(*model.Post)
+	_, err = ss.Post().Save(o1a)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c1.Id
 	o2.UserId = model.NewId()
 	o2.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24 * 2)
 	o2.Message = "zz" + model.NewId() + "b"
-	o2 = store.Must(ss.Post().Save(o2)).(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o2a := &model.Post{}
 	o2a.ChannelId = c1.Id
 	o2a.UserId = o2.UserId
 	o2a.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24 * 2)
 	o2a.Message = "zz" + model.NewId() + "b"
-	_ = store.Must(ss.Post().Save(o2a)).(*model.Post)
+	_, err = ss.Post().Save(o2a)
+	require.Nil(t, err)
 
 	time.Sleep(1 * time.Second)
 
@@ -1324,14 +1390,16 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 	o1.ChannelId = c1.Id
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "b"
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o3 := &model.Post{}
@@ -1339,14 +1407,16 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.DeleteAt = 1
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o4 := &model.Post{}
 	o4.ChannelId = model.NewId()
 	o4.UserId = model.NewId()
 	o4.Message = "zz" + model.NewId() + "b"
-	o4 = (<-ss.Post().Save(o4)).Data.(*model.Post)
+	o4, err = ss.Post().Save(o4)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	c2 := &model.Channel{}
@@ -1371,7 +1441,8 @@ func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlSupp
 	o5.ChannelId = c2.Id
 	o5.UserId = m2.UserId
 	o5.Message = "zz" + model.NewId() + "b"
-	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
+	o5, err = ss.Post().Save(o5)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	r1, err := ss.Post().GetFlaggedPosts(o1.ChannelId, 0, 2)
@@ -1511,14 +1582,16 @@ func testPostStoreGetFlaggedPosts(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "b"
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o3 := &model.Post{}
@@ -1526,7 +1599,8 @@ func testPostStoreGetFlaggedPosts(t *testing.T, ss store.Store) {
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.DeleteAt = 1
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	r1, err := ss.Post().GetFlaggedPosts(o1.UserId, 0, 2)
@@ -1620,14 +1694,15 @@ func testPostStoreGetFlaggedPostsForChannel(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
 	time.Sleep(2 * time.Millisecond)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "b"
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	// deleted post
@@ -1636,14 +1711,15 @@ func testPostStoreGetFlaggedPostsForChannel(t *testing.T, ss store.Store) {
 	o3.UserId = o1.ChannelId
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.DeleteAt = 1
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
 	time.Sleep(2 * time.Millisecond)
 
 	o4 := &model.Post{}
 	o4.ChannelId = model.NewId()
 	o4.UserId = model.NewId()
 	o4.Message = "zz" + model.NewId() + "b"
-	o4 = (<-ss.Post().Save(o4)).Data.(*model.Post)
+	o4, err = ss.Post().Save(o4)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	r, err := ss.Post().GetFlaggedPostsForChannel(o1.UserId, o1.ChannelId, 0, 10)
@@ -1726,14 +1802,16 @@ func testPostStoreGetPostsCreatedAt(t *testing.T, ss store.Store) {
 	o0.UserId = model.NewId()
 	o0.Message = "zz" + model.NewId() + "b"
 	o0.CreateAt = createTime
-	o0 = (<-ss.Post().Save(o0)).Data.(*model.Post)
+	o0, err := ss.Post().Save(o0)
+	require.Nil(t, err)
 
 	o1 := &model.Post{}
 	o1.ChannelId = o0.ChannelId
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
 	o1.CreateAt = createTime
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -1742,14 +1820,16 @@ func testPostStoreGetPostsCreatedAt(t *testing.T, ss store.Store) {
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
 	o2.CreateAt = createTime + 1
-	_ = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	_, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = model.NewId()
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.CreateAt = createTime
-	_ = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	_, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	r1, _ := ss.Post().GetPostsCreatedAt(o1.ChannelId, createTime)
 	assert.Equal(t, 2, len(r1))
@@ -1760,7 +1840,8 @@ func testPostStoreOverwrite(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
@@ -1768,13 +1849,14 @@ func testPostStoreOverwrite(t *testing.T, ss store.Store) {
 	o2.Message = "zz" + model.NewId() + "CCCCCCCCC"
 	o2.ParentId = o1.Id
 	o2.RootId = o1.Id
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = o1.ChannelId
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "QQQQQQQQQQ"
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
 
 	r1, err := ss.Post().Get(o1.Id)
 	if err != nil {
@@ -1850,12 +1932,13 @@ func testPostStoreOverwrite(t *testing.T, ss store.Store) {
 		t.Fatal("Failed to overwrite/get")
 	}
 
-	o4 := store.Must(ss.Post().Save(&model.Post{
+	o4, err := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 		Message:   model.NewId(),
 		Filenames: []string{"test"},
-	})).(*model.Post)
+	})
+	require.Nil(t, err)
 
 	r4, err := ss.Post().Get(o4.Id)
 	if err != nil {
@@ -1891,19 +1974,22 @@ func testPostStoreGetPostsByIds(t *testing.T, ss store.Store) {
 	o1.ChannelId = model.NewId()
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "CCCCCCCCC"
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = o1.ChannelId
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "QQQQQQQQQQ"
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	r1, err := ss.Post().Get(o1.Id)
 	if err != nil {
@@ -1963,13 +2049,15 @@ func testPostStoreGetPostsBatchForIndexing(t *testing.T, ss store.Store) {
 	o1.ChannelId = c1.Id
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c2.Id
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "CCCCCCCCC"
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = c1.Id
@@ -1977,7 +2065,7 @@ func testPostStoreGetPostsBatchForIndexing(t *testing.T, ss store.Store) {
 	o3.ParentId = o1.Id
 	o3.RootId = o1.Id
 	o3.Message = "zz" + model.NewId() + "QQQQQQQQQQ"
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
 
 	if r, err := ss.Post().GetPostsBatchForIndexing(o1.CreateAt, model.GetMillis()+100000, 100); err != nil {
 		t.Fatal(err)
@@ -2019,21 +2107,24 @@ func testPostStorePermanentDeleteBatch(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 	o1.CreateAt = 1000
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = model.NewId()
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 	o2.CreateAt = 1000
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	o3 := &model.Post{}
 	o3.ChannelId = model.NewId()
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 	o3.CreateAt = 100000
-	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
+	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	_, err := ss.Post().PermanentDeleteBatch(2000, 1000)
 	require.Nil(t, err)
@@ -2057,21 +2148,24 @@ func testPostStoreGetOldest(t *testing.T, ss store.Store) {
 	o0.UserId = model.NewId()
 	o0.Message = "zz" + model.NewId() + "b"
 	o0.CreateAt = 3
-	o0 = (<-ss.Post().Save(o0)).Data.(*model.Post)
+	o0, err := ss.Post().Save(o0)
+	require.Nil(t, err)
 
 	o1 := &model.Post{}
 	o1.ChannelId = o0.Id
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
 	o1.CreateAt = 2
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err = ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	o2 := &model.Post{}
 	o2.ChannelId = o1.ChannelId
 	o2.UserId = model.NewId()
 	o2.Message = "zz" + model.NewId() + "b"
 	o2.CreateAt = 1
-	o2 = (<-ss.Post().Save(o2)).Data.(*model.Post)
+	o2, err = ss.Post().Save(o2)
+	require.Nil(t, err)
 
 	r1, err := ss.Post().GetOldest()
 
@@ -2112,7 +2206,8 @@ func testPostStoreGetParentsForExportAfter(t *testing.T, ss store.Store) {
 	p1.UserId = u1.Id
 	p1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 	p1.CreateAt = 1000
-	p1 = (<-ss.Post().Save(p1)).Data.(*model.Post)
+	p1, err = ss.Post().Save(p1)
+	require.Nil(t, err)
 
 	posts, err := ss.Post().GetParentsForExportAfter(10000, strings.Repeat("0", 26))
 	assert.Nil(t, err)
@@ -2158,7 +2253,8 @@ func testPostStoreGetRepliesForExport(t *testing.T, ss store.Store) {
 	p1.UserId = u1.Id
 	p1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 	p1.CreateAt = 1000
-	p1 = (<-ss.Post().Save(p1)).Data.(*model.Post)
+	p1, err = ss.Post().Save(p1)
+	require.Nil(t, err)
 
 	p2 := &model.Post{}
 	p2.ChannelId = c1.Id
@@ -2167,7 +2263,8 @@ func testPostStoreGetRepliesForExport(t *testing.T, ss store.Store) {
 	p2.CreateAt = 1001
 	p2.ParentId = p1.Id
 	p2.RootId = p1.Id
-	p2 = (<-ss.Post().Save(p2)).Data.(*model.Post)
+	p2, err = ss.Post().Save(p2)
+	require.Nil(t, err)
 
 	r1, err := ss.Post().GetRepliesForExport(p1.Id)
 	assert.Nil(t, err)
@@ -2234,7 +2331,8 @@ func testPostStoreGetDirectPostParentsForExportAfter(t *testing.T, ss store.Stor
 	p1.UserId = u1.Id
 	p1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 	p1.CreateAt = 1000
-	p1 = (<-ss.Post().Save(p1)).Data.(*model.Post)
+	p1, err := ss.Post().Save(p1)
+	require.Nil(t, err)
 
 	r1, err := ss.Post().GetDirectPostParentsForExportAfter(10000, strings.Repeat("0", 26))
 	assert.Nil(t, err)
@@ -2289,7 +2387,8 @@ func testPostStoreGetDirectPostParentsForExportAfterDeleted(t *testing.T, ss sto
 	p1.UserId = u1.Id
 	p1.Message = "zz" + model.NewId() + "BBBBBBBBBBBB"
 	p1.CreateAt = 1000
-	p1 = (<-ss.Post().Save(p1)).Data.(*model.Post)
+	p1, err = ss.Post().Save(p1)
+	require.Nil(t, err)
 
 	o1a := &model.Post{}
 	*o1a = *p1
@@ -2348,7 +2447,8 @@ func testPostStoreGetDirectPostParentsForExportAfterBatched(t *testing.T, ss sto
 		p1.UserId = u1.Id
 		p1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 		p1.CreateAt = 1000
-		p1 = (<-ss.Post().Save(p1)).Data.(*model.Post)
+		p1, err := ss.Post().Save(p1)
+		require.Nil(t, err)
 		postIds = append(postIds, p1.Id)
 	}
 	sort.Slice(postIds, func(i, j int) bool { return postIds[i] < postIds[j] })

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -427,7 +427,8 @@ func testPreferenceCleanupFlagsBatch(t *testing.T, ss store.Store) {
 	o1.UserId = userId
 	o1.Message = "zz" + model.NewId() + "AAAAAAAAAAA"
 	o1.CreateAt = 1000
-	o1 = (<-ss.Post().Save(o1)).Data.(*model.Post)
+	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 
 	preference1 := model.Preference{
 		UserId:   userId,
@@ -443,7 +444,7 @@ func testPreferenceCleanupFlagsBatch(t *testing.T, ss store.Store) {
 		Value:    "true",
 	}
 
-	err := ss.Preference().Save(&model.Preferences{preference1, preference2})
+	err = ss.Preference().Save(&model.Preferences{preference1, preference2})
 	require.Nil(t, err)
 
 	_, err = ss.Preference().CleanupFlagsBatch(10000)

--- a/store/storetest/reaction_store.go
+++ b/store/storetest/reaction_store.go
@@ -21,10 +21,10 @@ func TestReactionStore(t *testing.T, ss store.Store) {
 }
 
 func testReactionSave(t *testing.T, ss store.Store) {
-	post := store.Must(ss.Post().Save(&model.Post{
+	post, _ := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
-	})).(*model.Post)
+	})
 	firstUpdateAt := post.UpdateAt
 
 	reaction1 := &model.Reaction{
@@ -107,10 +107,10 @@ func testReactionSave(t *testing.T, ss store.Store) {
 }
 
 func testReactionDelete(t *testing.T, ss store.Store) {
-	post := store.Must(ss.Post().Save(&model.Post{
+	post, _ := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
-	})).(*model.Post)
+	})
 
 	reaction := &model.Reaction{
 		UserId:    model.NewId(),
@@ -232,18 +232,18 @@ func testReactionGetForPost(t *testing.T, ss store.Store) {
 func testReactionDeleteAllWithEmojiName(t *testing.T, ss store.Store) {
 	emojiToDelete := model.NewId()
 
-	post := store.Must(ss.Post().Save(&model.Post{
+	post, _ := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
-	})).(*model.Post)
-	post2 := store.Must(ss.Post().Save(&model.Post{
+	})
+	post2, _ := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
-	})).(*model.Post)
-	post3 := store.Must(ss.Post().Save(&model.Post{
+	})
+	post3, _ := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
-	})).(*model.Post)
+	})
 
 	userId := model.NewId()
 
@@ -337,10 +337,10 @@ func testReactionDeleteAllWithEmojiName(t *testing.T, ss store.Store) {
 }
 
 func testReactionStorePermanentDeleteBatch(t *testing.T, ss store.Store) {
-	post := store.Must(ss.Post().Save(&model.Post{
+	post, _ := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
-	})).(*model.Post)
+	})
 
 	reactions := []*model.Reaction{
 		{

--- a/store/storetest/reaction_store.go
+++ b/store/storetest/reaction_store.go
@@ -21,10 +21,11 @@ func TestReactionStore(t *testing.T, ss store.Store) {
 }
 
 func testReactionSave(t *testing.T, ss store.Store) {
-	post, _ := ss.Post().Save(&model.Post{
+	post, err := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 	})
+	require.Nil(t, err)
 	firstUpdateAt := post.UpdateAt
 
 	reaction1 := &model.Reaction{
@@ -32,7 +33,8 @@ func testReactionSave(t *testing.T, ss store.Store) {
 		PostId:    post.Id,
 		EmojiName: model.NewId(),
 	}
-	if reaction, err := ss.Reaction().Save(reaction1); err != nil {
+	reaction, err := ss.Reaction().Save(reaction1)
+	if err != nil {
 		t.Fatal(err)
 	} else if saved := reaction; saved.UserId != reaction1.UserId ||
 		saved.PostId != reaction1.PostId || saved.EmojiName != reaction1.EmojiName {
@@ -107,10 +109,11 @@ func testReactionSave(t *testing.T, ss store.Store) {
 }
 
 func testReactionDelete(t *testing.T, ss store.Store) {
-	post, _ := ss.Post().Save(&model.Post{
+	post, err := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 	})
+	require.Nil(t, err)
 
 	reaction := &model.Reaction{
 		UserId:    model.NewId(),
@@ -118,7 +121,7 @@ func testReactionDelete(t *testing.T, ss store.Store) {
 		EmojiName: model.NewId(),
 	}
 
-	_, err := ss.Reaction().Save(reaction)
+	_, err = ss.Reaction().Save(reaction)
 	require.Nil(t, err)
 	result, err := ss.Post().Get(reaction.PostId)
 	if err != nil {
@@ -232,18 +235,21 @@ func testReactionGetForPost(t *testing.T, ss store.Store) {
 func testReactionDeleteAllWithEmojiName(t *testing.T, ss store.Store) {
 	emojiToDelete := model.NewId()
 
-	post, _ := ss.Post().Save(&model.Post{
+	post, err1 := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 	})
-	post2, _ := ss.Post().Save(&model.Post{
+	require.Nil(t, err1)
+	post2, err2 := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 	})
-	post3, _ := ss.Post().Save(&model.Post{
+	require.Nil(t, err2)
+	post3, err3 := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 	})
+	require.Nil(t, err3)
 
 	userId := model.NewId()
 
@@ -337,10 +343,11 @@ func testReactionDeleteAllWithEmojiName(t *testing.T, ss store.Store) {
 }
 
 func testReactionStorePermanentDeleteBatch(t *testing.T, ss store.Store) {
-	post, _ := ss.Post().Save(&model.Post{
+	post, err1 := ss.Post().Save(&model.Post{
 		ChannelId: model.NewId(),
 		UserId:    model.NewId(),
 	})
+	require.Nil(t, err1)
 
 	reactions := []*model.Reaction{
 		{

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1716,7 +1716,8 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	p1.Message = "this is a message for @" + u2.Username
 
 	// Post one message with mention to open channel
-	ss.Post().Save(&p1)
+	_, err := ss.Post().Save(&p1)
+	require.Nil(t, err)
 	store.Must(ss.Channel().IncrementMentionCount(c1.Id, u2.Id))
 
 	// Post 2 messages without mention to direct channel
@@ -1724,14 +1725,17 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	p2.ChannelId = c2.Id
 	p2.UserId = u1.Id
 	p2.Message = "first message"
-	ss.Post().Save(&p2)
+
+	_, err = ss.Post().Save(&p2)
+	require.Nil(t, err)
 	store.Must(ss.Channel().IncrementMentionCount(c2.Id, u2.Id))
 
 	p3 := model.Post{}
 	p3.ChannelId = c2.Id
 	p3.UserId = u1.Id
 	p3.Message = "second message"
-	ss.Post().Save(&p3)
+	_, err = ss.Post().Save(&p3)
+
 	store.Must(ss.Channel().IncrementMentionCount(c2.Id, u2.Id))
 
 	badge := (<-ss.User().GetUnreadCount(u2.Id)).Data.(int64)

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1735,6 +1735,7 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	p3.UserId = u1.Id
 	p3.Message = "second message"
 	_, err = ss.Post().Save(&p3)
+	require.Nil(t, err)
 
 	store.Must(ss.Channel().IncrementMentionCount(c2.Id, u2.Id))
 

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1716,7 +1716,7 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	p1.Message = "this is a message for @" + u2.Username
 
 	// Post one message with mention to open channel
-	store.Must(ss.Post().Save(&p1))
+	ss.Post().Save(&p1)
 	store.Must(ss.Channel().IncrementMentionCount(c1.Id, u2.Id))
 
 	// Post 2 messages without mention to direct channel
@@ -1724,14 +1724,14 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	p2.ChannelId = c2.Id
 	p2.UserId = u1.Id
 	p2.Message = "first message"
-	store.Must(ss.Post().Save(&p2))
+	ss.Post().Save(&p2)
 	store.Must(ss.Channel().IncrementMentionCount(c2.Id, u2.Id))
 
 	p3 := model.Post{}
 	p3.ChannelId = c2.Id
 	p3.UserId = u1.Id
 	p3.Message = "second message"
-	store.Must(ss.Post().Save(&p3))
+	ss.Post().Save(&p3)
 	store.Must(ss.Channel().IncrementMentionCount(c2.Id, u2.Id))
 
 	badge := (<-ss.User().GetUnreadCount(u2.Id)).Data.(int64)


### PR DESCRIPTION
#### Summary
This PR Migrates `Post.Save` to Sync by default in `Post Store` and updates all referencing files to not handle the response from a channel.

#### Ticket Link
Fixed #10987
