### PR TITLE
[MM-19344] add option to render latex

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -300,6 +300,7 @@ func (a *App) trackConfig() {
 		"disable_bots_when_owner_is_deactivated":                  *cfg.ServiceSettings.DisableBotsWhenOwnerIsDeactivated,
 		"enable_bot_account_creation":                             *cfg.ServiceSettings.EnableBotAccountCreation,
 		"enable_svgs":                                             *cfg.ServiceSettings.EnableSVGs,
+		"enable_latex":                                            *cfg.ServiceSettings.EnableLatex,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{

--- a/config/client.go
+++ b/config/client.go
@@ -44,6 +44,7 @@ func GenerateClientConfig(c *model.Config, diagnosticId string, license *model.L
 	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
 	props["EnableSVGs"] = strconv.FormatBool(*c.ServiceSettings.EnableSVGs)
 	props["EnableMarketplace"] = strconv.FormatBool(*c.PluginSettings.EnableMarketplace)
+	props["EnableLatex"] = strconv.FormatBool(*c.ServiceSettings.EnableLatex)
 
 	// This setting is only temporary, so keep using the old setting name for the mobile and web apps
 	props["ExperimentalEnablePostMetadata"] = "true"

--- a/model/config.go
+++ b/model/config.go
@@ -325,6 +325,7 @@ type ServiceSettings struct {
 	DisableBotsWhenOwnerIsDeactivated                 *bool `restricted:"true"`
 	EnableBotAccountCreation                          *bool
 	EnableSVGs                                        *bool
+	EnableLatex                                       *bool
 }
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {
@@ -687,6 +688,14 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 			s.EnableSVGs = NewBool(true)
 		} else {
 			s.EnableSVGs = NewBool(false)
+		}
+	}
+
+	if s.EnableLatex == nil {
+		if isUpdate {
+			s.EnableLatex = NewBool(true)
+		} else {
+			s.EnableLatex = NewBool(false)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
Add new setting to console to enable/disable rendering of latex code. When rendering is disable it'll do syntax highlighting. By default is set to false. This way it should prevent the app from crashing when sharing code that might outgrow assigned memory.

#### Ticket Link

[MM-19344](https://mattermost.atlassian.net/browse/MM-19344)
