### PR TITLE
[MM-21793] Allow bots to be added to group synced channels and teams

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -253,6 +253,26 @@ func (me *TestHelper) CreateWebSocketClientWithClient(client *model.Client4) (*m
 	return model.NewWebSocketClient4(fmt.Sprintf("ws://localhost:%v", me.App.Srv.ListenAddr.Port), client.AuthToken)
 }
 
+func (me *TestHelper) CreateBotWithSystemAdminClient() *model.Bot {
+	return me.CreateBotWithClient((me.SystemAdminClient))
+}
+
+func (me *TestHelper) CreateBotWithClient(client *model.Client4) *model.Bot {
+	bot := &model.Bot{
+		Username:    GenerateTestUsername(),
+		DisplayName: "a bot",
+		Description: "bot",
+	}
+
+	utils.DisableDebugLogForTest()
+	rbot, resp := client.CreateBot(bot)
+	if resp.Error != nil {
+		panic(resp.Error)
+	}
+	utils.EnableDebugLogForTest()
+	return rbot
+}
+
 func (me *TestHelper) CreateUser() *model.User {
 	return me.CreateUserWithClient(me.Client)
 }

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -1398,12 +1398,18 @@ func removeChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	user, err := c.App.GetUser(c.Params.UserId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
 	if !(channel.Type == model.CHANNEL_OPEN || channel.Type == model.CHANNEL_PRIVATE) {
 		c.Err = model.NewAppError("removeChannelMember", "api.channel.remove_channel_member.type.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
 
-	if channel.IsGroupConstrained() && (c.Params.UserId != c.App.Session.UserId) {
+	if channel.IsGroupConstrained() && (c.Params.UserId != c.App.Session.UserId) && !user.IsBot {
 		c.Err = model.NewAppError("removeChannelMember", "api.channel.remove_member.group_constrained.app_error", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/api4/team.go
+++ b/api4/team.go
@@ -626,7 +626,13 @@ func removeTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if team.IsGroupConstrained() && (c.Params.UserId != c.App.Session.UserId) {
+	user, err := c.App.GetUser(c.Params.UserId)
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	if team.IsGroupConstrained() && (c.Params.UserId != c.App.Session.UserId) && !user.IsBot {
 		c.Err = model.NewAppError("removeTeamMember", "api.team.remove_member.group_constrained.app_error", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/app/channel.go
+++ b/app/channel.go
@@ -1685,6 +1685,7 @@ func (a *App) removeUserFromChannel(userIdToRemove string, removerUserId string,
 		return err
 	}
 	isGuest := user.IsGuest()
+	isBot := user.IsBot
 
 	if channel.Name == model.DEFAULT_CHANNEL {
 		if !isGuest {
@@ -1692,7 +1693,7 @@ func (a *App) removeUserFromChannel(userIdToRemove string, removerUserId string,
 		}
 	}
 
-	if channel.IsGroupConstrained() && userIdToRemove != removerUserId {
+	if channel.IsGroupConstrained() && userIdToRemove != removerUserId && !isBot {
 		nonMembers, err := a.FilterNonGroupChannelMembers([]string{userIdToRemove}, channel)
 		if err != nil {
 			return model.NewAppError("removeUserFromChannel", "api.channel.remove_user_from_channel.app_error", nil, "", http.StatusInternalServerError)

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -194,6 +194,28 @@ func (me *TestHelper) CreateUserOrGuest(guest bool) *model.User {
 	return user
 }
 
+func (me *TestHelper) CreateBot() *model.Bot {
+	id := model.NewId()
+
+	bot := &model.Bot{
+		Username:    "bot" + id,
+		DisplayName: "a bot",
+		Description: "bot",
+		OwnerId:     me.BasicUser.Id,
+	}
+
+	me.App.Log.SetConsoleLevel(mlog.LevelError)
+	bot, err := me.App.CreateBot(bot)
+	if err != nil {
+		mlog.Error(err.Error())
+
+		time.Sleep(time.Second)
+		panic(err)
+	}
+	me.App.Log.SetConsoleLevel(mlog.LevelDebug)
+	return bot
+}
+
 func (me *TestHelper) CreateChannel(team *model.Team) *model.Channel {
 	return me.createChannel(team, model.CHANNEL_OPEN)
 }

--- a/app/user.go
+++ b/app/user.go
@@ -2064,69 +2064,54 @@ func (a *App) RestrictUsersGetByPermissions(userId string, options *model.UserGe
 }
 
 // FilterNonGroupTeamMembers returns the subset of the given user IDs of the users who are not members of groups
-// associated to the team.
-func (a *App) FilterNonGroupTeamMembers(userIDs []string, team *model.Team) ([]string, error) {
+// associated to the team excluding bots
+func (a *App) FilterNonGroupTeamMembers(userIds []string, team *model.Team) ([]string, error) {
 	teamGroupUsers, err := a.GetTeamGroupUsers(team.Id)
 	if err != nil {
 		return nil, err
 	}
-
-	// possible if no groups associated or no group members in any of the associated groups
-	if len(teamGroupUsers) == 0 {
-		return userIDs, nil
-	}
-
-	nonMemberIDs := []string{}
-
-	for _, userID := range userIDs {
-		userIsMember := false
-
-		for _, pu := range teamGroupUsers {
-			if pu.Id == userID {
-				userIsMember = true
-				break
-			}
-		}
-
-		if !userIsMember {
-			nonMemberIDs = append(nonMemberIDs, userID)
-		}
-	}
-
-	return nonMemberIDs, nil
+	return a.filterNonGroupUsers(userIds, teamGroupUsers)
 }
 
 // FilterNonGroupChannelMembers returns the subset of the given user IDs of the users who are not members of groups
-// associated to the channel.
-func (a *App) FilterNonGroupChannelMembers(userIDs []string, channel *model.Channel) ([]string, error) {
+// associated to the channel excluding bots
+func (a *App) FilterNonGroupChannelMembers(userIds []string, channel *model.Channel) ([]string, error) {
 	channelGroupUsers, err := a.GetChannelGroupUsers(channel.Id)
 	if err != nil {
 		return nil, err
 	}
+	return a.filterNonGroupUsers(userIds, channelGroupUsers)
+}
 
+// filterNonGroupUsers is a helper function that takes a list of user ids and a list of users
+// and returns the list of normal users present in userIds but not in groupUsers
+func (a *App) filterNonGroupUsers(userIds []string, groupUsers []*model.User) ([]string, error) {
 	// possible if no groups associated or no group members in any of the associated groups
-	if len(channelGroupUsers) == 0 {
-		return userIDs, nil
+	if len(groupUsers) == 0 {
+		return userIds, nil
 	}
 
-	nonMemberIDs := []string{}
+	nonMemberIds := []string{}
+	users, err := a.Srv.Store.User().GetProfileByIds(userIds, nil, false)
+	if err != nil {
+		return nil, err
+	}
 
-	for _, userID := range userIDs {
-		userIsMember := false
+	for _, user := range users {
+		if user.IsBot {
+			break
+		}
 
-		for _, pu := range channelGroupUsers {
-			if pu.Id == userID {
-				userIsMember = true
+		for _, pu := range groupUsers {
+			if pu.Id == user.Id {
 				break
 			}
 		}
 
-		if !userIsMember {
-			nonMemberIDs = append(nonMemberIDs, userID)
-		}
+		nonMemberIds = append(nonMemberIds, user.Id)
 	}
 
-	return nonMemberIDs, nil
+	return nonMemberIds, nil
 }
 
 func (a *App) RestrictUsersSearchByPermissions(userId string, options *model.UserSearchOptions) (*model.UserSearchOptions, *model.AppError) {

--- a/app/user.go
+++ b/app/user.go
@@ -2086,11 +2086,6 @@ func (a *App) FilterNonGroupChannelMembers(userIds []string, channel *model.Chan
 // filterNonGroupUsers is a helper function that takes a list of user ids and a list of users
 // and returns the list of normal users present in userIds but not in groupUsers
 func (a *App) filterNonGroupUsers(userIds []string, groupUsers []*model.User) ([]string, error) {
-	// possible if no groups associated or no group members in any of the associated groups
-	if len(groupUsers) == 0 {
-		return userIds, nil
-	}
-
 	nonMemberIds := []string{}
 	users, err := a.Srv.Store.User().GetProfileByIds(userIds, nil, false)
 	if err != nil {
@@ -2098,17 +2093,17 @@ func (a *App) filterNonGroupUsers(userIds []string, groupUsers []*model.User) ([
 	}
 
 	for _, user := range users {
-		if user.IsBot {
-			break
-		}
+		userIsMember := user.IsBot
 
 		for _, pu := range groupUsers {
 			if pu.Id == user.Id {
+				userIsMember = true
 				break
 			}
 		}
-
-		nonMemberIds = append(nonMemberIds, user.Id)
+		if !userIsMember {
+			nonMemberIds = append(nonMemberIds, user.Id)
+		}
 	}
 
 	return nonMemberIds, nil

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -812,7 +812,7 @@
   },
   {
     "id": "api.command_invite.group_constrained_user_denied",
-    "translation": "This channel is managed by groups.  This user is not part of a group that is synched to this channel."
+    "translation": "This channel is managed by groups.  This user is not part of a group that is synced to this channel."
   },
   {
     "id": "api.command_invite.hint",
@@ -1932,7 +1932,7 @@
   },
   {
     "id": "api.team.add_members.user_denied",
-    "translation": "This team is managed by groups.  This user is not part of a group that is synched to this team."
+    "translation": "This team is managed by groups.  This user is not part of a group that is synced to this team."
   },
   {
     "id": "api.team.add_user_to_team.added",


### PR DESCRIPTION
#### Summary
- Changes group synced team & channel behaviour to allow bots to be invited and removed 
- Also fixes the wording for the error when unable to remove group synced user


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-21793

#### Related Pull Requests
- Has web app changes: 

#### Behaviour tested
- [x] Adding a bot from the manage team members modal on a group synced team
- [x] Removing a bot from the manage team members modal on a group synced team
- [x] `/invite @botname` inside of private group synced channel
- [x] `/remove @botname` inside of private group synced channel
- [x] Removing a bot from the manage channel members modal in a private group synced channel

