### PR TITLE
migrate test to use testify

### DIFF
--- a/utils/license_test.go
+++ b/utils/license_test.go
@@ -14,26 +14,20 @@ import (
 
 func TestValidateLicense(t *testing.T) {
 	b1 := []byte("junk")
-	if ok, _ := ValidateLicense(b1); ok {
-		t.Fatal("should have failed - bad license")
-	}
+	ok, _ := ValidateLicense(b1)
+	require.False(t, ok, "should have failed - bad license")
 
 	b2 := []byte("junkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunkjunk")
-	if ok, _ := ValidateLicense(b2); ok {
-		t.Fatal("should have failed - bad license")
-	}
+	ok, _ = ValidateLicense(b2)
+	require.False(t, ok, "should have failed - bad license")
 }
 
 func TestGetLicenseFileLocation(t *testing.T) {
 	fileName := GetLicenseFileLocation("")
-	if len(fileName) == 0 {
-		t.Fatal("invalid default file name")
-	}
+	require.NotEqual(t, len(fileName), 0, "invalid default file name")
 
 	fileName = GetLicenseFileLocation("mattermost.mattermost-license")
-	if fileName != "mattermost.mattermost-license" {
-		t.Fatal("invalid file name")
-	}
+	require.Equal(t, fileName, "mattermost.mattermost-license", "invalid file name")
 }
 
 func TestGetLicenseFileFromDisk(t *testing.T) {

--- a/utils/urlencode_test.go
+++ b/utils/urlencode_test.go
@@ -5,6 +5,8 @@ package utils
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestUrlEncode(t *testing.T) {
@@ -12,24 +14,15 @@ func TestUrlEncode(t *testing.T) {
 	toEncode := "testing 1 2 3"
 	encoded := UrlEncode(toEncode)
 
-	if encoded != "testing%201%202%203" {
-		t.Log(encoded)
-		t.Fatal("should be equal")
-	}
+	require.Equal(t, encoded, "testing%201%202%203")
 
 	toEncode = "testing123"
 	encoded = UrlEncode(toEncode)
 
-	if encoded != "testing123" {
-		t.Log(encoded)
-		t.Fatal("should be equal")
-	}
+	require.Equal(t, encoded, "testing123")
 
 	toEncode = "testing$#~123"
 	encoded = UrlEncode(toEncode)
 
-	if encoded != "testing%24%23~123" {
-		t.Log(encoded)
-		t.Fatal("should be equal")
-	}
+	require.Equal(t, encoded, "testing%24%23~123")
 }


### PR DESCRIPTION
Issue #12891 

Summary
Convert utils/license_test.go and utils/urlencode_test.go t.Fatal calls into assert/require calls

Ticket Link
https://mattermost.atlassian.net/browse/MM-19671