### PR TITLE
MM-19670: Migrate tests to use testify (#12883)

### DIFF
--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -24,11 +24,9 @@ func TestYesterday(t *testing.T) {
 	actual := Yesterday()
 	expected := time.Now().AddDate(0, 0, -1)
 
-	assert := assert.New(t)
-
-	assert.Equal(actual.Year(), expected.Year())
-	assert.Equal(actual.Day(), expected.Day())
-	assert.Equal(actual.Month(), expected.Month())
+	assert.Equal(t, actual.Year(), expected.Year())
+	assert.Equal(t, actual.Day(), expected.Day())
+	assert.Equal(t, actual.Month(), expected.Month())
 }
 
 func TestStartOfDay(t *testing.T) {

--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -17,16 +17,16 @@ func TestMillisFromTime(t *testing.T) {
 	actual := MillisFromTime(input)
 	expected := int64(1420115640000)
 
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestYesterday(t *testing.T) {
 	actual := Yesterday()
 	expected := time.Now().AddDate(0, 0, -1)
 
-	assert.Equal(t, actual.Year(), expected.Year())
-	assert.Equal(t, actual.Day(), expected.Day())
-	assert.Equal(t, actual.Month(), expected.Month())
+	assert.Equal(t, expected.Year(), actual.Year())
+	assert.Equal(t, expected.Day(), actual.Day())
+	assert.Equal(t, expected.Month(), actual.Month())
 }
 
 func TestStartOfDay(t *testing.T) {
@@ -34,7 +34,7 @@ func TestStartOfDay(t *testing.T) {
 	actual := StartOfDay(input)
 	expected, _ := time.Parse(format, "2015-01-01 00:00:00.000000000")
 
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }
 
 func TestEndOfDay(t *testing.T) {
@@ -42,5 +42,5 @@ func TestEndOfDay(t *testing.T) {
 	actual := EndOfDay(input)
 	expected, _ := time.Parse(format, "2015-01-01 23:59:59.999999999")
 
-	assert.Equal(t, actual, expected)
+	assert.Equal(t, expected, actual)
 }

--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -6,6 +6,8 @@ package utils
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var format = "2006-01-02 15:04:05.000000000"
@@ -15,18 +17,18 @@ func TestMillisFromTime(t *testing.T) {
 	actual := MillisFromTime(input)
 	expected := int64(1420115640000)
 
-	if actual != expected {
-		t.Fatalf("TestMillisFromTime failed, %v=%v", expected, actual)
-	}
+	assert.Equal(t, actual, expected)
 }
 
 func TestYesterday(t *testing.T) {
 	actual := Yesterday()
 	expected := time.Now().AddDate(0, 0, -1)
 
-	if actual.Year() != expected.Year() || actual.Day() != expected.Day() || actual.Month() != expected.Month() {
-		t.Fatalf("TestYesterday failed, %v=%v", expected, actual)
-	}
+	assert := assert.New(t)
+
+	assert.Equal(actual.Year(), expected.Year())
+	assert.Equal(actual.Day(), expected.Day())
+	assert.Equal(actual.Month(), expected.Month())
 }
 
 func TestStartOfDay(t *testing.T) {
@@ -34,9 +36,7 @@ func TestStartOfDay(t *testing.T) {
 	actual := StartOfDay(input)
 	expected, _ := time.Parse(format, "2015-01-01 00:00:00.000000000")
 
-	if actual != expected {
-		t.Fatalf("TestStartOfDay failed, %v=%v", expected, actual)
-	}
+	assert.Equal(t, actual, expected)
 }
 
 func TestEndOfDay(t *testing.T) {
@@ -44,7 +44,5 @@ func TestEndOfDay(t *testing.T) {
 	actual := EndOfDay(input)
 	expected, _ := time.Parse(format, "2015-01-01 23:59:59.999999999")
 
-	if actual != expected {
-		t.Fatalf("TestEndOfDay failed, %v=%v", expected, actual)
-	}
+	assert.Equal(t, actual, expected)
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -46,7 +46,7 @@ func TestStringSliceDiff(t *testing.T) {
 	b := []string{"two", "seven", "four", "six"}
 	expected := []string{"one", "three", "five"}
 
-	assert.Equal(t, StringSliceDiff(a, b), expected)
+	assert.Equal(t, expected, StringSliceDiff(a, b))
 }
 
 func TestGetIpAddress(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -23,13 +23,10 @@ func TestStringArrayIntersection(t *testing.T) {
 		"def",
 	}
 
-	if len(StringArrayIntersection(a, b)) != 0 {
-		t.Fatal("should be 0")
-	}
+	assert := assert.New(t)
 
-	if len(StringArrayIntersection(a, c)) != 1 {
-		t.Fatal("should be 1")
-	}
+	assert.Equal(len(StringArrayIntersection(a, b)), 0)
+	assert.Equal(len(StringArrayIntersection(a, c)), 1)
 }
 
 func TestRemoveDuplicatesFromStringArray(t *testing.T) {
@@ -43,9 +40,7 @@ func TestRemoveDuplicatesFromStringArray(t *testing.T) {
 		"a",
 	}
 
-	if len(RemoveDuplicatesFromStringArray(a)) != 3 {
-		t.Fatal("should be 3")
-	}
+	assert.Equal(t, len(RemoveDuplicatesFromStringArray(a)), 3)
 }
 
 func TestStringSliceDiff(t *testing.T) {
@@ -57,6 +52,7 @@ func TestStringSliceDiff(t *testing.T) {
 }
 
 func TestGetIpAddress(t *testing.T) {
+	assert := assert.New(t)
 	// Test with a single IP in the X-Forwarded-For
 	httpRequest1 := http.Request{
 		Header: http.Header{
@@ -66,7 +62,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.0.0.1", GetIpAddress(&httpRequest1, []string{"X-Forwarded-For"}))
+	assert.Equal("10.0.0.1", GetIpAddress(&httpRequest1, []string{"X-Forwarded-For"}))
 
 	// Test with multiple IPs in the X-Forwarded-For
 	httpRequest2 := http.Request{
@@ -77,7 +73,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.0.0.1", GetIpAddress(&httpRequest2, []string{"X-Forwarded-For"}))
+	assert.Equal("10.0.0.1", GetIpAddress(&httpRequest2, []string{"X-Forwarded-For"}))
 
 	// Test with an empty X-Forwarded-For
 	httpRequest3 := http.Request{
@@ -88,7 +84,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest3, []string{"X-Forwarded-For", "X-Real-Ip"}))
+	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest3, []string{"X-Forwarded-For", "X-Real-Ip"}))
 
 	// Test without an X-Fowarded-For
 	httpRequest4 := http.Request{
@@ -98,14 +94,14 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest4, []string{"X-Forwarded-For", "X-Real-Ip"}))
+	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest4, []string{"X-Forwarded-For", "X-Real-Ip"}))
 
 	// Test without any headers
 	httpRequest5 := http.Request{
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.2.0.1", GetIpAddress(&httpRequest5, []string{"X-Forwarded-For", "X-Real-Ip"}))
+	assert.Equal("10.2.0.1", GetIpAddress(&httpRequest5, []string{"X-Forwarded-For", "X-Real-Ip"}))
 
 	// Test with both headers, but both untrusted
 	httpRequest6 := http.Request{
@@ -116,7 +112,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.2.0.1", GetIpAddress(&httpRequest6, nil))
+	assert.Equal("10.2.0.1", GetIpAddress(&httpRequest6, nil))
 
 	// Test with both headers, but only X-Real-Ip trusted
 	httpRequest7 := http.Request{
@@ -127,7 +123,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest7, []string{"X-Real-Ip"}))
+	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest7, []string{"X-Real-Ip"}))
 
 	// Test with X-Forwarded-For, comma separated, untrusted
 	httpRequest8 := http.Request{
@@ -137,7 +133,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.2.0.1", GetIpAddress(&httpRequest8, nil))
+	assert.Equal("10.2.0.1", GetIpAddress(&httpRequest8, nil))
 
 	// Test with X-Forwarded-For, comma separated, untrusted
 	httpRequest9 := http.Request{
@@ -147,7 +143,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.3.0.1", GetIpAddress(&httpRequest9, []string{"X-Forwarded-For"}))
+	assert.Equal("10.3.0.1", GetIpAddress(&httpRequest9, []string{"X-Forwarded-For"}))
 
 	// Test with both headers, both allowed, first one in trusted used
 	httpRequest10 := http.Request{
@@ -158,5 +154,5 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest10, []string{"X-Real-Ip", "X-Forwarded-For"}))
+	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest10, []string{"X-Real-Ip", "X-Forwarded-For"}))
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -23,10 +23,8 @@ func TestStringArrayIntersection(t *testing.T) {
 		"def",
 	}
 
-	assert := assert.New(t)
-
-	assert.Equal(len(StringArrayIntersection(a, b)), 0)
-	assert.Equal(len(StringArrayIntersection(a, c)), 1)
+	assert.Len(t, StringArrayIntersection(a, b), 0)
+	assert.Len(t, StringArrayIntersection(a, c), 1)
 }
 
 func TestRemoveDuplicatesFromStringArray(t *testing.T) {
@@ -40,7 +38,7 @@ func TestRemoveDuplicatesFromStringArray(t *testing.T) {
 		"a",
 	}
 
-	assert.Equal(t, len(RemoveDuplicatesFromStringArray(a)), 3)
+	assert.Len(t, RemoveDuplicatesFromStringArray(a), 3)
 }
 
 func TestStringSliceDiff(t *testing.T) {
@@ -52,7 +50,6 @@ func TestStringSliceDiff(t *testing.T) {
 }
 
 func TestGetIpAddress(t *testing.T) {
-	assert := assert.New(t)
 	// Test with a single IP in the X-Forwarded-For
 	httpRequest1 := http.Request{
 		Header: http.Header{
@@ -62,7 +59,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.0.0.1", GetIpAddress(&httpRequest1, []string{"X-Forwarded-For"}))
+	assert.Equal(t, "10.0.0.1", GetIpAddress(&httpRequest1, []string{"X-Forwarded-For"}))
 
 	// Test with multiple IPs in the X-Forwarded-For
 	httpRequest2 := http.Request{
@@ -73,7 +70,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.0.0.1", GetIpAddress(&httpRequest2, []string{"X-Forwarded-For"}))
+	assert.Equal(t, "10.0.0.1", GetIpAddress(&httpRequest2, []string{"X-Forwarded-For"}))
 
 	// Test with an empty X-Forwarded-For
 	httpRequest3 := http.Request{
@@ -84,7 +81,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest3, []string{"X-Forwarded-For", "X-Real-Ip"}))
+	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest3, []string{"X-Forwarded-For", "X-Real-Ip"}))
 
 	// Test without an X-Fowarded-For
 	httpRequest4 := http.Request{
@@ -94,14 +91,14 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest4, []string{"X-Forwarded-For", "X-Real-Ip"}))
+	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest4, []string{"X-Forwarded-For", "X-Real-Ip"}))
 
 	// Test without any headers
 	httpRequest5 := http.Request{
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.2.0.1", GetIpAddress(&httpRequest5, []string{"X-Forwarded-For", "X-Real-Ip"}))
+	assert.Equal(t, "10.2.0.1", GetIpAddress(&httpRequest5, []string{"X-Forwarded-For", "X-Real-Ip"}))
 
 	// Test with both headers, but both untrusted
 	httpRequest6 := http.Request{
@@ -112,7 +109,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.2.0.1", GetIpAddress(&httpRequest6, nil))
+	assert.Equal(t, "10.2.0.1", GetIpAddress(&httpRequest6, nil))
 
 	// Test with both headers, but only X-Real-Ip trusted
 	httpRequest7 := http.Request{
@@ -123,7 +120,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest7, []string{"X-Real-Ip"}))
+	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest7, []string{"X-Real-Ip"}))
 
 	// Test with X-Forwarded-For, comma separated, untrusted
 	httpRequest8 := http.Request{
@@ -133,7 +130,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.2.0.1", GetIpAddress(&httpRequest8, nil))
+	assert.Equal(t, "10.2.0.1", GetIpAddress(&httpRequest8, nil))
 
 	// Test with X-Forwarded-For, comma separated, untrusted
 	httpRequest9 := http.Request{
@@ -143,7 +140,7 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.3.0.1", GetIpAddress(&httpRequest9, []string{"X-Forwarded-For"}))
+	assert.Equal(t, "10.3.0.1", GetIpAddress(&httpRequest9, []string{"X-Forwarded-For"}))
 
 	// Test with both headers, both allowed, first one in trusted used
 	httpRequest10 := http.Request{
@@ -154,5 +151,5 @@ func TestGetIpAddress(t *testing.T) {
 		RemoteAddr: "10.2.0.1:12345",
 	}
 
-	assert.Equal("10.1.0.1", GetIpAddress(&httpRequest10, []string{"X-Real-Ip", "X-Forwarded-For"}))
+	assert.Equal(t, "10.1.0.1", GetIpAddress(&httpRequest10, []string{"X-Real-Ip", "X-Forwarded-For"}))
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrate tests from "utils/time_test.go" and "utils/utils_test.go" to use testify

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixed https://github.com/mattermost/mattermost-server/issues/12883