### PR TITLE
Migrated tests from "model/incoming_webhook_test.go" to use testify

### DIFF
--- a/model/incoming_webhook_test.go
+++ b/model/incoming_webhook_test.go
@@ -15,64 +15,64 @@ func TestIncomingWebhookJson(t *testing.T) {
 	json := o.ToJson()
 	ro := IncomingWebhookFromJson(strings.NewReader(json))
 
-	require.Equal(t, o.Id, ro.Id, "Ids do not match")
+	require.Equal(t, o.Id, ro.Id)
 }
 
 func TestIncomingWebhookIsValid(t *testing.T) {
 	o := IncomingWebhook{}
 
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.Id = NewId()
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.CreateAt = GetMillis()
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.UpdateAt = GetMillis()
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.UserId = "123"
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.UserId = NewId()
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.ChannelId = "123"
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.ChannelId = NewId()
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.TeamId = "123"
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.TeamId = NewId()
-	require.Equal(t, (*AppError)(nil), o.IsValid())
+	require.Nil(t, o.IsValid())
 
 	o.DisplayName = strings.Repeat("1", 65)
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.DisplayName = strings.Repeat("1", 64)
-	require.Equal(t, (*AppError)(nil), o.IsValid())
+	require.Nil(t, o.IsValid())
 
 	o.Description = strings.Repeat("1", 501)
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.Description = strings.Repeat("1", 500)
-	require.Equal(t, (*AppError)(nil), o.IsValid())
+	require.Nil(t, o.IsValid())
 
 	o.Username = strings.Repeat("1", 65)
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.Username = strings.Repeat("1", 64)
-	require.Equal(t, (*AppError)(nil), o.IsValid())
+	require.Nil(t, o.IsValid())
 
 	o.IconURL = strings.Repeat("1", 1025)
-	require.Error(t, o.IsValid(), "should be invalid")
+	require.Error(t, o.IsValid())
 
 	o.IconURL = strings.Repeat("1", 1024)
-	require.Equal(t, (*AppError)(nil), o.IsValid())
+	require.Nil(t, o.IsValid())
 }
 
 func TestIncomingWebhookPreSave(t *testing.T) {
@@ -143,18 +143,18 @@ func TestIncomingWebhookRequestFromJson(t *testing.T) {
 
 		// After it has been decoded, the JSON string won't contain the escape char anymore
 		expected := strings.Replace(text, `\"`, `"`, -1)
-		require.NotNil(t, iwr, "IncomingWebhookRequest should not be nil")
-		require.Equalf(t, expected, iwr.Text, "Sample %d text should be: %s, got: %s", i, expected, iwr.Text)
+		require.NotNil(t, iwr)
+		require.Equal(t, expected, iwr.Text)
 
 		attachment := iwr.Attachments[0]
-		require.Equalf(t, expected, attachment.Text, "Sample %d attachment text should be: %s, got: %s", i, expected, attachment.Text)
+		require.Equal(t, expected, attachment.Text)
 	}
 }
 
 func TestIncomingWebhookNullArrayItems(t *testing.T) {
 	payload := `{"attachments":[{"fields":[{"title":"foo","value":"bar","short":true}, null]}, null]}`
 	iwr, _ := IncomingWebhookRequestFromJson(strings.NewReader(payload))
-	require.NotNil(t, iwr,"IncomingWebhookRequest should not be nil" )
-	require.Len(t, iwr.Attachments, 1, "expected one attachment")
-	require.Len(t, iwr.Attachments[0].Fields, 1, "expected one field")
+	require.NotNil(t, iwr)
+	require.Len(t, iwr.Attachments, 1)
+	require.Len(t, iwr.Attachments[0].Fields, 1)
 }

