### PR TITLE
MM-17496: Skip adding user to default channel (rather than failing) w…

### DIFF
--- a/app/syncables.go
+++ b/app/syncables.go
@@ -57,7 +57,14 @@ func (a *App) CreateDefaultMemberships(since int64) error {
 
 		_, err = a.AddChannelMember(userChannel.UserID, channel, "", "")
 		if err != nil {
-			return err
+			if err.Id == "api.channel.add_user.to.channel.failed.deleted.app_error" {
+				a.Log.Info("Not adding user to channel because they have already left the team",
+					mlog.String("user_id", userChannel.UserID),
+					mlog.String("channel_id", userChannel.ChannelID),
+				)
+			} else {
+				return err
+			}
 		}
 
 		a.Log.Info("added channelmember",


### PR DESCRIPTION
…hen user has already left the parent team.

#### Summary

Skipping adding user to default channel (rather than returning error and failing the sync) when the user left the associated channel.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17496