### PR TITLE
Fix unnecessary type conversions

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -475,7 +475,7 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	startTime := time.Now()
 
-	results, err := c.App.SearchPostsInTeamForUser(terms, c.App.Session.UserId, c.Params.TeamId, isOrSearch, includeDeletedChannels, int(timeZoneOffset), page, perPage)
+	results, err := c.App.SearchPostsInTeamForUser(terms, c.App.Session.UserId, c.Params.TeamId, isOrSearch, includeDeletedChannels, timeZoneOffset, page, perPage)
 
 	elapsedTime := float64(time.Since(startTime)) / float64(time.Second)
 	metrics := c.App.Metrics

--- a/api4/team.go
+++ b/api4/team.go
@@ -911,7 +911,7 @@ func importTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := map[string]string{}
-	data["results"] = base64.StdEncoding.EncodeToString([]byte(log.Bytes()))
+	data["results"] = base64.StdEncoding.EncodeToString(log.Bytes())
 	if c.Err != nil {
 		w.WriteHeader(c.Err.StatusCode)
 	}

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -50,7 +50,7 @@ func TestHubStopWithMultipleConnections(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	s := httptest.NewServer(http.HandlerFunc(dummyWebsocketHandler(t)))
+	s := httptest.NewServer(dummyWebsocketHandler(t))
 	defer s.Close()
 
 	th.App.HubStart()
@@ -68,7 +68,7 @@ func TestHubStopRaceCondition(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	s := httptest.NewServer(http.HandlerFunc(dummyWebsocketHandler(t)))
+	s := httptest.NewServer(dummyWebsocketHandler(t))
 
 	th.App.HubStart()
 	wc1 := registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -86,17 +86,17 @@ func TestListChannels(t *testing.T) {
 
 	output := th.CheckCommand(t, "channel", "list", th.BasicTeam.Name)
 
-	require.True(t, strings.Contains(string(output), "town-square"), "should have channels")
+	require.True(t, strings.Contains(output, "town-square"), "should have channels")
 
-	require.True(t, strings.Contains(string(output), channel.Name+" (archived)"), "should have archived channel")
+	require.True(t, strings.Contains(output, channel.Name+" (archived)"), "should have archived channel")
 
-	require.True(t, strings.Contains(string(output), privateChannel.Name+" (private)"), "should have private channel")
+	require.True(t, strings.Contains(output, privateChannel.Name+" (private)"), "should have private channel")
 
 	th.Client.Must(th.Client.DeleteChannel(privateChannel.Id))
 
 	output = th.CheckCommand(t, "channel", "list", th.BasicTeam.Name)
 
-	require.True(t, strings.Contains(string(output), privateChannel.Name+" (archived) (private)"), "should have a channel both archived and private")
+	require.True(t, strings.Contains(output, privateChannel.Name+" (archived) (private)"), "should have a channel both archived and private")
 }
 
 func TestRestoreChannel(t *testing.T) {

--- a/cmd/mattermost/commands/command_test.go
+++ b/cmd/mattermost/commands/command_test.go
@@ -121,12 +121,12 @@ func TestCreateCommand(t *testing.T) {
 			if testCase.ExpectedErr == "" {
 				require.NotEmpty(t, cmds, "Failed to create command")
 				require.Equal(t, "testcmd", cmds[0].Trigger)
-				assert.Contains(t, string(actual), "PASS")
+				assert.Contains(t, actual, "PASS")
 			} else {
 				if len(cmds) > 1 {
 					require.Fail(t, "Created command that shouldn't have been created")
 				}
-				assert.Contains(t, string(actual), testCase.ExpectedErr)
+				assert.Contains(t, actual, testCase.ExpectedErr)
 			}
 		})
 	}
@@ -161,11 +161,11 @@ func TestShowCommand(t *testing.T) {
 		assert.Equal(t, len(commands), 1)
 
 		output := th.CheckCommand(t, "command", "show", command.Id)
-		assert.Contains(t, string(output), command.Id)
-		assert.Contains(t, string(output), command.TeamId)
-		assert.Contains(t, string(output), trigger)
-		assert.Contains(t, string(output), displayName)
-		assert.Contains(t, string(output), user.Username)
+		assert.Contains(t, output, command.Id)
+		assert.Contains(t, output, command.TeamId)
+		assert.Contains(t, output, trigger)
+		assert.Contains(t, output, displayName)
+		assert.Contains(t, output, user.Username)
 	})
 
 	t.Run("not existing command", func(t *testing.T) {
@@ -255,14 +255,14 @@ func TestModifyCommand(t *testing.T) {
 	t.Run("command not specified", func(t *testing.T) {
 		args := []string{"command", "", command.Id, "--trigger-word", "sometrigger"}
 		output, _ := th.RunCommandWithOutput(t, args...)
-		assert.Contains(t, string(output), "Error: unknown flag: --trigger-word")
+		assert.Contains(t, output, "Error: unknown flag: --trigger-word")
 	})
 
 	t.Run("modify command unchanged", func(t *testing.T) {
 		args := []string{"command", "modify", command.Id}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.DisplayName, command.DisplayName)
 		assert.Equal(t, cmd.Method, command.Method)
 		assert.Equal(t, cmd.TeamId, command.TeamId)
@@ -279,7 +279,7 @@ func TestModifyCommand(t *testing.T) {
 	t.Run("misspelled flag", func(t *testing.T) {
 		args := []string{"command", "", command.Id, "--trigger-wor", "sometrigger"}
 		output, _ := th.RunCommandWithOutput(t, args...)
-		assert.Contains(t, string(output), "Error: unknown flag:")
+		assert.Contains(t, output, "Error: unknown flag:")
 	})
 
 	t.Run("multiple flags nil error", func(t *testing.T) {
@@ -289,7 +289,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--trigger-word", testName, "--url", testURL, "--description", testDescription}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.Trigger, testName)
 		assert.Equal(t, cmd.URL, testURL)
 		assert.Equal(t, cmd.Description, testDescription)
@@ -300,7 +300,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--title", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.DisplayName, testVal)
 	})
 
@@ -309,7 +309,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--description", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.Description, testVal)
 	})
 
@@ -318,7 +318,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--trigger-word", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.Trigger, testVal)
 	})
 
@@ -326,14 +326,14 @@ func TestModifyCommand(t *testing.T) {
 		testVal := "bad trigger"
 		args := []string{"command", "modify", command.Id, "--trigger-word", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
-		assert.Contains(t, string(output), "Error: a trigger word must not contain spaces")
+		assert.Contains(t, output, "Error: a trigger word must not contain spaces")
 	})
 
 	t.Run("trigger with leading /", func(t *testing.T) {
 		testVal := "/bad-trigger"
 		args := []string{"command", "modify", command.Id, "--trigger-word", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
-		assert.Contains(t, string(output), "Error: a trigger word cannot begin with a /")
+		assert.Contains(t, output, "Error: a trigger word cannot begin with a /")
 	})
 
 	t.Run("blank trigger", func(t *testing.T) {
@@ -343,7 +343,7 @@ func TestModifyCommand(t *testing.T) {
 		cmd_modified, _ := th.App.GetCommand(command.Id)
 
 		// assert trigger remains unchanged
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd_unmodified.Trigger, cmd_modified.Trigger)
 	})
 
@@ -353,7 +353,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--url", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.URL, testVal)
 	})
 
