### PR TITLE
[MM-19120] Migrate tests from "model/security_bulletin_test.go" to use testify

### DIFF
--- a/model/security_bulletin_test.go
+++ b/model/security_bulletin_test.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 )
@@ -17,16 +18,12 @@ func TestSecurityBulletinToFromJson(t *testing.T) {
 	j := b.ToJson()
 	b1 := SecurityBulletinFromJson(strings.NewReader(j))
 
-	CheckString(t, b1.AppliesToVersion, b.AppliesToVersion)
-	CheckString(t, b1.Id, b.Id)
+	require.Equal(t, b, *b1)
 
 	// Malformed JSON
 	s2 := `{"wat"`
 	b2 := SecurityBulletinFromJson(strings.NewReader(s2))
-
-	if b2 != nil {
-		t.Fatal("expected nil")
-	}
+	require.Nil(t, b2)
 }
 
 func TestSecurityBulletinsToFromJson(t *testing.T) {
@@ -45,11 +42,11 @@ func TestSecurityBulletinsToFromJson(t *testing.T) {
 
 	b1 := SecurityBulletinsFromJson(strings.NewReader(j))
 
-	CheckInt(t, len(b1), 2)
+	require.Len(t, b1, 2)
 
 	// Malformed JSON
 	s2 := `{"wat"`
 	b2 := SecurityBulletinsFromJson(strings.NewReader(s2))
 
-	CheckInt(t, len(b2), 0)
+	require.Len(t, b2, 0)
 }


### PR DESCRIPTION
#### Summary
Converts model/security_bulletin_test.go `t.Fatal`/`CheckXxx` calls into testify `require` calls

#### Ticket Link
Fixes #12547