### PR TITLE
[MM-17919] Add permission check for guest users before sending a /msg command

### DIFF
--- a/app/command_msg.go
+++ b/app/command_msg.go
@@ -58,20 +58,13 @@ func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string
 		return &model.CommandResponse{Text: args.T("api.command_msg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
-	user, err := a.Srv.Store.User().Get(args.UserId)
+	canSee, err := a.UserCanSeeOtherUser(args.UserId, userProfile.Id)
 	if err != nil {
 		mlog.Error(err.Error())
 		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
-	if user.IsGuest() {
-		canSee, userErr := a.UserCanSeeOtherUser(args.UserId, userProfile.Id)
-		if userErr != nil {
-			mlog.Error(userErr.Error())
-			return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-		}
-		if !canSee {
-			return &model.CommandResponse{Text: args.T("api.command_msg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-		}
+	if !canSee {
+		return &model.CommandResponse{Text: args.T("api.command_msg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
 	// Find the channel based on this user

--- a/app/command_msg.go
+++ b/app/command_msg.go
@@ -58,6 +58,22 @@ func (me *msgProvider) DoCommand(a *App, args *model.CommandArgs, message string
 		return &model.CommandResponse{Text: args.T("api.command_msg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}
 
+	user, err := a.Srv.Store.User().Get(args.UserId)
+	if err != nil {
+		mlog.Error(err.Error())
+		return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	}
+	if user.IsGuest() {
+		canSee, userErr := a.UserCanSeeOtherUser(args.UserId, userProfile.Id)
+		if userErr != nil {
+			mlog.Error(userErr.Error())
+			return &model.CommandResponse{Text: args.T("api.command_msg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		}
+		if !canSee {
+			return &model.CommandResponse{Text: args.T("api.command_msg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		}
+	}
+
 	// Find the channel based on this user
 	channelName := model.GetDMNameFromIds(args.UserId, userProfile.Id)
 


### PR DESCRIPTION
#### Summary

Guest users were allowed to `/msg` other users in the system even if they were not in a common team/channel. This PR fixes that by checking if the guest can see the user he/she's attempting to message.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17919
