### PR TITLE
Migrate tests from "cmd/mattermost/commands/webhook_test.go" to use t…

### DIFF
--- a/cmd/mattermost/commands/webhook_test.go
+++ b/cmd/mattermost/commands/webhook_test.go
@@ -225,7 +225,7 @@ func TestModifyIncomingWebhook(t *testing.T) {
 	th.CheckCommand(t, "webhook", "modify-incoming", oldHook.Id, "--channel", modifiedChannelId, "--description", modifiedDescription, "--display-name", modifiedDisplayName, "--icon", modifiedIconUrl, "--lock-to-channel", strconv.FormatBool(modifiedChannelLocked))
 
 	modifiedHook, err := th.App.GetIncomingWebhook(oldHook.Id)
-	require.NoError(t, err, "unable to retrieve modified incoming webhook")
+	require.Nil(t, err, "unable to retrieve modified incoming webhook")
 
 	successUpdate := modifiedHook.DisplayName != modifiedDisplayName || modifiedHook.Description != modifiedDescription || modifiedHook.IconURL != modifiedIconUrl || modifiedHook.ChannelLocked != modifiedChannelLocked || modifiedHook.ChannelId != modifiedChannelId
 	require.False(t, successUpdate, "Failed to update incoming webhook")
@@ -372,7 +372,7 @@ func TestModifyOutgoingWebhook(t *testing.T) {
 	)
 
 	modifiedHook, err := th.App.GetOutgoingWebhook(oldHook.Id)
-	require.NoError(t, err, "unable to retrieve modified outgoing webhook")
+	require.Nil(t, err, "unable to retrieve modified outgoing webhook")
 
 	updateFailed := modifiedHook.ChannelId != modifiedChannelID ||
 		modifiedHook.DisplayName != modifiedDisplayName ||
@@ -437,6 +437,6 @@ func TestDeleteWebhooks(t *testing.T) {
 
 	hooksAfterDeletion := th.CheckCommand(t, "webhook", "list", th.BasicTeam.Name)
 
-	assert.Contains(t, hooksAfterDeletion, dispName, "Should not have incoming webhooks")
-	assert.Contains(t, hooksAfterDeletion, dispName2, "Should not have outgoing webhooks")
+	assert.NotContains(t, hooksAfterDeletion, dispName, "Should not have incoming webhooks")
+	assert.NotContains(t, hooksAfterDeletion, dispName2, "Should not have outgoing webhooks")
 }

--- a/cmd/mattermost/commands/webhook_test.go
+++ b/cmd/mattermost/commands/webhook_test.go
@@ -227,7 +227,11 @@ func TestModifyIncomingWebhook(t *testing.T) {
 	modifiedHook, err := th.App.GetIncomingWebhook(oldHook.Id)
 	require.Nil(t, err, "unable to retrieve modified incoming webhook")
 
-	successUpdate := modifiedHook.DisplayName != modifiedDisplayName || modifiedHook.Description != modifiedDescription || modifiedHook.IconURL != modifiedIconUrl || modifiedHook.ChannelLocked != modifiedChannelLocked || modifiedHook.ChannelId != modifiedChannelId
+	successUpdate := modifiedHook.DisplayName != modifiedDisplayName ||
+		modifiedHook.Description != modifiedDescription ||
+		modifiedHook.IconURL != modifiedIconUrl ||
+		modifiedHook.ChannelLocked != modifiedChannelLocked ||
+		modifiedHook.ChannelId != modifiedChannelId
 	require.False(t, successUpdate, "Failed to update incoming webhook")
 }
 

--- a/cmd/mattermost/commands/webhook_test.go
+++ b/cmd/mattermost/commands/webhook_test.go
@@ -160,7 +160,7 @@ func TestCreateIncomingWebhook(t *testing.T) {
 	th.CheckCommand(t, "webhook", "create-incoming", "--channel", th.BasicChannel.Id, "--user", th.BasicUser.Email, "--description", description, "--display-name", displayName)
 
 	webhooks, err := th.App.GetIncomingWebhooksPage(0, 1000)
-	require.NoError(t, err, "unable to retrieve incoming webhooks")
+	require.Nil(t, err, "unable to retrieve incoming webhooks")
 
 	found := false
 	for _, webhook := range webhooks {
@@ -205,7 +205,7 @@ func TestModifyIncomingWebhook(t *testing.T) {
 	}
 
 	oldHook, err := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, incomingWebhook)
-	require.NoError(t, err, "unable to create incoming webhooks")
+	require.Nil(t, err, "unable to create incoming webhooks")
 
 	defer func() {
 		th.App.DeleteIncomingWebhook(oldHook.Id)
@@ -285,7 +285,7 @@ func TestCreateOutgoingWebhook(t *testing.T) {
 	th.CheckCommand(t, "webhook", "create-outgoing", "--team", team, "--channel", th.BasicChannel.Id, "--display-name", displayName, "--trigger-word", triggerWord1, "--trigger-word", triggerWord2, "--url", callbackURL1, "--url", callbackURL2, "--user", user)
 
 	webhooks, err := th.App.GetOutgoingWebhooksPage(0, 1000)
-	require.NoError(t, err, "Unable to retreive outgoing webhooks")
+	require.Nil(t, err, "Unable to retreive outgoing webhooks")
 
 	found := false
 	for _, webhook := range webhooks {
@@ -334,7 +334,7 @@ func TestModifyOutgoingWebhook(t *testing.T) {
 	}
 
 	oldHook, err := th.App.CreateOutgoingWebhook(outgoingWebhook)
-	require.NoError(t, err, "unable to create outgoing webhooks: "+err.Error())
+	require.Nil(t, err, "unable to create outgoing webhooks: ")
 
 	defer func() {
 		th.App.DeleteOutgoingWebhook(oldHook.Id)

--- a/cmd/mattermost/commands/webhook_test.go
+++ b/cmd/mattermost/commands/webhook_test.go
@@ -5,9 +5,9 @@ package commands
 
 import (
 	"strconv"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/api4"
@@ -53,14 +53,8 @@ func TestListWebhooks(t *testing.T) {
 
 	output := th.CheckCommand(t, "webhook", "list", th.BasicTeam.Name)
 
-	if !strings.Contains(string(output), dispName) {
-		t.Fatal("should have incoming webhooks")
-	}
-
-	if !strings.Contains(string(output), dispName2) {
-		t.Fatal("should have outgoing webhooks")
-	}
-
+	assert.Contains(t, output, dispName, "should have incoming webhooks")
+	assert.Contains(t, output, dispName2, "should have outgoing webhooks")
 }
 
 func TestShowWebhook(t *testing.T) {
@@ -107,12 +101,8 @@ func TestShowWebhook(t *testing.T) {
 
 	// valid incoming webhook should return webhook data
 	output := th.CheckCommand(t, "webhook", "show", incomingWebhook.Id)
-	if !strings.Contains(string(output), "DisplayName: \""+dispName+"\"") {
-		t.Fatal("incoming: should have incominghook as displayname")
-	}
-	if !strings.Contains(string(output), "ChannelId: \""+hook.ChannelId+"\"") {
-		t.Fatal("incoming: should have a valid channelId")
-	}
+	assert.Contains(t, output, "DisplayName: \""+dispName+"\"", "incoming: should have incominghook as displayname")
+	assert.Contains(t, output, "ChannelId: \""+hook.ChannelId+"\"", "incoming: should have a valid channelId")
 
 	dispName = "outgoinghook"
 	outgoingHook := &model.OutgoingWebhook{
@@ -128,13 +118,9 @@ func TestShowWebhook(t *testing.T) {
 
 	// valid outgoing webhook should return webhook data
 	output = th.CheckCommand(t, "webhook", "show", outgoingWebhook.Id)
-	if !strings.Contains(string(output), "DisplayName: \""+dispName+"\"") {
-		t.Fatal("outgoing: should have outgoinghook as displayname")
-	}
-	if !strings.Contains(string(output), "ChannelId: \""+hook.ChannelId+"\"") {
-		t.Fatal("outgoing: should have a valid channelId")
-	}
 
+	assert.Contains(t, output, "DisplayName: \""+dispName+"\"", "outgoing: should have outgoinghook as displayname")
+	assert.Contains(t, output, "ChannelId: \""+hook.ChannelId+"\"", "outgoing: should have a valid channelId")
 }
 
 func TestCreateIncomingWebhook(t *testing.T) {
@@ -174,9 +160,7 @@ func TestCreateIncomingWebhook(t *testing.T) {
 	th.CheckCommand(t, "webhook", "create-incoming", "--channel", th.BasicChannel.Id, "--user", th.BasicUser.Email, "--description", description, "--display-name", displayName)
 
 	webhooks, err := th.App.GetIncomingWebhooksPage(0, 1000)
-	if err != nil {
-		t.Fatal("unable to retrieve incoming webhooks")
-	}
+	require.NoError(t, err, "unable to retrieve incoming webhooks")
 
 	found := false
 	for _, webhook := range webhooks {
@@ -184,9 +168,7 @@ func TestCreateIncomingWebhook(t *testing.T) {
 			found = true
 		}
 	}
-	if !found {
-		t.Fatal("Failed to create incoming webhook")
-	}
+	require.True(t, found, "Failed to create incoming webhook")
 }
 
 func TestModifyIncomingWebhook(t *testing.T) {
@@ -223,9 +205,8 @@ func TestModifyIncomingWebhook(t *testing.T) {
 	}
 
 	oldHook, err := th.App.CreateIncomingWebhookForChannel(th.BasicUser.Id, th.BasicChannel, incomingWebhook)
-	if err != nil {
-		t.Fatal("unable to create incoming webhooks")
-	}
+	require.NoError(t, err, "unable to create incoming webhooks")
+
 	defer func() {
 		th.App.DeleteIncomingWebhook(oldHook.Id)
 	}()
@@ -244,12 +225,10 @@ func TestModifyIncomingWebhook(t *testing.T) {
 	th.CheckCommand(t, "webhook", "modify-incoming", oldHook.Id, "--channel", modifiedChannelId, "--description", modifiedDescription, "--display-name", modifiedDisplayName, "--icon", modifiedIconUrl, "--lock-to-channel", strconv.FormatBool(modifiedChannelLocked))
 
 	modifiedHook, err := th.App.GetIncomingWebhook(oldHook.Id)
-	if err != nil {
-		t.Fatal("unable to retrieve modified incoming webhook")
-	}
-	if modifiedHook.DisplayName != modifiedDisplayName || modifiedHook.Description != modifiedDescription || modifiedHook.IconURL != modifiedIconUrl || modifiedHook.ChannelLocked != modifiedChannelLocked || modifiedHook.ChannelId != modifiedChannelId {
-		t.Fatal("Failed to update incoming webhook")
-	}
+	require.NoError(t, err, "unable to retrieve modified incoming webhook")
+
+	successUpdate := modifiedHook.DisplayName != modifiedDisplayName || modifiedHook.Description != modifiedDescription || modifiedHook.IconURL != modifiedIconUrl || modifiedHook.ChannelLocked != modifiedChannelLocked || modifiedHook.ChannelId != modifiedChannelId
+	require.False(t, successUpdate, "Failed to update incoming webhook")
 }
 
 func TestCreateOutgoingWebhook(t *testing.T) {
@@ -306,9 +285,7 @@ func TestCreateOutgoingWebhook(t *testing.T) {
 	th.CheckCommand(t, "webhook", "create-outgoing", "--team", team, "--channel", th.BasicChannel.Id, "--display-name", displayName, "--trigger-word", triggerWord1, "--trigger-word", triggerWord2, "--url", callbackURL1, "--url", callbackURL2, "--user", user)
 
 	webhooks, err := th.App.GetOutgoingWebhooksPage(0, 1000)
-	if err != nil {
-		t.Fatal("Unable to retreive outgoing webhooks")
-	}
+	require.NoError(t, err, "Unable to retreive outgoing webhooks")
 
 	found := false
 	for _, webhook := range webhooks {
@@ -316,9 +293,7 @@ func TestCreateOutgoingWebhook(t *testing.T) {
 			found = true
 		}
 	}
-	if !found {
-		t.Fatal("Failed to create incoming webhook")
-	}
+	require.True(t, found, "Failed to create incoming webhook")
 }
 
 func TestModifyOutgoingWebhook(t *testing.T) {
@@ -359,9 +334,8 @@ func TestModifyOutgoingWebhook(t *testing.T) {
 	}
 
 	oldHook, err := th.App.CreateOutgoingWebhook(outgoingWebhook)
-	if err != nil {
-		t.Fatal("unable to create outgoing webhooks: " + err.Error())
-	}
+	require.NoError(t, err, "unable to create outgoing webhooks: "+err.Error())
+
 	defer func() {
 		th.App.DeleteOutgoingWebhook(oldHook.Id)
 	}()
@@ -398,9 +372,7 @@ func TestModifyOutgoingWebhook(t *testing.T) {
 	)
 
 	modifiedHook, err := th.App.GetOutgoingWebhook(oldHook.Id)
-	if err != nil {
-		t.Fatal("unable to retrieve modified outgoing webhook")
-	}
+	require.NoError(t, err, "unable to retrieve modified outgoing webhook")
 
 	updateFailed := modifiedHook.ChannelId != modifiedChannelID ||
 		modifiedHook.DisplayName != modifiedDisplayName ||
@@ -415,9 +387,7 @@ func TestModifyOutgoingWebhook(t *testing.T) {
 		modifiedHook.CallbackURLs[0] != modifiedCallbackURLs[0] ||
 		modifiedHook.CallbackURLs[1] != modifiedCallbackURLs[1]
 
-	if updateFailed {
-		t.Fatal("Failed to update outgoing webhook")
-	}
+	require.False(t, updateFailed, "Failed to update outgoing webhook")
 }
 
 func TestDeleteWebhooks(t *testing.T) {
@@ -459,24 +429,14 @@ func TestDeleteWebhooks(t *testing.T) {
 
 	hooksBeforeDeletion := th.CheckCommand(t, "webhook", "list", th.BasicTeam.Name)
 
-	if !strings.Contains(string(hooksBeforeDeletion), dispName) {
-		t.Fatal("Should have incoming webhooks")
-	}
-
-	if !strings.Contains(string(hooksBeforeDeletion), dispName2) {
-		t.Fatal("Should have outgoing webhooks")
-	}
+	assert.Contains(t, hooksBeforeDeletion, dispName, "should have incoming webhooks")
+	assert.Contains(t, hooksBeforeDeletion, dispName2, "Should have outgoing webhooks")
 
 	th.CheckCommand(t, "webhook", "delete", incomingHook.Id)
 	th.CheckCommand(t, "webhook", "delete", outgoingHook.Id)
 
 	hooksAfterDeletion := th.CheckCommand(t, "webhook", "list", th.BasicTeam.Name)
 
-	if strings.Contains(string(hooksAfterDeletion), dispName) {
-		t.Fatal("Should not have incoming webhooks")
-	}
-
-	if strings.Contains(string(hooksAfterDeletion), dispName2) {
-		t.Fatal("Should not have outgoing webhooks")
-	}
+	assert.Contains(t, hooksAfterDeletion, dispName, "Should not have incoming webhooks")
+	assert.Contains(t, hooksAfterDeletion, dispName2, "Should not have outgoing webhooks")
 }


### PR DESCRIPTION
Migrated server tests from using the t.Fatal method calls on their checks to use the testify toolkit in the cmd/mattermost/commands/webhook_test.go file.

Fixes https://github.com/mattermost/mattermost-server/issues/12412