### PR TITLE
[MM-16744] Filter bots out of notifications for members not in channel

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -158,6 +158,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 				} else {
 					outOfChannelMentions = channelMentions
 				}
+				outOfChannelMentions = outOfChannelMentions.FilterWithoutBots()
 
 				if channel.Type != model.CHANNEL_GROUP {
 					a.Srv.Go(func() {

--- a/model/user.go
+++ b/model/user.go
@@ -161,6 +161,17 @@ func (u UserSlice) IDs() []string {
 	return ids
 }
 
+func (u UserSlice) FilterWithoutBots() UserSlice {
+	var matches []*User
+
+	for _, user := range u {
+		if !user.IsBot {
+			matches = append(matches, user)
+		}
+	}
+	return UserSlice(matches)
+}
+
 func (u UserSlice) FilterByActive(active bool) UserSlice {
 	var matches []*User
 

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -391,9 +391,9 @@ func TestIsValidLocale(t *testing.T) {
 
 func TestUserSlice(t *testing.T) {
 	t.Run("FilterByActive", func(t *testing.T) {
-		user0 := &User{Id: "user0", DeleteAt: 0}
-		user1 := &User{Id: "user1", DeleteAt: 0}
-		user2 := &User{Id: "user2", DeleteAt: 1}
+		user0 := &User{Id: "user0", DeleteAt: 0, IsBot: true}
+		user1 := &User{Id: "user1", DeleteAt: 0, IsBot: true}
+		user2 := &User{Id: "user2", DeleteAt: 1, IsBot: false}
 
 		slice := UserSlice([]*User{user0, user1, user2})
 
@@ -408,5 +408,8 @@ func TestUserSlice(t *testing.T) {
 		for _, user := range inactiveUsers {
 			assert.True(t, user.DeleteAt != 0)
 		}
+
+		nonBotUsers := slice.FilterWithoutBots()
+		assert.Equal(t, 1, len(nonBotUsers))
 	})
 }


### PR DESCRIPTION
#### Summary

When bots are mentioned in a channel they are not a member of, do not include them in the system message suggesting to add them to the channel.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-16744
Fixes https://github.com/mattermost/mattermost-server/issues/11329