### PR TITLE
Convert app/license_test.go  t.Fatal calls into assert/require calls

### DIFF
--- a/app/license_test.go
+++ b/app/license_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLoadLicense(t *testing.T) {
@@ -15,9 +16,7 @@ func TestLoadLicense(t *testing.T) {
 	defer th.TearDown()
 
 	th.App.LoadLicense()
-	if th.App.License() != nil {
-		t.Fatal("shouldn't have a valid license")
-	}
+	require.Nil(t, th.App.License(), "shouldn't have a valid license")
 }
 
 func TestSaveLicense(t *testing.T) {
@@ -26,18 +25,16 @@ func TestSaveLicense(t *testing.T) {
 
 	b1 := []byte("junk")
 
-	if _, err := th.App.SaveLicense(b1); err == nil {
-		t.Fatal("shouldn't have saved license")
-	}
+	_, err := th.App.SaveLicense(b1)
+	require.NotNil(t, err, "shouldn't have saved license")
 }
 
 func TestRemoveLicense(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	if err := th.App.RemoveLicense(); err != nil {
-		t.Fatal("should have removed license")
-	}
+	err := th.App.RemoveLicense()
+	require.Nil(t, err, "should have removed license")
 }
 
 func TestSetLicense(t *testing.T) {
@@ -49,18 +46,16 @@ func TestSetLicense(t *testing.T) {
 	l1.Customer = &model.Customer{}
 	l1.StartsAt = model.GetMillis() - 1000
 	l1.ExpiresAt = model.GetMillis() + 100000
-	if ok := th.App.SetLicense(l1); !ok {
-		t.Fatal("license should have worked")
-	}
+	ok := th.App.SetLicense(l1)
+	require.True(t, ok, "license should have worked")
 
 	l3 := &model.License{}
 	l3.Features = &model.Features{}
 	l3.Customer = &model.Customer{}
 	l3.StartsAt = model.GetMillis() + 10000
 	l3.ExpiresAt = model.GetMillis() + 100000
-	if ok := th.App.SetLicense(l3); !ok {
-		t.Fatal("license should have passed")
-	}
+	ok = th.App.SetLicense(l3)
+	require.True(t, ok, "license should have passed")
 }
 
 func TestClientLicenseEtag(t *testing.T) {
@@ -72,16 +67,12 @@ func TestClientLicenseEtag(t *testing.T) {
 	th.App.SetClientLicense(map[string]string{"SomeFeature": "true", "IsLicensed": "true"})
 
 	etag2 := th.App.GetClientLicenseEtag(false)
-	if etag1 == etag2 {
-		t.Fatal("etags should not match")
-	}
+	require.NotEqual(t, etag1, etag2, "etags should not match")
 
 	th.App.SetClientLicense(map[string]string{"SomeFeature": "true", "IsLicensed": "false"})
 
 	etag3 := th.App.GetClientLicenseEtag(false)
-	if etag2 == etag3 {
-		t.Fatal("etags should not match")
-	}
+	require.NotEqual(t, etag2, etag3, "etags should not match")
 }
 
 func TestGetSanitizedClientLicense(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Convert app/license_test.go  t.Fatal calls into assert/require calls
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/12207