### PR TITLE
command_help_test, cors_test: use testify

### DIFF
--- a/api4/command_help_test.go
+++ b/api4/command_help_test.go
@@ -6,6 +6,8 @@ package api4
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost-server/model"
 )
 
@@ -23,15 +25,11 @@ func TestHelpCommand(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.SupportSettings.HelpLink = "" })
 	rs1, _ := Client.ExecuteCommand(channel.Id, "/help ")
-	if rs1.GotoLocation != model.SUPPORT_SETTINGS_DEFAULT_HELP_LINK {
-		t.Fatal("failed to default help link")
-	}
+	require.Equal(t, rs1.GotoLocation, model.SUPPORT_SETTINGS_DEFAULT_HELP_LINK, "failed to default help link")
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.SupportSettings.HelpLink = "https://docs.mattermost.com/guides/user.html"
 	})
 	rs2, _ := Client.ExecuteCommand(channel.Id, "/help ")
-	if rs2.GotoLocation != "https://docs.mattermost.com/guides/user.html" {
-		t.Fatal("failed to help link")
-	}
+	require.Equal(t, rs2.GotoLocation, "https://docs.mattermost.com/guides/user.html", "failed to help link")
 }

--- a/api4/cors_test.go
+++ b/api4/cors_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -127,16 +129,13 @@ func TestCORSRequestHandling(t *testing.T) {
 			url := fmt.Sprintf("%v/api/v4/system/ping", host)
 
 			req, err := http.NewRequest("GET", url, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 			testcase.ModifyRequest(req)
 
 			client := &http.Client{}
 			resp, err := client.Do(req)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
+
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			assert.Equal(t, testcase.ExpectedAllowOrigin, resp.Header.Get(acAllowOrigin))
 			assert.Equal(t, testcase.ExpectedExposeHeaders, resp.Header.Get(acExposeHeaders))


### PR DESCRIPTION
#### Summary
Update `api4/command_help_test.go` and `api4/cors_test.go` to use `testify`.

#### Ticket Link
Fixes #12864 
[MM-19621](https://mattermost.atlassian.net/browse/MM-19621)