### PR TITLE
[MM-19127] Make desktop app respect previous manual status choice when waking up

### DIFF
--- a/wsapi/user.go
+++ b/wsapi/user.go
@@ -42,6 +42,12 @@ func (api *API) userUpdateActiveStatus(req *model.WebSocketRequest) (map[string]
 		return nil, NewInvalidWebSocketParamError(req.Action, "user_is_active")
 	}
 
+	if prevStatus, err := api.App.GetStatus(req.Session.UserId); err == nil {
+		if prevStatus.Manual && prevStatus.Status != model.STATUS_ONLINE && prevStatus.Status != model.STATUS_AWAY {
+			return nil, nil
+		}
+	}
+
 	var manual bool
 	if manual, ok = req.Data["manual"].(bool); !ok {
 		manual = false


### PR DESCRIPTION
#### Summary

This PR makes it so when the user's previous status was set manually to anything but `away` or `online`, the computer waking up from sleep does not overwrite the user's choice.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-19127