### PR TITLE
MM-16439: Print config ordered by key alphabetically for easy diff.

### DIFF
--- a/cmd/mattermost/commands/config.go
+++ b/cmd/mattermost/commands/config.go
@@ -203,7 +203,7 @@ func printConfigValues(configMap map[string]interface{}, configSetting []string,
 	switch value.Kind() {
 	case reflect.Map:
 		if len(configSetting) == 1 {
-			return printMap(value, 0), nil
+			return printStringMap(value, 0), nil
 		}
 		return printConfigValues(res.(map[string]interface{}), configSetting[1:], name)
 	default:

--- a/cmd/mattermost/commands/utils.go
+++ b/cmd/mattermost/commands/utils.go
@@ -66,8 +66,8 @@ func prettyPrintMap(configMap map[string]interface{}) string {
 	return printStringMap(value, 0)
 }
 
-// printStringMap takes a reflect.Value and prints it out, recursively if it's a map with the given tab settings
-// assumes the key values in the map are of type String, and orders the printed output based on the key values.
+// printStringMap takes a reflect.Value and prints it out alphabetically based on key values, which must be strings.
+// This is done recursively if it's a map, and uses the given tab settings.
 func printStringMap(value reflect.Value, tabVal int) string {
 	out := &bytes.Buffer{}
 

--- a/cmd/mattermost/commands/utils.go
+++ b/cmd/mattermost/commands/utils.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/mlog"
@@ -62,14 +63,25 @@ func structToMap(t interface{}) map[string]interface{} {
 // prettyPrintMap will return a prettyPrint version of a given map
 func prettyPrintMap(configMap map[string]interface{}) string {
 	value := reflect.ValueOf(configMap)
-	return printMap(value, 0)
+	return printStringMap(value, 0)
 }
 
-// printMap takes a reflect.Value and prints it out, recursively if it's a map with the given tab settings
-func printMap(value reflect.Value, tabVal int) string {
+// printStringMap takes a reflect.Value and prints it out, recursively if it's a map with the given tab settings
+// assumes the key values in the map are of type String, and orders the printed output based on the key values.
+func printStringMap(value reflect.Value, tabVal int) string {
 	out := &bytes.Buffer{}
 
-	for _, key := range value.MapKeys() {
+	var sortedKeys []string
+	stringToKeyMap := make(map[string]reflect.Value)
+	for _, k := range value.MapKeys() {
+		sortedKeys = append(sortedKeys, k.String())
+		stringToKeyMap[k.String()] = k
+	}
+
+	sort.Strings(sortedKeys)
+
+	for _, keyString := range sortedKeys {
+		key := stringToKeyMap[keyString]
 		val := value.MapIndex(key)
 		if newVal, ok := val.Interface().(map[string]interface{}); !ok {
 			fmt.Fprintf(out, "%s", strings.Repeat("\t", tabVal))
@@ -79,7 +91,7 @@ func printMap(value reflect.Value, tabVal int) string {
 			fmt.Fprintf(out, "%v:\n", key.Interface())
 			// going one level in, increase the tab
 			tabVal++
-			fmt.Fprintf(out, "%s", printMap(reflect.ValueOf(newVal), tabVal))
+			fmt.Fprintf(out, "%s", printStringMap(reflect.ValueOf(newVal), tabVal))
 			// coming back one level, decrease the tab
 			tabVal--
 		}

--- a/cmd/mattermost/commands/utils_test.go
+++ b/cmd/mattermost/commands/utils_test.go
@@ -139,7 +139,7 @@ func TestPrintMap(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.Name, func(t *testing.T) {
-			res := printMap(test.Input, 0)
+			res := printStringMap(test.Input, 0)
 
 			// create two slice of string formed by splitting our strings on \n
 			slice1 := strings.Split(res, "\n")


### PR DESCRIPTION
#### Summary
Print config ordered by key alphabetically for easy diffing of two different versions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16439