### PR TITLE
Include request_id in HTTP request logs

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -72,14 +72,16 @@ type Handler struct {
 
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
-	mlog.Debug("request:", mlog.String("method", r.Method), mlog.String("url", r.URL.Path))
+
+	requestID := model.NewId()
+	mlog.Debug("New HTTP request", mlog.String("method", r.Method), mlog.String("url", r.URL.Path), mlog.String("request_id", requestID))
 
 	c := &Context{}
 	c.App = app.New(
 		h.GetGlobalAppOptions()...,
 	)
 	c.App.T, _ = utils.GetTranslationsAndLocale(w, r)
-	c.App.RequestId = model.NewId()
+	c.App.RequestId = requestID
 	c.App.IpAddress = utils.GetIpAddress(r, c.App.Config().ServiceSettings.TrustedProxyIPHeader)
 	c.App.UserAgent = r.UserAgent()
 	c.App.AcceptLanguage = r.Header.Get("Accept-Language")

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -74,7 +74,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
 
 	requestID := model.NewId()
-	mlog.Debug("New HTTP request", mlog.String("method", r.Method), mlog.String("url", r.URL.Path), mlog.String("request_id", requestID))
+	mlog.Debug("Received HTTP request", mlog.String("method", r.Method), mlog.String("url", r.URL.Path), mlog.String("request_id", requestID))
 
 	c := &Context{}
 	c.App = app.New(


### PR DESCRIPTION
#### Summary
This adds the request_id to the HTTP request logs. I also altered the log message to be more consistent to other log messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19550
