### PR TITLE
Fix typo in server_app_adapters.go

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -186,7 +186,7 @@ func NewServer(options ...Option) (*Server, error) {
 		return nil, errors.Wrapf(err, "unable to load Mattermost translation files")
 	}
 
-	err := s.RunOldAppInitalization()
+	err := s.RunOldAppInitialization()
 	if err != nil {
 		return nil, err
 	}

--- a/app/server_app_adapters.go
+++ b/app/server_app_adapters.go
@@ -18,11 +18,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-// This is a bridge between the old and new initalization for the context refactor.
-// It calls app layer initalization code that then turns around and acts on the server.
-// Don't add anything new here, new initilization should be done in the server and
+// This is a bridge between the old and new initialization for the context refactor.
+// It calls app layer initialization code that then turns around and acts on the server.
+// Don't add anything new here, new initialization should be done in the server and
 // performed in the NewServer function.
-func (s *Server) RunOldAppInitalization() error {
+func (s *Server) RunOldAppInitialization() error {
 	s.FakeApp().CreatePushNotificationsHub()
 	s.FakeApp().StartPushNotificationsHubWorkers()
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Found some typo in server_app_adapters.go, "initalization" -> "initialization".
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
None