### PR TITLE
Update NPS plugin to 1.0.0-rc2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ TE_PACKAGES=$(shell go list ./...|grep -v plugin_tests)
 # Plugins Packages
 PLUGIN_PACKAGES=mattermost-plugin-zoom-v1.0.6
 PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-nps-v1.0.0-rc1
+PLUGIN_PACKAGES += mattermost-plugin-nps-v1.0.0-rc2
 PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v0.10.0
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.0.0


### PR DESCRIPTION
Includes part of the fix for https://mattermost.atlassian.net/browse/MM-8647 and an ESLint dependency upgrade from GitHub