### PR TITLE
MM-20681 Fix custom post types not marking channel unread when using Mark as Unread

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -1194,7 +1194,7 @@ func (a *App) countMentionsFromPost(user *model.User, post *model.Post) (int, *m
 			return 0, countErr
 		}
 
-		return int(count), countErr
+		return count, countErr
 	}
 
 	channelMember, err := a.GetChannelMember(channel.Id, user.Id)

--- a/model/post.go
+++ b/model/post.go
@@ -350,6 +350,19 @@ func (o *Post) IsSystemMessage() bool {
 	return len(o.Type) >= len(POST_SYSTEM_MESSAGE_PREFIX) && o.Type[:len(POST_SYSTEM_MESSAGE_PREFIX)] == POST_SYSTEM_MESSAGE_PREFIX
 }
 
+func (o *Post) IsJoinLeaveMessage() bool {
+	return o.Type != POST_JOIN_LEAVE ||
+		o.Type != POST_ADD_REMOVE ||
+		o.Type != POST_JOIN_CHANNEL ||
+		o.Type != POST_LEAVE_CHANNEL ||
+		o.Type != POST_JOIN_TEAM ||
+		o.Type != POST_LEAVE_TEAM ||
+		o.Type != POST_ADD_TO_CHANNEL ||
+		o.Type != POST_REMOVE_FROM_CHANNEL ||
+		o.Type != POST_ADD_TO_TEAM ||
+		o.Type != POST_REMOVE_FROM_TEAM
+}
+
 func (p *Post) Patch(patch *PostPatch) {
 	if patch.IsPinned != nil {
 		p.IsPinned = *patch.IsPinned

--- a/model/post.go
+++ b/model/post.go
@@ -351,16 +351,16 @@ func (o *Post) IsSystemMessage() bool {
 }
 
 func (o *Post) IsJoinLeaveMessage() bool {
-	return o.Type != POST_JOIN_LEAVE ||
-		o.Type != POST_ADD_REMOVE ||
-		o.Type != POST_JOIN_CHANNEL ||
-		o.Type != POST_LEAVE_CHANNEL ||
-		o.Type != POST_JOIN_TEAM ||
-		o.Type != POST_LEAVE_TEAM ||
-		o.Type != POST_ADD_TO_CHANNEL ||
-		o.Type != POST_REMOVE_FROM_CHANNEL ||
-		o.Type != POST_ADD_TO_TEAM ||
-		o.Type != POST_REMOVE_FROM_TEAM
+	return o.Type == POST_JOIN_LEAVE ||
+		o.Type == POST_ADD_REMOVE ||
+		o.Type == POST_JOIN_CHANNEL ||
+		o.Type == POST_LEAVE_CHANNEL ||
+		o.Type == POST_JOIN_TEAM ||
+		o.Type == POST_LEAVE_TEAM ||
+		o.Type == POST_ADD_TO_CHANNEL ||
+		o.Type == POST_REMOVE_FROM_CHANNEL ||
+		o.Type == POST_ADD_TO_TEAM ||
+		o.Type == POST_REMOVE_FROM_TEAM
 }
 
 func (p *Post) Patch(patch *PostPatch) {

--- a/store/store.go
+++ b/store/store.go
@@ -162,7 +162,7 @@ type ChannelStore interface {
 	PermanentDeleteMembersByChannel(channelId string) *model.AppError
 	UpdateLastViewedAt(channelIds []string, userId string) (map[string]int64, *model.AppError)
 	UpdateLastViewedAtPost(unreadPost *model.Post, userID string, mentionCount int) (*model.ChannelUnreadAt, *model.AppError)
-	CountPostsAfter(channelId string, timestamp int64, userId string) (int64, *model.AppError)
+	CountPostsAfter(channelId string, timestamp int64, userId string) (int, *model.AppError)
 	IncrementMentionCount(channelId string, userId string) *model.AppError
 	AnalyticsTypeCount(teamId string, channelType string) (int64, *model.AppError)
 	GetMembersForUser(teamId string, userId string) (*model.ChannelMembers, *model.AppError)

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -133,14 +133,14 @@ func (_m *ChannelStore) ClearCaches() {
 }
 
 // CountPostsAfter provides a mock function with given fields: channelId, timestamp, userId
-func (_m *ChannelStore) CountPostsAfter(channelId string, timestamp int64, userId string) (int64, *model.AppError) {
+func (_m *ChannelStore) CountPostsAfter(channelId string, timestamp int64, userId string) (int, *model.AppError) {
 	ret := _m.Called(channelId, timestamp, userId)
 
-	var r0 int64
-	if rf, ok := ret.Get(0).(func(string, int64, string) int64); ok {
+	var r0 int
+	if rf, ok := ret.Get(0).(func(string, int64, string) int); ok {
 		r0 = rf(channelId, timestamp, userId)
 	} else {
-		r0 = ret.Get(0).(int64)
+		r0 = ret.Get(0).(int)
 	}
 
 	var r1 *model.AppError


### PR DESCRIPTION
This PR is based off https://github.com/mattermost/mattermost-server/pull/13245. The changes specific to it are visible here: https://github.com/mattermost/mattermost-server/pull/13245

The previous version of this code only counted regular posts (ie posts with an empty post type) when updating the `ChannelMember.MsgCount`. That value is supposed to include all non-join/leave messages, so I've updated `CountPostsAfter` to match the expected behaviour.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-20681