### PR TITLE
MM-17426 Properly specify multiple Accept headers for post metadata

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -379,7 +379,8 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 		// /api/v4/image requires authentication, so bypass the API by hitting the proxy directly
 		body, contentType, err = a.ImageProxy.GetImageDirect(a.ImageProxy.GetUnproxiedImageURL(request.URL.String()))
 	} else {
-		request.Header.Add("Accept", "image/*, text/html")
+		request.Header.Add("Accept", "image/*")
+		request.Header.Add("Accept", "text/html")
 
 		client := a.HTTPService.MakeClient(false)
 		client.Timeout = time.Duration(*a.Config().ExperimentalSettings.LinkMetadataTimeoutMilliseconds) * time.Millisecond

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -380,7 +380,7 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 		body, contentType, err = a.ImageProxy.GetImageDirect(a.ImageProxy.GetUnproxiedImageURL(request.URL.String()))
 	} else {
 		request.Header.Add("Accept", "image/*")
-		request.Header.Add("Accept", "text/html")
+		request.Header.Add("Accept", "text/html;q=0.8")
 
 		client := a.HTTPService.MakeClient(false)
 		client.Timeout = time.Duration(*a.Config().ExperimentalSettings.LinkMetadataTimeoutMilliseconds) * time.Millisecond

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -1372,26 +1372,35 @@ func TestGetLinkMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query()
 
-		if strings.HasPrefix(r.URL.Path, "/image") {
-			height, _ := strconv.ParseInt(params["height"][0], 10, 0)
-			width, _ := strconv.ParseInt(params["width"][0], 10, 0)
+		writeImage := func(height, width int) {
 
-			img := image.NewGray(image.Rect(0, 0, int(width), int(height)))
+			img := image.NewGray(image.Rect(0, 0, height, width))
 
 			var encoder png.Encoder
 
 			encoder.Encode(w, img)
-		} else if strings.HasPrefix(r.URL.Path, "/opengraph") {
+		}
+
+		writeHTML := func(title string) {
 			w.Header().Set("Content-Type", "text/html")
 
 			w.Write([]byte(`
 				<html prefix="og:http://ogp.me/ns#">
 				<head>
-				<meta property="og:title" content="` + params["title"][0] + `" />
+				<meta property="og:title" content="` + title + `" />
 				</head>
 				<body>
 				</body>
 				</html>`))
+		}
+
+		if strings.HasPrefix(r.URL.Path, "/image") {
+			height, _ := strconv.ParseInt(params["height"][0], 10, 0)
+			width, _ := strconv.ParseInt(params["width"][0], 10, 0)
+
+			writeImage(int(height), int(width))
+		} else if strings.HasPrefix(r.URL.Path, "/opengraph") {
+			writeHTML(params["title"][0])
 		} else if strings.HasPrefix(r.URL.Path, "/json") {
 			w.Header().Set("Content-Type", "application/json")
 
@@ -1405,6 +1414,14 @@ func TestGetLinkMetadata(t *testing.T) {
 			case <-r.Context().Done():
 			}
 			w.Write([]byte("</html>"))
+		} else if strings.HasPrefix(r.URL.Path, "/mixed") {
+			for _, acceptedType := range r.Header["Accept"] {
+				if acceptedType == "image/*" || acceptedType == "image/png" {
+					writeImage(10, 10)
+				} else if acceptedType == "text/html" {
+					writeHTML("mixed")
+				}
+			}
 		} else {
 			w.WriteHeader(http.StatusInternalServerError)
 		}
@@ -1867,6 +1884,19 @@ func TestGetLinkMetadata(t *testing.T) {
 		assert.Nil(t, img)
 		assert.NotNil(t, err)
 		assert.IsType(t, imageproxy.Error{}, err)
+	})
+
+	t.Run("should prefer images for mixed content", func(t *testing.T) {
+		th := setup()
+		defer th.TearDown()
+
+		requestURL := server.URL + "/mixed?name=" + t.Name()
+		timestamp := int64(1547510400000)
+
+		og, img, err := th.App.getLinkMetadata(requestURL, timestamp, true)
+		assert.Nil(t, og)
+		assert.NotNil(t, img)
+		assert.Nil(t, err)
 	})
 }
 

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -1416,9 +1416,9 @@ func TestGetLinkMetadata(t *testing.T) {
 			w.Write([]byte("</html>"))
 		} else if strings.HasPrefix(r.URL.Path, "/mixed") {
 			for _, acceptedType := range r.Header["Accept"] {
-				if acceptedType == "image/*" || acceptedType == "image/png" {
+				if strings.HasPrefix(acceptedType, "image/*") || strings.HasPrefix(acceptedType, "image/png") {
 					writeImage(10, 10)
-				} else if acceptedType == "text/html" {
+				} else if strings.HasPrefix(acceptedType, "text/html") {
 					writeHTML("mixed")
 				}
 			}


### PR DESCRIPTION
We specify multiple Accept headers for the post metadata because we're either looking for image previews or HTML to scrape for OpenGraph metadata. The way that we were specifying both headers before was incorrect, so we'd sometimes get HTML results instead of an image for certain sites that serve multiple types of content on a single URL. This causes an OpenGraph preview to be displayed in certain places where we'd want an image preview to be displayed.

Oddly enough, the previous fix for this in https://github.com/mattermost/mattermost-server/pull/10241 did fix this issue for some websites (eg giphy.com), but not others (tenor.com)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17426