### PR TITLE
Remove references of GOPATH from circleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 
 executors:
   ubuntu:
-    working_directory: ~/go/src/github.com/mattermost/
+    working_directory: ~/go/mattermost/
     machine:
       image: "ubuntu-1604:201903-01"
     environment:
@@ -13,7 +13,7 @@ executors:
 
 jobs:
   setup:
-    working_directory: /go/src/github.com/mattermost/mattermost-server
+    working_directory: ~/go/mattermost/mattermost-server
     docker:
       - image: mattermost/mattermost-build-webapp:oct-2-2018
     steps:
@@ -33,7 +33,7 @@ jobs:
             npm ci && make build
           fi
       - persist_to_workspace:
-          root: /go/src/github.com/mattermost
+          root: ~/go/mattermost
           paths:
             - mattermost-webapp
             - mattermost-server
@@ -43,10 +43,10 @@ jobs:
   # check-i18n:
   #   docker:
   #   - image: circleci/golang:1.12
-  #   working_directory: /go/src/github.com/mattermost/
+  #   working_directory: ~/go/mattermost/
   #   steps:
   #     - attach_workspace:
-  #         at: /go/src/github.com/mattermost/
+  #         at: ~/go/mattermost/
   #     - run:
   #         command: |
   #           cd mattermost-server
@@ -57,10 +57,10 @@ jobs:
   build:
     docker:
       - image: mattermost/mattermost-build-server:oct-18-2019
-    working_directory: /go/src/github.com/mattermost
+    working_directory: ~/go/mattermost
     steps:
       - attach_workspace:
-          at: /go/src/github.com/mattermost/
+          at: ~/go/mattermost/
       - run:
           command: |
             echo "Installing golangci-lint"
@@ -71,13 +71,13 @@ jobs:
             make build BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'
             make package BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'
       - store_artifacts:
-          path: /go/src/github.com/mattermost/mattermost-server/dist/mattermost-team-linux-amd64.tar.gz
+          path: ~/go/mattermost/mattermost-server/dist/mattermost-team-linux-amd64.tar.gz
       - store_artifacts:
-          path: /go/src/github.com/mattermost/mattermost-server/dist/mattermost-team-osx-amd64.tar.gz
+          path: ~/go/mattermost/mattermost-server/dist/mattermost-team-osx-amd64.tar.gz
       - store_artifacts:
-          path: /go/src/github.com/mattermost/mattermost-server/dist/mattermost-team-windows-amd64.zip
+          path: ~/go/mattermost/mattermost-server/dist/mattermost-team-windows-amd64.zip
       - persist_to_workspace:
-          root: /go/src/github.com/mattermost
+          root: ~/go/mattermost
           paths:
             - mattermost-server
             - mattermost-webapp
@@ -87,7 +87,7 @@ jobs:
       name: ubuntu
     steps:
       - attach_workspace:
-          at: ~/go/src/github.com/mattermost
+          at: ~/go/mattermost
       - run:
           name: Run Docker compose
           command: |
@@ -123,8 +123,8 @@ jobs:
               --env MM_EMAILSETTINGS_SMTPSERVER=inbucket \
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
-              -v ~/go/src:/go/src \
-              -w /go/src/github.com/mattermost/mattermost-server \
+              -v ~/go/mattermost:~/go/mattermost \
+              -w ~/go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make test-server BUILD_NUMBER="$CIRCLE_BRANCH-$CIRCLE_PREVIOUS_BUILD_NUM" TESTFLAGS= TESTFLAGSEE='
           no_output_timeout: 1h
@@ -140,7 +140,7 @@ jobs:
             docker stats -a --no-stream > logs/docker_stats
             tar -czvf logs/docker_logs.tar.gz logs/docker-compose_logs logs/docker_ps logs/docker_stats
       - store_artifacts:
-          path: ~/go/src/github.com/mattermost/mattermost-server/build/logs
+          path: ~/go/mattermost/mattermost-server/build/logs
       - run:
           when: always
           command: |
@@ -148,16 +148,16 @@ jobs:
             mkdir -p test-results
             cp report.xml test-results
       - store_test_results:
-          path: ~/go/src/github.com/mattermost/mattermost-server/test-results/
+          path: ~/go/mattermost/mattermost-server/test-results/
       - store_artifacts:
-          path: ~/go/src/github.com/mattermost/mattermost-server/test-results/
+          path: ~/go/mattermost/mattermost-server/test-results/
 
   test-schema:
     executor:
       name: ubuntu
     steps:
       - attach_workspace:
-          at: ~/go/src/github.com/mattermost
+          at: ~/go/mattermost
       - run:
           name: Run Docker compose
           command: |
@@ -196,8 +196,8 @@ jobs:
               --env MM_SQLSETTINGS_DRIVERNAME=postgres \
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
-              -v ~/go/src:/go/src \
-              -w /go/src/github.com/mattermost/mattermost-server \
+              -v ~/go/mattermost:~/go/mattermost \
+              -w ~/go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="postgres://mmuser:mostest@postgres:5432/latest?sslmode=disable&connect_timeout=10" ARGS="version" run-cli'
             echo "Generating dump"
