### PR TITLE
Revert "Do not count deleted channels when checking max channel limit (#12021)"

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -160,7 +160,7 @@ func (a *App) CreateChannelWithUser(channel *model.Channel, userId string) (*mod
 	}
 
 	// Get total number of channels on current team
-	count, err := a.GetNumberOfChannelsOnTeam(channel.TeamId, false)
+	count, err := a.GetNumberOfChannelsOnTeam(channel.TeamId)
 	if err != nil {
 		return nil, err
 	}
@@ -1724,23 +1724,12 @@ func (a *App) RemoveUserFromChannel(userIdToRemove string, removerUserId string,
 	return nil
 }
 
-func (a *App) GetNumberOfChannelsOnTeam(teamId string, includeDeleted bool) (int, *model.AppError) {
+func (a *App) GetNumberOfChannelsOnTeam(teamId string) (int, *model.AppError) {
 	// Get total number of channels on current team
 	list, err := a.Srv.Store.Channel().GetTeamChannels(teamId)
 	if err != nil {
 		return 0, err
 	}
-
-	if !includeDeleted {
-		count := 0
-		for _, channel := range *list {
-			if channel.DeleteAt == 0 {
-				count++
-			}
-		}
-		return count, nil
-	}
-
 	return len(*list), nil
 }
 

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -1000,18 +1000,3 @@ func TestSearchChannelsForUser(t *testing.T) {
 		searchAndCheck(t, "dev", []string{"test-dev-1", "test-dev-2", "dev-3"})
 	})
 }
-
-func TestGetNumberOfChannelsOnTeam(t *testing.T) {
-	th := Setup(t).InitBasic()
-	defer th.TearDown()
-
-	th.App.DeleteChannel(th.BasicChannel, th.BasicUser.Id)
-
-	count, err := th.App.GetNumberOfChannelsOnTeam(th.BasicTeam.Id, true)
-	require.Nil(t, err)
-	assert.Equal(t, 3, count)
-
-	count, err = th.App.GetNumberOfChannelsOnTeam(th.BasicTeam.Id, false)
-	require.Nil(t, err)
-	assert.Equal(t, 2, count)
-}


### PR DESCRIPTION
#### Summary
As [requested](https://mattermost.atlassian.net/browse/MM-18038), this change reverts commit d6700e3b40fb7f11c300559b3c31b8799926ce3d. It seems the nuance is that archived channels (i.e. deleted channels) should count towards the limit. We're raised the dissonance with the help text and the in-product experience with UX to resolve this in a later release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-18038