### PR TITLE
[MM-17214] Use AddChannelMember method when registering a new guest

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -93,7 +93,7 @@ func (a *App) CreateUserWithToken(user *model.User, token *model.Token) (*model.
 
 	if token.Type == TOKEN_TYPE_GUEST_INVITATION {
 		for _, channel := range channels {
-			_, err := a.AddUserToChannel(ruser, channel)
+			_, err := a.AddChannelMember(ruser.Id, channel, "", "")
 			if err != nil {
 				mlog.Error(err.Error())
 			}


### PR DESCRIPTION
#### Summary
When registering a new user, this PR uses the `AddChannelMember` method instead of `AddUserToChannel`, triggering indexing, the plugins and the system message for the newly registered user.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17214
