### PR TITLE
Disable unused linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,7 @@ linters:
     - ineffassign
     - structcheck
     - unconvert
-    - unused
+    # - unused Disable until https://github.com/golangci/golangci-lint/issues/885 is fixed
     - varcheck
     # TODO: enable this later
     # - errcheck


### PR DESCRIPTION
#### Summary
There have been spontaneous failures with golangci lint. @agnivade discovered that they are happen when both `unused` and `govet` are used. This PR disables `unused` for now. I've chosen `unused` because there where only a few issues found by this linter and there are a lot more issues found by `govet`.

#### Ticket Link
Fixed https://mattermost.atlassian.net/browse/MM-21069