### PR TITLE
 Convert  tests in "app/plugin_hooks_test.go" to use assert/require 

### DIFF
--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -172,9 +172,8 @@ func TestHookMessageWillBePosted(t *testing.T) {
 			CreateAt:  model.GetMillis() - 10000,
 		}
 		post, err := th.App.CreatePost(post, th.BasicChannel, false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
+
 		assert.Equal(t, "message", post.Message)
 		retrievedPost, errSingle := th.App.Srv.Store.Post().GetSingle(post.Id)
 		require.Nil(t, errSingle)
@@ -217,15 +216,14 @@ func TestHookMessageWillBePosted(t *testing.T) {
 			CreateAt:  model.GetMillis() - 10000,
 		}
 		post, err := th.App.CreatePost(post, th.BasicChannel, false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
+
 		assert.Equal(t, "message_fromplugin", post.Message)
-		if retrievedPost, errSingle := th.App.Srv.Store.Post().GetSingle(post.Id); err != nil {
-			t.Fatal(errSingle)
-		} else {
-			assert.Equal(t, "message_fromplugin", retrievedPost.Message)
-		}
+		retrievedPost, errSingle := th.App.Srv.Store.Post().GetSingle(post.Id)
+		require.Nil(t, errSingle)
+
+		assert.Equal(t, "message_fromplugin", retrievedPost.Message)
+
 	})
 
 	t.Run("multiple updated", func(t *testing.T) {
@@ -286,9 +284,7 @@ func TestHookMessageWillBePosted(t *testing.T) {
 			CreateAt:  model.GetMillis() - 10000,
 		}
 		post, err := th.App.CreatePost(post, th.BasicChannel, false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.Nil(t, err)
 		assert.Equal(t, "prefix_message_suffix", post.Message)
 	})
 }
