### PR TITLE
Remove unused struct fields

### DIFF
--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -29,7 +29,6 @@ type PushNotificationsHub struct {
 }
 
 type PushNotification struct {
-	id                 string
 	notificationType   NotificationType
 	currentSessionId   string
 	userId             string

--- a/cmd/mattermost/commands/server_test.go
+++ b/cmd/mattermost/commands/server_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 type ServerTestHelper struct {
-	configStore        config.Store
 	disableConfigWatch bool
 	interruptChan      chan os.Signal
 	originalInterval   int


### PR DESCRIPTION
#### Summary
This PR removes unused struct fields. There where found via `structcheck`. Fixing this issue is part of the afford to fix all problems found by `golangci-lint`.

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-server/pull/12909