### PR TITLE
[MM-11227] Migrate "Channel.GetMembers" to Sync by default

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1293,11 +1293,11 @@ func (a *App) GetChannelMember(channelId string, userId string) (*model.ChannelM
 }
 
 func (a *App) GetChannelMembersPage(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError) {
-	result := <-a.Srv.Store.Channel().GetMembers(channelId, page*perPage, perPage)
-	if result.Err != nil {
-		return nil, result.Err
+	channelMembers, err := a.Srv.Store.Channel().GetMembers(channelId, page*perPage, perPage)
+	if err != nil {
+		return nil, err
 	}
-	return result.Data.(*model.ChannelMembers), nil
+	return channelMembers, nil
 }
 
 func (a *App) GetChannelMembersTimezones(channelId string) ([]string, *model.AppError) {

--- a/app/channel.go
+++ b/app/channel.go
@@ -1285,11 +1285,7 @@ func (a *App) GetChannelMember(channelId string, userId string) (*model.ChannelM
 }
 
 func (a *App) GetChannelMembersPage(channelId string, page, perPage int) (*model.ChannelMembers, *model.AppError) {
-	channelMembers, err := a.Srv.Store.Channel().GetMembers(channelId, page*perPage, perPage)
-	if err != nil {
-		return nil, err
-	}
-	return channelMembers, nil
+	return a.Srv.Store.Channel().GetMembers(channelId, page*perPage, perPage)
 }
 
 func (a *App) GetChannelMembersTimezones(channelId string) ([]string, *model.AppError) {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1407,17 +1407,14 @@ func (s SqlChannelStore) UpdateMember(member *model.ChannelMember) store.StoreCh
 	})
 }
 
-func (s SqlChannelStore) GetMembers(channelId string, offset, limit int) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		var dbMembers channelMemberWithSchemeRolesList
-		_, err := s.GetReplica().Select(&dbMembers, CHANNEL_MEMBERS_WITH_SCHEME_SELECT_QUERY+"WHERE ChannelId = :ChannelId LIMIT :Limit OFFSET :Offset", map[string]interface{}{"ChannelId": channelId, "Limit": limit, "Offset": offset})
-		if err != nil {
-			result.Err = model.NewAppError("SqlChannelStore.GetMembers", "store.sql_channel.get_members.app_error", nil, "channel_id="+channelId+","+err.Error(), http.StatusInternalServerError)
-			return
-		}
+func (s SqlChannelStore) GetMembers(channelId string, offset, limit int) (*model.ChannelMembers, *model.AppError) {
+	var dbMembers channelMemberWithSchemeRolesList
+	_, err := s.GetReplica().Select(&dbMembers, CHANNEL_MEMBERS_WITH_SCHEME_SELECT_QUERY+"WHERE ChannelId = :ChannelId LIMIT :Limit OFFSET :Offset", map[string]interface{}{"ChannelId": channelId, "Limit": limit, "Offset": offset})
+	if err != nil {
+		return nil, model.NewAppError("SqlChannelStore.GetMembers", "store.sql_channel.get_members.app_error", nil, "channel_id="+channelId+","+err.Error(), http.StatusInternalServerError)
+	}
 
-		result.Data = dbMembers.ToModel()
-	})
+	return dbMembers.ToModel(), nil
 }
 
 func (s SqlChannelStore) GetChannelMembersTimezones(channelId string) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -159,7 +159,7 @@ type ChannelStore interface {
 	GetForPost(postId string) StoreChannel
 	SaveMember(member *model.ChannelMember) StoreChannel
 	UpdateMember(member *model.ChannelMember) StoreChannel
-	GetMembers(channelId string, offset, limit int) StoreChannel
+	GetMembers(channelId string, offset, limit int) (*model.ChannelMembers, *model.AppError)
 	GetMember(channelId string, userId string) (*model.ChannelMember, *model.AppError)
 	GetChannelMembersTimezones(channelId string) StoreChannel
 	GetAllChannelMembersForUser(userId string, allowFromCache bool, includeDeleted bool) StoreChannel

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -153,7 +153,8 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 		t.Fatal("couldn't save direct channel", err)
 	}
 
-	members, _ := ss.Channel().GetMembers(o1.Id, 0, 100)
+	members, err := ss.Channel().GetMembers(o1.Id, 0, 100)
+	require.Nil(t, err)
 	if len(*members) != 2 {
 		t.Fatal("should have saved 2 members")
 	}
@@ -196,7 +197,8 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 		t.Fatal("couldn't save direct channel", err)
 	}
 
-	members, _ = ss.Channel().GetMembers(o1.Id, 0, 100)
+	members, err = ss.Channel().GetMembers(o1.Id, 0, 100)
+	require.Nil(t, err)
 	if len(*members) != 1 {
 		t.Fatal("should have saved just 1 member")
 	}
@@ -227,7 +229,8 @@ func testChannelStoreCreateDirectChannel(t *testing.T, ss store.Store) {
 		<-ss.Channel().PermanentDelete(c1.Id)
 	}()
 
-	members, _ := ss.Channel().GetMembers(c1.Id, 0, 100)
+	members, err := ss.Channel().GetMembers(c1.Id, 0, 100)
+	require.Nil(t, err)
 	if len(*members) != 2 {
 		t.Fatal("should have saved 2 members")
 	}

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -153,13 +153,13 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 		t.Fatal("couldn't save direct channel", err)
 	}
 
