### PR TITLE
Avoiding leaking users data through websockets for guest accounts

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -149,6 +149,11 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 	session.AddProp(model.SESSION_PROP_PLATFORM, plat)
 	session.AddProp(model.SESSION_PROP_OS, os)
 	session.AddProp(model.SESSION_PROP_BROWSER, fmt.Sprintf("%v/%v", bname, bversion))
+	if user.IsGuest() {
+		session.AddProp(model.SESSION_PROP_IS_GUEST, "true")
+	} else {
+		session.AddProp(model.SESSION_PROP_IS_GUEST, "false")
+	}
 
 	var err *model.AppError
 	if session, err = a.CreateSession(session); err != nil {

--- a/app/session.go
+++ b/app/session.go
@@ -101,15 +101,14 @@ func (a *App) UpdateSessionsIsGuest(userId string, isGuest bool) {
 
 	for _, session := range sessions {
 		if isGuest {
-			mlog.Error("UPDATING SESSIONS TO GUEST")
 			session.AddProp(model.SESSION_PROP_IS_GUEST, "true")
 		} else {
-			mlog.Error("UPDATING SESSIONS TO NOT GUEST")
 			session.AddProp(model.SESSION_PROP_IS_GUEST, "false")
 		}
-		_, err := a.Srv.Store.Session().Save(session)
+		err := a.Srv.Store.Session().UpdateProps(session)
 		if err != nil {
 			mlog.Error(fmt.Sprintf("Unable to update isGuest session: %s", err.Error()))
+			continue
 		}
 		a.AddSessionToCache(session)
 	}

--- a/app/session_test.go
+++ b/app/session_test.go
@@ -114,3 +114,57 @@ func TestGetSessionIdleTimeoutInMinutes(t *testing.T) {
 	_, err = th.App.GetSession(session.Token)
 	assert.Nil(t, err)
 }
+
+func TestUpdateSessionOnPromoteDemote(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	th.App.SetLicense(model.NewTestLicense())
+
+	t.Run("Promote Guest to User updates the session", func(t *testing.T) {
+		guest := th.CreateGuest()
+
+		session, err := th.App.CreateSession(&model.Session{UserId: guest.Id, Props: model.StringMap{model.SESSION_PROP_IS_GUEST: "true"}})
+		require.Nil(t, err)
+
+		rsession, err := th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		assert.Equal(t, "true", rsession.Props[model.SESSION_PROP_IS_GUEST])
+
+		err = th.App.PromoteGuestToUser(guest, th.BasicUser.Id)
+		require.Nil(t, err)
+
+		rsession, err = th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		assert.Equal(t, "false", rsession.Props[model.SESSION_PROP_IS_GUEST])
+
+		th.App.ClearSessionCacheForUser(session.UserId)
+
+		rsession, err = th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		assert.Equal(t, "false", rsession.Props[model.SESSION_PROP_IS_GUEST])
+	})
+
+	t.Run("Demote User to Guest updates the session", func(t *testing.T) {
+		user := th.CreateUser()
+
+		session, err := th.App.CreateSession(&model.Session{UserId: user.Id, Props: model.StringMap{model.SESSION_PROP_IS_GUEST: "false"}})
+		require.Nil(t, err)
+
+		rsession, err := th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		assert.Equal(t, "false", rsession.Props[model.SESSION_PROP_IS_GUEST])
+
+		err = th.App.DemoteUserToGuest(user)
+		require.Nil(t, err)
+
+		rsession, err = th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		assert.Equal(t, "true", rsession.Props[model.SESSION_PROP_IS_GUEST])
+
+		th.App.ClearSessionCacheForUser(session.UserId)
+		rsession, err = th.App.GetSession(session.Token)
+		require.Nil(t, err)
+		assert.Equal(t, "true", rsession.Props[model.SESSION_PROP_IS_GUEST])
+	})
+}

--- a/app/user.go
+++ b/app/user.go
@@ -1111,13 +1111,13 @@ func (a *App) sendUpdatedUserEvent(user model.User) {
 	adminCopyOfUser := user.DeepCopy()
 	a.SanitizeProfile(adminCopyOfUser, true)
 	adminMessage := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
-	adminMessage.Add("user", *adminCopyOfUser)
+	adminMessage.Add("user", &adminCopyOfUser)
 	adminMessage.Broadcast.ContainsSensitiveData = true
 	a.Publish(adminMessage)
 
 	a.SanitizeProfile(&user, false)
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
-	message.Add("user", user)
+	message.Add("user", &user)
 	message.Broadcast.ContainsSanitizedData = true
 	a.Publish(message)
 }
@@ -2275,6 +2275,8 @@ func (a *App) PromoteGuestToUser(user *model.User, requestorId string) *model.Ap
 	message.Add("user", promotedUser)
 	a.Publish(message)
 
+	a.UpdateSessionsIsGuest(promotedUser.Id, promotedUser.IsGuest())
+
 	return nil
 }
 
@@ -2294,6 +2296,8 @@ func (a *App) DemoteUserToGuest(user *model.User) *model.AppError {
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
 	message.Add("user", demotedUser)
 	a.Publish(message)
+
+	a.UpdateSessionsIsGuest(demotedUser.Id, demotedUser.IsGuest())
 
 	return nil
 }

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -356,6 +356,15 @@ func (webCon *WebConn) ShouldSendEvent(msg *model.WebSocketEvent) bool {
 		return webCon.IsMemberOfTeam(msg.Broadcast.TeamId)
 	}
 
+	if msg.Event == model.WEBSOCKET_EVENT_USER_UPDATED && webCon.GetSession().Props[model.SESSION_PROP_IS_GUEST] == "true" {
+		canSee, err := webCon.App.UserCanSeeOtherUser(webCon.UserId, msg.Data["user"].(*model.User).Id)
+		if err != nil {
+			mlog.Error("webhub.shouldSendEvent: " + err.Error())
+			return false
+		}
+		return canSee
+	}
+
 	return true
 }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6503,6 +6503,10 @@
     "translation": "Unable to update the last_activity_at"
   },
   {
+    "id": "store.sql_session.update_props.app_error",
+    "translation": "Unable to update session props"
+  },
+  {
     "id": "store.sql_session.update_roles.app_error",
     "translation": "Unable to update the roles"
   },

