### PR TITLE
Convert app/user_agent_test.go t.Fatal calls into assert/require calls

### DIFF
--- a/app/user_agent_test.go
+++ b/app/user_agent_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/avct/uasurfer"
+	"github.com/stretchr/testify/require"
 )
 
 type testUserAgent struct {
@@ -53,9 +54,8 @@ func TestGetPlatformName(t *testing.T) {
 		t.Run(fmt.Sprintf("GetPlatformName_%v", i), func(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
-			if actual := getPlatformName(ua); actual != expected[i] {
-				t.Fatalf("%v Got %v, expected %v", userAgent.Name, actual, expected[i])
-			}
+			actual := getPlatformName(ua)
+			require.Equalf(t, actual, expected[i], "%v Got %v, expected %v", userAgent.Name, actual, expected[i])
 		})
 	}
 }
@@ -83,9 +83,8 @@ func TestGetOSName(t *testing.T) {
 		t.Run(fmt.Sprintf("GetOSName_%v", i), func(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
-			if actual := getOSName(ua); actual != expected[i] {
-				t.Fatalf("Got %v, expected %v", actual, expected[i])
-			}
+			actual := getOSName(ua)
+			require.Equalf(t, actual, expected[i], "Got %v, expected %v", actual, expected[i])
 		})
 	}
 }
@@ -113,9 +112,8 @@ func TestGetBrowserName(t *testing.T) {
 		t.Run(fmt.Sprintf("GetBrowserName_%v", i), func(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
-			if actual := getBrowserName(ua, userAgent.UserAgent); actual != expected[i] {
-				t.Fatalf("Got %v, expected %v", actual, expected[i])
-			}
+			actual := getBrowserName(ua, userAgent.UserAgent)
+			require.Equalf(t, actual, expected[i], "Got %v, expected %v", actual, expected[i])
 		})
 	}
 }
@@ -143,9 +141,8 @@ func TestGetBrowserVersion(t *testing.T) {
 		t.Run(fmt.Sprintf("GetBrowserVersion_%v", i), func(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
-			if actual := getBrowserVersion(ua, userAgent.UserAgent); actual != expected[i] {
-				t.Fatalf("Got %v, expected %v", actual, expected[i])
-			}
+			actual := getBrowserVersion(ua, userAgent.UserAgent)
+			require.Equalf(t, actual, expected[i], "Got %v, expected %v", actual, expected[i])
 		})
 	}
 }

--- a/app/user_agent_test.go
+++ b/app/user_agent_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/avct/uasurfer"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 type testUserAgent struct {
@@ -55,7 +55,7 @@ func TestGetPlatformName(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
 			actual := getPlatformName(ua)
-			require.Equalf(t, actual, expected[i], "%v Got %v, expected %v", userAgent.Name, actual, expected[i])
+			assert.Equal(t, expected[i], actual)
 		})
 	}
 }
@@ -84,7 +84,7 @@ func TestGetOSName(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
 			actual := getOSName(ua)
-			require.Equalf(t, actual, expected[i], "Got %v, expected %v", actual, expected[i])
+			assert.Equal(t, expected[i], actual)
 		})
 	}
 }
@@ -113,7 +113,7 @@ func TestGetBrowserName(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
 			actual := getBrowserName(ua, userAgent.UserAgent)
-			require.Equalf(t, actual, expected[i], "Got %v, expected %v", actual, expected[i])
+			assert.Equal(t, expected[i], actual)
 		})
 	}
 }
@@ -142,7 +142,7 @@ func TestGetBrowserVersion(t *testing.T) {
 			ua := uasurfer.Parse(userAgent.UserAgent)
 
 			actual := getBrowserVersion(ua, userAgent.UserAgent)
-			require.Equalf(t, actual, expected[i], "Got %v, expected %v", actual, expected[i])
+			assert.Equal(t, expected[i], actual)
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Convert app/user_agent_test.go t.Fatal calls into assert/require calls
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/12213