### PR TITLE
MM-16474: SMTP password should be redacted in system console.

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2979,8 +2979,13 @@ func (o *Config) Sanitize() {
 	}
 
 	*o.FileSettings.PublicLinkSalt = FAKE_SETTING
+
 	if len(*o.FileSettings.AmazonS3SecretAccessKey) > 0 {
 		*o.FileSettings.AmazonS3SecretAccessKey = FAKE_SETTING
+	}
+
+	if o.EmailSettings.SMTPPassword != nil && len(*o.EmailSettings.SMTPPassword) > 0 {
+		*o.EmailSettings.SMTPPassword = FAKE_SETTING
 	}
 
 	if len(*o.GitLabSettings.Secret) > 0 {
@@ -2990,6 +2995,8 @@ func (o *Config) Sanitize() {
 	*o.SqlSettings.DataSource = FAKE_SETTING
 	*o.SqlSettings.AtRestEncryptKey = FAKE_SETTING
 
+	*o.ElasticsearchSettings.Password = FAKE_SETTING
+
 	for i := range o.SqlSettings.DataSourceReplicas {
 		o.SqlSettings.DataSourceReplicas[i] = FAKE_SETTING
 	}
@@ -2997,6 +3004,4 @@ func (o *Config) Sanitize() {
 	for i := range o.SqlSettings.DataSourceSearchReplicas {
 		o.SqlSettings.DataSourceSearchReplicas[i] = FAKE_SETTING
 	}
-
-	*o.ElasticsearchSettings.Password = FAKE_SETTING
 }

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -916,3 +916,28 @@ func TestLdapSettingsIsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigSanitize(t *testing.T) {
+	c := Config{}
+	c.SetDefaults()
+
+	*c.LdapSettings.BindPassword = "foo"
+	*c.FileSettings.AmazonS3SecretAccessKey = "bar"
+	*c.EmailSettings.SMTPPassword = "baz"
+	*c.GitLabSettings.Secret = "bingo"
+	c.SqlSettings.DataSourceReplicas = []string{"stuff"}
+	c.SqlSettings.DataSourceSearchReplicas = []string{"stuff"}
+
+	c.Sanitize()
+
+	assert.Equal(t, FAKE_SETTING, *c.LdapSettings.BindPassword)
+	assert.Equal(t, FAKE_SETTING, *c.FileSettings.PublicLinkSalt)
+	assert.Equal(t, FAKE_SETTING, *c.FileSettings.AmazonS3SecretAccessKey)
+	assert.Equal(t, FAKE_SETTING, *c.EmailSettings.SMTPPassword)
+	assert.Equal(t, FAKE_SETTING, *c.GitLabSettings.Secret)
+	assert.Equal(t, FAKE_SETTING, *c.SqlSettings.DataSource)
+	assert.Equal(t, FAKE_SETTING, *c.SqlSettings.AtRestEncryptKey)
+	assert.Equal(t, FAKE_SETTING, *c.ElasticsearchSettings.Password)
+	assert.Equal(t, FAKE_SETTING, c.SqlSettings.DataSourceReplicas[0])
+	assert.Equal(t, FAKE_SETTING, c.SqlSettings.DataSourceSearchReplicas[0])
+}


### PR DESCRIPTION
#### Summary
SMTP password should be redacted in system console.

Fix Santize function to be the opposite of the Desanitize function for
the config file, and add a unit test for Sanitize.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16474