### PR TITLE
[MM-16164] Migrate "Team.GetAll" to Sync by default

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -609,11 +609,7 @@ func (a *App) GetTeamByInviteId(inviteId string) (*model.Team, *model.AppError) 
 }
 
 func (a *App) GetAllTeams() ([]*model.Team, *model.AppError) {
-	data, err := a.Srv.Store.Team().GetAll()
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	return a.Srv.Store.Team().GetAll()
 }
 
 func (a *App) GetAllTeamsPage(offset int, limit int) ([]*model.Team, *model.AppError) {

--- a/app/team.go
+++ b/app/team.go
@@ -609,11 +609,11 @@ func (a *App) GetTeamByInviteId(inviteId string) (*model.Team, *model.AppError) 
 }
 
 func (a *App) GetAllTeams() ([]*model.Team, *model.AppError) {
-	result := <-a.Srv.Store.Team().GetAll()
-	if result.Err != nil {
-		return nil, result.Err
+	data, err := a.Srv.Store.Team().GetAll()
+	if err != nil {
+		return nil, err
 	}
-	return result.Data.([]*model.Team), nil
+	return data, nil
 }
 
 func (a *App) GetAllTeamsPage(offset int, limit int) ([]*model.Team, *model.AppError) {

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -357,16 +357,14 @@ func (s SqlTeamStore) SearchPrivate(term string) store.StoreChannel {
 	})
 }
 
-func (s SqlTeamStore) GetAll() store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		var data []*model.Team
-		if _, err := s.GetReplica().Select(&data, "SELECT * FROM Teams ORDER BY DisplayName"); err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.GetAllTeams", "store.sql_team.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
-			return
-		}
+func (s SqlTeamStore) GetAll() ([]*model.Team, *model.AppError) {
+	var data []*model.Team
 
-		result.Data = data
-	})
+	_, err := s.GetReplica().Select(&data, "SELECT * FROM Teams ORDER BY DisplayName")
+	if err != nil {
+		return nil, model.NewAppError("SqlTeamStore.GetAllTeams", "store.sql_team.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	return data, nil
 }
 
 func (s SqlTeamStore) GetAllPage(offset int, limit int) store.StoreChannel {

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -358,13 +358,13 @@ func (s SqlTeamStore) SearchPrivate(term string) store.StoreChannel {
 }
 
 func (s SqlTeamStore) GetAll() ([]*model.Team, *model.AppError) {
-	var data []*model.Team
+	var teams []*model.Team
 
-	_, err := s.GetReplica().Select(&data, "SELECT * FROM Teams ORDER BY DisplayName")
+	_, err := s.GetReplica().Select(&teams, "SELECT * FROM Teams ORDER BY DisplayName")
 	if err != nil {
 		return nil, model.NewAppError("SqlTeamStore.GetAllTeams", "store.sql_team.get_all.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
-	return data, nil
+	return teams, nil
 }
 
 func (s SqlTeamStore) GetAllPage(offset int, limit int) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -90,7 +90,7 @@ type TeamStore interface {
 	SearchAll(term string) StoreChannel
 	SearchOpen(term string) StoreChannel
 	SearchPrivate(term string) StoreChannel
-	GetAll() StoreChannel
+	GetAll() ([]*model.Team, *model.AppError)
 	GetAllPage(offset int, limit int) StoreChannel
 	GetAllPrivateTeamListing() StoreChannel
 	GetAllPrivateTeamPageListing(offset int, limit int) StoreChannel

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -108,19 +108,28 @@ func (_m *TeamStore) GetActiveMemberCount(teamId string) store.StoreChannel {
 }
 
 // GetAll provides a mock function with given fields:
-func (_m *TeamStore) GetAll() store.StoreChannel {
+func (_m *TeamStore) GetAll() ([]*model.Team, *model.AppError) {
 	ret := _m.Called()
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+	var r0 []*model.Team
+	if rf, ok := ret.Get(0).(func() []*model.Team); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.Team)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetAllForExportAfter provides a mock function with given fields: limit, afterId


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request migrates the `GetAll` in the `Team` store to use Sync by default. I followed the instructions laid out in the issue description and updated all relevant files.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Resolves #11090