### PR TITLE
Migrate "User.SearchWithoutTeam" to Sync by default

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -1782,11 +1782,10 @@ func (a *App) SearchUsersNotInTeam(notInTeamId string, term string, options *mod
 
 func (a *App) SearchUsersWithoutTeam(term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError) {
 	term = strings.TrimSpace(term)
-	result := <-a.Srv.Store.User().SearchWithoutTeam(term, options)
-	if result.Err != nil {
-		return nil, result.Err
+	users, err := a.Srv.Store.User().SearchWithoutTeam(term, options)
+	if err != nil {
+		return nil, err
 	}
-	users := result.Data.([]*model.User)
 
 	for _, user := range users {
 		a.SanitizeProfile(user, options.IsAdmin)

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1237,10 +1237,9 @@ func (us SqlUserStore) Search(teamId string, term string, options *model.UserSea
 	return result.Data.([]*model.User), nil
 }
 
-func (us SqlUserStore) SearchWithoutTeam(term string, options *model.UserSearchOptions) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		query := us.usersQuery.
-			Where(`(
+func (us SqlUserStore) SearchWithoutTeam(term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError) {
+	query := us.usersQuery.
+		Where(`(
 				SELECT
 					COUNT(0)
 				FROM
@@ -1249,11 +1248,14 @@ func (us SqlUserStore) SearchWithoutTeam(term string, options *model.UserSearchO
 					TeamMembers.UserId = u.Id
 					AND TeamMembers.DeleteAt = 0
 			) = 0`).
-			OrderBy("u.Username ASC").
-			Limit(uint64(options.Limit))
+		OrderBy("u.Username ASC").
+		Limit(uint64(options.Limit))
 
-		*result = us.performSearch(query, term, options)
-	})
+	result := us.performSearch(query, term, options)
+	if result.Err != nil {
+		return nil, result.Err
+	}
+	return result.Data.([]*model.User), nil
 }
 
 func (us SqlUserStore) SearchNotInTeam(notInTeamId string, term string, options *model.UserSearchOptions) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -292,7 +292,7 @@ type UserStore interface {
 	SearchNotInTeam(notInTeamId string, term string, options *model.UserSearchOptions) StoreChannel
 	SearchInChannel(channelId string, term string, options *model.UserSearchOptions) StoreChannel
 	SearchNotInChannel(teamId string, channelId string, term string, options *model.UserSearchOptions) StoreChannel
-	SearchWithoutTeam(term string, options *model.UserSearchOptions) StoreChannel
+	SearchWithoutTeam(term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError)
 	AnalyticsGetInactiveUsersCount() StoreChannel
 	AnalyticsGetSystemAdminCount() StoreChannel
 	GetProfilesNotInTeam(teamId string, groupConstrained bool, offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) StoreChannel

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -829,19 +829,28 @@ func (_m *UserStore) SearchNotInTeam(notInTeamId string, term string, options *m
 }
 
 // SearchWithoutTeam provides a mock function with given fields: term, options
-func (_m *UserStore) SearchWithoutTeam(term string, options *model.UserSearchOptions) store.StoreChannel {
+func (_m *UserStore) SearchWithoutTeam(term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError) {
 	ret := _m.Called(term, options)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, *model.UserSearchOptions) store.StoreChannel); ok {
+	var r0 []*model.User
+	if rf, ok := ret.Get(0).(func(string, *model.UserSearchOptions) []*model.User); ok {
 		r0 = rf(term, options)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.User)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, *model.UserSearchOptions) *model.AppError); ok {
+		r1 = rf(term, options)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // Update provides a mock function with given fields: user, allowRoleUpdate

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -3091,12 +3091,12 @@ func testUserStoreSearchWithoutTeam(t *testing.T, ss store.Store) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Description, func(t *testing.T) {
-			result := <-ss.User().SearchWithoutTeam(
+			users, err := ss.User().SearchWithoutTeam(
 				testCase.Term,
 				testCase.Options,
 			)
-			require.Nil(t, result.Err)
-			assertUsers(t, testCase.Expected, result.Data.([]*model.User))
+			require.Nil(t, err)
+			assertUsers(t, testCase.Expected, users)
 		})
 	}
 }


### PR DESCRIPTION
#### Summary
Migrate "User.SearchWithoutTeam" to Sync. Functions `User.SearchWithoutTeam`  returns `([]*model.User, *model.AppError)` instead of `store.StoreChannel` now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16570