### PR TITLE
Bumped the Jira plugin to v2.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ PLUGIN_PACKAGES += mattermost-plugin-github-v0.10.2
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-aws-SNS-v1.0.2
 PLUGIN_PACKAGES += mattermost-plugin-antivirus-v0.1.1
-PLUGIN_PACKAGES += mattermost-plugin-jira-v2.1.3
+PLUGIN_PACKAGES += mattermost-plugin-jira-v2.2.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.0.0
 


### PR DESCRIPTION
#### Summary
Bumper Jira plugin version to 2.2.0 - awaiting the release to be cut, see https://github.com/mattermost/mattermost-plugin-jira/pull/323

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-18451