### PR TITLE
Events for plugin communication

### DIFF
--- a/plugin/api.go
+++ b/plugin/api.go
@@ -920,6 +920,10 @@ type API interface {
 	//
 	// Minimum server version: 5.18
 	PluginHTTP(request *http.Request) *http.Response
+
+	SendPluginEvent(event string, payload interface{}) *model.AppError
+
+	SubscribePluginEvent(event string) *model.AppError
 }
 
 var handshake = plugin.HandshakeConfig{

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -476,6 +476,42 @@ func (s *hooksRPCServer) UserHasLeftTeam(args *Z_UserHasLeftTeamArgs, returns *Z
 	return nil
 }
 
+func init() {
+	hookNameToId["ReceivePluginEvent"] = ReceivePluginEventId
+}
+
+type Z_ReceivePluginEventArgs struct {
+	A *Context
+	B string
+	C interface{}
+}
+
+type Z_ReceivePluginEventReturns struct {
+}
+
+func (g *hooksRPCClient) ReceivePluginEvent(c *Context, event string, payload interface{}) {
+	_args := &Z_ReceivePluginEventArgs{c, event, payload}
+	_returns := &Z_ReceivePluginEventReturns{}
+	if g.implemented[ReceivePluginEventId] {
+		if err := g.client.Call("Plugin.ReceivePluginEvent", _args, _returns); err != nil {
+			g.log.Error("RPC call ReceivePluginEvent to plugin failed.", mlog.Err(err))
+		}
+	}
+
+}
+
+func (s *hooksRPCServer) ReceivePluginEvent(args *Z_ReceivePluginEventArgs, returns *Z_ReceivePluginEventReturns) error {
+	if hook, ok := s.impl.(interface {
+		ReceivePluginEvent(c *Context, event string, payload interface{})
+	}); ok {
+		hook.ReceivePluginEvent(args.A, args.B, args.C)
+
+	} else {
+		return encodableError(fmt.Errorf("Hook ReceivePluginEvent called but not implemented."))
+	}
+	return nil
+}
+
 type Z_RegisterCommandArgs struct {
 	A *model.Command
 }
@@ -4308,6 +4344,63 @@ func (s *apiRPCServer) DeleteBotIconImage(args *Z_DeleteBotIconImageArgs, return
 		returns.A = hook.DeleteBotIconImage(args.A)
 	} else {
 		return encodableError(fmt.Errorf("API DeleteBotIconImage called but not implemented."))
+	}
+	return nil
+}
+
+type Z_SendPluginEventArgs struct {
+	A string
+	B interface{}
+}
+
+type Z_SendPluginEventReturns struct {
+	A *model.AppError
+}
+
+func (g *apiRPCClient) SendPluginEvent(event string, payload interface{}) *model.AppError {
+	_args := &Z_SendPluginEventArgs{event, payload}
+	_returns := &Z_SendPluginEventReturns{}
+	if err := g.client.Call("Plugin.SendPluginEvent", _args, _returns); err != nil {
+		log.Printf("RPC call to SendPluginEvent API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) SendPluginEvent(args *Z_SendPluginEventArgs, returns *Z_SendPluginEventReturns) error {
+	if hook, ok := s.impl.(interface {
+		SendPluginEvent(event string, payload interface{}) *model.AppError
+	}); ok {
+		returns.A = hook.SendPluginEvent(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API SendPluginEvent called but not implemented."))
+	}
+	return nil
+}
+
+type Z_SubscribePluginEventArgs struct {
+	A string
+}
+
+type Z_SubscribePluginEventReturns struct {
+	A *model.AppError
+}
+
+func (g *apiRPCClient) SubscribePluginEvent(event string) *model.AppError {
+	_args := &Z_SubscribePluginEventArgs{event}
+	_returns := &Z_SubscribePluginEventReturns{}
+	if err := g.client.Call("Plugin.SubscribePluginEvent", _args, _returns); err != nil {
+		log.Printf("RPC call to SubscribePluginEvent API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) SubscribePluginEvent(args *Z_SubscribePluginEventArgs, returns *Z_SubscribePluginEventReturns) error {
+	if hook, ok := s.impl.(interface {
+		SubscribePluginEvent(event string) *model.AppError
+	}); ok {
+		returns.A = hook.SubscribePluginEvent(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API SubscribePluginEvent called but not implemented."))
 	}
 	return nil
 }

--- a/plugin/hooks.go
+++ b/plugin/hooks.go
@@ -33,6 +33,7 @@ const (
 	UserWillLogInId         = 15
 	UserHasLoggedInId       = 16
 	UserHasBeenCreatedId    = 17
+	ReceivePluginEventId    = 18
 	TotalHooksId            = iota
 )
 
@@ -155,4 +156,6 @@ type Hooks interface {
 	// Note that this method will be called for files uploaded by plugins, including the plugin that uploaded the post.
 	// FileInfo.Size will be automatically set properly if you modify the file.
 	FileWillBeUploaded(c *Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string)
+
+	ReceivePluginEvent(c *Context, event string, payload interface{})
 }


### PR DESCRIPTION
This an implementation proposal on how can we handle plugin to plugin communication in an easier way. The concept uses "events" to which plugins can subscribe and it is implemented using the current RPC communication that mattermost-server uses to handle plugin communication.

This way, any plugin that is subscribed to an event will get the message without any other necessary action.

**- Plugin API:**
	SubscribePluginEvent: allows to subscribe to an specific event
	SendPluginEvent: allows you to send an event

**- Hooks:**
	ReceivePluginEvent: allows you to handle events to which you have subscribed.


_Example:_
1. Plugin A gets subscribe to "Test" event
2. Plugin B sends a "Test" event
2. Plugin A gets the "Test" event

A simple code snippet:

**Plugin A**
```
// We can use the OnActivate hook in order to get subscribe to events
func (p *Plugin) OnActivate() {
	p.API.SubscribePluginEvent("Test")
}

// We get all events here
func (p *Plugin) ReceivePluginEvent(event string, payload interface{}) {
	
	switch event {
	case "Test":
		testEventMessage := payload.(string)
	}
}
```

**Plugin B**
```
func (p *Plugin) SomeMethod() {
	p.API.SendPluginEvent("Test", "test message")
}

```
Tests are still missing and any sort of comments on this would be appreciated. 

Thanks a lot!