### PR TITLE
SyncStore: Migrate User.GetForLogin method to Sync 

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -93,8 +93,8 @@ func (a *App) GetUserForLogin(id, loginId string) (*model.User, *model.AppError)
 	}
 
 	// Try to get the user by username/email
-	if result := <-a.Srv.Store.User().GetForLogin(loginId, enableUsername, enableEmail); result.Err == nil {
-		return result.Data.(*model.User), nil
+	if user, err := a.Srv.Store.User().GetForLogin(loginId, enableUsername, enableEmail); err == nil {
+		return user, nil
 	}
 
 	// Try to get the user with LDAP if enabled

--- a/store/store.go
+++ b/store/store.go
@@ -275,7 +275,7 @@ type UserStore interface {
 	GetByAuth(authData *string, authService string) (*model.User, *model.AppError)
 	GetAllUsingAuthService(authService string) ([]*model.User, *model.AppError)
 	GetByUsername(username string) StoreChannel
-	GetForLogin(loginId string, allowSignInWithUsername, allowSignInWithEmail bool) StoreChannel
+	GetForLogin(loginId string, allowSignInWithUsername, allowSignInWithEmail bool) (*model.User, *model.AppError)
 	VerifyEmail(userId, email string) (string, *model.AppError)
 	GetEtagForAllProfiles() StoreChannel
 	GetEtagForProfiles(teamId string) StoreChannel

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -405,19 +405,28 @@ func (_m *UserStore) GetEtagForProfilesNotInTeam(teamId string) store.StoreChann
 }
 
 // GetForLogin provides a mock function with given fields: loginId, allowSignInWithUsername, allowSignInWithEmail
-func (_m *UserStore) GetForLogin(loginId string, allowSignInWithUsername bool, allowSignInWithEmail bool) store.StoreChannel {
+func (_m *UserStore) GetForLogin(loginId string, allowSignInWithUsername bool, allowSignInWithEmail bool) (*model.User, *model.AppError) {
 	ret := _m.Called(loginId, allowSignInWithUsername, allowSignInWithEmail)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, bool, bool) store.StoreChannel); ok {
+	var r0 *model.User
+	if rf, ok := ret.Get(0).(func(string, bool, bool) *model.User); ok {
 		r0 = rf(loginId, allowSignInWithUsername, allowSignInWithEmail)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.User)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, bool, bool) *model.AppError); ok {
+		r1 = rf(loginId, allowSignInWithUsername, allowSignInWithEmail)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetNewUsersForTeam provides a mock function with given fields: teamId, offset, limit, viewRestrictions

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1698,45 +1698,45 @@ func testUserStoreGetForLogin(t *testing.T, ss store.Store) {
 	defer func() { require.Nil(t, ss.Bot().PermanentDelete(u3.Id)) }()
 
 	t.Run("get u1 by username, allow both", func(t *testing.T) {
-		result := <-ss.User().GetForLogin(u1.Username, true, true)
-		require.Nil(t, result.Err)
-		assert.Equal(t, u1, result.Data.(*model.User))
+		user, err := ss.User().GetForLogin(u1.Username, true, true)
+		require.Nil(t, err)
+		assert.Equal(t, u1, user)
 	})
 
 	t.Run("get u1 by username, allow only email", func(t *testing.T) {
-		result := <-ss.User().GetForLogin(u1.Username, false, true)
-		require.NotNil(t, result.Err)
-		require.Equal(t, result.Err.Id, "store.sql_user.get_for_login.app_error")
+		_, err := ss.User().GetForLogin(u1.Username, false, true)
+		require.NotNil(t, err)
+		require.Equal(t, err.Id, "store.sql_user.get_for_login.app_error")
 	})
 
 	t.Run("get u1 by email, allow both", func(t *testing.T) {
-		result := <-ss.User().GetForLogin(u1.Email, true, true)
-		require.Nil(t, result.Err)
-		assert.Equal(t, u1, result.Data.(*model.User))
+		user, err := ss.User().GetForLogin(u1.Email, true, true)
+		require.Nil(t, err)
+		assert.Equal(t, u1, user)
 	})
 
 	t.Run("get u1 by email, allow only username", func(t *testing.T) {
-		result := <-ss.User().GetForLogin(u1.Email, true, false)
-		require.NotNil(t, result.Err)
-		require.Equal(t, result.Err.Id, "store.sql_user.get_for_login.app_error")
+		_, err := ss.User().GetForLogin(u1.Email, true, false)
+		require.NotNil(t, err)
+		require.Equal(t, err.Id, "store.sql_user.get_for_login.app_error")
 	})
 
 	t.Run("get u2 by username, allow both", func(t *testing.T) {
-		result := <-ss.User().GetForLogin(u2.Username, true, true)
-		require.Nil(t, result.Err)
-		assert.Equal(t, u2, result.Data.(*model.User))
+		user, err := ss.User().GetForLogin(u2.Username, true, true)
+		require.Nil(t, err)
+		assert.Equal(t, u2, user)
 	})
 
 	t.Run("get u2 by email, allow both", func(t *testing.T) {
-		result := <-ss.User().GetForLogin(u2.Email, true, true)
-		require.Nil(t, result.Err)
-		assert.Equal(t, u2, result.Data.(*model.User))
+		user, err := ss.User().GetForLogin(u2.Email, true, true)
+		require.Nil(t, err)
+		assert.Equal(t, u2, user)
 	})
 
 	t.Run("get u2 by username, allow neither", func(t *testing.T) {
-		result := <-ss.User().GetForLogin(u2.Username, false, false)
-		require.NotNil(t, result.Err)
-		require.Equal(t, result.Err.Id, "store.sql_user.get_for_login.app_error")
+		_, err := ss.User().GetForLogin(u2.Username, false, false)
+		require.NotNil(t, err)
+		require.Equal(t, err.Id, "store.sql_user.get_for_login.app_error")
 	})
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR migrates GetForLogin in the Store layer to be sync by default

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

[Jira Ticket](https://mattermost.atlassian.net/browse/MM-16668)

#11452