### PR TITLE
[MM-19664] Migrate tests from api4/status_test.go to testify

### DIFF
--- a/api4/status_test.go
+++ b/api4/status_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetUserStatus(t *testing.T) {
@@ -13,44 +14,32 @@ func TestGetUserStatus(t *testing.T) {
 
 	userStatus, resp := Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
-	if userStatus.Status != "offline" {
-		t.Fatal("Should return offline status")
-	}
+	assert.Equal(t, "offline", userStatus.Status)
 
 	th.App.SetStatusOnline(th.BasicUser.Id, true)
 	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
-	if userStatus.Status != "online" {
-		t.Fatal("Should return online status")
-	}
+	assert.Equal(t, "online", userStatus.Status)
 
 	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
 	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
-	if userStatus.Status != "away" {
-		t.Fatal("Should return away status")
-	}
+	assert.Equal(t, "away", userStatus.Status)
 
 	th.App.SetStatusDoNotDisturb(th.BasicUser.Id)
 	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
-	if userStatus.Status != "dnd" {
-		t.Fatal("Should return dnd status")
-	}
+	assert.Equal(t, "dnd", userStatus.Status)
 
 	th.App.SetStatusOffline(th.BasicUser.Id, true)
 	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
 	CheckNoError(t, resp)
-	if userStatus.Status != "offline" {
-		t.Fatal("Should return offline status")
-	}
+	assert.Equal(t, "offline", userStatus.Status)
 
 	//Get user2 status logged as user1
 	userStatus, resp = Client.GetUserStatus(th.BasicUser2.Id, "")
 	CheckNoError(t, resp)
-	if userStatus.Status != "offline" {
-		t.Fatal("Should return offline status")
-	}
+	assert.Equal(t, "offline", userStatus.Status)
 
 	Client.Logout()
 
@@ -60,9 +49,7 @@ func TestGetUserStatus(t *testing.T) {
 	th.LoginBasic2()
 	userStatus, resp = Client.GetUserStatus(th.BasicUser2.Id, "")
 	CheckNoError(t, resp)
-	if userStatus.Status != "offline" {
-		t.Fatal("Should return offline status")
-	}
+	assert.Equal(t, "offline", userStatus.Status)
 }
 
 func TestGetUsersStatusesByIds(t *testing.T) {
@@ -75,9 +62,7 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 	usersStatuses, resp := Client.GetUsersStatusesByIds(usersIds)
 	CheckNoError(t, resp)
 	for _, userStatus := range usersStatuses {
-		if userStatus.Status != "offline" {
-			t.Fatal("Status should be offline")
-		}
+		assert.Equal(t, "offline", userStatus.Status)
 	}
 
 	th.App.SetStatusOnline(th.BasicUser.Id, true)
@@ -85,9 +70,7 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
 	CheckNoError(t, resp)
 	for _, userStatus := range usersStatuses {
-		if userStatus.Status != "online" {
-			t.Fatal("Status should be offline")
-		}
+		assert.Equal(t, "online", userStatus.Status)
 	}
 
 	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
@@ -95,9 +78,7 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
 	CheckNoError(t, resp)
 	for _, userStatus := range usersStatuses {
-		if userStatus.Status != "away" {
-			t.Fatal("Status should be offline")
-		}
+		assert.Equal(t, "away", userStatus.Status)
 	}
 
 	th.App.SetStatusDoNotDisturb(th.BasicUser.Id)
@@ -105,9 +86,7 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
 	CheckNoError(t, resp)
 	for _, userStatus := range usersStatuses {
-		if userStatus.Status != "dnd" {
-			t.Fatal("Status should be offline")
-		}
+		assert.Equal(t, "dnd", userStatus.Status)
 	}
 
 	Client.Logout()
@@ -124,30 +103,22 @@ func TestUpdateUserStatus(t *testing.T) {
 	toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser.Id}
 	updateUserStatus, resp := Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
 	CheckNoError(t, resp)
-	if updateUserStatus.Status != "online" {
-		t.Fatal("Should return online status")
-	}
+	assert.Equal(t, "online", updateUserStatus.Status)
 
 	toUpdateUserStatus.Status = "away"
 	updateUserStatus, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
 	CheckNoError(t, resp)
-	if updateUserStatus.Status != "away" {
-		t.Fatal("Should return away status")
-	}
+	assert.Equal(t, "away", updateUserStatus.Status)
 
 	toUpdateUserStatus.Status = "dnd"
 	updateUserStatus, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
 	CheckNoError(t, resp)
-	if updateUserStatus.Status != "dnd" {
-		t.Fatal("Should return dnd status")
-	}
+	assert.Equal(t, "dnd", updateUserStatus.Status)
 
 	toUpdateUserStatus.Status = "offline"
 	updateUserStatus, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
 	CheckNoError(t, resp)
-	if updateUserStatus.Status != "offline" {
-		t.Fatal("Should return offline status")
-	}
+	assert.Equal(t, "offline", updateUserStatus.Status)
 
 	toUpdateUserStatus.Status = "online"
 	toUpdateUserStatus.UserId = th.BasicUser2.Id
@@ -156,9 +127,7 @@ func TestUpdateUserStatus(t *testing.T) {
 
 	toUpdateUserStatus.Status = "online"
 	updateUserStatus, _ = th.SystemAdminClient.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
-	if updateUserStatus.Status != "online" {
-		t.Fatal("Should return online status")
-	}
+	assert.Equal(t, "online", updateUserStatus.Status)
 
 	_, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
 	CheckBadRequestStatus(t, resp)


### PR DESCRIPTION
#### Summary
This PR replaces the `t.Fatal` calls with `testify` helper calls.

#### Ticket Link
https://github.com/mattermost/mattermost-server/issues/12889