### PR TITLE
Removing FileStorePath from PluginEventData

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -267,8 +267,7 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 	require.True(t, pluginStored)
 
 	expectedPluginData := model.PluginEventData{
-		Id:            manifest.Id,
-		FileStorePath: expectedPath,
+		Id: manifest.Id,
 	}
 	expectedInstallMessage := &model.ClusterMessage{
 		Event:            model.CLUSTER_EVENT_INSTALL_PLUGIN,

--- a/model/plugin_event_data.go
+++ b/model/plugin_event_data.go
@@ -10,8 +10,7 @@ import (
 
 // PluginEventData used to notify peers about plugin changes.
 type PluginEventData struct {
-	Id            string `json:"id"`
-	FileStorePath string `json:"file_store_path"`
+	Id string `json:"id"`
 }
 
 func (p *PluginEventData) ToJson() string {


### PR DESCRIPTION
As per conversation https://github.com/mattermost/mattermost-server/pull/11615#discussion_r304061674 removing `FileStorePath` from `PluginEventData`