### PR TITLE
User Management > User role change not reflected in the UI without a refresh

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -36,6 +36,7 @@ type TestHelper struct {
 	Client               *model.Client4
 	BasicUser            *model.User
 	BasicUser2           *model.User
+	BasicUserGuest       *model.User
 	TeamAdminUser        *model.User
 	BasicTeam            *model.Team
 	BasicChannel         *model.Channel
@@ -209,8 +210,12 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.LinkUserToTeam(me.BasicUser, me.BasicTeam)
 	me.BasicUser2 = me.CreateUser()
 	me.LinkUserToTeam(me.BasicUser2, me.BasicTeam)
+	me.BasicUserGuest = me.CreateUser()
+	me.App.UpdateUserRoles(me.BasicUserGuest.Id, model.SYSTEM_GUEST_ROLE_ID, false)
+	me.LinkUserToTeam(me.BasicUserGuest, me.BasicTeam)
 	me.App.AddUserToChannel(me.BasicUser, me.BasicChannel)
 	me.App.AddUserToChannel(me.BasicUser2, me.BasicChannel)
+	me.App.AddUserToChannel(me.BasicUserGuest, me.BasicChannel)
 	me.App.AddUserToChannel(me.BasicUser, me.BasicChannel2)
 	me.App.AddUserToChannel(me.BasicUser2, me.BasicChannel2)
 	me.App.AddUserToChannel(me.BasicUser, me.BasicPrivateChannel)

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -36,7 +36,6 @@ type TestHelper struct {
 	Client               *model.Client4
 	BasicUser            *model.User
 	BasicUser2           *model.User
-	BasicUserGuest       *model.User
 	TeamAdminUser        *model.User
 	BasicTeam            *model.Team
 	BasicChannel         *model.Channel
@@ -210,12 +209,8 @@ func (me *TestHelper) InitBasic() *TestHelper {
 	me.LinkUserToTeam(me.BasicUser, me.BasicTeam)
 	me.BasicUser2 = me.CreateUser()
 	me.LinkUserToTeam(me.BasicUser2, me.BasicTeam)
-	me.BasicUserGuest = me.CreateUser()
-	me.App.UpdateUserRoles(me.BasicUserGuest.Id, model.SYSTEM_GUEST_ROLE_ID, false)
-	me.LinkUserToTeam(me.BasicUserGuest, me.BasicTeam)
 	me.App.AddUserToChannel(me.BasicUser, me.BasicChannel)
 	me.App.AddUserToChannel(me.BasicUser2, me.BasicChannel)
-	me.App.AddUserToChannel(me.BasicUserGuest, me.BasicChannel)
 	me.App.AddUserToChannel(me.BasicUser, me.BasicChannel2)
 	me.App.AddUserToChannel(me.BasicUser2, me.BasicChannel2)
 	me.App.AddUserToChannel(me.BasicUser, me.BasicPrivateChannel)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -4379,7 +4379,9 @@ func TestDemoteUserToGuest(t *testing.T) {
 		}()
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = true })
 		th.App.SetLicense(model.NewTestLicense())
-		_, respErr := th.SystemAdminClient.DemoteUserToGuest(user.Id)
+		_, respErr := th.SystemAdminClient.GetUser(user.Id, "")
+		CheckNoError(t, respErr)
+		_, respErr = th.SystemAdminClient.DemoteUserToGuest(user.Id)
 		CheckNoError(t, respErr)
 
 		assertExpectedWebsocketEvent(t, webSocketClient, model.WEBSOCKET_EVENT_USER_UPDATED, func(event *model.WebSocketEvent) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -4394,6 +4394,7 @@ func TestDemoteUserToGuest(t *testing.T) {
 			require.True(t, ok, "expected user")
 			assert.Equal(t, "system_guest", eventUser.Roles)
 		})
+		th.App.InvalidateAllCaches()
 	})
 }
 
