### PR TITLE
Log panic when exiting (if any)

### DIFF
--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -6,6 +6,7 @@ package testlib
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"testing"
 
@@ -120,6 +121,10 @@ func (h *MainHelper) Close() error {
 	}
 	if h.testResourcePath != "" {
 		os.RemoveAll(h.testResourcePath)
+	}
+
+	if r := recover(); r != nil {
+		log.Fatalln(r)
 	}
 
 	os.Exit(h.status)


### PR DESCRIPTION
#### Summary
When a test run is stopped by a panic, before it can go and log that error, `MainHelper.Close()` calls `os.Exit(...)` and the panic is lost, making it harder to debug what caused the error. Adding a `recover` block to catch the panic and log the error.
 
