### PR TITLE
Exposing enforce mfa in client config

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -274,6 +274,7 @@ func GenerateLimitedClientConfig(c *model.Config, diagnosticId string, license *
 	props["EnableMultifactorAuthentication"] = strconv.FormatBool(*c.ServiceSettings.EnableMultifactorAuthentication)
 	props["EnforceMultifactorAuthentication"] = "false"
 	props["EnableGuestAccounts"] = strconv.FormatBool(*c.GuestAccountsSettings.Enable)
+	props["GuestAccountsEnforceMultifactorAuthentication"] = strconv.FormatBool(*c.GuestAccountsSettings.EnforceMultifactorAuthentication)
 
 	if license != nil {
 		if *license.Features.LDAP {


### PR DESCRIPTION
#### Summary
Exposing enforce mfa in client config to decide properly if i need to redirect you to the mfa activation when enforce mfa is enforced for all users.

#### Ticket Link
[MM-17196](https://mattermost.atlassian.net/browse/MM-17196)