### PR TITLE
Disable plugin health check process check test

### DIFF
--- a/plugin/health_check_test.go
+++ b/plugin/health_check_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestPluginHealthCheck(t *testing.T) {
 	for name, f := range map[string]func(*testing.T){
-		"PluginHealthCheck_Success":                 testPluginHealthCheck_Success,
-		"PluginHealthCheck_PluginPanicProcessCheck": testPluginHealthCheck_PluginPanicProcessCheck,
+		"PluginHealthCheck_Success": testPluginHealthCheck_Success,
+		// "PluginHealthCheck_PluginPanicProcessCheck": testPluginHealthCheck_PluginPanicProcessCheck,
 		// "PluginHealthCheck_RPCPingFail":             testPluginHealthCheck_RPCPingFail,
 	} {
 		t.Run(name, f)


### PR DESCRIPTION
#### Summary
This PR disables a test affected by a race condition, waiting for the host OS to register the panicked plugin process as dead. Solutions for writing a deterministic test are being discussed by the EXT team.

#### Ticket Link
[Jira Ticket](https://mattermost.atlassian.net/projects/MM/issues/MM-16245)
