### PR TITLE
use the branch to tag the docker image and also build team edition

### DIFF
--- a/build/Jenkinsfile.branch
+++ b/build/Jenkinsfile.branch
@@ -124,9 +124,28 @@ pipeline {
           withCredentials([usernamePassword(credentialsId: 'matterbuild-docker-hub', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
             sh 'docker login --username ${DOCKER_USER} --password ${DOCKER_PASS}'
             sh """
-            export TAG='${env.BRANCH_NAME}.${env.BUILD_NUMBER}.${SERVER_GIT_COMMIT}'
+            export TAG='${env.BRANCH_NAME}'
             docker build --no-cache --build-arg MM_PACKAGE=https://releases.mattermost.com/mattermost-platform/${env.BRANCH_NAME}/mattermost-enterprise-linux-amd64.tar.gz -t mattermost/mattermost-enterprise-edition:\${TAG} build
             docker push mattermost/mattermost-enterprise-edition:\${TAG}
+            docker logout
+            """
+          }
+        }
+      }
+    }
+
+    stage ('Build Docker mattermost-team-edition') {
+      agent {
+        label 'default-mm-builder'
+      }
+      steps {
+        dir('src/github.com/mattermost/mattermost-server') {
+          withCredentials([usernamePassword(credentialsId: 'matterbuild-docker-hub', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
+            sh 'docker login --username ${DOCKER_USER} --password ${DOCKER_PASS}'
+            sh """
+            export TAG='${env.BRANCH_NAME}'
+            docker build --no-cache --build-arg MM_PACKAGE=https://releases.mattermost.com/mattermost-platform/${env.BRANCH_NAME}/mattermost-team-linux-amd64.tar.gz -t mattermost/mattermost-team-edition:\${TAG} build
+            docker push mattermost/mattermost-team-edition:\${TAG}
             docker logout
             """
           }


### PR DESCRIPTION
#### Summary
update to use the branch name only to make a bit easier to use in mattermod and also make the docker hub a bit cleaner.

also add a stage to build the team edition as well

#### Ticket Link
Part of this Jira: https://mattermost.atlassian.net/browse/MM-18865
