### PR TITLE
Add @ prefix for sender username in push notifications

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -640,7 +640,7 @@ type postNotification struct {
 func (n *postNotification) GetChannelName(userNameFormat string, excludeId string) string {
 	switch n.channel.Type {
 	case model.CHANNEL_DIRECT:
-		return n.sender.GetDisplayName(userNameFormat)
+		return n.sender.GetDisplayNameWithPrefix(userNameFormat, "@")
 	case model.CHANNEL_GROUP:
 		names := []string{}
 		for _, user := range n.profileMap {
@@ -670,7 +670,7 @@ func (n *postNotification) GetSenderName(userNameFormat string, overridesAllowed
 		}
 	}
 
-	return n.sender.GetDisplayName(userNameFormat)
+	return n.sender.GetDisplayNameWithPrefix(userNameFormat, "@")
 }
 
 // addMentionedUsers will add the mentioned user id in the struct's list for mentioned users

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1207,12 +1207,12 @@ func TestPostNotificationGetChannelName(t *testing.T) {
 		},
 		"direct channel, unspecified": {
 			channel:  &model.Channel{Type: model.CHANNEL_DIRECT},
-			expected: "sender",
+			expected: "@sender",
 		},
 		"direct channel, username": {
 			channel:    &model.Channel{Type: model.CHANNEL_DIRECT},
 			nameFormat: model.SHOW_USERNAME,
-			expected:   "sender",
+			expected:   "@sender",
 		},
 		"direct channel, full name": {
 			channel:    &model.Channel{Type: model.CHANNEL_DIRECT},
@@ -1290,11 +1290,11 @@ func TestPostNotificationGetSenderName(t *testing.T) {
 		expected       string
 	}{
 		"name format unspecified": {
-			expected: sender.Username,
+			expected: "@" + sender.Username,
 		},
 		"name format username": {
 			nameFormat: model.SHOW_USERNAME,
-			expected:   sender.Username,
+			expected:   "@" + sender.Username,
 		},
 		"name format full name": {
 			nameFormat: model.SHOW_FULLNAME,
@@ -1317,12 +1317,12 @@ func TestPostNotificationGetSenderName(t *testing.T) {
 			channel:        &model.Channel{Type: model.CHANNEL_DIRECT},
 			post:           overriddenPost,
 			allowOverrides: true,
-			expected:       sender.Username,
+			expected:       "@" + sender.Username,
 		},
 		"overridden username, overrides disabled": {
 			post:           overriddenPost,
 			allowOverrides: false,
-			expected:       sender.Username,
+			expected:       "@" + sender.Username,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/model/user.go
+++ b/model/user.go
@@ -539,8 +539,8 @@ func (u *User) GetFullName() string {
 	}
 }
 
-func (u *User) GetDisplayName(nameFormat string) string {
-	displayName := u.Username
+func (u *User) getDisplayName(baseName, nameFormat string) string {
+	displayName := baseName
 
 	if nameFormat == SHOW_NICKNAME_FULLNAME {
 		if len(u.Nickname) > 0 {
@@ -557,22 +557,16 @@ func (u *User) GetDisplayName(nameFormat string) string {
 	return displayName
 }
 
+func (u *User) GetDisplayName(nameFormat string) string {
+	displayName := u.Username
+
+	return u.getDisplayName(displayName, nameFormat)
+}
+
 func (u *User) GetDisplayNameWithPrefix(nameFormat, prefix string) string {
 	displayName := prefix + u.Username
 
-	if nameFormat == SHOW_NICKNAME_FULLNAME {
-		if len(u.Nickname) > 0 {
-			displayName = u.Nickname
-		} else if fullName := u.GetFullName(); len(fullName) > 0 {
-			displayName = fullName
-		}
-	} else if nameFormat == SHOW_FULLNAME {
-		if fullName := u.GetFullName(); len(fullName) > 0 {
-			displayName = fullName
-		}
-	}
-
-	return displayName
+	return u.getDisplayName(displayName, nameFormat)
 }
 
 func (u *User) GetRoles() []string {

--- a/model/user.go
+++ b/model/user.go
@@ -557,6 +557,24 @@ func (u *User) GetDisplayName(nameFormat string) string {
 	return displayName
 }
 
+func (u *User) GetDisplayNameWithPrefix(nameFormat, prefix string) string {
+	displayName := prefix + u.Username
+
+	if nameFormat == SHOW_NICKNAME_FULLNAME {
+		if len(u.Nickname) > 0 {
+			displayName = u.Nickname
+		} else if fullName := u.GetFullName(); len(fullName) > 0 {
+			displayName = fullName
+		}
+	} else if nameFormat == SHOW_FULLNAME {
+		if fullName := u.GetFullName(); len(fullName) > 0 {
+			displayName = fullName
+		}
+	}
+
+	return displayName
+}
+
 func (u *User) GetRoles() []string {
 	return strings.Fields(u.Roles)
 }

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -252,6 +252,42 @@ func TestUserGetDisplayName(t *testing.T) {
 	}
 }
 
+func TestUserGetDisplayNameWithPrefix(t *testing.T) {
+	user := User{Username: "username"}
+
+	if displayName := user.GetDisplayNameWithPrefix(SHOW_FULLNAME, "@"); displayName != "@username" {
+		t.Fatal("Display name should be username")
+	}
+
+	if displayName := user.GetDisplayNameWithPrefix(SHOW_NICKNAME_FULLNAME, "@"); displayName != "@username" {
+		t.Fatal("Display name should be username")
+	}
+
+	if displayName := user.GetDisplayNameWithPrefix(SHOW_USERNAME, "@"); displayName != "@username" {
+		t.Fatal("Display name should be username")
+	}
+
+	user.FirstName = "first"
+	user.LastName = "last"
+
+	if displayName := user.GetDisplayNameWithPrefix(SHOW_FULLNAME, "@"); displayName != "first last" {
+		t.Fatal("Display name should be full name")
+	}
+
+	if displayName := user.GetDisplayNameWithPrefix(SHOW_NICKNAME_FULLNAME, "@"); displayName != "first last" {
+		t.Fatal("Display name should be full name since there is no nickname")
+	}
+
+	if displayName := user.GetDisplayNameWithPrefix(SHOW_USERNAME, "@"); displayName != "@username" {
+		t.Fatal("Display name should be username")
+	}
+
+	user.Nickname = "nickname"
+	if displayName := user.GetDisplayNameWithPrefix(SHOW_NICKNAME_FULLNAME, "@"); displayName != "nickname" {
+		t.Fatal("Display name should be nickname")
+	}
+}
+
 var usernames = []struct {
 	value    string
 	expected bool


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Following the spec those push notifications where the sender name is the username we need to prepend an `@` sign so it is clear that is the username of the person sending the message. The current user model has a function `GetDisplayName` that will return the display name based on the teammateDisplayName setting and it is used in various places, so this PR adds a new function `GetDisplayNameWithPrefix` that is basically a copy of the previous one but will add a prefix to the username.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-16093