### PR TITLE
GH-13376: Improve community server links and phrasing in README.md to be more inviting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It's written in Golang and React and runs as a single Linux binary with MySQL or
 ## Try out Mattermost
 
 - [Join the Mattermost Contributor's server](https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676) to join community discussions about contributions, development and more
-- [Join the Mattermost Demo server](https://demo.mattermost.com/signup_email) (latest stable version. Use this server to generally play with Mattermost and take everything for a spin.)
+- [Join the Mattermost Demo server](https://demo.mattermost.com/signup_email) to try out Mattermost and explore sample use cases
 
 ## Deploy on Heroku
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Receive notifications of critical security updates. The sophistication of online
 - **Twitter** - Follow [Mattermost](https://twitter.com/mattermost)
 - **Blog** - Get the latest updates from the [Mattermost blog](https://mattermost.com/blog/).
 - **Email** - Subscribe to our [newsletter](http://mattermost.us11.list-manage.com/subscribe?u=6cdba22349ae374e188e7ab8e&id=2add1c8034) (1 or 2 per month)
-- **Mattermost** - Join the #contributors channel on [the Mattermost Community Server](https://community.mattermost.com/). 
+- **Mattermost** - Join the ~contributors channel on [the Mattermost Community Server](https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676). 
 - **IRC** - Join the #matterbridge channel on [Freenode](https://freenode.net/) (thanks to [matterircd](https://github.com/42wim/matterircd))
 
 Any other questions, mail us at info@mattermost.com. We’d love to meet you!

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ Receive notifications of critical security updates. The sophistication of online
 - **Blog** - Get the latest updates from the [Mattermost blog](https://mattermost.com/blog/).
 - **Email** - Subscribe to our [newsletter](http://mattermost.us11.list-manage.com/subscribe?u=6cdba22349ae374e188e7ab8e&id=2add1c8034) (1 or 2 per month)
 - **Mattermost** - Join the ~contributors channel on [the Mattermost Community Server](https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676). 
-- **IRC** - Join the #matterbridge channel on [Freenode](https://freenode.net/) (thanks to [matterircd](https://github.com/42wim/matterircd))
+- **IRC** - Join the #matterbridge channel on [Freenode](https://freenode.net/) (thanks to [matterircd](https://github.com/42wim/matterircd)).
 
 Any other questions, mail us at info@mattermost.com. We’d love to meet you!

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ It's written in Golang and React and runs as a single Linux binary with MySQL or
 
 ## Try out Mattermost
 
-- [Join the Mattermost Contributor's server](https://pre-release.mattermost.com/) (latest nightly builds, unstable)
-- [Join the Mattermost Demo server](https://demo.mattermost.com/signup_email) (latest stable version)
+- [Join the Mattermost Contributor's server](https://community.mattermost.com/) (latest nightly builds, unstable. Get into contact with us and our community here.)
+- [Join the Mattermost Demo server](https://demo.mattermost.com/signup_email) (latest stable version. Use this server to generally play with Mattermost and take everything for a spin.)
 
 ## Deploy on Heroku
 
@@ -48,7 +48,7 @@ Receive notifications of critical security updates. The sophistication of online
 
 - [Contribute Code](https://developers.mattermost.com/contribute/getting-started/)
 - [Find "Help Wanted" projects](https://github.com/mattermost/mattermost-server/issues?page=1&q=is%3Aissue+is%3Aopen+%22Help+Wanted%22&utf8=%E2%9C%93)
-- [Join Developer Discussion on a Mattermost Server for contributors](https://pre-release.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676)
+- [Join Developer Discussion on a Mattermost Server for contributors](https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676)
 - [File Bugs](http://www.mattermost.org/filing-issues/)
 - [Share Feature Ideas](https://www.mattermost.org/feature-ideas/)
 - [Get Troubleshooting Help](https://forum.mattermost.org/t/how-to-use-the-troubleshooting-forum/150)
@@ -65,6 +65,7 @@ Receive notifications of critical security updates. The sophistication of online
 - **Twitter** - Follow [Mattermost](https://twitter.com/mattermost)
 - **Blog** - Get the latest updates from the [Mattermost blog](https://mattermost.com/blog/).
 - **Email** - Subscribe to our [newsletter](http://mattermost.us11.list-manage.com/subscribe?u=6cdba22349ae374e188e7ab8e&id=2add1c8034) (1 or 2 per month)
+- **Mattermost** - Join the #contributors channel on [the Mattermost Community Server](https://community.mattermost.com/). 
 - **IRC** - Join the #matterbridge channel on [Freenode](https://freenode.net/) (thanks to [matterircd](https://github.com/42wim/matterircd))
 
 Any other questions, mail us at info@mattermost.com. We’d love to meet you!

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's written in Golang and React and runs as a single Linux binary with MySQL or
 
 ## Try out Mattermost
 
-- [Join the Mattermost Contributor's server](https://community.mattermost.com/) (latest nightly builds, unstable. Get into contact with us and our community here.)
+- [Join the Mattermost Contributor's server](https://community.mattermost.com/signup_user_complete/?id=f1924a8db44ff3bb41c96424cdc20676) to join community discussions about contributions, development and more
 - [Join the Mattermost Demo server](https://demo.mattermost.com/signup_email) (latest stable version. Use this server to generally play with Mattermost and take everything for a spin.)
 
 ## Deploy on Heroku


### PR DESCRIPTION
#### Summary
This pull request modifies the `README.md` file to achieve the following: 
 - Reference the community server as `community.mattermost.com` instead of `pre-release.mattermost.com` as mentioned by @lieut-data [here](https://community.mattermost.com/core/pl/9nzyqs3ewbrrjmyrhmrge4yjmo).
 - Add a bit of explanation on the purposes of the servers in "Try out Mattermost" to enable new people to choose the right one for their purpose.
 - Add a link to the community Mattermost server in the "Get the Latest News" section to direct people to the community server looking for it there.   

#### Ticket Link
This ticket is created in response to https://github.com/mattermost/mattermost-server/issues/13376 created after [this discussion](https://community.mattermost.com/core/pl/9nzyqs3ewbrrjmyrhmrge4yjmo) on the community server.

Fixes https://github.com/mattermost/mattermost-server/issues/13376