### PR TITLE
[MM-16698] Rework membership validation in list command handler

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -148,6 +148,11 @@ func listCommands(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !c.App.SessionHasPermissionToTeam(c.App.Session, teamId, model.PERMISSION_VIEW_TEAM) {
+		c.SetPermissionError(model.PERMISSION_VIEW_TEAM)
+		return
+	}
+
 	var commands []*model.Command
 	var err *model.AppError
 	if customOnly {

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -294,6 +294,25 @@ func TestListCommands(t *testing.T) {
 			t.Fatal("Should not list the custom command")
 		}
 	})
+
+	t.Run("NoMember", func(t *testing.T) {
+		Client.Logout()
+		user := th.CreateUser()
+		th.SystemAdminClient.RemoveTeamMember(th.BasicTeam.Id, user.Id)
+		Client.Login(user.Email, user.Password)
+		_, resp := Client.ListCommands(th.BasicTeam.Id, false)
+		CheckForbiddenStatus(t, resp)
+		_, resp = Client.ListCommands(th.BasicTeam.Id, true)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("NotLoggedIn", func(t *testing.T) {
+		Client.Logout()
+		_, resp := Client.ListCommands(th.BasicTeam.Id, false)
+		CheckUnauthorizedStatus(t, resp)
+		_, resp = Client.ListCommands(th.BasicTeam.Id, true)
+		CheckUnauthorizedStatus(t, resp)
+	})
 }
 
 func TestListAutocompleteCommands(t *testing.T) {
@@ -353,6 +372,21 @@ func TestListAutocompleteCommands(t *testing.T) {
 		if foundCustom {
 			t.Fatal("Should not list the custom command")
 		}
+	})
+
+	t.Run("NoMember", func(t *testing.T) {
+		Client.Logout()
+		user := th.CreateUser()
+		th.SystemAdminClient.RemoveTeamMember(th.BasicTeam.Id, user.Id)
+		Client.Login(user.Email, user.Password)
+		_, resp := Client.ListAutocompleteCommands(th.BasicTeam.Id)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("NotLoggedIn", func(t *testing.T) {
+		Client.Logout()
+		_, resp := Client.ListAutocompleteCommands(th.BasicTeam.Id)
+		CheckUnauthorizedStatus(t, resp)
 	})
 }
 


### PR DESCRIPTION
#### Summary
This PR adds an additional check to the listCommands API handler to validate that the requesting user is actually a team member of the team.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16698