### PR TITLE
Use old container names with docker-compose.

### DIFF
--- a/build/docker-compose.override.yml
+++ b/build/docker-compose.override.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+services:
+  mysql:
+    container_name: mattermost-mysql
+  postgres:
+    container_name: mattermost-postgres
+  minio:
+    container_name: mattermost-minio
+  inbucket:
+    container_name: mattermost-inbucket
+  openldap:
+    container_name: mattermost-openldap
+  elasticsearch:
+    container_name: mattermost-elasticsearch
+  redis:
+    container_name: mattermost-redis

--- a/build/docker-compose.prod.yml
+++ b/build/docker-compose.prod.yml
@@ -1,0 +1,16 @@
+version: '3.4'
+services:
+  mysql:
+    container_name: ''
+  postgres:
+    container_name: ''
+  minio:
+    container_name: ''
+  inbucket:
+    container_name: ''
+  openldap:
+    container_name: ''
+  elasticsearch:
+    container_name: ''
+  redis:
+    container_name: ''

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     tmpfs: /var/lib/mysql
     volumes:
      - "./docker/mysql.conf.d:/etc/mysql/conf.d"
+    container_name: mattermost-mysql
   postgres:
     image: "postgres:9.4"
     restart: always
@@ -28,6 +29,7 @@ services:
       POSTGRES_PASSWORD: mostest
       POSTGRES_DB: mattermost_test
     tmpfs: /var/lib/postgresql/data
+    container_name: mattermost-postgres
   minio:
     image: "minio/minio:RELEASE.2019-04-23T23-50-36Z"
     command: "server /data"
@@ -39,6 +41,7 @@ services:
       MINIO_ACCESS_KEY: minioaccesskey
       MINIO_SECRET_KEY: miniosecretkey
       MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
+    container_name: mattermost-minio
   inbucket:
     image: "jhillyerd/inbucket:release-1.2.0"
     restart: always
@@ -48,6 +51,7 @@ services:
       - "10025:10025"
       - "10080:10080"
       - "10110:10110"
+    container_name: mattermost-inbucket
   openldap:
     image: "osixia/openldap:1.2.2"
     restart: always
@@ -64,6 +68,7 @@ services:
     volumes:
       - "../tests/test-data.ldif:/test-data.ldif"
       - "../tests/qa-data.ldif:/qa-data.ldif"
+    container_name: mattermost-openldap
   elasticsearch:
     image: "mattermost/mattermost-elasticsearch-docker:6.5.1"
     networks:
@@ -75,12 +80,14 @@ services:
       http.host: "0.0.0.0"
       transport.host: "127.0.0.1"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    container_name: mattermost-elasticsearch
   redis:
     image: redis
     networks:
       - mm-test
     ports:
       - "6379:6379"
+    container_name: mattermost-redis
   start_dependencies:
     image: mattermost/mattermost-wait-for-dep:latest
     networks:


### PR DESCRIPTION
#### Summary

Adds container names matching the old names used for backwards compatibility.

#### Ticket Link

n/a