### PR TITLE
Stop plugin healthchecks before shutting down plugins

### DIFF
--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -294,6 +294,8 @@ func (env *Environment) Shutdown() {
 			rp.supervisor.Shutdown()
 		}
 
+		env.pluginHealthCheckJob.Cancel()
+
 		env.registeredPlugins.Delete(key)
 
 		return true

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -285,6 +285,8 @@ func (env *Environment) RestartPlugin(id string) error {
 // Shutdown deactivates all plugins and gracefully shuts down the environment.
 func (env *Environment) Shutdown() {
 	env.registeredPlugins.Range(func(key, value interface{}) bool {
+		env.pluginHealthCheckJob.Cancel()
+
 		rp := value.(*registeredPlugin)
 
 		if rp.supervisor != nil {
@@ -293,8 +295,6 @@ func (env *Environment) Shutdown() {
 			}
 			rp.supervisor.Shutdown()
 		}
-
-		env.pluginHealthCheckJob.Cancel()
 
 		env.registeredPlugins.Delete(key)
 

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -289,7 +289,6 @@ func (env *Environment) Shutdown() {
 	}
 
 	env.registeredPlugins.Range(func(key, value interface{}) bool {
-
 		rp := value.(*registeredPlugin)
 
 		if rp.supervisor != nil {

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -284,8 +284,11 @@ func (env *Environment) RestartPlugin(id string) error {
 
 // Shutdown deactivates all plugins and gracefully shuts down the environment.
 func (env *Environment) Shutdown() {
-	env.registeredPlugins.Range(func(key, value interface{}) bool {
+	if env.pluginHealthCheckJob != nil {
 		env.pluginHealthCheckJob.Cancel()
+	}
+
+	env.registeredPlugins.Range(func(key, value interface{}) bool {
 
 		rp := value.(*registeredPlugin)
 


### PR DESCRIPTION
#### Summary

The enterprise circleci pipeline is failing for quite some time and the failures are related to memory issues.
in the job logs we saw this error:
```
goroutine 566288 [select]:
github.com/mattermost/mattermost-server/plugin.(*PluginHealthCheckJob).Start.func1(0xc0cb2ef700)
    /go/src/github.com/mattermost/mattermost-server/plugin/health_check.go:60 +0x162
created by github.com/mattermost/mattermost-server/plugin.(*PluginHealthCheckJob).Start
    /go/src/github.com/mattermost/mattermost-server/plugin/health_check.go:51 +0x70
```

The root cause was not shutting down the plugin health checks when the server stops. In the CI pipeline, this resulted in hundreds of goroutines left holding onto plugin environments and all the associated memory.