### PR TITLE
MM-22340: Fixing flaky tests around Team name validation

### DIFF
--- a/api4/scheme_test.go
+++ b/api4/scheme_test.go
@@ -621,7 +621,7 @@ func TestDeleteScheme(t *testing.T) {
 
 		// Make sure this scheme is in use by a team.
 		team, err := th.App.Srv.Store.Team().Save(&model.Team{
-			Name:        model.NewId(),
+			Name:        "zz" + model.NewId(),
 			DisplayName: model.NewId(),
 			Email:       model.NewId() + "@nowhere.com",
 			Type:        model.TEAM_OPEN,

--- a/app/syncables_test.go
+++ b/app/syncables_test.go
@@ -16,7 +16,7 @@ func TestCreateDefaultMemberships(t *testing.T) {
 
 	singersTeam, err := th.App.CreateTeam(&model.Team{
 		DisplayName: "Singers",
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		Email:       "singers@test.com",
 		Type:        model.TEAM_OPEN,
 	})
@@ -26,7 +26,7 @@ func TestCreateDefaultMemberships(t *testing.T) {
 
 	nerdsTeam, err := th.App.CreateTeam(&model.Team{
 		DisplayName: "Nerds",
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		Email:       "nerds@test.com",
 		Type:        model.TEAM_INVITE,
 	})

--- a/manualtesting/manual_testing.go
+++ b/manualtesting/manual_testing.go
@@ -70,7 +70,7 @@ func manualTest(c *web.Context, w http.ResponseWriter, r *http.Request) {
 		// Create team for testing
 		team := &model.Team{
 			DisplayName: teamDisplayName[0],
-			Name:        utils.RandomName(utils.Range{Begin: 20, End: 20}, utils.LOWERCASE),
+			Name:        "zz" + utils.RandomName(utils.Range{Begin: 20, End: 20}, utils.LOWERCASE),
 			Email:       "success+" + model.NewId() + "simulator.amazonses.com",
 			Type:        model.TEAM_OPEN,
 		}

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -2271,7 +2271,7 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 		CompanyName:     model.NewId(),
 		AllowOpenInvite: false,
 		InviteId:        model.NewId(),
-		Name:            model.NewId(),
+		Name:            "zz" + model.NewId(),
 		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
 		Type:            model.TEAM_OPEN,
 	}
@@ -2322,7 +2322,7 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 		CompanyName:     model.NewId(),
 		AllowOpenInvite: false,
 		InviteId:        model.NewId(),
-		Name:            model.NewId(),
+		Name:            "zz" + model.NewId(),
 		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
 		Type:            model.TEAM_INVITE,
 	}
@@ -2505,7 +2505,7 @@ func testGetGroups(t *testing.T, ss store.Store) {
 		CompanyName:     model.NewId(),
 		AllowOpenInvite: false,
 		InviteId:        model.NewId(),
-		Name:            model.NewId(),
+		Name:            "zz" + model.NewId(),
 		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
 		Type:            model.TEAM_OPEN,
 	}
@@ -2566,7 +2566,7 @@ func testGetGroups(t *testing.T, ss store.Store) {
 		CompanyName:     model.NewId(),
 		AllowOpenInvite: false,
 		InviteId:        model.NewId(),
-		Name:            model.NewId(),
+		Name:            "zz" + model.NewId(),
 		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
 		Type:            model.TEAM_INVITE,
 	}
@@ -2811,7 +2811,7 @@ func testTeamMembersMinusGroupMembers(t *testing.T, ss store.Store) {
 		CompanyName:      model.NewId(),
 		AllowOpenInvite:  false,
 		InviteId:         model.NewId(),
-		Name:             model.NewId(),
+		Name:             "zz" + model.NewId(),
 		Email:            model.NewId() + "@simulator.amazonses.com",
 		Type:             model.TEAM_OPEN,
 		GroupConstrained: model.NewBool(true),
@@ -3279,7 +3279,7 @@ func groupTestAdminRoleGroupsForSyncableMemberTeam(t *testing.T, ss store.Store)
 
 	team := &model.Team{
 		DisplayName: "A Name",
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		Type:        model.CHANNEL_OPEN,
 	}
 	team, err = ss.Team().Save(team)
@@ -3382,7 +3382,7 @@ func groupTestPermittedSyncableAdminsTeam(t *testing.T, ss store.Store) {
 
 	team := &model.Team{
 		DisplayName: "A Name",
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		Type:        model.CHANNEL_OPEN,
 	}
 	team, err = ss.Team().Save(team)
@@ -3809,7 +3809,7 @@ func groupTestGroupTeamCount(t *testing.T, ss store.Store) {
 		Description:     model.NewId(),
 		AllowOpenInvite: false,
 		InviteId:        model.NewId(),
-		Name:            model.NewId(),
+		Name:            "zz" + model.NewId(),
 		Email:           model.NewId() + "@simulator.amazonses.com",
 		Type:            model.TEAM_OPEN,
 	})

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -1337,7 +1337,7 @@ func testGetTeamsByScheme(t *testing.T, ss store.Store) {
 
 	// Create and save some teams.
 	t1 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1345,7 +1345,7 @@ func testGetTeamsByScheme(t *testing.T, ss store.Store) {
 	}
 
 	t2 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1353,7 +1353,7 @@ func testGetTeamsByScheme(t *testing.T, ss store.Store) {
 	}
 
 	t3 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1464,7 +1464,7 @@ func testResetAllTeamSchemes(t *testing.T, ss store.Store) {
 	require.Nil(t, err)
 
 	t1 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1472,7 +1472,7 @@ func testResetAllTeamSchemes(t *testing.T, ss store.Store) {
 	}
 
 	t2 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1565,7 +1565,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 	assert.Equal(t, int64(0), count1)
 
 	t1 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1579,7 +1579,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 	assert.Equal(t, int64(1), count2)
 
 	t2 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1593,7 +1593,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 	assert.Equal(t, int64(2), count3)
 
 	t3 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1606,7 +1606,7 @@ func testTeamStoreAnalyticsGetTeamCountForScheme(t *testing.T, ss store.Store) {
 	assert.Equal(t, int64(2), count4)
 
 	t4 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,
@@ -1688,7 +1688,7 @@ func testTeamStoreGetTeamMembersForExport(t *testing.T, ss store.Store) {
 func testGroupSyncedTeamCount(t *testing.T, ss store.Store) {
 	team1, err := ss.Team().Save(&model.Team{
 		DisplayName:      model.NewId(),
-		Name:             model.NewId(),
+		Name:             "zz" + model.NewId(),
 		Email:            MakeEmail(),
 		Type:             model.TEAM_INVITE,
 		GroupConstrained: model.NewBool(true),
@@ -1699,7 +1699,7 @@ func testGroupSyncedTeamCount(t *testing.T, ss store.Store) {
 
 	team2, err := ss.Team().Save(&model.Team{
 		DisplayName: model.NewId(),
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_INVITE,
 	})

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -3535,7 +3535,7 @@ func testUserStoreAnalyticsGetSystemAdminCount(t *testing.T, ss store.Store) {
 func testUserStoreGetProfilesNotInTeam(t *testing.T, ss store.Store) {
 	team, err := ss.Team().Save(&model.Team{
 		DisplayName: "Team",
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		Type:        model.TEAM_OPEN,
 	})
 	require.Nil(t, err)
@@ -3847,7 +3847,7 @@ func testUserStoreGetUsersBatchForIndexing(t *testing.T, ss store.Store) {
 	// Set up all the objects needed
 	t1, err := ss.Team().Save(&model.Team{
 		DisplayName: "Team1",
-		Name:        model.NewId(),
+		Name:        "zz" + model.NewId(),
 		Type:        model.TEAM_OPEN,
 	})
 	require.Nil(t, err)


### PR DESCRIPTION
#### Summary
There was a low chance of having a Team with an invalid name generated with
`model.NewId` without any prefix. For example a Team name starting with `api`
is going to fail.

#### Ticket Link
[MM-22340](https://mattermost.atlassian.net/browse/MM-22340)