### PR TITLE
MM-17088: GOPROXY=off when compiling test go code

### DIFF
--- a/plugin/health_check_test.go
+++ b/plugin/health_check_test.go
@@ -51,12 +51,7 @@ func testPluginHealthCheck_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	bundle := model.BundleInfoForPath(dir)
-	log := mlog.NewLogger(&mlog.LoggerConfiguration{
-		EnableConsole: true,
-		ConsoleJson:   true,
-		ConsoleLevel:  "error",
-		EnableFile:    false,
-	})
+	log := mlog.NewTestingLogger(t)
 
 	supervisor, err := newSupervisor(bundle, log, nil)
 	require.Nil(t, err)
@@ -97,12 +92,7 @@ func testPluginHealthCheck_Panic(t *testing.T) {
 	require.NoError(t, err)
 
 	bundle := model.BundleInfoForPath(dir)
-	log := mlog.NewLogger(&mlog.LoggerConfiguration{
-		EnableConsole: true,
-		ConsoleJson:   true,
-		ConsoleLevel:  "error",
-		EnableFile:    false,
-	})
+	log := mlog.NewTestingLogger(t)
 
 	supervisor, err := newSupervisor(bundle, log, nil)
 	require.Nil(t, err)

--- a/utils/test_files_compiler.go
+++ b/utils/test_files_compiler.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -26,6 +27,12 @@ func goMod(t *testing.T, dir string, args ...string) {
 }
 
 func CompileGo(t *testing.T, sourceCode, outputPath string) {
+	start := time.Now()
+	defer func() {
+		end := time.Now()
+		t.Logf("Compiling took %f seconds", float64(end.Sub(start))/float64(time.Second))
+	}()
+
 	dir, err := ioutil.TempDir(".", "")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -56,6 +63,7 @@ func CompileGo(t *testing.T, sourceCode, outputPath string) {
 	cmd.Dir = dir
 	cmd.Stdout = out
 	cmd.Stderr = out
+	cmd.Env = append(os.Environ(), "GOPROXY=off")
 	err = cmd.Run()
 	if err != nil {
 		t.Log("Go compile errors:\n", out.String())


### PR DESCRIPTION
#### Summary
I didn't identify anything specifically flaky about TestPluginHealthCheck, but noting the build failure, I've opted to define `GOPROXY=off` to force the go compiler to use only local packages.

I've also tweaked the logging slightly to always route through `t.Log`, as well as dump compilation times (which are the largest part of the dynamic tests).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17088