### PR TITLE
[MM-21946] [MM-21945] Ensure deleted groups are not returned from the groups API

### DIFF
--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -905,7 +905,7 @@ func (s *SqlGroupStore) groupsBySyncableBaseQuery(st model.GroupSyncableType, t 
 			From("UserGroups ug").
 			LeftJoin("(SELECT GroupMembers.GroupId, COUNT(*) AS MemberCount FROM GroupMembers LEFT JOIN Users ON Users.Id = GroupMembers.UserId WHERE GroupMembers.DeleteAt = 0 AND Users.DeleteAt = 0 GROUP BY GroupId) AS Members ON Members.GroupId = ug.Id").
 			LeftJoin(fmt.Sprintf("%[1]s ON %[1]s.GroupId = ug.Id", table)).
-			Where(fmt.Sprintf("%[1]s.DeleteAt = 0 AND %[1]s.%[2]s = ?", table, idCol), syncableID).
+			Where(fmt.Sprintf("ug.DeleteAt = 0 AND %[1]s.DeleteAt = 0 AND %[1]s.%[2]s = ?", table, idCol), syncableID).
 			OrderBy("ug.DisplayName")
 	}
 
@@ -970,6 +970,7 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 			Select("g.*, coalesce(Members.MemberCount, 0) AS MemberCount").
 			From("UserGroups g").
 			LeftJoin("(SELECT GroupMembers.GroupId, COUNT(*) AS MemberCount FROM GroupMembers LEFT JOIN Users ON Users.Id = GroupMembers.UserId WHERE GroupMembers.DeleteAt = 0 AND Users.DeleteAt = 0 GROUP BY GroupId) AS Members ON Members.GroupId = g.Id").
+			Where("g.DeleteAt = 0").
 			Limit(uint64(perPage)).
 			Offset(uint64(page * perPage)).
 			OrderBy("g.DisplayName")
@@ -997,6 +998,7 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 					AND UserGroups.DeleteAt = 0
 					AND GroupTeams.TeamId = ?
 			)
+			AND g.DeleteAt = 0
 		`, opts.NotAssociatedToTeam)
 	}
 
@@ -1013,6 +1015,7 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 					AND UserGroups.DeleteAt = 0
 					AND GroupChannels.ChannelId = ?
 			)
+			AND g.DeleteAt = 0
 		`, opts.NotAssociatedToChannel)
 	}
 

