### PR TITLE
MM-20278  - Add Log Entries for where the config is loaded from (database or config files)

### DIFF
--- a/config/store.go
+++ b/config/store.go
@@ -4,8 +4,10 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
@@ -55,8 +57,12 @@ type Store interface {
 // NewStore creates a database or file store given a data source name by which to connect.
 func NewStore(dsn string, watch bool) (Store, error) {
 	if strings.HasPrefix(dsn, "mysql://") || strings.HasPrefix(dsn, "postgres://") {
+		msg := fmt.Sprintf("Loading configuration from the database. DSN: %s", dsn)
+		mlog.Info(msg)
 		return NewDatabaseStore(dsn)
 	}
 
+	msg := fmt.Sprintf("Loading configuration from a file. Path: %s", dsn)
+	mlog.Info(msg)
 	return NewFileStore(dsn, watch)
 }


### PR DESCRIPTION
#### Summary
Added logging for config path/dsn
Note: this code doesn't use structured logging because `NewStore` is called before the logger is initialized properly (since logger depends on config)

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/MM-20278