### PR TITLE
Remove fmt and vet checks from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,8 @@ jobs:
           at: /go/src/github.com/mattermost/
       - run:
           command: |
+            echo "Installing golangci-lint"
+            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.21.0
             cd mattermost-server
             make config-reset
             make check-style BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'

--- a/Makefile
+++ b/Makefile
@@ -149,37 +149,14 @@ else
 endif
 
 
-govet: ## Runs govet against all packages.
-	@echo Running GOVET
-	env GO111MODULE=off $(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
-	$(GO) vet $(GOFLAGS) $(ALL_PACKAGES) || exit 1
-	$(GO) vet -vettool=$(GOPATH)/bin/shadow $(GOFLAGS) $(ALL_PACKAGES) || exit 1
-
-checker:
+plugin-checker:
 	$(GO) run $(GOFLAGS) ./plugin/checker
-
-gofmt: ## Runs gofmt against all packages.
-	@echo Running GOFMT
-
-	@for package in $(TE_PACKAGES) $(EE_PACKAGES); do \
-		echo "Checking "$$package; \
-		files=$$($(GO) list $(GOFLAGS) -f '{{range .GoFiles}}{{$$.Dir}}/{{.}} {{end}}' $$package); \
-		if [ "$$files" ]; then \
-			gofmt_output=$$(gofmt -d -s $$files 2>&1); \
-			if [ "$$gofmt_output" ]; then \
-				echo "$$gofmt_output"; \
-				echo "gofmt failure"; \
-				exit 1; \
-			fi; \
-		fi; \
-	done
-	@echo "gofmt success"; \
 
 golangci-lint: ## Run golangci-lint on codebase
 # https://stackoverflow.com/a/677212/1027058 (check if a command exists or not)
 	@if ! [ -x "$$(command -v golangci-lint)" ]; then \
-		echo "Installing golangci-lint"; \
-		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.21.0; \
+		echo "golangci-lint is not installed. Please see https://github.com/golangci/golangci-lint#install for installation instructions."; \
+		exit 1; \
 	fi; \
 
 	@echo Running golangci-lint
@@ -231,7 +208,7 @@ check-licenses: ## Checks license status.
 check-prereqs: ## Checks prerequisite software status.
 	./scripts/prereq-check.sh
 
-check-style: golangci-lint checker check-licenses check-plugin-golint ## Runs golangci against all packages and also ensures plugin package golint compliant
+check-style: golangci-lint plugin-checker check-licenses check-plugin-golint ## Runs golangci against all packages and also ensures plugin package golint compliant
 
 check-plugin-golint: # Checks if golint returns any uncompliant code for any file that starts with plugin/helpers
 	@! golint ./plugin/ | grep plugin/helpers

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,8 @@ govet: ## Runs govet against all packages.
 	env GO111MODULE=off $(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	$(GO) vet $(GOFLAGS) $(ALL_PACKAGES) || exit 1
 	$(GO) vet -vettool=$(GOPATH)/bin/shadow $(GOFLAGS) $(ALL_PACKAGES) || exit 1
+
+checker:
 	$(GO) run $(GOFLAGS) ./plugin/checker
 
 gofmt: ## Runs gofmt against all packages.
@@ -173,11 +175,11 @@ gofmt: ## Runs gofmt against all packages.
 	done
 	@echo "gofmt success"; \
 
-golangci-lint: ## Run golangci-lint on codebasis
+golangci-lint: ## Run golangci-lint on codebase
 # https://stackoverflow.com/a/677212/1027058 (check if a command exists or not)
 	@if ! [ -x "$$(command -v golangci-lint)" ]; then \
-		echo "golangci-lint is not installed. Please see https://github.com/golangci/golangci-lint#install for installation instructions."; \
-		exit 1; \
+		echo "Installing golangci-lint"; \
+		curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.21.0; \
 	fi; \
 
 	@echo Running golangci-lint
@@ -229,8 +231,7 @@ check-licenses: ## Checks license status.
 check-prereqs: ## Checks prerequisite software status.
 	./scripts/prereq-check.sh
 
-# TODO: remove govet and gofmt checks once golangci-lint is being enforced.
-check-style: govet gofmt check-licenses check-plugin-golint ## Runs govet and gofmt against all packages and also ensures plugin package golint compliant
+check-style: golangci-lint checker check-licenses check-plugin-golint ## Runs golangci against all packages and also ensures plugin package golint compliant
 
 check-plugin-golint: # Checks if golint returns any uncompliant code for any file that starts with plugin/helpers
 	@! golint ./plugin/ | grep plugin/helpers

--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -99,9 +99,9 @@ pipeline {
 				withDockerContainer(args: '-u root --privileged -v ${WORKSPACE}/src:/go/src/', image: 'mattermost/mattermost-build-server:oct-18-2019') {
 					ansiColor('xterm') {
 						sh """
-							echo "Installing golangci-lint !"
-							curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.21.0
 							cd /go/src/github.com/mattermost/mattermost-server
+							echo "Installing golangci-lint"
+							curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.21.0
 							make config-reset
 							make check-style BUILD_NUMBER='${BRANCH_NAME}-${BUILD_NUMBER}'
 							make build BUILD_NUMBER='${BRANCH_NAME}-${BUILD_NUMBER}'

--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -99,7 +99,7 @@ pipeline {
 				withDockerContainer(args: '-u root --privileged -v ${WORKSPACE}/src:/go/src/', image: 'mattermost/mattermost-build-server:oct-18-2019') {
 					ansiColor('xterm') {
 						sh """
-							echo "Installing golangci-lint"
+							echo "Installing golangci-lint !"
 							curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.21.0
 							cd /go/src/github.com/mattermost/mattermost-server
 							make config-reset

--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -99,6 +99,8 @@ pipeline {
 				withDockerContainer(args: '-u root --privileged -v ${WORKSPACE}/src:/go/src/', image: 'mattermost/mattermost-build-server:oct-18-2019') {
 					ansiColor('xterm') {
 						sh """
+							echo "Installing golangci-lint"
+							curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.21.0
 							cd /go/src/github.com/mattermost/mattermost-server
 							make config-reset
 							make check-style BUILD_NUMBER='${BRANCH_NAME}-${BUILD_NUMBER}'

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -170,7 +170,6 @@ func TestConfigIsValidFakeAlgorithm(t *testing.T) {
 	require.Equal(t, "model.config.is_valid.saml_canonical_algorithm.app_error", err.Message)
 	*c1.SamlSettings.CanonicalAlgorithm = temp
 
-	temp = *c1.SamlSettings.SignatureAlgorithm
 	*c1.SamlSettings.SignatureAlgorithm = "Fake Algorithm"
 	err = c1.SamlSettings.isValid()
 	if err == nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- golangci-lint already does the vet and fmt checks. Remove those
as it is redundant now.
- Also start running golangci-lint as part of the CI pipeline now
just as an extra layer of reliability.
