### PR TITLE
[MM-18116] ‘make clean-old-docker’ doesn’t remove redundant old containers

### DIFF
--- a/build/legacy.mk
+++ b/build/legacy.mk
@@ -8,55 +8,55 @@ test-ee: test-server
 clean-old-docker:
 	@echo Removing docker containers
 
-	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-mysql$$ | wc -l) -eq 1 ]; then \
+	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-mysql$$ | wc -l) -ge 1 ]; then \
 		echo removing mattermost-mysql; \
 		docker stop mattermost-mysql > /dev/null; \
 		docker rm -v mattermost-mysql > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-mysql-unittest$$ | wc -l) -eq 1 ]; then \
+	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-mysql-unittest$$ | wc -l) -ge 1 ]; then \
 		echo removing mattermost-mysql-unittest; \
 		docker stop mattermost-mysql-unittest > /dev/null; \
 		docker rm -v mattermost-mysql-unittest > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-postgres$$ | wc -l) -eq 1 ]; then \
+	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-postgres$$ | wc -l) -ge 1 ]; then \
 		echo removing mattermost-postgres; \
 		docker stop mattermost-postgres > /dev/null; \
 		docker rm -v mattermost-postgres > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-postgres-unittest$$ | wc -l) -eq 1 ]; then \
+	@if [ $(shell docker ps -a --no-trunc --quiet --filter name=^/mattermost-postgres-unittest$$ | wc -l) -ge 1 ]; then \
 		echo removing mattermost-postgres-unittest; \
 		docker stop mattermost-postgres-unittest > /dev/null; \
 		docker rm -v mattermost-postgres-unittest > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a | grep -ci mattermost-openldap) -eq 1 ]; then \
+	@if [ $(shell docker ps -a | grep -ci mattermost-openldap) -ge 1 ]; then \
 		echo removing mattermost-openldap; \
 		docker stop mattermost-openldap > /dev/null; \
 		docker rm -v mattermost-openldap > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a | grep -ci mattermost-inbucket) -eq 1 ]; then \
+	@if [ $(shell docker ps -a | grep -ci mattermost-inbucket) -ge 1 ]; then \
 		echo removing mattermost-inbucket; \
 		docker stop mattermost-inbucket > /dev/null; \
 		docker rm -v mattermost-inbucket > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a | grep -ci mattermost-minio) -eq 1 ]; then \
+	@if [ $(shell docker ps -a | grep -ci mattermost-minio) -ge 1 ]; then \
 		echo removing mattermost-minio; \
 		docker stop mattermost-minio > /dev/null; \
 		docker rm -v mattermost-minio > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a | grep -ci mattermost-elasticsearch) -eq 1 ]; then \
+	@if [ $(shell docker ps -a | grep -ci mattermost-elasticsearch) -ge 1 ]; then \
 		echo removing mattermost-elasticsearch; \
 		docker stop mattermost-elasticsearch > /dev/null; \
 		docker rm -v mattermost-elasticsearch > /dev/null; \
 	fi
 
-	@if [ $(shell docker ps -a | grep -ci mattermost-redis) -eq 1 ]; then \
+	@if [ $(shell docker ps -a | grep -ci mattermost-redis) -ge 1 ]; then \
 		echo removing mattermost-redis; \
 		docker stop mattermost-redis > /dev/null; \
 		docker rm -v mattermost-redis > /dev/null; \


### PR DESCRIPTION
#### Summary
In cases where there are multiple docker containers that are outdated, make clean-old-docker fails to remove all of them. The makefile looks for only a single instance of a container.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-18116
