### PR TITLE
Exposing named error from zap api on our mlog api

### DIFF
--- a/mlog/log.go
+++ b/mlog/log.go
@@ -34,6 +34,7 @@ var Uint32 = zap.Uint32
 var String = zap.String
 var Any = zap.Any
 var Err = zap.Error
+var NamedErr = zap.NamedError
 var Bool = zap.Bool
 var Duration = zap.Duration
 


### PR DESCRIPTION
#### Summary
Exposing named error from zap api on our mlog api

This is needed for properly migrating the elasticsearch code to structured logging.