### PR TITLE
MM-18317 Migrate tests from import_validators_test.go to use testify

### DIFF
--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -85,9 +85,8 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 
 	// Test display name with numbers
 	data.DisplayName = ptrStr(strings.Repeat("1234567890", 100))
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid display name.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr("display name")
 

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/utils/fileutils"
 	"github.com/stretchr/testify/assert"
@@ -50,38 +52,38 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 			Permissions: &[]string{"invite_user"},
 		},
 	}
-	if err := validateSchemeImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.", err)
-	}
+
+	err := validateSchemeImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with various invalid names.
 	data.Name = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
 
+	// Test with empty string
 	data.Name = ptrStr("")
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
 
+	// Test with numbers
 	data.Name = ptrStr(strings.Repeat("1234567890", 100))
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr("name")
+
 	// Test with invalid display name.
 	data.DisplayName = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid display name.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
+	// Test with display name.
 	data.DisplayName = ptrStr("")
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid display name.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
+	// Test display name with numbers
 	data.DisplayName = ptrStr(strings.Repeat("1234567890", 100))
 	if err := validateSchemeImportData(&data); err == nil {
 		t.Fatal("Should have failed due to invalid display name.")
@@ -91,19 +93,18 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 
 	// Test with various missing roles.
 	data.DefaultTeamAdminRole = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultTeamAdminRole = &RoleImportData{
 		Name:        ptrStr("name"),
 		DisplayName: ptrStr("display name"),
 		Permissions: &[]string{"invite_user"},
 	}
+
 	data.DefaultTeamUserRole = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultTeamUserRole = &RoleImportData{
 		Name:        ptrStr("name"),
@@ -111,9 +112,8 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultChannelAdminRole = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultChannelAdminRole = &RoleImportData{
 		Name:        ptrStr("name"),
@@ -121,9 +121,8 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultChannelUserRole = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultChannelUserRole = &RoleImportData{
 		Name:        ptrStr("name"),
@@ -133,36 +132,31 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 
 	// Test with various invalid roles.
 	data.DefaultTeamAdminRole.Name = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultTeamAdminRole.Name = ptrStr("name")
 	data.DefaultTeamUserRole.Name = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultTeamUserRole.Name = ptrStr("name")
 	data.DefaultChannelAdminRole.Name = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultChannelAdminRole.Name = ptrStr("name")
 	data.DefaultChannelUserRole.Name = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultChannelUserRole.Name = ptrStr("name")
 
 	// Change to a Channel scope role, and check with missing or extra roles again.
 	data.Scope = ptrStr("channel")
 	data.DefaultTeamAdminRole = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to spurious role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to spurious role.")
 
 	data.DefaultTeamAdminRole = &RoleImportData{
 		Name:        ptrStr("name"),
@@ -170,9 +164,8 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultTeamUserRole = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to spurious role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to spurious role.")
 
 	data.DefaultTeamUserRole = &RoleImportData{
 		Name:        ptrStr("name"),
@@ -180,27 +173,23 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultTeamGuestRole = nil
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to spurious role.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to spurious role.")
 
 	data.DefaultTeamGuestRole = nil
 	data.DefaultTeamUserRole = nil
 	data.DefaultTeamAdminRole = nil
-	if err := validateSchemeImportData(&data); err != nil {
-		t.Fatal("Should have succeeded.")
-	}
+	err = validateSchemeImportData(&data)
+	require.Nil(t, err, "Should have succeeded.")
 
 	// Test with all combinations of optional parameters.
 	data.Description = ptrStr(strings.Repeat("1234567890", 1024))
-	if err := validateSchemeImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid description.")
-	}
+	err = validateSchemeImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid description.")
 
 	data.Description = ptrStr("description")
-	if err := validateSchemeImportData(&data); err != nil {
-		t.Fatal("Should have succeeded.")
-	}
+	err = validateSchemeImportData(&data)
+	require.Nil(t, err, "Should have succeeded.")
 }
 
 func TestImportValidateRoleImportData(t *testing.T) {
@@ -209,73 +198,62 @@ func TestImportValidateRoleImportData(t *testing.T) {
 		Name:        ptrStr("name"),
 		DisplayName: ptrStr("display name"),
 	}
-	if err := validateRoleImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.", err)
-	}
+	err := validateRoleImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with various invalid names.
 	data.Name = nil
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr("")
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr(strings.Repeat("1234567890", 100))
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr("name")
+
 	// Test with invalid display name.
 	data.DisplayName = nil
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid display name.")
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr("")
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid display name.")
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr(strings.Repeat("1234567890", 100))
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid display name.")
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr("display name")
 
 	// Test with various valid/invalid permissions.
 	data.Permissions = &[]string{}
-	if err := validateRoleImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.", err)
-	}
+	err = validateRoleImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	data.Permissions = &[]string{"invite_user", "add_user_to_team"}
-	if err := validateRoleImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.", err)
-	}
+	err = validateRoleImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	data.Permissions = &[]string{"invite_user", "add_user_to_team", "derp"}
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to invalid permission.", err)
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to invalid permission.")
 
 	data.Permissions = &[]string{"invite_user", "add_user_to_team"}
 
 	// Test with various valid/invalid descriptions.
 	data.Description = ptrStr(strings.Repeat("1234567890", 1024))
-	if err := validateRoleImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to invalid description.", err)
-	}
+	err = validateRoleImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to invalid description.")
 
 	data.Description = ptrStr("description")
-	if err := validateRoleImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.", err)
-	}
+	err = validateRoleImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 }
 
 func TestImportValidateTeamImportData(t *testing.T) {
@@ -286,76 +264,64 @@ func TestImportValidateTeamImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 	}
-	if err := validateTeamImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validateTeamImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with various invalid names.
 	data = TeamImportData{
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 	}
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing name.")
 
 	data.Name = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long name.")
 
 	data.Name = ptrStr("login")
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to reserved word in name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to reserved word in name.")
 
 	data.Name = ptrStr("Test::''ASD")
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to non alphanum characters in name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to non alphanum characters in name.")
 
 	data.Name = ptrStr("A")
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to short name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to short name.")
 
 	// Test team various invalid display names.
 	data = TeamImportData{
 		Name: ptrStr("teamname"),
 		Type: ptrStr("O"),
 	}
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing display_name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing display_name.")
 
 	data.DisplayName = ptrStr("")
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to empty display_name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to empty display_name.")
 
 	data.DisplayName = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long display_name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long display_name.")
 
 	// Test with various valid and invalid types.
 	data = TeamImportData{
 		Name:        ptrStr("teamname"),
 		DisplayName: ptrStr("Display Name"),
 	}
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing type.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing type.")
 
 	data.Type = ptrStr("A")
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid type.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid type.")
 
 	data.Type = ptrStr("I")
