### PR TITLE
[MM-16242] Unmask Account Lock Message

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1240,7 +1240,7 @@ func sendPasswordReset(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func login(c *Context, w http.ResponseWriter, r *http.Request) {
-	// Translate all login errors to generic. MFA error being an exception, since it's required for the login flow itself
+	// Mask all sensitive errors, with the exception of the following
 	defer func() {
 		if c.Err == nil {
 			return
@@ -1254,6 +1254,7 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 			"api.user.login.client_side_cert.certificate.app_error",
 			"api.user.login.inactive.app_error",
 			"api.user.login.not_verified.app_error",
+			"api.user.check_user_login_attempts.too_many.app_error",
 		}
 
 		maskError := true

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -4220,13 +4220,13 @@ func TestLoginLockout(t *testing.T) {
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
 	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials_email_username")
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
-	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials_email_username")
+	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
 	_, resp = th.Client.Login(th.BasicUser.Email, "wrong")
-	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials_email_username")
+	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
 
 	//Check if lock is active
 	_, resp = th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
-	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials_email_username")
+	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
 
 	// Fake user has MFA enabled
 	if result := <-th.Server.Store.User().UpdateMfaActive(th.BasicUser2.Id, true); result.Err != nil {
@@ -4239,9 +4239,9 @@ func TestLoginLockout(t *testing.T) {
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
 	CheckErrorMessage(t, resp, "api.user.check_user_mfa.bad_code.app_error")
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
-	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials_email_username")
+	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
 	_, resp = th.Client.LoginWithMFA(th.BasicUser2.Email, th.BasicUser2.Password, "000000")
-	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials_email_username")
+	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
 
 	// Fake user has MFA disabled
 	if result := <-th.Server.Store.User().UpdateMfaActive(th.BasicUser2.Id, false); result.Err != nil {
@@ -4250,5 +4250,5 @@ func TestLoginLockout(t *testing.T) {
 
 	//Check if lock is active
 	_, resp = th.Client.Login(th.BasicUser2.Email, th.BasicUser2.Password)
-	CheckErrorMessage(t, resp, "api.user.login.invalid_credentials_email_username")
+	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
 }


### PR DESCRIPTION
#### Summary
This ticket fixes a regression introduced from the login error message rework, where the account lockout message wasn't shown. This whitelists the lockout message to be unmasked, a follow up ticket to move to an eMail based notification / client specific lockout will be created.

FYI @lindalumitchell 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16242