### PR TITLE
[MM-16171] Migrate "Team.GetByInviteId" to Sync by default

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -459,7 +459,13 @@ func (a *App) AddUserToTeamByToken(userId string, tokenId string) (*model.Team, 
 }
 
 func (a *App) AddUserToTeamByInviteId(inviteId string, userId string) (*model.Team, *model.AppError) {
-	tchan := a.Srv.Store.Team().GetByInviteId(inviteId)
+	tchan := make(chan store.StoreResult, 1)
+	go func() {
+		team, err := a.Srv.Store.Team().GetByInviteId(inviteId)
+		tchan <- store.StoreResult{Data: team, Err: err}
+		close(tchan)
+	}()
+
 	uchan := make(chan store.StoreResult, 1)
 	go func() {
 		user, err := a.Srv.Store.User().Get(userId)
@@ -601,11 +607,7 @@ func (a *App) GetTeamByName(name string) (*model.Team, *model.AppError) {
 }
 
 func (a *App) GetTeamByInviteId(inviteId string) (*model.Team, *model.AppError) {
-	result := <-a.Srv.Store.Team().GetByInviteId(inviteId)
-	if result.Err != nil {
-		return nil, result.Err
-	}
-	return result.Data.(*model.Team), nil
+	return a.Srv.Store.Team().GetByInviteId(inviteId)
 }
 
 func (a *App) GetAllTeams() ([]*model.Team, *model.AppError) {
@@ -1211,12 +1213,12 @@ func (a *App) GetTeamIdFromQuery(query url.Values) (string, *model.AppError) {
 		return tokenData["teamId"], nil
 	}
 	if len(inviteId) > 0 {
-		result := <-a.Srv.Store.Team().GetByInviteId(inviteId)
-		if result.Err == nil {
-			return result.Data.(*model.Team).Id, nil
+		team, err := a.Srv.Store.Team().GetByInviteId(inviteId)
+		if err == nil {
+			return team.Id, nil
 		}
 		// soft fail, so we still create user but don't auto-join team
-		mlog.Error(fmt.Sprintf("%v", result.Err))
+		mlog.Error(fmt.Sprintf("%v", err))
 	}
 
 	return "", nil

--- a/app/user.go
+++ b/app/user.go
@@ -98,11 +98,10 @@ func (a *App) CreateUserWithInviteId(user *model.User, inviteId string) (*model.
 		return nil, err
 	}
 
-	result := <-a.Srv.Store.Team().GetByInviteId(inviteId)
-	if result.Err != nil {
-		return nil, result.Err
+	team, err := a.Srv.Store.Team().GetByInviteId(inviteId)
+	if err != nil {
+		return nil, err
 	}
-	team := result.Data.(*model.Team)
 
 	if team.IsGroupConstrained() {
 		return nil, model.NewAppError("CreateUserWithInviteId", "app.team.invite_id.group_constrained.error", nil, "", http.StatusForbidden)

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -274,22 +274,18 @@ func (s SqlTeamStore) Get(id string) (*model.Team, *model.AppError) {
 	return obj.(*model.Team), nil
 }
 
-func (s SqlTeamStore) GetByInviteId(inviteId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		team := model.Team{}
+func (s SqlTeamStore) GetByInviteId(inviteId string) (*model.Team, *model.AppError) {
+	team := model.Team{}
 
-		if err := s.GetReplica().SelectOne(&team, "SELECT * FROM Teams WHERE InviteId = :InviteId", map[string]interface{}{"InviteId": inviteId}); err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.finding.app_error", nil, "inviteId="+inviteId+", "+err.Error(), http.StatusNotFound)
-			return
-		}
+	err := s.GetReplica().SelectOne(&team, "SELECT * FROM Teams WHERE InviteId = :InviteId", map[string]interface{}{"InviteId": inviteId})
+	if err != nil {
+		return nil, model.NewAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.finding.app_error", nil, "inviteId="+inviteId+", "+err.Error(), http.StatusNotFound)
+	}
 
-		if len(inviteId) == 0 || team.InviteId != inviteId {
-			result.Err = model.NewAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.find.app_error", nil, "inviteId="+inviteId, http.StatusNotFound)
-			return
-		}
-
-		result.Data = &team
-	})
+	if len(inviteId) == 0 || team.InviteId != inviteId {
+		return nil, model.NewAppError("SqlTeamStore.GetByInviteId", "store.sql_team.get_by_invite_id.find.app_error", nil, "inviteId="+inviteId, http.StatusNotFound)
+	}
+	return &team, nil
 }
 
 func (s SqlTeamStore) GetByName(name string) (*model.Team, *model.AppError) {

--- a/store/store.go
+++ b/store/store.go
@@ -97,7 +97,7 @@ type TeamStore interface {
 	GetAllTeamListing() StoreChannel
 	GetAllTeamPageListing(offset int, limit int) StoreChannel
 	GetTeamsByUserId(userId string) StoreChannel
-	GetByInviteId(inviteId string) StoreChannel
+	GetByInviteId(inviteId string) (*model.Team, *model.AppError)
 	PermanentDelete(teamId string) StoreChannel
 	AnalyticsTeamCount() StoreChannel
 	SaveMember(member *model.TeamMember, maxUsersPerTeam int) StoreChannel

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -229,19 +229,28 @@ func (_m *TeamStore) GetAllTeamPageListing(offset int, limit int) store.StoreCha
 }
 
 // GetByInviteId provides a mock function with given fields: inviteId
-func (_m *TeamStore) GetByInviteId(inviteId string) store.StoreChannel {
+func (_m *TeamStore) GetByInviteId(inviteId string) (*model.Team, *model.AppError) {
 	ret := _m.Called(inviteId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 *model.Team
+	if rf, ok := ret.Get(0).(func(string) *model.Team); ok {
 		r0 = rf(inviteId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.Team)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(inviteId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetByName provides a mock function with given fields: name

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -406,15 +406,15 @@ func testTeamStoreGetByInviteId(t *testing.T, ss store.Store) {
 	o2.Email = MakeEmail()
 	o2.Type = model.TEAM_OPEN
 
-	if r1 := <-ss.Team().GetByInviteId(save1.InviteId); r1.Err != nil {
-		t.Fatal(r1.Err)
+	if r1, err := ss.Team().GetByInviteId(save1.InviteId); err != nil {
+		t.Fatal(err)
 	} else {
-		if r1.Data.(*model.Team).ToJson() != o1.ToJson() {
+		if r1.ToJson() != o1.ToJson() {
 			t.Fatal("invalid returned team")
 		}
 	}
 
-	if err := (<-ss.Team().GetByInviteId("")).Err; err == nil {
+	if _, err := ss.Team().GetByInviteId(""); err == nil {
 		t.Fatal("Missing id should have failed")
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This pull request migrates the `GetByInviteId` in the Team store to use Sync by default. I followed the instructions laid out in the issue description and updated all relevant files.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Resolves #11127 