-	if err := validateTeamImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid type.")
-	}
+	err = validateTeamImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid type.")
 
 	// Test with all the combinations of optional parameters.
 	data = TeamImportData{
@@ -365,32 +331,27 @@ func TestImportValidateTeamImportData(t *testing.T) {
 		Description:     ptrStr("The team description."),
 		AllowOpenInvite: ptrBool(true),
 	}
-	if err := validateTeamImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid optional properties.")
-	}
+	err = validateTeamImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid optional properties.")
 
 	data.AllowOpenInvite = ptrBool(false)
-	if err := validateTeamImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with allow open invites false.")
-	}
+	err = validateTeamImportData(&data)
+	require.Nil(t, err, "Should have succeeded with allow open invites false.")
 
 	data.Description = ptrStr(strings.Repeat("abcdefghij ", 26))
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long description.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long description.")
 
 	// Test with an empty scheme name.
 	data.Description = ptrStr("abcdefg")
 	data.Scheme = ptrStr("")
-	if err := validateTeamImportData(&data); err == nil {
-		t.Fatal("Should have failed due to empty scheme name.")
-	}
+	err = validateTeamImportData(&data)
+	require.NotNil(t, err, "Should have failed due to empty scheme name.")
 
 	// Test with a valid scheme name.
 	data.Scheme = ptrStr("abcdefg")