@@ -232,8 +232,8 @@ jobs:
               --env MM_SQLSETTINGS_DRIVERNAME=mysql \
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
-              -v ~/go/src:/go/src \
-              -w /go/src/github.com/mattermost/mattermost-server \
+              -v ~/go/mattermost:~/go/mattermost \
+              -w ~/go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="mmuser:mostest@tcp(mysql:3306)/latest?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s" ARGS="version" run-cli'
 
@@ -255,32 +255,32 @@ jobs:
   upload-s3-sha:
     docker:
       - image: 'circleci/python:2.7'
-    working_directory: ~/go/src/github.com/mattermost/enterprise
+    working_directory: ~/go/mattermost/enterprise
     steps:
       - attach_workspace:
-          at: ~/go/src/github.com/mattermost/
+          at: ~/go/mattermost/
       - run:
           command: |
-            cd ~/go/src/github.com/mattermost/mattermost-server/dist/
+            cd ~/go/mattermost/mattermost-server/dist/
             rm -rf mattermost
       - aws-s3/copy:
-          from: ~/go/src/github.com/mattermost/mattermost-server/dist/
+          from: ~/go/mattermost/mattermost-server/dist/
           to: "s3://releases.mattermost.com/mattermost-platform-pr/commit/${CIRCLE_SHA1}/"
           arguments: --acl public-read --cache-control "no-cache" --recursive
 
   upload-s3:
     docker:
     - image: 'circleci/python:2.7'
-    working_directory: ~/go/src/github.com/mattermost/enterprise
+    working_directory: ~/go/mattermost/enterprise
     steps:
       - attach_workspace:
-          at: ~/go/src/github.com/mattermost/
+          at: ~/go/mattermost/
       - run:
           command: |
-            cd ~/go/src/github.com/mattermost/mattermost-server/dist/
+            cd ~/go/mattermost/mattermost-server/dist/
             rm -rf mattermost
       - aws-s3/copy:
-          from: ~/go/src/github.com/mattermost/mattermost-server/dist/
+          from: ~/go/mattermost/mattermost-server/dist/
           to: s3://releases.mattermost.com/mattermost-platform-pr/$(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/
           arguments: --acl public-read --cache-control "no-cache" --recursive
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
               --env MM_EMAILSETTINGS_SMTPSERVER=inbucket \
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
-              -v ~/go/mattermost:~/go/mattermost \
+              -v ~/go/mattermost:/go/mattermost \
               -w ~/go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make test-server BUILD_NUMBER="$CIRCLE_BRANCH-$CIRCLE_PREVIOUS_BUILD_NUM" TESTFLAGS= TESTFLAGSEE='
@@ -196,7 +196,7 @@ jobs:
               --env MM_SQLSETTINGS_DRIVERNAME=postgres \
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
-              -v ~/go/mattermost:~/go/mattermost \
+              -v ~/go/mattermost:/go/mattermost \
               -w ~/go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="postgres://mmuser:mostest@postgres:5432/latest?sslmode=disable&connect_timeout=10" ARGS="version" run-cli'
@@ -232,7 +232,7 @@ jobs:
               --env MM_SQLSETTINGS_DRIVERNAME=mysql \
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
-              -v ~/go/mattermost:~/go/mattermost \
+              -v ~/go/mattermost:/go/mattermost \
               -w ~/go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="mmuser:mostest@tcp(mysql:3306)/latest?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s" ARGS="version" run-cli'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
               -v ~/go/mattermost:/go/mattermost \
-              -w ~/go/mattermost/mattermost-server \
+              -w /go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make test-server BUILD_NUMBER="$CIRCLE_BRANCH-$CIRCLE_PREVIOUS_BUILD_NUM" TESTFLAGS= TESTFLAGSEE='
           no_output_timeout: 1h
@@ -197,7 +197,7 @@ jobs:
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
               -v ~/go/mattermost:/go/mattermost \
-              -w ~/go/mattermost/mattermost-server \
+              -w /go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="postgres://mmuser:mostest@postgres:5432/latest?sslmode=disable&connect_timeout=10" ARGS="version" run-cli'
             echo "Generating dump"
@@ -233,7 +233,7 @@ jobs:
               --env MM_EMAILSETTINGS_SMTPPORT=10025 \
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
               -v ~/go/mattermost:/go/mattermost \
-              -w ~/go/mattermost/mattermost-server \
+              -w /go/mattermost/mattermost-server \
               mattermost/mattermost-build-server:oct-18-2019 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="mmuser:mostest@tcp(mysql:3306)/latest?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s" ARGS="version" run-cli'
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
And normalize all paths to refer from $HOME as ~ rather than
an absolute path.

We still need to remain under ~/go because the package building takes assets from $GOPATH/bin. A later commit will move everything from $GOPATH/bin to $GOBIN, and then we can get rid of ~/go prefix as well, and perform everything under ~/mattermost.


#### Ticket Link
Updates #13129

@hanzei 
