### PR TITLE
MM-19352 - Migrated test in store/storetest/audit_store.go to use testify

### DIFF
--- a/store/storetest/audit_store.go
+++ b/store/storetest/audit_store.go
@@ -45,9 +45,7 @@ func testAuditStore(t *testing.T, ss store.Store) {
 
 	audits, err = ss.Audit().Get("", 0, 100)
 	require.Nil(t, err)
-	if len(audits) < 4 {
-		t.Fatal("Failed to save and retrieve 4 audit logs")
-	}
+	require.Len(t, audits, 4, "Failed to save and retrieve 4 audit logs")
 
 	require.Nil(t, ss.Audit().PermanentDeleteByUser(audit.UserId))
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR aims to migrate tests to use testify, especially ones that should break the test with `t.Fatal` before

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12713
JIRA: https://mattermost.atlassian.net/browse/MM-19352
