### PR TITLE
Migrate "Post.GetPostsSince" to Sync by default #10976

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -616,11 +616,11 @@ func (a *App) GetPostsEtag(channelId string) string {
 }
 
 func (a *App) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
-	result := <-a.Srv.Store.Post().GetPostsSince(channelId, time, true)
-	if result.Err != nil {
-		return nil, result.Err
+	result, err := a.Srv.Store.Post().GetPostsSince(channelId, time, true)
+	if err != nil {
+		return nil, err
 	}
-	return result.Data.(*model.PostList), nil
+	return result, nil
 }
 
 func (a *App) GetSinglePost(postId string) (*model.Post, *model.AppError) {

--- a/app/post.go
+++ b/app/post.go
@@ -616,11 +616,7 @@ func (a *App) GetPostsEtag(channelId string) string {
 }
 
 func (a *App) GetPostsSince(channelId string, time int64) (*model.PostList, *model.AppError) {
-	result, err := a.Srv.Store.Post().GetPostsSince(channelId, time, true)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return a.Srv.Store.Post().GetPostsSince(channelId, time, true)
 }
 
 func (a *App) GetSinglePost(postId string) (*model.Post, *model.AppError) {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -565,7 +565,7 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 	for _, p := range posts {
 		list.AddPost(p)
 		if p.UpdateAt > time {
-				list.AddOrder(p.Id)
+			list.AddOrder(p.Id)
 		}
 		if latestUpdate < p.UpdateAt {
 			latestUpdate = p.UpdateAt

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -514,10 +514,6 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 			}
 			list := model.NewPostList()
 			return list, nil
-		} else {
-			if s.metrics != nil {
-				s.metrics.IncrementMemCacheMissCounter("Last Post Time")
-			}
 		}
 	}
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -504,32 +504,30 @@ func (s *SqlPostStore) GetPosts(channelId string, offset int, limit int, allowFr
 	return list, err
 }
 
-func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if allowFromCache {
-			// If the last post in the channel's time is less than or equal to the time we are getting posts since,
-			// we can safely return no posts.
-			if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) <= time {
-				if s.metrics != nil {
-					s.metrics.IncrementMemCacheHitCounter("Last Post Time")
-				}
-				list := model.NewPostList()
-				result.Data = list
-				return
-			} else {
-				if s.metrics != nil {
-					s.metrics.IncrementMemCacheMissCounter("Last Post Time")
-				}
+func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) (*model.PostList, *model.AppError) {
+	if allowFromCache {
+		// If the last post in the channel's time is less than or equal to the time we are getting posts since,
+		// we can safely return no posts.
+		if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) <= time {
+			if s.metrics != nil {
+				s.metrics.IncrementMemCacheHitCounter("Last Post Time")
 			}
+			list := model.NewPostList()
+			return list, nil
 		} else {
 			if s.metrics != nil {
 				s.metrics.IncrementMemCacheMissCounter("Last Post Time")
 			}
 		}
+	} else {
+		if s.metrics != nil {
+			s.metrics.IncrementMemCacheMissCounter("Last Post Time")
+		}
+	}
 
-		var posts []*model.Post
-		_, err := s.GetReplica().Select(&posts,
-			`(SELECT
+	var posts []*model.Post
+	_, err := s.GetReplica().Select(&posts,
+		`(SELECT
 			    *
 			FROM
 			    Posts
@@ -554,31 +552,30 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 			            AND ChannelId = :ChannelId
 			    LIMIT 1000) temp_tab))
 			ORDER BY CreateAt DESC`,
-			map[string]interface{}{"ChannelId": channelId, "Time": time})
+		map[string]interface{}{"ChannelId": channelId, "Time": time})
 
-		if err != nil {
-			result.Err = model.NewAppError("SqlPostStore.GetPostsSince", "store.sql_post.get_posts_since.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)
-		} else {
+	if err != nil {
+		return nil, model.NewAppError("SqlPostStore.GetPostsSince", "store.sql_post.get_posts_since.app_error", nil, "channelId="+channelId+err.Error(), http.StatusInternalServerError)
+	} else {
 
-			list := model.NewPostList()
+		list := model.NewPostList()
 
-			var latestUpdate int64 = 0
+		var latestUpdate int64 = 0
 
-			for _, p := range posts {
-				list.AddPost(p)
-				if p.UpdateAt > time {
-					list.AddOrder(p.Id)
-				}
-				if latestUpdate < p.UpdateAt {
-					latestUpdate = p.UpdateAt
-				}
+		for _, p := range posts {
+			list.AddPost(p)
+			if p.UpdateAt > time {
+				list.AddOrder(p.Id)
 			}
-
-			s.lastPostTimeCache.AddWithExpiresInSecs(channelId, latestUpdate, LAST_POST_TIME_CACHE_SEC)
-
-			result.Data = list
+			if latestUpdate < p.UpdateAt {
+				latestUpdate = p.UpdateAt
+			}
 		}
-	})
+
+		s.lastPostTimeCache.AddWithExpiresInSecs(channelId, latestUpdate, LAST_POST_TIME_CACHE_SEC)
+
+		return list, nil
+	}
 }
 
 func (s *SqlPostStore) GetPostsBefore(channelId string, postId string, limit int, offset int) (*model.PostList, *model.AppError) {

--- a/store/store.go
+++ b/store/store.go
@@ -223,7 +223,7 @@ type PostStore interface {
 	GetFlaggedPostsForChannel(userId, channelId string, offset int, limit int) (*model.PostList, *model.AppError)
 	GetPostsBefore(channelId string, postId string, numPosts int, offset int) (*model.PostList, *model.AppError)
 	GetPostsAfter(channelId string, postId string, numPosts int, offset int) (*model.PostList, *model.AppError)
-	GetPostsSince(channelId string, time int64, allowFromCache bool) StoreChannel
+	GetPostsSince(channelId string, time int64, allowFromCache bool) (*model.PostList, *model.AppError)
 	GetEtag(channelId string, allowFromCache bool) string
 	Search(teamId string, userId string, params *model.SearchParams) StoreChannel
 	AnalyticsUserCountsWithPostsByDay(teamId string) StoreChannel

--- a/store/storetest/mocks/PostStore.go
+++ b/store/storetest/mocks/PostStore.go
@@ -427,19 +427,28 @@ func (_m *PostStore) GetPostsCreatedAt(channelId string, time int64) ([]*model.P
 }
 
 // GetPostsSince provides a mock function with given fields: channelId, time, allowFromCache
-func (_m *PostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) store.StoreChannel {
+func (_m *PostStore) GetPostsSince(channelId string, time int64, allowFromCache bool) (*model.PostList, *model.AppError) {
 	ret := _m.Called(channelId, time, allowFromCache)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int64, bool) store.StoreChannel); ok {
+	var r0 *model.PostList
+	if rf, ok := ret.Get(0).(func(string, int64, bool) *model.PostList); ok {
 		r0 = rf(channelId, time, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.PostList)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int64, bool) *model.AppError); ok {
+		r1 = rf(channelId, time, allowFromCache)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetRepliesForExport provides a mock function with given fields: parentId

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -945,7 +945,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 	o5.RootId = o4.Id
 	o5 = (<-ss.Post().Save(o5)).Data.(*model.Post)
 
-	r1 := (<-ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, false)).Data.(*model.PostList)
+	r1, _ := ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, false)
 
 	if r1.Order[0] != o5.Id {
 		t.Fatal("invalid order")
@@ -971,7 +971,7 @@ func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
 		t.Fatal("Missing parent")
 	}
 
-	r2 := (<-ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, true)).Data.(*model.PostList)
+	r2, _ := ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, true)
 
 	if len(r2.Order) != 0 {
 		t.Fatal("wrong size ", len(r2.Posts))
@@ -1076,7 +1076,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	tt := []struct {
 		name                     string
 		searchParams             *model.SearchParams
-		extectedResultsCount     int
+		expectedResultsCount     int
 		expectedMessageResultIds []string
 	}{
 		{
@@ -1173,7 +1173,7 @@ func testPostStoreSearch(t *testing.T, ss store.Store) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			result := (<-ss.Post().Search(teamId, userId, tc.searchParams)).Data.(*model.PostList)
-			require.Len(t, result.Order, tc.extectedResultsCount)
+			require.Len(t, result.Order, tc.expectedResultsCount)
 			for _, expectedMessageResultId := range tc.expectedMessageResultIds {
 				assert.Contains(t, result.Order, expectedMessageResultId)
 			}


### PR DESCRIPTION
### Summary
Migrate `GetPostsSince` to sync by default, removing the `return.Do `wrapper.

### Ticket Link
Fixes #10976