### PR TITLE
[MM-19123] Migrate tests from "model/push_notification_test.go" to use testify

### DIFF
--- a/model/push_notification_test.go
+++ b/model/push_notification_test.go
@@ -4,9 +4,10 @@
 package model
 
 import (
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestPushNotification(t *testing.T) {

--- a/model/push_notification_test.go
+++ b/model/push_notification_test.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 )
@@ -13,9 +14,7 @@ func TestPushNotification(t *testing.T) {
 	json := msg.ToJson()
 	result := PushNotificationFromJson(strings.NewReader(json))
 
-	if msg.Platform != result.Platform {
-		t.Fatal("Ids do not match")
-	}
+	require.Equal(t, msg.Platform, result.Platform, "Ids do not match")
 }
 
 func TestPushNotificationDeviceId(t *testing.T) {
@@ -23,72 +22,44 @@ func TestPushNotificationDeviceId(t *testing.T) {
 	msg := PushNotification{Platform: "test"}
 
 	msg.SetDeviceIdAndPlatform("android:12345")
-	if msg.Platform != "android" {
-		t.Fatal(msg.Platform)
-	}
-	if msg.DeviceId != "12345" {
-		t.Fatal(msg.DeviceId)
-	}
+	require.Equal(t, msg.Platform, "android", msg.Platform)
+	require.Equal(t, msg.DeviceId, "12345", msg.DeviceId)
 	msg.Platform = ""
 	msg.DeviceId = ""
 
 	msg.SetDeviceIdAndPlatform("android:12:345")
-	if msg.Platform != "android" {
-		t.Fatal(msg.Platform)
-	}
-	if msg.DeviceId != "12:345" {
-		t.Fatal(msg.DeviceId)
-	}
+	require.Equal(t, msg.Platform, "android", msg.Platform)
+	require.Equal(t, msg.DeviceId, "12:345", msg.DeviceId)
 	msg.Platform = ""
 	msg.DeviceId = ""
 
 	msg.SetDeviceIdAndPlatform("android::12345")
-	if msg.Platform != "android" {
-		t.Fatal(msg.Platform)
-	}
-	if msg.DeviceId != ":12345" {
-		t.Fatal(msg.DeviceId)
-	}
+	require.Equal(t, msg.Platform, "android", msg.Platform)
+	require.Equal(t, msg.DeviceId, ":12345", msg.DeviceId)
 	msg.Platform = ""
 	msg.DeviceId = ""
 
 	msg.SetDeviceIdAndPlatform(":12345")
-	if msg.Platform != "" {
-		t.Fatal(msg.Platform)
-	}
-	if msg.DeviceId != "12345" {
-		t.Fatal(msg.DeviceId)
-	}
+	require.Equal(t, msg.Platform, "", msg.Platform)
+	require.Equal(t, msg.DeviceId, "12345", msg.DeviceId)
 	msg.Platform = ""
 	msg.DeviceId = ""
 
 	msg.SetDeviceIdAndPlatform("android:")
-	if msg.Platform != "android" {
-		t.Fatal(msg.Platform)
-	}
-	if msg.DeviceId != "" {
-		t.Fatal(msg.DeviceId)
-	}
+	require.Equal(t, msg.Platform, "android", msg.Platform)
+	require.Equal(t, msg.DeviceId, "", msg.DeviceId)
 	msg.Platform = ""
 	msg.DeviceId = ""
 
 	msg.SetDeviceIdAndPlatform("")
-	if msg.Platform != "" {
-		t.Fatal(msg.Platform)
-	}
-	if msg.DeviceId != "" {
-		t.Fatal(msg.DeviceId)
-	}
+	require.Equal(t, msg.Platform, "", msg.Platform)
+	require.Equal(t, msg.DeviceId, "", msg.DeviceId)
 	msg.Platform = ""
 	msg.DeviceId = ""
 
 	msg.SetDeviceIdAndPlatform(":")
-	if msg.Platform != "" {
-		t.Fatal(msg.Platform)
-	}
-	if msg.DeviceId != "" {
-		t.Fatal(msg.DeviceId)
-	}
+	require.Equal(t, msg.Platform, "", msg.Platform)
+	require.Equal(t, msg.DeviceId, "", msg.DeviceId)
 	msg.Platform = ""
 	msg.DeviceId = ""
 }


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Modify the calls to t.Fatal and the condition checks that lead to them, replacing them with calls to the testify require or assert

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #12544 