### PR TITLE
MM-16725 Respect env var overrides when setting config

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -64,7 +64,7 @@ func UseTestStore(store store.Store) {
 func setupTestHelper(enterprise bool, updateConfig func(*model.Config)) *TestHelper {
 	testStore.DropAllTables()
 
-	memoryStore, err := config.NewMemoryStore()
+	memoryStore, err := config.NewMemoryStoreWithOptions(&config.MemoryStoreOptions{IgnoreEnvironmentOverrides: true})
 	if err != nil {
 		panic("failed to initialize memory store: " + err.Error())
 	}

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -234,6 +234,7 @@ func TestGetEnvironmentConfig(t *testing.T) {
 	os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://example.mattermost.com")
 	os.Setenv("MM_SERVICESETTINGS_ENABLECUSTOMEMOJI", "true")
 	defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
+	defer os.Unsetenv("MM_SERVICESETTINGS_ENABLECUSTOMEMOJI")
 
 	th := Setup().InitBasic()
 	defer th.TearDown()

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -36,7 +36,7 @@ func setupTestHelper(enterprise bool, tb testing.TB) *TestHelper {
 	store := mainHelper.GetStore()
 	store.DropAllTables()
 
-	memoryStore, err := config.NewMemoryStore()
+	memoryStore, err := config.NewMemoryStoreWithOptions(&config.MemoryStoreOptions{IgnoreEnvironmentOverrides: true})
 	if err != nil {
 		panic("failed to initialize memory store: " + err.Error())
 	}

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -383,7 +383,7 @@ func TestPluginAPIGetPluginConfig(t *testing.T) {
 
 	api := NewPluginAPI(th.App, manifest)
 
-	pluginConfigJsonString := `{"mystringsetting": "str", "MyIntSetting": 32, "myboolsetting": true}`
+	pluginConfigJsonString := `{"mystringsetting": "str", "myintsetting": 32, "myboolsetting": true}`
 	var pluginConfig map[string]interface{}
 
 	if err := json.Unmarshal([]byte(pluginConfigJsonString), &pluginConfig); err != nil {

--- a/config/common.go
+++ b/config/common.go
@@ -42,7 +42,7 @@ func (cs *commonStore) GetEnvironmentOverrides() map[string]interface{} {
 // using the persist function argument.
 //
 // This function assumes no lock has been acquired, as it acquires a write lock itself.
-func (cs *commonStore) set(newCfg *model.Config, validate func(*model.Config) error, persist func(*model.Config) error) (*model.Config, error) {
+func (cs *commonStore) set(newCfg *model.Config, allowEnvironmentOverrides bool, validate func(*model.Config) error, persist func(*model.Config) error) (*model.Config, error) {
 	cs.configLock.Lock()
 	var unlockOnce sync.Once
 	defer unlockOnce.Do(cs.configLock.Unlock)
@@ -56,7 +56,14 @@ func (cs *commonStore) set(newCfg *model.Config, validate func(*model.Config) er
 	// 	return nil, errors.New("old configuration modified instead of cloning")
 	// }
 
-	newCfg = newCfg.Clone()
+	// To both clone and re-apply the environment variable overrides we marshal and then
+	// unmarshal the config again.
+	var err error
+	newCfg, _, err = unmarshalConfig(bytes.NewReader([]byte(newCfg.ToJson())), allowEnvironmentOverrides)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal config with env overrides")
+	}
+
 	newCfg.SetDefaults()
 
 	// Sometimes the config is received with "fake" data in sensitive fields. Apply the real

--- a/config/common.go
+++ b/config/common.go
@@ -6,6 +6,7 @@ package config
 import (
 	"bytes"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -59,7 +60,7 @@ func (cs *commonStore) set(newCfg *model.Config, allowEnvironmentOverrides bool,
 	// To both clone and re-apply the environment variable overrides we marshal and then
 	// unmarshal the config again.
 	var err error
-	newCfg, _, err = unmarshalConfig(bytes.NewReader([]byte(newCfg.ToJson())), allowEnvironmentOverrides)
+	newCfg, _, err = unmarshalConfig(strings.NewReader(newCfg.ToJson()), allowEnvironmentOverrides)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal config with env overrides")
 	}

--- a/config/common_test.go
+++ b/config/common_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/config"
@@ -131,6 +132,30 @@ func TestMergeConfigs(t *testing.T) {
 		assert.NotEqual(t, base.Get(), merged)
 		assert.NotEqual(t, patch, merged)
 		assert.Equal(t, expected, merged)
+	})
+}
+
+func TestConfigEnvironmentOverrides(t *testing.T) {
+	base, err := config.NewMemoryStore()
+	require.NoError(t, err)
+	originalConfig := &model.Config{}
+	originalConfig.ServiceSettings.SiteURL = newString("http://notoverriden.ca")
+
+	os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://overridden.ca")
+	defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
+
+	t.Run("loading config should respect environment variable overrides", func(t *testing.T) {
+		err := base.Load()
+		require.NoError(t, err)
+
+		assert.Equal(t, "http://overridden.ca", *base.Get().ServiceSettings.SiteURL)
+	})
+
+	t.Run("setting config should respect environment variable overrides", func(t *testing.T) {
+		_, err := base.Set(originalConfig)
+		require.NoError(t, err)
+
+		assert.Equal(t, "http://overridden.ca", *base.Get().ServiceSettings.SiteURL)
 	})
 }
 

--- a/config/database.go
+++ b/config/database.go
@@ -125,7 +125,7 @@ func parseDSN(dsn string) (string, string, error) {
 
 // Set replaces the current configuration in its entirety and updates the backing store.
 func (ds *DatabaseStore) Set(newCfg *model.Config) (*model.Config, error) {
-	return ds.commonStore.set(newCfg, ds.commonStore.validate, ds.persist)
+	return ds.commonStore.set(newCfg, true, ds.commonStore.validate, ds.persist)
 }
 
 // persist writes the configuration to the configured database.

--- a/config/database_test.go
+++ b/config/database_test.go
@@ -178,6 +178,7 @@ func TestDatabaseStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, ds.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://override")
+		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 		ds, err = config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -200,6 +201,7 @@ func TestDatabaseStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, ds.GetEnvironmentOverrides())
 
 		os.Setenv("MM_PLUGINSETTINGS_ENABLEUPLOADS", "true")
+		defer os.Unsetenv("MM_PLUGINSETTINGS_ENABLEUPLOADS")
 
 		ds, err = config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -222,6 +224,7 @@ func TestDatabaseStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, ds.GetEnvironmentOverrides())
 
 		os.Setenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM", "3000")
+		defer os.Unsetenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM")
 
 		ds, err = config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -244,6 +247,7 @@ func TestDatabaseStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, ds.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE", "123456")
+		defer os.Unsetenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE")
 
 		ds, err = config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -266,6 +270,7 @@ func TestDatabaseStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, ds.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		ds, err = config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -291,6 +296,7 @@ func TestDatabaseStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, ds.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db user:pwd@db2:5433/test-db2 user:pwd@db3:5434/test-db3")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		ds, err = config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -525,6 +531,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		assert.Equal(t, "http://minimal", *ds.Get().ServiceSettings.SiteURL)
 
 		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://override")
+		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 		err = ds.Load()
 		require.NoError(t, err)
@@ -537,6 +544,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://overridePersistEnvVariables")
+		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -557,6 +565,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_PLUGINSETTINGS_ENABLEUPLOADS", "true")
+		defer os.Unsetenv("MM_PLUGINSETTINGS_ENABLEUPLOADS")
 
 		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -579,6 +588,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM", "3000")
+		defer os.Unsetenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM")
 
 		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -601,6 +611,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE", "123456")
+		defer os.Unsetenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE")
 
 		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -623,6 +634,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)
@@ -647,6 +659,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		ds, err := config.NewDatabaseStore(fmt.Sprintf("%s://%s", *sqlSettings.DriverName, *sqlSettings.DataSource))
 		require.NoError(t, err)

--- a/config/file.go
+++ b/config/file.go
@@ -94,7 +94,7 @@ func resolveConfigFilePath(path string) (string, error) {
 
 // Set replaces the current configuration in its entirety and updates the backing store.
 func (fs *FileStore) Set(newCfg *model.Config) (*model.Config, error) {
-	return fs.commonStore.set(newCfg, func(cfg *model.Config) error {
+	return fs.commonStore.set(newCfg, true, func(cfg *model.Config) error {
 		if *fs.config.ClusterSettings.Enable && *fs.config.ClusterSettings.ReadOnlyConfig {
 			return ErrReadOnlyConfiguration
 		}

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -216,6 +216,7 @@ func TestFileStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, fs.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://override")
+		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 		fs, err = config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -237,6 +238,7 @@ func TestFileStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, fs.GetEnvironmentOverrides())
 
 		os.Setenv("MM_PLUGINSETTINGS_ENABLEUPLOADS", "true")
+		defer os.Unsetenv("MM_PLUGINSETTINGS_ENABLEUPLOADS")
 
 		fs, err = config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -258,6 +260,7 @@ func TestFileStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, fs.GetEnvironmentOverrides())
 
 		os.Setenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM", "3000")
+		defer os.Unsetenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM")
 
 		fs, err = config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -279,6 +282,7 @@ func TestFileStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, fs.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE", "123456")
+		defer os.Unsetenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE")
 
 		fs, err = config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -300,6 +304,7 @@ func TestFileStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, fs.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		fs, err = config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -324,6 +329,7 @@ func TestFileStoreGetEnivironmentOverrides(t *testing.T) {
 		assert.Empty(t, fs.GetEnvironmentOverrides())
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db user:pwd@db2:5433/test-db2 user:pwd@db3:5434/test-db3")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		fs, err = config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -541,6 +547,7 @@ func TestFileStoreLoad(t *testing.T) {
 		assert.Equal(t, "http://minimal", *fs.Get().ServiceSettings.SiteURL)
 
 		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://override")
+		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 		err = fs.Load()
 		require.NoError(t, err)
@@ -553,6 +560,7 @@ func TestFileStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://overridePersistEnvVariables")
+		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 		fs, err := config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -575,6 +583,7 @@ func TestFileStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_PLUGINSETTINGS_ENABLEUPLOADS", "true")
+		defer os.Unsetenv("MM_PLUGINSETTINGS_ENABLEUPLOADS")
 
 		fs, err := config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -597,6 +606,7 @@ func TestFileStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM", "3000")
+		defer os.Unsetenv("MM_TEAMSETTINGS_MAXUSERSPERTEAM")
 
 		fs, err := config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -619,6 +629,7 @@ func TestFileStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE", "123456")
+		defer os.Unsetenv("MM_SERVICESETTINGS_TLSSTRICTTRANSPORTMAXAGE")
 
 		fs, err := config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -641,6 +652,7 @@ func TestFileStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		fs, err := config.NewFileStore(path, false)
 		require.NoError(t, err)
@@ -665,6 +677,7 @@ func TestFileStoreLoad(t *testing.T) {
 		defer tearDown()
 
 		os.Setenv("MM_SQLSETTINGS_DATASOURCEREPLICAS", "user:pwd@db:5432/test-db")
+		defer os.Unsetenv("MM_SQLSETTINGS_DATASOURCEREPLICAS")
 
 		fs, err := config.NewFileStore(path, false)
 		require.NoError(t, err)

--- a/config/memory.go
+++ b/config/memory.go
@@ -73,7 +73,7 @@ func (ms *memoryStore) Set(newCfg *model.Config) (*model.Config, error) {
 		validate = nil
 	}
 
-	return ms.commonStore.set(newCfg, validate, ms.persist)
+	return ms.commonStore.set(newCfg, ms.allowEnvironmentOverrides, validate, ms.persist)
 }
 
 // persist copies the active config to the saved config.

--- a/config/memory_test.go
+++ b/config/memory_test.go
@@ -94,6 +94,7 @@ func TestMemoryStoreGetEnivironmentOverrides(t *testing.T) {
 	assert.Empty(t, ms.GetEnvironmentOverrides())
 
 	os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://override")
+	defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 	ms, err = config.NewMemoryStore()
 	require.NoError(t, err)
@@ -231,6 +232,7 @@ func TestMemoryStoreLoad(t *testing.T) {
 		defer ms.Close()
 
 		os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://override")
+		defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")
 
 		err = ms.Load()
 		require.NoError(t, err)

--- a/migrations/helper_test.go
+++ b/migrations/helper_test.go
@@ -32,7 +32,7 @@ func setupTestHelper(enterprise bool) *TestHelper {
 	store := mainHelper.GetStore()
 	store.DropAllTables()
 
-	memoryStore, err := config.NewMemoryStore()
+	memoryStore, err := config.NewMemoryStoreWithOptions(&config.MemoryStoreOptions{IgnoreEnvironmentOverrides: true})
 	if err != nil {
 		panic("failed to initialize memory store: " + err.Error())
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -248,7 +248,7 @@ type ServiceSettings struct {
 	EnableIncomingWebhooks                            *bool
 	EnableOutgoingWebhooks                            *bool
 	EnableCommands                                    *bool
-	DEPRECATED_DO_NOT_USE_EnableOnlyAdminIntegrations *bool `json:"EnableOnlyAdminIntegrations"` // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_EnableOnlyAdminIntegrations *bool `json:"EnableOnlyAdminIntegrations" mapstructure:"EnableOnlyAdminIntegrations"` // This field is deprecated and must not be used.
 	EnablePostUsernameOverride                        *bool
 	EnablePostIconOverride                            *bool
 	EnableLinkPreviews                                *bool
@@ -278,9 +278,9 @@ type ServiceSettings struct {
 	EnableGifPicker                                   *bool
 	GfycatApiKey                                      *string
 	GfycatApiSecret                                   *string
-	DEPRECATED_DO_NOT_USE_RestrictCustomEmojiCreation *string `json:"RestrictCustomEmojiCreation"` // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPostDelete          *string `json:"RestrictPostDelete"`          // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_AllowEditPost               *string `json:"AllowEditPost"`               // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictCustomEmojiCreation *string `json:"RestrictCustomEmojiCreation" mapstructure:"RestrictCustomEmojiCreation"` // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPostDelete          *string `json:"RestrictPostDelete" mapstructure:"RestrictPostDelete"`                   // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_AllowEditPost               *string `json:"AllowEditPost" mapstructure:"AllowEditPost"`                             // This field is deprecated and must not be used.
 	PostEditTimeLimit                                 *int
 	TimeBetweenUserTypingUpdatesMilliseconds          *int64 `restricted:"true"`
 	EnablePostSearch                                  *bool  `restricted:"true"`
@@ -1468,7 +1468,7 @@ func (s *ThemeSettings) SetDefaults() {
 type TeamSettings struct {
 	SiteName                                                  *string
 	MaxUsersPerTeam                                           *int
-	DEPRECATED_DO_NOT_USE_EnableTeamCreation                  *bool `json:"EnableTeamCreation"` // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_EnableTeamCreation                  *bool `json:"EnableTeamCreation" mapstructure:"EnableTeamCreation"` // This field is deprecated and must not be used.
 	EnableUserCreation                                        *bool
 	EnableOpenServer                                          *bool
 	EnableUserDeactivation                                    *bool
@@ -1477,14 +1477,14 @@ type TeamSettings struct {
 	CustomBrandText                                           *string
 	CustomDescriptionText                                     *string
 	RestrictDirectMessage                                     *string
-	DEPRECATED_DO_NOT_USE_RestrictTeamInvite                  *string `json:"RestrictTeamInvite"`                  // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPublicChannelManagement     *string `json:"RestrictPublicChannelManagement"`     // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelManagement    *string `json:"RestrictPrivateChannelManagement"`    // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPublicChannelCreation       *string `json:"RestrictPublicChannelCreation"`       // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelCreation      *string `json:"RestrictPrivateChannelCreation"`      // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPublicChannelDeletion       *string `json:"RestrictPublicChannelDeletion"`       // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelDeletion      *string `json:"RestrictPrivateChannelDeletion"`      // This field is deprecated and must not be used.
-	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelManageMembers *string `json:"RestrictPrivateChannelManageMembers"` // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictTeamInvite                  *string `json:"RestrictTeamInvite" mapstructure:"RestrictTeamInvite"`                                   // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPublicChannelManagement     *string `json:"RestrictPublicChannelManagement" mapstructure:"RestrictPublicChannelManagement"`         // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelManagement    *string `json:"RestrictPrivateChannelManagement" mapstructure:"RestrictPrivateChannelManagement"`       // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPublicChannelCreation       *string `json:"RestrictPublicChannelCreation" mapstructure:"RestrictPublicChannelCreation"`             // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelCreation      *string `json:"RestrictPrivateChannelCreation" mapstructure:"RestrictPrivateChannelCreation"`           // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPublicChannelDeletion       *string `json:"RestrictPublicChannelDeletion" mapstructure:"RestrictPublicChannelDeletion"`             // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelDeletion      *string `json:"RestrictPrivateChannelDeletion" mapstructure:"RestrictPrivateChannelDeletion"`           // This field is deprecated and must not be used.
+	DEPRECATED_DO_NOT_USE_RestrictPrivateChannelManageMembers *string `json:"RestrictPrivateChannelManageMembers" mapstructure:"RestrictPrivateChannelManageMembers"` // This field is deprecated and must not be used.
 	EnableXToLeaveChannelsFromLHS                             *bool
 	UserStatusAwayTimeout                                     *int64
 	MaxChannelsPerTeam                                        *int64

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -44,7 +44,7 @@ func Setup() *TestHelper {
 	store := mainHelper.GetStore()
 	store.DropAllTables()
 
-	memoryStore, err := config.NewMemoryStore()
+	memoryStore, err := config.NewMemoryStoreWithOptions(&config.MemoryStoreOptions{IgnoreEnvironmentOverrides: true})
 	if err != nil {
 		panic("failed to initialize memory store: " + err.Error())
 	}


### PR DESCRIPTION
#### Summary
When loading the config from the backing store we were correctly overriding config settings using the environment variables but when setting the config after an API request, a cluster configuration propagation event, or by some other method we were not applying the environment variable overrides. This was hard to notice when not running in HA because the API request from a change in the system console already had the environment variable overrides but running in HA with different app servers using different environment variable overrides (like we do on community.mattermost.com) the bug became more apparent.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16725