-	if err := validateTeamImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid scheme name.")
-	}
+	err = validateTeamImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid scheme name.")
 }
 
 func TestImportValidateChannelImportData(t *testing.T) {
@@ -402,9 +363,8 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 	}
-	if err := validateChannelImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validateChannelImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing team.
 	data = ChannelImportData{
@@ -412,9 +372,8 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 	}
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing team.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing team.")
 
 	// Test with various invalid names.
 	data = ChannelImportData{
@@ -422,24 +381,20 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 	}
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing name.")
 
 	data.Name = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long name.")
 
 	data.Name = ptrStr("Test::''ASD")
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to non alphanum characters in name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to non alphanum characters in name.")
 
 	data.Name = ptrStr("A")
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to short name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to short name.")
 
 	// Test team various invalid display names.
 	data = ChannelImportData{
@@ -447,19 +402,16 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		Name: ptrStr("channelname"),
 		Type: ptrStr("O"),
 	}
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing display_name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing display_name.")
 
 	data.DisplayName = ptrStr("")
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to empty display_name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to empty display_name.")
 
 	data.DisplayName = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long display_name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long display_name.")
 
 	// Test with various valid and invalid types.
 	data = ChannelImportData{
@@ -467,19 +419,16 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		Name:        ptrStr("channelname"),
 		DisplayName: ptrStr("Display Name"),
 	}
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to missing type.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to missing type.")
 
 	data.Type = ptrStr("A")
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid type.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid type.")
 
 	data.Type = ptrStr("P")
-	if err := validateChannelImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid type.")
-	}
+	err = validateChannelImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid type.")
 
 	// Test with all the combinations of optional parameters.
 	data = ChannelImportData{
@@ -490,33 +439,28 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		Header:      ptrStr("Channel Header Here"),
 		Purpose:     ptrStr("Channel Purpose Here"),
 	}
-	if err := validateChannelImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid optional properties.")
-	}
+	err = validateChannelImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid optional properties.")
 
 	data.Header = ptrStr(strings.Repeat("abcdefghij ", 103))
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long header.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long header.")
 
 	data.Header = ptrStr("Channel Header Here")
 	data.Purpose = ptrStr(strings.Repeat("abcdefghij ", 26))
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long purpose.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long purpose.")
 
 	// Test with an empty scheme name.
 	data.Purpose = ptrStr("abcdefg")
 	data.Scheme = ptrStr("")
-	if err := validateChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to empty scheme name.")
-	}
+	err = validateChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to empty scheme name.")
 
 	// Test with a valid scheme name.
 	data.Scheme = ptrStr("abcdefg")
-	if err := validateChannelImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid scheme name.")
-	}
+	err = validateChannelImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid scheme name.")
 }
 
 func TestImportValidateUserImportData(t *testing.T) {
@@ -526,55 +470,47 @@ func TestImportValidateUserImportData(t *testing.T) {
 		Username: ptrStr("bob"),
 		Email:    ptrStr("bob@example.com"),
 	}
-	if err := validateUserImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validateUserImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Invalid Usernames.
 	data.Username = nil
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to nil Username.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to nil Username.")
 
 	data.Username = ptrStr("")
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to 0 length Username.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to 0 length Username.")
 
 	data.Username = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to too long Username.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to too long Username.")
 
 	data.Username = ptrStr("i am a username with spaces and !!!")
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to invalid characters in Username.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to invalid characters in Username.");
 
 	data.Username = ptrStr("bob")
 
 	// Unexisting Picture Image
 	data.ProfileImage = ptrStr("not-existing-file")
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to not existing profile image file.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to not existing profile image file.")
+
 	data.ProfileImage = nil
 
 	// Invalid Emails
 	data.Email = nil
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to nil Email.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to nil Email.")
 
 	data.Email = ptrStr("")
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to 0 length Email.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to 0 length Email.")
 
 	data.Email = ptrStr(strings.Repeat("abcdefghij", 13))
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to too long Email.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to too long Email.")
 
 	data.Email = ptrStr("bob@example.com")
 
@@ -584,14 +520,12 @@ func TestImportValidateUserImportData(t *testing.T) {
 
 	data.AuthService = ptrStr("saml")
 	data.AuthData = ptrStr(strings.Repeat("abcdefghij", 15))
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to too long auth data.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to too long auth data.")
 
 	data.AuthData = ptrStr("bobbytables")
-	if err := validateUserImportData(&data); err != nil {
-		t.Fatal("Validation should have succeeded with valid auth service and auth data.")
-	}
+	err = validateUserImportData(&data)
+	require.Nil(t, err, "Validation should have succeeded with valid auth service and auth data.")
 
 	// Test a valid User with all fields populated.
 	testsDir, _ := fileutils.FindDir("tests")
@@ -608,44 +542,42 @@ func TestImportValidateUserImportData(t *testing.T) {
 		Roles:        ptrStr("system_user"),
 		Locale:       ptrStr("en"),
 	}
-	if err := validateUserImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err = validateUserImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test various invalid optional field values.
 	data.Nickname = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to too long Nickname.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to too long Nickname.")
+
 	data.Nickname = ptrStr("BobNick")
 
 	data.FirstName = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to too long First Name.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to too long First Name.")
+
 	data.FirstName = ptrStr("Bob")
 
 	data.LastName = ptrStr(strings.Repeat("abcdefghij", 7))
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to too long Last name.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to too long Last name.")
+
 	data.LastName = ptrStr("Blob")
 
 	data.Position = ptrStr(strings.Repeat("abcdefghij", 13))
-	if err := validateUserImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to too long Position.")
-	}
+	err = validateUserImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to too long Position.")
+
 	data.Position = ptrStr("The Boss")
 
 	data.Roles = nil
-	if err := validateUserImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err = validateUserImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	data.Roles = ptrStr("")
-	if err := validateUserImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err = validateUserImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
+
 	data.Roles = ptrStr("system_user")
 
 	// Try various valid/invalid notify props.
@@ -709,46 +641,41 @@ func TestImportValidateUserTeamsImportData(t *testing.T) {
 			Roles: ptrStr("team_admin team_user"),
 		},
 	}
