### PR TITLE
Remove explicit application/wasm mimetype

### DIFF
--- a/web/static.go
+++ b/web/static.go
@@ -4,7 +4,6 @@
 package web
 
 import (
-	"mime"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -30,8 +29,6 @@ func (w *Web) InitStatic() {
 		mlog.Debug("Using client directory", mlog.String("clientDir", staticDir))
 
 		subpath, _ := utils.GetSubpathFromConfig(w.ConfigService.Config())
-
-		mime.AddExtensionType(".wasm", "application/wasm")
 
 		staticHandler := staticFilesHandler(http.StripPrefix(path.Join(subpath, "static"), http.FileServer(http.Dir(staticDir))))
 		pluginHandler := staticFilesHandler(http.StripPrefix(path.Join(subpath, "static", "plugins"), http.FileServer(http.Dir(*w.ConfigService.Config().PluginSettings.ClientDirectory))))


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Go mime sniffer supports the application/wasm mimetype natively
now. So there is no need to set this explicitly.

#### Test steps:
1. Have any .wasm file inside the client/files directory.
2. Run `curl http://localhost:8065/static/files/<file.wasm> -v -o /dev/null`
3. Verify that you still see `Content-Type: application/wasm` in the response.
