### PR TITLE
MM-19022: Convert config/watcher_test.go t.Fatal calls into require calls

### DIFF
--- a/config/watcher_test.go
+++ b/config/watcher_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/utils/testutils"
 )
 
 func TestWatcherInvalidDirectory(t *testing.T) {
@@ -47,21 +49,9 @@ func TestWatcher(t *testing.T) {
 
 	// Write to a different file
 	ioutil.WriteFile(filepath.Join(tempDir, "unrelated"), []byte("data"), 0644)
-	require.False(t, wasCalled(called, 1*time.Second), "callback should not have been called for unrelated file")
+	require.False(t, testutils.WasCalled(called, 1*time.Second), "callback should not have been called for unrelated file")
 
 	// Write to the watched file
 	ioutil.WriteFile(f.Name(), []byte("data"), 0644)
-	require.True(t, wasCalled(called, 5*time.Second), "callback should have been called when file written")
-}
-
-// wasCalled reports whether a given callback channel was called
-// within the specified time duration or not.
-func wasCalled(c chan bool, duration time.Duration) bool {
-	wasCalled := false
-	select {
-	case <-c:
-		wasCalled = true
-	case <-time.After(duration):
-	}
-	return wasCalled
+	require.True(t, testutils.WasCalled(called, 5*time.Second), "callback should have been called when file written")
 }

--- a/utils/testutils/testutils.go
+++ b/utils/testutils/testutils.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/mattermost/mattermost-server/utils/fileutils"
 )
@@ -26,4 +27,16 @@ func ReadTestFile(name string) ([]byte, error) {
 	} else {
 		return data.Bytes(), nil
 	}
+}
+
+// WasCalled reports whether a given callback channel was called
+// within the specified time duration or not.
+func WasCalled(c chan bool, duration time.Duration) bool {
+	wasCalled := false
+	select {
+	case <-c:
+		wasCalled = true
+	case <-time.After(duration):
+	}
+	return wasCalled
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

- Converted calls to `t.Fatal` into require calls.
- Added a helper function `wasCalled` to accomplish this which can be used in further issues like - #12429 and #12428. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

[MM-19022](https://mattermost.atlassian.net/browse/MM-19022)

Fixes https://github.com/mattermost/mattermost-server/issues/12430