### PR TITLE
Automated cherry pick of #12033

### DIFF
--- a/utils/test_files_compiler.go
+++ b/utils/test_files_compiler.go
@@ -48,6 +48,7 @@ func CompileGo(t *testing.T, sourceCode, outputPath string) {
 		goMod(t, dir, "init", "mattermost.com/test")
 		goMod(t, dir, "edit", "-require", "github.com/mattermost/mattermost-server@v0.0.0")
 		goMod(t, dir, "edit", "-replace", fmt.Sprintf("github.com/mattermost/mattermost-server@v0.0.0=%s", mattermostServerPath))
+		goMod(t, dir, "edit", "-replace", fmt.Sprintf("git.apache.org/thrift.git=%s", "github.com/apache/thrift@v0.0.0-20180902110319-2566ecd5d999"))
 	}
 
 	cmd := exec.Command("go", "build", "-o", outputPath, "main.go")


### PR DESCRIPTION
Cherry pick of #12033 on release-5.15.

- #12033: when creating the go mod replace git.apache.org/thrift.git to

/cc  @cpanato