### PR TITLE
MM-16838 - Fix for flaky GetChannelsByScheme test

### DIFF
--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -3238,8 +3238,6 @@ func testChannelStoreGetChannelsByScheme(t *testing.T, ss store.Store) {
 
 	s1, err := ss.Scheme().Save(s1)
 	require.Nil(t, err)
-	s1, err = ss.Scheme().Save(s1)
-	require.Nil(t, err)
 	s2, err = ss.Scheme().Save(s2)
 	require.Nil(t, err)
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Removed extra unnecessary save done on a scheme object in the GetChannelsByScheme test. This could have been causing the intermittent error of `Message:"store.sql_scheme.save.update.app_error", DetailedError:"no record to update"` seen in the CI build tests. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Possibly fixes [MM-16838](https://mattermost.atlassian.net/browse/MM-16838)