### PR TITLE
[MM-16411] tagging the docker image using the sha instead of the PR number

### DIFF
--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -236,12 +236,38 @@ pipeline {
             }
         }
 
+        stage('Clean checkout') {
+            // We need to perform a clean checkout here to ge the original git commit hash from the PR
+            // Jenkins now merges master in top of the PR and this generate a new git hash
+            // We need to do that to build the docker image based on the original git commit and then this will be used by
+            // mattermod to update the test server.
+            steps {
+                sh """
+                    mkdir -p /tmp/mattermost-server
+                """
+                dir('/tmp/mattermost-server') {
+                    checkout([$class: 'GitSCM', branches: [[name: 'FETCH_HEAD']],
+                        doGenerateSubmoduleConfigurations: false, extensions: [],
+                        submoduleCfg: [], userRemoteConfigs:  [
+                        [refspec: "+refs/pull/${CHANGE_ID}/head:refs/remotes/origin/PR-${CHANGE_ID}",
+                        credentialsId: "310159d3-f7c5-4f5d-bfa1-151e3ef2db57",url: "https://github.com/mattermost/mattermost-server.git"]]])
+                    sh 'git rev-parse --short HEAD'
+                }
+            }
+        }
+
         stage('Trigger docker image') {
+            environment {
+                GIT_COMMIT_SHORT = sh(
+                        script: "cd /tmp/mattermost-server && printf \$(git rev-parse --short HEAD)",
+                        returnStdout: true
+                )
+            }
             when {
                 expression { env.CHANGE_ID != null }
             }
             steps {
-                build job: '../../mk/mattermost-enterprise-edition-release', parameters: [string(name: 'RELEASE', value: "${CHANGE_ID}"), booleanParam(name: 'FROM_PR', value: true)], propagate: false, wait: false
+                build job: '../../mk/mattermost-enterprise-edition-release', parameters: [string(name: 'RELEASE', value: "${CHANGE_ID}"), booleanParam(name: 'FROM_PR', value: true),string(name: 'PR_TAG', value: "${GIT_COMMIT_SHORT}")], propagate: false, wait: false
             }
         }
     }


### PR DESCRIPTION
#### Summary
This PR changes the way we tag the docker image for PRS. before we were using the PR + number to tag the image. the proposed idea is the use the short commit hash.

This will make the things  easier when we request a test server using the mattermost cloud infra, as well as the update of the test server

Also, we need to do a clean checkout to get the git commit hash to use to tag the docker image, when jenkins checkout it merges master in top of the PR which produce a new git hash and this is not store in the PR in github, so we need to get the git hash from github to use to tag the image and in sequence use in the test servers (using the cloud infra)

#### Ticket Link
Jira: https://mattermost.atlassian.net/browse/MM-16411