-	if err := validateUserTeamsImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err := validateUserTeamsImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
+
 	data[0].Name = ptrStr("teamname")
 
 	// Valid (nil roles)
 	data[0].Roles = nil
-	if err := validateUserTeamsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with empty roles.")
-	}
+	err = validateUserTeamsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (empty roles)
 	data[0].Roles = ptrStr("")
-	if err := validateUserTeamsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with empty roles.")
-	}
+	err = validateUserTeamsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (with roles)
 	data[0].Roles = ptrStr("team_admin team_user")
-	if err := validateUserTeamsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid roles.")
-	}
+	err = validateUserTeamsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid roles.")
 
 	// Valid (with JSON string of theme)
 	data[0].Theme = ptrStr(`{"awayIndicator":"#DBBD4E","buttonBg":"#23A1FF","buttonColor":"#FFFFFF","centerChannelBg":"#ffffff","centerChannelColor":"#333333","codeTheme":"github","image":"/static/files/a4a388b38b32678e83823ef1b3e17766.png","linkColor":"#2389d7","mentionBg":"#2389d7","mentionColor":"#ffffff","mentionHighlightBg":"#fff2bb","mentionHighlightLink":"#2f81b7","newMessageSeparator":"#FF8800","onlineIndicator":"#7DBE00","sidebarBg":"#fafafa","sidebarHeaderBg":"#3481B9","sidebarHeaderTextColor":"#ffffff","sidebarText":"#333333","sidebarTextActiveBorder":"#378FD2","sidebarTextActiveColor":"#111111","sidebarTextHoverBg":"#e6f2fa","sidebarUnreadText":"#333333","type":"Mattermost"}`)
-	if err := validateUserTeamsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid theme.")
-	}
+	err = validateUserTeamsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid theme.")
 
 	// Invalid (invalid JSON string of theme)
 	data[0].Theme = ptrStr(`This is the invalid string which cannot be marshalled to JSON object :) + {"#DBBD4E","buttonBg", "#23A1FF", buttonColor`)
-	if err := validateUserTeamsImportData(&data); err == nil {
-		t.Fatal("Should have fail with invalid JSON string of theme.")
-	}
+	err = validateUserTeamsImportData(&data)
+	require.NotNil(t, err, "Should have fail with invalid JSON string of theme.")
 
 	// Invalid (valid JSON but invalid theme description)
 	data[0].Theme = ptrStr(`{"somekey": 25, "json_obj1": {"color": "#DBBD4E","buttonBg": "#23A1FF"}}`)
-	if err := validateUserTeamsImportData(&data); err == nil {
-		t.Fatal("Should have fail with valid JSON which contains invalid string of theme description.")
-	}
+	err = validateUserTeamsImportData(&data)
+	require.NotNil(t, err, "Should have fail with valid JSON which contains invalid string of theme description.")
+
 	data[0].Theme = nil
 }
 
@@ -760,60 +687,51 @@ func TestImportValidateUserChannelsImportData(t *testing.T) {
 			Roles: ptrStr("channel_admin channel_user"),
 		},
 	}
-	if err := validateUserChannelsImportData(&data); err == nil {
-		t.Fatal("Should have failed due to invalid name.")
-	}
+	err := validateUserChannelsImportData(&data)
+	require.NotNil(t, err, "Should have failed due to invalid name.")
 	data[0].Name = ptrStr("channelname")
 
 	// Valid (nil roles)
 	data[0].Roles = nil