-	members, err2 := ss.Channel().GetMembers(o1.Id, 0, 100)
-	require.Nil(t, err2)
+	members, err := ss.Channel().GetMembers(o1.Id, 0, 100)
+	require.Nil(t, err)
 	if len(*members) != 2 {
 		t.Fatal("should have saved 2 members")
 	}
 
-	if _, err := ss.Channel().SaveDirectChannel(&o1, &m1, &m2); err == nil {
+	if _, err = ss.Channel().SaveDirectChannel(&o1, &m1, &m2); err == nil {
 		t.Fatal("shouldn't be able to update from save")
 	}
 
@@ -184,7 +184,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 	o1.Id = ""
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	if _, err := ss.Channel().SaveDirectChannel(&o1, &m1, &m2); err == nil {
+	if _, err = ss.Channel().SaveDirectChannel(&o1, &m1, &m2); err == nil {
 		t.Fatal("Should not be able to save non-direct channel")
 	}
 
@@ -193,7 +193,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 	o1.DisplayName = "Myself"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_DIRECT
-	if _, err := ss.Channel().SaveDirectChannel(&o1, &m1, &m1); err != nil {
+	if _, err = ss.Channel().SaveDirectChannel(&o1, &m1, &m1); err != nil {
 		t.Fatal("couldn't save direct channel", err)
 	}
 

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -153,7 +153,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 		t.Fatal("couldn't save direct channel", err)
 	}
 
-	members := (<-ss.Channel().GetMembers(o1.Id, 0, 100)).Data.(*model.ChannelMembers)
+	members, _ := ss.Channel().GetMembers(o1.Id, 0, 100)
 	if len(*members) != 2 {
 		t.Fatal("should have saved 2 members")
 	}
@@ -196,7 +196,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 		t.Fatal("couldn't save direct channel", err)
 	}
 
-	members = (<-ss.Channel().GetMembers(o1.Id, 0, 100)).Data.(*model.ChannelMembers)
+	members, _ = ss.Channel().GetMembers(o1.Id, 0, 100)
 	if len(*members) != 1 {
 		t.Fatal("should have saved just 1 member")
 	}
@@ -227,7 +227,7 @@ func testChannelStoreCreateDirectChannel(t *testing.T, ss store.Store) {
 		<-ss.Channel().PermanentDelete(c1.Id)
 	}()
 
-	members := (<-ss.Channel().GetMembers(c1.Id, 0, 100)).Data.(*model.ChannelMembers)
+	members, _ := ss.Channel().GetMembers(c1.Id, 0, 100)
 	if len(*members) != 2 {
 		t.Fatal("should have saved 2 members")
 	}
@@ -3430,9 +3430,8 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, ss store.Store) {
 	store.Must(ss.Channel().SaveMember(&m3))
 
 	// Get all the channel members. Check there are 3.
-	r1 := <-ss.Channel().GetMembers(c1.Id, 0, 1000)
-	assert.Nil(t, r1.Err)
-	d1 := r1.Data.(*model.ChannelMembers)
+	d1, err := ss.Channel().GetMembers(c1.Id, 0, 1000)
+	assert.Nil(t, err)
 	assert.Len(t, *d1, 3)
 
 	// Deactivate users 1 & 2.
@@ -3447,9 +3446,8 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, ss store.Store) {
 	assert.Nil(t, (<-ss.Channel().RemoveAllDeactivatedMembers(c1.Id)).Err)
 
 	// Get all the channel members. Check there is now only 1: m3.
-	r2 := <-ss.Channel().GetMembers(c1.Id, 0, 1000)
-	assert.Nil(t, r1.Err)
-	d2 := r2.Data.(*model.ChannelMembers)
+	d2, err := ss.Channel().GetMembers(c1.Id, 0, 1000)
+	assert.Nil(t, err)
 	assert.Len(t, *d2, 1)
 	assert.Equal(t, (*d2)[0].UserId, u3.Id)
 }

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -153,8 +153,8 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSuppli
 		t.Fatal("couldn't save direct channel", err)
 	}
 
-	members, err := ss.Channel().GetMembers(o1.Id, 0, 100)
-	require.Nil(t, err)
+	members, err2 := ss.Channel().GetMembers(o1.Id, 0, 100)
+	require.Nil(t, err2)
 	if len(*members) != 2 {
 		t.Fatal("should have saved 2 members")
 	}

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -597,19 +597,28 @@ func (_m *ChannelStore) GetMemberForPost(postId string, userId string) store.Sto
 }
 
 // GetMembers provides a mock function with given fields: channelId, offset, limit
-func (_m *ChannelStore) GetMembers(channelId string, offset int, limit int) store.StoreChannel {
+func (_m *ChannelStore) GetMembers(channelId string, offset int, limit int) (*model.ChannelMembers, *model.AppError) {
 	ret := _m.Called(channelId, offset, limit)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int, int) store.StoreChannel); ok {
+	var r0 *model.ChannelMembers
+	if rf, ok := ret.Get(0).(func(string, int, int) *model.ChannelMembers); ok {
 		r0 = rf(channelId, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.ChannelMembers)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int, int) *model.AppError); ok {
+		r1 = rf(channelId, offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetMembersByIds provides a mock function with given fields: channelId, userIds


### PR DESCRIPTION
#### Summary
This PR will migrate `Channel.GetMembers` to Sync by default

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/11227
