### PR TITLE
[MM-18638] Send mlog console output to stderr

### DIFF
--- a/mlog/default.go
+++ b/mlog/default.go
@@ -6,6 +6,7 @@ package mlog
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 )
 
 // defaultLog manually encodes the log to STDOUT, providing a basic, default logging implementation
@@ -22,9 +23,9 @@ func defaultLog(level, msg string, fields ...Field) {
 	}
 
 	if b, err := json.Marshal(log); err != nil {
-		fmt.Printf(`{"level":"error","msg":"failed to encode log message"}%s`, "\n")
+		fmt.Fprintf(os.Stderr, `{"level":"error","msg":"failed to encode log message"}%s`, "\n")
 	} else {
-		fmt.Printf("%s\n", b)
+		fmt.Fprintf(os.Stderr, "%s\n", b)
 	}
 }
 

--- a/mlog/default.go
+++ b/mlog/default.go
@@ -9,7 +9,7 @@ import (
 	"os"
 )
 
-// defaultLog manually encodes the log to STDOUT, providing a basic, default logging implementation
+// defaultLog manually encodes the log to STDERR, providing a basic, default logging implementation
 // before mlog is fully configured.
 func defaultLog(level, msg string, fields ...Field) {
 	log := struct {

--- a/mlog/log.go
+++ b/mlog/log.go
@@ -86,7 +86,7 @@ func NewLogger(config *LoggerConfiguration) *Logger {
 	}
 
 	if config.EnableConsole {
-		writer := zapcore.Lock(os.Stdout)
+		writer := zapcore.Lock(os.Stderr)
 		core := zapcore.NewCore(makeEncoder(config.ConsoleJson), writer, logger.consoleLevel)
 		cores = append(cores, core)
 	}


### PR DESCRIPTION
#### Summary

This PR updates `mlog` to write console output to `os.Stderr ` by default.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18638