### PR TITLE
Run ineffassign against codebase

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2507,6 +2507,7 @@ func TestRemoveChannelMember(t *testing.T) {
 		// Setup the system administrator to listen for websocket events from the channels.
 		th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
 		_, err := th.App.AddUserToChannel(th.SystemAdminUser, th.BasicChannel)
+		require.Nil(t, err)
 		_, err = th.App.AddUserToChannel(th.SystemAdminUser, th.BasicChannel2)
 		require.Nil(t, err)
 		props := map[string]string{}

--- a/app/migrations.go
+++ b/app/migrations.go
@@ -95,9 +95,9 @@ func (a *App) DoEmojisPermissionsMigration() {
 		return
 	}
 
-	var role *model.Role = nil
-	var systemAdminRole *model.Role = nil
-	var err *model.AppError = nil
+	var role *model.Role
+	var systemAdminRole *model.Role
+	var err *model.AppError
 
 	mlog.Info("Migrating emojis config to database.")
 	switch *a.Config().ServiceSettings.DEPRECATED_DO_NOT_USE_RestrictCustomEmojiCreation {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -186,7 +186,6 @@ func TestConfigIsValidFakeAlgorithm(t *testing.T) {
 	require.Equal(t, "model.config.is_valid.saml_digest_algorithm.app_error", err.Message)
 	*c1.SamlSettings.DigestAlgorithm = temp
 
-	temp = *c1.SamlSettings.SignatureAlgorithm
 	*c1.SamlSettings.SignatureAlgorithm = "Fake Algorithm"
 	err = c1.SamlSettings.isValid()
 	if err == nil {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1346,7 +1346,6 @@ func (s *SqlPostStore) GetOldest() (*model.Post, *model.AppError) {
 }
 
 func (s *SqlPostStore) determineMaxPostSize() int {
-	var maxPostSize int = model.POST_MESSAGE_MAX_RUNES_V1
 	var maxPostSizeBytes int32
 
 	if s.DriverName() == model.DATABASE_DRIVER_POSTGRES {
@@ -1384,7 +1383,7 @@ func (s *SqlPostStore) determineMaxPostSize() int {
 	}
 
 	// Assume a worst-case representation of four bytes per rune.
-	maxPostSize = int(maxPostSizeBytes) / 4
+	maxPostSize := int(maxPostSizeBytes) / 4
 
 	// To maintain backwards compatibility, don't yield a maximum post
 	// size smaller than the previous limit, even though it wasn't

--- a/store/sqlstore/supplier.go
+++ b/store/sqlstore/supplier.go
@@ -699,7 +699,7 @@ func (ss *SqlSupplier) AlterColumnDefaultIfExists(tableName string, columnName s
 		return false
 	}
 
-	var defaultValue = ""
+	var defaultValue string
 	if ss.DriverName() == model.DATABASE_DRIVER_MYSQL {
 		// Some column types in MySQL cannot have defaults, so don't try to configure anything.
 		if mySqlColDefault == nil {

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1267,7 +1267,7 @@ func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string
 func (us SqlUserStore) performSearch(query sq.SelectBuilder, term string, options *model.UserSearchOptions) ([]*model.User, *model.AppError) {
 	term = sanitizeSearchTerm(term, "*")
 
-	searchType := USER_SEARCH_TYPE_NAMES_NO_FULL_NAME
+	var searchType []string
 	if options.AllowEmails {
 		if options.AllowFullNames {
 			searchType = USER_SEARCH_TYPE_ALL

--- a/utils/merge_test.go
+++ b/utils/merge_test.go
@@ -513,7 +513,8 @@ func TestMergeWithSlices(t *testing.T) {
 		assert.Equal(t, expected, merged)
 		// of course this won't change merged, even if it did copy... but just in case.
 		m2 = append(m2, "test")
-		assert.Equal(t, 0, len(merged))
+		assert.Len(t, m2, 1)
+		assert.Len(t, merged, 0)
 	})
 
 	t.Run("slice is not copied. change in patch will not affect merged", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR fix ineffective assignments in the codebase. There where found via [`ineffassign`](https://github.com/gordonklaus/ineffassign). Fixing this issue is part of the afford to fix all problems found by `golangci-lint`.

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-server/pull/12909