--- a/model/incoming_webhook_test.go
+++ b/model/incoming_webhook_test.go
@@ -102,7 +102,7 @@ func TestIncomingWebhookRequestFromJson(t *testing.T) {
 		`,
 	}
 
-	for i, text := range texts {
+	for _, text := range texts {
 		// build a sample payload with the text
 		payload := `{
         "text": "` + text + `",

--- a/model/incoming_webhook_test.go
+++ b/model/incoming_webhook_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestIncomingWebhookJson(t *testing.T) {
@@ -13,102 +15,64 @@ func TestIncomingWebhookJson(t *testing.T) {
 	json := o.ToJson()
 	ro := IncomingWebhookFromJson(strings.NewReader(json))
 
-	if o.Id != ro.Id {
-		t.Fatal("Ids do not match")
-	}
+	require.Equal(t, o.Id, ro.Id, "Ids do not match")
 }
 
 func TestIncomingWebhookIsValid(t *testing.T) {
 	o := IncomingWebhook{}
 
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.Id = NewId()
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.CreateAt = GetMillis()
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.UpdateAt = GetMillis()
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.UserId = "123"
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.UserId = NewId()
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.ChannelId = "123"
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.ChannelId = NewId()
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.TeamId = "123"
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.TeamId = NewId()
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Equal(t, (*AppError)(nil), o.IsValid())
 
 	o.DisplayName = strings.Repeat("1", 65)
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.DisplayName = strings.Repeat("1", 64)
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Equal(t, (*AppError)(nil), o.IsValid())
 
 	o.Description = strings.Repeat("1", 501)
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.Description = strings.Repeat("1", 500)
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Equal(t, (*AppError)(nil), o.IsValid())
 
 	o.Username = strings.Repeat("1", 65)
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.Username = strings.Repeat("1", 64)
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Equal(t, (*AppError)(nil), o.IsValid())
 
 	o.IconURL = strings.Repeat("1", 1025)
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.IconURL = strings.Repeat("1", 1024)
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Equal(t, (*AppError)(nil), o.IsValid())
 }
 
 func TestIncomingWebhookPreSave(t *testing.T) {
@@ -179,30 +143,18 @@ func TestIncomingWebhookRequestFromJson(t *testing.T) {
 
 		// After it has been decoded, the JSON string won't contain the escape char anymore
 		expected := strings.Replace(text, `\"`, `"`, -1)
-		if iwr == nil {
-			t.Fatal("IncomingWebhookRequest should not be nil")
-		}
-		if iwr.Text != expected {
-			t.Fatalf("Sample %d text should be: %s, got: %s", i, expected, iwr.Text)
-		}
+		require.NotNil(t, iwr, "IncomingWebhookRequest should not be nil")
+		require.Equalf(t, expected, iwr.Text, "Sample %d text should be: %s, got: %s", i, expected, iwr.Text)
 
 		attachment := iwr.Attachments[0]
-		if attachment.Text != expected {
-			t.Fatalf("Sample %d attachment text should be: %s, got: %s", i, expected, attachment.Text)
-		}
+		require.Equalf(t, expected, attachment.Text, "Sample %d attachment text should be: %s, got: %s", i, expected, attachment.Text)
 	}
 }
 
 func TestIncomingWebhookNullArrayItems(t *testing.T) {
 	payload := `{"attachments":[{"fields":[{"title":"foo","value":"bar","short":true}, null]}, null]}`
 	iwr, _ := IncomingWebhookRequestFromJson(strings.NewReader(payload))
-	if iwr == nil {
-		t.Fatal("IncomingWebhookRequest should not be nil")
-	}
-	if len(iwr.Attachments) != 1 {
-		t.Fatalf("expected one attachment")
-	}
-	if len(iwr.Attachments[0].Fields) != 1 {
-		t.Fatalf("expected one field")
-	}
+	require.NotNil(t, iwr,"IncomingWebhookRequest should not be nil" )
+	require.Len(t, iwr.Attachments, 1, "expected one attachment")
+	require.Len(t, iwr.Attachments[0].Fields, 1, "expected one field")
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Replaced test assertions with testify
<!--
A description of what this pull request does.
-->

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12597
https://mattermost.atlassian.net/browse/MM-19159
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
