### PR TITLE
Dont build master or release branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,12 @@ workflows:
   version: 2
   untagged-build:
     jobs:
-      - setup
+      - setup:
+          filters:
+            branches:
+                ignore:
+                  - master
+                  - /^release-.*/
       # - check-i18n:
       #     requires:
       #       - setup


### PR DESCRIPTION
#### Summary
those branches are being built in the internal Jenkins

`master` and `release-*` are built using the internal release Jenkins, and it does both `TE` and `EE`, plus the docker images for the branches and push to the release s3 bucket. 
So we don't need to have another source of potentials flakes and debugging, also reduce the usage of credits we have (equals less money spend) and also have one source of truth 

will do the same for `enterprise` if we merge this one