### PR TITLE
[MM-20620] Handle trailing slash when building marketplace api path

### DIFF
--- a/services/marketplace/client.go
+++ b/services/marketplace/client.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/services/httpservice"
@@ -84,7 +85,7 @@ func closeBody(r *http.Response) {
 }
 
 func (c *Client) buildURL(urlPath string, args ...interface{}) string {
-	return fmt.Sprintf("%s%s", c.address, fmt.Sprintf(urlPath, args...))
+	return fmt.Sprintf("%s/%s", strings.TrimRight(c.address, "/"), strings.TrimLeft(fmt.Sprintf(urlPath, args...), "/"))
 }
 
 func (c *Client) doGet(u string) (*http.Response, error) {

--- a/services/marketplace/client_test.go
+++ b/services/marketplace/client_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package marketplace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildURL(t *testing.T) {
+	config := &Client{}
+
+	testCases := map[string]struct {
+		base     string
+		path     string
+		expected string
+	}{
+		"Base url with trailing slash and path with leading slash": {
+			base:     "https://api.integrations.mattermost.com/",
+			path:     "/api/v1/plugins",
+			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
+		},
+		"Base url with without trailing slash and path with leading slash": {
+			base:     "https://api.integrations.mattermost.com",
+			path:     "/api/v1/plugins",
+			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
+		},
+		"Base url with without trailing slash and path without leading slash": {
+			base:     "https://api.integrations.mattermost.com",
+			path:     "api/v1/plugins",
+			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
+		},
+	}
+
+	for name, tt := range testCases {
+		t.Run(name, func(t *testing.T) {
+			config.address = tt.base
+			actual := config.buildURL(tt.path)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/services/marketplace/client_test.go
+++ b/services/marketplace/client_test.go
@@ -22,12 +22,12 @@ func TestBuildURL(t *testing.T) {
 			path:     "/api/v1/plugins",
 			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
 		},
-		"Base url with without trailing slash and path with leading slash": {
+		"Base url without trailing slash and path with leading slash": {
 			base:     "https://api.integrations.mattermost.com",
 			path:     "/api/v1/plugins",
 			expected: "https://api.integrations.mattermost.com/api/v1/plugins",
 		},
-		"Base url with without trailing slash and path without leading slash": {
+		"Base url without trailing slash and path without leading slash": {
 			base:     "https://api.integrations.mattermost.com",
 			path:     "api/v1/plugins",
 			expected: "https://api.integrations.mattermost.com/api/v1/plugins",


### PR DESCRIPTION
#### Summary
- Update Client#buildURL to normalize both the incoming path and the existing marketplace url by removing leading & trailing slashes and then adding a single slash in between the two strings
- Also add some unit tests for `buildURL`

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/13271
JIRA: https://mattermost.atlassian.net/browse/MM-20620
