### PR TITLE
[MM-19629] Fix data race in server start goroutine

### DIFF
--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -72,15 +72,15 @@ func runServer(configStore config.Store, disableConfigWatch bool, usedPlatform b
 		mlog.Error("The platform binary has been deprecated, please switch to using the mattermost binary.")
 	}
 
+	api := api4.Init(server, server.AppOptions, server.Router)
+	wsapi.Init(server.FakeApp(), server.WebSocketRouter)
+	web.New(server, server.AppOptions, server.Router)
+
 	serverErr := server.Start()
 	if serverErr != nil {
 		mlog.Critical(serverErr.Error())
 		return serverErr
 	}
-
-	api := api4.Init(server, server.AppOptions, server.Router)
-	wsapi.Init(server.FakeApp(), server.WebSocketRouter)
-	web.New(server, server.AppOptions, server.Router)
 
 	// If we allow testing then listen for manual testing URL hits
 	if *server.Config().ServiceSettings.EnableTesting {


### PR DESCRIPTION
#### Sumary

This PR fixes a race condition between *main* and server startup goroutines.
Detailed info can be found in the ticket below.

#### Ticket

https://mattermost.atlassian.net/browse/MM-19629