### PR TITLE
[MM-20209] Invalidate channel members cache when promoting/demoting a guest

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -2293,6 +2293,8 @@ func (a *App) PromoteGuestToUser(user *model.User, requestorId string) *model.Ap
 		}
 
 		for _, member := range *channelMembers {
+			a.InvalidateCacheForChannelMembers(member.ChannelId)
+
 			evt := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_MEMBER_UPDATED, "", "", user.Id, nil)
 			evt.Add("channelMember", member.ToJson())
 			a.Publish(evt)
@@ -2332,6 +2334,8 @@ func (a *App) DemoteUserToGuest(user *model.User) *model.AppError {
 		}
 
 		for _, member := range *channelMembers {
+			a.InvalidateCacheForChannelMembers(member.ChannelId)
+
 			evt := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_MEMBER_UPDATED, "", "", user.Id, nil)
 			evt.Add("channelMember", member.ToJson())
 			a.Publish(evt)


### PR DESCRIPTION
#### Summary

PR fixes a problem with channel header not getting updated in channels (with only one guest) when promoting/demoting the guest user due to channel stats cache not getting refreshed.

#### Ticket

https://mattermost.atlassian.net/browse/MM-20209