### PR TITLE
Add fix for deleted users and add more verbosity for import errors

### DIFF
--- a/app/slackimport.go
+++ b/app/slackimport.go
@@ -785,7 +785,7 @@ func (a *App) SlackImport(fileData multipart.File, fileSize int64, teamID string
 		}
 
 		// get some sort of progress for very big imports
-		if (files-i) % (files/100) == 0 {
+		if (files-i)%(files/100) == 0 {
 			mlog.Debug(fmt.Sprintf("Slack Import: %d Slack files left to parse.", files-i))
 		}
 	}
@@ -794,25 +794,23 @@ func (a *App) SlackImport(fileData multipart.File, fileSize int64, teamID string
 	mlog.Debug(fmt.Sprintf("Slack Import: Checking for deleted Slack users."))
 	users = addDeletedUsers(users, channelUsers)
 
+	mlog.Debug(fmt.Sprintf("Slack Import: Converting user mentions."))
 	posts = SlackConvertUserMentions(users, posts)
-	mlog.Debug(fmt.Sprintf("Slack Import: Converted user mentions."))
+
+	mlog.Debug(fmt.Sprintf("Slack Import: Converting channel links."))
 	posts = SlackConvertChannelMentions(channels, posts)
-	mlog.Debug(fmt.Sprintf("Slack Import: Converted channel links."))
+
+	mlog.Debug(fmt.Sprintf("Slack Import: Converting post markup."))
 	posts = SlackConvertPostsMarkup(posts)
-	mlog.Debug(fmt.Sprintf("Slack Import: Converted post markup."))
 
-	mlog.Debug(fmt.Sprintf("Slack Import: Adding Slack users to team object."))
+	mlog.Debug(fmt.Sprintf("Slack Import: Importing Slack users to Mattermost server."))
 	addedUsers := a.SlackAddUsers(teamID, users, log)
-	mlog.Debug(fmt.Sprintf("Slack Import: Added Slack users to team object."))
 
-	mlog.Debug(fmt.Sprintf("Slack Import: Adding Slack bot users to team object."))
+	mlog.Debug(fmt.Sprintf("Slack Import: Importing Slack bot users to Mattermost server."))
 	botUser := a.SlackAddBotUser(teamID, log)
-	mlog.Debug(fmt.Sprintf("Slack Import: Added Slack bot users to team object."))
 
-	mlog.Debug(fmt.Sprintf("Slack Import: Adding Slack channels to Mattermost team."))
+	mlog.Debug(fmt.Sprintf("Slack Import: Importing Slack channels to Mattermost server."))
 	a.SlackAddChannels(teamID, channels, posts, addedUsers, uploads, botUser, log)
-	mlog.Debug(fmt.Sprintf("Slack Import: Added Slack channels to Mattermost team."))
-
 
 	if botUser != nil {
 		a.deactivateSlackBotUser(botUser)


### PR DESCRIPTION
Got to my hands on another dataset, this time it had users that have been deleted from the slack server. Turns out only the entries in the users.json get deleted, all the references in all the channels are being kept and left untouched. This results in nil pointers when those users are fetched from the users map.

What I did to work around this was to fetch all the users from all channels first and then compare these to the users.json to see if there might be users missing in there. If they are found those users are now being added as "deletedUser" to prevent the importer from crashing when messages from these users are being imported. Tested on the dataset provided as well as another one without missing users and the importer finished without any hiccups both times. 

There's probably more elegant ways to do this, but I experienced no noticeable impact in performance or memory usage with this solution on the dataset with around 10k users and way more than 500k messages so I think this should be g2g.

I also added a bit more info when the importer fails to load a channel by simply printing the error message to the console.

As always open for any suggestions and corrections.