### PR TITLE
migrate memory_test to use testify

### DIFF
--- a/config/memory_test.go
+++ b/config/memory_test.go
@@ -218,7 +218,7 @@ func TestMemoryStoreSet(t *testing.T) {
 		select {
 		case <-called:
 		case <-time.After(5 * time.Second):
-			t.Fatal("callback should have been called when config written")
+			require.Fail(t, "callback should have been called when config written")
 		}
 	})
 }
@@ -271,7 +271,7 @@ func TestMemoryStoreLoad(t *testing.T) {
 		select {
 		case <-called:
 		case <-time.After(5 * time.Second):
-			t.Fatal("callback should have been called when config loaded")
+			require.Fail(t, "callback should have been called when config loaded")
 		}
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/ x 
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs x
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
- Migrate from using t.Fatal to using testify package. 

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/12427

