### PR TITLE
Add gorilla/handlers dependency as it is used in enterprise version

### DIFF
--- a/cmd/mattermost/main.go
+++ b/cmd/mattermost/main.go
@@ -15,7 +15,7 @@ import (
 	_ "github.com/mattermost/mattermost-server/imports"
 
 	// Enterprise Deps
-	_ "github.com/dgryski/dgoogauth"
+	_ "github.com/gorilla/handlers"
 	_ "github.com/hako/durafmt"
 	_ "github.com/hashicorp/memberlist"
 	_ "github.com/mattermost/ldap"

--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,6 @@ require (
 	github.com/miekg/dns v1.1.19 // indirect
 	github.com/minio/minio-go/v6 v6.0.38
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/muesli/smartcrop v0.3.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.1 // indirect
 	github.com/onsi/ginkgo v1.8.0 // indirect


### PR DESCRIPTION


#### Summary
This PR adds `github.com/gorilla/handlers` to the [file](https://github.com/mattermost/mattermost-server/blob/master/cmd/mattermost/main.go) as it is used in enterprise version but not in community edition. It consequence is that when running `go mod tidy` it removes the dependecy from the `go.mod` file. 

Discussion thread: [link](https://community.mattermost.com/core/pl/qko3f9er3tgpue44cu4j78m5dh)
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
