### PR TITLE
MM-19663 | Migrate brand_test and cluster_test to testify

### DIFF
--- a/api4/brand_test.go
+++ b/api4/brand_test.go
@@ -47,7 +47,7 @@ func TestUploadBrandImage(t *testing.T) {
 	} else if resp.StatusCode == http.StatusUnauthorized {
 		CheckUnauthorizedStatus(t, resp)
 	} else {
-		require.FailNow(t, "Should have failed either forbidden or unauthorized")
+		require.Fail(t, "Should have failed either forbidden or unauthorized")
 	}
 
 	_, resp = th.SystemAdminClient.UploadBrandImage(data)

--- a/api4/brand_test.go
+++ b/api4/brand_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/utils/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetBrandImage(t *testing.T) {
@@ -32,9 +33,7 @@ func TestUploadBrandImage(t *testing.T) {
 	Client := th.Client
 
 	data, err := testutils.ReadTestFile("test.png")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	_, resp := Client.UploadBrandImage(data)
 	CheckForbiddenStatus(t, resp)
@@ -48,7 +47,7 @@ func TestUploadBrandImage(t *testing.T) {
 	} else if resp.StatusCode == http.StatusUnauthorized {
 		CheckUnauthorizedStatus(t, resp)
 	} else {
-		t.Fatal("Should have failed either forbidden or unauthorized")
+		require.FailNow(t, "Should have failed either forbidden or unauthorized")
 	}
 
 	_, resp = th.SystemAdminClient.UploadBrandImage(data)
@@ -60,9 +59,7 @@ func TestDeleteBrandImage(t *testing.T) {
 	defer th.TearDown()
 
 	data, err := testutils.ReadTestFile("test.png")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 
 	_, resp := th.SystemAdminClient.UploadBrandImage(data)
 	CheckCreatedStatus(t, resp)

--- a/api4/cluster_test.go
+++ b/api4/cluster_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetClusterStatus(t *testing.T) {
@@ -22,9 +23,7 @@ func TestGetClusterStatus(t *testing.T) {
 		infos, resp := th.SystemAdminClient.GetClusterStatus()
 		CheckNoError(t, resp)
 
-		if infos == nil {
-			t.Fatal("should not be nil")
-		}
+		require.NotNil(t, infos, "cluster status should not be nil")
 	})
 
 	t.Run("as restricted system admin", func(t *testing.T) {


### PR DESCRIPTION
#### Summary

Migrate the tests in the api4/cluster_test.go and api4/brand_test.go to use testify


#### Ticket Link

[MM-19663](https://mattermost.atlassian.net/browse/MM-19663)
Fixes #12890