### PR TITLE
Add KV helper methods to Helpers interface

### DIFF
--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -17,9 +17,11 @@ type Helpers interface {
 	// KVSetJSON stores a key-value pair.
 	KVSetJSON(key string, value interface{}) error
 
-	// VKCompareAndSetJSON updates a key-value pair if the current
-	// value is equal to oldValue. Inserts a key-value pair if oldValue is nil.
-	// Will not update it the current value != oldValue.
+	// KVCompareAndSetJSON updates a key-value pair if the current
+	// value is equal to oldValue.
+	// Returns (false, err) if DB/marshal/unmarshal error occurred
+	// Returns (false, nil) if current value != old value
+	// Returns (true, nil) if current value == old value or new key is inserted
 	KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) (bool, error)
 
 	// KVSetWithExpiryJSON stores a key-value pair with an expiry time.

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -10,6 +10,20 @@ type Helpers interface {
 	// the specifications of the passed bot.
 	// Returns the id of the bot created or existing.
 	EnsureBot(bot *model.Bot) (string, error)
+
+	// KVGetJSON retrievs a value based on the key.
+	KVGetJSON(key string, value interface{}) error
+
+	// KVSetJSON stores a key-value pair
+	KVSetJSON(key string, value interface{}) error
+
+	// VKCompareAndSetJSON updates a key-value pair if the current
+	// value is equal to oldValue. Inserts a key-value pair if oldValue is nil.
+	// Will not update it the current value != oldValue.
+	KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) error
+
+	// KVSetWithExpiryJSON stores a key-value pair with an expiry time.
+	KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error
 }
 
 type HelpersImpl struct {

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -6,7 +6,7 @@ package plugin
 import "github.com/mattermost/mattermost-server/model"
 
 type Helpers interface {
-	// EnsureBot ether returns an existing bot user or creates a bot user with
+	// EnsureBot either returns an existing bot user or creates a bot user with
 	// the specifications of the passed bot.
 	// Returns the id of the bot created or existing.
 	EnsureBot(bot *model.Bot) (string, error)
@@ -14,13 +14,13 @@ type Helpers interface {
 	// KVGetJSON retrievs a value based on the key.
 	KVGetJSON(key string, value interface{}) error
 
-	// KVSetJSON stores a key-value pair
+	// KVSetJSON stores a key-value pair.
 	KVSetJSON(key string, value interface{}) error
 
 	// VKCompareAndSetJSON updates a key-value pair if the current
 	// value is equal to oldValue. Inserts a key-value pair if oldValue is nil.
 	// Will not update it the current value != oldValue.
-	KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) error
+	KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) (bool, error)
 
 	// KVSetWithExpiryJSON stores a key-value pair with an expiry time.
 	KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error

--- a/plugin/helpers_bots.go
+++ b/plugin/helpers_bots.go
@@ -83,19 +83,18 @@ func (p *HelpersImpl) KVSetJSON(key string, value interface{}) error {
 	return p.API.KVSet(key, data)
 }
 
-func (p *HelpersImpl) KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) error {
+func (p *HelpersImpl) KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) (bool, error) {
 	oldData, err := json.Marshal(oldValue)
 	if err != nil {
-		return errors.Wrap(err, "unable to marshal old value")
+		return false, errors.Wrap(err, "unable to marshal old value")
 	}
 
 	newData, err := json.Marshal(newValue)
 	if err != nil {
-		return errors.Wrap(err, "unable to marshal new value")
+		return false, errors.Wrap(err, "unable to marshal new value")
 	}
 
-	_, err = p.API.KVCompareAndSet(key, oldData, newData)
-	return err
+	return p.API.KVCompareAndSet(key, oldData, newData)
 }
 
 func (p *HelpersImpl) KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error {

--- a/plugin/helpers_bots.go
+++ b/plugin/helpers_bots.go
@@ -4,6 +4,7 @@
 package plugin
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -63,4 +64,44 @@ func (p *HelpersImpl) EnsureBot(bot *model.Bot) (retBotId string, retErr error) 
 	}
 
 	return createdBot.UserId, nil
