### PR TITLE
MM-19138 - Adjust test to use require.

### DIFF
--- a/model/cluster_discovery_test.go
+++ b/model/cluster_discovery_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestClusterDiscovery(t *testing.T) {
@@ -18,9 +20,8 @@ func TestClusterDiscovery(t *testing.T) {
 	json := o.ToJson()
 	result1 := ClusterDiscoveryFromJson(strings.NewReader(json))
 
-	if result1.ClusterName != "cluster_name" {
-		t.Fatal("should be set")
-	}
+	require.NotNil(t, result1)
+	require.Equal(t, "cluster_name", result1.ClusterName)
 
 	result2 := ClusterDiscoveryFromJson(strings.NewReader(json))
 	result3 := ClusterDiscoveryFromJson(strings.NewReader(json))
@@ -31,9 +32,7 @@ func TestClusterDiscovery(t *testing.T) {
 	result3.Id = "3"
 	result3.Hostname = "something_diff"
 
-	if !o.IsEqual(result1) {
-		t.Fatal("Should be equal")
-	}
+	require.True(t, o.IsEqual(result1))
 
 	list := make([]*ClusterDiscovery, 0)
 	list = append(list, &o)
@@ -45,9 +44,7 @@ func TestClusterDiscovery(t *testing.T) {
 		return !o.IsEqual(in)
 	})
 
-	if len(rlist) != 1 {
-		t.Fatal("should only have 1 result")
-	}
+	require.Len(t, rlist, 1)
 
 	o.AutoFillHostname()
 	o.Hostname = ""

--- a/model/cluster_discovery_test.go
+++ b/model/cluster_discovery_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClusterDiscovery(t *testing.T) {
@@ -20,8 +20,8 @@ func TestClusterDiscovery(t *testing.T) {
 	json := o.ToJson()
 	result1 := ClusterDiscoveryFromJson(strings.NewReader(json))
 
-	require.NotNil(t, result1)
-	require.Equal(t, "cluster_name", result1.ClusterName)
+	assert.NotNil(t, result1)
+	assert.Equal(t, "cluster_name", result1.ClusterName)
 
 	result2 := ClusterDiscoveryFromJson(strings.NewReader(json))
 	result3 := ClusterDiscoveryFromJson(strings.NewReader(json))
@@ -32,7 +32,7 @@ func TestClusterDiscovery(t *testing.T) {
 	result3.Id = "3"
 	result3.Hostname = "something_diff"
 
-	require.True(t, o.IsEqual(result1))
+	assert.True(t, o.IsEqual(result1))
 
 	list := make([]*ClusterDiscovery, 0)
 	list = append(list, &o)
@@ -44,7 +44,7 @@ func TestClusterDiscovery(t *testing.T) {
 		return !o.IsEqual(in)
 	})
 
-	require.Len(t, rlist, 1)
+	assert.Len(t, rlist, 1)
 
 	o.AutoFillHostname()
 	o.Hostname = ""


### PR DESCRIPTION
#### Summary
This PR adjusts the test in `model/cluster_discovery_test.go` to use the `require` package.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12570
