### PR TITLE
MM-16921 Fix getPostsSince caching invalid data

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -554,7 +554,7 @@ func (s *SqlPostStore) GetPostsSince(channelId string, time int64, allowFromCach
 
 	list := model.NewPostList()
 
-	var latestUpdate int64 = 0
+	latestUpdate := time
 
 	for _, p := range posts {
 		list.AddPost(p)

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -335,7 +335,7 @@ func (s *SqlPostStore) InvalidateLastPostTimeCache(channelId string) {
 
 func (s *SqlPostStore) GetEtag(channelId string, allowFromCache bool) string {
 	if allowFromCache {
-		if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok && cacheItem.(int64) > 0 {
+		if cacheItem, ok := s.lastPostTimeCache.Get(channelId); ok {
 			if s.metrics != nil {
 				s.metrics.IncrementMemCacheHitCounter("Last Post Time")
 			}

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -932,100 +932,126 @@ func testPostStoreGetPostsBeforeAfter(t *testing.T, ss store.Store) {
 }
 
 func testPostStoreGetPostsSince(t *testing.T, ss store.Store) {
-	o0 := &model.Post{}
-	o0.ChannelId = model.NewId()
-	o0.UserId = model.NewId()
-	o0.Message = "zz" + model.NewId() + "b"
-	_, err := ss.Post().Save(o0)
-	require.Nil(t, err)
-	time.Sleep(2 * time.Millisecond)
+	t.Run("should return posts created after the given time", func(t *testing.T) {
+		channelId := model.NewId()
+		userId := model.NewId()
 
-	o1 := &model.Post{}
-	o1.ChannelId = model.NewId()
-	o1.UserId = model.NewId()
-	o1.Message = "zz" + model.NewId() + "b"
-	o1, err = ss.Post().Save(o1)
-	require.Nil(t, err)
-	time.Sleep(2 * time.Millisecond)
+		post1, err := ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
 
-	o2 := &model.Post{}
-	o2.ChannelId = o1.ChannelId
-	o2.UserId = model.NewId()
-	o2.Message = "zz" + model.NewId() + "b"
-	o2.ParentId = o1.Id
-	o2.RootId = o1.Id
-	_, err = ss.Post().Save(o2)
-	require.Nil(t, err)
-	time.Sleep(2 * time.Millisecond)
+		_, err = ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
 
-	o2a := &model.Post{}
-	o2a.ChannelId = o1.ChannelId
-	o2a.UserId = model.NewId()
-	o2a.Message = "zz" + model.NewId() + "b"
-	o2a.ParentId = o1.Id
-	o2a.RootId = o1.Id
-	o2a, err = ss.Post().Save(o2a)
-	require.Nil(t, err)
-	time.Sleep(2 * time.Millisecond)
+		post3, err := ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
 
-	o3 := &model.Post{}
-	o3.ChannelId = o1.ChannelId
-	o3.UserId = model.NewId()
-	o3.Message = "zz" + model.NewId() + "b"
-	o3.ParentId = o1.Id
-	o3.RootId = o1.Id
-	o3, err = ss.Post().Save(o3)
-	require.Nil(t, err)
-	time.Sleep(2 * time.Millisecond)
+		post4, err := ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
 
-	o4 := &model.Post{}
-	o4.ChannelId = o1.ChannelId
-	o4.UserId = model.NewId()
-	o4.Message = "zz" + model.NewId() + "b"
-	o4, err = ss.Post().Save(o4)
-	require.Nil(t, err)
-	time.Sleep(2 * time.Millisecond)
+		post5, err := ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+			RootId:    post3.Id,
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
 
-	o5 := &model.Post{}
-	o5.ChannelId = o1.ChannelId
-	o5.UserId = model.NewId()
-	o5.Message = "zz" + model.NewId() + "b"
-	o5.ParentId = o4.Id
-	o5.RootId = o4.Id
-	o5, err = ss.Post().Save(o5)
-	require.Nil(t, err)
+		post6, err := ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+			RootId:    post1.Id,
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
 
-	r1, _ := ss.Post().GetPostsSince(o1.ChannelId, o1.CreateAt, false)
+		postList, err := ss.Post().GetPostsSince(channelId, post3.CreateAt, false)
+		assert.Nil(t, err)
 
-	if r1.Order[0] != o5.Id {
-		t.Fatal("invalid order")
-	}
+		assert.Equal(t, []string{
+			post6.Id,
+			post5.Id,
+			post4.Id,
+			post3.Id,
+			post1.Id,
+		}, postList.Order)
 
-	if r1.Order[1] != o4.Id {
-		t.Fatal("invalid order")
-	}
+		assert.Len(t, postList.Posts, 5)
+		assert.NotNil(t, postList.Posts[post1.Id], "should return the parent post")
+		assert.NotNil(t, postList.Posts[post3.Id])
+		assert.NotNil(t, postList.Posts[post4.Id])
+		assert.NotNil(t, postList.Posts[post5.Id])
+		assert.NotNil(t, postList.Posts[post6.Id])
+	})
 
-	if r1.Order[2] != o3.Id {
-		t.Fatal("invalid order")
-	}
+	t.Run("should return empty list when nothing has changed", func(t *testing.T) {
+		channelId := model.NewId()
+		userId := model.NewId()
 
-	if r1.Order[3] != o2a.Id {
-		t.Fatal("invalid order")
-	}
+		post1, err := ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
 
-	if len(r1.Posts) != 6 {
-		t.Fatal("wrong size")
-	}
+		postList, err := ss.Post().GetPostsSince(channelId, post1.CreateAt, false)
+		assert.Nil(t, err)
 
-	if r1.Posts[o1.Id].Message != o1.Message {
-		t.Fatal("Missing parent")
-	}
+		assert.Equal(t, []string{}, postList.Order)
+		assert.Len(t, postList.Posts, 0)
+	})
 
-	r2, _ := ss.Post().GetPostsSince(o1.ChannelId, o5.UpdateAt, true)
+	t.Run("should not cache a timestamp of 0 when nothing has changed", func(t *testing.T) {
+		ss.Post().ClearCaches()
 
-	if len(r2.Order) != 0 {
-		t.Fatal("wrong size ", len(r2.Posts))
-	}
+		channelId := model.NewId()
+		userId := model.NewId()
+
+		post1, err := ss.Post().Save(&model.Post{
+			ChannelId: channelId,
+			UserId:    userId,
+			Message:   "message",
+		})
+		require.Nil(t, err)
+		time.Sleep(time.Millisecond)
+
+		// Make a request that returns no results
+		postList, err := ss.Post().GetPostsSince(channelId, post1.CreateAt, true)
+		require.Nil(t, err)
+		require.Equal(t, model.NewPostList(), postList)
+
+		// And then ensure that it doesn't cause future requests to also return no results
+		postList, err = ss.Post().GetPostsSince(channelId, post1.CreateAt-1, true)
+		assert.Nil(t, err)
+
+		assert.Equal(t, []string{post1.Id}, postList.Order)
+
+		assert.Len(t, postList.Posts, 1)
+		assert.NotNil(t, postList.Posts[post1.Id])
+	})
 }
 
 func testPostStoreGetPostBeforeAfter(t *testing.T, ss store.Store) {


### PR DESCRIPTION
The missing posts problem was caused by a few things:
1. GetPostsSince could sometimes cache that the latest post in the channel was at time 0. This happened whenever a call to it would return an empty post list ([link](https://github.com/mattermost/mattermost-server/blob/master/store/sqlstore/post_store.go#L557)). As lost as GetPostsSince has a 0 timestamp cached, future calls to it will always return an empty list ([link](https://github.com/mattermost/mattermost-server/blob/master/store/sqlstore/post_store.go#L509)).
2. GetPostsSince and GetEtag share a cache, so when a timestamp of 0 gets cached, it can cause any API to get posts to return stale data.
3. The previous two bugs have existed since 2016. The reason that this started to happen more frequently in 5.12 is that the web app hasn't actually used the GetPostsSince API for quite a while. The mobile app uses it, but it doesn't use etags as far as I know, so it may not have manifested.

Under certain circumstances, an invalid etag would be cached by the browser, and any time where the cached etag was reset to the invalid etag, the browser would return the stale post list.

I wasn't able to recreate this on community since it's either too busy or because something in NGINX was preventing it from returning 304 No Content responses that would make the browser use cached data, but I was able to reproduce it using my local instance with the following steps:

1. Open Mattermost in two browsers as two separate users. Make sure that caching is enabled.
2. Have both users join the same channel
3. Have the first user make a post in the channel (clears the etag cache), switch channels away, switch channels back (triggers an empty getPostsSince to cache 0, but doesn't return an etag), and then refresh the page (calls getPosts to save the etag in the browser).
4. Have the second user repeat the same process of making a post, switching away, switching back, and then refreshing the page.
5. Have the first user refresh the page. The first user should be missing the second user's post, although they may be missing more if a 0 etag was previously cached.

One other thing to note is that this doesn't actually affect master. When ICU was originally testing the scrolling changes back in February, we had hit and fixed this issue on one of the feature branches ([link](https://github.com/mattermost/mattermost-server/pull/10233)). Gabe and I decided to revert the earlier fix to ignore a cached etag of 0 since we'd rather avoid caching bad data in the first place.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16921