### PR TITLE
MM-15844: migrate post PermanentDeleteByUser to sync by default #10984

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1463,8 +1463,8 @@ func (a *App) PermanentDeleteUser(user *model.User) *model.AppError {
 		return result.Err
 	}
 
-	if result := <-a.Srv.Store.Post().PermanentDeleteByUser(user.Id); result.Err != nil {
-		return result.Err
+	if err := a.Srv.Store.Post().PermanentDeleteByUser(user.Id); err != nil {
+		return err
 	}
 
 	infos, err := a.Srv.Store.FileInfo().GetForUser(user.Id)

--- a/store/store.go
+++ b/store/store.go
@@ -215,7 +215,7 @@ type PostStore interface {
 	Get(id string) (*model.PostList, *model.AppError)
 	GetSingle(id string) (*model.Post, *model.AppError)
 	Delete(postId string, time int64, deleteByID string) *model.AppError
-	PermanentDeleteByUser(userId string) StoreChannel
+	PermanentDeleteByUser(userId string) *model.AppError
 	PermanentDeleteByChannel(channelId string) *model.AppError
 	GetPosts(channelId string, offset int, limit int, allowFromCache bool) (*model.PostList, *model.AppError)
 	GetFlaggedPosts(userId string, offset int, limit int) (*model.PostList, *model.AppError)

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -589,15 +589,15 @@ func (_m *PostStore) PermanentDeleteByChannel(channelId string) *model.AppError 
 }
 
 // PermanentDeleteByUser provides a mock function with given fields: userId
-func (_m *PostStore) PermanentDeleteByUser(userId string) store.StoreChannel {
+func (_m *PostStore) PermanentDeleteByUser(userId string) *model.AppError {
 	ret := _m.Called(userId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string) *model.AppError); ok {
 		r0 = rf(userId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -468,8 +468,8 @@ func testPostStorePermDelete1Level(t *testing.T, ss store.Store) {
 	o3.Message = "zz" + model.NewId() + "b"
 	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
 
-	if r2 := <-ss.Post().PermanentDeleteByUser(o2.UserId); r2.Err != nil {
-		t.Fatal(r2.Err)
+	if err2 := ss.Post().PermanentDeleteByUser(o2.UserId); err2 != nil {
+		t.Fatal(err2)
 	}
 
 	if _, err := ss.Post().Get(o1.Id); err != nil {
@@ -510,8 +510,8 @@ func testPostStorePermDelete1Level2(t *testing.T, ss store.Store) {
 	o3.Message = "zz" + model.NewId() + "b"
 	o3 = (<-ss.Post().Save(o3)).Data.(*model.Post)
 
-	if r2 := <-ss.Post().PermanentDeleteByUser(o1.UserId); r2.Err != nil {
-		t.Fatal(r2.Err)
+	if err2 := ss.Post().PermanentDeleteByUser(o1.UserId); err2 != nil {
+		t.Fatal(err2)
 	}
 
 	if _, err := ss.Post().Get(o1.Id); err == nil {


### PR DESCRIPTION
#### Summary
This PR Migrates `Post.PermanentDeleteByUser` to Sync by default in `Post Store` and updates all referencing files to not handle the response from a channel but instead the error directly.

#### Ticket Link
Fixed #10984
