### PR TITLE
MM-16277 Update NPS plugin to v1.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ TE_PACKAGES=$(shell go list ./...|grep -v plugin_tests)
 # Plugins Packages
 PLUGIN_PACKAGES=mattermost-plugin-zoom-v1.0.7
 PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-nps-v1.0.0-rc2
+PLUGIN_PACKAGES += mattermost-plugin-nps-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v0.10.2
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.0.0


### PR DESCRIPTION
No changes were made between this version and the current 1.0.0-rc2 version. In the future, I'm thinking we'll just do 1.0.0, 1.0.1, 1.0.2, etc releases for this plugin instead of doing RCs since it saves having to cut a final release with no changes like this

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16277