### PR TITLE
fix bin/mmctl detection using printf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ prepackaged-plugins: ## Populate the prepackaged-plugins directory
 
 prepackaged-binaries: ## Populate the prepackaged-binaries to the bin directory
 # Externally built binaries
-ifeq ($(shell test -f bin/mmctl && echo -n yes),yes)
+ifeq ($(shell test -f bin/mmctl && printf "yes"),yes)
 	@echo mmctl installed
 else ifeq ($(PLATFORM),Darwin)
 	@echo Downloading prepackaged binary: https://github.com/mattermost/mmctl/releases/$(MMCTL_REL_TO_DOWNLOAD)


### PR DESCRIPTION
#### Summary
The behaviour of `echo` [varies](https://stackoverflow.com/questions/8467424/echo-newline-in-bash-prints-literal-n) between operating systems. Use `printf` for maximum compatibility, ensuring `bin/mmctl` is reliably detected when using `make prepackaged-binaries` (it wasn't working for me on MacOS).