### PR TITLE
Fix plugin path

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -220,15 +220,6 @@ func (a *App) SyncPlugins() *model.AppError {
 	}
 
 	// Install plugins from the file store.
-	exists, appErr := a.FileExists(fileStorePluginFolder)
-	if appErr != nil {
-		return model.NewAppError("SyncPlugins", "app.plugin.sync.check_filestore.app_error", nil, appErr.Error(), http.StatusInternalServerError)
-	}
-	if !exists {
-		mlog.Info("Found no plugins folder in file store")
-		return nil
-	}
-
 	fileStorePaths, appErr := a.ListDirectory(fileStorePluginFolder)
 	if appErr != nil {
 		return model.NewAppError("SyncPlugins", "app.plugin.sync.list_filestore.app_error", nil, appErr.Error(), http.StatusInternalServerError)

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -231,7 +231,7 @@ func (a *App) SyncPlugins() *model.AppError {
 
 	for _, path := range fileStorePaths {
 		if !strings.HasSuffix(path, ".tar.gz") {
-			mlog.Info("Ignoring non-plugin in file store", mlog.String("bundle", path))
+			mlog.Warn("Ignoring non-plugin in file store", mlog.String("bundle", path))
 			continue
 		}
 
@@ -243,7 +243,7 @@ func (a *App) SyncPlugins() *model.AppError {
 		}
 		defer reader.Close()
 
-		mlog.Debug("Syncing plugin from file store", mlog.String("bundle", path))
+		mlog.Info("Syncing plugin from file store", mlog.String("bundle", path))
 		if _, err := a.installPluginLocally(reader, true); err != nil {
 			mlog.Error("Failed to sync plugin from file store", mlog.String("bundle", path), mlog.Err(err))
 		}

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -21,12 +21,11 @@ import (
 // a local plugin folder as "managed" by the file store.
 const managedPluginFileName = ".filestore"
 
-// fileStorePluginFolder is the folder name in the file store of the plugin bundles
-// installed.
-const fileStorePluginFolder = "./plugins"
+// fileStorePluginFolder is the folder name in the file store of the plugin bundles installed.
+const fileStorePluginFolder = "plugins"
 
 func (a *App) InstallPluginFromData(data model.PluginEventData) {
-	mlog.Debug(fmt.Sprintf("InstallPluginFromData. ID: %v", data.Id))
+	mlog.Debug("Installing plugin from cluster message", mlog.String("plugin_id", data.Id))
 
 	fileStorePath := a.getBundleStorePath(data.Id)
 	reader, appErr := a.FileReader(fileStorePath)
@@ -41,7 +40,7 @@ func (a *App) InstallPluginFromData(data model.PluginEventData) {
 }
 
 func (a *App) RemovePluginFromData(data model.PluginEventData) {
-	mlog.Debug(fmt.Sprintf("RemovePluginFromData. ID: %v", data.Id))
+	mlog.Debug("Uninstalling plugin from cluster message", mlog.String("plugin_id", data.Id))
 
 	if err := a.removePluginLocally(data.Id); err != nil {
 		mlog.Error("Failed to remove plugin locally", mlog.Err(err), mlog.String("id", data.Id))

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3443,10 +3443,6 @@
     "translation": "Unable to store the plugin to the configured file store."
   },
   {
-    "id": "app.plugin.sync.check_filestore.app_error",
-    "translation": "Error accessing the plugins folder in the file store."
-  },
-  {
     "id": "app.plugin.sync.list_filestore.app_error",
     "translation": "Error reading files from the plugins folder in the file store."
   },

--- a/services/filesstore/filesstore_test.go
+++ b/services/filesstore/filesstore_test.go
@@ -237,17 +237,29 @@ func (s *FileBackendTestSuite) TestListDirectory() {
 	path1 := "19700101/" + model.NewId()
 	path2 := "19800101/" + model.NewId()
 
+	paths, err := s.backend.ListDirectory("19700101")
+	s.Nil(err)
+	s.Len(*paths, 0)
+
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path1)
 	s.Nil(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
-	defer s.backend.RemoveFile(path1)
 
 	written, err = s.backend.WriteFile(bytes.NewReader(b), path2)
 	s.Nil(err)
 	s.EqualValues(len(b), written, "expected given number of bytes to have been written")
-	defer s.backend.RemoveFile(path2)
 
-	paths, err := s.backend.ListDirectory("")
+	paths, err = s.backend.ListDirectory("19700101")
+	s.Nil(err)
+	s.Len(*paths, 1)
+	s.Equal(path1, (*paths)[0])
+
+	paths, err = s.backend.ListDirectory("19700101/")
+	s.Nil(err)
+	s.Len(*paths, 1)
+	s.Equal(path1, (*paths)[0])
+
+	paths, err = s.backend.ListDirectory("")
 	s.Nil(err)
 
 	found1 := false
@@ -261,6 +273,9 @@ func (s *FileBackendTestSuite) TestListDirectory() {
 	}
 	s.True(found1)
 	s.True(found2)
+
+	s.backend.RemoveFile(path1)
+	s.backend.RemoveFile(path2)
 }
 
 func (s *FileBackendTestSuite) TestRemoveDirectory() {

--- a/services/filesstore/localstore.go
+++ b/services/filesstore/localstore.go
@@ -114,6 +114,9 @@ func (b *LocalFileBackend) ListDirectory(path string) (*[]string, *model.AppErro
 	var paths []string
 	fileInfos, err := ioutil.ReadDir(filepath.Join(b.directory, path))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return &paths, nil
+		}
 		return nil, model.NewAppError("ListDirectory", "utils.file.list_directory.local.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	for _, fileInfo := range fileInfos {

--- a/services/filesstore/s3store.go
+++ b/services/filesstore/s3store.go
@@ -240,13 +240,12 @@ func (b *S3FileBackend) ListDirectory(path string) (*[]string, *model.AppError) 
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
-	updatedPath := path
 	if !strings.HasSuffix(path, "/") && len(path) > 0 {
 		// s3Clnt returns only the path itself when "/" is not present
 		// appending "/" to make it consistent across all filesstores
-		updatedPath = path + "/"
+		path = path + "/"
 	}
-	for object := range s3Clnt.ListObjects(b.bucket, updatedPath, false, doneCh) {
+	for object := range s3Clnt.ListObjects(b.bucket, path, false, doneCh) {
 		if object.Err != nil {
 			return nil, model.NewAppError("ListDirectory", "utils.file.list_directory.s3.app_error", nil, object.Err.Error(), http.StatusInternalServerError)
 		}

--- a/services/filesstore/s3store.go
+++ b/services/filesstore/s3store.go
@@ -238,10 +238,15 @@ func (b *S3FileBackend) ListDirectory(path string) (*[]string, *model.AppError) 
 	}
 
 	doneCh := make(chan struct{})
-
 	defer close(doneCh)
 
-	for object := range s3Clnt.ListObjects(b.bucket, path, false, doneCh) {
+	updatedPath := path
+	if !strings.HasSuffix(path, "/") && len(path) > 0 {
+		// s3Clnt returns only the path itself when "/" is not present
+		// appending "/" to make it consistent across all filesstores
+		updatedPath = path + "/"
+	}
+	for object := range s3Clnt.ListObjects(b.bucket, updatedPath, false, doneCh) {
 		if object.Err != nil {
 			return nil, model.NewAppError("ListDirectory", "utils.file.list_directory.s3.app_error", nil, object.Err.Error(), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
- Updated `s3store.go` to return same result when querying `plugins` vs `plugins/`
- Updated `localstore.go` to not return an error when directory is not found
- Added unit test to cover new functionality

Once approved i'll merge this into https://github.com/mattermost/mattermost-server/pull/11608 to do the final testing and then merge it into the feature branch