### PR TITLE
MM-19030 GH-12422 Replaced t.Fatal with require.Equal

### DIFF
--- a/model/mfa_secret_test.go
+++ b/model/mfa_secret_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMfaSecretJson(t *testing.T) {
@@ -13,7 +15,5 @@ func TestMfaSecretJson(t *testing.T) {
 	json := secret.ToJson()
 	result := MfaSecretFromJson(strings.NewReader(json))
 
-	if secret.Secret != result.Secret {
-		t.Fatal("Secrets do not match")
-	}
+	require.Equal(t, secret.Secret, result.Secret, "Secrets do not match")
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Replace `t.Fatal` call with `require.Equal` call.
<!--
A description of what this pull request does.
-->
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #12422 
JIRA: https://mattermost.atlassian.net/browse/MM-19030