### PR TITLE
[MM-15886] Don't send {"status":"OK"} json response if mobile SSO login

### DIFF
--- a/web/oauth.go
+++ b/web/oauth.go
@@ -305,7 +305,6 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if action == model.OAUTH_ACTION_MOBILE {
-		ReturnStatusOK(w)
 		return
 	}
 


### PR DESCRIPTION
#### Summary
This PR resolves an issue with `{"status":"OK"}` flashing on the screen after signing on via SSO.  This occurs only on mobile. 

The issue was a call to `ReturnStatusOK()` which sends `{"status":"OK"}` through http.ResponseWriter.

I decided not to write a test for this case because 1) there aren't existing tests that exercise this part of the function and 2) the test would be written to check that nobody randomly decides to add this code back into the system.  

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-15886