### PR TITLE
[MM-15661] Create SendNotificationEmail and move config option check to it

### DIFF
--- a/app/admin.go
+++ b/app/admin.go
@@ -179,6 +179,10 @@ func (a *App) TestEmail(userId string, cfg *model.Config) *model.AppError {
 		return model.NewAppError("testEmail", "api.admin.test_email.missing_server", nil, utils.T("api.context.invalid_param.app_error", map[string]interface{}{"Name": "SMTPServer"}), http.StatusBadRequest)
 	}
 
+	if !*cfg.EmailSettings.SendEmailNotifications {
+		return nil
+	}
+
 	// if the user hasn't changed their email settings, fill in the actual SMTP password so that
 	// the user can verify an existing SMTP connection
 	if *cfg.EmailSettings.SMTPPassword == model.FAKE_SETTING {

--- a/app/email.go
+++ b/app/email.go
@@ -70,7 +70,7 @@ func (a *App) SendChangeUsernameEmail(oldUsername, newUsername, email, locale, s
 		map[string]interface{}{"TeamDisplayName": a.Config().TeamSettings.SiteName, "NewUsername": newUsername})
 	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendChangeUsernameEmail", "api.user.send_email_change_username_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -94,7 +94,7 @@ func (a *App) SendEmailChangeVerifyEmail(newUserEmail, locale, siteURL, token st
 	bodyPage.Props["VerifyUrl"] = link
 	bodyPage.Props["VerifyButton"] = T("api.templates.email_change_verify_body.button")
 
-	if err := a.SendMail(newUserEmail, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(newUserEmail, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendEmailChangeVerifyEmail", "api.user.send_email_change_verify_email_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -115,7 +115,7 @@ func (a *App) SendEmailChangeEmail(oldEmail, newEmail, locale, siteURL string) *
 		map[string]interface{}{"TeamDisplayName": a.Config().TeamSettings.SiteName, "NewEmail": newEmail})
 	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
-	if err := a.SendMail(oldEmail, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(oldEmail, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendEmailChangeEmail", "api.user.send_email_change_email_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -139,7 +139,7 @@ func (a *App) SendVerifyEmail(userEmail, locale, siteURL, token string) *model.A
 	bodyPage.Props["VerifyUrl"] = link
 	bodyPage.Props["Button"] = T("api.templates.verify_body.button")
 
-	if err := a.SendMail(userEmail, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(userEmail, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendVerifyEmail", "api.user.send_verify_email_and_forget.failed.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -159,7 +159,7 @@ func (a *App) SendSignInChangeEmail(email, method, locale, siteURL string) *mode
 		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"], "Method": method})
 	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendSignInChangeEmail", "api.user.send_sign_in_change_email_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -198,7 +198,7 @@ func (a *App) SendWelcomeEmail(userId string, email string, verified bool, local
 		bodyPage.Props["VerifyUrl"] = link
 	}
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendWelcomeEmail", "api.user.send_welcome_email_and_forget.failed.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -219,7 +219,7 @@ func (a *App) SendPasswordChangeEmail(email, method, locale, siteURL string) *mo
 		map[string]interface{}{"TeamDisplayName": a.Config().TeamSettings.SiteName, "TeamURL": siteURL, "Method": method})
 	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendPasswordChangeEmail", "api.user.send_password_change_email_and_forget.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -239,7 +239,7 @@ func (a *App) SendUserAccessTokenAddedEmail(email, locale, siteURL string) *mode
 		map[string]interface{}{"SiteName": a.ClientConfig()["SiteName"], "SiteURL": siteURL})
 	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendUserAccessTokenAddedEmail", "api.user.send_user_access_token.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -247,7 +247,6 @@ func (a *App) SendUserAccessTokenAddedEmail(email, locale, siteURL string) *mode
 }
 
 func (a *App) SendPasswordResetEmail(email string, token *model.Token, locale, siteURL string) (bool, *model.AppError) {
-
 	T := utils.GetUserTranslations(locale)
 
 	link := fmt.Sprintf("%s/reset_password_complete?token=%s", siteURL, url.QueryEscape(token.Token))
@@ -263,7 +262,7 @@ func (a *App) SendPasswordResetEmail(email string, token *model.Token, locale, s
 	bodyPage.Props["ResetUrl"] = link
 	bodyPage.Props["Button"] = T("api.templates.reset_body.button")
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return false, model.NewAppError("SendPasswordReset", "api.user.send_password_reset.send.app_error", nil, "err="+err.Message, http.StatusInternalServerError)
 	}
 
@@ -288,7 +287,7 @@ func (a *App) SendMfaChangeEmail(email string, activated bool, locale, siteURL s
 	}
 	bodyPage.Props["Warning"] = T("api.templates.email_warning")
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendMfaChangeEmail", "api.user.send_mfa_change_email.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
@@ -351,10 +350,6 @@ func (a *App) SendInviteEmails(team *model.Team, senderName string, senderUserId
 			}
 			bodyPage.Props["Link"] = fmt.Sprintf("%s/signup_user_complete/?d=%s&t=%s", siteURL, url.QueryEscape(data), url.QueryEscape(token.Token))
 
-			if !*a.Config().EmailSettings.SendEmailNotifications {
-				mlog.Info(fmt.Sprintf("sending invitation to %v %v", invite, bodyPage.Props["Link"]))
-			}
-
 			if err := a.SendMail(invite, subject, bodyPage.Render()); err != nil {
 				mlog.Error(fmt.Sprintf("Failed to send invite email successfully err=%v", err))
 			}
@@ -405,11 +400,18 @@ func (a *App) SendDeactivateAccountEmail(email string, locale, siteURL string) *
 		map[string]interface{}{"SiteURL": siteURL})
 	bodyPage.Props["Warning"] = T("api.templates.deactivate_body.warning")
 
-	if err := a.SendMail(email, subject, bodyPage.Render()); err != nil {
+	if err := a.SendNotificationMail(email, subject, bodyPage.Render()); err != nil {
 		return model.NewAppError("SendDeactivateEmail", "api.user.send_deactivate_email_and_forget.failed.error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil
+}
+
+func (a *App) SendNotificationMail(to, subject, htmlBody string) *model.AppError {
+	if !*a.Config().EmailSettings.SendEmailNotifications {
+		return nil
+	}
+	return a.SendMail(to, subject, htmlBody)
 }
 
 func (a *App) SendMail(to, subject, htmlBody string) *model.AppError {

--- a/app/email_batching.go
+++ b/app/email_batching.go
@@ -240,7 +240,7 @@ func (s *Server) sendBatchedEmailNotification(userId string, notifications []*ba
 	body.Props["Posts"] = template.HTML(contents)
 	body.Props["BodyText"] = translateFunc("api.email_batching.send_batched_email_notification.body_text", len(notifications))
 
-	if err := s.FakeApp().SendMail(user.Email, subject, body.Render()); err != nil {
+	if err := s.FakeApp().SendNotificationMail(user.Email, subject, body.Render()); err != nil {
 		mlog.Warn(fmt.Sprintf("Unable to send batched email notification err=%v", err), mlog.String("email", user.Email))
 	}
 }

--- a/app/notification_email.go
+++ b/app/notification_email.go
@@ -104,7 +104,7 @@ func (a *App) sendNotificationEmail(notification *postNotification, user *model.
 	var bodyText = a.getNotificationEmailBody(user, post, channel, channelName, senderName, team.Name, teamURL, emailNotificationContentsType, useMilitaryTime, translateFunc)
 
 	a.Srv.Go(func() {
-		if err := a.SendMail(user.Email, html.UnescapeString(subjectText), bodyText); err != nil {
+		if err := a.SendNotificationMail(user.Email, html.UnescapeString(subjectText), bodyText); err != nil {
 			mlog.Error(fmt.Sprint("Error to send the email", user.Email, err))
 		}
 	})

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -620,7 +620,7 @@ func (api *PluginAPI) SendMail(to, subject, htmlBody string) *model.AppError {
 		return model.NewAppError("SendMail", "plugin_api.send_mail.missing_htmlbody", nil, "", http.StatusBadRequest)
 	}
 
-	return api.app.SendMail(to, subject, htmlBody)
+	return api.app.SendNotificationMail(to, subject, htmlBody)
 }
 
 // Plugin Section

--- a/services/mailservice/mail.go
+++ b/services/mailservice/mail.go
@@ -214,7 +214,7 @@ func SendMailUsingConfig(to, subject, htmlBody string, config *model.Config, ena
 
 // allows for sending an email with attachments and differing MIME/SMTP recipients
 func SendMailUsingConfigAdvanced(mimeTo, smtpTo string, from, replyTo mail.Address, subject, htmlBody string, attachments []*model.FileInfo, mimeHeaders map[string]string, config *model.Config, enableComplianceFeatures bool) *model.AppError {
-	if !*config.EmailSettings.SendEmailNotifications || len(*config.EmailSettings.SMTPServer) == 0 {
+	if len(*config.EmailSettings.SMTPServer) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
#### Summary
This PR moves the conditional that checks for the `EmailSettings.SendEmailNotifications` config parameter from the email service to the application layer, and splits the `SendMail` function into two: `SendNotificationMail` that will send nothing if the config is not enabled, and `SendMail` that will send the email even with the check disabled.

This allows the platform to send email invites when the email notifications config option is disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15661

#### Related Pull Requests
- [Has webapp changes](https://github.com/mattermost/mattermost-webapp/pull/3037)