### PR TITLE
MM-17311 - Flaky TestGroupStore/UpsertMember

### DIFF
--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -6,6 +6,7 @@ package testlib
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
@@ -120,6 +121,10 @@ func (h *MainHelper) Close() error {
 	}
 	if h.testResourcePath != "" {
 		os.RemoveAll(h.testResourcePath)
+	}
+
+	if r := recover(); r != nil {
+		log.Fatalln(r)
 	}
 
 	os.Exit(h.status)

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -6,7 +6,6 @@ package testlib
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"testing"
 
@@ -121,10 +120,6 @@ func (h *MainHelper) Close() error {
 	}
 	if h.testResourcePath != "" {
 		os.RemoveAll(h.testResourcePath)
-	}
-
-	if r := recover(); r != nil {
-		log.Fatalln(r)
 	}
 
 	os.Exit(h.status)


### PR DESCRIPTION
#### Summary
`GroupStore.UpsertMember` uses `CreateAt: model.GetMillis()` to update `GroupMember`. When updated in quick successions, MySQL implementation of RowsAffected returns 0, even if the row exists but no actual changes were made, which eventually causes the test to fail.

- Went with the retry approach for now but in the future we should consider looking at https://github.com/go-sql-driver/mysql#clientfoundrows. Started a discussion: https://community.mattermost.com/core/pl/ugqb4pnfjinobnf6wnrff9gyka
#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-17311
