### PR TITLE
build docker first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,15 +298,9 @@ workflows:
       # - check-i18n:
       #     requires:
       #       - setup
-      - test:
-          requires:
-            - setup
-      - test-schema:
-          requires:
-            - setup
       - build:
           requires:
-            - test
+            - setup
       - upload-s3-sha:
           context: mattermost-ci-s3
           requires:
@@ -319,3 +313,9 @@ workflows:
           context: matterbuild-docker
           requires:
             - upload-s3-sha
+      - test:
+          requires:
+            - setup
+      - test-schema:
+          requires:
+            - setup


### PR DESCRIPTION
We are not using this pipeline to get the docker image to build a test server yet, but as soon we start using we need to make the docker image be accessible as fast as we can.
also, this sync the flow as we have in the Jenkins file