### PR TITLE
MM-21103: change plugin signature path

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -942,7 +942,7 @@ func TestInstallMarketplacePlugin(t *testing.T) {
 		require.Equal(t, "testplugin_v2", manifest.Id)
 		require.Equal(t, "1.2.3", manifest.Version)
 
-		filePath := filepath.Join(*th.App.Config().PluginSettings.Directory, "testplugin_v2.sig")
+		filePath := filepath.Join(*th.App.Config().PluginSettings.Directory, "testplugin_v2.tar.gz.sig")
 		savedSigFile, err := th.App.ReadFile(filePath)
 		require.Nil(t, err)
 		require.EqualValues(t, sigFile, savedSigFile)

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -244,6 +244,7 @@ func (a *App) SyncPlugins() *model.AppError {
 	if appErr != nil {
 		return appErr
 	}
+
 	for _, plugin := range pluginSignaturePathMap {
 		reader, appErr := a.FileReader(plugin.path)
 		if appErr != nil {
@@ -593,27 +594,18 @@ func (a *App) getPluginsFromFolder() (map[string]*pluginSignaturePath, *model.Ap
 	if appErr != nil {
 		return nil, model.NewAppError("getPluginsFromDir", "app.plugin.sync.list_filestore.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 	}
+
 	pluginSignaturePathMap := make(map[string]*pluginSignaturePath)
 	for _, path := range fileStorePaths {
 		if strings.HasSuffix(path, ".tar.gz") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz")
-			helper := &pluginSignaturePath{
+			pluginSignaturePathMap[id] = &pluginSignaturePath{
 				pluginId:      id,
 				path:          path,
-				signaturePath: "",
-			}
-			pluginSignaturePathMap[id] = helper
-		}
-	}
-	for _, path := range fileStorePaths {
-		if strings.HasSuffix(path, ".sig") {
-			id := strings.TrimSuffix(filepath.Base(path), ".sig")
-			if val, ok := pluginSignaturePathMap[id]; !ok {
-				mlog.Error("Unknown signature", mlog.String("path", path))
-			} else {
-				val.signaturePath = path
+				signaturePath: a.getSignatureStorePath(id),
 			}
 		}
 	}
+
 	return pluginSignaturePathMap, nil
 }

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -599,10 +599,21 @@ func (a *App) getPluginsFromFolder() (map[string]*pluginSignaturePath, *model.Ap
 	for _, path := range fileStorePaths {
 		if strings.HasSuffix(path, ".tar.gz") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz")
-			pluginSignaturePathMap[id] = &pluginSignaturePath{
+			helper := &pluginSignaturePath{
 				pluginId:      id,
 				path:          path,
-				signaturePath: a.getSignatureStorePath(id),
+				signaturePath: "",
+			}
+			pluginSignaturePathMap[id] = helper
+		}
+	}
+	for _, path := range fileStorePaths {
+		if strings.HasSuffix(path, ".tar.gz.sig") {
+			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz.sig")
+			if val, ok := pluginSignaturePathMap[id]; !ok {
+				mlog.Error("Unknown signature", mlog.String("path", path))
+			} else {
+				val.signaturePath = path
 			}
 		}
 	}

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -405,5 +405,5 @@ func (a *App) getBundleStorePath(id string) string {
 }
 
 func (a *App) getSignatureStorePath(id string) string {
-	return filepath.Join(fileStorePluginFolder, fmt.Sprintf("%s.sig", id))
+	return filepath.Join(fileStorePluginFolder, fmt.Sprintf("%s.tar.gz.sig", id))
 }

--- a/app/plugin_signature.go
+++ b/app/plugin_signature.go
@@ -119,6 +119,7 @@ func verifyBinarySignature(publicKey, signedFile, signature io.Reader) error {
 	}
 	return nil
 }
+
 func decodeIfArmored(reader io.Reader) (io.Reader, error) {
 	readBytes, err := ioutil.ReadAll(reader)
 	if err != nil {

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -537,7 +537,7 @@ func TestPluginSync(t *testing.T) {
 			pluginFileReader, err := os.Open(filepath.Join(path, "testplugin.tar.gz"))
 			require.NoError(t, err)
 			defer pluginFileReader.Close()
-			_, appErr = th.App.WriteFile(pluginFileReader, th.App.getBundleStorePath("testplugin.tar.gz"))
+			_, appErr = th.App.WriteFile(pluginFileReader, th.App.getBundleStorePath("testplugin"))
 			checkNoError(t, appErr)
 			// no signature
 			appErr = th.App.SyncPlugins()


### PR DESCRIPTION
#### Summary
Save as `<plugin_id>.tar.gz.sig` instead of `<plugin_id>.sig`. The latter was a relic of the previous design to support multiple plugin signatures, but now creates an inconsistency with how the original source files were supplied as `<some_name>.tar.gz` and `<some_name>.tar.gz.sig`.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-21103