### PR TITLE
Remove redundant in-line image tests

### DIFF
--- a/tests/test-markdown-basics.md
+++ b/tests/test-markdown-basics.md
@@ -90,27 +90,8 @@ in-line code
 
 ### In-line Images
 
-Mattermost/platform build status:  [![Build Status](https://travis-ci.org/mattermost/platform.svg?branch=master)](https://travis-ci.org/mattermost/platform)  
+(These image tests were moved into Se: MessagingMan.html)  
 
-GitHub favicon:  ![Github](https://assets-cdn.github.com/favicon.ico)
-
-GIF Image:  
-![gif](http://i.giphy.com/xNrM4cGJ8u3ao.gif)
-
-4K Wallpaper Image (11Mb):  
-![4K Image](http://4kwallpaper.xyz/wallpaper/Large-Galaxy-Lightyears-Space-4K-wallpaper.png)
-
-Panorama Image:  
-![Pano](http://amardeepphotography.com/wp-content/uploads/2012/11/Untitled_Panorama6small.jpg)
-
-Tall Portrait Image:  
-![Portrait](http://www.maniacworld.com/now-this-is-a-tall-building.jpg)
-
-Tall Portrait Image (resized):  
-![Portrait](http://www.maniacworld.com/now-this-is-a-tall-building.jpg =x200)
-
-Tall Portrait Image (resized to a square):  
-![Portrait](http://www.maniacworld.com/now-this-is-a-tall-building.jpg =200x200)
 
 ### Lines
 


### PR DESCRIPTION
#### Summary
Removing in-line image tests from this markdown file; some URLs became outdated, then were updated directly in the Selenium test (MessagingMan.html) rather than here.

#### Ticket Link
Old investigation ticket was https://mattermost.atlassian.net/browse/MM-13821 but since then the tests were updated elsewhere so I'm closing that ticket as done/invalid.

The Se test uses the following:
```
### In-line Images
###### Mattermost/platform build status:
[![Build Status](https://travis-ci.org/mattermost/platform.svg?branch=master)](https://travis-ci.org/mattermost/platform)

###### GitHub favicon:
![Github](http://github.com/favicon.ico)

###### GIF Image:
![gif](http://i.giphy.com/xNrM4cGJ8u3ao.gif)

###### 4K Wallpaper Image:
![4K Image](https://www.setaswall.com/wp-content/uploads/2017/03/Beautiful-4K-Wallpaper-3840x2160.jpg)

###### Panorama Image:
![Pano](http://amardeepphotography.com/wp-content/uploads/2012/11/Untitled_Panorama6small.jpg)

###### Tall Portrait Image:
![Portrait](https://upload.wikimedia.org/wikipedia/commons/0/07/The_Shard_from_the_Sky_Garden_2015.jpg)

###### Tall Portrait Image (resized):
![Portrait](https://upload.wikimedia.org/wikipedia/commons/0/07/The_Shard_from_the_Sky_Garden_2015.jpg =x200)

###### Tall Portrait Image (resized to a square):
![Portrait](https://upload.wikimedia.org/wikipedia/commons/0/07/The_Shard_from_the_Sky_Garden_2015.jpg =200x200)
```
