### PR TITLE
MM-18721: disable SIGPIPE handling

### DIFF
--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -91,7 +91,7 @@ func runServer(configStore config.Store, disableConfigWatch bool, usedPlatform b
 
 	// wait for kill signal before attempting to gracefully shutdown
 	// the running service
-	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM, syscall.SIGPIPE)
+	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	<-interruptChan
 
 	return nil


### PR DESCRIPTION
#### Summary
We recently added support for handling SIGPIPE cleanly, in order to safely shutdown plugins in the event that the STDOUT/STDERR had been closed unexpectedly. Unfortunately, this signal is also emitted when writing to a closed socket connection: an event that occurs frequently for a webserver. Normally, if no signal handler is registered for same, the Go subsystem distinguishes the file descriptor and ignores those from the network. But once a handler is registered, all SIGPIPEs are passed through: and sadly there is no way to distinguish the original file descriptor.

We don't strictly need the SIGPIPE handling for development any longer since `make stop-server` no longer shuts down the logrus process which explained the majority of hanging plugin processes. It remains suboptimal that a signal can terminate the server and leave plugin processes hanging, but the current symptoms are worse.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18721