### PR TITLE
Automated cherry pick of #11990

### DIFF
--- a/app/notification_email_test.go
+++ b/app/notification_email_test.go
@@ -25,7 +25,7 @@ func TestGetDirectMessageNotificationEmailSubject(t *testing.T) {
 		CreateAt: 1501804801000,
 	}
 	translateFunc := utils.GetUserTranslations("en")
-	subject := getDirectMessageNotificationEmailSubject(user, post, translateFunc, "http://localhost:8065", "sender", true)
+	subject := getDirectMessageNotificationEmailSubject(user, post, translateFunc, "http://localhost:8065", "@sender", true)
 	if !strings.HasPrefix(subject, expectedPrefix) {
 		t.Fatal("Expected subject line prefix '" + expectedPrefix + "', got " + subject)
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3348,7 +3348,7 @@
   },
   {
     "id": "app.notification.subject.direct.full",
-    "translation": "[{{.SiteName}}] New Direct Message from @{{.SenderDisplayName}} on {{.Month}} {{.Day}}, {{.Year}}"
+    "translation": "[{{.SiteName}}] New Direct Message from {{.SenderDisplayName}} on {{.Month}} {{.Day}}, {{.Year}}"
   },
   {
     "id": "app.notification.subject.group_message.full",


### PR DESCRIPTION
Cherry pick of #11990 on release-5.15.

- #11990: Remove @ sign from app.notification.subject.direct.full

/cc  @enahum