### PR TITLE
MM-18894: Update production marketplace URL

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -174,7 +174,7 @@ const (
 	PLUGIN_SETTINGS_DEFAULT_DIRECTORY          = "./plugins"
 	PLUGIN_SETTINGS_DEFAULT_CLIENT_DIRECTORY   = "./client/plugins"
 	PLUGIN_SETTINGS_DEFAULT_ENABLE_MARKETPLACE = true
-	PLUGIN_SETTINGS_DEFAULT_MARKETPLACE_URL    = "https://marketplace.integrations.mattermost.com"
+	PLUGIN_SETTINGS_DEFAULT_MARKETPLACE_URL    = "https://api.integrations.mattermost.com"
 
 	COMPLIANCE_EXPORT_TYPE_CSV             = "csv"
 	COMPLIANCE_EXPORT_TYPE_ACTIANCE        = "actiance"


### PR DESCRIPTION
#### Summary
Pivoting to locate the default marketplace at api.integrations.mattermost.com. This is effectively a data-only change, and thus has no unit tests.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18894