### PR TITLE
MM-19015 Migrate tests from "cmd/mattermost/commands/config_test.go" to use testify

### DIFF
--- a/cmd/mattermost/commands/config_test.go
+++ b/cmd/mattermost/commands/config_test.go
@@ -453,9 +453,7 @@ func TestUpdateMap(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			err := UpdateMap(configMap, test.configSettings, test.newVal)
 
-			if err != nil {
-				t.Fatal("Wasn't expecting an error: ", err)
-			}
+			require.Nil(t, err, "Wasn't expecting an error")
 
 			if !contains(configMap, test.expected, test.configSettings) {
 				t.Error("update didn't happen")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
 - change t.fatal to use require package of the testify toolkit.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
[MM-19015](https://mattermost.atlassian.net/browse/MM-19015)