### PR TITLE
MM-17235: fix flaky TestChannelStore tests

### DIFF
--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -751,31 +751,26 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 }
 
 func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
-	o1 := model.Channel{}
+	o1 := &model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
 	o1.Name = "zz" + model.NewId() + "b"
 	o1.Type = model.CHANNEL_OPEN
-	_, err := ss.Channel().Save(&o1, -1)
+	_, err := ss.Channel().Save(o1, -1)
 	require.Nil(t, err)
 
 	now := model.GetMillis()
-	err = ss.Channel().Delete(o1.Id, model.GetMillis())
+	err = ss.Channel().Delete(o1.Id, now)
 	require.Nil(t, err, "channel should have been deleted")
 	o1.DeleteAt = now
 	o1.UpdateAt = now
 
-	if r1, err := ss.Channel().GetDeletedByName(o1.TeamId, o1.Name); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1.ToJson() != o1.ToJson() {
-			t.Fatal("invalid returned channel")
-		}
-	}
+	r1, err := ss.Channel().GetDeletedByName(o1.TeamId, o1.Name)
+	require.Nil(t, err)
+	require.Equal(t, o1, r1)
 
-	if _, err := ss.Channel().GetDeletedByName(o1.TeamId, ""); err == nil {
-		t.Fatal("Missing id should have failed")
-	}
+	_, err = ss.Channel().GetDeletedByName(o1.TeamId, "")
+	require.NotNil(t, err, "missing id should have failed")
 }
 
 func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
@@ -2285,7 +2280,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 
 	o10.DeleteAt = model.GetMillis()
 	o10.UpdateAt = o10.DeleteAt
-	err = ss.Channel().Delete(o10.Id, model.GetMillis())
+	err = ss.Channel().Delete(o10.Id, o10.DeleteAt)
 	require.Nil(t, err, "channel should have been deleted")
 
 	t.Run("three public channels matching 'ChannelA', but already a member of one and one deleted", func(t *testing.T) {
@@ -2480,7 +2475,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	require.Nil(t, err)
 	o13.DeleteAt = model.GetMillis()
 	o13.UpdateAt = o13.DeleteAt
-	err = ss.Channel().Delete(o13.Id, model.GetMillis())
+	err = ss.Channel().Delete(o13.Id, o13.DeleteAt)
 	require.Nil(t, err, "channel should have been deleted")
 
 	testCases := []struct {


### PR DESCRIPTION
#### Summary
Address more model.GetMillis() races.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17325