### PR TITLE
Bump app version to 5.22

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -13,6 +13,8 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"5.22.0",
+	"5.21.0",
 	"5.20.0",
 	"5.19.0",
 	"5.18.0",


### PR DESCRIPTION
#### Summary
Given that the release branch for 5.20 has been cut, we can safely bump the app version to 5.22 now. Please note that we will have to bump the version on the 5.21 release branch, after 5.20 is cut.

#### Ticket Link
None