### PR TITLE
[MM-17219] Return an empty list instead of null when no teams

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -729,7 +729,7 @@ func updateTeamMemberSchemeRoles(c *Context, w http.ResponseWriter, r *http.Requ
 }
 
 func getAllTeams(c *Context, w http.ResponseWriter, r *http.Request) {
-	var teams []*model.Team
+	teams := []*model.Team{}
 	var err *model.AppError
 	var teamsWithCount *model.TeamsWithCount
 


### PR DESCRIPTION
#### Summary
A `null` response from the endpoint was causing the reducer to fail with a javascript error. Initialising the teams variable to an empty slice ensures that the empty response will be an empty list, which the client is able to process correctly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17219
