### PR TITLE
Add 5.20 method to release branches for adding GOBIN.

### DIFF
--- a/build/Jenkinsfile.branch
+++ b/build/Jenkinsfile.branch
@@ -51,7 +51,7 @@ pipeline {
               platformStages.platformCheckoutRedux(env.BRANCH_NAME)
               SERVER_GIT_COMMIT=platformStages.platformServerCommitHash()
               try {
-                platformStages.newPlatformBuild(env.BRANCH_NAME + '.' + env.BUILD_NUMBER + '.' + SERVER_GIT_COMMIT, rndEE, false, mmBuilderServer, mmBuilderWebapp)
+                platformStages.after5Dot20AddGOBINBuild(env.BRANCH_NAME + '.' + env.BUILD_NUMBER + '.' + SERVER_GIT_COMMIT, rndEE, false, mmBuilderServer, mmBuilderWebapp)
               } finally {
                 platformStages.platformPublishResults()
                 platformStages.platformCleanDockerCompose(rndEE)
@@ -71,7 +71,7 @@ pipeline {
               platformStages.platformCheckoutRedux(env.BRANCH_NAME)
               SERVER_GIT_COMMIT=platformStages.platformServerCommitHash()
               try {
-                platformStages.newPlatformBuild(env.BRANCH_NAME + '.' + env.BUILD_NUMBER + '.' + SERVER_GIT_COMMIT, rndTE, false, mmBuilderServer, mmBuilderWebapp)
+                platformStages.after5Dot20AddGOBINBuild(env.BRANCH_NAME + '.' + env.BUILD_NUMBER + '.' + SERVER_GIT_COMMIT, rndTE, false, mmBuilderServer, mmBuilderWebapp)
               } finally {
                 platformStages.platformPublishResults()
                 platformStages.platformCleanDockerCompose(rndTE)


### PR DESCRIPTION
Use new Jenkins release method for usage with GOBIN. 