### PR TITLE
Revert 5.17 cherrypick "Trim whitespace of Display Name when channel is created"

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -223,8 +223,6 @@ func (a *App) RenameChannel(channel *model.Channel, newChannelName string, newDi
 }
 
 func (a *App) CreateChannel(channel *model.Channel, addMember bool) (*model.Channel, *model.AppError) {
-	channel.DisplayName = strings.TrimSpace(channel.DisplayName)
-
 	sc, err := a.Srv.Store.Channel().Save(channel, *a.Config().TeamSettings.MaxChannelsPerTeam)
 	if err != nil {
 		return nil, err

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -277,14 +277,6 @@ func TestCreateChannelPrivateCreatesChannelMemberHistoryRecord(t *testing.T) {
 	assert.Equal(t, th.BasicUser.Id, histories[0].UserId)
 	assert.Equal(t, privateChannel.Id, histories[0].ChannelId)
 }
-func TestCreateChannelDisplayNameTrimsWhitespace(t *testing.T) {
-	th := Setup(t).InitBasic()
-	defer th.TearDown()
-
-	channel, err := th.App.CreateChannel(&model.Channel{DisplayName: "  Public 1  ", Name: "public1", Type: model.CHANNEL_OPEN, TeamId: th.BasicTeam.Id}, false)
-	require.Nil(t, err)
-	require.Equal(t, channel.DisplayName, "Public 1")
-}
 
 func TestUpdateChannelPrivacy(t *testing.T) {
 	th := Setup(t).InitBasic()


### PR DESCRIPTION
#### Summary

This change introduces new functionality, and therefore should not be included in the quality release 5.17

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-18831

#### Related Pull Requests

https://github.com/mattermost/mattermost-server/pull/12380
https://github.com/mattermost/mattermost-server/pull/12825

cc @amyblais 