### PR TITLE
[MM-15220] Add generic error field to SubmitDialogResponse

### DIFF
--- a/app/integration_action_test.go
+++ b/app/integration_action_test.go
@@ -430,6 +430,7 @@ func TestSubmitInteractiveDialog(t *testing.T) {
 		assert.Equal(t, "value1", val)
 
 		resp := model.SubmitDialogResponse{
+			Error: "some generic error",
 			Errors: map[string]string{"name1": "some error"},
 		}
 
@@ -444,6 +445,7 @@ func TestSubmitInteractiveDialog(t *testing.T) {
 	resp, err := th.App.SubmitInteractiveDialog(submit)
 	assert.Nil(t, err)
 	require.NotNil(t, resp)
+	assert.Equal(t, "some generic error", resp.Error)
 	assert.Equal(t, "some error", resp.Errors["name1"])
 
 	submit.URL = ""

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -221,6 +221,7 @@ type SubmitDialogRequest struct {
 }
 
 type SubmitDialogResponse struct {
+	Error  string            `json:"error,omitempty"`
 	Errors map[string]string `json:"errors,omitempty"`
 }
 

--- a/model/integration_action_test.go
+++ b/model/integration_action_test.go
@@ -141,6 +141,7 @@ func TestSubmitDialogRequestToJson(t *testing.T) {
 func TestSubmitDialogResponseToJson(t *testing.T) {
 	t.Run("all fine", func(t *testing.T) {
 		request := SubmitDialogResponse{
+			Error: "some generic error",
 			Errors: map[string]string{
 				"text":  "some text",
 				"float": "1.2",


### PR DESCRIPTION
This implements the API changes for GH-12043.

This will allow integrations to return an generic error message that is
not tied to a specific dialog field.

GH-12043
MM-15220


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->