### PR TITLE
Migrate "Team.UpdateDisplayName" to Sync by default #11096

### DIFF
--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -254,7 +254,7 @@ func (s SqlTeamStore) Update(team *model.Team) (*model.Team, *model.AppError) {
 	return team, nil
 }
 
-func (s SqlTeamStore) UpdateDisplayName(name string, teamId string) *model.AppError  {
+func (s SqlTeamStore) UpdateDisplayName(name string, teamId string) *model.AppError {
 	if _, err := s.GetMaster().Exec("UPDATE Teams SET DisplayName = :Name WHERE Id = :Id", map[string]interface{}{"Name": name, "Id": teamId}); err != nil {
 		return model.NewAppError("SqlTeamStore.UpdateName", "store.sql_team.update_display_name.app_error", nil, "team_id="+teamId, http.StatusInternalServerError)
 	}

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -254,15 +254,12 @@ func (s SqlTeamStore) Update(team *model.Team) (*model.Team, *model.AppError) {
 	return team, nil
 }
 
-func (s SqlTeamStore) UpdateDisplayName(name string, teamId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if _, err := s.GetMaster().Exec("UPDATE Teams SET DisplayName = :Name WHERE Id = :Id", map[string]interface{}{"Name": name, "Id": teamId}); err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.UpdateName", "store.sql_team.update_display_name.app_error", nil, "team_id="+teamId, http.StatusInternalServerError)
-			return
-		}
+func (s SqlTeamStore) UpdateDisplayName(name string, teamId string) *model.AppError  {
+	if _, err := s.GetMaster().Exec("UPDATE Teams SET DisplayName = :Name WHERE Id = :Id", map[string]interface{}{"Name": name, "Id": teamId}); err != nil {
+		return model.NewAppError("SqlTeamStore.UpdateName", "store.sql_team.update_display_name.app_error", nil, "team_id="+teamId, http.StatusInternalServerError)
+	}
 
-		result.Data = teamId
-	})
+	return nil
 }
 
 func (s SqlTeamStore) Get(id string) (*model.Team, *model.AppError) {

--- a/store/store.go
+++ b/store/store.go
@@ -83,7 +83,7 @@ type Store interface {
 type TeamStore interface {
 	Save(team *model.Team) (*model.Team, *model.AppError)
 	Update(team *model.Team) (*model.Team, *model.AppError)
-	UpdateDisplayName(name string, teamId string) StoreChannel
+	UpdateDisplayName(name string, teamId string) *model.AppError
 	Get(id string) (*model.Team, *model.AppError)
 	GetByName(name string) StoreChannel
 	SearchByName(name string) ([]*model.Team, *model.AppError)

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -684,15 +684,15 @@ func (_m *TeamStore) Update(team *model.Team) (*model.Team, *model.AppError) {
 }
 
 // UpdateDisplayName provides a mock function with given fields: name, teamId
-func (_m *TeamStore) UpdateDisplayName(name string, teamId string) store.StoreChannel {
+func (_m *TeamStore) UpdateDisplayName(name string, teamId string) *model.AppError {
 	ret := _m.Called(name, teamId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string) *model.AppError); ok {
 		r0 = rf(name, teamId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -112,7 +112,7 @@ func testTeamStoreUpdateDisplayName(t *testing.T, ss store.Store) {
 
 	newDisplayName := "NewDisplayName"
 
-	if err = (<-ss.Team().UpdateDisplayName(newDisplayName, o1.Id)).Err; err != nil {
+	if err = ss.Team().UpdateDisplayName(newDisplayName, o1.Id); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Summary
Migrate Preference to Sync by default removing the `return.Do `wrapper.

Ticket Link
Fixes #11096
