### PR TITLE
Fixed some ineffective assignments

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2931,6 +2931,7 @@ func TestGetChannelMembersTimezones(t *testing.T) {
 
 	user.Timezone["manualTimezone"] = ""
 	_, resp = Client.UpdateUser(user)
+	CheckNoError(t, resp)
 
 	timezone, resp = Client.GetChannelMembersTimezones(th.BasicChannel.Id)
 	CheckNoError(t, resp)

--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -238,9 +238,9 @@ func TestGetEmojiList(t *testing.T) {
 			found = true
 			break
 		}
-		if found {
-			t.Fatalf("should not get a deleted emoji %v", emojis[0].Id)
-		}
+	}
+	if found {
+		t.Fatalf("should not get a deleted emoji %v", emojis[0].Id)
 	}
 
 	listEmoji, resp = Client.GetEmojiList(0, 1)

--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/utils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateEmoji(t *testing.T) {
@@ -239,9 +240,7 @@ func TestGetEmojiList(t *testing.T) {
 			break
 		}
 	}
-	if found {
-		t.Fatalf("should not get a deleted emoji %v", emojis[0].Id)
-	}
+	require.Falsef(t, found, "should not get a deleted emoji %v", emojis[0].Id)
 
 	listEmoji, resp = Client.GetEmojiList(0, 1)
 	CheckNoError(t, resp)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1379,6 +1379,7 @@ func TestGetUsersByGroupChannelIds(t *testing.T) {
 
 	th.LoginBasic2()
 	usersByChannelId, resp = th.Client.GetUsersByGroupChannelIds([]string{gc1.Id})
+	CheckNoError(t, resp)
 
 	_, ok := usersByChannelId[gc1.Id]
 	require.False(t, ok)
@@ -4425,6 +4426,7 @@ func TestRegisterTermsOfServiceAction(t *testing.T) {
 
 	success, resp := th.Client.RegisterTermsOfServiceAction(th.BasicUser.Id, "st_1", true)
 	CheckErrorMessage(t, resp, "store.sql_terms_of_service_store.get.no_rows.app_error")
+	assert.True(t, *success)
 
 	termsOfService, err := th.App.CreateTermsOfService("terms of service", th.BasicUser.Id)
 	if err != nil {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -4426,7 +4426,7 @@ func TestRegisterTermsOfServiceAction(t *testing.T) {
 
 	success, resp := th.Client.RegisterTermsOfServiceAction(th.BasicUser.Id, "st_1", true)
 	CheckErrorMessage(t, resp, "store.sql_terms_of_service_store.get.no_rows.app_error")
-	assert.True(t, *success)
+	assert.Nil(t, success)
 
 	termsOfService, err := th.App.CreateTermsOfService("terms of service", th.BasicUser.Id)
 	if err != nil {

--- a/app/bot_test.go
+++ b/app/bot_test.go
@@ -632,6 +632,7 @@ func TestSetBotIconImage(t *testing.T) {
 			Username: "username",
 			Id:       th.BasicUser.Id,
 		})
+		require.Nil(t, err)
 		defer th.App.PermanentDeleteBot(bot.UserId)
 
 		fpath := fmt.Sprintf("/bots/%v/icon.svg", bot.UserId)
@@ -683,6 +684,7 @@ func TestGetBotIconImage(t *testing.T) {
 			Username: "username",
 			Id:       th.BasicUser.Id,
 		})
+		require.Nil(t, err)
 		defer th.App.PermanentDeleteBot(bot.UserId)
 
 		svgFile.Seek(0, 0)
@@ -729,6 +731,7 @@ func TestDeleteBotIconImage(t *testing.T) {
 			Username: "username",
 			Id:       th.BasicUser.Id,
 		})
+		require.Nil(t, err)
 		defer th.App.PermanentDeleteBot(bot.UserId)
 
 		// Set icon

--- a/cmd/mattermost/commands/teamargs.go
+++ b/cmd/mattermost/commands/teamargs.go
@@ -21,7 +21,7 @@ func getTeamFromTeamArg(a *app.App, teamArg string) *model.Team {
 	var team *model.Team
 	team, err := a.Srv.Store.Team().GetByName(teamArg)
 
-	if team == nil {
+	if err != nil {
 		var t *model.Team
 		if t, err = a.Srv.Store.Team().Get(teamArg); err == nil {
 			team = t

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -198,6 +198,7 @@ func TestFileStoreGet(t *testing.T) {
 
 	newCfg := &model.Config{}
 	oldCfg, err := fs.Set(newCfg)
+	require.NoError(t, err)
 
 	assert.True(t, oldCfg == cfg, "returned config after set() changed original")
 	assert.False(t, newCfg == cfg, "returned config should have been different from original")

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -42,6 +42,9 @@ func migrateFile(name string, source Store, destination Store) error {
 
 	if fileExists {
 		file, err := source.GetFile(name)
+		if err != nil {
+			return errors.Wrapf(err, "failed to migrate %s", name)
+		}
 		err = destination.SetFile(name, file)
 		if err != nil {
 			return errors.Wrapf(err, "failed to migrate %s", name)

--- a/model/file_info.go
+++ b/model/file_info.go
@@ -158,8 +158,7 @@ func GetInfoForBytes(name string, data []byte) (*FileInfo, *AppError) {
 				if gifConfig, err := gif.DecodeAll(bytes.NewReader(data)); err != nil {
 					// Still return the rest of the info even though it doesn't appear to be an actual gif
 					info.HasPreviewImage = true
-					err := NewAppError("GetInfoForBytes", "model.file_info.get.gif.app_error", nil, "name="+name, http.StatusBadRequest)
-					return info, err
+					return info, NewAppError("GetInfoForBytes", "model.file_info.get.gif.app_error", nil, "name="+name, http.StatusBadRequest)
 				} else {
 					info.HasPreviewImage = len(gifConfig.Image) == 1
 				}

--- a/model/file_info.go
+++ b/model/file_info.go
@@ -158,7 +158,8 @@ func GetInfoForBytes(name string, data []byte) (*FileInfo, *AppError) {
 				if gifConfig, err := gif.DecodeAll(bytes.NewReader(data)); err != nil {
 					// Still return the rest of the info even though it doesn't appear to be an actual gif
 					info.HasPreviewImage = true
-					err = NewAppError("GetInfoForBytes", "model.file_info.get.gif.app_error", nil, "name="+name, http.StatusBadRequest)
+					err := NewAppError("GetInfoForBytes", "model.file_info.get.gif.app_error", nil, "name="+name, http.StatusBadRequest)
+					return info, err
 				} else {
 					info.HasPreviewImage = len(gifConfig.Image) == 1
 				}

--- a/model/integration_action_test.go
+++ b/model/integration_action_test.go
@@ -24,6 +24,7 @@ func TestTriggerIdDecodeAndVerification(t *testing.T) {
 	t.Run("should succeed decoding and validation", func(t *testing.T) {
 		userId := NewId()
 		clientTriggerId, triggerId, err := GenerateTriggerId(userId, key)
+		assert.Nil(t, err)
 		decodedClientTriggerId, decodedUserId, err := DecodeAndVerifyTriggerId(triggerId, key)
 		assert.Nil(t, err)
 		assert.Equal(t, clientTriggerId, decodedClientTriggerId)
@@ -35,6 +36,7 @@ func TestTriggerIdDecodeAndVerification(t *testing.T) {
 			UserId: NewId(),
 		}
 		clientTriggerId, triggerId, err := actionReq.GenerateTriggerId(key)
+		assert.Nil(t, err)
 		dialogReq := &OpenDialogRequest{TriggerId: triggerId}
 		decodedClientTriggerId, decodedUserId, err := dialogReq.DecodeAndVerifyTriggerId(key)
 		assert.Nil(t, err)

--- a/model/integration_action_test.go
+++ b/model/integration_action_test.go
@@ -24,7 +24,7 @@ func TestTriggerIdDecodeAndVerification(t *testing.T) {
 	t.Run("should succeed decoding and validation", func(t *testing.T) {
 		userId := NewId()
 		clientTriggerId, triggerId, err := GenerateTriggerId(userId, key)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		decodedClientTriggerId, decodedUserId, err := DecodeAndVerifyTriggerId(triggerId, key)
 		assert.Nil(t, err)
 		assert.Equal(t, clientTriggerId, decodedClientTriggerId)
@@ -36,7 +36,7 @@ func TestTriggerIdDecodeAndVerification(t *testing.T) {
 			UserId: NewId(),
 		}
 		clientTriggerId, triggerId, err := actionReq.GenerateTriggerId(key)
-		assert.Nil(t, err)
+		require.Nil(t, err)
 		dialogReq := &OpenDialogRequest{TriggerId: triggerId}
 		decodedClientTriggerId, decodedUserId, err := dialogReq.DecodeAndVerifyTriggerId(key)
 		assert.Nil(t, err)

--- a/model/link_metadata.go
+++ b/model/link_metadata.go
@@ -56,8 +56,7 @@ func firstNImages(images []*opengraph.Image, maxImages int) []*opengraph.Image {
 	}
 	numImages := len(images)
 	if numImages > maxImages {
-		subImages := make([]*opengraph.Image, maxImages)
-		subImages = images[0:maxImages]
+		subImages := images[0:maxImages]
 		return subImages
 	}
 	return images

--- a/model/link_metadata.go
+++ b/model/link_metadata.go
@@ -56,8 +56,7 @@ func firstNImages(images []*opengraph.Image, maxImages int) []*opengraph.Image {
 	}
 	numImages := len(images)
 	if numImages > maxImages {
-		subImages := images[0:maxImages]
-		return subImages
+		return images[0:maxImages]
 	}
 	return images
 }

--- a/store/storetest/audit_store.go
+++ b/store/storetest/audit_store.go
@@ -40,11 +40,11 @@ func testAuditStore(t *testing.T, ss store.Store) {
 	assert.Equal(t, "extra", audits[0].ExtraInfo)
 
 	audits, err = ss.Audit().Get("missing", 0, 100)
-
+	require.Nil(t, err)
 	assert.Len(t, audits, 0)
 
 	audits, err = ss.Audit().Get("", 0, 100)
-
+	require.Nil(t, err)
 	if len(audits) < 4 {
 		t.Fatal("Failed to save and retrieve 4 audit logs")
 	}
@@ -65,12 +65,14 @@ func testAuditStorePermanentDeleteBatch(t *testing.T, ss store.Store) {
 	require.Nil(t, ss.Audit().Save(a3))
 
 	audits, err := ss.Audit().Get(a1.UserId, 0, 100)
+	require.Nil(t, err)
 	assert.Len(t, audits, 3)
 
 	_, err = ss.Audit().PermanentDeleteBatch(cutoff, 1000000)
 	require.Nil(t, err)
 
 	audits, err = ss.Audit().Get(a1.UserId, 0, 100)
+	require.Nil(t, err)
 	assert.Len(t, audits, 1)
 
 	require.Nil(t, ss.Audit().PermanentDeleteByUser(a1.UserId))

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -3349,6 +3349,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 		Message:   "test",
 		IsPinned:  true,
 	})
+	require.Nil(t, err)
 
 	if pl, errGet := ss.Channel().GetPinnedPosts(o1.Id); errGet != nil {
 		t.Fatal(errGet)

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -1761,6 +1761,7 @@ func testGetGroupsByChannel(t *testing.T, ss store.Store) {
 			if tc.TotalCount != nil {
 				var count int64
 				count, err = ss.Group().CountGroupsByChannel(tc.ChannelId, tc.Opts)
+				require.Nil(t, err)
 				require.Equal(t, *tc.TotalCount, count)
 			}
 		})
@@ -1975,6 +1976,7 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 			if tc.TotalCount != nil {
 				var count int64
 				count, err = ss.Group().CountGroupsByTeam(tc.TeamId, tc.Opts)
+				require.Nil(t, err)
 				require.Equal(t, *tc.TotalCount, count)
 			}
 		})

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -1735,6 +1735,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 		UserId:      model.NewId(),
 	}
 	_, err = ss.Bot().Save(bot1)
+	require.Nil(t, err)
 
 	b1 := &model.Post{}
 	b1.Message = "bot message one"
@@ -2118,6 +2119,7 @@ func testPostStoreGetFlaggedPostsForChannel(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.Message = "zz" + model.NewId() + "b"
 	o1, err := ss.Post().Save(o1)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o2 := &model.Post{}
@@ -2135,6 +2137,7 @@ func testPostStoreGetFlaggedPostsForChannel(t *testing.T, ss store.Store) {
 	o3.Message = "zz" + model.NewId() + "b"
 	o3.DeleteAt = 1
 	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 	time.Sleep(2 * time.Millisecond)
 
 	o4 := &model.Post{}
@@ -2280,6 +2283,7 @@ func testPostStoreOverwrite(t *testing.T, ss store.Store) {
 	o3.UserId = model.NewId()
 	o3.Message = "zz" + model.NewId() + "QQQQQQQQQQ"
 	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	r1, err := ss.Post().Get(o1.Id, false)
 	if err != nil {
@@ -2489,6 +2493,7 @@ func testPostStoreGetPostsBatchForIndexing(t *testing.T, ss store.Store) {
 	o3.RootId = o1.Id
 	o3.Message = "zz" + model.NewId() + "QQQQQQQQQQ"
 	o3, err = ss.Post().Save(o3)
+	require.Nil(t, err)
 
 	if r, err := ss.Post().GetPostsBatchForIndexing(o1.CreateAt, model.GetMillis()+100000, 100); err != nil {
 		t.Fatal(err)

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -745,7 +745,7 @@ func testGetAllPublicTeamPageListing(t *testing.T, ss store.Store) {
 	assert.Nil(t, err)
 	assert.Equal(t, []*model.Team{t1, t3, t5}, teams)
 
-	teams, err = ss.Team().GetAllPublicTeamPageListing(1, 1)
+	_, err = ss.Team().GetAllPublicTeamPageListing(1, 1)
 	assert.Nil(t, err)
 }
 

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -3489,18 +3489,22 @@ func testUserStoreAnalyticsActiveCount(t *testing.T, ss store.Store, s SqlSuppli
 
 	// Daily counts (without bots)
 	count, err := ss.User().AnalyticsActiveCount(DAY_MILLISECONDS, model.UserCountOptions{IncludeBotAccounts: false})
+	require.Nil(t, err)
 	assert.Equal(t, int64(2), count)
 
 	// Daily counts (with bots)
 	count, err = ss.User().AnalyticsActiveCount(DAY_MILLISECONDS, model.UserCountOptions{IncludeBotAccounts: true})
+	require.Nil(t, err)
 	assert.Equal(t, int64(3), count)
 
 	// Monthly counts (without bots)
 	count, err = ss.User().AnalyticsActiveCount(MONTH_MILLISECONDS, model.UserCountOptions{IncludeBotAccounts: false})
+	require.Nil(t, err)
 	assert.Equal(t, int64(3), count)
 
 	// Monthly counts - (with bots)
 	count, err = ss.User().AnalyticsActiveCount(MONTH_MILLISECONDS, model.UserCountOptions{IncludeBotAccounts: true})
+	require.Nil(t, err)
 	assert.Equal(t, int64(4), count)
 }
 
@@ -4878,6 +4882,7 @@ func testUserStoreResetLastPictureUpdate(t *testing.T, ss store.Store) {
 	u1 := &model.User{}
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(u1)
+	require.Nil(t, err)
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u1.Id)) }()
 	_, err = ss.Team().SaveMember(&model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
 	require.Nil(t, err)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Caught by the ineffassign tool. This does not remove all cases yet.
Just the most important ones. The cases still remaining are:

```
mattermost/mattermost-server/api4/openGraph.go:40:2: ineffectual assignment to ok
mattermost/mattermost-server/app/migrations.go:100:6: ineffectual assignment to err
mattermost/mattermost-server/model/config_test.go:189:2: ineffectual assignment to temp
mattermost/mattermost-server/store/sqlstore/post_store.go:1340:6: ineffectual assignment to maxPostSize
mattermost/mattermost-server/store/sqlstore/user_store.go:1270:2: ineffectual assignment to searchType
mattermost/mattermost-server/utils/merge_test.go:515:3: ineffectual assignment to m2
```