@@ -4449,5 +4450,6 @@ func TestPromoteGuestToUser(t *testing.T) {
 			require.True(t, ok, "expected user")
 			assert.Equal(t, "system_user", eventUser.Roles)
 		})
+		th.App.InvalidateAllCaches()
 	})
 }

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -4404,7 +4404,8 @@ func TestPromoteGuestToUser(t *testing.T) {
 			th.Server.Metrics, th.Server.Cluster, th.Server.CacheProvider)
 		defer th.TearDown()
 
-		user := th.BasicUserGuest
+		user := th.BasicUser
+		th.App.UpdateUserRoles(user.Id, model.SYSTEM_GUEST_ROLE_ID, false)
 
 		webSocketClient, err := th.CreateWebSocketClient()
 		assert.Nil(t, err)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/app"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/services/mailservice"
+	"github.com/mattermost/mattermost-server/v5/store/localcachelayer"
 	"github.com/mattermost/mattermost-server/v5/utils/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -4340,4 +4341,110 @@ func TestLoginLockout(t *testing.T) {
 	//Check if lock is active
 	_, resp = th.Client.Login(th.BasicUser2.Email, th.BasicUser2.Password)
 	CheckErrorMessage(t, resp, "api.user.check_user_login_attempts.too_many.app_error")
+}
+
+func TestDemoteUserToGuest(t *testing.T) {
+	t.Run("websocket update user event", func(t *testing.T) {
+		th := Setup().InitBasic()
+		th.Server.Store = localcachelayer.NewLocalCacheLayer(th.Server.Store,
+			th.Server.Metrics, th.Server.Cluster, th.Server.CacheProvider)
+		defer th.TearDown()
+
+		user := th.BasicUser
+
+		webSocketClient, err := th.CreateWebSocketClient()
+		assert.Nil(t, err)
+		defer webSocketClient.Close()
+
+		webSocketClient.Listen()
+
+		time.Sleep(300 * time.Millisecond)
+		resp := <-webSocketClient.ResponseChannel
+		require.Equal(t, model.STATUS_OK, resp.Status)
+
+		adminWebSocketClient, err := th.CreateWebSocketSystemAdminClient()
+		assert.Nil(t, err)
+		defer adminWebSocketClient.Close()
+
+		adminWebSocketClient.Listen()
+
+		time.Sleep(300 * time.Millisecond)
+		resp = <-adminWebSocketClient.ResponseChannel
+		require.Equal(t, model.STATUS_OK, resp.Status)
+
+		enableGuestAccounts := *th.App.Config().GuestAccountsSettings.Enable
+		defer func() {
+			th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = enableGuestAccounts })
+			th.App.RemoveLicense()
+		}()
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = true })
+		th.App.SetLicense(model.NewTestLicense())
+		_, respErr := th.SystemAdminClient.DemoteUserToGuest(user.Id)
+		CheckNoError(t, respErr)
+
+		assertExpectedWebsocketEvent(t, webSocketClient, model.WEBSOCKET_EVENT_USER_UPDATED, func(event *model.WebSocketEvent) {
+			eventUser, ok := event.GetData()["user"].(*model.User)
+			require.True(t, ok, "expected user")
+			assert.Equal(t, "system_guest", eventUser.Roles)
+		})
+		assertExpectedWebsocketEvent(t, adminWebSocketClient, model.WEBSOCKET_EVENT_USER_UPDATED, func(event *model.WebSocketEvent) {
+			eventUser, ok := event.GetData()["user"].(*model.User)
+			require.True(t, ok, "expected user")
+			assert.Equal(t, "system_guest", eventUser.Roles)
+		})
+	})
+}
+
+func TestPromoteGuestToUser(t *testing.T) {
+	t.Run("websocket update user event", func(t *testing.T) {
+		th := Setup().InitBasic()
+		th.Server.Store = localcachelayer.NewLocalCacheLayer(th.Server.Store,
+			th.Server.Metrics, th.Server.Cluster, th.Server.CacheProvider)
+		defer th.TearDown()
+
+		user := th.BasicUserGuest
+
+		webSocketClient, err := th.CreateWebSocketClient()
+		assert.Nil(t, err)
+		defer webSocketClient.Close()
+
+		webSocketClient.Listen()
+
+		time.Sleep(300 * time.Millisecond)
+		resp := <-webSocketClient.ResponseChannel
+		require.Equal(t, model.STATUS_OK, resp.Status)
+
+		adminWebSocketClient, err := th.CreateWebSocketSystemAdminClient()
+		assert.Nil(t, err)
+		defer adminWebSocketClient.Close()
+
+		adminWebSocketClient.Listen()
+
+		time.Sleep(300 * time.Millisecond)
+		resp = <-adminWebSocketClient.ResponseChannel
+		require.Equal(t, model.STATUS_OK, resp.Status)
+
+		enableGuestAccounts := *th.App.Config().GuestAccountsSettings.Enable
+		defer func() {
+			th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = enableGuestAccounts })
+			th.App.RemoveLicense()
+		}()
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = true })
+		th.App.SetLicense(model.NewTestLicense())
+		_, respErr := th.SystemAdminClient.GetUser(user.Id, "")
+		CheckNoError(t, respErr)
+		_, respErr = th.SystemAdminClient.PromoteGuestToUser(user.Id)
+		CheckNoError(t, respErr)
+
+		assertExpectedWebsocketEvent(t, webSocketClient, model.WEBSOCKET_EVENT_USER_UPDATED, func(event *model.WebSocketEvent) {
+			eventUser, ok := event.GetData()["user"].(*model.User)
+			require.True(t, ok, "expected user")
+			assert.Equal(t, "system_user", eventUser.Roles)
+		})
+		assertExpectedWebsocketEvent(t, adminWebSocketClient, model.WEBSOCKET_EVENT_USER_UPDATED, func(event *model.WebSocketEvent) {
+			eventUser, ok := event.GetData()["user"].(*model.User)
+			require.True(t, ok, "expected user")
+			assert.Equal(t, "system_user", eventUser.Roles)
+		})
+	})
 }

