### PR TITLE
When creating the go mod for plugin test replace git.apache.org/thrift.git to github.com/apache/thrift

### DIFF
--- a/utils/test_files_compiler.go
+++ b/utils/test_files_compiler.go
@@ -49,6 +49,7 @@ func CompileGo(t *testing.T, sourceCode, outputPath string) {
 		goMod(t, dir, "init", "mattermost.com/test")
 		goMod(t, dir, "edit", "-require", "github.com/mattermost/mattermost-server@v0.0.0")
 		goMod(t, dir, "edit", "-replace", fmt.Sprintf("github.com/mattermost/mattermost-server@v0.0.0=%s", mattermostServerPath))
+		goMod(t, dir, "edit", "-replace", fmt.Sprintf("git.apache.org/thrift.git=%s", "github.com/apache/thrift@v0.0.0-20180902110319-2566ecd5d999"))
 	}
 
 	out := &bytes.Buffer{}


### PR DESCRIPTION
#### Summary
git.apache.org is down since 31.09.2019 this migate the issue pointing the thrift to use github.com/apache/thrift

