### PR TITLE
[MM-16647] Fix issue with setting mention count

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -182,10 +182,10 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 	for id := range mentionedUserIds {
 		mentionedUsersList = append(mentionedUsersList, id)
 		umc := make(chan *model.AppError, 1)
-		go func() {
-			umc <- a.Srv.Store.Channel().IncrementMentionCount(post.ChannelId, id)
+		go func(userId string) {
+			umc <- a.Srv.Store.Channel().IncrementMentionCount(post.ChannelId, userId)
 			close(umc)
-		}()
+		}(id)
 		updateMentionChans = append(updateMentionChans, umc)
 	}
 


### PR DESCRIPTION
This change does the following:
 - Fixes a bug where mention counts could be set incorrectly for
   users in the database.
 - Updates the original notification unit test to check for more
   possible notification issues.
 - Adds a new unit test that performs mention count checking to
   prevent a regression to this fix.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16647
