### PR TITLE
Changing default smtp port to use the new inbucket port as default

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -1231,7 +1231,7 @@ func (s *EmailSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.SMTPPort == nil || len(*s.SMTPPort) == 0 {
-		s.SMTPPort = NewString("2500")
+		s.SMTPPort = NewString("10025")
 	}
 
 	if s.ConnectionSecurity == nil || *s.ConnectionSecurity == CONN_SECURITY_PLAIN {


### PR DESCRIPTION
#### Summary
Before the docker compose change for the development environment, the default
SMTP port was the previous inbucket port, now the inbucket port has change, so
the default port should change too.