### PR TITLE
MM-20345: Fixing etag problem not reloading all users when needed

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -605,11 +605,6 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			profiles, err = c.App.GetUsersInChannelPage(inChannelId, c.Params.Page, c.Params.PerPage, c.IsSystemAdmin())
 		}
 	} else {
-		etag = c.App.GetUsersEtag(restrictions.Hash())
-		if c.HandleEtag(etag, "Get Users", w, r) {
-			return
-		}
-
 		userGetOptions, err = c.App.RestrictUsersGetByPermissions(c.App.Session.UserId, userGetOptions)
 		if err != nil {
 			c.Err = err

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1847,9 +1847,6 @@ func TestGetUsers(t *testing.T) {
 		CheckUserSanitization(t, u)
 	}
 
-	rusers, resp = th.Client.GetUsers(0, 60, resp.Etag)
-	CheckEtag(t, rusers, resp)
-
 	rusers, resp = th.Client.GetUsers(0, 1, "")
 	CheckNoError(t, resp)
 	require.Len(t, rusers, 1, "should be 1 per page")


### PR DESCRIPTION
#### Summary
This is part of the problem of the MM-20345 bug, when you get all the users it was generating an etag based on your view restrictions, but is not enough to decide to not update the data, so we need also all the memberships to all the channels (which is not possible), so I removed the etag completely here.

#### Ticket Link
[MM-20345](https://mattermost.atlassian.net/browse/MM-20345)