### PR TITLE
MM-16114 Preventing plugin startup failure if bot account already exists as regular user.

### DIFF
--- a/plugin/helpers_bots.go
+++ b/plugin/helpers_bots.go
@@ -46,10 +46,10 @@ func (p *HelpersImpl) EnsureBot(bot *model.Bot) (retBotId string, retErr error) 
 			if kvSetErr := p.API.KVSet(BOT_USER_KEY, []byte(user.Id)); kvSetErr != nil {
 				p.API.LogWarn("Failed to set claimed bot user id.", "userid", user.Id, "err", kvSetErr)
 			}
-			return user.Id, nil
 		} else {
-			return "", errors.New("unable to create bot because user exists with the same name")
+			p.API.LogError("Plugin attempted to use an account that already exists. Convert user to a bot account in the CLI by running 'mattermost user convert <username> --bot'. If the user is an existing user account you want to preserve, change its username and restart the Mattermost server, after which the plugin will create a bot account with that name. For more information about bot accounts, see https://mattermost.com/pl/default-bot-accounts", "username", bot.Username, "user_id", user.Id)
 		}
+		return user.Id, nil
 	}
 
 	// Create a new bot user for the plugin


### PR DESCRIPTION
#### Summary
Allows the plugin to takeover a regular user account with EnsureBot while logging an error letting the admin know what happened. 