### PR TITLE
implements plugin helpers to assist with building new slash commands

### DIFF
--- a/plugin/helpers.go
+++ b/plugin/helpers.go
@@ -29,6 +29,12 @@ type Helpers interface {
 	//
 	// Minimum server version: 5.6
 	KVSetWithExpiryJSON(key string, value interface{}, expireInSeconds int64) error
+
+	// SplitCommandArgs is a helper that parses command arguments into a command, action, and parameters.
+	SplitCommandArgs(args *model.CommandArgs) (string, string, []string)
+
+	// RegisterSlashCommand is a helper used to call a provided callback function for a given trigger and passes action/parameters to the callback.
+	RegisterSlashCommand(args *model.CommandArgs, trigger string, callback func(string, []string, *model.CommandArgs) (*model.CommandResponse, *model.AppError)) (*model.CommandResponse, error)
 }
 
 type HelpersImpl struct {

--- a/plugin/helpers_slash.go
+++ b/plugin/helpers_slash.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package plugin
+
+import (
+	"strings"
+
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/pkg/errors"
+)
+
+// SplitCommandArgs is a helper that parses command arguments into a command, action, and parameters.
+func (p *HelpersImpl) SplitCommandArgs(args *model.CommandArgs) (string, string, []string) {
+	split := strings.Fields(args.Command)
+	command := split[0]
+	parameters := []string{}
+	action := ""
+
+	if len(split) > 1 {
+		action = split[1]
+	}
+	if len(split) > 2 {
+		parameters = split[2:]
+	}
+
+	return command, action, parameters
+}
+
+// RegisterSlashCommand is a helper used to call a provided callback function for a given trigger and passes action/parameters to the callback.
+func (p *HelpersImpl) RegisterSlashCommand(args *model.CommandArgs, trigger string, callback func(string, []string, *model.CommandArgs) (*model.CommandResponse, *model.AppError)) (*model.CommandResponse, error) {
+	command, action, parameters := p.SplitCommandArgs(args)
+	if callback == nil {
+		return nil, errors.New("missing callback function")
+	}	
+	if command != "/" + trigger {
+		return nil, nil
+	}
+
+	commandResponse, err := callback(action, parameters, args)
+	if err != nil {
+		return nil, errors.Wrap(err, "error occured with RegisterSlashCommand callback")
+	}
+
+	return commandResponse, nil
+}


### PR DESCRIPTION
#### Summary
Implements a couple new helper commands to assist in the creation of plugins that use slash commands:

- adds SplitCommandArguments helper that takes CommandArgs and splits  them into a command (string), action (string), and parameters ([]string).
- adds RegisterSlashCommand helper that matches a given slash command trigger with a callback function.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16801
