### PR TITLE
MM-21008 Fix CLI nil pointer panic

### DIFF
--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -519,6 +519,10 @@ func modifyChannelCmdF(command *cobra.Command, args []string) error {
 	}
 
 	user := getUserFromUserArg(a, username)
+	if user == nil {
+		return fmt.Errorf("Unable to find user: '%v'", username)
+	}
+
 	if _, err := a.UpdateChannelPrivacy(channel, user); err != nil {
 		return errors.Wrapf(err, "Failed to update channel ('%s') privacy", args[0])
 	}

--- a/cmd/mattermost/commands/channel_test.go
+++ b/cmd/mattermost/commands/channel_test.go
@@ -227,3 +227,30 @@ func Test_searchChannelCmdF(t *testing.T) {
 		})
 	}
 }
+
+func TestModifyChannel(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	channel1 := th.CreatePrivateChannel()
+	channel2 := th.CreatePrivateChannel()
+
+	th.CheckCommand(t, "channel", "modify", "--public", th.BasicTeam.Name+":"+channel1.Name, "--username", th.BasicUser2.Email)
+	res, err := th.App.Srv.Store.Channel().Get(channel1.Id, false)
+	require.Nil(t, err)
+	assert.Equal(t, model.CHANNEL_OPEN, res.Type)
+
+	// should fail because user doesn't exist
+	require.Error(t, th.RunCommand(t, "channel", "modify", "--public", th.BasicTeam.Name+":"+channel2.Name, "--username", "idonotexist"))
+
+	pchannel1 := th.CreatePublicChannel()
+	pchannel2 := th.CreatePublicChannel()
+
+	th.CheckCommand(t, "channel", "modify", "--private", th.BasicTeam.Name+":"+pchannel1.Name, "--username", th.BasicUser2.Email)
+	res, err = th.App.Srv.Store.Channel().Get(pchannel1.Id, false)
+	require.Nil(t, err)
+	assert.Equal(t, model.CHANNEL_PRIVATE, res.Type)
+
+	// should fail because user doesn't exist
+	require.Error(t, th.RunCommand(t, "channel", "modify", "--private", th.BasicTeam.Name+":"+pchannel2.Name, "--username", "idonotexist"))
+}


### PR DESCRIPTION
#### Summary
Fixes panic when using the `mattermost channel modify` CLI command to change channel public status. If you mistype the username or the system fails to find the user the command will panic because it did not check if it succeeded in retrieving the user. 

Fixes #13325 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21008
