### PR TITLE
GH-12795: Replace t.fatal with testify package functions

### DIFF
--- a/web/context_test.go
+++ b/web/context_test.go
@@ -3,6 +3,8 @@ package web
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRequireHookId(t *testing.T) {
@@ -11,21 +13,14 @@ func TestRequireHookId(t *testing.T) {
 		c.Params = &Params{HookId: "abcdefghijklmnopqrstuvwxyz"}
 		c.RequireHookId()
 
-		if c.Err != nil {
-			t.Fatal("Hook Id is Valid. Should not have set error in context")
-		}
+		require.Nil(t, c.Err, "Hook Id is Valid. Should not have set error in context")
 	})
 
 	t.Run("WhenHookIdIsInvalid", func(t *testing.T) {
 		c.Params = &Params{HookId: "abc"}
 		c.RequireHookId()
 
-		if c.Err == nil {
-			t.Fatal("Should have set Error in context")
-		}
-
-		if c.Err.StatusCode != http.StatusBadRequest {
-			t.Fatal("Should have set status as 400")
-		}
+		require.Error(t, c.Err, "Should have set Error in context")
+		require.Equal(t, http.StatusBadRequest, c.Err.StatusCode, "Should have set status as 400")
 	})
 }


### PR DESCRIPTION
#### Summary
Migrate tests from "web/context_test.go" to use testify

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/12795
