### PR TITLE
use testify's assert on channel_search's tests

### DIFF
--- a/model/channel_search_test.go
+++ b/model/channel_search_test.go
@@ -6,6 +6,8 @@ package model
 import (
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChannelSearchJson(t *testing.T) {
@@ -13,7 +15,5 @@ func TestChannelSearchJson(t *testing.T) {
 	json := channelSearch.ToJson()
 	rchannelSearch := ChannelSearchFromJson(strings.NewReader(json))
 
-	if channelSearch.Term != rchannelSearch.Term {
-		t.Fatal("Terms do not match")
-	}
+	assert.Equal(t, channelSearch.Term, rchannelSearch.Term)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Convert model/channel_search_test.go to use Testify's assert instead of t.Fatal
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes https://github.com/mattermost/mattermost-server/issues/12671
Jira: https://mattermost.atlassian.net/browse/MM-19270