### PR TITLE
MM-17411: fix err != nil check

### DIFF
--- a/services/mfa/mfa.go
+++ b/services/mfa/mfa.go
@@ -99,8 +99,8 @@ func (m *Mfa) Activate(user *model.User, token string) *model.AppError {
 		return model.NewAppError("Activate", "mfa.activate.bad_token.app_error", nil, "", http.StatusUnauthorized)
 	}
 
-	if err = m.Store.User().UpdateMfaActive(user.Id, true); err != nil {
-		return model.NewAppError("Activate", "mfa.activate.save_active.app_error", nil, err.Error(), http.StatusInternalServerError)
+	if appErr := m.Store.User().UpdateMfaActive(user.Id, true); appErr != nil {
+		return model.NewAppError("Activate", "mfa.activate.save_active.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 	}
 
 	return nil

--- a/services/mfa/mfa_test.go
+++ b/services/mfa/mfa_test.go
@@ -4,9 +4,13 @@
 package mfa
 
 import (
+	b32 "encoding/base32"
+	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/dgryski/dgoogauth"
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin/plugintest/mock"
 	"github.com/mattermost/mattermost-server/store/storetest/mocks"
@@ -66,4 +70,28 @@ func TestGetIssuerFromUrl(t *testing.T) {
 	for _, c := range cases {
 		assert.Equal(t, c.Expected, getIssuerFromUrl(c.Input))
 	}
+}
+
+func TestActivate(t *testing.T) {
+	user := &model.User{Id: model.NewId(), Roles: "system_user"}
+
+	config := model.Config{}
+	config.SetDefaults()
+	config.ServiceSettings.EnableMultifactorAuthentication = model.NewBool(true)
+	configService := testutils.StaticConfigService{Cfg: &config}
+	storeMock := mocks.Store{}
+	userStoreMock := mocks.UserStore{}
+	userStoreMock.On("UpdateMfaActive", user.Id, mock.AnythingOfType("bool")).Return(func(userId string, active bool) *model.AppError {
+		return nil
+	})
+	storeMock.On("User").Return(&userStoreMock)
+
+	mfa := Mfa{configService, &storeMock}
+
+	user.MfaSecret = b32.StdEncoding.EncodeToString([]byte(model.NewRandomString(MFA_SECRET_SIZE)))
+
+	token := dgoogauth.ComputeCode(user.MfaSecret, time.Now().UTC().Unix()/30)
+
+	err := mfa.Activate(user, fmt.Sprintf("%06d", token))
+	require.Nil(t, err)
 }


### PR DESCRIPTION
#### Summary
Address another classic case of `var err error` and then trying to assign a `*model.AppError`. We really need to switch to passing `error` everywhere.



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17411