### PR TITLE
MM-19012 Migrate tests from "cmd/mattermost/commands/channel_test.go" to use testify

### DIFF
--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -86,25 +86,17 @@ func TestListChannels(t *testing.T) {
 
 	output := th.CheckCommand(t, "channel", "list", th.BasicTeam.Name)
 
-	if !strings.Contains(string(output), "town-square") {
-		t.Fatal("should have channels")
-	}
+	require.True(t, strings.Contains(string(output), "town-square"), "should have channels")
 
-	if !strings.Contains(string(output), channel.Name+" (archived)") {
-		t.Fatal("should have archived channel")
-	}
+	require.True(t, strings.Contains(string(output), channel.Name+" (archived)"), "should have archived channel")
 
-	if !strings.Contains(string(output), privateChannel.Name+" (private)") {
-		t.Fatal("should have private channel")
-	}
+	require.True(t, strings.Contains(string(output), privateChannel.Name+" (private)"), "should have private channel")
 
 	th.Client.Must(th.Client.DeleteChannel(privateChannel.Id))
 
 	output = th.CheckCommand(t, "channel", "list", th.BasicTeam.Name)
 
-	if !strings.Contains(string(output), privateChannel.Name+" (archived) (private)") {
-		t.Fatal("should have a channel both archived and private")
-	}
+	require.True(t, strings.Contains(string(output), privateChannel.Name+" (archived) (private)"), "should have a channel both archived and private")
 }
 
 func TestRestoreChannel(t *testing.T) {


### PR DESCRIPTION
 <!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Modify the calls to t.Fatal and the condition checks that lead to them, replacing them with calls to the testify require or assert,
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-19012]( https://mattermost.atlassian.net/browse/MM-19012)

Fixes https://github.com/mattermost/mattermost-server/issues/12411