### PR TITLE
store/storetest: migrate command_store.go to use testify

### DIFF
--- a/store/storetest/command_store.go
+++ b/store/storetest/command_store.go
@@ -6,6 +6,8 @@ package storetest
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/store"
 )
@@ -30,13 +32,11 @@ func testCommandStoreSave(t *testing.T, ss store.Store) {
 	o1.URL = "http://nowhere.com/"
 	o1.Trigger = "trigger"
 
-	if _, err := ss.Command().Save(&o1); err != nil {
-		t.Fatal("couldn't save item", err)
-	}
+	_, err := ss.Command().Save(&o1)
+	require.Nil(t, err, "couldn't save item")
 
-	if _, err := ss.Command().Save(&o1); err == nil {
-		t.Fatal("shouldn't be able to update from save")
-	}
+	_, err = ss.Command().Save(&o1)
+	require.NotNil(t, err, "shouldn't be able to update from save")
 }
 
 func testCommandStoreGet(t *testing.T, ss store.Store) {
@@ -48,21 +48,14 @@ func testCommandStoreGet(t *testing.T, ss store.Store) {
 	o1.Trigger = "trigger"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if r1, err := ss.Command().Get(o1.Id); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1.CreateAt != o1.CreateAt {
-			t.Fatal("invalid returned command")
-		}
-	}
+	r1, err := ss.Command().Get(o1.Id)
+	require.Nil(t, err)
+	require.Equal(t, r1.CreateAt, o1.CreateAt, "invalid returned command")
 
-	if _, err := ss.Command().Get("123"); err == nil {
-		t.Fatal("Missing id should have failed")
-	}
+	_, err = ss.Command().Get("123")
+	require.NotNil(t, err, "Mising id should have failed")
 }
 
 func testCommandStoreGetByTeam(t *testing.T, ss store.Store) {
@@ -74,25 +67,15 @@ func testCommandStoreGetByTeam(t *testing.T, ss store.Store) {
 	o1.Trigger = "trigger"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if r1, err := ss.Command().GetByTeam(o1.TeamId); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1[0].CreateAt != o1.CreateAt {
-			t.Fatal("invalid returned command")
-		}
-	}
+	r1, err := ss.Command().GetByTeam(o1.TeamId)
+	require.Nil(t, err)
+	require.Equal(t, r1[0].CreateAt, o1.CreateAt, "invalid returned command")
 
-	if result, err := ss.Command().GetByTeam("123"); err != nil {
-		t.Fatal(err)
-	} else {
-		if len(result) != 0 {
-			t.Fatal("no commands should have returned")
-		}
-	}
+	result, err := ss.Command().GetByTeam("123")
+	require.Nil(t, err)
+	require.Len(t, result, 0, "no commands should have returned")
 }
 
 func testCommandStoreGetByTrigger(t *testing.T, ss store.Store) {
@@ -111,30 +94,21 @@ func testCommandStoreGetByTrigger(t *testing.T, ss store.Store) {
 	o2.Trigger = "trigger1"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
+
 	_, err = ss.Command().Save(o2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
+
 	var r1 *model.Command
-	if r1, err = ss.Command().GetByTrigger(o1.TeamId, o1.Trigger); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1.Id != o1.Id {
-			t.Fatal("invalid returned command")
-		}
-	}
+	r1, err = ss.Command().GetByTrigger(o1.TeamId, o1.Trigger)
+	require.Nil(t, err)
+	require.Equal(t, r1.Id, o1.Id, "invalid returned command")
 
 	err = ss.Command().Delete(o1.Id, model.GetMillis())
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if _, err := ss.Command().GetByTrigger(o1.TeamId, o1.Trigger); err == nil {
-		t.Fatal("no commands should have returned")
-	}
+	_, err = ss.Command().GetByTrigger(o1.TeamId, o1.Trigger)
+	require.NotNil(t, err, "no commnds should have returned")
 }
 
 func testCommandStoreDelete(t *testing.T, ss store.Store) {
@@ -146,26 +120,17 @@ func testCommandStoreDelete(t *testing.T, ss store.Store) {
 	o1.Trigger = "trigger"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if r1, err := ss.Command().Get(o1.Id); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1.CreateAt != o1.CreateAt {
-			t.Fatal("invalid returned command")
-		}
-	}
+	r1, err := ss.Command().Get(o1.Id)
+	require.Nil(t, err)
+	require.Equal(t, r1.CreateAt, o1.CreateAt, "invalid returned command")
 
-	if err := ss.Command().Delete(o1.Id, model.GetMillis()); err != nil {
-		t.Fatal(err)
-	}
+	err = ss.Command().Delete(o1.Id, model.GetMillis())
+	require.Nil(t, err)
 
-	if r3, err := ss.Command().Get(o1.Id); err == nil {
-		t.Log(r3)
-		t.Fatal("Missing id should have failed")
-	}
+	_, err = ss.Command().Get(o1.Id)
+	require.NotNil(t, err, "Missing id should have failed")
 }
 
 func testCommandStoreDeleteByTeam(t *testing.T, ss store.Store) {
@@ -177,26 +142,17 @@ func testCommandStoreDeleteByTeam(t *testing.T, ss store.Store) {
 	o1.Trigger = "trigger"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if r1, err := ss.Command().Get(o1.Id); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1.CreateAt != o1.CreateAt {
-			t.Fatal("invalid returned command")
-		}
-	}
+	r1, err := ss.Command().Get(o1.Id)
+	require.Nil(t, err)
+	require.Equal(t, r1.CreateAt, o1.CreateAt, "invalid returned command")
 
-	if err := ss.Command().PermanentDeleteByTeam(o1.TeamId); err != nil {
-		t.Fatal(err)
-	}
+	err = ss.Command().PermanentDeleteByTeam(o1.TeamId)
+	require.Nil(t, err)
 
-	if r3, err := ss.Command().Get(o1.Id); err == nil {
-		t.Log(r3)
-		t.Fatal("Missing id should have failed")
-	}
+	_, err = ss.Command().Get(o1.Id)
+	require.NotNil(t, err, "Missing id should have failed")
 }
 
 func testCommandStoreDeleteByUser(t *testing.T, ss store.Store) {
@@ -208,26 +164,17 @@ func testCommandStoreDeleteByUser(t *testing.T, ss store.Store) {
 	o1.Trigger = "trigger"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if r1, err := ss.Command().Get(o1.Id); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1.CreateAt != o1.CreateAt {
-			t.Fatal("invalid returned command")
-		}
-	}
+	r1, err := ss.Command().Get(o1.Id)
+	require.Nil(t, err)
+	require.Equal(t, r1.CreateAt, o1.CreateAt, "invalid returned command")
 
-	if err := ss.Command().PermanentDeleteByUser(o1.CreatorId); err != nil {
-		t.Fatal(err)
-	}
+	err = ss.Command().PermanentDeleteByUser(o1.CreatorId)
+	require.Nil(t, err)
 
-	if r3, err := ss.Command().Get(o1.Id); err == nil {
-		t.Log(r3)
-		t.Fatal("Missing id should have failed")
-	}
+	_, err = ss.Command().Get(o1.Id)
+	require.NotNil(t, err, "Missing id should have failed")
 }
 
 func testCommandStoreUpdate(t *testing.T, ss store.Store) {
@@ -239,21 +186,17 @@ func testCommandStoreUpdate(t *testing.T, ss store.Store) {
 	o1.Trigger = "trigger"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	o1.Token = model.NewId()
 
-	if _, err := ss.Command().Update(o1); err != nil {
-		t.Fatal(err)
-	}
+	_, err = ss.Command().Update(o1)
+	require.Nil(t, err)
 
 	o1.URL = "junk"
 
-	if _, err := ss.Command().Update(o1); err == nil {
-		t.Fatal("should have failed - bad URL")
-	}
+	_, err = ss.Command().Update(o1)
+	require.NotNil(t, err, "should have failed - bad URL")
 }
 
 func testCommandCount(t *testing.T, ss store.Store) {
@@ -265,23 +208,13 @@ func testCommandCount(t *testing.T, ss store.Store) {
 	o1.Trigger = "trigger"
 
 	o1, err := ss.Command().Save(o1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
-	if r1, err := ss.Command().AnalyticsCommandCount(""); err != nil {
-		t.Fatal(err)
-	} else {
-		if r1 == 0 {
-			t.Fatal("should be at least 1 command")
-		}
-	}
+	r1, err := ss.Command().AnalyticsCommandCount("")
+	require.Nil(t, err)
+	require.NotEqual(t, r1, 0, "should be at least 1 command")
 
-	if r2, err := ss.Command().AnalyticsCommandCount(o1.TeamId); err != nil {
-		t.Fatal(err)
-	} else {
-		if r2 != 1 {
-			t.Fatal("should be 1 command")
-		}
-	}
+	r2, err := ss.Command().AnalyticsCommandCount(o1.TeamId)
+	require.Nil(t, err)
+	require.Equal(t, r2, 1, "should be 1 command")
 }

--- a/store/storetest/command_store.go
+++ b/store/storetest/command_store.go
@@ -71,11 +71,12 @@ func testCommandStoreGetByTeam(t *testing.T, ss store.Store) {
 
 	r1, err := ss.Command().GetByTeam(o1.TeamId)
 	require.Nil(t, err)
+	require.NotEmpty(t, r1, "no command returned")
 	require.Equal(t, r1[0].CreateAt, o1.CreateAt, "invalid returned command")
 
 	result, err := ss.Command().GetByTeam("123")
 	require.Nil(t, err)
-	require.Len(t, result, 0, "no commands should have returned")
+	require.Empty(t, result, "no commands should have returned")
 }
 
 func testCommandStoreGetByTrigger(t *testing.T, ss store.Store) {
@@ -108,7 +109,7 @@ func testCommandStoreGetByTrigger(t *testing.T, ss store.Store) {
 	require.Nil(t, err)
 
 	_, err = ss.Command().GetByTrigger(o1.TeamId, o1.Trigger)
-	require.NotNil(t, err, "no commnds should have returned")
+	require.NotNil(t, err, "no commands should have returned")
 }
 
 func testCommandStoreDelete(t *testing.T, ss store.Store) {
@@ -212,9 +213,9 @@ func testCommandCount(t *testing.T, ss store.Store) {
 
 	r1, err := ss.Command().AnalyticsCommandCount("")
 	require.Nil(t, err)
-	require.NotEqual(t, r1, 0, "should be at least 1 command")
+	require.NotZero(t, r1, "should be at least 1 command")
 
 	r2, err := ss.Command().AnalyticsCommandCount(o1.TeamId)
 	require.Nil(t, err)
-	require.Equal(t, r2, 1, "should be 1 command")
+	require.Equal(t, r2, int64(1), "should be 1 command")
 }


### PR DESCRIPTION
#### Summary
Modify the calls to `t.Fatal` method to using `require` functions in `store/storetest/command_store.go`

#### Ticket Link
Fixes: #12716 