### PR TITLE
fix tmpfs usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,8 +117,8 @@ start-docker: ## Starts the docker containers for local development.
 ifeq ($(IS_CI),false)
 	@echo Starting docker containers
 
-	docker-compose --no-ansi run --rm start_dependencies
-	cat tests/${LDAP_DATA}-data.ldif | docker-compose --no-ansi exec -T openldap bash -c 'ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest || true';
+	docker-compose run --rm start_dependencies
+	cat tests/${LDAP_DATA}-data.ldif | docker-compose exec -T openldap bash -c 'ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest || true';
 
 else
 	@echo CI Build: skipping docker start
@@ -127,14 +127,14 @@ endif
 stop-docker: ## Stops the docker containers for local development.
 	@echo Stopping docker containers
 
-	docker-compose --no-ansi stop
+	docker-compose stop
 
 
 clean-docker: ## Deletes the docker containers for local development.
 	@echo Removing docker containers
 
-	docker-compose --no-ansi down -v
-	docker-compose --no-ansi rm -v
+	docker-compose down -v
+	docker-compose rm -v
 
 
 govet: ## Runs govet against all packages.

--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -1,0 +1,58 @@
+version: '2.4'
+services:
+  mysql:
+    image: "mysql:5.7"
+    restart: always
+    networks:
+      - mm-test
+    environment:
+      MYSQL_ROOT_HOST: "%"
+      MYSQL_ROOT_PASSWORD: mostest
+      MYSQL_PASSWORD: mostest
+      MYSQL_USER: mmuser
+      MYSQL_DATABASE: mattermost_test
+  postgres:
+    image: "postgres:9.4"
+    restart: always
+    networks:
+      - mm-test
+    environment:
+      POSTGRES_USER: mmuser
+      POSTGRES_PASSWORD: mostest
+      POSTGRES_DB: mattermost_test
+  minio:
+    image: "minio/minio:RELEASE.2019-04-23T23-50-36Z"
+    command: "server /data"
+    networks:
+      - mm-test
+    environment:
+      MINIO_ACCESS_KEY: minioaccesskey
+      MINIO_SECRET_KEY: miniosecretkey
+      MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
+  inbucket:
+    image: "jhillyerd/inbucket:release-1.2.0"
+    restart: always
+    networks:
+      - mm-test
+  openldap:
+    image: "osixia/openldap:1.2.2"
+    restart: always
+    networks:
+      - mm-test
+    environment:
+      LDAP_TLS_VERIFY_CLIENT: "never"
+      LDAP_ORGANISATION: "Mattermost Test"
+      LDAP_DOMAIN: "mm.test.com"
+      LDAP_ADMIN_PASSWORD: "mostest"
+  elasticsearch:
+    image: "mattermost/mattermost-elasticsearch-docker:6.5.1"
+    networks:
+      - mm-test
+    environment:
+      http.host: "0.0.0.0"
+      transport.host: "127.0.0.1"
+      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+  redis:
+    image: redis
+    networks:
+      - mm-test

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,65 +1,37 @@
 version: '2.4'
 services:
   mysql:
-    image: "mysql:5.7"
-    restart: always
-    networks:
-      - mm-test
-    environment:
-      MYSQL_ROOT_HOST: "%"
-      MYSQL_ROOT_PASSWORD: mostest
-      MYSQL_PASSWORD: mostest
-      MYSQL_USER: mmuser
-      MYSQL_DATABASE: mattermost_test
+    extends:
+        file: docker-compose.common.yml
+        service: mysql
     tmpfs: /var/lib/mysql
     volumes:
      - "./docker/mysql.conf.d:/etc/mysql/conf.d"
   postgres:
-    image: "postgres:9.4"
-    restart: always
-    networks:
-      - mm-test
-    environment:
-      POSTGRES_USER: mmuser
-      POSTGRES_PASSWORD: mostest
-      POSTGRES_DB: mattermost_test
+    extends:
+        file: docker-compose.common.yml
+        service: postgres
     tmpfs: /var/lib/postgresql/data
   minio:
-    image: "minio/minio:RELEASE.2019-04-23T23-50-36Z"
-    command: "server /data"
-    networks:
-      - mm-test
-    environment:
-      MINIO_ACCESS_KEY: minioaccesskey
-      MINIO_SECRET_KEY: miniosecretkey
-      MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
+    extends:
+        file: docker-compose.common.yml
+        service: minio
   inbucket:
-    image: "jhillyerd/inbucket:release-1.2.0"
-    restart: always
-    networks:
-      - mm-test
+    extends:
+        file: docker-compose.common.yml
+        service: inbucket
   openldap:
-    image: "osixia/openldap:1.2.2"
-    restart: always
-    networks:
-      - mm-test
-    environment:
-      LDAP_TLS_VERIFY_CLIENT: "never"
-      LDAP_ORGANISATION: "Mattermost Test"
-      LDAP_DOMAIN: "mm.test.com"
-      LDAP_ADMIN_PASSWORD: "mostest"
+    extends:
+        file: docker-compose.common.yml
+        service: openldap
   elasticsearch:
-    image: "mattermost/mattermost-elasticsearch-docker:6.5.1"
-    networks:
-      - mm-test
-    environment:
-      http.host: "0.0.0.0"
-      transport.host: "127.0.0.1"
-      ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    extends:
+        file: docker-compose.common.yml
+        service: elasticsearch
   redis:
-    image: redis
-    networks:
-      - mm-test
+    extends:
+        file: docker-compose.common.yml
+        service: redis
 
   start_dependencies:
     image: mattermost/mattermost-wait-for-dep:latest

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,21 +5,21 @@ services:
     ports:
       - "3306:3306"
     extends:
-        file: build/docker-compose.yml
+        file: build/docker-compose.common.yml
         service: mysql
   postgres:
     container_name: mattermost-postgres
     ports:
       - "5432:5432"
     extends:
-        file: build/docker-compose.yml
+        file: build/docker-compose.common.yml
         service: postgres
   minio:
     container_name: mattermost-minio
     ports:
       - "9000:9000"
     extends:
-        file: build/docker-compose.yml
+        file: build/docker-compose.common.yml
         service: minio
   inbucket:
     container_name: mattermost-inbucket
@@ -28,7 +28,7 @@ services:
       - "10080:10080"
       - "10110:10110"
     extends:
-        file: build/docker-compose.yml
+        file: build/docker-compose.common.yml
         service: inbucket
   openldap:
     container_name: mattermost-openldap
@@ -36,7 +36,7 @@ services:
       - "389:389"
       - "636:636"
     extends:
-        file: build/docker-compose.yml
+        file: build/docker-compose.common.yml
         service: openldap
   elasticsearch:
     container_name: mattermost-elasticsearch
@@ -44,14 +44,14 @@ services:
       - "9200:9200"
       - "9300:9300"
     extends:
-        file: build/docker-compose.yml
+        file: build/docker-compose.common.yml
         service: elasticsearch
   redis:
     container_name: mattermost-redis
     ports:
       - "6379:6379"
     extends:
-        file: build/docker-compose.yml
+        file: build/docker-compose.common.yml
         service: redis
   start_dependencies:
     image: mattermost/mattermost-wait-for-dep:latest


### PR DESCRIPTION
#### Summary
We use tmpfs for CI builds to speed things up, but this is unsuitable for local development. Also, don't use `--no-ansi` in the `Makefile` to allow colours to show up.