### PR TITLE
services/filestore: migrate s3store_test to testify

### DIFF
--- a/services/filesstore/s3store_test.go
+++ b/services/filesstore/s3store_test.go
@@ -14,17 +14,16 @@ func TestCheckMandatoryS3Fields(t *testing.T) {
 	cfg := model.FileSettings{}
 
 	err := CheckMandatoryS3Fields(&cfg)
-	res := err == nil || err.Message != "api.admin.test_s3.missing_s3_bucket"
-	require.False(t, res, "should've failed with missing s3 bucket")
+	require.NotNil(t, err)
+	require.Equal(t, err.Message, "api.admin.test_s3.missing_s3_bucket", "should've failed with missing s3 bucket")
 
 	cfg.AmazonS3Bucket = model.NewString("test-mm")
 	err = CheckMandatoryS3Fields(&cfg)
-	require.Nil(t, err, "should've not failed")
+	require.Nil(t, err)
 
 	cfg.AmazonS3Endpoint = model.NewString("")
 	err = CheckMandatoryS3Fields(&cfg)
 
-	res = err != nil || *cfg.AmazonS3Endpoint != "s3.amazonaws.com"
-	require.False(t, res, "should've not failed because it should set the endpoint to the default")
-
+	require.Nil(t, err)
+	require.Equal(t, *cfg.AmazonS3Endpoint, "s3.amazonaws.com", "should've set the endpoint to the default")
 }

--- a/services/filesstore/s3store_test.go
+++ b/services/filesstore/s3store_test.go
@@ -7,26 +7,24 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCheckMandatoryS3Fields(t *testing.T) {
 	cfg := model.FileSettings{}
 
 	err := CheckMandatoryS3Fields(&cfg)
-	if err == nil || err.Message != "api.admin.test_s3.missing_s3_bucket" {
-		t.Fatal("should've failed with missing s3 bucket")
-	}
+	res := err == nil || err.Message != "api.admin.test_s3.missing_s3_bucket"
+	require.False(t, res, "should've failed with missing s3 bucket")
 
 	cfg.AmazonS3Bucket = model.NewString("test-mm")
 	err = CheckMandatoryS3Fields(&cfg)
-	if err != nil {
-		t.Fatal("should've not failed")
-	}
+	require.Nil(t, err, "should've not failed")
 
 	cfg.AmazonS3Endpoint = model.NewString("")
 	err = CheckMandatoryS3Fields(&cfg)
-	if err != nil || *cfg.AmazonS3Endpoint != "s3.amazonaws.com" {
-		t.Fatal("should've not failed because it should set the endpoint to the default")
-	}
+
+	res = err != nil || *cfg.AmazonS3Endpoint != "s3.amazonaws.com"
+	require.False(t, res, "should've not failed because it should set the endpoint to the default")
 
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
change `t.Fatal` method to `require` functions in `services/filesstore/s3store_test.go`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes: #12664 