### PR TITLE
MM-22057: Limit incoming request bodies

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -647,6 +647,11 @@ func (a *App) UploadFileX(channelId, name string, input io.Reader,
 func (t *uploadFileTask) readAll() *model.AppError {
 	_, err := t.buf.ReadFrom(t.limitedInput)
 	if err != nil {
+		// Ugly hack: the error is not exported from net/http.
+		if err.Error() == "http: request body too large" {
+			return t.newAppError("api.file.upload_file.too_large_detailed.app_error",
+				"", http.StatusRequestEntityTooLarge, "Length", t.buf.Len(), "Limit", t.limit)
+		}
 		return t.newAppError("api.file.upload_file.read_request.app_error",
 			err.Error(), http.StatusBadRequest)
 	}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -90,6 +90,12 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c.App.Path = r.URL.Path
 	c.Log = c.App.Log
 
+	// Set the max request body size to be equal to MaxFileSize.
+	// Ideally, non-file request bodies should be smaller than file request bodies,
+	// but we don't have a clean way to identify all file upload handlers.
+	// So to keep it simple, we clamp it to the max file size.
+	r.Body = http.MaxBytesReader(w, r.Body, *c.App.Config().FileSettings.MaxFileSize)
+
 	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
 	siteURLHeader := app.GetProtocol(r) + "://" + r.Host + subpath
 	c.SetSiteURLHeader(siteURLHeader)

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -4,6 +4,7 @@
 package web
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -94,7 +95,9 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Ideally, non-file request bodies should be smaller than file request bodies,
 	// but we don't have a clean way to identify all file upload handlers.
 	// So to keep it simple, we clamp it to the max file size.
-	r.Body = http.MaxBytesReader(w, r.Body, *c.App.Config().FileSettings.MaxFileSize)
+	// We add a buffer of bytes.MinRead so that file sizes close to max file size
+	// do not get cut off.
+	r.Body = http.MaxBytesReader(w, r.Body, *c.App.Config().FileSettings.MaxFileSize+bytes.MinRead)
 
 	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
 	siteURLHeader := app.GetProtocol(r) + "://" + r.Host + subpath


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Set the max request body size to be equal to MaxFileSize.
Ideally, non-file request bodies should be smaller than file request bodies,
but we don't have a clean way to identify all file upload handlers.

There shouldn't be any valid request which exceeds the max file upload size.
So this is a safe global limit to apply.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22057