### PR TITLE
MM-17087 - Disable plugin on removal

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -255,6 +255,8 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	testCluster.ClearMessages()
+
 	// Successful upload
 	manifest, resp := th.SystemAdminClient.UploadPlugin(bytes.NewReader(tarData))
 	CheckNoError(t, resp)
@@ -266,6 +268,7 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 	require.Nil(t, err)
 	require.True(t, pluginStored)
 
+	messages := testCluster.GetMessages()
 	expectedPluginData := model.PluginEventData{
 		Id: manifest.Id,
 	}
@@ -275,15 +278,22 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 		WaitForAllToSend: true,
 		Data:             expectedPluginData.ToJson(),
 	}
-	expectedMessages := findClusterMessages(model.CLUSTER_EVENT_INSTALL_PLUGIN, testCluster.GetMessages())
-	require.Equal(t, []*model.ClusterMessage{expectedInstallMessage}, expectedMessages)
+	actualMessages := findClusterMessages(model.CLUSTER_EVENT_INSTALL_PLUGIN, messages)
+	require.Equal(t, []*model.ClusterMessage{expectedInstallMessage}, actualMessages)
+
+	// Upgrade
+	testCluster.ClearMessages()
+	manifest, resp = th.SystemAdminClient.UploadPluginForced(bytes.NewReader(tarData))
+	CheckNoError(t, resp)
+	require.Equal(t, "testplugin", manifest.Id)
 
 	// Successful remove
 	testCluster.ClearMessages()
-
 	ok, resp := th.SystemAdminClient.RemovePlugin(manifest.Id)
 	CheckNoError(t, resp)
 	require.True(t, ok)
+
+	messages = testCluster.GetMessages()
 
 	expectedRemoveMessage := &model.ClusterMessage{
 		Event:            model.CLUSTER_EVENT_REMOVE_PLUGIN,
@@ -291,12 +301,116 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 		WaitForAllToSend: true,
 		Data:             expectedPluginData.ToJson(),
 	}
-	expectedMessages = findClusterMessages(model.CLUSTER_EVENT_REMOVE_PLUGIN, testCluster.GetMessages())
-	require.Equal(t, []*model.ClusterMessage{expectedRemoveMessage}, expectedMessages)
+	actualMessages = findClusterMessages(model.CLUSTER_EVENT_REMOVE_PLUGIN, messages)
+	require.Equal(t, []*model.ClusterMessage{expectedRemoveMessage}, actualMessages)
 
 	pluginStored, err = th.App.FileExists(expectedPath)
 	require.Nil(t, err)
 	require.False(t, pluginStored)
