### PR TITLE
MM-19613 - Include prepackaged plugins in marketplace results

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -505,7 +505,7 @@ func (a *App) getRemotePlugins(filter *model.MarketplacePluginFilter) (map[strin
 func (a *App) mergePrepackagePlugins(remoteMarketplacePlugins map[string]*model.MarketplacePlugin) *model.AppError {
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
-		return model.NewAppError("GetMarketplacePlugins", "app.plugin.config.app_error", nil, "", http.StatusInternalServerError)
+		return model.NewAppError("mergePrepackagePlugins", "app.plugin.config.app_error", nil, "", http.StatusInternalServerError)
 	}
 
 	for _, prepackaged := range pluginsEnvironment.PrepackagedPlugins() {
@@ -526,17 +526,17 @@ func (a *App) mergePrepackagePlugins(remoteMarketplacePlugins map[string]*model.
 		}
 
 		// If available in the markteplace, only overwrite if newer.
-		var prepackagedVersion, marketplaceVersion semver.Version
-
 		prepackagedVersion, err := semver.Parse(prepackaged.Manifest.Version)
 		if err != nil {
-			return model.NewAppError("GetMarketplacePlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
+			return model.NewAppError("mergePrepackagePlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
 		}
 
 		marketplacePlugin := remoteMarketplacePlugins[prepackaged.Manifest.Id]
+
+		var marketplaceVersion semver.Version
 		marketplaceVersion, err = semver.Parse(marketplacePlugin.Manifest.Version)
 		if err != nil {
-			return model.NewAppError("GetMarketplacePlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
+			return model.NewAppError("mergePrepackagePlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
 		}
 
 		if prepackagedVersion.GT(marketplaceVersion) {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -532,9 +532,7 @@ func (a *App) mergePrepackagePlugins(remoteMarketplacePlugins map[string]*model.
 		}
 
 		marketplacePlugin := remoteMarketplacePlugins[prepackaged.Manifest.Id]
-
-		var marketplaceVersion semver.Version
-		marketplaceVersion, err = semver.Parse(marketplacePlugin.Manifest.Version)
+		marketplaceVersion, err := semver.Parse(marketplacePlugin.Manifest.Version)
 		if err != nil {
 			return model.NewAppError("mergePrepackagePlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
 		}

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -501,7 +501,7 @@ func (a *App) getRemotePlugins(filter *model.MarketplacePluginFilter) (map[strin
 	return result, nil
 }
 
-// mergePrepackagePlugins returns a merged list of pre-packaged plugins and remote marketplace plugins.
+// mergePrepackagePlugins merges pre-packaged plugins to remote marketplace plugins list.
 func (a *App) mergePrepackagePlugins(remoteMarketplacePlugins map[string]*model.MarketplacePlugin) *model.AppError {
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
@@ -545,7 +545,7 @@ func (a *App) mergePrepackagePlugins(remoteMarketplacePlugins map[string]*model.
 	return nil
 }
 
-// addLocalPlugins returns a merged list of locally installed and remote marketplace plugins.
+// mergeLocalPlugins merges locally installed plugins to remote marketplace plugins list.
 func (a *App) mergeLocalPlugins(remoteMarketplacePlugins map[string]*model.MarketplacePlugin) *model.AppError {
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -470,7 +470,7 @@ func (a *App) getRemotePlugins(filter *model.MarketplacePluginFilter) (map[strin
 
 	pluginsEnvironment := a.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
-		return nil, model.NewAppError("GetMarketplacePlugins", "app.plugin.config.app_error", nil, "", http.StatusInternalServerError)
+		return nil, model.NewAppError("getRemotePlugins", "app.plugin.config.app_error", nil, "", http.StatusInternalServerError)
 	}
 
 	marketplaceClient, err := marketplace.NewClient(
@@ -478,7 +478,7 @@ func (a *App) getRemotePlugins(filter *model.MarketplacePluginFilter) (map[strin
 		a.HTTPService,
 	)
 	if err != nil {
-		return nil, model.NewAppError("GetMarketplacePlugins", "app.plugin.marketplace_client.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("getRemotePlugins", "app.plugin.marketplace_client.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	// Fetch all plugins from marketplace.
@@ -487,7 +487,7 @@ func (a *App) getRemotePlugins(filter *model.MarketplacePluginFilter) (map[strin
 		ServerVersion: model.CurrentVersion,
 	})
 	if err != nil {
-		return nil, model.NewAppError("GetMarketplacePlugins", "app.plugin.marketplace_client.failed_to_fetch", nil, err.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("getRemotePlugins", "app.plugin.marketplace_client.failed_to_fetch", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	for _, p := range marketplacePlugins {

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -96,6 +96,10 @@ func (env *Environment) Available() ([]*model.BundleInfo, error) {
 	return scanSearchPath(env.pluginDir)
 }
 
+func (env *Environment) PrepackagedPlugins() []*PrepackagedPlugin {
+	return env.prepackagedPlugins
+}
+
 // Returns a list of all currently active plugins within the environment.
 func (env *Environment) Active() []*model.BundleInfo {
 	activePlugins := []*model.BundleInfo{}


### PR DESCRIPTION
#### Summary

`GetMarketplacePlugins` will also include prepackaged plugins allowing them to be installed from webapp when:  

- `EnableRemoteMarketplace` is disabled and/or `local_only` was requested.
- A prepackaged plugin has a newer version than a same one available in the marketplace service.

#### Ticket Link
[MM-19613](https://mattermost.atlassian.net/browse/MM-19613)
