### PR TITLE
MM-21254: Removing unnused/unnecesary getClientLicense etag

### DIFF
--- a/api4/license.go
+++ b/api4/license.go
@@ -30,11 +30,6 @@ func getClientLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	etag := c.App.GetClientLicenseEtag(true)
-	if c.HandleEtag(etag, "Get Client License", w, r) {
-		return
-	}
-
 	var clientLicense map[string]string
 
 	if c.App.SessionHasPermissionTo(c.App.Session, model.PERMISSION_MANAGE_SYSTEM) {
@@ -43,7 +38,6 @@ func getClientLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		clientLicense = c.App.GetSanitizedClientLicense()
 	}
 
-	w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 	w.Write([]byte(model.MapToJson(clientLicense)))
 }
 

--- a/app/license.go
+++ b/app/license.go
@@ -4,8 +4,6 @@
 package app
 
 import (
-	"crypto/md5"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -189,22 +187,6 @@ func (s *Server) RemoveLicenseListener(id string) {
 
 func (a *App) RemoveLicenseListener(id string) {
 	delete(a.Srv.licenseListeners, id)
-}
-
-func (a *App) GetClientLicenseEtag(useSanitized bool) string {
-	value := ""
-
-	lic := a.ClientLicense()
-
-	if useSanitized {
-		lic = a.GetSanitizedClientLicense()
-	}
-
-	for k, v := range lic {
-		value += fmt.Sprintf("%s:%s;", k, v)
-	}
-
-	return model.Etag(fmt.Sprintf("%x", md5.Sum([]byte(value))))
 }
 
 func (a *App) GetSanitizedClientLicense() map[string]string {

--- a/app/license_test.go
+++ b/app/license_test.go
@@ -58,23 +58,6 @@ func TestSetLicense(t *testing.T) {
 	require.True(t, ok, "license should have passed")
 }
 
-func TestClientLicenseEtag(t *testing.T) {
-	th := Setup(t)
-	defer th.TearDown()
-
-	etag1 := th.App.GetClientLicenseEtag(false)
-
-	th.App.SetClientLicense(map[string]string{"SomeFeature": "true", "IsLicensed": "true"})
-
-	etag2 := th.App.GetClientLicenseEtag(false)
-	require.NotEqual(t, etag1, etag2, "etags should not match")
-
-	th.App.SetClientLicense(map[string]string{"SomeFeature": "true", "IsLicensed": "false"})
-
-	etag3 := th.App.GetClientLicenseEtag(false)
-	require.NotEqual(t, etag2, etag3, "etags should not match")
-}
-
 func TestGetSanitizedClientLicense(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()


### PR DESCRIPTION
#### Summary
Removing unnused/unnecesary getClientLicense etag generation. It wasn't
generating it consistenly before, so there is no performance penalties in this
PR.

#### Ticket Link
[MM-21254](https://mattermost.atlassian.net/browse/MM-21254)