### PR TITLE
MM-17224 - Bulk export fails due to missing user

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -410,6 +411,7 @@ func (a *App) BuildPostReactions(postId string) (*[]ReactionImportData, *model.A
 		var user *model.User
 		user, err = a.Srv.Store.User().Get(reaction.UserId)
 		if err != nil {
+			mlog.Info(fmt.Sprintf("Skipping reactions for user %v, since the entity doesn't exist anymore", reaction.UserId))
 			continue // this is a valid case, the user that reacted might've been deleted by now
 		}
 		reactionsOfPost = append(reactionsOfPost, *ImportReactionFromPost(user, reaction))

--- a/app/export.go
+++ b/app/export.go
@@ -410,7 +410,7 @@ func (a *App) BuildPostReactions(postId string) (*[]ReactionImportData, *model.A
 		var user *model.User
 		user, err = a.Srv.Store.User().Get(reaction.UserId)
 		if err != nil {
-			return nil, err
+			continue // this is a valid case, the user that reacted might've been deleted by now
 		}
 		reactionsOfPost = append(reactionsOfPost, *ImportReactionFromPost(user, reaction))
 	}

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -18,15 +18,22 @@ func TestReactionsOfPost(t *testing.T) {
 
 	post := th.BasicPost
 	post.HasReactions = true
-
+	th.BasicUser2.DeleteAt = 1234
 	reactionObject := model.Reaction{
 		UserId:    th.BasicUser.Id,
 		PostId:    post.Id,
 		EmojiName: "emoji",
 		CreateAt:  model.GetMillis(),
 	}
+	reactionObjectDeleted := model.Reaction{
+		UserId:    th.BasicUser2.Id,
+		PostId:    post.Id,
+		EmojiName: "emoji",
+		CreateAt:  model.GetMillis(),
+	}
 
 	th.App.SaveReactionForPost(&reactionObject)
+	th.App.SaveReactionForPost(&reactionObjectDeleted)
 	reactionsOfPost, err := th.App.BuildPostReactions(post.Id)
 	require.Nil(t, err)
 


### PR DESCRIPTION

#### Summary
Bulk export fails with the following error log: "Error: SqlUserStore.Get: Unable to find the user., user_id=XXXXXXXXXXXXXXXXX"

The cause of this issue is little complex.If executing the deleting user command, PermanentDeleteUser doesn't delete any reactions that deleting user add. So reactions that the deleted user add are left.After that, when executing bulk export, it collects all reactions and try to get user who add a reaction. It results in error of bulk export.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-17224

