### PR TITLE
MM-16378: revert plugin health check config removal

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -597,6 +597,7 @@ func (a *App) trackConfig() {
 		"enable":                        *cfg.PluginSettings.Enable,
 		"enable_uploads":                *cfg.PluginSettings.EnableUploads,
 		"allow_insecure_download_url":   *cfg.PluginSettings.AllowInsecureDownloadUrl,
+		"enable_health_check":           *cfg.PluginSettings.EnableHealthCheck,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_DATA_RETENTION, map[string]interface{}{

--- a/app/server.go
+++ b/app/server.go
@@ -204,12 +204,12 @@ func NewServer(options ...Option) (*Server, error) {
 	// Start plugin health check job
 	pluginsEnvironment := s.PluginsEnvironment
 	if pluginsEnvironment != nil {
-		pluginsEnvironment.InitPluginHealthCheckJob(*s.Config().PluginSettings.EnableHealthCheck)
+		pluginsEnvironment.InitPluginHealthCheckJob(*s.Config().PluginSettings.Enable && *s.Config().PluginSettings.EnableHealthCheck)
 	}
 	s.AddConfigListener(func(_, c *model.Config) {
 		pluginsEnvironment := s.PluginsEnvironment
 		if pluginsEnvironment != nil {
-			pluginsEnvironment.InitPluginHealthCheckJob(*c.PluginSettings.EnableHealthCheck)
+			pluginsEnvironment.InitPluginHealthCheckJob(*s.Config().PluginSettings.Enable && *c.PluginSettings.EnableHealthCheck)
 		}
 	})
 

--- a/app/server.go
+++ b/app/server.go
@@ -204,8 +204,14 @@ func NewServer(options ...Option) (*Server, error) {
 	// Start plugin health check job
 	pluginsEnvironment := s.PluginsEnvironment
 	if pluginsEnvironment != nil {
-		pluginsEnvironment.InitPluginHealthCheckJob()
+		pluginsEnvironment.InitPluginHealthCheckJob(*s.Config().PluginSettings.EnableHealthCheck)
 	}
+	s.AddConfigListener(func(_, c *model.Config) {
+		pluginsEnvironment := s.PluginsEnvironment
+		if pluginsEnvironment != nil {
+			pluginsEnvironment.InitPluginHealthCheckJob(*c.PluginSettings.EnableHealthCheck)
+		}
+	})
 
 	mlog.Info(fmt.Sprintf("Current version is %v (%v/%v/%v/%v)", model.CurrentVersion, model.BuildNumber, model.BuildDate, model.BuildHash, model.BuildHashEnterprise))
 	mlog.Info(fmt.Sprintf("Enterprise Enabled: %v", model.BuildEnterpriseReady))

--- a/mlog/log.go
+++ b/mlog/log.go
@@ -34,6 +34,7 @@ var String = zap.String
 var Any = zap.Any
 var Err = zap.Error
 var Bool = zap.Bool
+var Duration = zap.Duration
 
 type LoggerConfiguration struct {
 	EnableConsole bool

--- a/model/config.go
+++ b/model/config.go
@@ -2187,6 +2187,7 @@ type PluginSettings struct {
 	Enable                   *bool
 	EnableUploads            *bool   `restricted:"true"`
 	AllowInsecureDownloadUrl *bool   `restricted:"true"`
+	EnableHealthCheck        *bool   `restricted:"true"`
 	Directory                *string `restricted:"true"`
 	ClientDirectory          *string `restricted:"true"`
 	Plugins                  map[string]map[string]interface{}
@@ -2204,6 +2205,10 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 
 	if s.AllowInsecureDownloadUrl == nil {
 		s.AllowInsecureDownloadUrl = NewBool(false)
+	}
+
+	if s.EnableHealthCheck == nil {
+		s.EnableHealthCheck = NewBool(true)
 	}
 
 	if s.Directory == nil {

--- a/plugin/health_check.go
+++ b/plugin/health_check.go
@@ -24,11 +24,20 @@ type PluginHealthCheckJob struct {
 	env       *Environment
 }
 
-// InitPluginHealthCheckJob starts a new job for checking all active plugins
-func (env *Environment) InitPluginHealthCheckJob() {
-	job := newPluginHealthCheckJob(env)
-	env.pluginHealthCheckJob = job
-	job.Start()
+// InitPluginHealthCheckJob starts a new job if one is not running and is set to enabled, or kills an existing one if set to disabled.
+func (env *Environment) InitPluginHealthCheckJob(enable bool) {
+	// Config is set to enable. No job exists, start a new job.
+	if enable && env.pluginHealthCheckJob == nil {
+		job := newPluginHealthCheckJob(env)
+		env.pluginHealthCheckJob = job
+		job.Start()
+	}
+
+	// Config is set to disable. Job exists, kill existing job.
+	if !enable && env.pluginHealthCheckJob != nil {
+		env.pluginHealthCheckJob.Cancel()
+		env.pluginHealthCheckJob = nil
+	}
 }
 
 // Start continuously runs health checks on all active plugins, on a timer.

--- a/plugin/health_check_test.go
+++ b/plugin/health_check_test.go
@@ -130,8 +130,8 @@ func TestShouldDeactivatePlugin(t *testing.T) {
 
 	// Failures are recent enough to restart
 	rp = newRegisteredPlugin(bundle)
-	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION*0.2*time.Minute))
-	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION*0.1*time.Minute))
+	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION/10*2))
+	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION/10))
 	rp.failTimeStamps = append(rp.failTimeStamps, now)
 
 	result = shouldDeactivatePlugin(rp)
@@ -139,8 +139,8 @@ func TestShouldDeactivatePlugin(t *testing.T) {
 
 	// Failures are too spaced out to warrant a restart
 	rp = newRegisteredPlugin(bundle)
-	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION*2*time.Minute))
-	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION*1*time.Minute))
+	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION*2))
+	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION*1))
 	rp.failTimeStamps = append(rp.failTimeStamps, now)
 
 	result = shouldDeactivatePlugin(rp)
@@ -148,7 +148,7 @@ func TestShouldDeactivatePlugin(t *testing.T) {
 
 	// Not enough failures are present to warrant a restart
 	rp = newRegisteredPlugin(bundle)
-	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION*0.1*time.Minute))
+	rp.failTimeStamps = append(rp.failTimeStamps, now.Add(-HEALTH_CHECK_DISABLE_DURATION/10))
 	rp.failTimeStamps = append(rp.failTimeStamps, now)
 
 	result = shouldDeactivatePlugin(rp)


### PR DESCRIPTION
#### Summary
Revert https://github.com/mattermost/mattermost-server/commit/4e5f6fcfbc85ea24788241c716862e1833c6f60e, restoring the ability to disable plugin health checks.

I've also thrown in a commit here to improve logging of the job, as well as fully disable it whenever plugins are themselves disabled.

I'll be submitting a separate PR to reduce the health check to just the ping interactions vs. the process signals.

@prapti, I suspect we'll verify this one after merging, along with the fix for https://mattermost.atlassian.net/browse/MM-17488.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16378