### PR TITLE
GH-13570 Allow /static/plugins/* endpoint responses to be cached (except for 404s)

### DIFF
--- a/web/static.go
+++ b/web/static.go
@@ -34,7 +34,7 @@ func (w *Web) InitStatic() {
 		mime.AddExtensionType(".wasm", "application/wasm")
 
 		staticHandler := staticFilesHandler(http.StripPrefix(path.Join(subpath, "static"), http.FileServer(http.Dir(staticDir))))
-		pluginHandler := staticFilesWithValidationHandler(http.StripPrefix(path.Join(subpath, "static", "plugins"), http.FileServer(http.Dir(*w.ConfigService.Config().PluginSettings.ClientDirectory))))
+		pluginHandler := noCacheOnNotFoundHandler(staticFilesHandler(http.StripPrefix(path.Join(subpath, "static", "plugins"), http.FileServer(http.Dir(*w.ConfigService.Config().PluginSettings.ClientDirectory)))))
 
 		if *w.ConfigService.Config().ServiceSettings.WebserverMode == "gzip" {
 			staticHandler = gziphandler.GzipHandler(staticHandler)
@@ -87,17 +87,22 @@ func staticFilesHandler(handler http.Handler) http.Handler {
 	})
 }
 
-func staticFilesWithValidationHandler(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Require validation from any cache, achieved via Last-Modified and the
-		// http.FileServer.
-		w.Header().Set("Cache-Control", "no-cache, public")
+type notFoundNoCacheRespWr struct {
+	http.ResponseWriter
+}
 
-		if strings.HasSuffix(r.URL.Path, "/") {
-			http.NotFound(w, r)
-			return
-		}
-		handler.ServeHTTP(w, r)
+func (w *notFoundNoCacheRespWr) WriteHeader(statusCode int) {
+	if statusCode == http.StatusNotFound {
+		// we have a 404, update our cache header first then fall through
+		w.Header().Set("Cache-Control", "no-cache, public")
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+// a handler that disallows caching the response if the response is a 404
+func noCacheOnNotFoundHandler(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handler.ServeHTTP(&notFoundNoCacheRespWr{ResponseWriter: w}, r)
 	})
 }
 

--- a/web/static.go
+++ b/web/static.go
@@ -34,7 +34,7 @@ func (w *Web) InitStatic() {
 		mime.AddExtensionType(".wasm", "application/wasm")
 
 		staticHandler := staticFilesHandler(http.StripPrefix(path.Join(subpath, "static"), http.FileServer(http.Dir(staticDir))))
-		pluginHandler := noCacheOnNotFoundHandler(staticFilesHandler(http.StripPrefix(path.Join(subpath, "static", "plugins"), http.FileServer(http.Dir(*w.ConfigService.Config().PluginSettings.ClientDirectory)))))
+		pluginHandler := staticFilesHandler(http.StripPrefix(path.Join(subpath, "static", "plugins"), http.FileServer(http.Dir(*w.ConfigService.Config().PluginSettings.ClientDirectory))))
 
 		if *w.ConfigService.Config().ServiceSettings.WebserverMode == "gzip" {
 			staticHandler = gziphandler.GzipHandler(staticHandler)
@@ -77,6 +77,9 @@ func root(c *Context, w http.ResponseWriter, r *http.Request) {
 
 func staticFilesHandler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//wrap our ResponseWriter with our no-cache 404-handler
+		w = &notFoundNoCacheResponseWriter{ResponseWriter: w}
+
 		w.Header().Set("Cache-Control", "max-age=31556926, public")
 
 		if strings.HasSuffix(r.URL.Path, "/") {
@@ -87,23 +90,16 @@ func staticFilesHandler(handler http.Handler) http.Handler {
 	})
 }
 
-type notFoundNoCacheRespWr struct {
+type notFoundNoCacheResponseWriter struct {
 	http.ResponseWriter
 }
 
-func (w *notFoundNoCacheRespWr) WriteHeader(statusCode int) {
+func (w *notFoundNoCacheResponseWriter) WriteHeader(statusCode int) {
 	if statusCode == http.StatusNotFound {
 		// we have a 404, update our cache header first then fall through
 		w.Header().Set("Cache-Control", "no-cache, public")
 	}
 	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-// a handler that disallows caching the response if the response is a 404
-func noCacheOnNotFoundHandler(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handler.ServeHTTP(&notFoundNoCacheRespWr{ResponseWriter: w}, r)
-	})
 }
 
 func robotsHandler(w http.ResponseWriter, r *http.Request) {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -184,7 +184,7 @@ func TestStaticFilesRequest(t *testing.T) {
 	th.Web.MainRouter.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t, mainJS, res.Body.String())
-	assert.Equal(t, []string{"no-cache, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+	assert.Equal(t, []string{"max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
 
 	// Verify cached access to the bundle with an If-Modified-Since timestamp in the future
 	future := time.Now().Add(24 * time.Hour)
@@ -194,7 +194,7 @@ func TestStaticFilesRequest(t *testing.T) {
 	th.Web.MainRouter.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusNotModified, res.Code)
 	assert.Empty(t, res.Body.String())
-	assert.Equal(t, []string{"no-cache, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+	assert.Equal(t, []string{"max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
 
 	// Verify access to the bundle with an If-Modified-Since timestamp in the past
 	past := time.Now().Add(-24 * time.Hour)
@@ -204,7 +204,7 @@ func TestStaticFilesRequest(t *testing.T) {
 	th.Web.MainRouter.ServeHTTP(res, req)
 	assert.Equal(t, http.StatusOK, res.Code)
 	assert.Equal(t, mainJS, res.Body.String())
-	assert.Equal(t, []string{"no-cache, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+	assert.Equal(t, []string{"max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
 
 	// Verify handling of 404.
 	req, _ = http.NewRequest("GET", "/static/plugins/com.mattermost.sample/404.js", nil)


### PR DESCRIPTION
#### Summary
Reinstates "allow caching" as the default behavior for the `/static/plugins/*` endpoint.  If there's a 404 response then caching is disabled.  This should improve upon the behavior added in https://mattermost.atlassian.net/browse/MM-20948.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/13570
