### PR TITLE
MM-17549: support upgrading plugins

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -206,7 +206,7 @@ func TestPlugin(t *testing.T) {
 
 	// Deactivate error case
 	ok, resp = th.SystemAdminClient.DisablePlugin("junk")
-	CheckBadRequestStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 	assert.False(t, ok)
 
 	// Get error cases
@@ -241,7 +241,7 @@ func TestPlugin(t *testing.T) {
 
 	// Remove error cases
 	ok, resp = th.SystemAdminClient.RemovePlugin(manifest.Id)
-	CheckBadRequestStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 	assert.False(t, ok)
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = false })
@@ -253,7 +253,7 @@ func TestPlugin(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	_, resp = th.SystemAdminClient.RemovePlugin("bad.id")
-	CheckBadRequestStatus(t, resp)
+	CheckNotFoundStatus(t, resp)
 }
 
 func TestNotifyClusterPluginEvent(t *testing.T) {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -364,7 +364,7 @@ func (a *App) DisablePlugin(id string) *model.AppError {
 	}
 
 	if manifest == nil {
-		return model.NewAppError("DisablePlugin", "app.plugin.not_installed.app_error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("DisablePlugin", "app.plugin.not_installed.app_error", nil, "", http.StatusNotFound)
 	}
 
 	a.UpdateConfig(func(cfg *model.Config) {

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -280,7 +280,7 @@ func (a *App) removePluginLocally(id string) *model.AppError {
 	}
 
 	if manifest == nil {
-		return model.NewAppError("removePlugin", "app.plugin.not_installed.app_error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("removePlugin", "app.plugin.not_installed.app_error", nil, "", http.StatusNotFound)
 	}
 
 	pluginsEnvironment.Deactivate(id)


### PR DESCRIPTION
#### Summary
This is a minor change to support e2e testing of plugin upgrade by returning a 404 instead of a 400 when trying to delete a plugin that is not installed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-17549