### PR TITLE
MM-19574 Don't return metadata for deleted posts

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -87,6 +87,11 @@ func (a *App) PreparePostForClient(originalPost *model.Post, isNewPost bool, isE
 
 	post.Metadata = &model.PostMetadata{}
 
+	if post.DeleteAt > 0 {
+		// Don't fill out metadata for deleted posts
+		return post
+	}
+
 	// Emojis and reaction counts
 	if emojis, reactions, err := a.getEmojisAndReactionsForPost(post); err != nil {
 		mlog.Warn("Failed to get emojis and reactions for a post", mlog.String("post_id", post.Id), mlog.Err(err))


### PR DESCRIPTION
Nothing particularly special here. We just want to stop returning metadata for deleted posts to prevent clients from getting into weird states like https://mattermost.atlassian.net/browse/MM-19507

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19574