### PR TITLE
[MM-21048] Add CSRF check for handlers that do not require a session but have one

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -222,7 +222,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // checkCSRFToken performs a CSRF check on the provided request with the given CSRF token. Returns whether or not
 // a CSRF check occurred and whether or not it succeeded.
 func (h *Handler) checkCSRFToken(c *Context, r *http.Request, token string, tokenLocation app.TokenLocation, session *model.Session) (checked bool, passed bool) {
-	csrfCheckNeeded := c.Err == nil && tokenLocation == app.TokenLocationCookie && h.RequireSession && !h.TrustRequester && r.Method != "GET"
+	csrfCheckNeeded := session != nil && c.Err == nil && tokenLocation == app.TokenLocationCookie && !h.TrustRequester && r.Method != "GET"
 	csrfCheckPassed := false
 
 	if csrfCheckNeeded {


### PR DESCRIPTION
#### Summary

PR enables CSRF check also for handlers that do not require an authenticated session but still might get one.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21048