### PR TITLE
Migrate tests from "model/analytics_row_test.go" to use testify

### DIFF
--- a/model/analytics_row_test.go
+++ b/model/analytics_row_test.go
@@ -6,32 +6,23 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func TestAnalyticsRowJson(t *testing.T) {
-	a1 := AnalyticsRow{}
-	a1.Name = "2015-10-12"
-	a1.Value = 12345.0
-	json := a1.ToJson()
-	ra1 := AnalyticsRowFromJson(strings.NewReader(json))
+var a1 = AnalyticsRow{
+	Name:  "2015-10-12",
+	Value: 12345.0,
+}
 
-	if a1.Name != ra1.Name {
-		t.Fatal("days didn't match")
-	}
+func TestAnalyticsRowJson(t *testing.T) {
+	ra1 := AnalyticsRowFromJson(strings.NewReader(a1.ToJson()))
+	require.Equal(t, a1.Name, ra1.Name, "days didn't match")
 }
 
 func TestAnalyticsRowsJson(t *testing.T) {
-	a1 := AnalyticsRow{}
-	a1.Name = "2015-10-12"
-	a1.Value = 12345.0
-
 	var a1s AnalyticsRows = make([]*AnalyticsRow, 1)
 	a1s[0] = &a1
-
-	ljson := a1s.ToJson()
-	results := AnalyticsRowsFromJson(strings.NewReader(ljson))
-
-	if a1s[0].Name != results[0].Name {
-		t.Fatal("Ids do not match")
-	}
+	results := AnalyticsRowsFromJson(strings.NewReader(a1s.ToJson()))
+	require.Equal(t, a1s[0].Name, results[0].Name, "Ids do not match")
 }


### PR DESCRIPTION
Mattermost is migrating its server tests from using the t.Fatal method calls on their checks to use the testify toolkit. The goal of this migration is to improve the readability of the tests, making them more concise and meaningful. This Help Wanted issue is to migrate the tests in the model/analytics_row_test.go file.

The expected way to migrate this is to go to the model/analytics_row_test.go file and modify the calls to t.Fatal and the condition checks that lead to them, replacing them with calls to the the require package if a failure should stop the execution of the test, or the assert package if it shouldn't.

Fixes: https://github.com/mattermost/mattermost-server/issues/12596
