### PR TITLE
[MM-16173] Migrate Team.AnalyticsTeamCount to Sync by default #11126

### DIFF
--- a/app/analytics.go
+++ b/app/analytics.go
@@ -67,7 +67,7 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 		teamCountChan := make(chan store.StoreResult, 1)
 		go func() {
 			teamCount, err := a.Srv.Store.Team().AnalyticsTeamCount()
-			teamCountChan <- store.StoreResult{Data:teamCount, Err:err}
+			teamCountChan <- store.StoreResult{Data: teamCount, Err: err}
 			close(teamCountChan)
 		}()
 

--- a/app/analytics.go
+++ b/app/analytics.go
@@ -46,7 +46,6 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 
 		openChan := a.Srv.Store.Channel().AnalyticsTypeCount(teamId, model.CHANNEL_OPEN)
 		privateChan := a.Srv.Store.Channel().AnalyticsTypeCount(teamId, model.CHANNEL_PRIVATE)
-		teamChan := a.Srv.Store.Team().AnalyticsTeamCount()
 
 		var userChan store.StoreChannel
 		var userInactiveChan store.StoreChannel
@@ -108,11 +107,11 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 			rows[10].Value = float64(r.Data.(int64))
 		}
 
-		r = <-teamChan
-		if r.Err != nil {
-			return nil, r.Err
+		if teamCount, err := a.Srv.Store.Team().AnalyticsTeamCount(); err != nil {
+			rows[4].Value = float64(teamCount)
+		} else {
+			return nil, err
 		}
-		rows[4].Value = float64(r.Data.(int64))
 
 		// If in HA mode then aggregrate all the stats
 		if a.Cluster != nil && *a.Config().ClusterSettings.Enable {

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -166,7 +166,10 @@ func (a *App) trackActivity() {
 		inactiveUserCount = iucr.Data.(int64)
 	}
 
-	teamCount, _ = a.Srv.Store.Team().AnalyticsTeamCount()
+	teamCount, err := a.Srv.Store.Team().AnalyticsTeamCount()
+	if err != nil {
+		mlog.Error(err.Error())
+	}
 
 	if ucc := <-a.Srv.Store.Channel().AnalyticsTypeCount("", "O"); ucc.Err == nil {
 		publicChannelCount = ucc.Data.(int64)

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -166,9 +166,7 @@ func (a *App) trackActivity() {
 		inactiveUserCount = iucr.Data.(int64)
 	}
 
-	if tcr := <-a.Srv.Store.Team().AnalyticsTeamCount(); tcr.Err == nil {
-		teamCount = tcr.Data.(int64)
-	}
+	teamCount, _ = a.Srv.Store.Team().AnalyticsTeamCount()
 
 	if ucc := <-a.Srv.Store.Channel().AnalyticsTypeCount("", "O"); ucc.Err == nil {
 		publicChannelCount = ucc.Data.(int64)

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -478,12 +478,14 @@ func (me *TestHelper) ResetEmojisMigration() {
 }
 
 func (me *TestHelper) CheckTeamCount(t *testing.T, expected int64) {
-	if r := <-me.App.Srv.Store.Team().AnalyticsTeamCount(); r.Err == nil {
-		if r.Data.(int64) != expected {
-			t.Fatalf("Unexpected number of teams. Expected: %v, found: %v", expected, r.Data.(int64))
-		}
-	} else {
+	teamCount, err := me.App.Srv.Store.Team().AnalyticsTeamCount()
+
+	if err != nil {
 		t.Fatalf("Failed to get team count.")
+	}
+
+	if teamCount != expected {
+		t.Fatalf("Unexpected number of teams. Expected: %v, found: %v", expected, teamCount)
 	}
 }
 

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -479,11 +479,9 @@ func (me *TestHelper) ResetEmojisMigration() {
 
 func (me *TestHelper) CheckTeamCount(t *testing.T, expected int64) {
 	teamCount, err := me.App.Srv.Store.Team().AnalyticsTeamCount()
-
 	if err != nil {
 		t.Fatalf("Failed to get team count.")
 	}
-
 	if teamCount != expected {
 		t.Fatalf("Unexpected number of teams. Expected: %v, found: %v", expected, teamCount)
 	}

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -569,7 +569,6 @@ func TestImportImportTeam(t *testing.T) {
 
 	// Check how many teams are in the database.
 	teamsCount, err := th.App.Srv.Store.Team().AnalyticsTeamCount()
-
 	if err != nil {
 		t.Fatalf("Failed to get team count.")
 	}

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -568,10 +568,9 @@ func TestImportImportTeam(t *testing.T) {
 	scheme2 := th.SetupTeamScheme()
 
 	// Check how many teams are in the database.
-	var teamsCount int64
-	if r := <-th.App.Srv.Store.Team().AnalyticsTeamCount(); r.Err == nil {
-		teamsCount = r.Data.(int64)
-	} else {
+	teamsCount, err := th.App.Srv.Store.Team().AnalyticsTeamCount()
+
+	if err != nil {
 		t.Fatalf("Failed to get team count.")
 	}
 

--- a/app/security_update_check.go
+++ b/app/security_update_check.go
@@ -79,8 +79,8 @@ func (s *Server) DoSecurityUpdateCheck() {
 			v.Set(PROP_SECURITY_ACTIVE_USER_COUNT, strconv.FormatInt(ucr.Data.(int64), 10))
 		}
 
-		if tcr := <-s.Store.Team().AnalyticsTeamCount(); tcr.Err == nil {
-			v.Set(PROP_SECURITY_TEAM_COUNT, strconv.FormatInt(tcr.Data.(int64), 10))
+		if teamCount, err := s.Store.Team().AnalyticsTeamCount(); err == nil {
+			v.Set(PROP_SECURITY_TEAM_COUNT, strconv.FormatInt(teamCount, 10))
 		}
 
 		res, err := http.Get(SECURITY_URL + "/security?" + v.Encode())

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -474,8 +474,7 @@ func (s SqlTeamStore) AnalyticsTeamCount() (int64, *model.AppError) {
 	c, err := s.GetReplica().SelectInt("SELECT COUNT(*) FROM Teams WHERE DeleteAt = 0", map[string]interface{}{})
 
 	if err != nil {
-		err := model.NewAppError("SqlTeamStore.AnalyticsTeamCount", "store.sql_team.analytics_team_count.app_error", nil, err.Error(), http.StatusInternalServerError)
-		return int64(0), err
+		return int64(0), model.NewAppError("SqlTeamStore.AnalyticsTeamCount", "store.sql_team.analytics_team_count.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return c, nil

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -470,15 +470,15 @@ func (s SqlTeamStore) PermanentDelete(teamId string) store.StoreChannel {
 	})
 }
 
-func (s SqlTeamStore) AnalyticsTeamCount() store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		c, err := s.GetReplica().SelectInt("SELECT COUNT(*) FROM Teams WHERE DeleteAt = 0", map[string]interface{}{})
-		if err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.AnalyticsTeamCount", "store.sql_team.analytics_team_count.app_error", nil, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		result.Data = c
-	})
+func (s SqlTeamStore) AnalyticsTeamCount() (int64, *model.AppError) {
+	c, err := s.GetReplica().SelectInt("SELECT COUNT(*) FROM Teams WHERE DeleteAt = 0", map[string]interface{}{})
+
+	if err != nil {
+		err := model.NewAppError("SqlTeamStore.AnalyticsTeamCount", "store.sql_team.analytics_team_count.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return int64(0), err
+	}
+
+	return c, nil
 }
 
 func (s SqlTeamStore) getTeamMembersWithSchemeSelectQuery() sq.SelectBuilder {

--- a/store/store.go
+++ b/store/store.go
@@ -99,7 +99,7 @@ type TeamStore interface {
 	GetTeamsByUserId(userId string) StoreChannel
 	GetByInviteId(inviteId string) StoreChannel
 	PermanentDelete(teamId string) StoreChannel
-	AnalyticsTeamCount() StoreChannel
+	AnalyticsTeamCount() (int64, *model.AppError)
 	SaveMember(member *model.TeamMember, maxUsersPerTeam int) StoreChannel
 	UpdateMember(member *model.TeamMember) StoreChannel
 	GetMember(teamId string, userId string) StoreChannel

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -30,19 +30,26 @@ func (_m *TeamStore) AnalyticsGetTeamCountForScheme(schemeId string) store.Store
 }
 
 // AnalyticsTeamCount provides a mock function with given fields:
-func (_m *TeamStore) AnalyticsTeamCount() store.StoreChannel {
+func (_m *TeamStore) AnalyticsTeamCount() (int64, *model.AppError) {
 	ret := _m.Called()
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+	var r0 int64
+	if rf, ok := ret.Get(0).(func() int64); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
 		}
 	}
 
-	return r0
+	return r0, r1
 }
 
 // ClearAllCustomRoleAssignments provides a mock function with given fields:

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -774,10 +774,10 @@ func testTeamCount(t *testing.T, ss store.Store) {
 	_, err := ss.Team().Save(&o1)
 	require.Nil(t, err)
 
-	if r1 := <-ss.Team().AnalyticsTeamCount(); r1.Err != nil {
-		t.Fatal(r1.Err)
+	if teamCount, err := ss.Team().AnalyticsTeamCount(); err != nil {
+		t.Fatal(err)
 	} else {
-		if r1.Data.(int64) == 0 {
+		if teamCount == 0 {
 			t.Fatal("should be at least 1 team")
 		}
 	}


### PR DESCRIPTION
### [MM-16173] Migrate Team.AnalyticsTeamCount to Sync by default #11126
+ Modified team_store.AnalyticsTeamCount to return (int64, *model.AppError) instead of store.StoreChannel.
+ Updated the mock store to reflect new return value.
+ Updated referencing code to handle new sync return value.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR modifies team_store.AnalyticsTeamCount to return (int64, *mode.AppError) instead of a store.StoreChannel. This will make the call sync.

#### Ticket Link
[MM-16173](https://mattermost.atlassian.net/browse/MM-16173)

Fixes #11126

##### Notes

> app/analytics.go

I moved the var down in the method body. This was to let the openChan and privateChan run their async code and then we block on the analytics team count. I know some people prefer to have all the var initialized at the top of the method, so I could move that around if you want.

> security_update_check.go 
> diagnostics.go

The default behaviour seemed to be to ignore errors, so I left it as that. But it might be good to alter these methods to handle an error from the sync call. Just let me know... I can put that in if you wanted. 




[MM-16173]: https://mattermost.atlassian.net/browse/MM-16173