### PR TITLE
[MM-17958] Add additional input validation for user creation

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -86,6 +86,8 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user.SanitizeInput()
+
 	tokenId := r.URL.Query().Get("t")
 	inviteId := r.URL.Query().Get("iid")
 

--- a/model/user.go
+++ b/model/user.go
@@ -494,6 +494,18 @@ func (u *User) Sanitize(options map[string]bool) {
 	}
 }
 
+// Remove any input data from the user object that is not user controlled
+func (u *User) SanitizeInput() {
+	u.AuthData = NewString("")
+	u.AuthService = ""
+	u.LastPasswordUpdate = 0
+	u.LastPictureUpdate = 0
+	u.FailedAttempts = 0
+	u.EmailVerified = false
+	u.MfaActive = false
+	u.MfaSecret = ""
+}
+
 func (u *User) ClearNonProfileFields() {
 	u.Password = ""
 	u.AuthData = NewString("")


### PR DESCRIPTION
#### Summary
This pull request adds additional filtering to the user object created as part of the signup flow.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17958