+}
+
+func (p *HelpersImpl) KVGetJSON(key string, value interface{}) error {
+	data, err := p.API.KVGet(key)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(data, value)
+}
+
+func (p *HelpersImpl) KVSetJSON(key string, value interface{}) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return p.API.KVSet(key, data)
+}
+
+func (p *HelpersImpl) KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) error {
+	oldData, err := json.Marshal(oldValue)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal old value")
+	}
+
+	newData, err := json.Marshal(newValue)
+	if err != nil {
+		return errors.Wrap(err, "unable to marshal new value")
+	}
+
+	_, err = p.API.KVCompareAndSet(key, oldData, newData)
+	return err
+}
+
+func (p *HelpersImpl) KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return p.API.KVSetWithExpiry(key, data, expireInSeconds)
 }

--- a/plugin/helpers_bots_test.go
+++ b/plugin/helpers_bots_test.go
@@ -223,7 +223,7 @@ func TestKVSetJSON(t *testing.T) {
 
 	t.Run("JSON Marshal error", func(t *testing.T) {
 		api := setupAPI()
-		api.AssertNotCalled(t, "KVSetJSON")
+		api.AssertNotCalled(t, "KVSet")
 
 		p := &plugin.HelpersImpl{API: api}
 

--- a/plugin/helpers_bots_test.go
+++ b/plugin/helpers_bots_test.go
@@ -153,3 +153,162 @@ func TestEnsureBot(t *testing.T) {
 		})
 	})
 }
