### PR TITLE
Typo in French translation for utils.mail.connect_smtp.open.app_error

### DIFF
--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -6944,7 +6944,7 @@
   },
   {
     "id": "utils.mail.connect_smtp.open.app_error",
-    "translation": "Échec de l'ouverture de la connexion sql"
+    "translation": "Échec de l'ouverture de la connexion SMTP"
   },
   {
     "id": "utils.mail.connect_smtp.open_tls.app_error",


### PR DESCRIPTION
#### Summary
Fix a typo in French translation for `utils.mail.connect_smtp.open.app_error`.

#### Ticket Link
Not available.
