### PR TITLE
Migrate "User.GetProfilesWithoutTeam" to Sync by default

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -583,11 +583,11 @@ func (a *App) GetUsersWithoutTeamPage(page int, perPage int, asAdmin bool, viewR
 }
 
 func (a *App) GetUsersWithoutTeam(offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError) {
-	result := <-a.Srv.Store.User().GetProfilesWithoutTeam(offset, limit, viewRestrictions)
-	if result.Err != nil {
-		return nil, result.Err
+	users, err := a.Srv.Store.User().GetProfilesWithoutTeam(offset, limit, viewRestrictions)
+	if err != nil {
+		return nil, err
 	}
-	return result.Data.([]*model.User), nil
+	return users, nil
 }
 
 // GetTeamGroupUsers returns the users who are associated to the team via GroupTeams and GroupMembers.

--- a/app/user.go
+++ b/app/user.go
@@ -583,11 +583,7 @@ func (a *App) GetUsersWithoutTeamPage(page int, perPage int, asAdmin bool, viewR
 }
 
 func (a *App) GetUsersWithoutTeam(offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError) {
-	users, err := a.Srv.Store.User().GetProfilesWithoutTeam(offset, limit, viewRestrictions)
-	if err != nil {
-		return nil, err
-	}
-	return users, nil
+	return a.Srv.Store.User().GetProfilesWithoutTeam(offset, limit, viewRestrictions)
 }
 
 // GetTeamGroupUsers returns the users who are associated to the team via GroupTeams and GroupMembers.

--- a/store/store.go
+++ b/store/store.go
@@ -267,7 +267,7 @@ type UserStore interface {
 	GetProfilesInChannelByStatus(channelId string, offset int, limit int) StoreChannel
 	GetAllProfilesInChannel(channelId string, allowFromCache bool) (map[string]*model.User, *model.AppError)
 	GetProfilesNotInChannel(teamId string, channelId string, groupConstrained bool, offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError)
-	GetProfilesWithoutTeam(offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) StoreChannel
+	GetProfilesWithoutTeam(offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError)
 	GetProfilesByUsernames(usernames []string, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError)
 	GetAllProfiles(options *model.UserGetOptions) ([]*model.User, *model.AppError)
 	GetProfiles(options *model.UserGetOptions) ([]*model.User, *model.AppError)

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -674,19 +674,28 @@ func (_m *UserStore) GetProfilesNotInTeam(teamId string, groupConstrained bool, 
 }
 
 // GetProfilesWithoutTeam provides a mock function with given fields: offset, limit, viewRestrictions
-func (_m *UserStore) GetProfilesWithoutTeam(offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) store.StoreChannel {
+func (_m *UserStore) GetProfilesWithoutTeam(offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError) {
 	ret := _m.Called(offset, limit, viewRestrictions)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(int, int, *model.ViewUsersRestrictions) store.StoreChannel); ok {
+	var r0 []*model.User
+	if rf, ok := ret.Get(0).(func(int, int, *model.ViewUsersRestrictions) []*model.User); ok {
 		r0 = rf(offset, limit, viewRestrictions)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.User)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(int, int, *model.ViewUsersRestrictions) *model.AppError); ok {
+		r1 = rf(offset, limit, viewRestrictions)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetRecentlyActiveUsersForTeam provides a mock function with given fields: teamId, offset, limit, viewRestrictions

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -886,21 +886,21 @@ func testUserStoreGetProfilesWithoutTeam(t *testing.T, ss store.Store) {
 	defer func() { require.Nil(t, ss.Bot().PermanentDelete(u3.Id)) }()
 
 	t.Run("get, offset 0, limit 100", func(t *testing.T) {
-		result := <-ss.User().GetProfilesWithoutTeam(0, 100, nil)
-		require.Nil(t, result.Err)
-		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+		result, err := ss.User().GetProfilesWithoutTeam(0, 100, nil)
+		require.Nil(t, err)
+		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result)
 	})
 
 	t.Run("get, offset 1, limit 1", func(t *testing.T) {
-		result := <-ss.User().GetProfilesWithoutTeam(1, 1, nil)
-		require.Nil(t, result.Err)
-		assert.Equal(t, []*model.User{sanitized(u3)}, result.Data.([]*model.User))
+		result, err := ss.User().GetProfilesWithoutTeam(1, 1, nil)
+		require.Nil(t, err)
+		assert.Equal(t, []*model.User{sanitized(u3)}, result)
 	})
 
 	t.Run("get, offset 2, limit 1", func(t *testing.T) {
-		result := <-ss.User().GetProfilesWithoutTeam(2, 1, nil)
-		require.Nil(t, result.Err)
-		assert.Equal(t, []*model.User{}, result.Data.([]*model.User))
+		result, nil := ss.User().GetProfilesWithoutTeam(2, 1, nil)
+		require.Nil(t, nil)
+		assert.Equal(t, []*model.User{}, result)
 	})
 }
 

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -886,21 +886,21 @@ func testUserStoreGetProfilesWithoutTeam(t *testing.T, ss store.Store) {
 	defer func() { require.Nil(t, ss.Bot().PermanentDelete(u3.Id)) }()
 
 	t.Run("get, offset 0, limit 100", func(t *testing.T) {
-		result, err := ss.User().GetProfilesWithoutTeam(0, 100, nil)
+		users, err := ss.User().GetProfilesWithoutTeam(0, 100, nil)
 		require.Nil(t, err)
-		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result)
+		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, users)
 	})
 
 	t.Run("get, offset 1, limit 1", func(t *testing.T) {
-		result, err := ss.User().GetProfilesWithoutTeam(1, 1, nil)
+		users, err := ss.User().GetProfilesWithoutTeam(1, 1, nil)
 		require.Nil(t, err)
-		assert.Equal(t, []*model.User{sanitized(u3)}, result)
+		assert.Equal(t, []*model.User{sanitized(u3)}, users)
 	})
 
 	t.Run("get, offset 2, limit 1", func(t *testing.T) {
-		result, nil := ss.User().GetProfilesWithoutTeam(2, 1, nil)
-		require.Nil(t, nil)
-		assert.Equal(t, []*model.User{}, result)
+		users, err := ss.User().GetProfilesWithoutTeam(2, 1, nil)
+		require.Nil(t, err)
+		assert.Equal(t, []*model.User{}, users)
 	})
 }
 


### PR DESCRIPTION
#### Summary
This PR migrates `User.GetProfilesWithoutTeam` to Sync by default.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/11458

#### Notes

I am still very new to Golang, please let me know if anything doesn't conform to proper style, as I am very eager to learn (and to contribute to Mattermost)!

