### PR TITLE
[MM-19235] Migrate tests from "model/cluster_info_test.go" to use testify

### DIFF
--- a/model/cluster_info_test.go
+++ b/model/cluster_info_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClusterInfoJson(t *testing.T) {
@@ -13,9 +15,7 @@ func TestClusterInfoJson(t *testing.T) {
 	json := cluster.ToJson()
 	result := ClusterInfoFromJson(strings.NewReader(json))
 
-	if cluster.IpAddress != result.IpAddress {
-		t.Fatal("Ids do not match")
-	}
+	assert.Equal(t, cluster.IpAddress, result.IpAddress, "Ids do not match")
 }
 
 func TestClusterInfosJson(t *testing.T) {
@@ -25,7 +25,5 @@ func TestClusterInfosJson(t *testing.T) {
 	json := ClusterInfosToJson(clusterInfos)
 	result := ClusterInfosFromJson(strings.NewReader(json))
 
-	if clusterInfos[0].IpAddress != result[0].IpAddress {
-		t.Fatal("Ids do not match")
-	}
+	assert.Equal(t, clusterInfos[0].IpAddress, result[0].IpAddress, "Ids do not match")
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Replaced test assertions with testify

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes #12635
Fixes https://mattermost.atlassian.net/browse/MM-19235