### PR TITLE
[MM-18628] Fix flaky OpenGraph test

### DIFF
--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -60,7 +60,8 @@ func TestPreparePostListForClient(t *testing.T) {
 func TestPreparePostForClient(t *testing.T) {
 	var serverURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
+		switch r.URL.Path {
+		case "/":
 			w.Header().Set("Content-Type", "text/html")
 			w.Write([]byte(`
 			<html>
@@ -73,25 +74,25 @@ func TestPreparePostForClient(t *testing.T) {
 			<meta property="og:description" content="Contribute to hmhealey/test-files development by creating an account on GitHub." />
 			</head>
 			</html>`))
-		} else if r.URL.Path == "/test-image1.png" {
+		case "/test-image1.png":
 			file, err := testutils.ReadTestFile("test.png")
 			require.Nil(t, err)
 
 			w.Header().Set("Content-Type", "image/png")
 			w.Write(file)
-		} else if r.URL.Path == "/test-image2.png" {
+		case "/test-image2.png":
 			file, err := testutils.ReadTestFile("test-data-graph.png")
 			require.Nil(t, err)
 
 			w.Header().Set("Content-Type", "image/png")
 			w.Write(file)
-		} else if r.URL.Path == "/test-image3.png" {
+		case "/test-image3.png":
 			file, err := testutils.ReadTestFile("qa-data-graph.png")
 			require.Nil(t, err)
 
 			w.Header().Set("Content-Type", "image/png")
 			w.Write(file)
-		} else {
+		default:
 			require.Fail(t, "Invalid path", r.URL.Path)
 		}
 	}))
@@ -534,7 +535,8 @@ func testProxyLinkedImage(t *testing.T, th *TestHelper, shouldProxy bool) {
 func testProxyOpenGraphImage(t *testing.T, th *TestHelper, shouldProxy bool) {
 	var serverURL string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
+		switch r.URL.Path {
+		case "/":
 			w.Header().Set("Content-Type", "text/html")
 			w.Write([]byte(`
 			<html>
@@ -547,13 +549,13 @@ func testProxyOpenGraphImage(t *testing.T, th *TestHelper, shouldProxy bool) {
 			<meta property="og:description" content="Contribute to hmhealey/test-files development by creating an account on GitHub." />
 			</head>
 			</html>`))
-		} else if r.URL.Path == "/test-image3.png" {
+		case "/test-image3.png":
 			file, err := testutils.ReadTestFile("qa-data-graph.png")
 			require.Nil(t, err)
 
 			w.Header().Set("Content-Type", "image/png")
 			w.Write(file)
-		} else {
+		default:
 			require.Fail(t, "Invalid path", r.URL.Path)
 		}
 	}))

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -58,12 +58,53 @@ func TestPreparePostListForClient(t *testing.T) {
 }
 
 func TestPreparePostForClient(t *testing.T) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte(`
+			<html>
+			<head>
+			<meta property="og:image" content="` + serverURL + `/test-image3.png" />
+			<meta property="og:site_name" content="GitHub" />
+			<meta property="og:type" content="object" />
+			<meta property="og:title" content="hmhealey/test-files" />
+			<meta property="og:url" content="https://github.com/hmhealey/test-files" />
+			<meta property="og:description" content="Contribute to hmhealey/test-files development by creating an account on GitHub." />
+			</head>
+			</html>`))
+		} else if r.URL.Path == "/test-image1.png" {
+			file, err := testutils.ReadTestFile("test.png")
+			require.Nil(t, err)
+
+			w.Header().Set("Content-Type", "image/png")
+			w.Write(file)
+		} else if r.URL.Path == "/test-image2.png" {
+			file, err := testutils.ReadTestFile("test-data-graph.png")
+			require.Nil(t, err)
+
+			w.Header().Set("Content-Type", "image/png")
+			w.Write(file)
+		} else if r.URL.Path == "/test-image3.png" {
+			file, err := testutils.ReadTestFile("qa-data-graph.png")
+			require.Nil(t, err)
+
+			w.Header().Set("Content-Type", "image/png")
+			w.Write(file)
+		} else {
+			require.Fail(t, "Invalid path", r.URL.Path)
+		}
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
 	setup := func() *TestHelper {
 		th := Setup(t).InitBasic()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ServiceSettings.EnableLinkPreviews = true
 			*cfg.ImageProxySettings.Enable = false
+			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost,127.0.0.1"
 		})
 
 		return th
