### PR TITLE
Fixes #13580 : notification.log should be ignored in the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ _testmain.go
 *.prof
 
 # Log files
+*.log
 *mattermost.log*
 *mattermost.log.jsonl
 *npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -54,9 +54,7 @@ _testmain.go
 
 # Log files
 *.log
-*mattermost.log*
-*mattermost.log.jsonl
-*npm-debug.log*
+*.log.jsonl
 
 .tmp
 


### PR DESCRIPTION
#### Summary
Added any log file to be ignored in gitignore

#### Ticket Link
Fixes : https://github.com/mattermost/mattermost-server/issues/13580
Jira : nill