### PR TITLE
Remove a potential tabnabbing attack in a template.

### DIFF
--- a/templates/unsupported_browser.html
+++ b/templates/unsupported_browser.html
@@ -292,7 +292,7 @@
                         {{template "unsupported_browser-system_browser" .Props.SystemBrowser}}
                     {{end}}
                     <div class='learn-more-about-sup'>
-                        <a href='https://docs.mattermost.com/install/requirements.html#pc-web' target='_blank'>{{.Props.LearnMoreString}}</a>
+                        <a href='https://docs.mattermost.com/install/requirements.html#pc-web' target='_blank' rel='noopener noreferrer'>{{.Props.LearnMoreString}}</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
My company's security scanner picked up on a potential problem in this
template in our deployed Mattermost instance.

https://www.owasp.org/index.php/Reverse_Tabnabbing