### PR TITLE
MM-16951 Close database connections last on shutdown

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -332,10 +332,6 @@ func (s *Server) Shutdown() error {
 	s.StopHTTPServer()
 	s.WaitForGoroutines()
 
-	if s.Store != nil {
-		s.Store.Close()
-	}
-
 	if s.htmlTemplateWatcher != nil {
 		s.htmlTemplateWatcher.Close()
 	}
@@ -356,6 +352,10 @@ func (s *Server) Shutdown() error {
 	if s.Jobs != nil && s.runjobs {
 		s.Jobs.StopWorkers()
 		s.Jobs.StopSchedulers()
+	}
+
+	if s.Store != nil {
+		s.Store.Close()
 	}
 
 	mlog.Info("Server stopped")


### PR DESCRIPTION
#### Summary
The job workers and cluster discovery components require access to the database during shutdown. To avoid issues, we leave the database open until the last step of the shutdown process.

#### Ticket Link
Fixes [MM-16951].

[MM-16951]: https://mattermost.atlassian.net/browse/MM-16951