+}
+
+func TestDisableOnRemove(t *testing.T) {
+	path, _ := fileutils.FindDir("tests")
+	tarData, err := ioutil.ReadFile(filepath.Join(path, "testplugin.tar.gz"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		Description string
+		Upgrade     bool
+	}{
+		{
+			"Remove without upgrading",
+			false,
+		},
+		{
+			"Remove after upgrading",
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			th := Setup().InitBasic()
+			defer th.TearDown()
+
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				*cfg.PluginSettings.Enable = true
+				*cfg.PluginSettings.EnableUploads = true
+			})
+
+			// Upload
+			manifest, resp := th.SystemAdminClient.UploadPlugin(bytes.NewReader(tarData))
+			CheckNoError(t, resp)
+			require.Equal(t, "testplugin", manifest.Id)
+
+			// Check initial status
+			pluginsResp, resp := th.SystemAdminClient.GetPlugins()
+			CheckNoError(t, resp)
+			require.Len(t, pluginsResp.Active, 0)
+			require.Equal(t, pluginsResp.Inactive, []*model.PluginInfo{&model.PluginInfo{
+				Manifest: *manifest,
+			}})
+
+			// Enable plugin
+			ok, resp := th.SystemAdminClient.EnablePlugin(manifest.Id)
+			CheckNoError(t, resp)
+			require.True(t, ok)
+
+			// Confirm enabled status
+			pluginsResp, resp = th.SystemAdminClient.GetPlugins()
+			CheckNoError(t, resp)
+			require.Len(t, pluginsResp.Inactive, 0)
+			require.Equal(t, pluginsResp.Active, []*model.PluginInfo{&model.PluginInfo{
+				Manifest: *manifest,
+			}})
+
+			if tc.Upgrade {
+				// Upgrade
+				manifest, resp = th.SystemAdminClient.UploadPluginForced(bytes.NewReader(tarData))
+				CheckNoError(t, resp)
+				require.Equal(t, "testplugin", manifest.Id)
+
+				// Plugin should remain active
+				pluginsResp, resp = th.SystemAdminClient.GetPlugins()
+				CheckNoError(t, resp)
+				require.Len(t, pluginsResp.Inactive, 0)
+				require.Equal(t, pluginsResp.Active, []*model.PluginInfo{&model.PluginInfo{
+					Manifest: *manifest,
+				}})
+			}
+
+			// Remove plugin
+			ok, resp = th.SystemAdminClient.RemovePlugin(manifest.Id)
+			CheckNoError(t, resp)
+			require.True(t, ok)
+
+			// Plugin should have no status
+			pluginsResp, resp = th.SystemAdminClient.GetPlugins()
+			CheckNoError(t, resp)
+			require.Len(t, pluginsResp.Inactive, 0)
+			require.Len(t, pluginsResp.Active, 0)
+
+			// Upload same plugin
+			manifest, resp = th.SystemAdminClient.UploadPlugin(bytes.NewReader(tarData))
+			CheckNoError(t, resp)
+			require.Equal(t, "testplugin", manifest.Id)
+
+			// Plugin should be inactive
+			pluginsResp, resp = th.SystemAdminClient.GetPlugins()
+			CheckNoError(t, resp)
+			require.Len(t, pluginsResp.Active, 0)
+			require.Equal(t, pluginsResp.Inactive, []*model.PluginInfo{&model.PluginInfo{
+				Manifest: *manifest,
+			}})
+
+			// Clean up
+			ok, resp = th.SystemAdminClient.RemovePlugin(manifest.Id)
+			CheckNoError(t, resp)
+			require.True(t, ok)
+		})
+	}
 }
 
 func findClusterMessages(event string, msgs []*model.ClusterMessage) []*model.ClusterMessage {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -403,7 +403,6 @@ func (a *App) GetPlugins() (*model.PluginsResponse, *model.AppError) {
 // notifyPluginEnabled notifies connected websocket clients across all peers if the version of the given
 // plugin is same across them.
 //
-//
 // When a peer finds itself in agreement with all other peers as to the version of the given plugin,
 // it will notify all connected websocket clients (across all peers) to trigger the (re-)installation.
 // There is a small chance that this never occurs, because the last server to finish installing dies before it can announce.

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -440,6 +440,10 @@ func (a *App) notifyPluginEnabled(manifest *model.Manifest) error {
 	}
 	statuses = append(statuses, localStatus)
 
+	// This will not guard against the race condition of enabling a plugin immediately after installation.
+	// As GetPluginStatuses() will not return the new plugin (since other peers are racing to install),
+	// this peer will end up checking status against itself and will notify all webclients (including peer webclients),
+	// which may result in a 404.
 	for _, status := range statuses {
 		if status.PluginId == manifest.Id && status.Version != manifest.Version {
 			// Not ready

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/plugin"
 	"github.com/mattermost/mattermost-server/services/filesstore"
 	"github.com/mattermost/mattermost-server/utils/fileutils"
+	"github.com/pkg/errors"
 )
 
 // GetPluginsEnvironment returns the plugin environment for use if plugins are enabled and
@@ -412,8 +413,12 @@ func (a *App) GetPlugins() (*model.PluginsResponse, *model.AppError) {
 // verifies successfully is guaranteed to notify.
 // This may result in multiple notifications going out,
 // however webapp plugin enable/disable operations are idempotent.
-func (a *App) notifyPluginEnabled(manifest *model.Manifest) *model.AppError {
-	if !manifest.HasClient() {
+func (a *App) notifyPluginEnabled(manifest *model.Manifest) error {
+	pluginsEnvironment := a.GetPluginsEnvironment()
+	if pluginsEnvironment == nil {
+		return errors.New("pluginsEnvironment is nil")
+	}
+	if !manifest.HasClient() || !pluginsEnvironment.IsActive(manifest.Id) {
 		return nil
 	}
 

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -289,6 +289,7 @@ func (a *App) GetActivePluginManifests() ([]*model.Manifest, *model.AppError) {
 
 // EnablePlugin will set the config for an installed plugin to enabled, triggering asynchronous
 // activation if inactive anywhere in the cluster.
+// Notifies cluster peers through config change.
 func (a *App) EnablePlugin(id string) *model.AppError {
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
@@ -331,6 +332,7 @@ func (a *App) EnablePlugin(id string) *model.AppError {
 }
 
 // DisablePlugin will set the config for an installed plugin to disabled, triggering deactivation if active.
+// Notifies cluster peers through config change.
 func (a *App) DisablePlugin(id string) *model.AppError {
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -446,7 +446,7 @@ func (a *App) notifyPluginEnabled(manifest *model.Manifest) error {
 	// which may result in a 404.
 	for _, status := range statuses {
 		if status.PluginId == manifest.Id && status.Version != manifest.Version {
-			// Not ready
+			mlog.Debug("Not ready to notify webclients", mlog.String("cluster_id", status.ClusterId), mlog.String("plugin_id", manifest.Id))
 			return nil
 		}
 	}

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 	"github.com/mattermost/mattermost-server/utils"
+	"github.com/pkg/errors"
 )
 
 // managedPluginFileName is the file name of the flag file that marks
@@ -34,8 +35,13 @@ func (a *App) InstallPluginFromData(data model.PluginEventData) {
 	}
 	defer reader.Close()
 
-	if _, appErr = a.installPluginLocally(reader, true); appErr != nil {
+	manifest, appErr := a.installPluginLocally(reader, true)
+	if appErr != nil {
 		mlog.Error("Failed to unpack plugin from filestore", mlog.Err(appErr), mlog.String("path", fileStorePath))
+	}
+
+	if err := a.notifyPluginEvents(manifest); err != nil {
+		mlog.Error("Failed to notify plugin events", mlog.Err(err))
 	}
 }
 
@@ -44,6 +50,10 @@ func (a *App) RemovePluginFromData(data model.PluginEventData) {
 
 	if err := a.removePluginLocally(data.Id); err != nil {
 		mlog.Error("Failed to remove plugin locally", mlog.Err(err), mlog.String("id", data.Id))
+	}
+
+	if err := a.notifyPluginStatusesChanged(); err != nil {
+		mlog.Error("failed to notify plugin status changed", mlog.Err(err))
 	}
 }
 
@@ -61,10 +71,11 @@ func (a *App) installPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Mani
 	// Store bundle in the file store to allow access from other servers.
 	pluginFile.Seek(0, 0)
 
-	if _, err := a.WriteFile(pluginFile, a.getBundleStorePath(manifest.Id)); err != nil {
-		return nil, model.NewAppError("uploadPlugin", "app.plugin.store_bundle.app_error", nil, err.Error(), http.StatusInternalServerError)
+	if _, appErr := a.WriteFile(pluginFile, a.getBundleStorePath(manifest.Id)); appErr != nil {
+		return nil, model.NewAppError("uploadPlugin", "app.plugin.store_bundle.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 	}
 
+	// Notify cluster peers async.
 	a.notifyClusterPluginEvent(
 		model.CLUSTER_EVENT_INSTALL_PLUGIN,
 		model.PluginEventData{
@@ -72,29 +83,33 @@ func (a *App) installPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Mani
 		},
 	)
 
+	if err := a.notifyPluginEvents(manifest); err != nil {
+		mlog.Error("Failed to notify plugin events", mlog.Err(err))
+	}
+
 	return manifest, nil
 }
 
 func (a *App) installPluginLocally(pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError) {
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
-		return nil, model.NewAppError("installPlugin", "app.plugin.disabled.app_error", nil, "", http.StatusNotImplemented)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	tmpDir, err := ioutil.TempDir("", "plugintmp")
 	if err != nil {
-		return nil, model.NewAppError("installPlugin", "app.plugin.filesystem.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.filesystem.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	defer os.RemoveAll(tmpDir)
 
 	if err = utils.ExtractTarGz(pluginFile, tmpDir); err != nil {
-		return nil, model.NewAppError("installPlugin", "app.plugin.extract.app_error", nil, err.Error(), http.StatusBadRequest)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.extract.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
 	tmpPluginDir := tmpDir
 	dir, err := ioutil.ReadDir(tmpDir)
 	if err != nil {
-		return nil, model.NewAppError("installPlugin", "app.plugin.filesystem.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.filesystem.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	if len(dir) == 1 && dir[0].IsDir() {
@@ -103,30 +118,27 @@ func (a *App) installPluginLocally(pluginFile io.ReadSeeker, replace bool) (*mod
 
 	manifest, _, err := model.FindManifest(tmpPluginDir)
 	if err != nil {
-		return nil, model.NewAppError("installPlugin", "app.plugin.manifest.app_error", nil, err.Error(), http.StatusBadRequest)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.manifest.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
 	if !plugin.IsValidId(manifest.Id) {
-		return nil, model.NewAppError("installPlugin", "app.plugin.invalid_id.app_error", map[string]interface{}{"Min": plugin.MinIdLength, "Max": plugin.MaxIdLength, "Regex": plugin.ValidIdRegex}, "", http.StatusBadRequest)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.invalid_id.app_error", map[string]interface{}{"Min": plugin.MinIdLength, "Max": plugin.MaxIdLength, "Regex": plugin.ValidIdRegex}, "", http.StatusBadRequest)
 	}
-
-	// Stash the previous state of the plugin, if available
-	stashed := a.Config().PluginSettings.PluginStates[manifest.Id]
 
 	bundles, err := pluginsEnvironment.Available()
 	if err != nil {
-		return nil, model.NewAppError("installPlugin", "app.plugin.install.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.install.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	// Check that there is no plugin with the same ID
 	for _, bundle := range bundles {
 		if bundle.Manifest != nil && bundle.Manifest.Id == manifest.Id {
 			if !replace {
-				return nil, model.NewAppError("installPlugin", "app.plugin.install_id.app_error", nil, "", http.StatusBadRequest)
+				return nil, model.NewAppError("installPluginLocally", "app.plugin.install_id.app_error", nil, "", http.StatusBadRequest)
 			}
 
 			if err := a.removePluginLocally(manifest.Id); err != nil {
-				return nil, model.NewAppError("installPlugin", "app.plugin.install_id_failed_remove.app_error", nil, "", http.StatusBadRequest)
+				return nil, model.NewAppError("installPluginLocally", "app.plugin.install_id_failed_remove.app_error", nil, "", http.StatusBadRequest)
 			}
 		}
 	}
@@ -134,22 +146,24 @@ func (a *App) installPluginLocally(pluginFile io.ReadSeeker, replace bool) (*mod
 	pluginPath := filepath.Join(*a.Config().PluginSettings.Directory, manifest.Id)
 	err = utils.CopyDir(tmpPluginDir, pluginPath)
 	if err != nil {
-		return nil, model.NewAppError("installPlugin", "app.plugin.mvdir.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.mvdir.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	// Flag plugin locally as managed by the filestore.
 	f, err := os.Create(filepath.Join(pluginPath, managedPluginFileName))
 	if err != nil {
-		return nil, model.NewAppError("uploadPlugin", "app.plugin.flag_managed.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("installPluginLocally", "app.plugin.flag_managed.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	f.Close()
 
-	if stashed != nil && stashed.Enable {
-		a.EnablePlugin(manifest.Id)
-	}
-
-	if err := a.notifyPluginStatusesChanged(); err != nil {
-		mlog.Error("failed to notify plugin status changed", mlog.Err(err))
+	// Activate plugin if it was previously activated.
+	pluginState := a.Config().PluginSettings.PluginStates[manifest.Id]
+	if pluginState != nil && pluginState.Enable {
+		updatedManifest, _, err := pluginsEnvironment.Activate(manifest.Id)
+		if err != nil {
+			return nil, model.NewAppError("installPluginLocally", "app.plugin.restart.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+		manifest = updatedManifest
 	}
 
 	return manifest, nil
@@ -160,6 +174,11 @@ func (a *App) RemovePlugin(id string) *model.AppError {
 }
 
 func (a *App) removePlugin(id string) *model.AppError {
+	// Disable plugin before removal and notify cluster peers sync.
+	if err := a.DisablePlugin(id); err != nil {
+		return err
+	}
+
 	if err := a.removePluginLocally(id); err != nil {
 		return err
 	}
@@ -177,6 +196,7 @@ func (a *App) removePlugin(id string) *model.AppError {
 		return model.NewAppError("removePlugin", "app.plugin.remove_bundle.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
+	// Notify cluster peers async.
 	a.notifyClusterPluginEvent(
 		model.CLUSTER_EVENT_REMOVE_PLUGIN,
 		model.PluginEventData{
@@ -212,19 +232,32 @@ func (a *App) removePluginLocally(id string) *model.AppError {
 		return model.NewAppError("removePlugin", "app.plugin.not_installed.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	if pluginsEnvironment.IsActive(id) && manifest.HasClient() {
-		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_PLUGIN_DISABLED, "", "", "", nil)
-		message.Add("manifest", manifest.ClientManifest())
-		a.Publish(message)
-	}
-
 	pluginsEnvironment.Deactivate(id)
 	pluginsEnvironment.RemovePlugin(id)
 	a.UnregisterPluginCommands(id)
 
-	err = os.RemoveAll(pluginPath)
-	if err != nil {
+	if err := os.RemoveAll(pluginPath); err != nil {
 		return model.NewAppError("removePlugin", "app.plugin.remove.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
+}
+
+func (a *App) notifyPluginEvents(manifest *model.Manifest) error {
+	pluginsEnvironment := a.GetPluginsEnvironment()
+	if pluginsEnvironment == nil {
+		return errors.New("pluginsEnvironment is nil")
+	}
+
+	if pluginsEnvironment.IsActive(manifest.Id) {
+		// Notify all cluster clients if ready
+		if appErr := a.notifyPluginEnabled(manifest); appErr != nil {
+			return errors.Wrap(appErr, "failed notify plugin enabled")
+		}
+	}
+
+	if err := a.notifyPluginStatusesChanged(); err != nil {
+		return errors.Wrap(err, "failed to notify plugin status changed")
 	}
 
 	return nil

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -181,7 +181,8 @@ func (a *App) RemovePlugin(id string) *model.AppError {
 }
 
 func (a *App) removePlugin(id string) *model.AppError {
-	// Disable plugin before removal and notify cluster peers sync.
+	// Disable plugin before removal to make sure this
+	// plugin remains disabled on re-install.
 	if err := a.DisablePlugin(id); err != nil {
 		return err
 	}

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -179,6 +179,14 @@ func (a *App) installPluginLocally(pluginFile io.ReadSeeker, replace bool) (*mod
 	}
 	f.Close()
 
+	if manifest.HasWebapp() {
+		updatedManifest, err := pluginsEnvironment.GenerateWebappBundle(manifest.Id)
+		if err != nil {
+			return nil, model.NewAppError("installPluginLocally", "app.plugin.webapp_bundle.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+		manifest = updatedManifest
+	}
+
 	// Activate plugin if it was previously activated.
 	pluginState := a.Config().PluginSettings.PluginStates[manifest.Id]
 	if pluginState != nil && pluginState.Enable {

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -180,7 +180,7 @@ func (a *App) installPluginLocally(pluginFile io.ReadSeeker, replace bool) (*mod
 	f.Close()
 
 	if manifest.HasWebapp() {
-		updatedManifest, err := pluginsEnvironment.GenerateWebappBundle(manifest.Id)
+		updatedManifest, err := pluginsEnvironment.UnpackWebappBundle(manifest.Id)
 		if err != nil {
 			return nil, model.NewAppError("installPluginLocally", "app.plugin.webapp_bundle.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3507,6 +3507,10 @@
     "translation": "Unable to remove plugin bundle from file store."
   },
   {
+    "id": "app.plugin.restart.app_error",
+    "translation": "Unable to restart plugin on upgrade."
+  },
+  {
     "id": "app.plugin.store_bundle.app_error",
     "translation": "Unable to store the plugin to the configured file store."
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3527,6 +3527,10 @@
     "translation": "Plugins and/or plugin uploads have been disabled."
   },
   {
+    "id": "app.plugin.webapp_bundle.app_error",
+    "translation": "Unable to generate plugin webapp bundle."
+  },
+  {
     "id": "app.role.check_roles_exist.role_not_found",
     "translation": "The provided role does not exist"
   },

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -240,7 +240,9 @@ func (env *Environment) Activate(id string) (manifest *model.Manifest, activated
 		}
 
 		hash := fnv.New64a()
-		hash.Write(sourceBundleFileContents)
+		if _, err := hash.Write(sourceBundleFileContents); err != nil {
+			return nil, false, errors.Wrapf(err, "unable to generate hash for webapp bundle: %v", id)
+		}
 		pluginInfo.Manifest.Webapp.BundleHash = hash.Sum([]byte{})
 
 		if err := os.Rename(

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -217,40 +217,11 @@ func (env *Environment) Activate(id string) (manifest *model.Manifest, activated
 	componentActivated := false
 
 	if pluginInfo.Manifest.HasWebapp() {
-		bundlePath := filepath.Clean(pluginInfo.Manifest.Webapp.BundlePath)
-		if bundlePath == "" || bundlePath[0] == '.' {
-			return nil, false, fmt.Errorf("invalid webapp bundle path")
-		}
-		bundlePath = filepath.Join(env.pluginDir, id, bundlePath)
-		destinationPath := filepath.Join(env.webappPluginDir, id)
-
-		if err := os.RemoveAll(destinationPath); err != nil {
-			return nil, false, errors.Wrapf(err, "unable to remove old webapp bundle directory: %v", destinationPath)
-		}
-
-		if err := utils.CopyDir(filepath.Dir(bundlePath), destinationPath); err != nil {
-			return nil, false, errors.Wrapf(err, "unable to copy webapp bundle directory: %v", id)
-		}
-
-		sourceBundleFilepath := filepath.Join(destinationPath, filepath.Base(bundlePath))
-
-		sourceBundleFileContents, err := ioutil.ReadFile(sourceBundleFilepath)
+		updatedManifest, err := env.GenerateWebappBundle(id)
 		if err != nil {
-			return nil, false, errors.Wrapf(err, "unable to read webapp bundle: %v", id)
+			return nil, false, errors.Wrapf(err, "unable to generate webapp bundle: %v", id)
 		}
-
-		hash := fnv.New64a()
-		if _, err := hash.Write(sourceBundleFileContents); err != nil {
-			return nil, false, errors.Wrapf(err, "unable to generate hash for webapp bundle: %v", id)
-		}
-		pluginInfo.Manifest.Webapp.BundleHash = hash.Sum([]byte{})
-
-		if err := os.Rename(
-			sourceBundleFilepath,
-			filepath.Join(destinationPath, fmt.Sprintf("%s_%x_bundle.js", id, pluginInfo.Manifest.Webapp.BundleHash)),
-		); err != nil {
-			return nil, false, errors.Wrapf(err, "unable to rename webapp bundle: %v", id)
-		}
+		pluginInfo.Manifest.Webapp.BundleHash = updatedManifest.Webapp.BundleHash
 
 		componentActivated = true
 	}
@@ -327,6 +298,63 @@ func (env *Environment) Shutdown() {
 
 		return true
 	})
+}
+
+// GenerateWebappBundle generates webapp bundle for a given plugin id.
+func (env *Environment) GenerateWebappBundle(id string) (*model.Manifest, error) {
+	plugins, err := env.Available()
+	if err != nil {
+		return nil, errors.New("Unable to get available plugins")
+	}
+	var manifest *model.Manifest
+	for _, p := range plugins {
+		if p.Manifest != nil && p.Manifest.Id == id {
+			if manifest != nil {
+				return nil, fmt.Errorf("multiple plugins found: %v", id)
+			}
+			manifest = p.Manifest
+		}
+	}
+	if manifest == nil {
+		return nil, fmt.Errorf("plugin not found: %v", id)
+	}
+
+	bundlePath := filepath.Clean(manifest.Webapp.BundlePath)
+	if bundlePath == "" || bundlePath[0] == '.' {
+		return nil, fmt.Errorf("invalid webapp bundle path")
+	}
+	bundlePath = filepath.Join(env.pluginDir, id, bundlePath)
+	destinationPath := filepath.Join(env.webappPluginDir, id)
+
+	if err := os.RemoveAll(destinationPath); err != nil {
+		return nil, errors.Wrapf(err, "unable to remove old webapp bundle directory: %v", destinationPath)
+	}
+
+	if err := utils.CopyDir(filepath.Dir(bundlePath), destinationPath); err != nil {
+		return nil, errors.Wrapf(err, "unable to copy webapp bundle directory: %v", id)
+	}
+
+	sourceBundleFilepath := filepath.Join(destinationPath, filepath.Base(bundlePath))
+
+	sourceBundleFileContents, err := ioutil.ReadFile(sourceBundleFilepath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read webapp bundle: %v", id)
+	}
+
+	hash := fnv.New64a()
+	if _, err := hash.Write(sourceBundleFileContents); err != nil {
+		return nil, errors.Wrapf(err, "unable to generate hash for webapp bundle: %v", id)
+	}
+	manifest.Webapp.BundleHash = hash.Sum([]byte{})
+
+	if err := os.Rename(
+		sourceBundleFilepath,
+		filepath.Join(destinationPath, fmt.Sprintf("%s_%x_bundle.js", id, manifest.Webapp.BundleHash)),
+	); err != nil {
+		return nil, errors.Wrapf(err, "unable to rename webapp bundle: %v", id)
+	}
+
+	return manifest, nil
 }
 
 // HooksForPlugin returns the hooks API for the plugin with the given id.

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -326,11 +326,11 @@ func (env *Environment) GenerateWebappBundle(id string) (*model.Manifest, error)
 	bundlePath = filepath.Join(env.pluginDir, id, bundlePath)
 	destinationPath := filepath.Join(env.webappPluginDir, id)
 
-	if err := os.RemoveAll(destinationPath); err != nil {
+	if err = os.RemoveAll(destinationPath); err != nil {
 		return nil, errors.Wrapf(err, "unable to remove old webapp bundle directory: %v", destinationPath)
 	}
 
-	if err := utils.CopyDir(filepath.Dir(bundlePath), destinationPath); err != nil {
+	if err = utils.CopyDir(filepath.Dir(bundlePath), destinationPath); err != nil {
 		return nil, errors.Wrapf(err, "unable to copy webapp bundle directory: %v", id)
 	}
 
@@ -342,12 +342,12 @@ func (env *Environment) GenerateWebappBundle(id string) (*model.Manifest, error)
 	}
 
 	hash := fnv.New64a()
-	if _, err := hash.Write(sourceBundleFileContents); err != nil {
+	if _, err = hash.Write(sourceBundleFileContents); err != nil {
 		return nil, errors.Wrapf(err, "unable to generate hash for webapp bundle: %v", id)
 	}
 	manifest.Webapp.BundleHash = hash.Sum([]byte{})
 
-	if err := os.Rename(
+	if err = os.Rename(
 		sourceBundleFilepath,
 		filepath.Join(destinationPath, fmt.Sprintf("%s_%x_bundle.js", id, manifest.Webapp.BundleHash)),
 	); err != nil {

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -217,7 +217,7 @@ func (env *Environment) Activate(id string) (manifest *model.Manifest, activated
 	componentActivated := false
 
 	if pluginInfo.Manifest.HasWebapp() {
-		updatedManifest, err := env.GenerateWebappBundle(id)
+		updatedManifest, err := env.UnpackWebappBundle(id)
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "unable to generate webapp bundle: %v", id)
 		}
@@ -300,8 +300,8 @@ func (env *Environment) Shutdown() {
 	})
 }
 
-// GenerateWebappBundle generates webapp bundle for a given plugin id.
-func (env *Environment) GenerateWebappBundle(id string) (*model.Manifest, error) {
+// UnpackWebappBundle unpacks webapp bundle for a given plugin id on disk.
+func (env *Environment) UnpackWebappBundle(id string) (*model.Manifest, error) {
 	plugins, err := env.Available()
 	if err != nil {
 		return nil, errors.New("Unable to get available plugins")


### PR DESCRIPTION
#### Summary
- Disable plugin on removal
- Updated cluster peers synchronization logic to notify clients ONLY after all cluster peers have been fully updated, as opposed to notifying them when one of them was updated
- Re-activates plugin on upgrade via `PluginEnvironment` as opposed to `EnablePlugin` api which caused a config change + notify cluster peer of a config change and wreaked havoc -- true story.
- Added a unit test to confirm `disabled` state on plugin re-install
- Not able to write a unit test to test cluster functionality, but hopefully in the future we can add isolated env to test these cases and lock down behaviour

#### Dev testing
- Wrote a mini stress script that does the following. See attached script to the jira.
 -- Removed plugin 1.0
 -- Installs plugin 1.0
 -- Enables plugin
 -- Installs plugin 2.0
 -- Installs plugin 1.0
 -- repeat
- With the stress test, I was still able to reproduce a 404 bundle not found (1 in ~100 runs), however that was probably caused by my script that had already upgraded to the newer plugin version (as we remove bundle on deactivate/upgrade) while the clients were going and fetching the bundle, not a 100% certain though. That is my theory as i couldn't find any error logs for `missing_plugin`, which is caused when the plugin is missing from an instance.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-17087

#### Related Pull Requests
- Has webapp changes (https://github.com/mattermost/mattermost-webapp/pull/3425)