### PR TITLE
[GH-13106] Migrate channelMemberCountsCache cache from store/sqlstore/channel_store.go to the new store/localcachelayer

### DIFF
--- a/model/cluster_message.go
+++ b/model/cluster_message.go
@@ -24,6 +24,7 @@ const (
 	CLUSTER_EVENT_CLEAR_SESSION_CACHE_FOR_USER                      = "clear_session_user"
 	CLUSTER_EVENT_INVALIDATE_CACHE_FOR_ROLES                        = "inv_roles"
 	CLUSTER_EVENT_INVALIDATE_CACHE_FOR_SCHEMES                      = "inv_schemes"
+	CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNELS                     = "inv_channels"
 	CLUSTER_EVENT_CLEAR_SESSION_CACHE_FOR_ALL_USERS                 = "inv_all_user_sessions"
 	CLUSTER_EVENT_INSTALL_PLUGIN                                    = "install_plugin"
 	CLUSTER_EVENT_REMOVE_PLUGIN                                     = "remove_plugin"

--- a/store/localcachelayer/channel_layer.go
+++ b/store/localcachelayer/channel_layer.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
+// See License.txt for license information.
+
+package localcachelayer
+
+import (
+	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/store"
+)
+
+type LocalCacheChannelStore struct {
+	store.ChannelStore
+	rootStore *LocalCacheStore
+}
+
+func (s *LocalCacheChannelStore) handleClusterInvalidateChannel(msg *model.ClusterMessage) {
+	if msg.Data == CLEAR_CACHE_MESSAGE_DATA {
+		s.rootStore.channelMemberCountsCache.Purge()
+	} else {
+		s.rootStore.channelMemberCountsCache.Remove(msg.Data)
+	}
+}
+
+func (s LocalCacheChannelStore) ClearCaches() {
+	s.rootStore.channelMemberCountsCache.Purge()
+	s.ChannelStore.ClearCaches()
+	if s.rootStore.metrics != nil {
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Channel Member Counts - Purge")
+	}
+}
+
+func (s LocalCacheChannelStore) InvalidateMemberCount(channelId string) {
+	s.rootStore.channelMemberCountsCache.Remove(channelId)
+	if s.rootStore.metrics != nil {
+		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Channel Member Counts - Remove by ChannelId")
+	}
+}
+
+func (s LocalCacheChannelStore) GetMemberCount(channelId string, allowFromCache bool) (int64, *model.AppError) {
+	if allowFromCache {
+		if count := s.rootStore.doStandardReadCache(s.rootStore.channelMemberCountsCache, channelId); count != nil {
+			return count.(int64), nil
+		}
+	}
+	count, err := s.ChannelStore.GetMemberCount(channelId, allowFromCache)
+
+	if allowFromCache && err == nil {
+		s.rootStore.doStandardAddToCache(s.rootStore.channelMemberCountsCache, channelId, count)
+	}
+
+	return count, err
+}
+
+func (s LocalCacheChannelStore) GetMemberCountFromCache(channelId string) int64 {
+	if count := s.rootStore.doStandardReadCache(s.rootStore.channelMemberCountsCache, channelId); count != nil {
+		return count.(int64)
+	}
+
+	count, err := s.GetMemberCount(channelId, true)
+	if err != nil {
+		return 0
+	}
+
+	return count
+}

--- a/store/localcachelayer/channel_layer_test.go
+++ b/store/localcachelayer/channel_layer_test.go
@@ -1,0 +1,88 @@
+package localcachelayer
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/store/storetest"
+	"github.com/mattermost/mattermost-server/store/storetest/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelStore(t *testing.T) {
+	StoreTest(t, storetest.TestReactionStore)
+}
+
+func TestChannelStoreChannelMemberCountsCache(t *testing.T) {
+	countResult := int64(10)
+
+	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		count, err := cachedStore.Channel().GetMemberCount("id", true)
+		require.Nil(t, err)
+		assert.Equal(t, count, countResult)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+		count, err = cachedStore.Channel().GetMemberCount("id", true)
+		require.Nil(t, err)
+		assert.Equal(t, count, countResult)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+	})
+
+	t.Run("first call not cached, second force no cached", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		cachedStore.Channel().GetMemberCount("id", true)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+		cachedStore.Channel().GetMemberCount("id", false)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 2)
+	})
+
+	t.Run("first call force no cached, second not cached, third cached", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		cachedStore.Channel().GetMemberCount("id", false)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+		cachedStore.Channel().GetMemberCount("id", true)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 2)
+		cachedStore.Channel().GetMemberCount("id", true)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 2)
+	})
+
+	t.Run("first call with GetMemberCountFromCache not cached, second cached and returning same data", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		count := cachedStore.Channel().GetMemberCountFromCache("id")
+		assert.Equal(t, count, countResult)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+		count = cachedStore.Channel().GetMemberCountFromCache("id")
+		assert.Equal(t, count, countResult)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+	})
+
+	t.Run("first call not cached, clear cache, second call not cached", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		cachedStore.Channel().GetMemberCount("id", true)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+		cachedStore.Channel().ClearCaches()
+		cachedStore.Channel().GetMemberCount("id", true)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 2)
+	})
+
+	t.Run("first call not cached, invalidate cache, second call not cached", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		cachedStore.Channel().GetMemberCount("id", true)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 1)
+		cachedStore.Channel().InvalidateMemberCount("id")
+		cachedStore.Channel().GetMemberCount("id", true)
+		mockStore.Channel().(*mocks.ChannelStore).AssertNumberOfCalls(t, "GetMemberCount", 2)
+	})
+}

