### PR TITLE
[MM-19007] Migrate tests from "app/job_test.go" to use testify

### DIFF
--- a/app/job_test.go
+++ b/app/job_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,11 +24,9 @@ func TestGetJob(t *testing.T) {
 
 	defer th.App.Srv.Store.Job().Delete(status.Id)
 
-	if received, err := th.App.GetJob(status.Id); err != nil {
-		t.Fatal(err)
-	} else if received.Id != status.Id || received.Status != status.Status {
-		t.Fatal("inccorrect job status received")
-	}
+	received, err := th.App.GetJob(status.Id)
+	require.Nil(t, err)
+	assert.Equal(t, status, received, "incorrect job status received")
 }
 
 func TestGetJobByType(t *testing.T) {
@@ -60,21 +59,14 @@ func TestGetJobByType(t *testing.T) {
 		defer th.App.Srv.Store.Job().Delete(status.Id)
 	}
 
-	if received, err := th.App.GetJobsByType(jobType, 0, 2); err != nil {
-		t.Fatal(err)
-	} else if len(received) != 2 {
-		t.Fatal("received wrong number of statuses")
-	} else if received[0].Id != statuses[2].Id {
-		t.Fatal("should've received newest job first")
-	} else if received[1].Id != statuses[0].Id {
-		t.Fatal("should've received second newest job second")
-	}
+	received, err := th.App.GetJobsByType(jobType, 0, 2)
+	require.Nil(t, err)
+	require.Len(t, received, 2, "received wrong number of statuses")
+	assert.Equal(t, statuses[2], received[0], "should've received newest job first")
+	assert.Equal(t, statuses[0], received[1], "should've received second newest job second")
 
-	if received, err := th.App.GetJobsByType(jobType, 2, 2); err != nil {
-		t.Fatal(err)
-	} else if len(received) != 1 {
-		t.Fatal("received wrong number of statuses")
-	} else if received[0].Id != statuses[1].Id {
-		t.Fatal("should've received oldest job last")
-	}
+	received, err = th.App.GetJobsByType(jobType, 2, 2)
+	require.Nil(t, err)
+	require.Len(t, received, 1, "received wrong number of statuses")
+	assert.Equal(t, statuses[1], received[0], "should've received oldest job last")
 }


### PR DESCRIPTION
#### Summary
Converts app/job_test.go `t.Fatal` calls into testify `assert/require` calls

#### Ticket Link
Fixes #12416