### PR TITLE
[MM-16782] Migrate "Team.GetTeamMembersForExport" to Sync by default

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -252,13 +252,11 @@ func (a *App) ExportAllUsers(writer io.Writer) *model.AppError {
 func (a *App) buildUserTeamAndChannelMemberships(userId string) (*[]UserTeamImportData, *model.AppError) {
 	var memberships []UserTeamImportData
 
-	result := <-a.Srv.Store.Team().GetTeamMembersForExport(userId)
+	members, err := a.Srv.Store.Team().GetTeamMembersForExport(userId)
 
-	if result.Err != nil {
-		return nil, result.Err
+	if err != nil {
+		return nil, err
 	}
-
-	members := result.Data.([]*model.TeamMemberForExport)
 
 	for _, member := range members {
 		// Skip deleted.

--- a/store/store.go
+++ b/store/store.go
@@ -121,7 +121,7 @@ type TeamStore interface {
 	ClearAllCustomRoleAssignments() StoreChannel
 	AnalyticsGetTeamCountForScheme(schemeId string) StoreChannel
 	GetAllForExportAfter(limit int, afterId string) StoreChannel
-	GetTeamMembersForExport(userId string) StoreChannel
+	GetTeamMembersForExport(userId string) ([]*model.TeamMemberForExport, *model.AppError)
 	UserBelongsToTeams(userId string, teamIds []string) StoreChannel
 	GetUserTeamIds(userId string, allowFromCache bool) StoreChannel
 	InvalidateAllTeamIdsForUser(userId string)

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -445,19 +445,28 @@ func (_m *TeamStore) GetMembersByIds(teamId string, userIds []string, restrictio
 }
 
 // GetTeamMembersForExport provides a mock function with given fields: userId
-func (_m *TeamStore) GetTeamMembersForExport(userId string) store.StoreChannel {
+func (_m *TeamStore) GetTeamMembersForExport(userId string) ([]*model.TeamMemberForExport, *model.AppError) {
 	ret := _m.Called(userId)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string) store.StoreChannel); ok {
+	var r0 []*model.TeamMemberForExport
+	if rf, ok := ret.Get(0).(func(string) []*model.TeamMemberForExport); ok {
 		r0 = rf(userId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.TeamMemberForExport)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(userId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetTeamsByScheme provides a mock function with given fields: schemeId, offset, limit

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -1647,10 +1647,9 @@ func testTeamStoreGetTeamMembersForExport(t *testing.T, ss store.Store) {
 	m2 := &model.TeamMember{TeamId: t1.Id, UserId: u2.Id}
 	store.Must(ss.Team().SaveMember(m2, -1))
 
-	r1 := <-ss.Team().GetTeamMembersForExport(u1.Id)
-	assert.Nil(t, r1.Err)
+	d1, err := ss.Team().GetTeamMembersForExport(u1.Id)
+	assert.Nil(t, err)
 
-	d1 := r1.Data.([]*model.TeamMemberForExport)
 	assert.Len(t, d1, 1)
 
 	tmfe1 := d1[0]


### PR DESCRIPTION
Summary
Migrate `Team.GetTeamMembersForExport` to sync by default.

Fixes https://github.com/mattermost/mattermost-server/issues/11546
