### PR TITLE
[MM-21020] Return same error when creating a duplicate channel

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5943,10 +5943,6 @@
     "translation": "You've reached the limit of the number of allowed channels."
   },
   {
-    "id": "store.sql_channel.save_channel.previously.app_error",
-    "translation": "A channel with that URL was previously created"
-  },
-  {
     "id": "store.sql_channel.save_channel.save.app_error",
     "translation": "Unable to save the channel"
   },

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -575,9 +575,6 @@ func (s SqlChannelStore) saveChannelT(transaction *gorp.Transaction, channel *mo
 		if IsUniqueConstraintError(err, []string{"Name", "channels_name_teamid_key"}) {
 			dupChannel := model.Channel{}
 			s.GetMaster().SelectOne(&dupChannel, "SELECT * FROM Channels WHERE TeamId = :TeamId AND Name = :Name", map[string]interface{}{"TeamId": channel.TeamId, "Name": channel.Name})
-			if dupChannel.DeleteAt > 0 {
-				return nil, model.NewAppError("SqlChannelStore.Save", "store.sql_channel.save_channel.previously.app_error", nil, "id="+channel.Id+", "+err.Error(), http.StatusBadRequest)
-			}
 			return &dupChannel, model.NewAppError("SqlChannelStore.Save", store.CHANNEL_EXISTS_ERROR, nil, "id="+channel.Id+", "+err.Error(), http.StatusBadRequest)
 		}
 		return nil, model.NewAppError("SqlChannelStore.Save", "store.sql_channel.save_channel.save.app_error", nil, "id="+channel.Id+", "+err.Error(), http.StatusInternalServerError)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -122,7 +122,7 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_OPEN
 
 	_, err = ss.Channel().Save(&o1, -1)
-	require.Nil(t, err, "should have saved channel", err)
+	require.Nil(t, err, "should have saved channel")
 
 	o2 := o1
 	o2.Id = ""
@@ -132,7 +132,7 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	require.Equal(t, store.CHANNEL_EXISTS_ERROR, err.Id)
 
 	err = ss.Channel().Delete(o1.Id, 100)
-	require.Nil(t, err, "should have deleted channel", err)
+	require.Nil(t, err, "should have deleted channel")
 
 	o2.Id = ""
 	_, err = ss.Channel().Save(&o2, -1)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -114,6 +114,30 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	o1.Type = model.CHANNEL_DIRECT
 	_, err = ss.Channel().Save(&o1, -1)
 	require.NotNil(t, err, "should not be able to save direct channel")
+
+	o1 = model.Channel{}
+	o1.TeamId = teamId
+	o1.DisplayName = "Name"
+	o1.Name = "zz" + model.NewId() + "b"
+	o1.Type = model.CHANNEL_OPEN
+
+	_, err = ss.Channel().Save(&o1, -1)
+	require.Nil(t, err, "should have saved channel", err)
+
+	o2 := o1
+	o2.Id = ""
+
+	_, err = ss.Channel().Save(&o2, -1)
+	require.NotNil(t, err, "should have failed to save a duplicate channel")
+	require.Equal(t, store.CHANNEL_EXISTS_ERROR, err.Id)
+
+	err = ss.Channel().Delete(o1.Id, 100)
+	require.Nil(t, err, "should have deleted channel", err)
+
+	o2.Id = ""
+	_, err = ss.Channel().Save(&o2, -1)
+	require.NotNil(t, err, "should have failed to save a duplicate of an archived channel")
+	require.Equal(t, store.CHANNEL_EXISTS_ERROR, err.Id)
 }
 
 func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlSupplier) {


### PR DESCRIPTION
#### Summary

PR makes sure we return the same error when attempting to create a channel with the same name of an existing one, whether or not the existing one is active or archived.

#### Ticket

https://mattermost.atlassian.net/browse/MM-21020