### PR TITLE
MM-17477: Truncates group display name upon linking.

### DIFF
--- a/api4/ldap.go
+++ b/api4/ldap.go
@@ -155,13 +155,21 @@ func linkLdapGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 	var status int
 	var newOrUpdatedGroup *model.Group
 
+	// Truncate display name if necessary
+	var displayName string
+	if len(ldapGroup.DisplayName) > model.GroupDisplayNameMaxLength {
+		displayName = ldapGroup.DisplayName[:model.GroupDisplayNameMaxLength]
+	} else {
+		displayName = ldapGroup.DisplayName
+	}
+
 	// Group has been previously linked
 	if group != nil {
 		if group.DeleteAt == 0 {
 			newOrUpdatedGroup = group
 		} else {
 			group.DeleteAt = 0
-			group.DisplayName = ldapGroup.DisplayName
+			group.DisplayName = displayName
 			group.RemoteId = ldapGroup.RemoteId
 			newOrUpdatedGroup, err = c.App.UpdateGroup(group)
 			if err != nil {
@@ -178,7 +186,7 @@ func linkLdapGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		// the LDAP group name with an appended duplicate-breaker.
 		newGroup := &model.Group{
 			Name:        model.NewId(),
-			DisplayName: ldapGroup.DisplayName,
+			DisplayName: displayName,
 			RemoteId:    ldapGroup.RemoteId,
 			Source:      model.GroupSourceLdap,
 		}


### PR DESCRIPTION
#### Summary

Truncates the display name of a group with a name > 128 characters upon linking (not just in the sync job, as before).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-17477
