### PR TITLE
MM-16796: reduce plugin job interval to once per day

### DIFF
--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -25,8 +25,6 @@ type Helpers interface {
 	KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) (bool, error)
 
 	// KVSetWithExpiryJSON stores a key-value pair with an expiry time.
-	//
-	// Minimum server version: 5.6
 	KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error
 }
 

--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -25,6 +25,8 @@ type Helpers interface {
 	KVCompareAndSetJSON(key string, oldValue interface{}, newValue interface{}) (bool, error)
 
 	// KVSetWithExpiryJSON stores a key-value pair with an expiry time.
+	//
+	// Minimum server version: 5.6
 	KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error
 }
 

--- a/plugin/scheduler/scheduler.go
+++ b/plugin/scheduler/scheduler.go
@@ -11,6 +11,8 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 )
 
+const pluginsJobInterval = 24 * 60 * 60 * time.Second
+
 type Scheduler struct {
 	App *app.App
 }
@@ -32,7 +34,7 @@ func (scheduler *Scheduler) Enabled(cfg *model.Config) bool {
 }
 
 func (scheduler *Scheduler) NextScheduleTime(cfg *model.Config, now time.Time, pendingJobs bool, lastSuccessfulJob *model.Job) *time.Time {
-	nextTime := time.Now().Add(60 * time.Second)
+	nextTime := time.Now().Add(pluginsJobInterval)
 	return &nextTime
 }
 

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -699,6 +699,9 @@ func UpgradeDatabaseToVersion512(sqlStore SqlStore) {
 
 func UpgradeDatabaseToVersion513(sqlStore SqlStore) {
 	if shouldPerformUpgrade(sqlStore, VERSION_5_12_0, VERSION_5_13_0) {
+		// The previous jobs ran once per minute, cluttering the Jobs table with somewhat useless entries. Clean that up.
+		sqlStore.GetMaster().Exec("DELETE FROM Jobs WHERE Type = 'plugins'")
+
 		saveSchemaVersion(sqlStore, VERSION_5_13_0)
 	}
 }


### PR DESCRIPTION
#### Summary
The Jobs infrastructure isn't currently setup for running frequent jobs,
as it spams the Jobs table with useless records. Update the plugin job
interval to run less frequently -- since the cleanup doesn't affect
semantics anyway -- and clean up the previously created entries in the Jobs table.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16796