### PR TITLE
Bumped Autolink plugin version to 1.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ TE_PACKAGES=$(shell go list ./...)
 
 # Plugins Packages
 PLUGIN_PACKAGES=mattermost-plugin-zoom-v1.0.7
-PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.1.0
+PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.0.3
 PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.0.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v0.10.2


### PR DESCRIPTION
#### Summary
Bump the autolink plugin version to 1.1.1

- Awaiting https://github.com/mattermost/mattermost-plugin-autolink/pull/77