### PR TITLE
Restricting groupmsg command to only allow to create group chats with know people

### DIFF
--- a/app/command_groupmsg.go
+++ b/app/command_groupmsg.go
@@ -47,22 +47,26 @@ func (me *groupmsgProvider) DoCommand(a *App, args *model.CommandArgs, message s
 	for _, username := range users {
 		username = strings.TrimSpace(username)
 		username = strings.TrimPrefix(username, "@")
-		if targetUser, err := a.Srv.Store.User().GetByUsername(username); err != nil {
+		targetUser, err := a.Srv.Store.User().GetByUsername(username)
+		if err != nil {
 			invalidUsernames = append(invalidUsernames, username)
-		} else {
-			canSee, err := a.UserCanSeeOtherUser(args.UserId, targetUser.Id)
-			if err != nil {
-				return &model.CommandResponse{Text: args.T("api.command_groupmsg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
-			}
-			if !canSee {
-				invalidUsernames = append(invalidUsernames, username)
-			} else {
-				_, exists := targetUsers[targetUser.Id]
-				if !exists && targetUser.Id != args.UserId {
-					targetUsers[targetUser.Id] = targetUser
-					targetUsersSlice = append(targetUsersSlice, targetUser.Id)
-				}
-			}
+			continue
+		}
+
+		canSee, err := a.UserCanSeeOtherUser(args.UserId, targetUser.Id)
+		if err != nil {
+			return &model.CommandResponse{Text: args.T("api.command_groupmsg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+		}
+
+		if !canSee {
+			invalidUsernames = append(invalidUsernames, username)
+			continue
+		}
+
+		_, exists := targetUsers[targetUser.Id]
+		if !exists && targetUser.Id != args.UserId {
+			targetUsers[targetUser.Id] = targetUser
+			targetUsersSlice = append(targetUsersSlice, targetUser.Id)
 		}
 	}
 

--- a/app/command_groupmsg.go
+++ b/app/command_groupmsg.go
@@ -92,6 +92,23 @@ func (me *groupmsgProvider) DoCommand(a *App, args *model.CommandArgs, message s
 		}
 	}
 
+	canSeeAll := true
+	for _, id := range targetUsersSlice {
+		if args.UserId != id {
+			canSee, err := a.UserCanSeeOtherUser(args.UserId, id)
+			if err != nil {
+				return &model.CommandResponse{Text: args.T("api.command_groupmsg.fail.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+			}
+			if !canSee {
+				canSeeAll = false
+			}
+		}
+	}
+
+	if !canSeeAll {
+		return &model.CommandResponse{Text: args.T("api.command_groupmsg.missing.app_error"), ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
+	}
+
 	var groupChannel *model.Channel
 	var channelErr *model.AppError
 

--- a/app/command_groupmsg_test.go
+++ b/app/command_groupmsg_test.go
@@ -80,7 +80,7 @@ func TestGroupMsgProvider(t *testing.T) {
 			},
 		}, targetUsers+"hello")
 
-		assert.Equal(t, "api.command_groupmsg.missing.app_error", resp.Text)
+		assert.Equal(t, "api.command_groupmsg.invalid_user.app_error", resp.Text)
 		assert.Equal(t, "", resp.GotoLocation)
 	})
 

--- a/app/command_groupmsg_test.go
+++ b/app/command_groupmsg_test.go
@@ -52,46 +52,67 @@ func TestGroupMsgProvider(t *testing.T) {
 	th.LinkUserToTeam(th.BasicUser, team)
 	cmd := &groupmsgProvider{}
 
-	// Check without permission to create a GM channel.
-	resp := cmd.DoCommand(th.App, &model.CommandArgs{
-		T:       i18n.IdentityTfunc(),
-		SiteURL: "http://test.url",
-		TeamId:  team.Id,
-		UserId:  th.BasicUser.Id,
-		Session: model.Session{
-			Roles: "",
-		},
-	}, targetUsers+"hello")
+	t.Run("Check without permission to create a GM channel.", func(t *testing.T) {
+		resp := cmd.DoCommand(th.App, &model.CommandArgs{
+			T:       i18n.IdentityTfunc(),
+			SiteURL: "http://test.url",
+			TeamId:  team.Id,
+			UserId:  th.BasicUser.Id,
+			Session: model.Session{
+				Roles: "",
+			},
+		}, targetUsers+"hello")
 
-	channelName := model.GetGroupNameFromUserIds([]string{th.BasicUser.Id, th.BasicUser2.Id, user3.Id})
-	assert.Equal(t, "api.command_groupmsg.permission.app_error", resp.Text)
-	assert.Equal(t, "", resp.GotoLocation)
+		assert.Equal(t, "api.command_groupmsg.permission.app_error", resp.Text)
+		assert.Equal(t, "", resp.GotoLocation)
+	})
 
-	// Check with permission to create a GM channel.
-	resp = cmd.DoCommand(th.App, &model.CommandArgs{
-		T:       i18n.IdentityTfunc(),
-		SiteURL: "http://test.url",
-		TeamId:  team.Id,
-		UserId:  th.BasicUser.Id,
-		Session: model.Session{
-			Roles: model.SYSTEM_USER_ROLE_ID,
-		},
-	}, targetUsers+"hello")
+	t.Run("Check without permissions to view a user in the list.", func(t *testing.T) {
+		th.RemovePermissionFromRole(model.PERMISSION_VIEW_MEMBERS.Id, model.SYSTEM_USER_ROLE_ID)
+		defer th.AddPermissionToRole(model.PERMISSION_VIEW_MEMBERS.Id, model.SYSTEM_USER_ROLE_ID)
+		resp := cmd.DoCommand(th.App, &model.CommandArgs{
+			T:       i18n.IdentityTfunc(),
+			SiteURL: "http://test.url",
+			TeamId:  team.Id,
+			UserId:  th.BasicUser.Id,
+			Session: model.Session{
+				Roles: model.SYSTEM_USER_ROLE_ID,
+			},
+		}, targetUsers+"hello")
 
-	assert.Equal(t, "", resp.Text)
-	assert.Equal(t, "http://test.url/"+team.Name+"/channels/"+channelName, resp.GotoLocation)
+		assert.Equal(t, "api.command_groupmsg.missing.app_error", resp.Text)
+		assert.Equal(t, "", resp.GotoLocation)
+	})
 
-	// Check without permission to post to an existing GM channel.
-	resp = cmd.DoCommand(th.App, &model.CommandArgs{
-		T:       i18n.IdentityTfunc(),
-		SiteURL: "http://test.url",
-		TeamId:  team.Id,
-		UserId:  th.BasicUser.Id,
-		Session: model.Session{
-			Roles: "",
-		},
-	}, targetUsers+"hello")
+	t.Run("Check with permission to create a GM channel.", func(t *testing.T) {
+		resp := cmd.DoCommand(th.App, &model.CommandArgs{
+			T:       i18n.IdentityTfunc(),
+			SiteURL: "http://test.url",
+			TeamId:  team.Id,
+			UserId:  th.BasicUser.Id,
+			Session: model.Session{
+				Roles: model.SYSTEM_USER_ROLE_ID,
+			},
+		}, targetUsers+"hello")
 
-	assert.Equal(t, "", resp.Text)
-	assert.Equal(t, "http://test.url/"+team.Name+"/channels/"+channelName, resp.GotoLocation)
+		channelName := model.GetGroupNameFromUserIds([]string{th.BasicUser.Id, th.BasicUser2.Id, user3.Id})
+		assert.Equal(t, "", resp.Text)
+		assert.Equal(t, "http://test.url/"+team.Name+"/channels/"+channelName, resp.GotoLocation)
+	})
+
+	t.Run("Check without permission to post to an existing GM channel.", func(t *testing.T) {
+		resp := cmd.DoCommand(th.App, &model.CommandArgs{
+			T:       i18n.IdentityTfunc(),
+			SiteURL: "http://test.url",
+			TeamId:  team.Id,
+			UserId:  th.BasicUser.Id,
+			Session: model.Session{
+				Roles: "",
+			},
+		}, targetUsers+"hello")
+
+		channelName := model.GetGroupNameFromUserIds([]string{th.BasicUser.Id, th.BasicUser2.Id, user3.Id})
+		assert.Equal(t, "", resp.Text)
+		assert.Equal(t, "http://test.url/"+team.Name+"/channels/"+channelName, resp.GotoLocation)
+	})
 }


### PR DESCRIPTION
#### Summary
Restricting groupmsg command to only allow to create group chats with know people

#### Ticket Link
[MM-18229](https://mattermost.atlassian.net/browse/MM-18229)