### PR TITLE
MM-17609 Add EnableSVGs setting 

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -299,6 +299,7 @@ func (a *App) trackConfig() {
 		"experimental_ldap_group_sync":                            *cfg.ServiceSettings.ExperimentalLdapGroupSync,
 		"disable_bots_when_owner_is_deactivated":                  *cfg.ServiceSettings.DisableBotsWhenOwnerIsDeactivated,
 		"enable_bot_account_creation":                             *cfg.ServiceSettings.EnableBotAccountCreation,
+		"enable_svgs":                                             *cfg.ServiceSettings.EnableSVGs,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -495,7 +495,13 @@ func cacheLinkMetadata(requestURL string, timestamp int64, og *opengraph.OpenGra
 }
 
 func (a *App) parseLinkMetadata(requestURL string, body io.Reader, contentType string) (*opengraph.OpenGraph, *model.PostImage, error) {
-	if strings.HasPrefix(contentType, "image") {
+	if contentType == "image/svg+xml" {
+		image := &model.PostImage{
+			Format: "svg",
+		}
+
+		return nil, image, nil
+	} else if strings.HasPrefix(contentType, "image") {
 		image, err := parseImages(io.LimitReader(body, MaxMetadataImageSize))
 		return nil, image, err
 	} else if strings.HasPrefix(contentType, "text/html") {

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -2013,6 +2013,16 @@ func TestParseLinkMetadata(t *testing.T) {
 		assert.Nil(t, og)
 		assert.Nil(t, dimensions)
 	})
+
+	t.Run("svg", func(t *testing.T) {
+		og, dimensions, err := th.App.parseLinkMetadata("http://example.com/image.svg", nil, "image/svg+xml")
+		assert.Nil(t, err)
+
+		assert.Nil(t, og)
+		assert.Equal(t, &model.PostImage{
+			Format: "svg",
+		}, dimensions)
+	})
 }
 
 func TestParseImages(t *testing.T) {

--- a/config/client.go
+++ b/config/client.go
@@ -42,6 +42,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
 	props["ExperimentalEnableDefaultChannelLeaveJoinMessages"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages)
 	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
+	props["EnableSVGs"] = strconv.FormatBool(*c.ServiceSettings.EnableSVGs)
 
 	// This setting is only temporary, so keep using the old setting name for the mobile and web apps
 	props["ExperimentalEnablePostMetadata"] = "true"

--- a/model/config.go
+++ b/model/config.go
@@ -307,6 +307,7 @@ type ServiceSettings struct {
 	ExperimentalLdapGroupSync                         *bool
 	DisableBotsWhenOwnerIsDeactivated                 *bool `restricted:"true"`
 	EnableBotAccountCreation                          *bool
+	EnableSVGs                                        *bool
 }
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {
@@ -666,6 +667,14 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.EnableBotAccountCreation == nil {
 		s.EnableBotAccountCreation = NewBool(false)
+	}
+
+	if s.EnableSVGs == nil {
+		if isUpdate {
+			s.EnableSVGs = NewBool(true)
+		} else {
+			s.EnableSVGs = NewBool(false)
+		}
 	}
 }
 


### PR DESCRIPTION
This is adding a new setting to enable/disable SVG rendering in the web app. The setting will be disabled by default on new installs, and enabled by default on existing installs to maintain backwards compatibility.

The mobile app currently doesn't render SVGs, so no changes are required to support it there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17609

#### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/3437