### PR TITLE
MM-19117 Migrate tests from "model/system_test.go" to use testify #12550

### DIFF
--- a/model/system_test.go
+++ b/model/system_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestSystemJson(t *testing.T) {
@@ -13,7 +15,5 @@ func TestSystemJson(t *testing.T) {
 	json := system.ToJson()
 	result := SystemFromJson(strings.NewReader(json))
 
-	if result.Name != "test" {
-		t.Fatal("Ids do not match")
-	}
+	require.Equal(t, "test", result.Name, "ids do not match")
 }


### PR DESCRIPTION
Summary

Migrate tests from "model/system_test.go" to use testify

Ticket Link

[MM-19177](https://mattermost.atlassian.net/browse/MM-19117)

Fixes https://github.com/mattermost/mattermost-server/issues/12550