### PR TITLE
Automated cherry pick of #12840

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -39,8 +39,8 @@ func GetCommandProvider(name string) CommandProvider {
 	return nil
 }
 
-func (a *App) CreateCommandPost(post *model.Post, teamId string, response *model.CommandResponse, isCodeBlock bool) (*model.Post, *model.AppError) {
-	if isCodeBlock {
+func (a *App) CreateCommandPost(post *model.Post, teamId string, response *model.CommandResponse, skipSlackParsing bool) (*model.Post, *model.AppError) {
+	if skipSlackParsing {
 		post.Message = response.Text
 	} else {
 		post.Message = model.ParseSlackLinksToMarkdown(response.Text)
@@ -436,15 +436,15 @@ func (a *App) HandleCommandResponsePost(command *model.Command, args *model.Comm
 	}
 
 	// Do not process text if this is a code block
-	isCodeBlock := command.Trigger == "code"
+	skipSlackParsing := command.Trigger == "code"
 
 	// Process Slack text replacements
-	if !isCodeBlock {
+	if !skipSlackParsing {
 		response.Text = a.ProcessSlackText(response.Text)
 		response.Attachments = a.ProcessSlackAttachments(response.Attachments)
 	}
 
-	if _, err := a.CreateCommandPost(post, args.TeamId, response, isCodeBlock); err != nil {
+	if _, err := a.CreateCommandPost(post, args.TeamId, response, skipSlackParsing); err != nil {
 		return post, err
 	}
 

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -68,7 +68,8 @@ func TestCreateCommandPost(t *testing.T) {
 		Text: "some message",
 	}
 
-	_, err := th.App.CreateCommandPost(post, th.BasicTeam.Id, resp)
+	isCodeBlock := false
+	_, err := th.App.CreateCommandPost(post, th.BasicTeam.Id, resp, isCodeBlock)
 	if err == nil || err.Id != "api.context.invalid_param.app_error" {
 		t.Fatal("should have failed - bad post type")
 	}
@@ -205,7 +206,23 @@ func TestHandleCommandResponsePost(t *testing.T) {
 	if err == nil || err.Id != "api.command.command_post.forbidden.app_error" {
 		t.Fatal("should have failed - forbidden channel post")
 	}
+
+	// Test that /code text is not converted with the Slack text conversion.
+	command.Trigger = "code"
+	resp.ChannelId = ""
+	resp.Text = "<test.com|test website>"
+	resp.Attachments = []*model.SlackAttachment{
+		&model.SlackAttachment{
+			Text: "<!here>",
+		},
+	}
+	post, err = th.App.HandleCommandResponsePost(command, args, resp, builtIn)
+
+	assert.Nil(t, err)
+	assert.Equal(t, resp.Text, post.Message, "/code text should not be converted to Slack links")
+	assert.Equal(t, "<!here>", resp.Attachments[0].Text)
 }
+
 func TestHandleCommandResponse(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -68,8 +68,8 @@ func TestCreateCommandPost(t *testing.T) {
 		Text: "some message",
 	}
 
-	isCodeBlock := false
-	_, err := th.App.CreateCommandPost(post, th.BasicTeam.Id, resp, isCodeBlock)
+	skipSlackParsing := false
+	_, err := th.App.CreateCommandPost(post, th.BasicTeam.Id, resp, skipSlackParsing)
 	if err == nil || err.Id != "api.context.invalid_param.app_error" {
 		t.Fatal("should have failed - bad post type")
 	}


### PR DESCRIPTION
Cherry pick of #12840 on release-5.17.

- #12840: text from /code command needs to be treated differently

/cc  @cpoile