### PR TITLE
Bump app version to 5.18

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -13,6 +13,8 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"5.18.0",
+	"5.17.0",
 	"5.16.0",
 	"5.15.0",
 	"5.14.0",


### PR DESCRIPTION
#### Summary
Given that the release branch for 5.16 has been cut, we can safely bump the app version to 5.18 now. Please note that we will have to bump the version on the 5.17 release branch, after 5.16 is cut.

For more context see https://github.com/mattermost/mattermost-server/pull/12172
