### PR TITLE
MM-16548: Fixing bug with empty type in the second line of the bulk import

### DIFF
--- a/app/import.go
+++ b/app/import.go
@@ -44,7 +44,7 @@ func (a *App) BulkImport(fileReader io.Reader, dryRun bool, workers int) (*model
 	errorsChan := make(chan LineImportWorkerError, (2*workers)+1) // size chosen to ensure it never gets filled up completely.
 	var wg sync.WaitGroup
 	var linesChan chan LineImportWorkerData
-	lastLineType := ""
+	lastLineType := "begin"
 
 	for scanner.Scan() {
 		decoder := json.NewDecoder(strings.NewReader(scanner.Text()))
@@ -68,7 +68,7 @@ func (a *App) BulkImport(fileReader io.Reader, dryRun bool, workers int) (*model
 		}
 
 		if line.Type != lastLineType {
-			if lastLineType != "" {
+			if lastLineType != "begin" {
 				// Changing type. Clear out the worker queue before continuing.
 				close(linesChan)
 				wg.Wait()

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -226,6 +226,14 @@ func TestImportBulkImport(t *testing.T) {
 	if err, line := th.App.BulkImport(strings.NewReader(data3), false, 2); err == nil || line != 1 {
 		t.Fatalf("Should have failed due to missing version line on line 1.")
 	}
+
+	t.Run("First item after version without type", func(t *testing.T) {
+		data := `{"type": "version", "version": 1}
+{"name": "custom-emoji-troll", "image": "bulkdata/emoji/trollolol.png"}`
+		err, line := th.App.BulkImport(strings.NewReader(data), false, 2)
+		require.NotNil(t, err, "Should have failed due to invalid type on line 2.")
+		require.Equal(t, 2, line, "Should have failed due to invalid type on line 2.")
+	})
 }
 
 func TestImportProcessImportDataFileVersionLine(t *testing.T) {


### PR DESCRIPTION
#### Summary
The way that we were detecting the first import iteration was colliding with the "empty type" case for import.

#### Ticket Link
[MM-16548](https://mattermost.atlassian.net/browse/MM-16548)