### PR TITLE
[MM-18202] Bump jira plugin version to 2.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ PLUGIN_PACKAGES += mattermost-plugin-github-v0.10.2
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-aws-SNS-v1.0.2
 PLUGIN_PACKAGES += mattermost-plugin-antivirus-v0.1.1
-PLUGIN_PACKAGES += mattermost-plugin-jira-v2.1.0
+PLUGIN_PACKAGES += mattermost-plugin-jira-v2.1.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.0.0
 


### PR DESCRIPTION
#### Summary

This PR helps include recent bug fixes affecting users running early versions of Jira Server 7.x

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18202

#### Related Pull Requests

https://github.com/mattermost/mattermost-plugin-jira/pull/287