### PR TITLE
Migrate tests from model/websocket_request_test.go to use testifyy

### DIFF
--- a/model/websocket_request_test.go
+++ b/model/websocket_request_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestWebSocketRequest(t *testing.T) {
@@ -13,13 +15,9 @@ func TestWebSocketRequest(t *testing.T) {
 	json := m.ToJson()
 	result := WebSocketRequestFromJson(strings.NewReader(json))
 
-	if result == nil {
-		t.Fatal("should not be nil")
-	}
+	require.NotNil(t, err, "should not be nil")
 
 	badresult := WebSocketRequestFromJson(strings.NewReader("junk"))
 
-	if badresult != nil {
-		t.Fatal("should have been nil")
-	}
+	require.Nil(t, err, "should have been nil")
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This pull request migrates two calls to `t.Fatal` to use the testify toolkit.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12425