### PR TITLE
Automated cherry pick of #13562

### DIFF
--- a/api4/saml_test.go
+++ b/api4/saml_test.go
@@ -4,7 +4,12 @@
 package api4
 
 import (
+	"net/http"
 	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetSamlMetadata(t *testing.T) {
@@ -16,4 +21,32 @@ func TestGetSamlMetadata(t *testing.T) {
 	CheckNotImplementedStatus(t, resp)
 
 	// Rest is tested by enterprise tests
+}
+
+func TestSamlCompleteCSRFPass(t *testing.T) {
+	th := Setup().InitBasic()
+	defer th.TearDown()
+
+	url := th.Client.Url + "/login/sso/saml"
+	req, err := http.NewRequest("POST", url, nil)
+	if err != nil {
+		return
+	}
+
+	cookie1 := &http.Cookie{
+		Name:  model.SESSION_COOKIE_USER,
+		Value: th.BasicUser.Username,
+	}
+	cookie2 := &http.Cookie{
+		Name:  model.SESSION_COOKIE_TOKEN,
+		Value: th.Client.AuthToken,
+	}
+	req.AddCookie(cookie1)
+	req.AddCookie(cookie2)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.NotEqual(t, http.StatusUnauthorized, resp.StatusCode)
+	defer resp.Body.Close()
 }

--- a/web/saml.go
+++ b/web/saml.go
@@ -13,8 +13,8 @@ import (
 )
 
 func (w *Web) InitSaml() {
-	w.MainRouter.Handle("/login/sso/saml", w.NewHandler(loginWithSaml)).Methods("GET")
-	w.MainRouter.Handle("/login/sso/saml", w.NewHandler(completeSaml)).Methods("POST")
+	w.MainRouter.Handle("/login/sso/saml", w.ApiHandler(loginWithSaml)).Methods("GET")
+	w.MainRouter.Handle("/login/sso/saml", w.ApiHandlerTrustRequester(completeSaml)).Methods("POST")
 }
 
 func loginWithSaml(c *Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Cherry pick of #13562 on release-5.19.

- #13562: Use ApiTrustRequester for SAML complete endpoint

/cc  @streamer45