### PR TITLE
MM-17767: Remove ExperimentalLdapGroupSync config.

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -296,7 +296,6 @@ func (a *App) trackConfig() {
 		"experimental_strict_csrf_enforcement":                    *cfg.ServiceSettings.ExperimentalStrictCSRFEnforcement,
 		"enable_email_invitations":                                *cfg.ServiceSettings.EnableEmailInvitations,
 		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,
-		"experimental_ldap_group_sync":                            *cfg.ServiceSettings.ExperimentalLdapGroupSync,
 		"disable_bots_when_owner_is_deactivated":                  *cfg.ServiceSettings.DisableBotsWhenOwnerIsDeactivated,
 		"enable_bot_account_creation":                             *cfg.ServiceSettings.EnableBotAccountCreation,
 		"enable_svgs":                                             *cfg.ServiceSettings.EnableSVGs,

--- a/model/config.go
+++ b/model/config.go
@@ -306,7 +306,6 @@ type ServiceSettings struct {
 	DisableLegacyMFA                                  *bool `restricted:"true"`
 	ExperimentalStrictCSRFEnforcement                 *bool `restricted:"true"`
 	EnableEmailInvitations                            *bool
-	ExperimentalLdapGroupSync                         *bool
 	DisableBotsWhenOwnerIsDeactivated                 *bool `restricted:"true"`
 	EnableBotAccountCreation                          *bool
 	EnableSVGs                                        *bool
@@ -653,10 +652,6 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.DisableLegacyMFA == nil {
 		s.DisableLegacyMFA = NewBool(!isUpdate)
-	}
-
-	if s.ExperimentalLdapGroupSync == nil {
-		s.ExperimentalLdapGroupSync = NewBool(false)
 	}
 
 	if s.ExperimentalStrictCSRFEnforcement == nil {

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -65,7 +65,6 @@
         "ImageProxyOptions": "",
         "EnableAPITeamDeletion": false,
         "ExperimentalEnableHardenedMode": false,
-        "ExperimentalLdapGroupSync": true
     },
     "TeamSettings": {
         "SiteName": "Mattermost",


### PR DESCRIPTION
#### Summary

Removes `ExperimentalLdapGroupSync` config so that the feature is always enabled.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17767

#### Dependency

https://github.com/mattermost/enterprise/pull/499