### PR TITLE
MM-19172: Add golangci-lint to the CI pipeline

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+
+linters:
+  disable-all: true
+  enable:
+    - unused
+    - gosimple
+    - structcheck
+    - varcheck
+    - ineffassign
+    - deadcode
+    - unconvert
+    # TODO: enable these later
+    # - govet
+    # - gofmt
+    # - errcheck
+    # - staticcheck
+    # - unparam
+
+issues:
+  exclude-rules:
+    - linters:
+      # ignore warnings to simplify v, _ := to v :=
+      - gosimple
+      text: "S1005:"
+
+    - linters:
+      # ignore unused warnings from enterprise code
+      # add more as required.
+      - unused
+      text: "RedisSupplier|LocalCacheSupplier|Enterprise"
+
+  # TODO: slowly remove all warnings from the codebase and remove this.
+  new-from-rev: HEAD~

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,7 @@
+run:
+  timeout: 5m
+  modules-download-mode: vendor
+
 linters-settings:
   govet:
     check-shadowing: true
@@ -5,32 +9,22 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - unused
-    - gosimple
-    - structcheck
-    - varcheck
-    - ineffassign
     - deadcode
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - structcheck
     - unconvert
-    # TODO: enable these later
-    # - govet
-    # - gofmt
+    - unused
+    - varcheck
+    # TODO: enable this later
     # - errcheck
-    # - staticcheck
-    # - unparam
 
 issues:
   exclude-rules:
-    - linters:
-      # ignore warnings to simplify v, _ := to v :=
-      - gosimple
-      text: "S1005:"
-
     - linters:
       # ignore unused warnings from enterprise code
       # add more as required.
       - unused
       text: "RedisSupplier|LocalCacheSupplier|Enterprise"
-
-  # TODO: slowly remove all warnings from the codebase and remove this.
-  new-from-rev: HEAD~

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,18 @@ gofmt: ## Runs gofmt against all packages.
 	done
 	@echo "gofmt success"; \
 
+golangci-lint:
+# https://stackoverflow.com/a/677212/1027058 (check if a command exists or not)
+# https://github.com/golangci/golangci-lint#binary-release
+# It is recommended to NOT use go get, but instead use a binary release pinned to a version.
+	@if ! [ -x "$$(command -v golangci-lint)" ]; then \
+		echo "Installing golangci-lint"; \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.21.0; \
+	fi; \
+
+	@echo Running golangci-lint
+	$(GOPATH)/bin/golangci-lint run --timeout=5m
+
 megacheck: ## Run megacheck on codebasis
 	env GO111MODULE=off go get -u honnef.co/go/tools/cmd/megacheck
 	$(GOPATH)/bin/megacheck $(TE_PACKAGES)
@@ -219,7 +231,8 @@ check-licenses: ## Checks license status.
 check-prereqs: ## Checks prerequisite software status.
 	./scripts/prereq-check.sh
 
-check-style: govet gofmt check-licenses ## Runs govet and gofmt against all packages.
+# TODO: move govet and gofmt checks inside golangci-lint once it starts running without --new-from-rev.
+check-style: govet gofmt golangci-lint check-licenses ## Runs govet, gofmt and golangci-lint against all packages.
 
 test-te-race: ## Checks for race conditions in the team edition.
 	@echo Testing TE race conditions

--- a/Makefile
+++ b/Makefile
@@ -178,12 +178,12 @@ golangci-lint:
 # https://github.com/golangci/golangci-lint#binary-release
 # It is recommended to NOT use go get, but instead use a binary release pinned to a version.
 	@if ! [ -x "$$(command -v golangci-lint)" ]; then \
-		echo "Installing golangci-lint"; \
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.21.0; \
+		echo "golangci-lint is not installed. Please run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.21.0"; \
+		exit 1; \
 	fi; \
 
 	@echo Running golangci-lint
-	$(GOPATH)/bin/golangci-lint run --timeout=5m
+	$(GOPATH)/bin/golangci-lint run
 
 megacheck: ## Run megacheck on codebasis
 	env GO111MODULE=off go get -u honnef.co/go/tools/cmd/megacheck
@@ -231,8 +231,8 @@ check-licenses: ## Checks license status.
 check-prereqs: ## Checks prerequisite software status.
 	./scripts/prereq-check.sh
 
-# TODO: move govet and gofmt checks inside golangci-lint once it starts running without --new-from-rev.
-check-style: govet gofmt golangci-lint check-licenses ## Runs govet, gofmt and golangci-lint against all packages.
+# TODO: remove govet and gofmt checks once golangci-lint is being enforced.
+check-style: govet gofmt check-licenses ## Runs govet and gofmt against all packages.
 
 test-te-race: ## Checks for race conditions in the team edition.
 	@echo Testing TE race conditions


### PR DESCRIPTION
#### Summary
To start off with, we are using the new-from-rev=HEAD~ option which just checks the current
commit. This allows us to quickly integrate golangci-lint and not spend time in fixing all the
outstanding issues.

Things pending:
- Slowly fix the existing issues. To test them, just uncomment the "new-from-rev: HEAD~" line
from .golangci.yml and have at it.
- There are a number of unused functions and methods which are only invoked from enterprise code.
We are ignoring them for now because removing them will stop enterprise build from working.
  The correct solution here is to use a build tag to separate TE and EE code. As a long term goal,
we would want to use that build tag throughout the EE codebase and remove the `TE_PACKAGES` and `EE_PACKAGES` variables in the Makefile and just use the build tag. That makes things a lot cleaner and avoids the need to spawn a "go list" every time to get the correct list of packages.


#### Ticket Link
[MM-19172](https://mattermost.atlassian.net/browse/MM-19172)