### PR TITLE
MM-21548: Fix Flakey Test

### DIFF
--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -3688,7 +3688,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlSupplier)
 	})
 
 	o1.DeleteAt = model.GetMillis()
-	o1.UpdateAt = model.GetMillis()
+	o1.UpdateAt = o1.DeleteAt
 
 	e := ss.Channel().Delete(o1.Id, o1.DeleteAt)
 	require.Nil(t, e, "channel should have been deleted")

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -3967,7 +3967,7 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, ss store.Store) {
 
 	// Deactivate users 1 & 2.
 	u1.DeleteAt = model.GetMillis()
-	u2.DeleteAt = model.GetMillis()
+	u2.DeleteAt = u1.DeleteAt
 	_, err = ss.User().Update(&u1, true)
 	require.Nil(t, err)
 	_, err = ss.User().Update(&u2, true)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -3967,7 +3967,7 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, ss store.Store) {
 
 	// Deactivate users 1 & 2.
 	u1.DeleteAt = model.GetMillis()
-	u2.DeleteAt = u1.DeleteAt
+	u2.DeleteAt = model.GetMillis()
 	_, err = ss.User().Update(&u1, true)
 	require.Nil(t, err)
 	_, err = ss.User().Update(&u2, true)


### PR DESCRIPTION
#### Summary
If testing conditions fall just right, DeleteAt and UpdateAt can be set to different values, 1 millisecond apart. You can duplicate the error by putting a 1 ms sleep between when the values are set. 
Fix is to simply always set the UpdateAt property from the DeleteAt property.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21548