--- a/app/user.go
+++ b/app/user.go
@@ -2269,6 +2269,7 @@ func (a *App) getListOfAllowedChannelsForTeam(teamId string, viewRestrictions *m
 // guest roles to regular user roles.
 func (a *App) PromoteGuestToUser(user *model.User, requestorId string) *model.AppError {
 	err := a.Srv.Store.User().PromoteGuestToUser(user.Id)
+	a.InvalidateCacheForUser(user.Id)
 	if err != nil {
 		return err
 	}
@@ -2314,7 +2315,6 @@ func (a *App) PromoteGuestToUser(user *model.User, requestorId string) *model.Ap
 		}
 	}
 
-	a.InvalidateCacheForUser(user.Id)
 	a.ClearSessionCacheForUser(user.Id)
 	return nil
 }
@@ -2323,6 +2323,7 @@ func (a *App) PromoteGuestToUser(user *model.User, requestorId string) *model.Ap
 // regular user roles to guest roles.
 func (a *App) DemoteUserToGuest(user *model.User) *model.AppError {
 	err := a.Srv.Store.User().DemoteUserToGuest(user.Id)
+	a.InvalidateCacheForUser(user.Id)
 	if err != nil {
 		return err
 	}
@@ -2357,7 +2358,6 @@ func (a *App) DemoteUserToGuest(user *model.User) *model.AppError {
 		}
 	}
 
-	a.InvalidateCacheForUser(user.Id)
 	a.ClearSessionCacheForUser(user.Id)
 
 	return nil


### PR DESCRIPTION
We're updating the user in the store but we're not invalidating the
cache until the end so we're sending the old copy of it when we're
calling `sendUpdatedUserEvent`

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

When a system admin tries to demote/promote a user, the role is not updated but in the server is doing it right. Basically the problem is that we're sending the cached profile through the websocket instead of the new one.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-21875