@@ -289,7 +330,7 @@ func TestPreparePostForClient(t *testing.T) {
 		post, err := th.App.CreatePost(&model.Post{
 			UserId:    th.BasicUser.Id,
 			ChannelId: th.BasicChannel.Id,
-			Message:   "This is ![our logo](https://github.com/hmhealey/test-files/raw/master/logoVertical.png) and ![our icon](https://github.com/hmhealey/test-files/raw/master/icon.png)",
+			Message:   fmt.Sprintf("This is ![our logo](%s/test-image2.png) and ![our icon](%s/test-image1.png)", server.URL, server.URL),
 		}, th.BasicChannel, false)
 		require.Nil(t, err)
 
@@ -300,14 +341,14 @@ func TestPreparePostForClient(t *testing.T) {
 			require.Len(t, imageDimensions, 2)
 			assert.Equal(t, &model.PostImage{
 				Format: "png",
-				Width:  1068,
-				Height: 552,
-			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/logoVertical.png"])
+				Width:  1280,
+				Height: 1780,
+			}, imageDimensions[server.URL+"/test-image2.png"])
 			assert.Equal(t, &model.PostImage{
 				Format: "png",
-				Width:  501,
-				Height: 501,
-			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/icon.png"])
+				Width:  408,
+				Height: 336,
+			}, imageDimensions[server.URL+"/test-image1.png"])
 		})
 	})
 
@@ -332,8 +373,8 @@ func TestPreparePostForClient(t *testing.T) {
 		post, err := th.App.CreatePost(&model.Post{
 			UserId:    th.BasicUser.Id,
 			ChannelId: th.BasicChannel.Id,
-			Message: `This is our logo: https://github.com/hmhealey/test-files/raw/master/logoVertical.png
-	And this is our icon: https://github.com/hmhealey/test-files/raw/master/icon.png`,
+			Message: `This is our logo: ` + server.URL + `/test-image2.png
+	And this is our icon: ` + server.URL + `/test-image1.png`,
 		}, th.BasicChannel, false)
 		require.Nil(t, err)
 
@@ -345,7 +386,7 @@ func TestPreparePostForClient(t *testing.T) {
 			assert.ElementsMatch(t, []*model.PostEmbed{
 				{
 					Type: model.POST_EMBED_IMAGE,
-					URL:  "https://github.com/hmhealey/test-files/raw/master/logoVertical.png",
+					URL:  server.URL + "/test-image2.png",
 				},
 			}, clientPost.Metadata.Embeds)
 		})
@@ -355,9 +396,9 @@ func TestPreparePostForClient(t *testing.T) {
 			require.Len(t, imageDimensions, 1)
 			assert.Equal(t, &model.PostImage{
 				Format: "png",
-				Width:  1068,
-				Height: 552,
-			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/logoVertical.png"])
+				Width:  1280,
+				Height: 1780,
+			}, imageDimensions[server.URL+"/test-image2.png"])
 		})
 	})
 
@@ -368,7 +409,7 @@ func TestPreparePostForClient(t *testing.T) {
 		post, err := th.App.CreatePost(&model.Post{
 			UserId:    th.BasicUser.Id,
 			ChannelId: th.BasicChannel.Id,
-			Message:   `This is our web page: https://github.com/hmhealey/test-files`,
+			Message:   `This is our web page: ` + server.URL,
 		}, th.BasicChannel, false)
 		require.Nil(t, err)
 
@@ -378,13 +419,13 @@ func TestPreparePostForClient(t *testing.T) {
 
 		t.Run("populates embeds", func(t *testing.T) {
 			assert.Equal(t, firstEmbed.Type, model.POST_EMBED_OPENGRAPH)
-			assert.Equal(t, firstEmbed.URL, "https://github.com/hmhealey/test-files")
+			assert.Equal(t, firstEmbed.URL, server.URL)
 			assert.Equal(t, ogData.Description, "Contribute to hmhealey/test-files development by creating an account on GitHub.")
 			assert.Equal(t, ogData.SiteName, "GitHub")
 			assert.Equal(t, ogData.Title, "hmhealey/test-files")
 			assert.Equal(t, ogData.Type, "object")
-			assert.Equal(t, ogData.URL, "https://github.com/hmhealey/test-files")
-			assert.Equal(t, ogData.Images[0].URL, "https://avatars1.githubusercontent.com/u/3277310?s=400&v=4")
+			assert.Equal(t, ogData.URL, server.URL)
+			assert.Equal(t, ogData.Images[0].URL, server.URL+"/test-image3.png")
 		})
 
 		t.Run("populates image dimensions", func(t *testing.T) {
@@ -392,9 +433,9 @@ func TestPreparePostForClient(t *testing.T) {
 			require.Len(t, imageDimensions, 1)
 			assert.Equal(t, &model.PostImage{
 				Format: "png",
-				Width:  420,
-				Height: 420,
-			}, imageDimensions["https://avatars1.githubusercontent.com/u/3277310?s=400&v=4"])
+				Width:  1790,
+				Height: 1340,
+			}, imageDimensions[server.URL+"/test-image3.png"])
 		})
 	})
 
