### PR TITLE
MM-22579 Fix panic when receiving a config to update to if some settings are not set

### DIFF
--- a/api4/config.go
+++ b/api4/config.go
@@ -57,6 +57,8 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	cfg.SetDefaults()
+
 	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -103,6 +103,11 @@ func TestUpdateConfig(t *testing.T) {
 
 	require.Equal(t, SiteName, cfg.TeamSettings.SiteName, "It should update the SiteName")
 
+	t.Run("Should set defaults for missing fields", func(t *testing.T) {
+		_, appErr := th.SystemAdminClient.DoApiPut(th.SystemAdminClient.GetConfigRoute(), `{"ServiceSettings":{}}`)
+		require.Nil(t, appErr)
+	})
+
 	t.Run("Should fail with validation error if invalid config setting is passed", func(t *testing.T) {
 		//Revert the change
 		badcfg := cfg.Clone()


### PR DESCRIPTION
#### Summary
Need to set the defaults to make sure we don't panic when checking config validity. Primarily an issue when the client making the API request omits sections or fields for whatever reason.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22579