### PR TITLE
[MM-19805] Don't set pluginState manually on plugin install

### DIFF
--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -203,16 +203,6 @@ func (a *App) installPluginLocally(pluginFile io.ReadSeeker, replace bool) (*mod
 		manifest = updatedManifest
 	}
 
-	// Activate plugin if it was previously activated.
-	pluginState := a.Config().PluginSettings.PluginStates[manifest.Id]
-	if pluginState != nil && pluginState.Enable {
-		updatedManifest, _, err := pluginsEnvironment.Activate(manifest.Id)
-		if err != nil {
-			return nil, model.NewAppError("installPluginLocally", "app.plugin.restart.app_error", nil, err.Error(), http.StatusInternalServerError)
-		}
-		manifest = updatedManifest
-	}
-
 	return manifest, nil
 }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3543,10 +3543,6 @@
     "translation": "Unable to remove plugin bundle from file store."
   },
   {
-    "id": "app.plugin.restart.app_error",
-    "translation": "Unable to restart plugin on upgrade."
-  },
-  {
     "id": "app.plugin.store_bundle.app_error",
     "translation": "Unable to store the plugin to the configured file store."
   },


### PR DESCRIPTION
#### Summary
Don't set pluginState manually on plugin install. `SyncPluginsActiveState` will take care of this. (https://github.com/mattermost/mattermost-server/blob/master/app/plugin.go#L91-L112) Otherwise the websocket event doesn't get send to the client.

Given this is touching a critical part of the code, please take you time to review. I've tested the change local and didn't found any side effects. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-19805
