### PR TITLE
[MM-16005] Check listOfAllowedChannels to be a not nil empty slice

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1711,7 +1711,7 @@ func (a *App) SearchUsersInTeam(teamId string, term string, options *model.UserS
 		if err != nil {
 			return nil, err
 		}
-		if len(listOfAllowedChannels) == 0 {
+		if listOfAllowedChannels != nil && len(listOfAllowedChannels) == 0 {
 			return []*model.User{}, nil
 		}
 

--- a/app/user.go
+++ b/app/user.go
@@ -2102,6 +2102,11 @@ func (a *App) GetViewUsersRestrictions(userId string) (*model.ViewUsersRestricti
 	return &model.ViewUsersRestrictions{Teams: teamIdsWithPermission, Channels: channelIds}, nil
 }
 
+/**
+ * Returns a list with the channel ids that the user has permissions to view on a
+ * team. If the result is an empty list, the user can't view any channel; if it's
+ * nil, there are no restrictions for the user in the specified team.
+ */
 func (a *App) GetViewUsersRestrictionsForTeam(userId string, teamId string) ([]string, *model.AppError) {
 	if a.HasPermissionTo(userId, model.PERMISSION_VIEW_MEMBERS) {
 		return nil, nil


### PR DESCRIPTION
#### Summary
The problem here had to do with the return type for a `nil`
`[]string`. If `listOfAllowedChannels` is an empty list, that means
that the user doesn't have permissions to view anything, hence we have
to return an empty result. If it is `nil`, there are no restrictions
and we can proceed.

`[]string(nil)` behaves both as a `nil` value and as an "empty" slice,
so this improves the check to be able to distinguish between both
cases.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16005

#### Related Pull Requests
 - [Has enterprise changes](https://github.com/mattermost/enterprise/pull/446)
