### PR TITLE
MM-18881 - Attempting to configure uninstalled plugins gets stuck at Loading... without timeout.

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -305,10 +305,32 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 	require.Equal(t, "testplugin", manifest.Id)
 
 	// Successful remove
+	webSocketClient, err := th.CreateWebSocketSystemAdminClient()
+	require.Nil(t, err)
+	webSocketClient.Listen()
+	done := make(chan bool)
+	go func() {
+		for {
+			select {
+			case resp := <-webSocketClient.EventChannel:
+				if resp.Event == model.WEBSOCKET_EVENT_PLUGIN_STATUSES_CHANGED && len(resp.Data["plugin_statuses"].([]interface{})) == 0 {
+					done <- true
+					return
+				}
+			case <-time.After(5 * time.Second):
+				done <- false
+				return
+			}
+		}
+	}()
+
 	testCluster.ClearMessages()
 	ok, resp := th.SystemAdminClient.RemovePlugin(manifest.Id)
 	CheckNoError(t, resp)
 	require.True(t, ok)
+
+	result := <-done
+	require.True(t, result, "plugin_statuses_changed websocket event was not received")
 
 	messages = testCluster.GetMessages()
 

--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -308,6 +308,7 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 	webSocketClient, err := th.CreateWebSocketSystemAdminClient()
 	require.Nil(t, err)
 	webSocketClient.Listen()
+	defer webSocketClient.Close()
 	done := make(chan bool)
 	go func() {
 		for {

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -251,6 +251,10 @@ func (a *App) removePlugin(id string) *model.AppError {
 		},
 	)
 
+	if err := a.notifyPluginStatusesChanged(); err != nil {
+		mlog.Error("Failed to notify plugin status changed", mlog.Err(err))
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### Summary
Emitting `notifyPluginStatusesChanged` when a plugin is removed.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-18881