### PR TITLE
Includes 'i18n-extract' in 'make help' output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,4 +466,4 @@ endif
 
 ## Help documentatin à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' ./Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' ./Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
#### Summary

Same change to server repo as done in https://github.com/mattermost/mattermost-webapp/pull/3405 to include `i18n-extract` in `make help` output.

#### Ticket Link

n/a