### PR TITLE
Migrate tests from "api4/terms_of_service_test.go" to use testify

### DIFF
--- a/api4/terms_of_service_test.go
+++ b/api4/terms_of_service_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetTermsOfService(t *testing.T) {
@@ -13,9 +14,7 @@ func TestGetTermsOfService(t *testing.T) {
 	Client := th.Client
 
 	_, err := th.App.CreateTermsOfService("abc", th.BasicUser.Id)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	termsOfService, resp := Client.GetTermsOfService("")
 	CheckNoError(t, resp)


### PR DESCRIPTION
#### Summary
Migrate tests from "api4/terms_of_service_test.go" to use testify

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12789
