### PR TITLE
[MM-17300] Do not add empty string as a keyword key

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -593,7 +593,9 @@ func (a *App) getMentionKeywordsInChannel(profiles map[string]*model.User, lookF
 			for _, k := range splitKeys {
 				// note that these are made lower case so that we can do a case insensitive check for them
 				key := strings.ToLower(k)
-				keywords[key] = append(keywords[key], id)
+				if key != "" {
+					keywords[key] = append(keywords[key], id)
+				}
 			}
 		}
 

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1169,11 +1169,10 @@ func TestGetMentionKeywords(t *testing.T) {
 
 	profiles = map[string]*model.User{userNoMentionKeys.Id: userNoMentionKeys}
 	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapEmptyOff)
-	if len(mentions) != 1 {
-		t.Fatal("should've returned one mention keyword")
-	} else if ids, ok := mentions["@user"]; !ok || ids[0] != userNoMentionKeys.Id {
-		t.Fatal("should've returned mention key of @user")
-	}
+	assert.Equal(t, 1, len(mentions), "should've returned one metion keyword")
+	ids, ok := mentions["@user"]
+	assert.True(t, ok)
+	assert.Equal(t, userNoMentionKeys.Id, ids[0], "should've returned mention key of @user")
 }
 
 func TestGetMentionsEnabledFields(t *testing.T) {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1150,6 +1150,30 @@ func TestGetMentionKeywords(t *testing.T) {
 	} else if _, ok := mentions["@here"]; ok {
 		t.Fatal("should not have mentioned any user with @here")
 	}
+
+	// user with empty mention keys
+	userNoMentionKeys := &model.User{
+		Id:        model.NewId(),
+		FirstName: "First",
+		Username:  "User",
+		NotifyProps: map[string]string{
+			"mention_keys": ",",
+		},
+	}
+
+	channelMemberNotifyPropsMapEmptyOff := map[string]model.StringMap{
+		userNoMentionKeys.Id: {
+			"ignore_channel_mentions": model.IGNORE_CHANNEL_MENTIONS_OFF,
+		},
+	}
+
+	profiles = map[string]*model.User{userNoMentionKeys.Id: userNoMentionKeys}
+	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapEmptyOff)
+	if len(mentions) != 1 {
+		t.Fatal("should've returned one mention keyword")
+	} else if ids, ok := mentions["@user"]; !ok || ids[0] != userNoMentionKeys.Id {
+		t.Fatal("should've returned mention key of @user")
+	}
 }
 
 func TestGetMentionsEnabledFields(t *testing.T) {


### PR DESCRIPTION
#### Summary
When a `---` message is posted the [trimmed word here](https://github.com/mattermost/mattermost-server/blob/MM-17300/app/notification.go#L746) is an empty string. If a profile's notify props includes an empty string once split, then the [key here](https://github.com/mattermost/mattermost-server/blob/MM-17300/app/notification.go#L595) is an empty string causing that empty string to be used as a keyword for all profile ids in that channel and sending a notification to all channel members.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17300
