### PR TITLE
MM-16295 Properly disabling plugins that are not marked as running.

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -57,7 +57,7 @@ func (a *App) SyncPluginsActiveState() {
 		}
 
 		// Deactivate any plugins that have been disabled.
-		for _, plugin := range pluginsEnvironment.Active() {
+		for _, plugin := range availablePlugins {
 			// Determine if plugin is enabled
 			pluginId := plugin.Manifest.Id
 			pluginEnabled := false


### PR DESCRIPTION
Instead of going though the active plugins to find disabled we go though all plugins because some may have failed to start, but still need disabling. 