### PR TITLE
[MM-21115] Add permissions check on user_typing event

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -32,17 +32,18 @@ type TestHelper struct {
 	Server      *app.Server
 	ConfigStore config.Store
 
-	Client              *model.Client4
-	BasicUser           *model.User
-	BasicUser2          *model.User
-	TeamAdminUser       *model.User
-	BasicTeam           *model.Team
-	BasicChannel        *model.Channel
-	BasicPrivateChannel *model.Channel
-	BasicDeletedChannel *model.Channel
-	BasicChannel2       *model.Channel
-	BasicPost           *model.Post
-	Group               *model.Group
+	Client               *model.Client4
+	BasicUser            *model.User
+	BasicUser2           *model.User
+	TeamAdminUser        *model.User
+	BasicTeam            *model.Team
+	BasicChannel         *model.Channel
+	BasicPrivateChannel  *model.Channel
+	BasicPrivateChannel2 *model.Channel
+	BasicDeletedChannel  *model.Channel
+	BasicChannel2        *model.Channel
+	BasicPost            *model.Post
+	Group                *model.Group
 
 	SystemAdminClient *model.Client4
 	SystemAdminUser   *model.User
@@ -193,6 +194,7 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.BasicTeam = me.CreateTeam()
 	me.BasicChannel = me.CreatePublicChannel()
 	me.BasicPrivateChannel = me.CreatePrivateChannel()
+	me.BasicPrivateChannel2 = me.CreatePrivateChannel()
 	me.BasicDeletedChannel = me.CreatePublicChannel()
 	me.BasicChannel2 = me.CreatePublicChannel()
 	me.BasicPost = me.CreatePost()

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -850,7 +850,7 @@ func TestGetAllChannelsWithCount(t *testing.T) {
 	for _, c := range *channels {
 		require.NotEqual(t, c.TeamId, "")
 	}
-	require.Equal(t, int64(5), total)
+	require.Equal(t, int64(6), total)
 
 	channels, _, resp = th.SystemAdminClient.GetAllChannelsWithCount(0, 10, "")
 	CheckNoError(t, resp)

--- a/api4/websocket_test.go
+++ b/api4/websocket_test.go
@@ -64,6 +64,17 @@ func TestWebSocket(t *testing.T) {
 	resp = <-WebSocketClient.ResponseChannel
 	require.Equal(t, resp.Error.Id, "api.websocket_handler.invalid_param.app_error", "should have been invalid param response")
 	require.Equal(t, resp.Error.DetailedError, "", "detailed error not cleared")
+
+	WebSocketClient.UserTyping(th.BasicChannel.Id, "")
+	time.Sleep(300 * time.Millisecond)
+	resp = <-WebSocketClient.ResponseChannel
+	require.Nil(t, resp.Error)
+
+	WebSocketClient.UserTyping(th.BasicPrivateChannel2.Id, "")
+	time.Sleep(300 * time.Millisecond)
+	resp = <-WebSocketClient.ResponseChannel
+	require.Equal(t, resp.Error.Id, "api.websocket_handler.invalid_param.app_error", "should have been invalid param response")
+	require.Equal(t, resp.Error.DetailedError, "", "detailed error not cleared")
 }
 
 func TestWebSocketTrailingSlash(t *testing.T) {

--- a/wsapi/user.go
+++ b/wsapi/user.go
@@ -24,6 +24,10 @@ func (api *API) userTyping(req *model.WebSocketRequest) (map[string]interface{},
 		return nil, NewInvalidWebSocketParamError(req.Action, "channel_id")
 	}
 
+	if !api.App.SessionHasPermissionToChannel(req.Session, channelId, model.PERMISSION_CREATE_POST) {
+		return nil, NewInvalidWebSocketParamError(req.Action, "channel_id")
+	}
+
 	var parentId string
 	if parentId, ok = req.Data["parent_id"].(string); !ok {
 		parentId = ""


### PR DESCRIPTION
#### Summary

PR adds a permissions check before sending the `user_typing` WebSocket event.  
A bit of a **note**: the fix in itself is trivial but the cost in performance might be significant since it's a very frequent event. 

#### Ticket

https://mattermost.atlassian.net/browse/MM-21115

