### PR TITLE
Issue 11030: fix HasFile to avoid false positives for no filename

### DIFF
--- a/config/database_test.go
+++ b/config/database_test.go
@@ -611,6 +611,19 @@ func TestDatabaseHasFile(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, has)
 	})
+
+	t.Run("has non-existent empty string", func(t *testing.T) {
+		_, tearDown := setupConfigDatabase(t, minimalConfig, nil)
+		defer tearDown()
+
+		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *mainHelper.Settings.DriverName, *mainHelper.Settings.DataSource))
+		require.NoError(t, err)
+		defer ds.Close()
+
+		has, err := ds.HasFile("")
+		require.NoError(t, err)
+		require.False(t, has)
+	})
 }
 
 func TestDatabaseRemoveFile(t *testing.T) {

--- a/config/file.go
+++ b/config/file.go
@@ -184,6 +184,10 @@ func (fs *FileStore) SetFile(name string, data []byte) error {
 
 // HasFile returns true if the given file was previously persisted.
 func (fs *FileStore) HasFile(name string) (bool, error) {
+	if name == "" {
+		return false, nil
+	}
+
 	resolvedPath := filepath.Join(filepath.Dir(fs.path), name)
 
 	_, err := os.Stat(resolvedPath)

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -688,7 +688,6 @@ func TestFileSetFile(t *testing.T) {
 }
 
 func TestFileHasFile(t *testing.T) {
-
 	t.Run("has non-existent", func(t *testing.T) {
 		path, tearDown := setupConfigFile(t, minimalConfig)
 		defer tearDown()
@@ -739,6 +738,19 @@ func TestFileHasFile(t *testing.T) {
 		has, err := fs.HasFile(f.Name())
 		require.NoError(t, err)
 		require.True(t, has)
+	})
+
+	t.Run("has empty string", func(t *testing.T) {
+		path, tearDown := setupConfigFile(t, minimalConfig)
+		defer tearDown()
+
+		fs, err := config.NewFileStore(path, true)
+		require.NoError(t, err)
+		defer fs.Close()
+
+		has, err := fs.HasFile("")
+		require.NoError(t, err)
+		require.False(t, has)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Fix a regression in the file-based `HasFile` check that spuriously accepts an empty string and tests the existence of the parent folder.

I've added an equivalent database test, but I note that it's not subject to the same problem given there is no path resolution required. (And technically an empty string is currently allowed as a filename there.)

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/11030