@@ -332,9 +328,7 @@ func TestHookMessageHasBeenPosted(t *testing.T) {
 		CreateAt:  model.GetMillis() - 10000,
 	}
 	_, err := th.App.CreatePost(post, th.BasicChannel, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 }
 
 func TestHookMessageWillBeUpdated(t *testing.T) {
@@ -373,15 +367,11 @@ func TestHookMessageWillBeUpdated(t *testing.T) {
 		CreateAt:  model.GetMillis() - 10000,
 	}
 	post, err := th.App.CreatePost(post, th.BasicChannel, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	assert.Equal(t, "message_", post.Message)
 	post.Message = post.Message + "edited_"
 	post, err = th.App.UpdatePost(post, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	assert.Equal(t, "message_edited_fromplugin", post.Message)
 }
 
@@ -425,15 +415,11 @@ func TestHookMessageHasBeenUpdated(t *testing.T) {
 		CreateAt:  model.GetMillis() - 10000,
 	}
 	post, err := th.App.CreatePost(post, th.BasicChannel, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	assert.Equal(t, "message_", post.Message)
 	post.Message = post.Message + "edited"
 	_, err = th.App.UpdatePost(post, true)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 }
 
 func TestHookFileWillBeUploaded(t *testing.T) {
@@ -540,7 +526,7 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 	t.Run("allowed", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-
+      
 		var mockAPI plugintest.API
 		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
 		mockAPI.On("LogDebug", "testhook.txt").Return(nil)
@@ -988,7 +974,5 @@ func TestHookContext(t *testing.T) {
 		CreateAt:  model.GetMillis() - 10000,
 	}
 	_, err := th.App.CreatePost(post, th.BasicChannel, false)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 }

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -220,9 +220,7 @@ func TestHookMessageWillBePosted(t *testing.T) {
 		assert.Equal(t, "message_fromplugin", post.Message)
 		retrievedPost, errSingle := th.App.Srv.Store.Post().GetSingle(post.Id)
 		require.Nil(t, errSingle)
-
 		assert.Equal(t, "message_fromplugin", retrievedPost.Message)
-
 	})
 
 	t.Run("multiple updated", func(t *testing.T) {
@@ -567,8 +565,8 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 		assert.Nil(t, err)
 		assert.NotNil(t, response)
 		assert.Equal(t, 1, len(response.FileInfos))
+		
 		fileId := response.FileInfos[0].Id
-
 		fileInfo, err := th.App.GetFileInfo(fileId)
 		assert.Nil(t, err)
 		assert.NotNil(t, fileInfo)
@@ -663,7 +661,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	defer th.TearDown()
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
-	assert.Empty(t, err, "Error updating user password: %s", err)
+	assert.Nil(t, err, "Error updating user password: %s", err)
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
 			`
@@ -701,7 +699,7 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	assert.Empty(t, err, "Error updating user password: %s", err)
+	assert.Nil(t, err, "Error updating user password: %s", err)
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -731,8 +729,7 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 	w := httptest.NewRecorder()
 	session, err := th.App.DoLogin(w, r, th.BasicUser, "")
 
-	assert.Empty(t, err, "Expected nil, got %s", err)
-
+	assert.Nil(t, err, "Expected nil, got %s", err)
 	assert.Equal(t, session.UserId, th.BasicUser.Id)
 }
 
@@ -742,7 +739,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	assert.Empty(t, err, "Error updating user password: %s", err)
+	assert.Nil(t, err, "Error updating user password: %s", err)
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -773,14 +770,13 @@ func TestUserHasLoggedIn(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	assert.Empty(t, err, "Expected nil, got %s", err)
+	assert.Nil(t, err, "Expected nil, got %s", err)
 
 	time.Sleep(2 * time.Second)
 
 	user, _ := th.App.GetUser(th.BasicUser.Id)
 
 	assert.Equal(t, user.FirstName, "plugin-callback-success", "Expected firstname overwrite, got default")
-
 }
 
 func TestUserHasBeenCreated(t *testing.T) {
@@ -826,7 +822,6 @@ func TestUserHasBeenCreated(t *testing.T) {
 
 	user, err = th.App.GetUser(user.Id)
 	require.Nil(t, err)
-
 	require.Equal(t, "plugin-callback-success", user.Nickname)
 }
 

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -663,7 +663,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	defer th.TearDown()
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
-	assert.NoError(t, err,"Error updating user password: %s",err) 
+	assert.Empty(t, err, "Error updating user password: %s", err)
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
 			`
@@ -692,7 +692,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	assert.NotContains(t, err.Id, "Login rejected by plugin","Expected Login rejected by plugin, got %s",err.Id) 
+	assert.NotContains(t, err.Id, "Login rejected by plugin", "Expected Login rejected by plugin, got %s", err.Id)
 }
 
 func TestUserWillLogInIn_Passed(t *testing.T) {
@@ -701,8 +701,7 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	assert.NoError(t, err,"Error updating user password: %s",err) 
-		
+	assert.Empty(t, err, "Error updating user password: %s", err)
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -732,7 +731,7 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 	w := httptest.NewRecorder()
 	session, err := th.App.DoLogin(w, r, th.BasicUser, "")
 
-	assert.NoError(t, err,"Expected nil, got %s",err) 
+	assert.Empty(t, err, "Expected nil, got %s", err)
 
 	assert.Equal(t, session.UserId, th.BasicUser.Id)
 }
@@ -743,7 +742,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	assert.NoError(t, err,"Error updating user password: %s",err) 
+	assert.Empty(t, err, "Error updating user password: %s", err)
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -774,7 +773,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	assert.NoError(t, err,"Expected nil, got %s",err) 
+	assert.Empty(t, err, "Expected nil, got %s", err)
 
 	time.Sleep(2 * time.Second)
 

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -692,7 +692,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	assert.NotContains(t, err.Id, "Login rejected by plugin", "Expected Login rejected by plugin, got %s", err.Id)
+	assert.Contains(t, err.Id, "Login rejected by plugin", "Expected Login rejected by plugin, got %s", err.Id)
 }
 
 func TestUserWillLogInIn_Passed(t *testing.T) {

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -663,10 +663,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	defer th.TearDown()
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
-	if !assert.NoError(t, err) {
-
-		assert.Errorf(t, err, "Error updating user password: %s")
-	}
+	assert.NoError(t, err,"Error updating user password: %s",err) 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
 			`
@@ -695,9 +692,7 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	if assert.NotContains(t, err.Id, "Login rejected by plugin") {
-		assert.Errorf(t, err.Id, "Expected Login rejected by plugin, got %s")
-	}
+	assert.NotContains(t, err.Id, "Login rejected by plugin","Expected Login rejected by plugin, got %s",err.Id) 
 }
 
 func TestUserWillLogInIn_Passed(t *testing.T) {
@@ -706,9 +701,8 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	if !assert.NoError(t, err) {
-		assert.Errorf(t, err, "Error updating user password: %s")
-	}
+	assert.NoError(t, err,"Error updating user password: %s",err) 
+		
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -738,9 +732,7 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 	w := httptest.NewRecorder()
 	session, err := th.App.DoLogin(w, r, th.BasicUser, "")
 
-	if !assert.NoError(t, err) {
-		assert.Errorf(t, err, "Expected nil, got %s")
-	}
+	assert.NoError(t, err,"Expected nil, got %s",err) 
 
 	assert.Equal(t, session.UserId, th.BasicUser.Id)
 }
@@ -751,9 +743,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	if !assert.NoError(t, err) {
-		assert.Errorf(t, err, "Error updating user password: %s")
-	}
+	assert.NoError(t, err,"Error updating user password: %s",err) 
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
@@ -784,9 +774,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	if !assert.NoError(t, err) {
-		assert.Errorf(t, err, "Expected nil, got %s")
-	}
+	assert.NoError(t, err,"Expected nil, got %s",err) 
 
 	time.Sleep(2 * time.Second)
 

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -526,7 +525,7 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 	t.Run("allowed", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-      
+
 		var mockAPI plugintest.API
 		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
 		mockAPI.On("LogDebug", "testhook.txt").Return(nil)
@@ -664,11 +663,10 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	defer th.TearDown()
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
+	if !assert.NoError(t, err) {
 
-	if err != nil {
-		t.Errorf("Error updating user password: %s", err)
+		assert.Errorf(t, err, "Error updating user password: %s")
 	}
-
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
 		[]string{
 			`
@@ -697,8 +695,8 @@ func TestUserWillLogIn_Blocked(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	if !strings.HasPrefix(err.Id, "Login rejected by plugin") {
-		t.Errorf("Expected Login rejected by plugin, got %s", err.Id)
+	if assert.NotContains(t, err.Id, "Login rejected by plugin") {
+		assert.Errorf(t, err.Id, "Expected Login rejected by plugin, got %s")
 	}
 }
 
@@ -708,8 +706,8 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	if err != nil {
-		t.Errorf("Error updating user password: %s", err)
+	if !assert.NoError(t, err) {
+		assert.Errorf(t, err, "Error updating user password: %s")
 	}
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
@@ -740,13 +738,11 @@ func TestUserWillLogInIn_Passed(t *testing.T) {
 	w := httptest.NewRecorder()
 	session, err := th.App.DoLogin(w, r, th.BasicUser, "")
 
-	if err != nil {
-		t.Errorf("Expected nil, got %s", err)
+	if !assert.NoError(t, err) {
+		assert.Errorf(t, err, "Expected nil, got %s")
 	}
 
-	if session.UserId != th.BasicUser.Id {
-		t.Errorf("Expected %s, got %s", th.BasicUser.Id, session.UserId)
-	}
+	assert.Equal(t, session.UserId, th.BasicUser.Id)
 }
 
 func TestUserHasLoggedIn(t *testing.T) {
@@ -755,8 +751,8 @@ func TestUserHasLoggedIn(t *testing.T) {
 
 	err := th.App.UpdatePassword(th.BasicUser, "hunter2")
 
-	if err != nil {
-		t.Errorf("Error updating user password: %s", err)
+	if !assert.NoError(t, err) {
+		assert.Errorf(t, err, "Error updating user password: %s")
 	}
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
@@ -788,17 +784,16 @@ func TestUserHasLoggedIn(t *testing.T) {
 	w := httptest.NewRecorder()
 	_, err = th.App.DoLogin(w, r, th.BasicUser, "")
 
-	if err != nil {
-		t.Errorf("Expected nil, got %s", err)
+	if !assert.NoError(t, err) {
+		assert.Errorf(t, err, "Expected nil, got %s")
 	}
 
 	time.Sleep(2 * time.Second)
 
 	user, _ := th.App.GetUser(th.BasicUser.Id)
 
-	if user.FirstName != "plugin-callback-success" {
-		t.Errorf("Expected firstname overwrite, got default")
-	}
+	assert.Equal(t, user.FirstName, "plugin-callback-success", "Expected firstname overwrite, got default")
+
 }
 
 func TestUserHasBeenCreated(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary 
This pr is in reference to migrating the tests from "app/plugin_hooks_test.go" to use testify. 
The t.Fatal have been replaced with require and the Errorf have been replaced by apt assert package methhods.
<!--
A description of what this pull request does.
-->

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/12058
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
