### PR TITLE
[MM-19118] Migrate tests from "model/websocket_message_test.go" to use testify

### DIFF
--- a/model/websocket_message_test.go
+++ b/model/websocket_message_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWebSocketEvent(t *testing.T) {
@@ -17,21 +18,13 @@ func TestWebSocketEvent(t *testing.T) {
 	result := WebSocketEventFromJson(strings.NewReader(json))
 
 	badresult := WebSocketEventFromJson(strings.NewReader("junk"))
-	if badresult != nil {
-		t.Fatal("should not have parsed")
-	}
+	require.Nil(t, badresult, "should not have parsed")
 
-	if !m.IsValid() {
-		t.Fatal("should be valid")
-	}
+	require.True(t, m.IsValid(), "should be valid")
 
-	if m.Broadcast.TeamId != result.Broadcast.TeamId {
-		t.Fatal("Ids do not match")
-	}
-
-	if m.Data["RootId"] != result.Data["RootId"] {
-		t.Fatal("Ids do not match")
-	}
+	require.Equal(t, m.Broadcast.TeamId, result.Broadcast.TeamId, "Ids do not match")
+	
+	require.Equal(t, m.Data["RootId"], result.Data["RootId"], "Ids do not match")
 }
 
 func TestWebSocketResponse(t *testing.T) {
@@ -44,17 +37,11 @@ func TestWebSocketResponse(t *testing.T) {
 	WebSocketResponseFromJson(strings.NewReader(json2))
 
 	badresult := WebSocketResponseFromJson(strings.NewReader("junk"))
-	if badresult != nil {
-		t.Fatal("should not have parsed")
-	}
+	require.Nil(t, badresult, "should not have parsed")
 
-	if !m.IsValid() {
-		t.Fatal("should be valid")
-	}
+	require.True(t, m.IsValid(), "should be valid")
 
-	if m.Data["RootId"] != result.Data["RootId"] {
-		t.Fatal("Ids do not match")
-	}
+	require.Equal(t, m.Data["RootId"], result.Data["RootId"], "Ids do not match")
 }
 
 func TestWebSocketEvent_PrecomputeJSON(t *testing.T) {

--- a/model/websocket_message_test.go
+++ b/model/websocket_message_test.go
@@ -23,7 +23,7 @@ func TestWebSocketEvent(t *testing.T) {
 	require.True(t, m.IsValid(), "should be valid")
 
 	require.Equal(t, m.Broadcast.TeamId, result.Broadcast.TeamId, "Ids do not match")
-	
+
 	require.Equal(t, m.Data["RootId"], result.Data["RootId"], "Ids do not match")
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Modify the calls to t.Fatal and the condition checks that lead to them, replacing them with calls to the testify require or assert

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #12549 