### PR TITLE
Do not count deleted channels when checking max channel limit

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -160,7 +160,7 @@ func (a *App) CreateChannelWithUser(channel *model.Channel, userId string) (*mod
 	}
 
 	// Get total number of channels on current team
-	count, err := a.GetNumberOfChannelsOnTeam(channel.TeamId)
+	count, err := a.GetNumberOfChannelsOnTeam(channel.TeamId, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1720,12 +1720,23 @@ func (a *App) RemoveUserFromChannel(userIdToRemove string, removerUserId string,
 	return nil
 }
 
-func (a *App) GetNumberOfChannelsOnTeam(teamId string) (int, *model.AppError) {
+func (a *App) GetNumberOfChannelsOnTeam(teamId string, includeDeleted bool) (int, *model.AppError) {
 	// Get total number of channels on current team
 	list, err := a.Srv.Store.Channel().GetTeamChannels(teamId)
 	if err != nil {
 		return 0, err
 	}
+
+	if !includeDeleted {
+		count := 0
+		for _, channel := range *list {
+			if channel.DeleteAt == 0 {
+				count++
+			}
+		}
+		return count, nil
+	}
+
 	return len(*list), nil
 }
 

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -1041,3 +1041,18 @@ func TestSearchChannelsForUser(t *testing.T) {
 		searchAndCheck(t, "dev", []string{"test-dev-1", "test-dev-2", "dev-3"})
 	})
 }
+
+func TestGetNumberOfChannelsOnTeam(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	th.App.DeleteChannel(th.BasicChannel, th.BasicUser.Id)
+
+	count, err := th.App.GetNumberOfChannelsOnTeam(th.BasicTeam.Id, true)
+	require.Nil(t, err)
+	assert.Equal(t, 3, count)
+
+	count, err = th.App.GetNumberOfChannelsOnTeam(th.BasicTeam.Id, false)
+	require.Nil(t, err)
+	assert.Equal(t, 2, count)
+}


### PR DESCRIPTION
#### Summary
Do not count deleted channels when checking max channel limit. This is just matching the behaviour in the store code.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18038