### PR TITLE
[MM-16672] Migrate "User.GetSystemAdminProfiles" to Sync by default

### DIFF
--- a/app/security_update_check.go
+++ b/app/security_update_check.go
@@ -94,12 +94,11 @@ func (s *Server) DoSecurityUpdateCheck() {
 		for _, bulletin := range bulletins {
 			if bulletin.AppliesToVersion == model.CurrentVersion {
 				if props["SecurityBulletin_"+bulletin.Id] == "" {
-					results := <-s.Store.User().GetSystemAdminProfiles()
-					if results.Err != nil {
+					users, userErr := s.Store.User().GetSystemAdminProfiles()
+					if userErr != nil {
 						mlog.Error("Failed to get system admins for security update information from Mattermost.")
 						return
 					}
-					users := results.Data.(map[string]*model.User)
 
 					resBody, err := http.Get(SECURITY_URL + "/bulletins/" + bulletin.Id)
 					if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -280,7 +280,7 @@ type UserStore interface {
 	GetEtagForAllProfiles() StoreChannel
 	GetEtagForProfiles(teamId string) StoreChannel
 	UpdateFailedPasswordAttempts(userId string, attempts int) StoreChannel
-	GetSystemAdminProfiles() StoreChannel
+	GetSystemAdminProfiles() (map[string]*model.User, *model.AppError)
 	PermanentDelete(userId string) *model.AppError
 	AnalyticsActiveCount(time int64) StoreChannel
 	GetUnreadCount(userId string) (int64, error)

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -617,19 +617,28 @@ func (_m *UserStore) GetRecentlyActiveUsersForTeam(teamId string, offset int, li
 }
 
 // GetSystemAdminProfiles provides a mock function with given fields:
-func (_m *UserStore) GetSystemAdminProfiles() store.StoreChannel {
+func (_m *UserStore) GetSystemAdminProfiles() (map[string]*model.User, *model.AppError) {
 	ret := _m.Called()
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func() store.StoreChannel); ok {
+	var r0 map[string]*model.User
+	if rf, ok := ret.Get(0).(func() map[string]*model.User); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(map[string]*model.User)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetTeamGroupUsers provides a mock function with given fields: teamID

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1449,12 +1449,12 @@ func testUserStoreGetSystemAdminProfiles(t *testing.T, ss store.Store) {
 	defer func() { require.Nil(t, ss.Bot().PermanentDelete(u3.Id)) }()
 
 	t.Run("all system admin profiles", func(t *testing.T) {
-		result := <-ss.User().GetSystemAdminProfiles()
-		require.Nil(t, result.Err)
+		result, userError := ss.User().GetSystemAdminProfiles()
+		require.Nil(t, userError)
 		assert.Equal(t, map[string]*model.User{
 			u1.Id: sanitized(u1),
 			u3.Id: sanitized(u3),
-		}, result.Data.(map[string]*model.User))
+		}, result)
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--

-->
Migrate "User.GetSystemAdminProfiles" to Sync by default and updates any impacted code.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.



Otherwise, link the JIRA ticket.
-->
  Fixes https://github.com/mattermost/mattermost-server/issues/11448