### PR TITLE
Automated cherry pick of #13848

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -253,6 +253,7 @@ func (a *App) sendTeamEvent(team *model.Team, event string) {
 	sanitizedTeam.Sanitize()
 
 	message := model.NewWebSocketEvent(event, "", "", "", nil)
+	message.Broadcast.ContainsSensitiveData = true
 	message.Add("team", sanitizedTeam.ToJson())
 	a.Publish(message)
 }

--- a/app/team.go
+++ b/app/team.go
@@ -252,8 +252,12 @@ func (a *App) sendTeamEvent(team *model.Team, event string) {
 	*sanitizedTeam = *team
 	sanitizedTeam.Sanitize()
 
-	message := model.NewWebSocketEvent(event, "", "", "", nil)
-	message.Broadcast.ContainsSensitiveData = true
+	teamId := "" // no filtering by teamId by default
+	if event == model.WEBSOCKET_EVENT_UPDATE_TEAM {
+		// in case of update_team event - we send the message only to members of that team
+		teamId = team.Id
+	}
+	message := model.NewWebSocketEvent(event, teamId, "", "", nil)
 	message.Add("team", sanitizedTeam.ToJson())
 	a.Publish(message)
 }

--- a/app/web_conn_test.go
+++ b/app/web_conn_test.go
@@ -16,8 +16,13 @@ import (
 func TestWebConnShouldSendEvent(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
-
-	session, err := th.App.CreateSession(&model.Session{UserId: th.BasicUser.Id, Roles: th.BasicUser.GetRawRoles()})
+	session, err := th.App.CreateSession(&model.Session{UserId: th.BasicUser.Id, Roles: th.BasicUser.GetRawRoles(), TeamMembers: []*model.TeamMember{
+		{
+			UserId: th.BasicUser.Id,
+			TeamId: th.BasicTeam.Id,
+			Roles:  model.TEAM_USER_ROLE_ID,
+		},
+	}})
 	require.Nil(t, err)
 
 	basicUserWc := &WebConn{
@@ -30,7 +35,13 @@ func TestWebConnShouldSendEvent(t *testing.T) {
 	basicUserWc.SetSessionToken(session.Token)
 	basicUserWc.SetSessionExpiresAt(session.ExpiresAt)
 
-	session2, err := th.App.CreateSession(&model.Session{UserId: th.BasicUser2.Id, Roles: th.BasicUser2.GetRawRoles()})
+	session2, err := th.App.CreateSession(&model.Session{UserId: th.BasicUser2.Id, Roles: th.BasicUser2.GetRawRoles(), TeamMembers: []*model.TeamMember{
+		{
+			UserId: th.BasicUser2.Id,
+			TeamId: th.BasicTeam.Id,
+			Roles:  model.TEAM_ADMIN_ROLE_ID,
+		},
+	}})
 	require.Nil(t, err)
 
 	basicUser2Wc := &WebConn{
@@ -79,4 +90,11 @@ func TestWebConnShouldSendEvent(t *testing.T) {
 		assert.Equal(t, c.User2Expected, basicUser2Wc.ShouldSendEvent(event), c.Description)
 		assert.Equal(t, c.AdminExpected, adminUserWc.ShouldSendEvent(event), c.Description)
 	}
+
+	event2 := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_UPDATE_TEAM, th.BasicTeam.Id, "", "", nil)
+	assert.True(t, basicUserWc.ShouldSendEvent(event2))
+	assert.True(t, basicUser2Wc.ShouldSendEvent(event2))
+
+	event3 := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_UPDATE_TEAM, "wrongId", "", "", nil)
+	assert.False(t, basicUserWc.ShouldSendEvent(event3))
 }


### PR DESCRIPTION
Cherry pick of #13848 on release-5.20.

- #13848: fixes sending of update_team to every user

/cc  @reflog