### PR TITLE
Fix failing TestFileSetFile

### DIFF
--- a/config/file_test.go
+++ b/config/file_test.go
@@ -923,7 +923,7 @@ func TestFileSetFile(t *testing.T) {
 
 	t.Run("should set right permissions", func(t *testing.T) {
 		absolutePath := filepath.Join(filepath.Dir(path), "new")
-		err := fs.SetFile(absolutePath, []byte("data"))
+		err := fs.SetFile("new", []byte("data"))
 		require.NoError(t, err)
 		fi, err := os.Stat(absolutePath)
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary

Fixes failing TestFileSetFile due to using the wrong path.