+
+func TestKVGetJSON(t *testing.T) {
+	setupAPI := func() *plugintest.API {
+		return &plugintest.API{}
+	}
+
+	t.Run("KVGet error", func(t *testing.T) {
+		p := &plugin.HelpersImpl{}
+
+		api := setupAPI()
+		api.On("KVGet", plugin.BOT_USER_KEY).Return(nil, &model.AppError{})
+		p.API = api
+
+		var dat map[string]interface{}
+
+		err := p.KVGetJSON(plugin.BOT_USER_KEY, dat)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Malformed JSON", func(t *testing.T) {
+		key := "test-key"
+
+		p := &plugin.HelpersImpl{}
+
+		api := setupAPI()
+		api.On("KVGet", key).Return([]byte(`{{:}"val-a": 10}`), nil)
+		p.API = api
+
+		var dat map[string]interface{}
+
+		err := p.KVGetJSON(key, &dat)
+
+		assert.NotNil(t, err)
+		assert.Nil(t, dat)
+	})
+
+	t.Run("Valid parameters passed (happy-path)", func(t *testing.T) {
+		key := "test-key"
+
+		p := &plugin.HelpersImpl{}
+
+		api := setupAPI()
+		api.On("KVGet", key).Return([]byte(`{"val-a": 10}`), nil)
+		p.API = api
+
+		var dat map[string]interface{}
+
+		err := p.KVGetJSON(key, &dat)
+
+		assert.Nil(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"val-a": float64(10),
+		}, dat)
+	})
+}
+
+func TestKVSetJSON(t *testing.T) {
+	key := "test-key"
+
+	setupAPI := func() *plugintest.API {
+		return &plugintest.API{}
+	}
+
+	t.Run("JSON Marshal error", func(t *testing.T) {
+		api := setupAPI()
+
+		p := &plugin.HelpersImpl{API: api}
+
+		err := p.KVSetJSON(key, func() { return })
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Valid parameters passed (Happy-path)", func(t *testing.T) {
+		api := setupAPI()
+		api.On("KVSet", key, []byte(`{"val-a":10}`)).Return(nil)
+
+		p := &plugin.HelpersImpl{API: api}
+
+		err := p.KVSetJSON(key, map[string]interface{}{
+			"val-a": float64(10),
+		})
+
+		assert.Nil(t, err)
+	})
+}
+
+func TestKVCompareAndSetJSON(t *testing.T) {
+	key := "test-key"
+	setupAPI := func() *plugintest.API {
+		return &plugintest.API{}
+	}
+
+	t.Run("old value JSON marshal error", func(t *testing.T) {
+		api := setupAPI()
+		p := &plugin.HelpersImpl{API: api}
+
+		ok, err := p.KVCompareAndSetJSON(key, func() { return }, map[string]interface{}{})
+
+		assert.Equal(t, false, ok)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("new value JSON marshal error", func(t *testing.T) {
+		api := setupAPI()
+		p := &plugin.HelpersImpl{API: api}
+
+		ok, err := p.KVCompareAndSetJSON(key, map[string]interface{}{}, func() { return })
+
+		assert.Equal(t, false, ok)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Valid parameters passed (happy-path)", func(t *testing.T) {
+		api := setupAPI()
+		api.On("KVCompareAndSet", key, []byte(`{"val-a":10}`), []byte(`{"val-b":20}`)).Return(false, nil)
+		p := &plugin.HelpersImpl{API: api}
+
+		ok, err := p.KVCompareAndSetJSON(key, map[string]interface{}{
+			"val-a": 10,
+		}, map[string]interface{}{
+			"val-b": 20,
+		})
+
+		assert.Equal(t, false, ok)
+		assert.Nil(t, err)
+	})
+}
+
+func TestKVSetWithExpiryJSON(t *testing.T) {
+	key := "test-key"
+
+	setupAPI := func() *plugintest.API {
+		return &plugintest.API{}
+	}
+
+	t.Run("JSON Marshal error", func(t *testing.T) {
+		api := setupAPI()
+
+		p := &plugin.HelpersImpl{API: api}
+
+		err := p.KVSetWithExpiryJSON(key, func() { return }, 100)
+
+		assert.NotNil(t, err)
+	})
+
+	t.Run("valid parameters passed (happy-path)", func(t *testing.T) {
+		api := setupAPI()
+		api.On("KVSetWithExpiry", key, []byte(`{"val-a":10}`), int64(100)).Return(nil)
+
+		p := &plugin.HelpersImpl{API: api}
+
+		err := p.KVSetWithExpiryJSON(key, map[string]interface{}{
+			"val-a": float64(10),
+		}, 100)
+
+		assert.Nil(t, err)
+	})
+}

--- a/plugin/helpers_bots_test.go
+++ b/plugin/helpers_bots_test.go
@@ -169,7 +169,10 @@ func TestKVGetJSON(t *testing.T) {
 		var dat map[string]interface{}
 
 		err := p.KVGetJSON(plugin.BOT_USER_KEY, dat)
+
+		api.AssertExpectations(t)
 		assert.NotNil(t, err)
+		assert.Nil(t, dat)
 	})
 
 	t.Run("Malformed JSON", func(t *testing.T) {
@@ -185,6 +188,7 @@ func TestKVGetJSON(t *testing.T) {
 
 		err := p.KVGetJSON(key, &dat)
 
+		api.AssertExpectations(t)
 		assert.NotNil(t, err)
 		assert.Nil(t, dat)
 	})
@@ -202,6 +206,7 @@ func TestKVGetJSON(t *testing.T) {
 
 		err := p.KVGetJSON(key, &dat)
 
+		api.AssertExpectations(t)
 		assert.Nil(t, err)
 		assert.Equal(t, map[string]interface{}{
 			"val-a": float64(10),
@@ -218,11 +223,13 @@ func TestKVSetJSON(t *testing.T) {
 
 	t.Run("JSON Marshal error", func(t *testing.T) {
 		api := setupAPI()
+		api.AssertNotCalled(t, "KVSetJSON")
 
 		p := &plugin.HelpersImpl{API: api}
 
 		err := p.KVSetJSON(key, func() { return })
 
+		api.AssertExpectations(t)
 		assert.NotNil(t, err)
 	})
 
@@ -236,6 +243,7 @@ func TestKVSetJSON(t *testing.T) {
 			"val-a": float64(10),
 		})
 
+		api.AssertExpectations(t)
 		assert.Nil(t, err)
 	})
 }
@@ -248,20 +256,25 @@ func TestKVCompareAndSetJSON(t *testing.T) {
 
 	t.Run("old value JSON marshal error", func(t *testing.T) {
 		api := setupAPI()
+		api.AssertNotCalled(t, "KVCompareAndSet")
 		p := &plugin.HelpersImpl{API: api}
 
 		ok, err := p.KVCompareAndSetJSON(key, func() { return }, map[string]interface{}{})
 
+		api.AssertExpectations(t)
 		assert.Equal(t, false, ok)
 		assert.NotNil(t, err)
 	})
 
 	t.Run("new value JSON marshal error", func(t *testing.T) {
 		api := setupAPI()
+		api.AssertNotCalled(t, "KVCompareAndSet")
+
 		p := &plugin.HelpersImpl{API: api}
 
 		ok, err := p.KVCompareAndSetJSON(key, map[string]interface{}{}, func() { return })
 
+		api.AssertExpectations(t)
 		assert.Equal(t, false, ok)
 		assert.NotNil(t, err)
 	})
@@ -277,6 +290,7 @@ func TestKVCompareAndSetJSON(t *testing.T) {
 			"val-b": 20,
 		})
 
+		api.AssertExpectations(t)
 		assert.Equal(t, false, ok)
 		assert.Nil(t, err)
 	})
