### PR TITLE
[MM-16561] Store: Migrate UserStore.GetUnreadCount to sync as default

### DIFF
--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -72,11 +72,11 @@ func (a *App) sendPushNotificationSync(post *model.Post, user *model.User, chann
 		SenderId:  post.UserId,
 	}
 
-	if badge := <-a.Srv.Store.User().GetUnreadCount(user.Id); badge.Err != nil {
+	if unreadCount, err := a.Srv.Store.User().GetUnreadCount(user.Id); err != nil {
 		msg.Badge = 1
-		mlog.Error(fmt.Sprint("We could not get the unread message count for the user", user.Id, badge.Err), mlog.String("user_id", user.Id))
+		mlog.Error(fmt.Sprint("We could not get the unread message count for the user", user.Id, err), mlog.String("user_id", user.Id))
 	} else {
-		msg.Badge = int(badge.Data.(int64))
+		msg.Badge = int(unreadCount)
 	}
 
 	contentsConfig := *cfg.EmailSettings.PushNotificationContents
@@ -232,11 +232,11 @@ func (a *App) ClearPushNotificationSync(currentSessionId, userId, channelId stri
 		ContentAvailable: 1,
 	}
 
-	if badge := <-a.Srv.Store.User().GetUnreadCount(userId); badge.Err != nil {
+	if unreadCount, err := a.Srv.Store.User().GetUnreadCount(userId); err != nil {
 		msg.Badge = 0
-		mlog.Error(fmt.Sprint("We could not get the unread message count for the user", userId, badge.Err), mlog.String("user_id", userId))
+		mlog.Error(fmt.Sprint("We could not get the unread message count for the user", userId, err), mlog.String("user_id", userId))
 	} else {
-		msg.Badge = int(badge.Data.(int64))
+		msg.Badge = int(unreadCount)
 	}
 
 	for _, session := range sessions {

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1203,20 +1203,21 @@ func (us SqlUserStore) AnalyticsActiveCount(timePeriod int64) store.StoreChannel
 	})
 }
 
-func (us SqlUserStore) GetUnreadCount(userId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		if count, err := us.GetReplica().SelectInt(`
+func (us SqlUserStore) GetUnreadCount(userId string) (int64, error) {
+	query := `
 		SELECT SUM(CASE WHEN c.Type = 'D' THEN (c.TotalMsgCount - cm.MsgCount) ELSE cm.MentionCount END)
 		FROM Channels c
 		INNER JOIN ChannelMembers cm
-		      ON cm.ChannelId = c.Id
-		      AND cm.UserId = :UserId
-		      AND c.DeleteAt = 0`, map[string]interface{}{"UserId": userId}); err != nil {
-			result.Err = model.NewAppError("SqlUserStore.GetMentionCount", "store.sql_user.get_unread_count.app_error", nil, err.Error(), http.StatusInternalServerError)
-		} else {
-			result.Data = count
-		}
-	})
+			ON cm.ChannelId = c.Id
+			AND cm.UserId = :UserId
+			AND c.DeleteAt = 0
+	`
+	count, err := us.GetReplica().SelectInt(query, map[string]interface{}{"UserId": userId})
+	if err != nil {
+		return count, model.NewAppError("SqlUserStore.GetMentionCount", "store.sql_user.get_unread_count.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return count, nil
 }
 
 func (us SqlUserStore) GetUnreadCountForChannel(userId string, channelId string) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -283,7 +283,7 @@ type UserStore interface {
 	GetSystemAdminProfiles() StoreChannel
 	PermanentDelete(userId string) *model.AppError
 	AnalyticsActiveCount(time int64) StoreChannel
-	GetUnreadCount(userId string) StoreChannel
+	GetUnreadCount(userId string) (int64, error)
 	GetUnreadCountForChannel(userId string, channelId string) StoreChannel
 	GetAnyUnreadPostCountForChannel(userId string, channelId string) StoreChannel
 	GetRecentlyActiveUsersForTeam(teamId string, offset, limit int, viewRestrictions *model.ViewUsersRestrictions) StoreChannel

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -583,19 +583,24 @@ func (_m *UserStore) GetTeamGroupUsers(teamID string) store.StoreChannel {
 }
 
 // GetUnreadCount provides a mock function with given fields: userId
-func (_m *UserStore) GetUnreadCount(userId string) store.StoreChannel {
+func (_m *UserStore) GetUnreadCount(userId string) (int64, error) {
 	ret := _m.Called(userId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
 		r0 = rf(userId)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
-		}
+		r0 = ret.Get(0).(int64)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(userId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetUnreadCountForChannel provides a mock function with given fields: userId, channelId

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1875,7 +1875,8 @@ func testUserUnreadCount(t *testing.T, ss store.Store) {
 	err = ss.Channel().IncrementMentionCount(c2.Id, u2.Id)
 	require.Nil(t, err)
 
-	badge := (<-ss.User().GetUnreadCount(u2.Id)).Data.(int64)
+	badge, unreadCountErr := ss.User().GetUnreadCount(u2.Id)
+	require.Nil(t, unreadCountErr)
 	if badge != 3 {
 		t.Fatal("should have 3 unread messages")
 	}


### PR DESCRIPTION
## Summary
This PR Migrates `TeamStore.GetChannelUnreadsForAllTeams` to Sync by default in `Team Store` and updates all referencing files to not handle the response from a channel but instead the response and the error directly.

Ticket Link
Fixes #11395