### PR TITLE
[MM-17758] Explicits the search configuration when using full text search in postgres

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2248,7 +2248,7 @@ func (s SqlChannelStore) buildFulltextClause(term string, searchColumns string) 
 
 		fulltextTerm = strings.Join(splitTerm, " ")
 
-		fulltextClause = fmt.Sprintf("((to_tsvector('english', %s)) @@ to_tsquery(:FulltextTerm))", convertMySQLFullTextColumnsToPostgres(searchColumns))
+		fulltextClause = fmt.Sprintf("((to_tsvector('english', %s)) @@ to_tsquery('english', :FulltextTerm))", convertMySQLFullTextColumnsToPostgres(searchColumns))
 	} else if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
 		splitTerm := strings.Fields(fulltextTerm)
 		for i, t := range strings.Fields(fulltextTerm) {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1019,7 +1019,7 @@ func (s *SqlPostStore) Search(teamId string, userId string, params *model.Search
 			queryParams["Terms"] = "(" + strings.Join(strings.Fields(terms), " & ") + ")" + excludeClause
 		}
 
-		searchClause := fmt.Sprintf("AND to_tsvector('english', %s) @@  to_tsquery(:Terms)", searchType)
+		searchClause := fmt.Sprintf("AND to_tsvector('english', %s) @@  to_tsquery('english', :Terms)", searchType)
 		searchQuery = strings.Replace(searchQuery, "SEARCH_CLAUSE", searchClause, 1)
 	} else if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
 		searchClause := fmt.Sprintf("AND MATCH (%s) AGAINST (:Terms IN BOOLEAN MODE)", searchType)


### PR DESCRIPTION
#### Summary
When using full text search in postgres and not explicitly stating the search configuration, [default_text_search_config](https://www.postgresql.org/docs/9.4/runtime-config-client.html#GUC-DEFAULT-TEXT-SEARCH-CONFIG) is used, which can differ from the `english` that we use when creating the indexes depending on the `lc_ctype` locale of the host, and causing searches not to return results.

This PR explicits the same config used when creating the indexes to avoid a missmatch.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17758