### PR TITLE
[MM-16658] Migrate User.GetProfilesInChannel to Sync by default #11462

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -516,11 +516,7 @@ func (a *App) GetUsersNotInTeamEtag(teamId string, restrictionsHash string) stri
 }
 
 func (a *App) GetUsersInChannel(channelId string, offset int, limit int) ([]*model.User, *model.AppError) {
-	result, err := a.Srv.Store.User().GetProfilesInChannel(channelId, offset, limit)
-	if err != nil {
-		return nil, err
-	}
-	return result, nil
+	return a.Srv.Store.User().GetProfilesInChannel(channelId, offset, limit)
 }
 
 func (a *App) GetUsersInChannelByStatus(channelId string, offset int, limit int) ([]*model.User, *model.AppError) {

--- a/app/user.go
+++ b/app/user.go
@@ -516,11 +516,11 @@ func (a *App) GetUsersNotInTeamEtag(teamId string, restrictionsHash string) stri
 }
 
 func (a *App) GetUsersInChannel(channelId string, offset int, limit int) ([]*model.User, *model.AppError) {
-	result := <-a.Srv.Store.User().GetProfilesInChannel(channelId, offset, limit)
-	if result.Err != nil {
-		return nil, result.Err
+	result, err := a.Srv.Store.User().GetProfilesInChannel(channelId, offset, limit)
+	if err != nil {
+		return nil, err
 	}
-	return result.Data.([]*model.User), nil
+	return result, nil
 }
 
 func (a *App) GetUsersInChannelByStatus(channelId string, offset int, limit int) ([]*model.User, *model.AppError) {

--- a/store/store.go
+++ b/store/store.go
@@ -266,7 +266,7 @@ type UserStore interface {
 	ClearCaches()
 	InvalidateProfilesInChannelCacheByUser(userId string)
 	InvalidateProfilesInChannelCache(channelId string)
-	GetProfilesInChannel(channelId string, offset int, limit int) StoreChannel
+	GetProfilesInChannel(channelId string, offset int, limit int) ([]*model.User, *model.AppError)
 	GetProfilesInChannelByStatus(channelId string, offset int, limit int) ([]*model.User, *model.AppError)
 	GetAllProfilesInChannel(channelId string, allowFromCache bool) (map[string]*model.User, *model.AppError)
 	GetProfilesNotInChannel(teamId string, channelId string, groupConstrained bool, offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, *model.AppError)

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -608,19 +608,28 @@ func (_m *UserStore) GetProfilesByUsernames(usernames []string, viewRestrictions
 }
 
 // GetProfilesInChannel provides a mock function with given fields: channelId, offset, limit
-func (_m *UserStore) GetProfilesInChannel(channelId string, offset int, limit int) store.StoreChannel {
+func (_m *UserStore) GetProfilesInChannel(channelId string, offset int, limit int) ([]*model.User, *model.AppError) {
 	ret := _m.Called(channelId, offset, limit)
 
-	var r0 store.StoreChannel
-	if rf, ok := ret.Get(0).(func(string, int, int) store.StoreChannel); ok {
+	var r0 []*model.User
+	if rf, ok := ret.Get(0).(func(string, int, int) []*model.User); ok {
 		r0 = rf(channelId, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(store.StoreChannel)
+			r0 = ret.Get(0).([]*model.User)
 		}
 	}
 
-	return r0
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, int, int) *model.AppError); ok {
+		r1 = rf(channelId, offset, limit)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // GetProfilesInChannelByStatus provides a mock function with given fields: channelId, offset, limit

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -747,21 +747,21 @@ func testUserStoreGetProfilesInChannel(t *testing.T, ss store.Store) {
 	})
 	require.Nil(t, err)
 	t.Run("get in channel 1, offset 0, limit 100", func(t *testing.T) {
-		result, err := ss.User().GetProfilesInChannel(c1.Id, 0, 100)
+		users, err := ss.User().GetProfilesInChannel(c1.Id, 0, 100)
 		require.Nil(t, err)
-		assert.Equal(t, []*model.User{sanitized(u1), sanitized(u2), sanitized(u3)}, result)
+		assert.Equal(t, []*model.User{sanitized(u1), sanitized(u2), sanitized(u3)}, users)
 	})
 
 	t.Run("get in channel 1, offset 1, limit 2", func(t *testing.T) {
-		result, err := ss.User().GetProfilesInChannel(c1.Id, 1, 2)
+		users, err := ss.User().GetProfilesInChannel(c1.Id, 1, 2)
 		require.Nil(t, err)
-		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result)
+		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, users)
 	})
 
 	t.Run("get in channel 2, offset 0, limit 1", func(t *testing.T) {
-		result, err := ss.User().GetProfilesInChannel(c2.Id, 0, 1)
+		users, err := ss.User().GetProfilesInChannel(c2.Id, 0, 1)
 		require.Nil(t, err)
-		assert.Equal(t, []*model.User{sanitized(u1)}, result)
+		assert.Equal(t, []*model.User{sanitized(u1)}, users)
 	})
 }
 

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -747,21 +747,21 @@ func testUserStoreGetProfilesInChannel(t *testing.T, ss store.Store) {
 	})
 	require.Nil(t, err)
 	t.Run("get in channel 1, offset 0, limit 100", func(t *testing.T) {
-		result := <-ss.User().GetProfilesInChannel(c1.Id, 0, 100)
-		require.Nil(t, result.Err)
-		assert.Equal(t, []*model.User{sanitized(u1), sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+		result, err := ss.User().GetProfilesInChannel(c1.Id, 0, 100)
+		require.Nil(t, err)
+		assert.Equal(t, []*model.User{sanitized(u1), sanitized(u2), sanitized(u3)}, result)
 	})
 
 	t.Run("get in channel 1, offset 1, limit 2", func(t *testing.T) {
-		result := <-ss.User().GetProfilesInChannel(c1.Id, 1, 2)
-		require.Nil(t, result.Err)
-		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result.Data.([]*model.User))
+		result, err := ss.User().GetProfilesInChannel(c1.Id, 1, 2)
+		require.Nil(t, err)
+		assert.Equal(t, []*model.User{sanitized(u2), sanitized(u3)}, result)
 	})
 
 	t.Run("get in channel 2, offset 0, limit 1", func(t *testing.T) {
-		result := <-ss.User().GetProfilesInChannel(c2.Id, 0, 1)
-		require.Nil(t, result.Err)
-		assert.Equal(t, []*model.User{sanitized(u1)}, result.Data.([]*model.User))
+		result, err := ss.User().GetProfilesInChannel(c2.Id, 0, 1)
+		require.Nil(t, err)
+		assert.Equal(t, []*model.User{sanitized(u1)}, result)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Migrate `User.GetProfilesInChannel` to sync by default.

#### Ticket Link
Fixes #11462