### PR TITLE
Add telemetry for new cluster settings

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -524,6 +524,9 @@ func (a *App) trackConfig() {
 
 	a.SendDiagnostic(TRACK_CONFIG_CLUSTER, map[string]interface{}{
 		"enable":                  *cfg.ClusterSettings.Enable,
+		"network_interface":       isDefault(*cfg.ClusterSettings.NetworkInterface, ""),
+		"bind_address":            isDefault(*cfg.ClusterSettings.BindAddress, ""),
+		"advertise_address":       isDefault(*cfg.ClusterSettings.AdvertiseAddress, ""),
 		"use_ip_address":          *cfg.ClusterSettings.UseIpAddress,
 		"use_experimental_gossip": *cfg.ClusterSettings.UseExperimentalGossip,
 		"read_only_config":        *cfg.ClusterSettings.ReadOnlyConfig,


### PR DESCRIPTION
Track if the default value is used for NetworkInterface, BindAddress and AdvertiseAddress.

Do not track the actual value, as this could expose sensitive data of the system.

PRs that added the settings:
 - https://github.com/mattermost/mattermost-server/pull/11283
 - https://github.com/mattermost/mattermost-server/pull/10917