### PR TITLE
MM-17607: large [brand, team, profile] images crash the server

### DIFF
--- a/app/brand.go
+++ b/app/brand.go
@@ -39,7 +39,7 @@ func (a *App) SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 	}
 
 	if config.Width*config.Height > model.MaxImageSize {
-		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.too_large.app_error", nil, err.Error(), http.StatusBadRequest)
+		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.too_large.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	file.Seek(0, 0)

--- a/app/team.go
+++ b/app/team.go
@@ -1361,7 +1361,7 @@ func (a *App) SetTeamIconFromMultiPartFile(teamId string, file multipart.File) *
 		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 	if config.Width*config.Height > model.MaxImageSize {
-		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.too_large.app_error", nil, err.Error(), http.StatusBadRequest)
+		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.too_large.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	file.Seek(0, 0)

--- a/app/user.go
+++ b/app/user.go
@@ -867,7 +867,7 @@ func (a *App) SetProfileImageFromMultiPartFile(userId string, file multipart.Fil
 		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 	if config.Width*config.Height > model.MaxImageSize {
-		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.too_large.app_error", nil, err.Error(), http.StatusBadRequest)
+		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.too_large.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	file.Seek(0, 0)


### PR DESCRIPTION
#### Summary
Due to a bug in creating the user-friendly error message, attempts to upload special image files with the size exceeding https://github.com/mattermost/mattermost-server/blob/4734215a114ef7fd7dcf4ccf3f72a7568b170229/model/file.go#L12 was leading to a crash in the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17607