@@ -364,7 +364,7 @@ func TestModifyCommand(t *testing.T) {
 		cmd_modified, _ := th.App.GetCommand(command.Id)
 
 		//assert URL remains unchanged
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd_unmodified.URL, cmd_modified.URL)
 	})
 
@@ -373,7 +373,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--icon", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.IconURL, testVal)
 	})
 
@@ -382,7 +382,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--creator", testVal.Username}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.CreatorId, testVal.Id)
 	})
 
@@ -390,14 +390,14 @@ func TestModifyCommand(t *testing.T) {
 		testVal := "fakeuser"
 		args := []string{"command", "modify", command.Id, "--creator", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
-		assert.Contains(t, string(output), "unable to find user")
+		assert.Contains(t, output, "unable to find user")
 	})
 
 	t.Run("creator not admin user", func(t *testing.T) {
 		testVal := user.Username
 		args := []string{"command", "modify", command.Id, "--creator", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
-		assert.Contains(t, string(output), "the creator must be a user who has permissions to manage slash commands")
+		assert.Contains(t, output, "the creator must be a user who has permissions to manage slash commands")
 	})
 
 	t.Run("response username nil error", func(t *testing.T) {
@@ -405,7 +405,7 @@ func TestModifyCommand(t *testing.T) {
 		args := []string{"command", "modify", command.Id, "--response-username", testVal}
 		output, _ := th.RunCommandWithOutput(t, args...)
 		cmd, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output), "PASS")
+		assert.Contains(t, output, "PASS")
 		assert.Equal(t, cmd.Username, testVal)
 	})
 
