### PR TITLE
Fix bots being unable to post when personal access tokens are disabled.

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -3932,6 +3932,30 @@ func TestUserAccessTokenDisableConfig(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
+func TestUserAccessTokenDisableConfigBotsExcluded(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.EnableBotAccountCreation = true
+		*cfg.ServiceSettings.EnableUserAccessTokens = false
+	})
+
+	bot, resp := th.SystemAdminClient.CreateBot(&model.Bot{
+		Username:    GenerateTestUsername(),
+		DisplayName: "a bot",
+		Description: "bot",
+	})
+	CheckCreatedStatus(t, resp)
+
+	rtoken, resp := th.SystemAdminClient.CreateUserAccessToken(bot.UserId, "test token")
+	th.Client.AuthToken = rtoken.Token
+	CheckNoError(t, resp)
+
+	_, resp = th.Client.GetMe("")
+	CheckNoError(t, resp)
+}
+
 func TestGetUsersByStatus(t *testing.T) {
 	th := Setup()
 	defer th.TearDown()

--- a/app/session.go
+++ b/app/session.go
@@ -262,10 +262,6 @@ func (a *App) CreateUserAccessToken(token *model.UserAccessToken) (*model.UserAc
 }
 
 func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Session, *model.AppError) {
-	if !*a.Config().ServiceSettings.EnableUserAccessTokens {
-		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "EnableUserAccessTokens=false", http.StatusUnauthorized)
-	}
-
 	var token *model.UserAccessToken
 	result := <-a.Srv.Store.UserAccessToken().GetByToken(tokenString)
 	if result.Err != nil {
@@ -282,6 +278,10 @@ func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Sessio
 		return nil, err
 	}
 
+	if !*a.Config().ServiceSettings.EnableUserAccessTokens && !user.IsBot {
+		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "EnableUserAccessTokens=false", http.StatusUnauthorized)
+	}
+
 	if user.DeleteAt != 0 {
 		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "inactive_user_id="+user.Id, http.StatusUnauthorized)
 	}
@@ -295,6 +295,9 @@ func (a *App) createSessionForUserAccessToken(tokenString string) (*model.Sessio
 
 	session.AddProp(model.SESSION_PROP_USER_ACCESS_TOKEN_ID, token.Id)
 	session.AddProp(model.SESSION_PROP_TYPE, model.SESSION_TYPE_USER_ACCESS_TOKEN)
+	if user.IsBot {
+		session.AddProp(model.SESSION_PROP_IS_BOT, model.SESSION_PROP_IS_BOT_VALUE)
+	}
 	session.SetExpireInDays(model.SESSION_USER_ACCESS_TOKEN_EXPIRY)
 
 	session, err = a.Srv.Store.Session().Save(session)

--- a/model/session.go
+++ b/model/session.go
@@ -19,6 +19,8 @@ const (
 	SESSION_PROP_BROWSER              = "browser"
 	SESSION_PROP_TYPE                 = "type"
 	SESSION_PROP_USER_ACCESS_TOKEN_ID = "user_access_token_id"
+	SESSION_PROP_IS_BOT               = "is_bot"
+	SESSION_PROP_IS_BOT_VALUE         = "true"
 	SESSION_TYPE_USER_ACCESS_TOKEN    = "UserAccessToken"
 	SESSION_ACTIVITY_TIMEOUT          = 1000 * 60 * 5 // 5 minutes
 	SESSION_USER_ACCESS_TOKEN_EXPIRY  = 100 * 365     // 100 years

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -688,6 +688,9 @@ func UpgradeDatabaseToVersion512(sqlStore SqlStore) {
 		sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultChannelGuestRole", "text", "VARCHAR(64)")
 		sqlStore.GetMaster().Exec("UPDATE Schemes SET DefaultTeamGuestRole = '', DefaultChannelGuestRole = ''")
 
+		// Saturday, January 24, 2065 5:20:00 AM GMT. To remove all personal access token sessions.
+		sqlStore.GetMaster().Exec("DELETE FROM Sessions WHERE ExpiresAt > 3000000000000")
+
 		saveSchemaVersion(sqlStore, VERSION_5_12_0)
 	}
 }

--- a/web/context.go
+++ b/web/context.go
@@ -86,7 +86,10 @@ func (c *Context) IsSystemAdmin() bool {
 }
 
 func (c *Context) SessionRequired() {
-	if !*c.App.Config().ServiceSettings.EnableUserAccessTokens && c.App.Session.Props[model.SESSION_PROP_TYPE] == model.SESSION_TYPE_USER_ACCESS_TOKEN {
+	if !*c.App.Config().ServiceSettings.EnableUserAccessTokens &&
+		c.App.Session.Props[model.SESSION_PROP_TYPE] == model.SESSION_TYPE_USER_ACCESS_TOKEN &&
+		c.App.Session.Props[model.SESSION_PROP_IS_BOT] != model.SESSION_PROP_IS_BOT_VALUE {
+
 		c.Err = model.NewAppError("", "api.context.session_expired.app_error", nil, "UserAccessToken", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
#### Summary
Adds a prop to sessions created by bot access tokens to exclude them from being disabled when the `EnableUserAccessTokens` setting is false. 

Needs a migration for any existing sessions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16148
