### PR TITLE
MM-21209: Use the LRU cache for UserStore.Get call too

### DIFF
--- a/app/server_app_adapters.go
+++ b/app/server_app_adapters.go
@@ -61,7 +61,11 @@ func (s *Server) RunOldAppInitialization() error {
 
 	if s.FakeApp().Srv.newStore == nil {
 		s.FakeApp().Srv.newStore = func() store.Store {
-			return store.NewTimerLayer(localcachelayer.NewLocalCacheLayer(sqlstore.NewSqlSupplier(s.FakeApp().Config().SqlSettings, s.Metrics), s.Metrics, s.Cluster), s.Metrics)
+			return store.NewTimerLayer(
+				localcachelayer.NewLocalCacheLayer(
+					sqlstore.NewSqlSupplier(s.FakeApp().Config().SqlSettings, s.Metrics),
+					s.Metrics, s.Cluster),
+				s.Metrics)
 		}
 	}
 

--- a/store/localcachelayer/main_test.go
+++ b/store/localcachelayer/main_test.go
@@ -98,6 +98,7 @@ func getMockStore() *mocks.Store {
 	mockUserStore := mocks.UserStore{}
 	mockUserStore.On("GetProfileByIds", []string{"123"}, &store.UserGetByIdsOpts{}, true).Return(fakeUser, nil)
 	mockUserStore.On("GetProfileByIds", []string{"123"}, &store.UserGetByIdsOpts{}, false).Return(fakeUser, nil)
+	mockUserStore.On("Get", "123").Return(fakeUser[0], nil)
 	mockStore.On("User").Return(&mockUserStore)
 
 	fakeUserTeamIds := []string{"1", "2", "3"}

--- a/store/localcachelayer/user_layer.go
+++ b/store/localcachelayer/user_layer.go
@@ -80,8 +80,27 @@ func (s LocalCacheUserStore) GetProfileByIds(userIds []string, options *store.Us
 		for _, user := range remainingUsers {
 			s.rootStore.doStandardAddToCache(s.rootStore.userProfileByIdsCache, user.Id, user)
 		}
-
 	}
 
 	return users, nil
+}
+
+// Get is a cache wrapper around the SqlStore method to get a user profile by id.
+// It checks if the user entry is present in the cache, returning the entry from cache
+// if it is present. Otherwise, it fetches the entry from the store and stores it in the
+// cache.
+func (s LocalCacheUserStore) Get(id string) (*model.User, *model.AppError) {
+	cacheItem := s.rootStore.doStandardReadCache(s.rootStore.userProfileByIdsCache, id)
+	if cacheItem != nil {
+		s.rootStore.metrics.AddMemCacheHitCounter("Profile By Id", float64(1))
+		u := *cacheItem.(*model.User)
+		return &u, nil
+	}
+	s.rootStore.metrics.AddMemCacheMissCounter("Profile By Id", float64(1))
+	user, err := s.UserStore.Get(id)
+	if err != nil {
+		return nil, model.NewAppError("SqlUserStore.Get", "store.sql_user.get.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	s.rootStore.doStandardAddToCache(s.rootStore.userProfileByIdsCache, id, user)
+	return user, nil
 }

--- a/store/localcachelayer/user_layer.go
+++ b/store/localcachelayer/user_layer.go
@@ -92,11 +92,15 @@ func (s LocalCacheUserStore) GetProfileByIds(userIds []string, options *store.Us
 func (s LocalCacheUserStore) Get(id string) (*model.User, *model.AppError) {
 	cacheItem := s.rootStore.doStandardReadCache(s.rootStore.userProfileByIdsCache, id)
 	if cacheItem != nil {
-		s.rootStore.metrics.AddMemCacheHitCounter("Profile By Id", float64(1))
+		if s.rootStore.metrics != nil {
+			s.rootStore.metrics.AddMemCacheHitCounter("Profile By Id", float64(1))
+		}
 		u := *cacheItem.(*model.User)
 		return &u, nil
 	}
-	s.rootStore.metrics.AddMemCacheMissCounter("Profile By Id", float64(1))
+	if s.rootStore.metrics != nil {
+		s.rootStore.metrics.AddMemCacheMissCounter("Profile By Id", float64(1))
+	}
 	user, err := s.UserStore.Get(id)
 	if err != nil {
 		return nil, model.NewAppError("SqlUserStore.Get", "store.sql_user.get.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/store/localcachelayer/user_layer_test.go
+++ b/store/localcachelayer/user_layer_test.go
@@ -19,7 +19,7 @@ func TestUserStore(t *testing.T) {
 	StoreTestWithSqlSupplier(t, storetest.TestUserStore)
 }
 
-func TestUserStoreCache(t *testing.T) {
+func TestUserStoreGetProfileByIdsCache(t *testing.T) {
 	fakeUserIds := []string{"123"}
 	fakeUser := []*model.User{{Id: "123"}}
 
@@ -62,5 +62,38 @@ func TestUserStoreCache(t *testing.T) {
 
 		_, _ = cachedStore.User().GetProfileByIds(fakeUserIds, &store.UserGetByIdsOpts{}, true)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetProfileByIds", 2)
+	})
+}
+
+func TestUserStoreGetCache(t *testing.T) {
+	fakeUserId := "123"
+	fakeUser := &model.User{Id: "123"}
+
+	t.Run("first call not cached, second cached and returning same data", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		gotUser, err := cachedStore.User().Get(fakeUserId)
+		require.Nil(t, err)
+		assert.Equal(t, fakeUser, gotUser)
+		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 1)
+
+		_, _ = cachedStore.User().Get(fakeUserId)
+		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 1)
+	})
+
+	t.Run("first call not cached, invalidate, and then not cached again", func(t *testing.T) {
+		mockStore := getMockStore()
+		cachedStore := NewLocalCacheLayer(mockStore, nil, nil)
+
+		gotUser, err := cachedStore.User().Get(fakeUserId)
+		require.Nil(t, err)
+		assert.Equal(t, fakeUser, gotUser)
+		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 1)
+
+		cachedStore.User().InvalidatProfileCacheForUser("123")
+
+		_, _ = cachedStore.User().Get(fakeUserId)
+		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 2)
 	})
 }

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -4949,6 +4949,8 @@ func testUserStoreResetLastPictureUpdate(t *testing.T, ss store.Store) {
 	err = ss.User().ResetLastPictureUpdate(u1.Id)
 	require.Nil(t, err)
 
+	ss.User().InvalidatProfileCacheForUser(u1.Id)
+
 	user2, err := ss.User().Get(u1.Id)
 	require.Nil(t, err)
 


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We already have userProfileByIdsCache to store the user profiles by Id.
It just wasn't being used for the (*UserStore).Get method. We add a wrapper
method in LocalCacheUserStore to intercept that call and check for the
presence of the user Id in the cache.

There is no need to add any code for invalidation as all of that is already
present.

Loadtest results for the basic profile:

## Loadtest Results
### Score: 34.38 (-3.79, relative to baseline)
The score is the average of the 95th percentile, median and interquartile ranges in the routes below.

### Routes
#### GET /users/[user id]/channels/[channel id]/unread
| Metric | Baseline | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- |
| Hits | 53 | 47 | -6 | -11.32%
| Error Rate | 0.00% | 0.00% | 0% | 0% |
| Mean Response Time | 2.68ms | 2.83ms | +0.15ms | +5.62% |
| Median Response Time | 2.00ms | 2.00ms | 0ms | 0% |
| 95th Percentile | 7.00ms | 7.00ms | 0ms | 0% |

#### GET /users/email/[email]
| Metric | Baseline | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- |
| Hits | 500 | 500 | 0 | 0%
| Error Rate | 0.00% | 0.00% | 0% | 0% |
| Mean Response Time | 12.69ms | 7.48ms | -5.22ms | -41.11% |
| Median Response Time | 10.00ms | 4.00ms | -6.00ms | -60.00% |
| 95th Percentile | 32.00ms | 23.00ms | -9.00ms | -28.12% |

#### GET /users/me
| Metric | Baseline | Actual | Delta | Delta % |
| --- | --- | --- | --- | --- |
| Hits | 62 | 61 | -1 | -1.61%
| Error Rate | 0.00% | 0.00% | 0% | 0% |
| Mean Response Time | 9.18ms | 6.98ms | -2.19ms | -23.90% |
| Median Response Time | 7.00ms | 6.00ms | -1.00ms | -14.29% |
| 95th Percentile | 14.00ms | 9.00ms | -5.00ms | -35.71% |

The load test is not very indicative of changes that have happened. But it is inconclusive anyways. With some manual verification using mmctl, I have verified that there is indeed a small improvement with caching.

First time:
```
time ./mmctl user search agniva.quicksilver@gmail.com
...
...
real	0m0.086s
user	0m0.017s
sys	0m0.001s
```

Second time:
```
$time ./mmctl user search agniva.quicksilver@gmail.com
...
real	0m0.012s
user	0m0.011s
sys	0m0.001s
```
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-21209