### PR TITLE
MM-16935 - Flaky test: Elastic Search IndexChannel Error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 
 	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-elasticsearch$$ | wc -l) -eq 0 ]; then \
 		echo starting mattermost-elasticsearch; \
-		docker run --name mattermost-elasticsearch -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" -e "ES_JAVA_OPTS=-Xms250m -Xmx250m" -d mattermost/mattermost-elasticsearch-docker:6.5.1 > /dev/null; \
+		docker run --name mattermost-elasticsearch -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" -d mattermost/mattermost-elasticsearch-docker:6.5.1 > /dev/null; \
 	elif [ $(shell docker ps --no-trunc --quiet --filter name=^/mattermost-elasticsearch$$ | wc -l) -eq 0 ]; then \
 		echo restarting mattermost-elasticsearch; \
 		docker start mattermost-elasticsearch> /dev/null; \

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -88,6 +88,10 @@ func setupTestHelper(enterprise bool, updateConfig func(*model.Config)) *TestHel
 		*cfg.TeamSettings.MaxUsersPerTeam = 50
 		*cfg.RateLimitSettings.Enable = false
 		*cfg.EmailSettings.SendEmailNotifications = true
+
+		// Disable sniffing, otherwise elastic client fails to connect to docker node
+		// More details: https://github.com/olivere/elastic/wiki/Sniffing
+		*cfg.ElasticsearchSettings.Sniff = false
 	})
 	prevListenAddress := *th.App.Config().ServiceSettings.ListenAddress
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -58,7 +58,7 @@ services:
     environment:
       http.host: "0.0.0.0"
       transport.host: "127.0.0.1"
-      ES_JAVA_OPTS: "-Xms250m -Xmx250m"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
   redis:
     image: redis
     networks:


### PR DESCRIPTION
#### Summary
Fixing jenkins build failures caused by elastic docker container running out of memory and resulting in flaky elastic search tests
- Bumping up JVM heapsize to `512m` for elastic search container
- Disabled `cfg.ElasticsearchSettings.Sniff` for tests to allow running enterprise tests locally on Mac OSX

Example build: https://build.mattermost.com/blue/organizations/jenkins/mp%2Fmattermost-server-pr-new/detail/PR-11698/2/tests/

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-16935