### PR TITLE
change t.Fatal to assert.Equal in post_list_test.go

### DIFF
--- a/model/post_list_test.go
+++ b/model/post_list_test.go
@@ -24,17 +24,9 @@ func TestPostListJson(t *testing.T) {
 	json := pl.ToJson()
 	rpl := PostListFromJson(strings.NewReader(json))
 
-	if rpl.Posts[p1.Id].Message != p1.Message {
-		t.Fatal("failed to serialize")
-	}
-
-	if rpl.Posts[p2.Id].Message != p2.Message {
-		t.Fatal("failed to serialize")
-	}
-
-	if rpl.Order[1] != p2.Id {
-		t.Fatal("failed to serialize")
-	}
+	assert.Equal(t, rpl.Posts[p1.Id].Message, p1.Message, "failed to serialize p1 message")
+	assert.Equal(t, rpl.Posts[p2.Id].Message, p2.Message, "failed to serialize p2 message")
+	assert.Equal(t, rpl.Order[1], p2.Id, "failed to serialize p2 Id")
 }
 
 func TestPostListExtend(t *testing.T) {


### PR DESCRIPTION
**Summary**
change t.Fatal to assert.Equal in post_list_test.go for compering rpl with p1 and p2

**Ticket Link**
[MM-19271](https://mattermost.atlassian.net/browse/MM-19271)