### PR TITLE
add stop-docker to stop make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,7 +398,7 @@ stop-client: ## Stops the webapp.
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) stop
 
-stop: stop-server stop-client ## Stops server and client.
+stop: stop-server stop-client stop-docker ## Stops server, client and the docker compose.
 
 restart: restart-server restart-client ## Restarts the server and webapp.
 


### PR DESCRIPTION
#### Summary
I feel this was missing, when i run `make stop` I would like to stop everything including the server / client and docker-compose.

so we dont need to run additional commands to stop, only if needed like `stop-server`