### PR TITLE
[MM-17604] Fix websocket message not being broadcasted when a user automatically joins a channel

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -104,6 +104,11 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 
 		a.InvalidateCacheForChannelMembers(channel.Id)
 
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_ADDED, "", channel.Id, "", nil)
+		message.Add("user_id", user.Id)
+		message.Add("team_id", channel.TeamId)
+		a.Publish(message)
+
 	}
 
 	if a.IsESIndexingEnabled() {


### PR DESCRIPTION
#### Summary
Currently when a user signs up for a team and joins that team, they will automatically join `town-square` and `off-topic` and other channels mentioned in `TeamSettings.ExperimentalDefaultChannels` in `config.js` however the websocket message `user_added` is not broadcasted. This PR fixes this problem.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/11823
[Jira Link](https://mattermost.atlassian.net/browse/MM-17604)