### PR TITLE
MM-20305: Adds ability to choose whether deleted teams are included i…

### DIFF
--- a/app/analytics.go
+++ b/app/analytics.go
@@ -84,7 +84,7 @@ func (a *App) GetAnalytics(name string, teamId string) (model.AnalyticsRows, *mo
 
 		teamCountChan := make(chan store.StoreResult, 1)
 		go func() {
-			teamCount, err := a.Srv.Store.Team().AnalyticsTeamCount()
+			teamCount, err := a.Srv.Store.Team().AnalyticsTeamCount(false)
 			teamCountChan <- store.StoreResult{Data: teamCount, Err: err}
 			close(teamCountChan)
 		}()

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -148,7 +148,7 @@ func (a *App) trackActivity() {
 		inactiveUserCount = iucr
 	}
 
-	teamCount, err := a.Srv.Store.Team().AnalyticsTeamCount()
+	teamCount, err := a.Srv.Store.Team().AnalyticsTeamCount(false)
 	if err != nil {
 		mlog.Error(err.Error())
 	}

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -499,7 +499,7 @@ func (me *TestHelper) ResetEmojisMigration() {
 }
 
 func (me *TestHelper) CheckTeamCount(t *testing.T, expected int64) {
-	teamCount, err := me.App.Srv.Store.Team().AnalyticsTeamCount()
+	teamCount, err := me.App.Srv.Store.Team().AnalyticsTeamCount(false)
 	require.Nil(t, err, "Failed to get team count.")
 	require.Equalf(t, teamCount, expected, "Unexpected number of teams. Expected: %v, found: %v", expected, teamCount)
 }

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -505,7 +505,7 @@ func TestImportImportTeam(t *testing.T) {
 	scheme2 := th.SetupTeamScheme()
 
 	// Check how many teams are in the database.
-	teamsCount, err := th.App.Srv.Store.Team().AnalyticsTeamCount()
+	teamsCount, err := th.App.Srv.Store.Team().AnalyticsTeamCount(false)
 	require.Nil(t, err, "Failed to get team count.")
 
 	data := TeamImportData{

--- a/app/security_update_check.go
+++ b/app/security_update_check.go
@@ -76,7 +76,7 @@ func (s *Server) DoSecurityUpdateCheck() {
 			v.Set(PROP_SECURITY_ACTIVE_USER_COUNT, strconv.FormatInt(ucr, 10))
 		}
 
-		if teamCount, err := s.Store.Team().AnalyticsTeamCount(); err == nil {
+		if teamCount, err := s.Store.Team().AnalyticsTeamCount(false); err == nil {
 			v.Set(PROP_SECURITY_TEAM_COUNT, strconv.FormatInt(teamCount, 10))
 		}
 

--- a/app/team.go
+++ b/app/team.go
@@ -659,7 +659,7 @@ func (a *App) GetAllTeamsPage(offset int, limit int) ([]*model.Team, *model.AppE
 }
 
 func (a *App) GetAllTeamsPageWithCount(offset int, limit int) (*model.TeamsWithCount, *model.AppError) {
-	totalCount, err := a.Srv.Store.Team().AnalyticsTeamCount()
+	totalCount, err := a.Srv.Store.Team().AnalyticsTeamCount(true)
 	if err != nil {
 		return nil, err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -80,7 +80,7 @@ type TeamStore interface {
 	GetTeamsByUserId(userId string) ([]*model.Team, *model.AppError)
 	GetByInviteId(inviteId string) (*model.Team, *model.AppError)
 	PermanentDelete(teamId string) *model.AppError
-	AnalyticsTeamCount() (int64, *model.AppError)
+	AnalyticsTeamCount(includeDeleted bool) (int64, *model.AppError)
 	AnalyticsPublicTeamCount() (int64, *model.AppError)
 	AnalyticsPrivateTeamCount() (int64, *model.AppError)
 	SaveMember(member *model.TeamMember, maxUsersPerTeam int) (*model.TeamMember, *model.AppError)

--- a/store/storetest/mocks/TeamStore.go
+++ b/store/storetest/mocks/TeamStore.go
@@ -83,20 +83,20 @@ func (_m *TeamStore) AnalyticsPublicTeamCount() (int64, *model.AppError) {
 	return r0, r1
 }
 
-// AnalyticsTeamCount provides a mock function with given fields:
-func (_m *TeamStore) AnalyticsTeamCount() (int64, *model.AppError) {
-	ret := _m.Called()
+// AnalyticsTeamCount provides a mock function with given fields: includeDeleted
+func (_m *TeamStore) AnalyticsTeamCount(includeDeleted bool) (int64, *model.AppError) {
+	ret := _m.Called(includeDeleted)
 
 	var r0 int64
-	if rf, ok := ret.Get(0).(func() int64); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(bool) int64); ok {
+		r0 = rf(includeDeleted)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
 	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(bool) *model.AppError); ok {
+		r1 = rf(includeDeleted)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/store/timer_layer.go
+++ b/store/timer_layer.go
@@ -5162,10 +5162,10 @@ func (s *TimerLayerTeamStore) AnalyticsPublicTeamCount() (int64, *model.AppError
 	return resultVar0, resultVar1
 }
 
-func (s *TimerLayerTeamStore) AnalyticsTeamCount() (int64, *model.AppError) {
+func (s *TimerLayerTeamStore) AnalyticsTeamCount(includeDeleted bool) (int64, *model.AppError) {
 	start := timemodule.Now()
 
-	resultVar0, resultVar1 := s.TeamStore.AnalyticsTeamCount()
+	resultVar0, resultVar1 := s.TeamStore.AnalyticsTeamCount(includeDeleted)
 
 	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
 	if s.Root.Metrics != nil {


### PR DESCRIPTION
…n the count query.

#### Summary

Adds boolean parameter to include deleted teams in count query. Uses it to include deleted teams in the count for /admin_console/user_management/teams.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-20305
