### PR TITLE
fix bash to not build webapp when it is already built

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,9 @@ jobs:
           git checkout $CIRCLE_BRANCH || git checkout master
           export WEBAPP_GIT_COMMIT=$(git rev-parse HEAD)
           echo "$WEBAPP_GIT_COMMIT"
-          curl -f -o ./dist.tar.gz https://releases.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz && mkdir ./dist && tar -xvf ./dist.tar.gz -C ./dist --strip-components=1 || echo "curl failed" && export CURL_FAILED=1
+          export CURL_FAILED=0
+          curl -f -o ./dist.tar.gz https://releases.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz && mkdir ./dist && tar -xvf ./dist.tar.gz -C ./dist --strip-components=1 || export CURL_FAILED=1
+
           if [ $CURL_FAILED -eq 1 ]
           then
             npm ci && cd node_modules/mattermost-redux && npm install && npm run build && cd ../.. && make build


### PR DESCRIPTION
#### Summary
when using the `||` in bash you can have just one command in the right side if have more it will always run for some reason that I did not know and did not research

the issue was, if webapp is already built and we download that sucessufuly it always runs the npm install, and we don't want that. this PR fix this