### PR TITLE
[MM-16773] Migrate Team.RemoveAllMembersByTeam to Sync by default

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -1075,8 +1075,8 @@ func (a *App) PermanentDeleteTeam(team *model.Team) *model.AppError {
 		}
 	}
 
-	if result := <-a.Srv.Store.Team().RemoveAllMembersByTeam(team.Id); result.Err != nil {
-		return result.Err
+	if err := a.Srv.Store.Team().RemoveAllMembersByTeam(team.Id); err != nil {
+		return err
 	}
 
 	if err := a.Srv.Store.Command().PermanentDeleteByTeam(team.Id); err != nil {

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -776,13 +776,12 @@ func (s SqlTeamStore) RemoveMember(teamId string, userId string) store.StoreChan
 	})
 }
 
-func (s SqlTeamStore) RemoveAllMembersByTeam(teamId string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		_, err := s.GetMaster().Exec("DELETE FROM TeamMembers WHERE TeamId = :TeamId", map[string]interface{}{"TeamId": teamId})
-		if err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.RemoveMember", "store.sql_team.remove_member.app_error", nil, "team_id="+teamId+", "+err.Error(), http.StatusInternalServerError)
-		}
-	})
+func (s SqlTeamStore) RemoveAllMembersByTeam(teamId string) *model.AppError {
+	_, err := s.GetMaster().Exec("DELETE FROM TeamMembers WHERE TeamId = :TeamId", map[string]interface{}{"TeamId": teamId})
+	if err != nil {
+		return model.NewAppError("SqlTeamStore.RemoveMember", "store.sql_team.remove_member.app_error", nil, "team_id="+teamId+", "+err.Error(), http.StatusInternalServerError)
+	}
+	return nil
 }
 
 func (s SqlTeamStore) RemoveAllMembersByUser(userId string) store.StoreChannel {

--- a/store/store.go
+++ b/store/store.go
@@ -112,7 +112,7 @@ type TeamStore interface {
 	GetChannelUnreadsForAllTeams(excludeTeamId, userId string) ([]*model.ChannelUnread, *model.AppError)
 	GetChannelUnreadsForTeam(teamId, userId string) ([]*model.ChannelUnread, *model.AppError)
 	RemoveMember(teamId string, userId string) StoreChannel
-	RemoveAllMembersByTeam(teamId string) StoreChannel
+	RemoveAllMembersByTeam(teamId string) *model.AppError
 	RemoveAllMembersByUser(userId string) StoreChannel
 	UpdateLastTeamIconUpdate(teamId string, curTime int64) StoreChannel
 	GetTeamsByScheme(schemeId string, offset int, limit int) StoreChannel

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -619,15 +619,15 @@ func (_m *TeamStore) PermanentDelete(teamId string) *model.AppError {
 }
 
 // RemoveAllMembersByTeam provides a mock function with given fields: teamId
-func (_m *TeamStore) RemoveAllMembersByTeam(teamId string) store.StoreChannel {
+func (_m *TeamStore) RemoveAllMembersByTeam(teamId string) *model.AppError {
 	ret := _m.Called(teamId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(string) *model.AppError); ok {
 		r0 = rf(teamId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).(*model.AppError)
 		}
 	}
 

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -818,8 +818,8 @@ func testTeamMembers(t *testing.T, ss store.Store) {
 
 	store.Must(ss.Team().SaveMember(m1, -1))
 
-	if r1 := <-ss.Team().RemoveAllMembersByTeam(teamId1); r1.Err != nil {
-		t.Fatal(r1.Err)
+	if err := ss.Team().RemoveAllMembersByTeam(teamId1); err != nil {
+		t.Fatal(err)
 	}
 
 	if ms, err := ss.Team().GetMembers(teamId1, 0, 100, nil); err != nil {
@@ -885,8 +885,8 @@ func testTeamMembersWithPagination(t *testing.T, ss store.Store) {
 
 	store.Must(ss.Team().SaveMember(m1, -1))
 
-	r1 = <-ss.Team().RemoveAllMembersByTeam(teamId1)
-	require.Nil(t, r1.Err)
+	err = ss.Team().RemoveAllMembersByTeam(teamId1)
+	require.Nil(t, err)
 
 	uid := model.NewId()
 	m4 := &model.TeamMember{TeamId: teamId1, UserId: uid}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR migrates RemoveAllMembersByTeam in the Store layer to be sync by default

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

[Jira Ticket](https://mattermost.atlassian.net/browse/MM-16773)

Fixes #11555