### PR TITLE
[MM-18319] Replace t.Fatal with assert.Equals

### DIFF
--- a/app/notification_push_test.go
+++ b/app/notification_push_test.go
@@ -881,7 +881,7 @@ func TestGetPushNotificationMessage(t *testing.T) {
 				*cfg.EmailSettings.PushNotificationContents = pushNotificationContents
 			})
 
-			if actualMessage := th.App.getPushNotificationMessage(
+			actualMessage := th.App.getPushNotificationMessage(
 				tc.Message,
 				tc.explicitMention,
 				tc.channelWideMention,
@@ -891,9 +891,9 @@ func TestGetPushNotificationMessage(t *testing.T) {
 				tc.ChannelType,
 				tc.replyToThreadType,
 				utils.GetUserTranslations(locale),
-			); actualMessage != tc.ExpectedMessage {
-				t.Fatalf("Received incorrect push notification message `%v`, expected `%v`", actualMessage, tc.ExpectedMessage)
-			}
+			)
+
+			assert.Equal(t, tc.ExpectedMessage, actualMessage)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Replace t.Fatal with assert.Equals
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/12067