@@ -291,11 +305,13 @@ func TestKVSetWithExpiryJSON(t *testing.T) {
 
 	t.Run("JSON Marshal error", func(t *testing.T) {
 		api := setupAPI()
+		api.AssertNotCalled(t, "KVSetWithExpiry")
 
 		p := &plugin.HelpersImpl{API: api}
 
 		err := p.KVSetWithExpiryJSON(key, func() { return }, 100)
 
+		api.AssertExpectations(t)
 		assert.NotNil(t, err)
 	})
 
@@ -309,6 +325,7 @@ func TestKVSetWithExpiryJSON(t *testing.T) {
 			"val-a": float64(10),
 		}, 100)
 
+		api.AssertExpectations(t)
 		assert.Nil(t, err)
 	})
 }

--- a/plugin/plugintest/helpers.go
+++ b/plugin/plugintest/helpers.go
@@ -34,17 +34,24 @@ func (_m *Helpers) EnsureBot(bot *model.Bot) (string, error) {
 }
 
 // KVCompareAndSetJSON provides a mock function with given fields: key, oldValue, newValue
-func (_m *Helpers) KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) error {
+func (_m *Helpers) KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) (bool, error) {
 	ret := _m.Called(key, oldValue, newValue)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, interface{}, interface{}) error); ok {
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, interface{}, interface{}) bool); ok {
 		r0 = rf(key, oldValue, newValue)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, interface{}, interface{}) error); ok {
+		r1 = rf(key, oldValue, newValue)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // KVGetJSON provides a mock function with given fields: key, value

--- a/plugin/plugintest/helpers.go
+++ b/plugin/plugintest/helpers.go
@@ -32,3 +32,59 @@ func (_m *Helpers) EnsureBot(bot *model.Bot) (string, error) {
 
 	return r0, r1
 }
+
+// KVCompareAndSetJSON provides a mock function with given fields: key, oldValue, newValue
+func (_m *Helpers) KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) error {
+	ret := _m.Called(key, oldValue, newValue)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, interface{}, interface{}) error); ok {
+		r0 = rf(key, oldValue, newValue)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// KVGetJSON provides a mock function with given fields: key, value
+func (_m *Helpers) KVGetJSON(key string, value interface{}) error {
+	ret := _m.Called(key, value)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, interface{}) error); ok {
+		r0 = rf(key, value)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// KVSetJSON provides a mock function with given fields: key, value
+func (_m *Helpers) KVSetJSON(key string, value interface{}) error {
+	ret := _m.Called(key, value)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, interface{}) error); ok {
+		r0 = rf(key, value)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// KVSetWithExpiryJSON provides a mock function with given fields: key, value, expireInSeconds
+func (_m *Helpers) KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error {
+	ret := _m.Called(key, value, expireInSeconds)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, interface{}, int64) error); ok {
+		r0 = rf(key, value, expireInSeconds)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}


### PR DESCRIPTION
#### Summary
This pull request adds the helper methods KVGet, KVSet, KVSetWithExpiry, and KVCompareAndSet to the Helpers interface in the plugin package.

#### Ticket Link
Jira Ticket: https://mattermost.atlassian.net/browse/MM-8602
Fixes https://github.com/mattermost/mattermost-server/issues/11193