-	if err := validateUserChannelsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with empty roles.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (empty roles)
 	data[0].Roles = ptrStr("")
-	if err := validateUserChannelsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with empty roles.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (with roles)
 	data[0].Roles = ptrStr("channel_admin channel_user")
-	if err := validateUserChannelsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid roles.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid roles.")
 
 	// Empty notify props.
 	data[0].NotifyProps = &UserChannelNotifyPropsImportData{}
-	if err := validateUserChannelsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with empty notify props.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with empty notify props.")
 
 	// Invalid desktop notify props.
 	data[0].NotifyProps.Desktop = ptrStr("invalid")
-	if err := validateUserChannelsImportData(&data); err == nil {
-		t.Fatal("Should have failed with invalid desktop notify props.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.NotNil(t, err, "Should have failed with invalid desktop notify props.")
 
 	// Invalid mobile notify props.
 	data[0].NotifyProps.Desktop = ptrStr("mention")
 	data[0].NotifyProps.Mobile = ptrStr("invalid")
-	if err := validateUserChannelsImportData(&data); err == nil {
-		t.Fatal("Should have failed with invalid mobile notify props.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.NotNil(t, err, "Should have failed with invalid mobile notify props.")
 
 	// Invalid mark_unread notify props.
 	data[0].NotifyProps.Mobile = ptrStr("mention")
 	data[0].NotifyProps.MarkUnread = ptrStr("invalid")
-	if err := validateUserChannelsImportData(&data); err == nil {
-		t.Fatal("Should have failed with invalid mark_unread notify props.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.NotNil(t, err, "Should have failed with invalid mark_unread notify props.")
 
 	// Valid notify props.
 	data[0].NotifyProps.MarkUnread = ptrStr("mention")
-	if err := validateUserChannelsImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid notify props.")
-	}
+	err = validateUserChannelsImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid notify props.")
 }
 
 func TestImportValidateReactionImportData(t *testing.T) {
@@ -824,34 +742,31 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}
-	if err := validateReactionImportData(&data, parentCreateAt); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validateReactionImportData(&data, parentCreateAt)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing required properties.
 	data = ReactionImportData{
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}
-	if err := validateReactionImportData(&data, parentCreateAt); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = ReactionImportData{
 		User:     ptrStr("username"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateReactionImportData(&data, parentCreateAt); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
+
 
 	data = ReactionImportData{
 		User:      ptrStr("username"),
 		EmojiName: ptrStr("emoji"),
 	}
-	if err := validateReactionImportData(&data, parentCreateAt); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	// Test with invalid emoji name.
 	data = ReactionImportData{
@@ -859,9 +774,8 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr(strings.Repeat("1234567890", 500)),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}
-	if err := validateReactionImportData(&data, parentCreateAt); err == nil {
-		t.Fatal("Should have failed due to too long emoji name.")
-	}
+	err = validateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to too long emoji name.")
 
 	// Test with invalid CreateAt
 	data = ReactionImportData{
@@ -869,18 +783,16 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(0),
 	}
-	if err := validateReactionImportData(&data, parentCreateAt); err == nil {
-		t.Fatal("Should have failed due to 0 create-at value.")
-	}
+	err = validateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 
 	data = ReactionImportData{
 		User:      ptrStr("username"),
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(parentCreateAt - 100),
 	}
-	if err := validateReactionImportData(&data, parentCreateAt); err == nil {
-		t.Fatal("Should have failed due parent with newer create-at value.")
-	}
+	err = validateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due parent with newer create-at value.")
 }
 
 func TestImportValidateReplyImportData(t *testing.T) {
@@ -892,34 +804,30 @@ func TestImportValidateReplyImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateReplyImportData(&data, parentCreateAt, maxPostSize); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing required properties.
 	data = ReplyImportData{
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateReplyImportData(&data, parentCreateAt, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = ReplyImportData{
 		User:     ptrStr("username"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateReplyImportData(&data, parentCreateAt, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = ReplyImportData{
 		User:    ptrStr("username"),
 		Message: ptrStr("message"),
 	}
-	if err := validateReplyImportData(&data, parentCreateAt, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	// Test with invalid message.
 	data = ReplyImportData{
@@ -927,9 +835,8 @@ func TestImportValidateReplyImportData(t *testing.T) {
 		Message:  ptrStr(strings.Repeat("0", maxPostSize+1)),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateReplyImportData(&data, parentCreateAt, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to too long message.")
-	}
+	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to too long message.")
 
 	// Test with invalid CreateAt
 	data = ReplyImportData{
@@ -937,18 +844,16 @@ func TestImportValidateReplyImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(0),
 	}
-	if err := validateReplyImportData(&data, parentCreateAt, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to 0 create-at value.")
-	}
+	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 
 	data = ReplyImportData{
 		User:     ptrStr("username"),
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(parentCreateAt - 100),
 	}
-	if err := validateReplyImportData(&data, parentCreateAt, maxPostSize); err == nil {
-		t.Fatal("Should have failed due parent with newer create-at value.")
-	}
+	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	require.NotNil(t, err, "Should have failed due parent with newer create-at value.")
 }
 
 func TestImportValidatePostImportData(t *testing.T) {
@@ -962,9 +867,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validatePostImportData(&data, maxPostSize)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing required properties.
 	data = PostImportData{
@@ -973,9 +877,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = PostImportData{
 		Team:     ptrStr("teamname"),
@@ -983,9 +886,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = PostImportData{
 		Team:     ptrStr("teamname"),
@@ -993,9 +895,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = PostImportData{
 		Team:     ptrStr("teamname"),
@@ -1003,9 +904,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		User:     ptrStr("username"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = PostImportData{
 		Team:    ptrStr("teamname"),
@@ -1013,9 +913,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		User:    ptrStr("username"),
 		Message: ptrStr("message"),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	// Test with invalid message.
 	data = PostImportData{
@@ -1025,9 +924,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		Message:  ptrStr(strings.Repeat("0", maxPostSize+1)),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to too long message.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to too long message.")
 
 	// Test with invalid CreateAt
 	data = PostImportData{
@@ -1037,9 +935,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(0),
 	}
-	if err := validatePostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to 0 create-at value.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 
 	// Test with valid all optional parameters.
 	reactions := []ReactionImportData{ReactionImportData{
@@ -1047,11 +944,13 @@ func TestImportValidatePostImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}}
+
 	replies := []ReplyImportData{ReplyImportData{
 		User:     ptrStr("username"),
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}}
+
 	data = PostImportData{
 		Team:      ptrStr("teamname"),
 		Channel:   ptrStr("channelname"),
@@ -1061,9 +960,8 @@ func TestImportValidatePostImportData(t *testing.T) {
 		Reactions: &reactions,
 		Replies:   &replies,
 	}
-	if err := validatePostImportData(&data, maxPostSize); err != nil {
-		t.Fatal("Should have succeeded.")
-	}
+	err = validatePostImportData(&data, maxPostSize)
+	require.Nil(t, err, "Should have succeeded.")
 }
 
 func TestImportValidateDirectChannelImportData(t *testing.T) {
@@ -1075,9 +973,8 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	if err := validateDirectChannelImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validateDirectChannelImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with valid number of members for group message.
 	data = DirectChannelImportData{
@@ -1087,9 +984,8 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	if err := validateDirectChannelImportData(&data); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err = validateDirectChannelImportData(&data)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with all the combinations of optional parameters.
 	data = DirectChannelImportData{
@@ -1099,32 +995,28 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 		},
 		Header: ptrStr("Channel Header Here"),
 	}
-	if err := validateDirectChannelImportData(&data); err != nil {
-		t.Fatal("Should have succeeded with valid optional properties.")
-	}
+	err = validateDirectChannelImportData(&data)
+	require.Nil(t, err, "Should have succeeded with valid optional properties.")
 
 	// Test with invalid Header.
 	data.Header = ptrStr(strings.Repeat("abcdefghij ", 103))
-	if err := validateDirectChannelImportData(&data); err == nil {
-		t.Fatal("Should have failed due to too long header.")
-	}
+	err = validateDirectChannelImportData(&data)
+	require.NotNil(t, err, "Should have failed due to too long header.")
 
 	// Test with different combinations of invalid member counts.
 	data = DirectChannelImportData{
 		Members: &[]string{},
 	}
-	if err := validateDirectChannelImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to invalid number of members.")
-	}
+	err = validateDirectChannelImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to invalid number of members.")
 
 	data = DirectChannelImportData{
 		Members: &[]string{
 			model.NewId(),
 		},
 	}
-	if err := validateDirectChannelImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to invalid number of members.")
-	}
+	err = validateDirectChannelImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to invalid number of members.")
 
 	data = DirectChannelImportData{
 		Members: &[]string{
@@ -1139,9 +1031,8 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	if err := validateDirectChannelImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to invalid number of members.")
-	}
+	err = validateDirectChannelImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to invalid number of members.")
 
 	// Test with invalid FavoritedBy
 	member1 := model.NewId()
@@ -1156,9 +1047,8 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	if err := validateDirectChannelImportData(&data); err == nil {
-		t.Fatal("Validation should have failed due to non-member favorited.")
-	}
+	err = validateDirectChannelImportData(&data)
+	require.NotNil(t, err, "Validation should have failed due to non-member favorited.")
 
 	// Test with valid FavoritedBy
 	data = DirectChannelImportData{
@@ -1171,9 +1061,8 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			member2,
 		},
 	}
-	if err := validateDirectChannelImportData(&data); err != nil {
-		t.Fatal(err)
-	}
+	err = validateDirectChannelImportData(&data)
+	require.Nil(t, err, "Validation should succeed with valid favorited member")
 }
 
 func TestImportValidateDirectPostImportData(t *testing.T) {
@@ -1189,9 +1078,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err := validateDirectPostImportData(&data, maxPostSize)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing required properties.
 	data = DirectPostImportData{
@@ -1199,9 +1087,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = DirectPostImportData{
 		ChannelMembers: &[]string{
@@ -1211,9 +1098,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = DirectPostImportData{
 		ChannelMembers: &[]string{
@@ -1223,9 +1109,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		User:     ptrStr("username"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = DirectPostImportData{
 		ChannelMembers: &[]string{
@@ -1235,9 +1120,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		User:    ptrStr("username"),
 		Message: ptrStr("message"),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to missing required property.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	// Test with invalid numbers of channel members.
 	data = DirectPostImportData{
@@ -1246,9 +1130,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:        ptrStr("message"),
 		CreateAt:       ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to unsuitable number of members.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to unsuitable number of members.")
 
 	data = DirectPostImportData{
 		ChannelMembers: &[]string{
@@ -1258,9 +1141,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to unsuitable number of members.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to unsuitable number of members.")
 
 	data = DirectPostImportData{
 		ChannelMembers: &[]string{
@@ -1279,9 +1161,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to unsuitable number of members.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to unsuitable number of members.")
 
 	// Test with group message number of members.
 	data = DirectPostImportData{
@@ -1294,9 +1175,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err != nil {
-		t.Fatal("Validation failed but should have been valid.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with invalid message.
 	data = DirectPostImportData{
@@ -1308,9 +1188,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr(strings.Repeat("0", maxPostSize+1)),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to too long message.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to too long message.")
 
 	// Test with invalid CreateAt
 	data = DirectPostImportData{
@@ -1322,9 +1201,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(0),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Should have failed due to 0 create-at value.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 
 	// Test with invalid FlaggedBy
 	member1 := model.NewId()
@@ -1342,9 +1220,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err == nil {
-		t.Fatal("Validation should have failed due to non-member flagged.")
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.NotNil(t, err, "Validation should have failed due to non-member flagged.")
 
 	// Test with valid FlaggedBy
 	data = DirectPostImportData{
@@ -1360,9 +1237,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	if err := validateDirectPostImportData(&data, maxPostSize); err != nil {
-		t.Fatal(err)
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.Nil(t, err, "Validation should succeed with post flagged by members")
 
 	// Test with valid all optional parameters.
 	reactions := []ReactionImportData{ReactionImportData{
@@ -1370,11 +1246,13 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}}
+
 	replies := []ReplyImportData{ReplyImportData{
 		User:     ptrStr("username"),
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}}
+
 	data = DirectPostImportData{
 		ChannelMembers: &[]string{
 			member1,
@@ -1391,9 +1269,8 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Replies:   &replies,
 	}
 
-	if err := validateDirectPostImportData(&data, maxPostSize); err != nil {
-		t.Fatal(err)
-	}
+	err = validateDirectPostImportData(&data, maxPostSize)
+	require.Nil(t, err, "Validation should succeed with valid optional parameters")
 }
 
 func TestImportValidateEmojiImportData(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Convert app/webhooks_test.go t.Fatal calls into assert/require calls
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-18317](https://mattermost.atlassian.net/browse/MM-18317)

Fixes https://github.com/mattermost/mattermost-server/issues/12069