### PR TITLE
Replace time.After with time.NewTimer

### DIFF
--- a/jobs/schedulers.go
+++ b/jobs/schedulers.go
@@ -86,11 +86,13 @@ func (schedulers *Schedulers) Start() *Schedulers {
 			}
 
 			for {
+				timer := time.NewTimer(1 * time.Minute)
 				select {
 				case <-schedulers.stop:
 					mlog.Debug("Schedulers received stop signal.")
+					timer.Stop()
 					return
-				case now = <-time.After(1 * time.Minute):
+				case now = <-timer.C:
 					cfg := schedulers.jobs.Config()
 
 					for idx, nextTime := range schedulers.nextRunTimes {
@@ -128,6 +130,7 @@ func (schedulers *Schedulers) Start() *Schedulers {
 						}
 					}
 				}
+				timer.Stop()
 			}
 		})
 	}()


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
time.After might leave stray timers if other channels in select triggered early

<!--
A description of what this pull request does.
-->

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