@@ -408,7 +449,7 @@ func TestPreparePostForClient(t *testing.T) {
 			Props: map[string]interface{}{
 				"attachments": []interface{}{
 					map[string]interface{}{
-						"text": "![icon](https://github.com/hmhealey/test-files/raw/master/icon.png)",
+						"text": "![icon](" + server.URL + "/test-image1.png)",
 					},
 				},
 			},
@@ -430,9 +471,9 @@ func TestPreparePostForClient(t *testing.T) {
 			require.Len(t, imageDimensions, 1)
 			assert.Equal(t, &model.PostImage{
 				Format: "png",
-				Width:  501,
-				Height: 501,
-			}, imageDimensions["https://github.com/hmhealey/test-files/raw/master/icon.png"])
+				Width:  408,
+				Height: 336,
+			}, imageDimensions[server.URL+"/test-image1.png"])
 		})
 	})
 }
@@ -444,6 +485,7 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ServiceSettings.EnableLinkPreviews = true
 			*cfg.ServiceSettings.SiteURL = "http://mymattermost.com"
+			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost,127.0.0.1"
 			*cfg.ImageProxySettings.Enable = true
 			*cfg.ImageProxySettings.ImageProxyType = "atmos/camo"
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
@@ -490,10 +532,38 @@ func testProxyLinkedImage(t *testing.T, th *TestHelper, shouldProxy bool) {
 }
 
 func testProxyOpenGraphImage(t *testing.T, th *TestHelper, shouldProxy bool) {
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte(`
+			<html>
+			<head>
+			<meta property="og:image" content="` + serverURL + `/test-image3.png" />
+			<meta property="og:site_name" content="GitHub" />
+			<meta property="og:type" content="object" />
+			<meta property="og:title" content="hmhealey/test-files" />
+			<meta property="og:url" content="https://github.com/hmhealey/test-files" />
+			<meta property="og:description" content="Contribute to hmhealey/test-files development by creating an account on GitHub." />
+			</head>
+			</html>`))
+		} else if r.URL.Path == "/test-image3.png" {
+			file, err := testutils.ReadTestFile("qa-data-graph.png")
+			require.Nil(t, err)
+
+			w.Header().Set("Content-Type", "image/png")
+			w.Write(file)
+		} else {
+			require.Fail(t, "Invalid path", r.URL.Path)
+		}
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
 	post, err := th.App.CreatePost(&model.Post{
 		UserId:    th.BasicUser.Id,
 		ChannelId: th.BasicChannel.Id,
-		Message:   `This is our web page: https://github.com/hmhealey/test-files`,
+		Message:   `This is our web page: ` + server.URL,
 	}, th.BasicChannel, false)
 	require.Nil(t, err)
 
@@ -502,10 +572,11 @@ func testProxyOpenGraphImage(t *testing.T, th *TestHelper, shouldProxy bool) {
 
 	embed := embeds[0]
 	assert.Equal(t, model.POST_EMBED_OPENGRAPH, embed.Type, "embed type should be OpenGraph")
-	assert.Equal(t, "https://github.com/hmhealey/test-files", embed.URL, "embed URL should be correct")
+	assert.Equal(t, server.URL, embed.URL, "embed URL should be correct")
 
 	og, ok := embed.Data.(*opengraph.OpenGraph)
-	assert.Equal(t, true, ok, "data should be non-nil OpenGraph data")
+	assert.True(t, ok, "data should be non-nil OpenGraph data")
+	assert.NotNil(t, og, "data should be non-nil OpenGraph data")
 	assert.Equal(t, "GitHub", og.SiteName, "OpenGraph data should be correctly populated")
 
 	require.Len(t, og.Images, 1, "OpenGraph data should have one image")
@@ -513,9 +584,9 @@ func testProxyOpenGraphImage(t *testing.T, th *TestHelper, shouldProxy bool) {
 	image := og.Images[0]
 	if shouldProxy {
 		assert.Equal(t, "", image.URL, "image URL should not be set with proxy")
-		assert.Equal(t, "http://mymattermost.com/api/v4/image?url=https%3A%2F%2Favatars1.githubusercontent.com%2Fu%2F3277310%3Fs%3D400%26v%3D4", image.SecureURL, "secure image URL should be sent through proxy")
+		assert.Equal(t, "http://mymattermost.com/api/v4/image?url="+url.QueryEscape(server.URL+"/test-image3.png"), image.SecureURL, "secure image URL should be sent through proxy")
 	} else {
-		assert.Equal(t, "https://avatars1.githubusercontent.com/u/3277310?s=400&v=4", image.URL, "image URL should be set")
+		assert.Equal(t, server.URL+"/test-image3.png", image.URL, "image URL should be set")
 		assert.Equal(t, "", image.SecureURL, "secure image URL should not be set")
 	}
 }


### PR DESCRIPTION
#### Summary

This PR makes the `TestPreparePostForClient` and `TestPreparePostForClientWithImageProxy` tests use a local httptest server instead of hitting github.com directly during the tests.

There was an issue with intermittent failures of fetching the data from github at: https://github.com/mattermost/mattermost-server/blob/b8f0546c1936fd13c7af8df74b70dcbb0af4765d/app/post_metadata.go#L386-L394 After these changes, I've confirmed these tests pass with no internet connection.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18628