### PR TITLE
license, openGraph tests: convert to testify

### DIFF
--- a/api4/license_test.go
+++ b/api4/license_test.go
@@ -26,13 +26,13 @@ func TestGetOldClientLicense(t *testing.T) {
 
 	_, err := Client.DoApiGet("/license/client", "")
 	require.Error(t, err, "get /license/client did not return an error")
-	require.Equalf(t, err.StatusCode, http.StatusNotImplemented,
-		"expected 501 Not Implemented, got %v", err.StatusCode)
+	require.Equal(t, err.StatusCode, http.StatusNotImplemented,
+		"expected 501 Not Implemented")
 
 	_, err = Client.DoApiGet("/license/client?format=junk", "")
 	require.Error(t, err, "get /license/client?format=junk did not return an error")
-	require.Equalf(t, err.StatusCode, http.StatusBadRequest,
-		"expected 400 Bad Request, got %v", err.StatusCode)
+	require.Equal(t, err.StatusCode, http.StatusBadRequest,
+		"expected 400 Bad Request")
 
 	license, resp = th.SystemAdminClient.GetOldClientLicense("")
 	CheckNoError(t, resp)

--- a/api4/license_test.go
+++ b/api4/license_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -15,22 +17,22 @@ func TestGetOldClientLicense(t *testing.T) {
 	license, resp := Client.GetOldClientLicense("")
 	CheckNoError(t, resp)
 
-	if len(license["IsLicensed"]) == 0 {
-		t.Fatal("license not returned correctly")
-	}
+	require.NotEqual(t, license["IsLicensed"], 0, "license not returned correctly")
 
 	Client.Logout()
 
 	_, resp = Client.GetOldClientLicense("")
 	CheckNoError(t, resp)
 
-	if _, err := Client.DoApiGet("/license/client", ""); err == nil || err.StatusCode != http.StatusNotImplemented {
-		t.Fatal("should have errored with 501")
-	}
+	_, err := Client.DoApiGet("/license/client", "")
+	require.Error(t, err, "get /license/client did not return an error")
+	require.Equalf(t, err.StatusCode, http.StatusNotImplemented,
+		"expected 501 Not Implemented, got %v", err.StatusCode)
 
-	if _, err := Client.DoApiGet("/license/client?format=junk", ""); err == nil || err.StatusCode != http.StatusBadRequest {
-		t.Fatal("should have errored with 400")
-	}
+	_, err = Client.DoApiGet("/license/client?format=junk", "")
+	require.Error(t, err, "get /license/client?format=junk did not return an error")
+	require.Equalf(t, err.StatusCode, http.StatusBadRequest,
+		"expected 400 Bad Request, got %v", err.StatusCode)
 
 	license, resp = th.SystemAdminClient.GetOldClientLicense("")
 	CheckNoError(t, resp)

--- a/api4/license_test.go
+++ b/api4/license_test.go
@@ -17,7 +17,7 @@ func TestGetOldClientLicense(t *testing.T) {
 	license, resp := Client.GetOldClientLicense("")
 	CheckNoError(t, resp)
 
-	require.NotEqual(t, license["IsLicensed"], 0, "license not returned correctly")
+	require.NotEqual(t, license["IsLicensed"], "", "license not returned correctly")
 
 	Client.Logout()
 

--- a/api4/openGraph_test.go
+++ b/api4/openGraph_test.go
@@ -63,12 +63,10 @@ func TestGetOpenGraphMetadata(t *testing.T) {
 		CheckNoError(t, resp)
 
 		require.Equalf(t, openGraph["title"], data["title"].(string),
-			"OG data title mismatch for path \"%s\". Expected title: \"%s\". Actual title: \"%s\"",
-			data["path"].(string), data["title"].(string), openGraph["title"])
+			"OG data title mismatch for path \"%s\".")
 
-		require.Equalf(t, ogDataCacheMissCount, data["cacheMissCount"].(int),
-			"Cache miss count didn't match. Expected value %d. Actual value %d.",
-			data["cacheMissCount"].(int), ogDataCacheMissCount)
+		require.Equal(t, ogDataCacheMissCount, data["cacheMissCount"].(int),
+			"Cache miss count didn't match.")
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableLinkPreviews = false })

--- a/api4/openGraph_test.go
+++ b/api4/openGraph_test.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/model"
 )
@@ -61,19 +61,14 @@ func TestGetOpenGraphMetadata(t *testing.T) {
 
 		openGraph, resp := Client.OpenGraph(ts.URL + data["path"].(string))
 		CheckNoError(t, resp)
-		if strings.Compare(openGraph["title"], data["title"].(string)) != 0 {
-			t.Fatal(fmt.Sprintf(
-				"OG data title mismatch for path \"%s\". Expected title: \"%s\". Actual title: \"%s\"",
-				data["path"].(string), data["title"].(string), openGraph["title"],
-			))
-		}
 
-		if ogDataCacheMissCount != data["cacheMissCount"].(int) {
-			t.Fatal(fmt.Sprintf(
-				"Cache miss count didn't match. Expected value %d. Actual value %d.",
-				data["cacheMissCount"].(int), ogDataCacheMissCount,
-			))
-		}
+		require.Equalf(t, openGraph["title"], data["title"].(string),
+			"OG data title mismatch for path \"%s\". Expected title: \"%s\". Actual title: \"%s\"",
+			data["path"].(string), data["title"].(string), openGraph["title"])
+
+		require.Equalf(t, ogDataCacheMissCount, data["cacheMissCount"].(int),
+			"Cache miss count didn't match. Expected value %d. Actual value %d.",
+			data["cacheMissCount"].(int), ogDataCacheMissCount)
 	}
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableLinkPreviews = false })


### PR DESCRIPTION
#### Summary
Update `api4/license_test.go` and `api4/openGraph_test.go` to use `testify`.

#### Ticket Link
Fixes #12860 
[MM-19625](https://mattermost.atlassian.net/browse/MM-19625)