### PR TITLE
MM-16001 Adding bot description field to bot users.

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -83,6 +83,7 @@ type User struct {
 	MfaSecret              string    `json:"mfa_secret,omitempty"`
 	LastActivityAt         int64     `db:"-" json:"last_activity_at,omitempty"`
 	IsBot                  bool      `db:"-" json:"is_bot,omitempty"`
+	BotDescription         string    `db:"-" json:"bot_description,omitempty"`
 	TermsOfServiceId       string    `db:"-" json:"terms_of_service_id,omitempty"`
 	TermsOfServiceCreateAt int64     `db:"-" json:"terms_of_service_create_at,omitempty"`
 }

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -69,7 +69,7 @@ func NewSqlUserStore(sqlStore SqlStore, metrics einterfaces.MetricsInterface) st
 	}
 
 	us.usersQuery = us.getQueryBuilder().
-		Select("u.*", "b.UserId IS NOT NULL AS IsBot").
+		Select("u.*", "b.UserId IS NOT NULL AS IsBot", "COALESCE(b.Description, '') AS BotDescription").
 		From("Users u").
 		LeftJoin("Bots b ON ( b.UserId = u.Id )")
 

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -258,11 +258,13 @@ func testUserStoreGet(t *testing.T, ss store.Store) {
 		Username: model.NewId(),
 	})).(*model.User)
 	store.Must(ss.Bot().Save(&model.Bot{
-		UserId:   u2.Id,
-		Username: u2.Username,
-		OwnerId:  u1.Id,
+		UserId:      u2.Id,
+		Username:    u2.Username,
+		Description: "bot description",
+		OwnerId:     u1.Id,
 	}))
 	u2.IsBot = true
+	u2.BotDescription = "bot description"
 	defer func() { store.Must(ss.Bot().PermanentDelete(u2.Id)) }()
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u2.Id)) }()
 
@@ -285,6 +287,7 @@ func testUserStoreGet(t *testing.T, ss store.Store) {
 		require.Nil(t, err)
 		require.Equal(t, u2, actual)
 		require.True(t, actual.IsBot)
+		require.Equal(t, "bot description", actual.BotDescription)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Related client PR: https://github.com/mattermost/mattermost-webapp/pull/2921

The issue was that the clients need the bot description to display in verious places in the UI (channel header, profile popover) but they where using the bot accounts api to retrieve that information. That API is restricted with a separate set of permissions so it was failing for some users.

This PR removes the secondary retrieval process and includes the bot description with users that are bots. This allows all clients that need to display this information access with only a single request while keeping the bots API for administration only. It also ensures that the two APIs don't diverge in terms of permissions. (they had already done so).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16001