### PR TITLE
Changes method name, removes error case.

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2178,7 +2178,7 @@ func TestAddChannelMember(t *testing.T) {
 	require.Nil(t, appErr)
 
 	// Add user to group
-	_, appErr = th.App.CreateOrRestoreGroupMember(th.Group.Id, user.Id)
+	_, appErr = th.App.UpsertGroupMember(th.Group.Id, user.Id)
 	require.Nil(t, appErr)
 
 	_, resp = th.SystemAdminClient.AddChannelMember(privateChannel.Id, user.Id)
@@ -2748,9 +2748,9 @@ func TestChannelMembersMinusGroupMembers(t *testing.T) {
 	group1 := th.CreateGroup()
 	group2 := th.CreateGroup()
 
-	_, err = th.App.CreateOrRestoreGroupMember(group1.Id, user1.Id)
+	_, err = th.App.UpsertGroupMember(group1.Id, user1.Id)
 	require.Nil(t, err)
-	_, err = th.App.CreateOrRestoreGroupMember(group2.Id, user2.Id)
+	_, err = th.App.UpsertGroupMember(group2.Id, user2.Id)
 	require.Nil(t, err)
 
 	// No permissions

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -1540,7 +1540,7 @@ func TestAddTeamMember(t *testing.T) {
 	require.Nil(t, err)
 
 	// Add user to group
-	_, err = th.App.CreateOrRestoreGroupMember(th.Group.Id, otherUser.Id)
+	_, err = th.App.UpsertGroupMember(th.Group.Id, otherUser.Id)
 	require.Nil(t, err)
 
 	_, resp = th.SystemAdminClient.AddTeamMember(team.Id, otherUser.Id)
@@ -1755,7 +1755,7 @@ func TestAddTeamMembers(t *testing.T) {
 	require.Nil(t, err)
 
 	// Add user to group
-	_, err = th.App.CreateOrRestoreGroupMember(th.Group.Id, userList[0])
+	_, err = th.App.UpsertGroupMember(th.Group.Id, userList[0])
 	require.Nil(t, err)
 
 	_, resp = Client.AddTeamMembers(team.Id, userList)
@@ -2525,9 +2525,9 @@ func TestTeamMembersMinusGroupMembers(t *testing.T) {
 	group1 := th.CreateGroup()
 	group2 := th.CreateGroup()
 
-	_, err = th.App.CreateOrRestoreGroupMember(group1.Id, user1.Id)
+	_, err = th.App.UpsertGroupMember(group1.Id, user1.Id)
 	require.Nil(t, err)
-	_, err = th.App.CreateOrRestoreGroupMember(group2.Id, user2.Id)
+	_, err = th.App.UpsertGroupMember(group2.Id, user2.Id)
 	require.Nil(t, err)
 
 	// No permissions

--- a/app/group.go
+++ b/app/group.go
@@ -79,8 +79,8 @@ func (a *App) GetGroupMemberUsersPage(groupID string, page int, perPage int) ([]
 	return members, count, nil
 }
 
-func (a *App) CreateOrRestoreGroupMember(groupID string, userID string) (*model.GroupMember, *model.AppError) {
-	result := <-a.Srv.Store.Group().CreateOrRestoreMember(groupID, userID)
+func (a *App) UpsertGroupMember(groupID string, userID string) (*model.GroupMember, *model.AppError) {
+	result := <-a.Srv.Store.Group().UpsertMember(groupID, userID)
 	if result.Err != nil {
 		return nil, result.Err
 	}

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -105,11 +105,11 @@ func TestCreateOrRestoreGroupMember(t *testing.T) {
 	defer th.TearDown()
 	group := th.CreateGroup()
 
-	g, err := th.App.CreateOrRestoreGroupMember(group.Id, th.BasicUser.Id)
+	g, err := th.App.UpsertGroupMember(group.Id, th.BasicUser.Id)
 	require.Nil(t, err)
 	require.NotNil(t, g)
 
-	g, err = th.App.CreateOrRestoreGroupMember(group.Id, th.BasicUser.Id)
+	g, err = th.App.UpsertGroupMember(group.Id, th.BasicUser.Id)
 	require.NotNil(t, err)
 	require.Nil(t, g)
 }
@@ -118,7 +118,7 @@ func TestDeleteGroupMember(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 	group := th.CreateGroup()
-	groupMember, err := th.App.CreateOrRestoreGroupMember(group.Id, th.BasicUser.Id)
+	groupMember, err := th.App.UpsertGroupMember(group.Id, th.BasicUser.Id)
 	require.Nil(t, err)
 	require.NotNil(t, groupMember)
 

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -110,8 +110,8 @@ func TestCreateOrRestoreGroupMember(t *testing.T) {
 	require.NotNil(t, g)
 
 	g, err = th.App.UpsertGroupMember(group.Id, th.BasicUser.Id)
-	require.NotNil(t, err)
-	require.Nil(t, g)
+	require.Nil(t, err)
+	require.NotNil(t, g)
 }
 
 func TestDeleteGroupMember(t *testing.T) {

--- a/app/syncables_test.go
+++ b/app/syncables_test.go
@@ -89,12 +89,12 @@ func TestCreateDefaultMemberships(t *testing.T) {
 	singer1 := th.BasicUser
 	scientist1 := th.BasicUser2
 
-	_, err = th.App.CreateOrRestoreGroupMember(gleeGroup.Id, singer1.Id)
+	_, err = th.App.UpsertGroupMember(gleeGroup.Id, singer1.Id)
 	if err != nil {
 		t.Errorf("test groupmember not created: %s", err.Error())
 	}
 
-	scientistGroupMember, err := th.App.CreateOrRestoreGroupMember(scienceGroup.Id, scientist1.Id)
+	scientistGroupMember, err := th.App.UpsertGroupMember(scienceGroup.Id, scientist1.Id)
 	if err != nil {
 		t.Errorf("test groupmember not created: %s", err.Error())
 	}
@@ -375,7 +375,7 @@ func TestDeleteGroupMemberships(t *testing.T) {
 	require.Equal(t, 3, int(cmemberCount))
 
 	// add a user to the group
-	_, err = th.App.CreateOrRestoreGroupMember(group.Id, th.SystemAdminUser.Id)
+	_, err = th.App.UpsertGroupMember(group.Id, th.SystemAdminUser.Id)
 	require.Nil(t, err)
 
 	// run the delete

--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -335,7 +335,7 @@ func (s *SqlGroupStore) GetMemberCount(groupID string) store.StoreChannel {
 	})
 }
 
-func (s *SqlGroupStore) CreateOrRestoreMember(groupID string, userID string) store.StoreChannel {
+func (s *SqlGroupStore) UpsertMember(groupID string, userID string) store.StoreChannel {
 	return store.Do(func(result *store.StoreResult) {
 
 		member := &model.GroupMember{
@@ -360,11 +360,6 @@ func (s *SqlGroupStore) CreateOrRestoreMember(groupID string, userID string) sto
 				result.Err = model.NewAppError("SqlGroupStore.GroupCreateOrRestoreMember", "store.select_error", nil, "group_id="+member.GroupId+"user_id="+member.UserId+","+err.Error(), http.StatusInternalServerError)
 				return
 			}
-		}
-
-		if retrievedMember != nil && retrievedMember.DeleteAt == 0 {
-			result.Err = model.NewAppError("SqlGroupStore.GroupCreateOrRestoreMember", "store.sql_group.uniqueness_error", nil, "group_id="+member.GroupId+", user_id="+member.UserId, http.StatusBadRequest)
-			return
 		}
 
 		if retrievedMember == nil {

--- a/store/store.go
+++ b/store/store.go
@@ -583,7 +583,7 @@ type GroupStore interface {
 	GetMemberUsers(groupID string) StoreChannel
 	GetMemberUsersPage(groupID string, offset int, limit int) StoreChannel
 	GetMemberCount(groupID string) StoreChannel
-	CreateOrRestoreMember(groupID string, userID string) StoreChannel
+	UpsertMember(groupID string, userID string) StoreChannel
 	DeleteMember(groupID string, userID string) StoreChannel
 
 	CreateGroupSyncable(groupSyncable *model.GroupSyncable) (*model.GroupSyncable, *model.AppError)

--- a/store/storetest/mocks/GroupStore.go
+++ b/store/storetest/mocks/GroupStore.go
@@ -221,22 +221,6 @@ func (_m *GroupStore) CreateGroupSyncable(groupSyncable *model.GroupSyncable) (*
 	return r0, r1
 }
 
-// CreateOrRestoreMember provides a mock function with given fields: groupID, userID
-func (_m *GroupStore) CreateOrRestoreMember(groupID string, userID string) store.StoreChannel {
-	ret := _m.Called(groupID, userID)
-
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
-		r0 = rf(groupID, userID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
-		}
-	}
-
-	return r0
-}
-
 // Delete provides a mock function with given fields: groupID
 func (_m *GroupStore) Delete(groupID string) store.StoreChannel {
 	ret := _m.Called(groupID)
@@ -654,4 +638,20 @@ func (_m *GroupStore) UpdateGroupSyncable(groupSyncable *model.GroupSyncable) (*
 	}
 
 	return r0, r1
+}
+
+// UpsertMember provides a mock function with given fields: groupID, userID
+func (_m *GroupStore) UpsertMember(groupID string, userID string) store.StoreChannel {
+	ret := _m.Called(groupID, userID)
+
+	var r0 store.StoreChannel
+	if rf, ok := ret.Get(0).(func(string, string) store.StoreChannel); ok {
+		r0 = rf(groupID, userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(store.StoreChannel)
+		}
+	}
+
+	return r0
 }

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1134,7 +1134,7 @@ func testUserStoreGetProfilesNotInChannel(t *testing.T, ss store.Store) {
 
 	// add two members to the group
 	for _, u := range []*model.User{u1, u2} {
-		res := <-ss.Group().CreateOrRestoreMember(group.Id, u.Id)
+		res := <-ss.Group().UpsertMember(group.Id, u.Id)
 		require.Nil(t, res.Err)
 	}
 
@@ -3467,7 +3467,7 @@ func testUserStoreGetProfilesNotInTeam(t *testing.T, ss store.Store) {
 
 	// add two members to the group
 	for _, u := range []*model.User{u1, u2} {
-		res := <-ss.Group().CreateOrRestoreMember(group.Id, u.Id)
+		res := <-ss.Group().UpsertMember(group.Id, u.Id)
 		require.Nil(t, res.Err)
 	}
 
@@ -3776,9 +3776,9 @@ func testUserStoreGetTeamGroupUsers(t *testing.T, ss store.Store) {
 	groupB := testGroups[1]
 
 	// add members to groups
-	res = <-ss.Group().CreateOrRestoreMember(groupA.Id, userGroupA.Id)
+	res = <-ss.Group().UpsertMember(groupA.Id, userGroupA.Id)
 	require.Nil(t, res.Err)
-	res = <-ss.Group().CreateOrRestoreMember(groupB.Id, userGroupB.Id)
+	res = <-ss.Group().UpsertMember(groupB.Id, userGroupB.Id)
 	require.Nil(t, res.Err)
 
 	// association one group to team
@@ -3898,9 +3898,9 @@ func testUserStoreGetChannelGroupUsers(t *testing.T, ss store.Store) {
 	groupB := testGroups[1]
 
 	// add members to groups
-	res = <-ss.Group().CreateOrRestoreMember(groupA.Id, userGroupA.Id)
+	res = <-ss.Group().UpsertMember(groupA.Id, userGroupA.Id)
 	require.Nil(t, res.Err)
-	res = <-ss.Group().CreateOrRestoreMember(groupB.Id, userGroupB.Id)
+	res = <-ss.Group().UpsertMember(groupB.Id, userGroupB.Id)
 	require.Nil(t, res.Err)
 
 	// association one group to channel


### PR DESCRIPTION
#### Summary

Changes a method name from `CreateOrRestore...` to `Upsert...`. Removes "error" case where the record already exists and is un-deleted. It's the desired state.

#### Ticket Link

n/a


#### Dependency

https://github.com/mattermost/enterprise/pull/464