### PR TITLE
MM: 16479: ensure replacement file finishes io.Copy

### DIFF
--- a/plugin/client_rpc.go
+++ b/plugin/client_rpc.go
@@ -403,18 +403,17 @@ func (g *hooksRPCClient) FileWillBeUploaded(c *Context, info *model.FileInfo, fi
 			return
 		}
 		defer replacementFileConnection.Close()
-		if _, err := io.Copy(output, replacementFileConnection); err != nil && err != io.EOF {
+		if _, err := io.Copy(output, replacementFileConnection); err != nil {
 			g.log.Error("Error reading replacement file.", mlog.Err(err))
 		}
 	}()
 
 	_args := &Z_FileWillBeUploadedArgs{c, info, uploadedFileStreamId, replacementFileStreamId}
 	_returns := &Z_FileWillBeUploadedReturns{A: _args.B}
-	if g.implemented[FileWillBeUploadedId] {
-		if err := g.client.Call("Plugin.FileWillBeUploaded", _args, _returns); err != nil {
-			g.log.Error("RPC call FileWillBeUploaded to plugin failed.", mlog.Err(err))
-		}
+	if err := g.client.Call("Plugin.FileWillBeUploaded", _args, _returns); err != nil {
+		g.log.Error("RPC call FileWillBeUploaded to plugin failed.", mlog.Err(err))
 	}
+
 	return _returns.A, _returns.B
 }
 


### PR DESCRIPTION
#### Summary
We've had a flaky unit test for a while that's actually exposed a bug in the `FileWillBeUploaded` hook: sometimes we allow the hook to return before the `io.Copy` in the goroutine completes. This manifested infrequently in the unit tests, and was also [spotted](https://community.mattermost.com/core/pl/oficg6nb9bb6igzz87fpumgxuo) by community member @scottleedavis before @streamer45 correctly identified the race condition at play.

I haven't been able to find a way to reliably reproduce this issue as a unit test -- but we /do/ know the existing unit tests have spotted the problem, so I'm counting on those to continue to help as such.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-16479