### PR TITLE
MM-18167: fix KV* helpers error handling

### DIFF
--- a/plugin/helpers_kv.go
+++ b/plugin/helpers_kv.go
@@ -61,12 +61,12 @@ func (p *HelpersImpl) KVCompareAndSetJSON(key string, oldValue interface{}, newV
 		}
 	}
 
-	changed, appErr := p.API.KVCompareAndSet(key, oldData, newData)
+	set, appErr := p.API.KVCompareAndSet(key, oldData, newData)
 	if appErr != nil {
-		return changed, appErr
+		return set, appErr
 	}
 
-	return changed, nil
+	return set, nil
 }
 
 // KVCompareAndDeleteJSON is a wrapper around KVCompareAndDelete to simplify atomically deleting a JSON object from the key value store.

--- a/plugin/helpers_kv.go
+++ b/plugin/helpers_kv.go
@@ -34,7 +34,12 @@ func (p *HelpersImpl) KVSetJSON(key string, value interface{}) error {
 		return err
 	}
 
-	return p.API.KVSet(key, data)
+	appErr := p.API.KVSet(key, data)
+	if appErr != nil {
+		return appErr
+	}
+
+	return nil
 }
 
 // KVCompareAndSetJSON is a wrapper around KVCompareAndSet to simplify atomically writing a JSON object to the key value store.
@@ -56,7 +61,12 @@ func (p *HelpersImpl) KVCompareAndSetJSON(key string, oldValue interface{}, newV
 		}
 	}
 
-	return p.API.KVCompareAndSet(key, oldData, newData)
+	changed, appErr := p.API.KVCompareAndSet(key, oldData, newData)
+	if appErr != nil {
+		return changed, appErr
+	}
+
+	return changed, nil
 }
 
 // KVCompareAndDeleteJSON is a wrapper around KVCompareAndDelete to simplify atomically deleting a JSON object from the key value store.
@@ -71,7 +81,12 @@ func (p *HelpersImpl) KVCompareAndDeleteJSON(key string, oldValue interface{}) (
 		}
 	}
 
-	return p.API.KVCompareAndDelete(key, oldData)
+	deleted, appErr := p.API.KVCompareAndDelete(key, oldData)
+	if appErr != nil {
+		return deleted, appErr
+	}
+
+	return deleted, nil
 }
 
 // KVSetWithExpiryJSON is a wrapper around KVSetWithExpiry to simplify atomically writing a JSON object with expiry to the key value store.
@@ -81,5 +96,10 @@ func (p *HelpersImpl) KVSetWithExpiryJSON(key string, value interface{}, expireI
 		return err
 	}
 
-	return p.API.KVSetWithExpiry(key, data, expireInSeconds)
+	appErr := p.API.KVSetWithExpiry(key, data, expireInSeconds)
+	if appErr != nil {
+		return appErr
+	}
+
+	return nil
 }

--- a/plugin/helpers_kv_test.go
+++ b/plugin/helpers_kv_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var nilAppError *model.AppError
-
 func TestKVGetJSON(t *testing.T) {
 	t.Run("KVGet error", func(t *testing.T) {
 		p := &plugin.HelpersImpl{}
@@ -107,7 +105,7 @@ func TestKVSetJSON(t *testing.T) {
 
 	t.Run("marshallable struct", func(t *testing.T) {
 		api := &plugintest.API{}
-		api.On("KVSet", "test-key", []byte(`{"val-a":10}`)).Return(nilAppError)
+		api.On("KVSet", "test-key", []byte(`{"val-a":10}`)).Return(nil)
 
 		p := &plugin.HelpersImpl{API: api}
 


### PR DESCRIPTION
#### Summary
Returning a `nil` `*model.AppError` does not make a `nil` `error` interface. As a consequence, all of the KV* helper methods would always appear to fail, even if the underlying API call was successful.

Fix this mismatch by explicitly assigning `appErr` in the helpers and only ever returning a `nil` `error` interface. Extend unit tests to achieve 100% coverage of the associated files.

In the long run, we must change all function signatures to return the `error` interface instead of the abomination that is returning `*model.AppError` today.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18167