### PR TITLE
[MM-16183] Store: Migrate TeamStore.GetChannelUnreadsForAllTeams to s…

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -1005,11 +1005,10 @@ func (a *App) FindTeamByName(name string) bool {
 }
 
 func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userId string) ([]*model.TeamUnread, *model.AppError) {
-	result := <-a.Srv.Store.Team().GetChannelUnreadsForAllTeams(excludeTeamId, userId)
-	if result.Err != nil {
-		return nil, result.Err
+	data, err := a.Srv.Store.Team().GetChannelUnreadsForAllTeams(excludeTeamId, userId)
+	if err != nil {
+		return nil, err
 	}
-	data := result.Data.([]*model.ChannelUnread)
 	members := []*model.TeamUnread{}
 	membersMap := make(map[string]*model.TeamUnread)
 

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -728,27 +728,25 @@ func (s SqlTeamStore) GetTeamsForUserWithPagination(userId string, page, perPage
 	return dbMembers.ToModel(), nil
 }
 
-func (s SqlTeamStore) GetChannelUnreadsForAllTeams(excludeTeamId, userId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		var data []*model.ChannelUnread
-		_, err := s.GetReplica().Select(&data,
-			`SELECT
-				Channels.TeamId TeamId, Channels.Id ChannelId, (Channels.TotalMsgCount - ChannelMembers.MsgCount) MsgCount, ChannelMembers.MentionCount MentionCount, ChannelMembers.NotifyProps NotifyProps
-			FROM
-				Channels, ChannelMembers
-			WHERE
-				Id = ChannelId
-                AND UserId = :UserId
-                AND DeleteAt = 0
-                AND TeamId != :TeamId`,
-			map[string]interface{}{"UserId": userId, "TeamId": excludeTeamId})
+func (s SqlTeamStore) GetChannelUnreadsForAllTeams(excludeTeamId, userId string) ([]*model.ChannelUnread, *model.AppError) {
+	var data []*model.ChannelUnread
+	_, err := s.GetReplica().Select(&data,
+		`SELECT
+			Channels.TeamId TeamId, Channels.Id ChannelId, (Channels.TotalMsgCount - ChannelMembers.MsgCount) MsgCount, ChannelMembers.MentionCount MentionCount, ChannelMembers.NotifyProps NotifyProps
+		FROM
+			Channels, ChannelMembers
+		WHERE
+			Id = ChannelId
+			AND UserId = :UserId
+			AND DeleteAt = 0
+			AND TeamId != :TeamId`,
+		map[string]interface{}{"UserId": userId, "TeamId": excludeTeamId})
 
-		if err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.GetChannelUnreadsForAllTeams", "store.sql_team.get_unread.app_error", nil, "userId="+userId+" "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		result.Data = data
-	})
+	if err != nil {
+		return nil, model.NewAppError("SqlTeamStore.GetChannelUnreadsForAllTeams", "store.sql_team.get_unread.app_error", nil, "userId="+userId+" "+err.Error(), http.StatusInternalServerError)
+	}
+
+	return data, nil
 }
 
 func (s SqlTeamStore) GetChannelUnreadsForTeam(teamId, userId string) ([]*model.ChannelUnread, *model.AppError) {

--- a/store/store.go
+++ b/store/store.go
@@ -109,7 +109,7 @@ type TeamStore interface {
 	GetActiveMemberCount(teamId string) (int64, *model.AppError)
 	GetTeamsForUser(userId string) ([]*model.TeamMember, *model.AppError)
 	GetTeamsForUserWithPagination(userId string, page, perPage int) ([]*model.TeamMember, *model.AppError)
-	GetChannelUnreadsForAllTeams(excludeTeamId, userId string) StoreChannel
+	GetChannelUnreadsForAllTeams(excludeTeamId, userId string) ([]*model.ChannelUnread, *model.AppError)
 	GetChannelUnreadsForTeam(teamId, userId string) ([]*model.ChannelUnread, *model.AppError)
 	RemoveMember(teamId string, userId string) StoreChannel
 	RemoveAllMembersByTeam(teamId string) StoreChannel

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -320,19 +320,28 @@ func (_m *TeamStore) GetByName(name string) (*model.Team, *model.AppError) {
 }
 
 // GetChannelUnreadsForAllTeams provides a mock function with given fields: excludeTeamId, userId
-func (_m *TeamStore) GetChannelUnreadsForAllTeams(excludeTeamId string, userId string) store.StoreChannel {
+func (_m *TeamStore) GetChannelUnreadsForAllTeams(excludeTeamId string, userId string) ([]*model.ChannelUnread, *model.AppError) {
 	ret := _m.Called(excludeTeamId, userId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+	var r0 []*model.ChannelUnread
+	if rf, ok := ret.Get(0).(func(string, string) []*model.ChannelUnread); ok {
 		r0 = rf(excludeTeamId, userId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.ChannelUnread)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, string) *model.AppError); ok {
+		r1 = rf(excludeTeamId, userId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetChannelUnreadsForTeam provides a mock function with given fields: teamId, userId

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -1197,13 +1197,12 @@ func testGetChannelUnreadsForAllTeams(t *testing.T, ss store.Store) {
 	cm2 := &model.ChannelMember{ChannelId: c2.Id, UserId: m2.UserId, NotifyProps: model.GetDefaultChannelNotifyProps(), MsgCount: 90}
 	store.Must(ss.Channel().SaveMember(cm2))
 
-	if r1 := <-ss.Team().GetChannelUnreadsForAllTeams("", uid); r1.Err != nil {
-		t.Fatal(r1.Err)
+	if ms1, err := ss.Team().GetChannelUnreadsForAllTeams("", uid); err != nil {
+		t.Fatal(err)
 	} else {
-		ms := r1.Data.([]*model.ChannelUnread)
 		membersMap := make(map[string]bool)
-		for i := range ms {
-			id := ms[i].TeamId
+		for i := range ms1 {
+			id := ms1[i].TeamId
 			if _, ok := membersMap[id]; !ok {
 				membersMap[id] = true
 			}
@@ -1212,18 +1211,17 @@ func testGetChannelUnreadsForAllTeams(t *testing.T, ss store.Store) {
 			t.Fatal("Should be the unreads for all the teams")
 		}
 
-		if ms[0].MsgCount != 10 {
+		if ms1[0].MsgCount != 10 {
 			t.Fatal("subtraction failed")
 		}
 	}
 
-	if r2 := <-ss.Team().GetChannelUnreadsForAllTeams(teamId1, uid); r2.Err != nil {
-		t.Fatal(r2.Err)
+	if ms2, err := ss.Team().GetChannelUnreadsForAllTeams(teamId1, uid); err != nil {
+		t.Fatal(err)
 	} else {
-		ms := r2.Data.([]*model.ChannelUnread)
 		membersMap := make(map[string]bool)
-		for i := range ms {
-			id := ms[i].TeamId
+		for i := range ms2 {
+			id := ms2[i].TeamId
 			if _, ok := membersMap[id]; !ok {
 				membersMap[id] = true
 			}
@@ -1233,7 +1231,7 @@ func testGetChannelUnreadsForAllTeams(t *testing.T, ss store.Store) {
 			t.Fatal("Should be the unreads for just one team")
 		}
 
-		if ms[0].MsgCount != 10 {
+		if ms2[0].MsgCount != 10 {
 			t.Fatal("subtraction failed")
 		}
 	}


### PR DESCRIPTION
## Summary
This PR Migrates `TeamStore.GetChannelUnreadsForAllTeams` to Sync by default in `Team Store` and updates all referencing files to not handle the response from a channel but instead the response and the error directly.

Ticket Link
Fixes #11116 