### PR TITLE
MM-17412: update post incorrectly removing files

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -501,9 +501,6 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Updating the file_ids of a post is not a supported operation and will be ignored
-	post.FileIds = nil
-
 	if !c.App.SessionHasPermissionToChannelByPost(c.App.Session, c.Params.PostId, model.PERMISSION_EDIT_POST) {
 		c.SetPermissionError(model.PERMISSION_EDIT_POST)
 		return
@@ -514,6 +511,9 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetPermissionError(model.PERMISSION_EDIT_POST)
 		return
 	}
+
+	// Updating the file_ids of a post is not a supported operation and will be ignored
+	post.FileIds = originalPost.FileIds
 
 	if c.App.Session.UserId != originalPost.UserId {
 		if !c.App.SessionHasPermissionToChannelByPost(c.App.Session, c.Params.PostId, model.PERMISSION_EDIT_OTHERS_POSTS) {

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -568,14 +568,14 @@ func TestUpdatePost(t *testing.T) {
 
 		assert.Equal(t, rupost.Message, msg, "failed to updates")
 		assert.NotEqual(t, 0, rupost.EditAt, "EditAt not updated for post")
-		assert.Empty(t, rupost.FileIds, "FileIds should have not have been updated")
+		assert.Equal(t, model.StringArray(fileIds), rupost.FileIds, "FileIds should have not have been updated")
 
 		actual, resp := Client.GetPost(rpost.Id, "")
 		CheckNoError(t, resp)
 
 		assert.Equal(t, actual.Message, msg, "failed to updates")
 		assert.NotEqual(t, 0, actual.EditAt, "EditAt not updated for post")
-		assert.Empty(t, actual.FileIds, "FileIds should have not have been updated")
+		assert.Equal(t, model.StringArray(fileIds), actual.FileIds, "FileIds should have not have been updated")
 	})
 
 	t.Run("new message, invalid props", func(t *testing.T) {
@@ -635,7 +635,7 @@ func TestUpdatePost(t *testing.T) {
 
 		actual, resp := Client.GetPost(rpost.Id, "")
 		CheckNoError(t, resp)
-		assert.Empty(t, actual.FileIds)
+		assert.Equal(t, model.StringArray(fileIds), actual.FileIds)
 	})
 
 	t.Run("add slack attachments", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
The `updatePost` endpoint incorrectly stripped the files from posts. The `patchPost` had the same code, but executed the `post.Patch` operation, which explicitly ignores a `nil` `FileIds`. The update code path accepted the `nil` value and cleared things out.

This PR is broken up into individual commits if you'd like to review it that way.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17412