### PR TITLE
Mobile sessions to be excluded from idle timeout

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -79,6 +79,7 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 	if session != nil &&
 		*a.Config().ServiceSettings.SessionIdleTimeoutInMinutes > 0 &&
 		!session.IsOAuth &&
+		!session.IsMobileApp() &&
 		session.Props[model.SESSION_PROP_TYPE] != model.SESSION_TYPE_USER_ACCESS_TOKEN {
 
 		timeout := int64(*a.Config().ServiceSettings.SessionIdleTimeoutInMinutes) * 1000 * 60


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
As discussed with @crspeller we are going to exclude the mobile sessions for now as described in the system console and then for the next release will add a new setting to control the idle timeout for mobile sessions explicitly as we do with session lengths (ticket here https://mattermost.atlassian.net/browse/MM-16111)

Note: Submitting only against the release branch.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-15971