### PR TITLE
MM-15788: Unmasks errors related to max team members and accounts.

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1255,6 +1255,8 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 			"api.user.login.inactive.app_error",
 			"api.user.login.not_verified.app_error",
 			"api.user.check_user_login_attempts.too_many.app_error",
+			"app.team.join_user_to_team.max_accounts.app_error",
+			"store.sql_user.save.max_accounts.app_error",
 		}
 
 		maskError := true


### PR DESCRIPTION
#### Summary

Enables the display of a message that Mattermost has reached its maximum configured number of users accounts or team members.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-15788

#### Screenshot

<img width="479" alt="Screen Shot 2019-06-17 at 12 48 12 PM" src="https://user-images.githubusercontent.com/1149597/59622136-c99b4580-90fe-11e9-9903-40690e8badfd.png">
