### PR TITLE
MM-16783 Migrate "Team.UserBelongsToTeams" to Sync by default

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -2086,7 +2086,7 @@ func (a *App) UserCanSeeOtherUser(userId string, otherUserId string) (bool, *mod
 	}
 
 	if len(restrictions.Teams) > 0 {
-		result, err := a.userBelongsToTeams(otherUserId, restrictions.Teams)
+		result, err := a.Srv.Store.Team().UserBelongsToTeams(otherUserId, restrictions.Teams)
 		if err != nil {
 			return false, err
 		}
@@ -2096,7 +2096,7 @@ func (a *App) UserCanSeeOtherUser(userId string, otherUserId string) (bool, *mod
 	}
 
 	if len(restrictions.Channels) > 0 {
-		result, err := a.userBelongsToChannels(otherUserId, restrictions.Channels)
+		result, err := a.Srv.Store.Team().UserBelongsToTeams(otherUserId, restrictions.Channels)
 		if err != nil {
 			return false, err
 		}
@@ -2106,14 +2106,6 @@ func (a *App) UserCanSeeOtherUser(userId string, otherUserId string) (bool, *mod
 	}
 
 	return false, nil
-}
-
-func (a *App) userBelongsToTeams(userId string, teamIds []string) (bool, *model.AppError) {
-	result := <-a.Srv.Store.Team().UserBelongsToTeams(userId, teamIds)
-	if result.Err != nil {
-		return false, result.Err
-	}
-	return result.Data.(bool), nil
 }
 
 func (a *App) userBelongsToChannels(userId string, channelIds []string) (bool, *model.AppError) {

--- a/app/user.go
+++ b/app/user.go
@@ -2096,7 +2096,7 @@ func (a *App) UserCanSeeOtherUser(userId string, otherUserId string) (bool, *mod
 	}
 
 	if len(restrictions.Channels) > 0 {
-		result, err := a.Srv.Store.Team().UserBelongsToTeams(otherUserId, restrictions.Channels)
+		result, err := a.userBelongsToChannels(otherUserId, restrictions.Channels)
 		if err != nil {
 			return false, err
 		}

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -1062,27 +1062,26 @@ func (s SqlTeamStore) GetTeamMembersForExport(userId string) ([]*model.TeamMembe
 	return members, nil
 }
 
-func (s SqlTeamStore) UserBelongsToTeams(userId string, teamIds []string) store.StoreChannel {
-	return store.Do(func(result *store.StoreResult) {
-		props := make(map[string]interface{})
-		props["UserId"] = userId
-		idQuery := ""
+func (s SqlTeamStore) UserBelongsToTeams(userId string, teamIds []string) (bool, *model.AppError) {
+	props := make(map[string]interface{})
+	props["UserId"] = userId
+	idQuery := ""
 
-		for index, teamId := range teamIds {
-			if len(idQuery) > 0 {
-				idQuery += ", "
-			}
+	for index, teamId := range teamIds {
+		if len(idQuery) > 0 {
+			idQuery += ", "
+		}
 
-			props["teamId"+strconv.Itoa(index)] = teamId
-			idQuery += ":teamId" + strconv.Itoa(index)
-		}
-		c, err := s.GetReplica().SelectInt("SELECT Count(*) FROM TeamMembers WHERE UserId = :UserId AND TeamId IN ("+idQuery+") AND DeleteAt = 0", props)
-		if err != nil {
-			result.Err = model.NewAppError("SqlTeamStore.UserBelongsToTeams", "store.sql_team.user_belongs_to_teams.app_error", nil, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		result.Data = c > 0
-	})
+		props["teamId"+strconv.Itoa(index)] = teamId
+		idQuery += ":teamId" + strconv.Itoa(index)
+	}
+
+	c, err := s.GetReplica().SelectInt("SELECT Count(*) FROM TeamMembers WHERE UserId = :UserId AND TeamId IN ("+idQuery+") AND DeleteAt = 0", props)
+	if err != nil {
+		return false, model.NewAppError("SqlTeamStore.UserBelongsToTeams", "store.sql_team.user_belongs_to_teams.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return c > 0, nil
 }
 
 func applyTeamMemberViewRestrictionsFilter(query sq.SelectBuilder, teamId string, restrictions *model.ViewUsersRestrictions) sq.SelectBuilder {

--- a/store/store.go
+++ b/store/store.go
@@ -122,7 +122,7 @@ type TeamStore interface {
 	AnalyticsGetTeamCountForScheme(schemeId string) StoreChannel
 	GetAllForExportAfter(limit int, afterId string) ([]*model.TeamForExport, *model.AppError)
 	GetTeamMembersForExport(userId string) ([]*model.TeamMemberForExport, *model.AppError)
-	UserBelongsToTeams(userId string, teamIds []string) StoreChannel
+	UserBelongsToTeams(userId string, teamIds []string) (bool, *model.AppError)
 	GetUserTeamIds(userId string, allowFromCache bool) ([]string, *model.AppError)
 	InvalidateAllTeamIdsForUser(userId string)
 	ClearCaches()

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -933,17 +933,24 @@ func (_m *TeamStore) UpdateMember(member *model.TeamMember) (*model.TeamMember, 
 }
 
 // UserBelongsToTeams provides a mock function with given fields: userId, teamIds
-func (_m *TeamStore) UserBelongsToTeams(userId string, teamIds []string) store.StoreChannel {
+func (_m *TeamStore) UserBelongsToTeams(userId string, teamIds []string) (bool, *model.AppError) {
 	ret := _m.Called(userId, teamIds)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, []string) store.StoreChannel); ok {
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, []string) bool); ok {
 		r0 = rf(userId, teamIds)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, []string) *model.AppError); ok {
+		r1 = rf(userId, teamIds)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
 		}
 	}
 
-	return r0
+	return r0, r1
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Transforms "Team.UserBelongsToTeams" to a synchronous method, updates the calls and removes a wrapper for the async method.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/11545