### PR TITLE
MM-17620 - Web: Error when entering an invalid MFA token is unclear

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4176,7 +4176,7 @@
   },
   {
     "id": "mfa.validate_token.authenticate.app_error",
-    "translation": "Error trying to authenticate MFA token"
+    "translation": "Invalid MFA token."
   },
   {
     "id": "migrations.worker.run_advanced_permissions_phase_2_migration.invalid_progress",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
When an invalid format is used for an MFA token, (ie, Alpha characters or not 6/8 digits). The Authenticate method returns an error which we handle differently. We can't change the error id, as the web app code handles these error differently. Therefore we need to simply change the error text to match the other error (valid formatted, but invalid token(.
```
{
    "id": "api.user.check_user_mfa.bad_code.app_error",
    "translation": "Invalid MFA token."
  },
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17620
