### PR TITLE
[MM-21217] Disallow changing type when updating a channel

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -143,8 +143,13 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(channel.Type) > 0 && channel.Type != oldChannel.Type {
+		c.Err = model.NewAppError("updateChannel", "api.channel.update_channel.typechange.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
 	if oldChannel.Name == model.DEFAULT_CHANNEL {
-		if (len(channel.Name) > 0 && channel.Name != oldChannel.Name) || (len(channel.Type) > 0 && channel.Type != oldChannel.Type) {
+		if len(channel.Name) > 0 && channel.Name != oldChannel.Name {
 			c.Err = model.NewAppError("updateChannel", "api.channel.update_channel.tried.app_error", map[string]interface{}{"Channel": model.DEFAULT_CHANNEL}, "", http.StatusBadRequest)
 			return
 		}
@@ -161,10 +166,6 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if len(channel.Name) > 0 {
 		oldChannel.Name = channel.Name
-	}
-
-	if len(channel.Type) > 0 {
-		oldChannel.Type = channel.Type
 	}
 
 	if channel.GroupConstrained != nil {

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -169,6 +169,18 @@ func TestUpdateChannel(t *testing.T) {
 	require.Equal(t, private.Header, newPrivateChannel.Header, "Update failed for Header in private channel")
 	require.Equal(t, private.Purpose, newPrivateChannel.Purpose, "Update failed for Purpose in private channel")
 
+	// Test that changing the type fails and returns error
+
+	private.Type = model.CHANNEL_OPEN
+	newPrivateChannel, resp = Client.UpdateChannel(private)
+	CheckBadRequestStatus(t, resp)
+
+	// Test that keeping the same type succeeds
+
+	private.Type = model.CHANNEL_PRIVATE
+	newPrivateChannel, resp = Client.UpdateChannel(private)
+	CheckNoError(t, resp)
+
 	//Non existing channel
 	channel1 := &model.Channel{DisplayName: "Test API Name for apiv4", Name: GenerateTestChannelName(), Type: model.CHANNEL_OPEN, TeamId: team.Id}
 	_, resp = Client.UpdateChannel(channel1)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -376,6 +376,10 @@
     "translation": "Tried to perform an invalid update of the default channel {{.Channel}}"
   },
   {
+    "id": "api.channel.update_channel.typechange.app_error",
+    "translation": "Channel type cannot be updated"
+  },
+  {
     "id": "api.channel.update_channel_member_roles.changing_guest_role.app_error",
     "translation": "Invalid channel member update: You can't add or remove the guest role manually"
   },


### PR DESCRIPTION
#### Summary

PR eliminates the possibility of changing a channel's type through the `/update` endpoint.
The new `/privacy` endpoint should be used for such purposes.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21217