--- a/model/session.go
+++ b/model/session.go
@@ -22,6 +22,7 @@ const (
 	SESSION_PROP_IS_BOT               = "is_bot"
 	SESSION_PROP_IS_BOT_VALUE         = "true"
 	SESSION_TYPE_USER_ACCESS_TOKEN    = "UserAccessToken"
+	SESSION_PROP_IS_GUEST             = "is_guest"
 	SESSION_ACTIVITY_TIMEOUT          = 1000 * 60 * 5 // 5 minutes
 	SESSION_USER_ACCESS_TOKEN_EXPIRY  = 100 * 365     // 100 years
 )

--- a/store/sqlstore/session_store.go
+++ b/store/sqlstore/session_store.go
@@ -206,6 +206,23 @@ func (me SqlSessionStore) UpdateDeviceId(id string, deviceId string, expiresAt i
 	return deviceId, nil
 }
 
+func (me SqlSessionStore) UpdateProps(session *model.Session) *model.AppError {
+	oldSession, appErr := me.Get(session.Id)
+	if appErr != nil {
+		return appErr
+	}
+	oldSession.Props = session.Props
+
+	count, err := me.GetMaster().Update(oldSession)
+	if err != nil {
+		return model.NewAppError("SqlSessionStore.UpdateProps", "store.sql_session.update_props.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	if count != 1 {
+		return model.NewAppError("SqlSessionStore.UpdateProps", "store.sql_session.update_props.app_error", nil, "", http.StatusInternalServerError)
+	}
+	return nil
+}
+
 func (me SqlSessionStore) AnalyticsSessionCount() (int64, *model.AppError) {
 	query :=
 		`SELECT

--- a/store/store.go
+++ b/store/store.go
@@ -327,6 +327,7 @@ type SessionStore interface {
 	UpdateLastActivityAt(sessionId string, time int64) *model.AppError
 	UpdateRoles(userId string, roles string) (string, *model.AppError)
 	UpdateDeviceId(id string, deviceId string, expiresAt int64) (string, *model.AppError)
+	UpdateProps(session *model.Session) *model.AppError
 	AnalyticsSessionCount() (int64, *model.AppError)
 	Cleanup(expiryTime int64, batchSize int64)
 }

--- a/store/storetest/mocks/SessionStore.go
+++ b/store/storetest/mocks/SessionStore.go
@@ -227,6 +227,22 @@ func (_m *SessionStore) UpdateLastActivityAt(sessionId string, time int64) *mode
 	return r0
 }
 
+// UpdateProps provides a mock function with given fields: session
+func (_m *SessionStore) UpdateProps(session *model.Session) *model.AppError {
+	ret := _m.Called(session)
+
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(*model.Session) *model.AppError); ok {
+		r0 = rf(session)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
+		}
+	}
+
+	return r0
+}
+
 // UpdateRoles provides a mock function with given fields: userId, roles
 func (_m *SessionStore) UpdateRoles(userId string, roles string) (string, *model.AppError) {
 	ret := _m.Called(userId, roles)


### PR DESCRIPTION
#### Summary
Avoiding leaking users data through websockets for guest accounts. Now the
guest accounts only receive update notifications from users that they can see.

#### Ticket Link
[MM-15810](https://mattermost.atlassian.net/browse/MM-15810)