--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -963,16 +963,16 @@ func (s *SqlGroupStore) GetGroupsByTeam(teamId string, opts model.GroupSearchOpt
 func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts) ([]*model.Group, *model.AppError) {
 	var groups []*model.Group
 
-	groupsQuery := s.getQueryBuilder().Select("g.*").From("UserGroups g")
+	groupsQuery := s.getQueryBuilder().Select("g.*")
 
 	if opts.IncludeMemberCount {
 		groupsQuery = s.getQueryBuilder().
 			Select("g.*, coalesce(Members.MemberCount, 0) AS MemberCount").
-			From("UserGroups g").
 			LeftJoin("(SELECT GroupMembers.GroupId, COUNT(*) AS MemberCount FROM GroupMembers LEFT JOIN Users ON Users.Id = GroupMembers.UserId WHERE GroupMembers.DeleteAt = 0 AND Users.DeleteAt = 0 GROUP BY GroupId) AS Members ON Members.GroupId = g.Id")
 	}
 
 	groupsQuery = groupsQuery.
+		From("UserGroups g").
 		Where("g.DeleteAt = 0").
 		Limit(uint64(perPage)).
 		Offset(uint64(page * perPage)).

--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -963,17 +963,20 @@ func (s *SqlGroupStore) GetGroupsByTeam(teamId string, opts model.GroupSearchOpt
 func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts) ([]*model.Group, *model.AppError) {
 	var groups []*model.Group
 
-	groupsQuery := s.getQueryBuilder().Select("g.*").From("UserGroups g").Limit(uint64(perPage)).Offset(uint64(page * perPage)).OrderBy("g.DisplayName")
+	groupsQuery := s.getQueryBuilder().Select("g.*").From("UserGroups g")
 
 	if opts.IncludeMemberCount {
 		groupsQuery = s.getQueryBuilder().
 			Select("g.*, coalesce(Members.MemberCount, 0) AS MemberCount").
 			From("UserGroups g").
-			LeftJoin("(SELECT GroupMembers.GroupId, COUNT(*) AS MemberCount FROM GroupMembers LEFT JOIN Users ON Users.Id = GroupMembers.UserId WHERE GroupMembers.DeleteAt = 0 AND Users.DeleteAt = 0 GROUP BY GroupId) AS Members ON Members.GroupId = g.Id").
-			Limit(uint64(perPage)).
-			Offset(uint64(page * perPage)).
-			OrderBy("g.DisplayName")
+			LeftJoin("(SELECT GroupMembers.GroupId, COUNT(*) AS MemberCount FROM GroupMembers LEFT JOIN Users ON Users.Id = GroupMembers.UserId WHERE GroupMembers.DeleteAt = 0 AND Users.DeleteAt = 0 GROUP BY GroupId) AS Members ON Members.GroupId = g.Id")
 	}
+
+	groupsQuery = groupsQuery.
+		Where("g.DeleteAt = 0").
+		Limit(uint64(perPage)).
+		Offset(uint64(page * perPage)).
+		OrderBy("g.DisplayName")
 
 	if len(opts.Q) > 0 {
 		pattern := fmt.Sprintf("%%%s%%", sanitizeSearchTerm(opts.Q, "\\"))
@@ -1015,8 +1018,6 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 			)
 		`, opts.NotAssociatedToChannel)
 	}
-
-	groupsQuery = groupsQuery.Where("g.DeleteAt = 0")
 
 	queryString, args, err := groupsQuery.ToSql()
 	if err != nil {

--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -970,7 +970,6 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 			Select("g.*, coalesce(Members.MemberCount, 0) AS MemberCount").
 			From("UserGroups g").
 			LeftJoin("(SELECT GroupMembers.GroupId, COUNT(*) AS MemberCount FROM GroupMembers LEFT JOIN Users ON Users.Id = GroupMembers.UserId WHERE GroupMembers.DeleteAt = 0 AND Users.DeleteAt = 0 GROUP BY GroupId) AS Members ON Members.GroupId = g.Id").
-			Where("g.DeleteAt = 0").
 			Limit(uint64(perPage)).
 			Offset(uint64(page * perPage)).
 			OrderBy("g.DisplayName")
@@ -998,7 +997,6 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 					AND UserGroups.DeleteAt = 0
 					AND GroupTeams.TeamId = ?
 			)
-			AND g.DeleteAt = 0
 		`, opts.NotAssociatedToTeam)
 	}
 
@@ -1015,9 +1013,10 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 					AND UserGroups.DeleteAt = 0
 					AND GroupChannels.ChannelId = ?
 			)
-			AND g.DeleteAt = 0
 		`, opts.NotAssociatedToChannel)
 	}
+
+	groupsQuery = groupsQuery.Where("g.DeleteAt = 0")
 
 	queryString, args, err := groupsQuery.ToSql()
 	if err != nil {


### PR DESCRIPTION
#### Summary
- Ensures that `getGroups`, `getGroupsByTeam` and `getGroupsByChannel` api endpoints do not return deleted `UserGroups` by appending`ug.DeleteAt = 0` to queries where they were not previously present

#### Ticket Link
- Fixes two tickets caused by the same issue
https://mattermost.atlassian.net/browse/MM-21946
https://mattermost.atlassian.net/browse/MM-21945

#### Testing
- In order to reproduce I had to connect to the database and modify one of my `UserGroup` entries to have a `DeleteAt` entry of `1`
- Then I opened the add groups to team modal and the deleted group was not present as expected