### PR TITLE
MM-19274 - Migrate tests from "model/config_test.go" to use testify

### DIFF
--- a/model/config_test.go
+++ b/model/config_test.go
@@ -63,49 +63,36 @@ func TestConfigEmptySiteName(t *testing.T) {
 	}
 	c1.SetDefaults()
 
-	if *c1.TeamSettings.SiteName != TEAM_SETTINGS_DEFAULT_SITE_NAME {
-		t.Fatal("TeamSettings.SiteName should default to " + TEAM_SETTINGS_DEFAULT_SITE_NAME)
-	}
+	require.Equal(t, *c1.TeamSettings.SiteName, TEAM_SETTINGS_DEFAULT_SITE_NAME)
 }
 
 func TestConfigDefaultFileSettingsDirectory(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()
 
-	if *c1.FileSettings.Directory != "./data/" {
-		t.Fatal("FileSettings.Directory should default to './data/'")
-	}
+	require.Equal(t, *c1.FileSettings.Directory, "./data/")
 }
 
 func TestConfigDefaultEmailNotificationContentsType(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()
 
-	if *c1.EmailSettings.EmailNotificationContentsType != EMAIL_NOTIFICATION_CONTENTS_FULL {
-		t.Fatal("EmailSettings.EmailNotificationContentsType should default to 'full'")
-	}
+	require.Equal(t, *c1.EmailSettings.EmailNotificationContentsType, EMAIL_NOTIFICATION_CONTENTS_FULL)
 }
 
 func TestConfigDefaultFileSettingsS3SSE(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()
 
-	if *c1.FileSettings.AmazonS3SSE {
-		t.Fatal("FileSettings.AmazonS3SSE should default to false")
-	}
+	require.False(t, *c1.FileSettings.AmazonS3SSE)
 }
 
 func TestConfigDefaultSignatureAlgorithm(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()
 
-	if *c1.SamlSettings.SignatureAlgorithm != SAML_SETTINGS_DEFAULT_SIGNATURE_ALGORITHM {
-		t.Fatal("SamlSettings.SignatureAlgorithm default not set")
-	}
-
-	if *c1.SamlSettings.CanonicalAlgorithm != SAML_SETTINGS_DEFAULT_CANONICAL_ALGORITHM {
-		t.Fatal("SamlSettings.CanonicalAlgorithm default not set")
-	}
+	require.Equal(t, *c1.SamlSettings.SignatureAlgorithm, SAML_SETTINGS_DEFAULT_SIGNATURE_ALGORITHM)
+	require.Equal(t, *c1.SamlSettings.CanonicalAlgorithm, SAML_SETTINGS_DEFAULT_CANONICAL_ALGORITHM)
 }
 
 func TestConfigOverwriteSignatureAlgorithm(t *testing.T) {
@@ -119,12 +106,8 @@ func TestConfigOverwriteSignatureAlgorithm(t *testing.T) {
 
 	c1.SetDefaults()
 
-	if *c1.SamlSettings.SignatureAlgorithm != testAlgorithm {
-		t.Fatal("SamlSettings.SignatureAlgorithm should be overwritten")
-	}
-	if *c1.SamlSettings.CanonicalAlgorithm != testAlgorithm {
-		t.Fatal("SamlSettings.CanonicalAlgorithm should be overwritten")
-	}
+	require.Equal(t, *c1.SamlSettings.SignatureAlgorithm, testAlgorithm)
+	require.Equal(t, *c1.SamlSettings.CanonicalAlgorithm, testAlgorithm)
 }
 
 func TestConfigIsValidDefaultAlgorithms(t *testing.T) {
@@ -142,9 +125,7 @@ func TestConfigIsValidDefaultAlgorithms(t *testing.T) {
 	*c1.SamlSettings.UsernameAttribute = "Username"
 
 	err := c1.SamlSettings.isValid()
-	if err != nil {
-		t.Fatal("SAMLSettings validation should pass with default settings")
-	}
+	require.Nil(t, err)
 }
 
 func TestConfigIsValidFakeAlgorithm(t *testing.T) {
@@ -164,17 +145,15 @@ func TestConfigIsValidFakeAlgorithm(t *testing.T) {
 	temp := *c1.SamlSettings.CanonicalAlgorithm
 	*c1.SamlSettings.CanonicalAlgorithm = "Fake Algorithm"
 	err := c1.SamlSettings.isValid()
-	if err == nil {
-		t.Fatal("SAMLSettings validation should fail with fake Canonical Algorithm")
-	}
+	require.NotNil(t, err)
+
 	require.Equal(t, "model.config.is_valid.saml_canonical_algorithm.app_error", err.Message)
 	*c1.SamlSettings.CanonicalAlgorithm = temp
 
 	*c1.SamlSettings.SignatureAlgorithm = "Fake Algorithm"
 	err = c1.SamlSettings.isValid()
-	if err == nil {
-		t.Fatal("SAMLSettings validation should pass with fake signature settings")
-	}
+	require.NotNil(t, err)
+
 	require.Equal(t, "model.config.is_valid.saml_signature_algorithm.app_error", err.Message)
 }
 
@@ -188,18 +167,14 @@ func TestConfigOverwriteGuestSettings(t *testing.T) {
 
 	c1.SetDefaults()
 
-	if *c1.SamlSettings.GuestAttribute != attribute {
-		t.Fatal("SamlSettings.GuestAttribute should be overwritten")
-	}
+	require.Equal(t, *c1.SamlSettings.GuestAttribute, attribute)
 }
 
 func TestConfigDefaultServiceSettingsExperimentalGroupUnreadChannels(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()
 
-	if *c1.ServiceSettings.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED {
-		t.Fatal("ServiceSettings.ExperimentalGroupUnreadChannels should default to 'disabled'")
-	}
+	require.Equal(t, *c1.ServiceSettings.ExperimentalGroupUnreadChannels, GROUP_UNREAD_CHANNELS_DISABLED)
 
 	// This setting was briefly a boolean, so ensure that those values still work as expected
 	c1 = Config{
@@ -209,9 +184,7 @@ func TestConfigDefaultServiceSettingsExperimentalGroupUnreadChannels(t *testing.
 	}
 	c1.SetDefaults()
 
-	if *c1.ServiceSettings.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DEFAULT_ON {
-		t.Fatal("ServiceSettings.ExperimentalGroupUnreadChannels should set true to 'default on'")
-	}
+	require.Equal(t, *c1.ServiceSettings.ExperimentalGroupUnreadChannels, GROUP_UNREAD_CHANNELS_DEFAULT_ON)
 
 	c1 = Config{
 		ServiceSettings: ServiceSettings{
@@ -220,9 +193,7 @@ func TestConfigDefaultServiceSettingsExperimentalGroupUnreadChannels(t *testing.
 	}
 	c1.SetDefaults()
 
-	if *c1.ServiceSettings.ExperimentalGroupUnreadChannels != GROUP_UNREAD_CHANNELS_DISABLED {
-		t.Fatal("ServiceSettings.ExperimentalGroupUnreadChannels should set false to 'disabled'")
-	}
+	require.Equal(t, *c1.ServiceSettings.ExperimentalGroupUnreadChannels, GROUP_UNREAD_CHANNELS_DISABLED)
 }
 
 func TestConfigDefaultNPSPluginState(t *testing.T) {
@@ -281,9 +252,7 @@ func TestTeamSettingsIsValidSiteNameEmpty(t *testing.T) {
 
 	// should fail fast because ts.SiteName is not set
 	err := c1.TeamSettings.isValid()
-	if err == nil {
-		t.Fatal("TeamSettings validation should fail with an empty SiteName")
-	}
+	require.NotNil(t, err)
 }
 
 func TestMessageExportSettingsIsValidEnableExportNotSet(t *testing.T) {


### PR DESCRIPTION

#### Summary
Migrate tests from "model/config_test.go" to use testify
#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/12667