--- a/store/localcachelayer/layer.go
+++ b/store/localcachelayer/layer.go
@@ -20,19 +20,24 @@ const (
 	SCHEME_CACHE_SIZE = 20000
 	SCHEME_CACHE_SEC  = 30 * 60
 
+	CHANNEL_MEMBERS_COUNTS_CACHE_SIZE = model.CHANNEL_CACHE_SIZE
+	CHANNEL_MEMBERS_COUNTS_CACHE_SEC  = 30 * 60
+
 	CLEAR_CACHE_MESSAGE_DATA = ""
 )
 
 type LocalCacheStore struct {
 	store.Store
-	metrics       einterfaces.MetricsInterface
-	cluster       einterfaces.ClusterInterface
-	reaction      LocalCacheReactionStore
-	reactionCache *utils.Cache
-	role          LocalCacheRoleStore
-	roleCache     *utils.Cache
-	scheme        LocalCacheSchemeStore
-	schemeCache   *utils.Cache
+	metrics                  einterfaces.MetricsInterface
+	cluster                  einterfaces.ClusterInterface
+	reaction                 LocalCacheReactionStore
+	reactionCache            *utils.Cache
+	role                     LocalCacheRoleStore
+	roleCache                *utils.Cache
+	scheme                   LocalCacheSchemeStore
+	schemeCache              *utils.Cache
+	channel                  LocalCacheChannelStore
+	channelMemberCountsCache *utils.Cache
 }
 
 func NewLocalCacheLayer(baseStore store.Store, metrics einterfaces.MetricsInterface, cluster einterfaces.ClusterInterface) LocalCacheStore {
@@ -47,11 +52,14 @@ func NewLocalCacheLayer(baseStore store.Store, metrics einterfaces.MetricsInterf
 	localCacheStore.role = LocalCacheRoleStore{RoleStore: baseStore.Role(), rootStore: &localCacheStore}
 	localCacheStore.schemeCache = utils.NewLruWithParams(SCHEME_CACHE_SIZE, "Scheme", SCHEME_CACHE_SEC, model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_SCHEMES)
 	localCacheStore.scheme = LocalCacheSchemeStore{SchemeStore: baseStore.Scheme(), rootStore: &localCacheStore}
+	localCacheStore.channelMemberCountsCache = utils.NewLruWithParams(CHANNEL_MEMBERS_COUNTS_CACHE_SIZE, "ChannelMemberCounts", CHANNEL_MEMBERS_COUNTS_CACHE_SEC, model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_CHANNELS)
+	localCacheStore.channel = LocalCacheChannelStore{ChannelStore: baseStore.Channel(), rootStore: &localCacheStore}
 
 	if cluster != nil {
 		cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_REACTIONS, localCacheStore.reaction.handleClusterInvalidateReaction)
 		cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_ROLES, localCacheStore.role.handleClusterInvalidateRole)
 		cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_SCHEMES, localCacheStore.scheme.handleClusterInvalidateScheme)
+		cluster.RegisterClusterMessageHandler(model.CLUSTER_EVENT_INVALIDATE_CACHE_FOR_SCHEMES, localCacheStore.channel.handleClusterInvalidateChannel)
 	}
 	return localCacheStore
 }
@@ -66,6 +74,10 @@ func (s LocalCacheStore) Role() store.RoleStore {
 
 func (s LocalCacheStore) Scheme() store.SchemeStore {
 	return s.scheme
+}
+
+func (s LocalCacheStore) Channel() store.ChannelStore {
+	return s.channel
 }
 
 func (s LocalCacheStore) DropAllTables() {
@@ -118,4 +130,5 @@ func (s *LocalCacheStore) doClearCacheCluster(cache *utils.Cache) {
 
 func (s *LocalCacheStore) Invalidate() {
 	s.doClearCacheCluster(s.reactionCache)
+	s.doClearCacheCluster(s.channelMemberCountsCache)
 }

--- a/store/localcachelayer/main_test.go
+++ b/store/localcachelayer/main_test.go
@@ -41,6 +41,13 @@ func getMockStore() *mocks.Store {
 	mockSchemesStore.On("PermanentDeleteAll").Return(nil)
 	mockStore.On("Scheme").Return(&mockSchemesStore)
 
+	mockCount := int64(10)
+	mockChannelStore := mocks.ChannelStore{}
+	mockChannelStore.On("ClearCaches").Return()
+	mockChannelStore.On("GetMemberCount", "id", true).Return(mockCount, nil)
+	mockChannelStore.On("GetMemberCount", "id", false).Return(mockCount, nil)
+	mockStore.On("Channel").Return(&mockChannelStore)
+
 	return &mockStore
 }
 


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Migrate channelMemberCountsCache cache from store/sqlstore/channel_store.go to the new store/localcachelayer
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://github.com/mattermost/mattermost-server/issues/13106