### PR TITLE
Bump zoom plugin version to v1.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ TESTFLAGSEE ?= -short
 TE_PACKAGES=$(shell $(GO) list ./...)
 
 # Plugins Packages
-PLUGIN_PACKAGES?=mattermost-plugin-zoom-v1.2.0
+PLUGIN_PACKAGES?=mattermost-plugin-zoom-v1.3.0
 PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.1.2
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.0.3
 PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.0.2


### PR DESCRIPTION
#### Summary
Roll back Zoom version from 1.2.0 to 1.1.2 equivalent commit (named `v1.3.0`)

Relevant Conversation
https://community.mattermost.com/core/pl/ppjt5k8e9pr898xqiqxios3bxy

plugin | prev | new 
--- | --- | ---
zoom | `v1.2.0` | `v1.3.0`