### PR TITLE
MM-19237: convert t.Fatal to use require calls

### DIFF
--- a/model/emoji_test.go
+++ b/model/emoji_test.go
@@ -20,8 +20,7 @@ func TestEmojiIsValid(t *testing.T) {
 		Name:      "name",
 	}
 
-	err := emoji.IsValid()
-	require.Nil(t, err)
+	require.Nil(t, emoji.IsValid())
 
 	emoji.Id = "1234"
 	require.NotNil(t, emoji.IsValid())

--- a/model/emoji_test.go
+++ b/model/emoji_test.go
@@ -20,9 +20,8 @@ func TestEmojiIsValid(t *testing.T) {
 		Name:      "name",
 	}
 
-	if err := emoji.IsValid(); err != nil {
-		t.Fatal(err)
-	}
+	err := emoji.IsValid()
+	require.Nil(t, err)
 
 	emoji.Id = "1234"
 	require.NotNil(t, emoji.IsValid())


### PR DESCRIPTION
#### Summary
Converts model/emoji_test.go to use require calls instead of t.Fatal

#### Ticket Link
[MM-19237](https://mattermost.atlassian.net/browse/MM-19237)
Fixes https://github.com/mattermost/mattermost-server/issues/12633