### PR TITLE
use testify's assert on modeltestlib tests

### DIFF
--- a/model/modeltestlib_test.go
+++ b/model/modeltestlib_test.go
@@ -4,48 +4,31 @@
 package model
 
 import (
-	"runtime/debug"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func CheckInt(t *testing.T, got int, expected int) {
-	if got != expected {
-		debug.PrintStack()
-		t.Fatalf("Got: %v, Expected: %v", got, expected)
-	}
+	assert.Equal(t, got, expected)
 }
 
 func CheckInt64(t *testing.T, got int64, expected int64) {
-	if got != expected {
-		debug.PrintStack()
-		t.Fatalf("Got: %v, Expected: %v", got, expected)
-	}
+	assert.Equal(t, got, expected)
 }
 
 func CheckString(t *testing.T, got string, expected string) {
-	if got != expected {
-		debug.PrintStack()
-		t.Fatalf("Got: %v, Expected: %v", got, expected)
-	}
+	assert.Equal(t, got, expected)
 }
 
 func CheckTrue(t *testing.T, test bool) {
-	if !test {
-		debug.PrintStack()
-		t.Fatal("Expected true")
-	}
+	assert.True(t, test)
 }
 
 func CheckFalse(t *testing.T, test bool) {
-	if test {
-		debug.PrintStack()
-		t.Fatal("Expected true")
-	}
+	assert.False(t, test)
 }
 
 func CheckBool(t *testing.T, got bool, expected bool) {
-	if got != expected {
-		debug.PrintStack()
-		t.Fatalf("Got: %v, Expected: %v", got, expected)
-	}
+	assert.Equal(t, got, expected)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Convert model/modeltestlib_test.go to use Testify's assert instead of t.Fatal
#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/12669
Jira: https://mattermost.atlassian.net/browse/MM-19272