### PR TITLE
MM-19135 Migrate tests from "model/channel_member_test.go" to use testify #12573

### DIFF
--- a/model/channel_member_test.go
+++ b/model/channel_member_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestChannelMemberJson(t *testing.T) {
@@ -13,22 +15,16 @@ func TestChannelMemberJson(t *testing.T) {
 	json := o.ToJson()
 	ro := ChannelMemberFromJson(strings.NewReader(json))
 
-	if o.ChannelId != ro.ChannelId {
-		t.Fatal("Ids do not match")
-	}
+	require.Equal(t, o.ChannelId, ro.ChannelId, "ids do not match")
 }
 
 func TestChannelMemberIsValid(t *testing.T) {
 	o := ChannelMember{}
 
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.ChannelId = NewId()
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.NotifyProps = GetDefaultChannelNotifyProps()
 	o.UserId = NewId()
@@ -40,34 +36,22 @@ func TestChannelMemberIsValid(t *testing.T) {
 	}*/
 
 	o.NotifyProps["desktop"] = "junk"
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.NotifyProps["desktop"] = "123456789012345678901"
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.NotifyProps["desktop"] = CHANNEL_NOTIFY_ALL
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.NotifyProps["mark_unread"] = "123456789012345678901"
-	if err := o.IsValid(); err == nil {
-		t.Fatal("should be invalid")
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.NotifyProps["mark_unread"] = CHANNEL_MARK_UNREAD_ALL
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 
 	o.Roles = ""
-	if err := o.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	require.Error(t, o.IsValid(), "should be invalid")
 }
 
 func TestChannelUnreadJson(t *testing.T) {
@@ -75,11 +59,6 @@ func TestChannelUnreadJson(t *testing.T) {
 	json := o.ToJson()
 	ro := ChannelUnreadFromJson(strings.NewReader(json))
 
-	if o.TeamId != ro.TeamId {
-		t.Fatal("Team Ids do not match")
-	}
-
-	if o.MentionCount != ro.MentionCount {
-		t.Fatal("MentionCount do not match")
-	}
+	require.Equal(t, o.TeamId, ro.TeamId, "team Ids do not match")
+	require.Equal(t, o.MentionCount, ro.MentionCount, "mention count do not match")
 }


### PR DESCRIPTION
Summary

MM-19135 Migrate tests from "model/channel_member_test.go" to use testify #12573

Ticket Link

[MM-19117](https://mattermost.atlassian.net/browse/MM-19117)

Fixes #12573