@@ -416,13 +416,13 @@ func TestModifyCommand(t *testing.T) {
 		// set post and check
 		output_set, _ := th.RunCommandWithOutput(t, args_set...)
 		cmd_set, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output_set), "PASS")
+		assert.Contains(t, output_set, "PASS")
 		assert.Equal(t, cmd_set.Method, "P")
 
 		// unset post and check
 		output_unset, _ := th.RunCommandWithOutput(t, args_unset...)
 		cmd_unset, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output_unset), "PASS")
+		assert.Contains(t, output_unset, "PASS")
 		assert.Equal(t, cmd_unset.Method, "G")
 	})
 
@@ -433,13 +433,13 @@ func TestModifyCommand(t *testing.T) {
 		// set autocomplete and check
 		output_set, _ := th.RunCommandWithOutput(t, args_set...)
 		cmd_set, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output_set), "PASS")
+		assert.Contains(t, output_set, "PASS")
 		assert.Equal(t, cmd_set.AutoComplete, true)
 
 		// unset autocomplete and check
 		output_unset, _ := th.RunCommandWithOutput(t, args_unset...)
 		cmd_unset, _ := th.App.GetCommand(command.Id)
-		assert.Contains(t, string(output_unset), "PASS")
+		assert.Contains(t, output_unset, "PASS")
 		assert.Equal(t, cmd_unset.AutoComplete, false)
 	})
 }

--- a/cmd/mattermost/commands/config_test.go
+++ b/cmd/mattermost/commands/config_test.go
@@ -111,10 +111,10 @@ func TestConfigGet(t *testing.T) {
 	t.Run("check output", func(t *testing.T) {
 		output := th.CheckCommand(t, "config", "get", "MessageExportSettings")
 
-		assert.Contains(t, string(output), "EnableExport")
-		assert.Contains(t, string(output), "ExportFormat")
-		assert.Contains(t, string(output), "DailyRunTime")
-		assert.Contains(t, string(output), "ExportFromTimestamp")
+		assert.Contains(t, output, "EnableExport")
+		assert.Contains(t, output, "ExportFormat")
+		assert.Contains(t, output, "DailyRunTime")
+		assert.Contains(t, output, "ExportFromTimestamp")
 	})
 }
 
@@ -138,33 +138,33 @@ func TestConfigSet(t *testing.T) {
 	t.Run("Error when the wrong value is set", func(t *testing.T) {
 		assert.Error(t, th.RunCommand(t, "config", "set", "EmailSettings.ConnectionSecurity", "invalid-key"))
 		output := th.CheckCommand(t, "config", "get", "EmailSettings.ConnectionSecurity")
-		assert.NotContains(t, string(output), "invalid-key")
+		assert.NotContains(t, output, "invalid-key")
 	})
 
 	t.Run("Error when the parameter of an unknown plugin is set", func(t *testing.T) {
 		output, err := th.RunCommandWithOutput(t, "config", "set", "PluginSettings.Plugins.someplugin", "true")
 		assert.Error(t, err)
-		assert.NotContains(t, string(output), "panic")
+		assert.NotContains(t, output, "panic")
 	})
 
 	t.Run("Error when the wrong locale is set", func(t *testing.T) {
 		th.CheckCommand(t, "config", "set", "LocalizationSettings.DefaultServerLocale", "es")
 		assert.Error(t, th.RunCommand(t, "config", "set", "LocalizationSettings.DefaultServerLocale", "invalid-key"))
 		output := th.CheckCommand(t, "config", "get", "LocalizationSettings.DefaultServerLocale")
-		assert.NotContains(t, string(output), "invalid-key")
-		assert.NotContains(t, string(output), "\"en\"")
+		assert.NotContains(t, output, "invalid-key")
+		assert.NotContains(t, output, "\"en\"")
 	})
 
 	t.Run("Success when a valid value is set", func(t *testing.T) {
 		assert.NoError(t, th.RunCommand(t, "config", "set", "EmailSettings.ConnectionSecurity", "TLS"))
 		output := th.CheckCommand(t, "config", "get", "EmailSettings.ConnectionSecurity")
-		assert.Contains(t, string(output), "TLS")
+		assert.Contains(t, output, "TLS")
 	})
 
 	t.Run("Success when a valid locale is set", func(t *testing.T) {
 		assert.NoError(t, th.RunCommand(t, "config", "set", "LocalizationSettings.DefaultServerLocale", "es"))
 		output := th.CheckCommand(t, "config", "get", "LocalizationSettings.DefaultServerLocale")
-		assert.Contains(t, string(output), "\"es\"")
+		assert.Contains(t, output, "\"es\"")
 	})
 }
 
