### PR TITLE
MM-21116: Improve channelSearch SQL query generation

### DIFF
--- a/store/sqlstore/channel_store_test.go
+++ b/store/sqlstore/channel_store_test.go
@@ -27,8 +27,8 @@ func TestChannelSearchQuerySQLInjection(t *testing.T) {
 			}
 
 			opts := store.ChannelSearchOpts{}
-			dd := s.channelSearchQuery("'or'1'=sleep(3))); -- -", opts, false)
-			query, _, err := dd.ToSql()
+			builder := s.channelSearchQuery("'or'1'=sleep(3))); -- -", opts, false)
+			query, _, err := builder.ToSql()
 			require.Nil(t, err)
 			assert.NotContains(t, query, "sleep")
 		})

--- a/store/sqlstore/channel_store_test.go
+++ b/store/sqlstore/channel_store_test.go
@@ -8,13 +8,31 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/store"
 	"github.com/mattermost/mattermost-server/v5/store/storetest"
 )
 
 func TestChannelStore(t *testing.T) {
 	StoreTestWithSqlSupplier(t, storetest.TestChannelStore)
+}
+
+func TestChannelSearchQuerySQLInjection(t *testing.T) {
+	for _, st := range storeTypes {
+		t.Run(st.Name, func(t *testing.T) {
+			s := &SqlChannelStore{
+				SqlStore: st.SqlSupplier,
+			}
+
+			opts := store.ChannelSearchOpts{}
+			dd := s.channelSearchQuery("'or'1'=sleep(3))); -- -", opts, false)
+			query, _, err := dd.ToSql()
+			require.Nil(t, err)
+			assert.NotContains(t, query, "sleep")
+		})
+	}
 }
 
 func TestChannelStoreInternalDataTypes(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
The likeTerm from buildFulltextClause was being built inefficient using strings.
We change it to use squirrel to build the query.

And while at it, we also change the len check with checking with
an empty string which is more idiomatic. Both compile to the same
code, so there is no difference performance wise.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21116
