### PR TITLE
GH-12781: Migrate tests to use testify

### DIFF
--- a/store/sqlstore/preference_store_test.go
+++ b/store/sqlstore/preference_store_test.go
@@ -63,9 +63,9 @@ func TestDeleteUnusedFeatures(t *testing.T) {
                     WHERE Category = :Category
                     AND Value = :Val
                     AND Name LIKE '`+store.FEATURE_TOGGLE_PREFIX+`%'`, map[string]interface{}{"Category": model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS, "Val": "false"}); err != nil {
-			t.Fatal(err)
+			require.Nil(t, err)
 		} else if val != 0 {
-			t.Fatalf("Found %d features with value 'false', expected all to be deleted", val)
+			require.Fail(t, "Found %d features with value 'false', expected all to be deleted", val)
 		}
 		//
 		// make sure features with value "true" remain saved
@@ -74,9 +74,9 @@ func TestDeleteUnusedFeatures(t *testing.T) {
                     WHERE Category = :Category
                     AND Value = :Val
                     AND Name LIKE '`+store.FEATURE_TOGGLE_PREFIX+`%'`, map[string]interface{}{"Category": model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS, "Val": "true"}); err != nil {
-			t.Fatal(err)
+			require.Nil(t, err)
 		} else if val == 0 {
-			t.Fatalf("Found %d features with value 'true', expected to find at least %d features", val, 2)
+			require.Fail(t, "Found %d features with value 'true', expected to find at least %d features", val, 2)
 		}
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Migrate tests from using t.Fatal() methods in some cases to use appropriate testify methods to check errors.

#### Ticket Link

If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

Fixes https://github.com/mattermost/mattermost-server/issues/12781

#### Jira ticket 
[ticket](https://mattermost.atlassian.net/browse/MM-19455)
