### PR TITLE
[MM-16378] Remove "enable plugin health check" config option

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -586,7 +586,6 @@ func (a *App) trackConfig() {
 		"enable_zoom":                   pluginActivated(cfg.PluginSettings.PluginStates, "zoom"),
 		"enable":                        *cfg.PluginSettings.Enable,
 		"enable_uploads":                *cfg.PluginSettings.EnableUploads,
-		"enable_health_check":           *cfg.PluginSettings.EnableHealthCheck,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_DATA_RETENTION, map[string]interface{}{

--- a/app/server.go
+++ b/app/server.go
@@ -201,14 +201,8 @@ func NewServer(options ...Option) (*Server, error) {
 	// Start plugin health check job
 	pluginsEnvironment := s.PluginsEnvironment
 	if pluginsEnvironment != nil {
-		pluginsEnvironment.InitPluginHealthCheckJob(*s.Config().PluginSettings.EnableHealthCheck)
+		pluginsEnvironment.InitPluginHealthCheckJob()
 	}
-	s.AddConfigListener(func(_, c *model.Config) {
-		pluginsEnvironment := s.PluginsEnvironment
-		if pluginsEnvironment != nil {
-			pluginsEnvironment.InitPluginHealthCheckJob(*c.PluginSettings.EnableHealthCheck)
-		}
-	})
 
 	mlog.Info(fmt.Sprintf("Current version is %v (%v/%v/%v/%v)", model.CurrentVersion, model.BuildNumber, model.BuildDate, model.BuildHash, model.BuildHashEnterprise))
 	mlog.Info(fmt.Sprintf("Enterprise Enabled: %v", model.BuildEnterpriseReady))

--- a/model/config.go
+++ b/model/config.go
@@ -2173,13 +2173,12 @@ type PluginState struct {
 }
 
 type PluginSettings struct {
-	Enable            *bool
-	EnableUploads     *bool   `restricted:"true"`
-	EnableHealthCheck *bool   `restricted:"true"`
-	Directory         *string `restricted:"true"`
-	ClientDirectory   *string `restricted:"true"`
-	Plugins           map[string]map[string]interface{}
-	PluginStates      map[string]*PluginState
+	Enable          *bool
+	EnableUploads   *bool   `restricted:"true"`
+	Directory       *string `restricted:"true"`
+	ClientDirectory *string `restricted:"true"`
+	Plugins         map[string]map[string]interface{}
+	PluginStates    map[string]*PluginState
 }
 
 func (s *PluginSettings) SetDefaults(ls LogSettings) {
@@ -2189,10 +2188,6 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 
 	if s.EnableUploads == nil {
 		s.EnableUploads = NewBool(false)
-	}
-
-	if s.EnableHealthCheck == nil {
-		s.EnableHealthCheck = NewBool(true)
 	}
 
 	if s.Directory == nil {

--- a/plugin/health_check.go
+++ b/plugin/health_check.go
@@ -29,20 +29,11 @@ type PluginHealthStatus struct {
 	lastError      error
 }
 
-// InitPluginHealthCheckJob starts a new job if one is not running and is set to enabled, or kills an existing one if set to disabled.
-func (env *Environment) InitPluginHealthCheckJob(enable bool) {
-	// Config is set to enable. No job exists, start a new job.
-	if enable && env.pluginHealthCheckJob == nil {
-		job := newPluginHealthCheckJob(env)
-		env.pluginHealthCheckJob = job
-		job.Start()
-	}
-
-	// Config is set to disable. Job exists, kill existing job.
-	if !enable && env.pluginHealthCheckJob != nil {
-		env.pluginHealthCheckJob.Cancel()
-		env.pluginHealthCheckJob = nil
-	}
+// InitPluginHealthCheckJob starts a new job for checking all active plugins
+func (env *Environment) InitPluginHealthCheckJob() {
+	job := newPluginHealthCheckJob(env)
+	env.pluginHealthCheckJob = job
+	job.Start()
 }
 
 // Start continuously runs health checks on all active plugins, on a timer.


### PR DESCRIPTION
#### Summary

This PR removes the config value `PluginSettings.EnableHealthCheck`, as it has been determined that there isn't a practical reason why we would want admins to turn off the health check functionality. Discussion on this is here https://github.com/mattermost/mattermost-webapp/pull/2959

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16378
