### PR TITLE
MM-17438: allow attaching nouser files to posts

### DIFF
--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -196,15 +196,20 @@ func (fs SqlFileInfoStore) GetForUser(userId string) ([]*model.FileInfo, *model.
 }
 
 func (fs SqlFileInfoStore) AttachToPost(fileId, postId, creatorId string) *model.AppError {
-	sqlResult, err := fs.GetMaster().Exec(
-		`UPDATE
-					FileInfo
-				SET
-					PostId = :PostId
-				WHERE
-					Id = :Id
-					AND PostId = ''
-					AND CreatorId = :CreatorId`, map[string]interface{}{"PostId": postId, "Id": fileId, "CreatorId": creatorId})
+	sqlResult, err := fs.GetMaster().Exec(`
+		UPDATE
+			FileInfo
+		SET
+			PostId = :PostId
+		WHERE
+			Id = :Id
+			AND PostId = ''
+			AND CreatorId = :CreatorId
+	`, map[string]interface{}{
+		"PostId":    postId,
+		"Id":        fileId,
+		"CreatorId": creatorId,
+	})
 	if err != nil {
 		return model.NewAppError("SqlFileInfoStore.AttachToPost",
 			"store.sql_file_info.attach_to_post.app_error", nil, "post_id="+postId+", file_id="+fileId+", err="+err.Error(), http.StatusInternalServerError)

--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -204,7 +204,7 @@ func (fs SqlFileInfoStore) AttachToPost(fileId, postId, creatorId string) *model
 		WHERE
 			Id = :Id
 			AND PostId = ''
-			AND CreatorId = :CreatorId
+			AND (CreatorId = :CreatorId OR CreatorId = 'nouser')
 	`, map[string]interface{}{
 		"PostId":    postId,
 		"Id":        fileId,

--- a/store/storetest/file_info_store.go
+++ b/store/storetest/file_info_store.go
@@ -5,6 +5,7 @@ package storetest
 
 import (
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
@@ -255,6 +256,12 @@ func testFileInfoGetForUser(t *testing.T, ss store.Store) {
 	assert.Len(t, userPosts, 1)
 }
 
+type byFileInfoId []*model.FileInfo
+
+func (a byFileInfoId) Len() int           { return len(a) }
+func (a byFileInfoId) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byFileInfoId) Less(i, j int) bool { return a[i].Id < a[j].Id }
+
 func testFileInfoAttachToPost(t *testing.T, ss store.Store) {
 	t.Run("should attach files", func(t *testing.T) {
 		userId := model.NewId()
@@ -276,16 +283,19 @@ func testFileInfoAttachToPost(t *testing.T, ss store.Store) {
 
 		err = ss.FileInfo().AttachToPost(info1.Id, postId, userId)
 		assert.Nil(t, err)
+		info1.PostId = postId
 
 		err = ss.FileInfo().AttachToPost(info2.Id, postId, userId)
 		assert.Nil(t, err)
+		info2.PostId = postId
 
 		data, err := ss.FileInfo().GetForPost(postId, true, false, false)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 
-		assert.Len(t, data, 2)
-		assert.True(t, data[0].Id == info1.Id || data[0].Id == info2.Id)
-		assert.True(t, data[1].Id == info1.Id || data[1].Id == info2.Id)
+		expected := []*model.FileInfo{info1, info2}
+		sort.Sort(byFileInfoId(expected))
+		sort.Sort(byFileInfoId(data))
+		assert.Equal(t, expected, data)
 	})
 
 	t.Run("should not attach files to multiple posts", func(t *testing.T) {
@@ -301,10 +311,10 @@ func testFileInfoAttachToPost(t *testing.T, ss store.Store) {
 		require.Equal(t, "", info.PostId)
 
 		err = ss.FileInfo().AttachToPost(info.Id, model.NewId(), userId)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 
 		err = ss.FileInfo().AttachToPost(info.Id, postId, userId)
-		assert.NotNil(t, err)
+		require.NotNil(t, err)
 	})
 
 	t.Run("should not attach files owned from a different user", func(t *testing.T) {
@@ -321,6 +331,25 @@ func testFileInfoAttachToPost(t *testing.T, ss store.Store) {
 
 		err = ss.FileInfo().AttachToPost(info.Id, postId, userId)
 		assert.NotNil(t, err)
+	})
+
+	t.Run("should attach files uploaded by nouser", func(t *testing.T) {
+		postId := model.NewId()
+
+		info, err := ss.FileInfo().Save(&model.FileInfo{
+			CreatorId: "nouser",
+			Path:      "file.txt",
+		})
+		require.Nil(t, err)
+		assert.Equal(t, "", info.PostId)
+
+		err = ss.FileInfo().AttachToPost(info.Id, postId, model.NewId())
+		require.Nil(t, err)
+
+		data, err := ss.FileInfo().GetForPost(postId, true, false, false)
+		require.Nil(t, err)
+		info.PostId = postId
+		assert.Equal(t, []*model.FileInfo{info}, data)
 	})
 }
 


### PR DESCRIPTION
#### Summary
As part of https://mattermost.atlassian.net/browse/MM-13718, the file info store was modified to only attach a file to a post on two conditions:
* if the `PostId` was already empty
* and if the `CreatorId` matched the requesting user

Unfortunately, files uploaded by plugins are marked as being created by `nouser` (literally), and thus fail the check when attaching a file to a post created for a real user. This PR effectively tweaks the query to allow a `CreatorId` of `nouser` too. It's not possible to leverage this via the API proper, since it's not possible to upload a file outside of a user context.

Technically, if a plugin uploads a file and another user knows that file id, they can claim it for themselves on a new post. I don't know the full history of `nouser`, but I'm suspecting this is not a meaningful concern. Open to suggestions!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17438