### PR TITLE
Unbinding the permission INVITE_GUEST from INVITE_USER

### DIFF
--- a/app/permissions_migrations.go
+++ b/app/permissions_migrations.go
@@ -282,11 +282,7 @@ func getAddManageGuestsPermissionsMigration() permissionsMap {
 	return permissionsMap{
 		permissionTransformation{
 			On:  isRole(model.SYSTEM_ADMIN_ROLE_ID),
-			Add: []string{PERMISSION_PROMOTE_GUEST, PERMISSION_DEMOTE_TO_GUEST},
-		},
-		permissionTransformation{
-			On:  permissionExists(PERMISSION_INVITE_USER),
-			Add: []string{PERMISSION_INVITE_GUEST},
+			Add: []string{PERMISSION_PROMOTE_GUEST, PERMISSION_DEMOTE_TO_GUEST, PERMISSION_INVITE_GUEST},
 		},
 	}
 }


### PR DESCRIPTION
#### Summary
Now `INVITE_GUEST` permissions is only given to system admin, before of that
was given to any user with `INVITE_USER` permission during the migration
execution.

#### Ticket Link
[MM-19684](https://mattermost.atlassian.net/browse/MM-19684)