### PR TITLE
MM-19553: Generate valid passwords on bulk import.

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -334,7 +334,7 @@ func (a *App) ImportUser(data *UserImportData, dryRun bool) *model.AppError {
 		authData = nil
 	} else {
 		// If no AuthData or Password is specified, we must generate a password.
-		password = model.NewId()
+		password = model.GeneratePassword(*a.Config().PasswordSettings.MinimumLength)
 		authData = nil
 	}
 

--- a/model/user.go
+++ b/model/user.go
@@ -9,10 +9,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/mattermost/mattermost-server/services/timezones"
@@ -835,4 +837,28 @@ func UsersWithGroupsAndCountFromJson(data io.Reader) *UsersWithGroupsAndCount {
 	bodyBytes, _ := ioutil.ReadAll(data)
 	json.Unmarshal(bodyBytes, uwg)
 	return uwg
+}
+
+var passwordRandomSource = rand.NewSource(time.Now().Unix())
+var passwordSpecialChars = "!$%^&*(),."
+var passwordNumbers = "0123456789"
+var passwordUpperCaseLetters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+var passwordLowerCaseLetters = "abcdefghijklmnopqrstuvwxyz"
+var passwordAllChars = passwordSpecialChars + passwordNumbers + passwordUpperCaseLetters + passwordLowerCaseLetters
+
+func GeneratePassword(minimumLength int) string {
+	r := rand.New(passwordRandomSource)
+
+	// Make sure we are guaranteed at least one of each type to meet any possible password complexity requirements.
+	password := string([]rune(passwordUpperCaseLetters)[r.Intn(len(passwordUpperCaseLetters))]) +
+		string([]rune(passwordNumbers)[r.Intn(len(passwordNumbers))]) +
+		string([]rune(passwordLowerCaseLetters)[r.Intn(len(passwordLowerCaseLetters))]) +
+		string([]rune(passwordSpecialChars)[r.Intn(len(passwordSpecialChars))])
+
+	for len(password) < minimumLength {
+		i := r.Intn(len(passwordAllChars))
+		password = password + string([]rune(passwordAllChars)[i])
+	}
+
+	return password
 }

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"fmt"
+	"math/rand"
 	"net/http"
 	"strings"
 	"testing"
@@ -63,7 +64,7 @@ func TestUserPreSave(t *testing.T) {
 	user.PreSave()
 	user.Etag(true, true)
 	assert.NotNil(t, user.Timezone, "Timezone is nil")
-	assert.Equal(t, user.Timezone["useAutomaticTimezone"], "true", "Timezone is not set to default");
+	assert.Equal(t, user.Timezone["useAutomaticTimezone"], "true", "Timezone is not set to default")
 }
 
 func TestUserPreUpdate(t *testing.T) {
@@ -348,5 +349,27 @@ func TestUserSlice(t *testing.T) {
 
 		nonBotUsers := slice.FilterWithoutBots()
 		assert.Equal(t, 1, len(nonBotUsers))
+	})
+}
+
+func TestGeneratePassword(t *testing.T) {
+	passwordRandomSource = rand.NewSource(12345)
+
+	t.Run("Should be the minimum length or 4, whichever is less", func(t *testing.T) {
+		password1 := GeneratePassword(5)
+		assert.Len(t, password1, 5)
+		password2 := GeneratePassword(10)
+		assert.Len(t, password2, 10)
+		password3 := GeneratePassword(1)
+		assert.Len(t, password3, 4)
+	})
+
+	t.Run("Should contain at least one of symbols, upper case, lower case and numbers", func(t *testing.T) {
+		password := GeneratePassword(4)
+		require.Len(t, password, 4)
+		assert.Contains(t, []rune(passwordUpperCaseLetters), []rune(password)[0])
+		assert.Contains(t, []rune(passwordNumbers), []rune(password)[1])
+		assert.Contains(t, []rune(passwordLowerCaseLetters), []rune(password)[2])
+		assert.Contains(t, []rune(passwordSpecialChars), []rune(password)[3])
 	})
 }


### PR DESCRIPTION
## Summary
This changes the bulk import so when it needs to generate a password
because no password or auth data was supplied, it now takes into account
the configured minimum length, as well as assuming all other distinct
character types are configured to be required. It should now generate
valid passwords regardless of the password policy configuration in the
Mattermost configuration file.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19553