### PR TITLE
revert zoom plugin to previous release v1.1.2 for 5.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ TESTFLAGSEE ?= -short
 TE_PACKAGES=$(shell $(GO) list ./...)
 
 # Plugins Packages
-PLUGIN_PACKAGES?=mattermost-plugin-zoom-v1.2.0
+PLUGIN_PACKAGES?=mattermost-plugin-zoom-v1.1.2
 PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.1.2
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.0.3
 PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.0.2


### PR DESCRIPTION
#### Summary
The zoom plugin needs to be reverted to the previous version for this bundle.

#### Ticket Link
n/a