@@ -339,9 +339,9 @@ func TestConfigShow(t *testing.T) {
 
 	t.Run("successfully dumping config", func(t *testing.T) {
 		output := th.CheckCommand(t, "config", "show")
-		assert.Contains(t, string(output), "SqlSettings")
-		assert.Contains(t, string(output), "MessageExportSettings")
-		assert.Contains(t, string(output), "AnnouncementSettings")
+		assert.Contains(t, output, "SqlSettings")
+		assert.Contains(t, output, "MessageExportSettings")
+		assert.Contains(t, output, "AnnouncementSettings")
 	})
 
 	t.Run("successfully dumping config as json", func(t *testing.T) {

--- a/cmd/mattermost/commands/group_test.go
+++ b/cmd/mattermost/commands/group_test.go
@@ -114,7 +114,7 @@ func TestChannelGroupStatus(t *testing.T) {
 
 	// get status, should be Disabled
 	output := th.CheckCommand(t, "group", "channel", "status", th.BasicTeam.Name+":"+channel.Name)
-	require.Contains(t, string(output), "Disabled")
+	require.Contains(t, output, "Disabled")
 
 	// add group and enable
 	id := model.NewId()
@@ -143,7 +143,7 @@ func TestChannelGroupStatus(t *testing.T) {
 
 	// get status, should be enabled
 	output = th.CheckCommand(t, "group", "channel", "status", th.BasicTeam.Name+":"+channel.Name)
-	require.Contains(t, string(output), "Enabled")
+	require.Contains(t, output, "Enabled")
 
 	// try to get status of nonexistent channel, should fail
 	require.Error(t, th.RunCommand(t, "group", "channel", "status", th.BasicTeam.Name+":"+channel.Name+"asdf"))
@@ -204,8 +204,8 @@ func TestChannelGroupList(t *testing.T) {
 
 	// list groups
 	output := th.CheckCommand(t, "group", "channel", "list", th.BasicTeam.Name+":"+channel.Name)
-	require.Contains(t, string(output), g1.DisplayName)
-	require.Contains(t, string(output), g2.DisplayName)
+	require.Contains(t, output, g1.DisplayName)
+	require.Contains(t, output, g2.DisplayName)
 
 	// try to get list of nonexistent channel, should fail
 	require.Error(t, th.RunCommand(t, "group", "channel", "list", th.BasicTeam.Name+":"+channel.Name+"asdf"))
@@ -301,7 +301,7 @@ func TestTeamGroupStatus(t *testing.T) {
 
 	// get status, should be Disabled
 	output := th.CheckCommand(t, "group", "team", "status", th.BasicTeam.Name)
-	require.Contains(t, string(output), "Disabled")
+	require.Contains(t, output, "Disabled")
 
 	// add group and enable
 	id := model.NewId()
@@ -330,7 +330,7 @@ func TestTeamGroupStatus(t *testing.T) {
 
 	// get status, should be enabled
 	output = th.CheckCommand(t, "group", "team", "status", th.BasicTeam.Name)
-	require.Contains(t, string(output), "Enabled")
+	require.Contains(t, output, "Enabled")
 
 	// try to get status of nonexistent channel, should fail
 	require.Error(t, th.RunCommand(t, "group", "team", "status", th.BasicTeam.Name+"asdf"))
@@ -388,8 +388,8 @@ func TestTeamGroupList(t *testing.T) {
 
 	// list groups
 	output := th.CheckCommand(t, "group", "team", "list", th.BasicTeam.Name)
-	require.Contains(t, string(output), g1.DisplayName)
-	require.Contains(t, string(output), g2.DisplayName)
+	require.Contains(t, output, g1.DisplayName)
+	require.Contains(t, output, g2.DisplayName)
 
 	// try to get list of nonexistent team, should fail
 	require.Error(t, th.RunCommand(t, "group", "team", "list", th.BasicTeam.Name+"asdf"))

--- a/mlog/stdlog.go
+++ b/mlog/stdlog.go
@@ -81,7 +81,7 @@ type loggerWriter struct {
 func (l *loggerWriter) Write(p []byte) (int, error) {
 	trimmed := string(bytes.TrimSpace(p))
 	for _, line := range strings.Split(trimmed, "\n") {
-		l.logFunc(string(line))
+		l.logFunc(line)
 	}
 	return len(p), nil
 }

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -284,7 +284,7 @@ func DecodeAndVerifyTriggerId(triggerId string, s *ecdsa.PrivateKey) (string, st
 		R, S *big.Int
 	}
 
-	if _, err := asn1.Unmarshal([]byte(signature), &esig); err != nil {
+	if _, err := asn1.Unmarshal(signature, &esig); err != nil {
 		return "", "", NewAppError("DecodeAndVerifyTriggerId", "interactive_message.decode_trigger_id.signature_decode_failed", nil, err.Error(), http.StatusBadRequest)
 	}
 

--- a/services/imageproxy/local.go
+++ b/services/imageproxy/local.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"time"
 
 	"github.com/mattermost/mattermost-server/mlog"
 	"github.com/mattermost/mattermost-server/services/httpservice"
@@ -58,7 +57,7 @@ func makeLocalBackend(proxy *ImageProxy) *LocalBackend {
 		impl.DefaultBaseURL = baseURL
 	}
 
-	impl.Timeout = time.Duration(httpservice.RequestTimeout)
+	impl.Timeout = httpservice.RequestTimeout
 	impl.ContentTypes = imageContentTypes
 
 	return &LocalBackend{

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -1038,7 +1038,7 @@ func testDeleteGroupSyncable(t *testing.T, ss store.Store) {
 	require.Equal(t, err.Id, "store.sql_group.no_rows")
 
 	// Non-existent Team
-	_, err = ss.Group().DeleteGroupSyncable(groupTeam.GroupId, string(model.NewId()), model.GroupSyncableTypeTeam)
+	_, err = ss.Group().DeleteGroupSyncable(groupTeam.GroupId, model.NewId(), model.GroupSyncableTypeTeam)
 	require.Equal(t, err.Id, "store.sql_group.no_rows")
 
 	// Happy path...
@@ -1795,10 +1795,10 @@ func testGetGroupsByChannel(t *testing.T, ss store.Store) {
 	_, err = ss.User().Update(user2, true)
 	require.Nil(t, err)
 
-	group1WithMemberCount := model.Group(*group1)
+	group1WithMemberCount := *group1
 	group1WithMemberCount.MemberCount = model.NewInt(1)
 
-	group2WithMemberCount := model.Group(*group2)
+	group2WithMemberCount := *group2
 	group2WithMemberCount.MemberCount = model.NewInt(0)
 
 	testCases := []struct {
@@ -2009,10 +2009,10 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 	_, err = ss.User().Update(user2, true)
 	require.Nil(t, err)
 
-	group1WithMemberCount := model.Group(*group1)
+	group1WithMemberCount := *group1
 	group1WithMemberCount.MemberCount = model.NewInt(1)
 
-	group2WithMemberCount := model.Group(*group2)
+	group2WithMemberCount := *group2
 	group2WithMemberCount.MemberCount = model.NewInt(0)
 
 	testCases := []struct {


### PR DESCRIPTION
#### Summary
This PR fixes unnecessary type conversions in the codebase. There where found via [`unconvert`](https://github.com/mdempsky/unconvert). Fixing this issue is part of the afford to fix all problems found by `golangci-lint`.

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-server/pull/12909