### PR TITLE
Redirect stderr to stdout for dev-readable logrus output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ run-server: validate-go-version start-docker ## Starts the server.
 	@echo Running mattermost for development
 
 	mkdir -p $(BUILD_WEBAPP_DIR)/dist/files
-	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' $(PLATFORM_FILES) --disableconfigwatch | \
+	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' $(PLATFORM_FILES) --disableconfigwatch 2>&1 | \
 	    $(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' $(PLATFORM_FILES) logs --logrus &
 
 debug-server: start-docker ## Compile and start server using delve.


### PR DESCRIPTION
#### Summary
- Send stderr to stdout during development
- logrus dev-readable output was stopped because of #12366 

#### Links
- #12366