### PR TITLE
Fixing flaky test around websocket counts in analytics API endpoint

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -360,10 +360,11 @@ func TestGetAnalyticsOld(t *testing.T) {
 
 	WebSocketClient, err := th.CreateWebSocketClient()
 	require.Nil(t, err)
+	time.Sleep(100 * time.Millisecond)
 	rows2, resp2 = th.SystemAdminClient.GetAnalyticsOld("standard", "")
 	CheckNoError(t, resp2)
 	assert.Equal(t, "total_websocket_connections", rows2[5].Name)
-	assert.Equal(t, float64(th.App.TotalWebsocketConnections()), rows2[5].Value)
+	assert.Equal(t, float64(1), rows2[5].Value)
 
 	WebSocketClient.Close()
 


### PR DESCRIPTION
#### Summary
The flaky test was a super weird race condition where the websocket connection is not counted yet, but is already "started", this happens because the goroutines schedule is not giving the control to the server to handle the channel received for register the websocket connection on time.

I think this fix should avoid the problem in the future (is not super sexy solution, but should deal with the underneath problem, giving the websocket connection time to be counted there).

#### Ticket Link
[MM-19004](https://mattermost.atlassian.net/browse/MM-19004)