### PR TITLE
MM-16500: Adds ability to retrieve the total count of teams via the API.

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -627,6 +627,8 @@ func TestGetAllTeams(t *testing.T) {
 		PerPage       int
 		Permissions   []string
 		ExpectedTeams []string
+		WithCount     bool
+		ExpectedCount int64
 	}{
 		{
 			Name:          "Get 1 team per page",
@@ -677,6 +679,15 @@ func TestGetAllTeams(t *testing.T) {
 			Permissions:   []string{},
 			ExpectedTeams: []string{},
 		},
+		{
+			Name:          "Get all teams with count",
+			Page:          0,
+			PerPage:       10,
+			Permissions:   []string{model.PERMISSION_LIST_PUBLIC_TEAMS.Id, model.PERMISSION_LIST_PRIVATE_TEAMS.Id},
+			ExpectedTeams: []string{th.BasicTeam.Id, team1.Id, team2.Id, team3.Id},
+			WithCount:     true,
+			ExpectedCount: 4,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -694,12 +705,18 @@ func TestGetAllTeams(t *testing.T) {
 			}
 
 			var teams []*model.Team
-			teams, resp = Client.GetAllTeams("", tc.Page, tc.PerPage)
+			var count int64
+			if tc.WithCount {
+				teams, count, resp = Client.GetAllTeamsWithTotalCount("", tc.Page, tc.PerPage)
+			} else {
+				teams, resp = Client.GetAllTeams("", tc.Page, tc.PerPage)
+			}
 			CheckNoError(t, resp)
 			require.Equal(t, len(tc.ExpectedTeams), len(teams))
 			for idx, team := range teams {
 				assert.Equal(t, tc.ExpectedTeams[idx], team.Id)
 			}
+			require.Equal(t, tc.ExpectedCount, count)
 		})
 	}
 

--- a/app/team.go
+++ b/app/team.go
@@ -613,6 +613,18 @@ func (a *App) GetAllTeamsPage(offset int, limit int) ([]*model.Team, *model.AppE
 	return a.Srv.Store.Team().GetAllPage(offset, limit)
 }
 
+func (a *App) GetAllTeamsPageWithCount(offset int, limit int) (*model.TeamsWithCount, *model.AppError) {
+	totalCount, err := a.Srv.Store.Team().AnalyticsTeamCount()
+	if err != nil {
+		return nil, err
+	}
+	teams, err := a.Srv.Store.Team().GetAllPage(offset, limit)
+	if err != nil {
+		return nil, err
+	}
+	return &model.TeamsWithCount{Teams: teams, TotalCount: totalCount}, nil
+}
+
 func (a *App) GetAllPrivateTeams() ([]*model.Team, *model.AppError) {
 	result := <-a.Srv.Store.Team().GetAllPrivateTeamListing()
 	if result.Err != nil {

--- a/model/client4.go
+++ b/model/client4.go
@@ -1500,6 +1500,18 @@ func (c *Client4) GetAllTeams(etag string, page int, perPage int) ([]*Team, *Res
 	return TeamListFromJson(r.Body), BuildResponse(r)
 }
 
+// GetAllTeamsWithTotalCount returns all teams based on permissions.
+func (c *Client4) GetAllTeamsWithTotalCount(etag string, page int, perPage int) ([]*Team, int64, *Response) {
+	query := fmt.Sprintf("?page=%v&per_page=%v&include_total_count=true", page, perPage)
+	r, err := c.DoApiGet(c.GetTeamsRoute()+query, etag)
+	if err != nil {
+		return nil, 0, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	teamsListWithCount := TeamsWithCountFromJson(r.Body)
+	return teamsListWithCount.Teams, teamsListWithCount.TotalCount, BuildResponse(r)
+}
+
 // GetTeamByName returns a team based on the provided team name string.
 func (c *Client4) GetTeamByName(name, etag string) (*Team, *Response) {
 	r, err := c.DoApiGet(c.GetTeamByNameRoute(name), etag)

--- a/model/team.go
+++ b/model/team.go
@@ -62,6 +62,11 @@ type Invites struct {
 	Invites []map[string]string `json:"invites"`
 }
 
+type TeamsWithCount struct {
+	Teams      []*Team `json:"teams"`
+	TotalCount int64   `json:"total_count"`
+}
+
 func InvitesFromJson(data io.Reader) *Invites {
 	var o *Invites
 	json.NewDecoder(data).Decode(&o)
@@ -106,6 +111,17 @@ func TeamMapFromJson(data io.Reader) map[string]*Team {
 func TeamListToJson(t []*Team) string {
 	b, _ := json.Marshal(t)
 	return string(b)
+}
+
+func TeamsWithCountToJson(tlc *TeamsWithCount) []byte {
+	b, _ := json.Marshal(tlc)
+	return b
+}
+
+func TeamsWithCountFromJson(data io.Reader) *TeamsWithCount {
+	var twc *TeamsWithCount
+	json.NewDecoder(data).Decode(&twc)
+	return twc
 }
 
 func TeamListFromJson(data io.Reader) []*Team {

--- a/web/params.go
+++ b/web/params.go
@@ -69,6 +69,7 @@ type Params struct {
 	NotAssociatedToGroup   string
 	ExcludeDefaultChannels bool
 	GroupIDs               string
+	IncludeTotalCount      bool
 }
 
 func ParamsFromRequest(r *http.Request) *Params {
@@ -270,6 +271,10 @@ func ParamsFromRequest(r *http.Request) *Params {
 	}
 
 	params.GroupIDs = query.Get("group_ids")
+
+	if val, err := strconv.ParseBool(query.Get("include_total_count")); err == nil {
+		params.IncludeTotalCount = val
+	}
 
 	return params
 }


### PR DESCRIPTION
#### Summary

Adds ability to retrieve the total count of teams for use by paginated teams views.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16500