### PR TITLE
.gitignore prepackaged_plugins and report.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ imports/imports.go
 .prebuild
 .npminstall
 .yarninstall
+/prepackaged_plugins
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
@@ -91,6 +92,7 @@ ecover.out
 cprofile.out
 *.test
 webapp/coverage
+/report.xml
 
 .agignore
 .ctags


### PR DESCRIPTION
#### Summary
Ignore `prepackaged_plugins/` and `report.xml`, artifacts of various processes but not meant for commit.