### PR TITLE
MM-22619: check for nil plugins environment

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -636,22 +636,23 @@ func (a *App) trackConfig() {
 	}
 
 	pluginsEnvironment := a.GetPluginsEnvironment()
-
-	if plugins, appErr := pluginsEnvironment.Available(); appErr != nil {
-		mlog.Error("Unable to add plugin versions to diagnostics", mlog.Err(appErr))
-	} else {
-		pluginConfigData["version_antivirus"] = pluginVersion(plugins, "antivirus")
-		pluginConfigData["version_autolink"] = pluginVersion(plugins, "mattermost-autolink")
-		pluginConfigData["version_aws_sns"] = pluginVersion(plugins, "com.mattermost.aws-sns")
-		pluginConfigData["version_custom_user_attributes"] = pluginVersion(plugins, "com.mattermost.custom-attributes")
-		pluginConfigData["version_github"] = pluginVersion(plugins, "github")
-		pluginConfigData["version_gitlab"] = pluginVersion(plugins, "com.github.manland.mattermost-plugin-gitlab")
-		pluginConfigData["version_jenkins"] = pluginVersion(plugins, "jenkins")
-		pluginConfigData["version_jira"] = pluginVersion(plugins, "jira")
-		pluginConfigData["version_nps"] = pluginVersion(plugins, "com.mattermost.nps")
-		pluginConfigData["version_webex"] = pluginVersion(plugins, "com.mattermost.webex")
-		pluginConfigData["version_welcome_bot"] = pluginVersion(plugins, "com.mattermost.welcomebot")
-		pluginConfigData["version_zoom"] = pluginVersion(plugins, "zoom")
+	if pluginsEnvironment != nil {
+		if plugins, appErr := pluginsEnvironment.Available(); appErr != nil {
+			mlog.Error("Unable to add plugin versions to diagnostics", mlog.Err(appErr))
+		} else {
+			pluginConfigData["version_antivirus"] = pluginVersion(plugins, "antivirus")
+			pluginConfigData["version_autolink"] = pluginVersion(plugins, "mattermost-autolink")
+			pluginConfigData["version_aws_sns"] = pluginVersion(plugins, "com.mattermost.aws-sns")
+			pluginConfigData["version_custom_user_attributes"] = pluginVersion(plugins, "com.mattermost.custom-attributes")
+			pluginConfigData["version_github"] = pluginVersion(plugins, "github")
+			pluginConfigData["version_gitlab"] = pluginVersion(plugins, "com.github.manland.mattermost-plugin-gitlab")
+			pluginConfigData["version_jenkins"] = pluginVersion(plugins, "jenkins")
+			pluginConfigData["version_jira"] = pluginVersion(plugins, "jira")
+			pluginConfigData["version_nps"] = pluginVersion(plugins, "com.mattermost.nps")
+			pluginConfigData["version_webex"] = pluginVersion(plugins, "com.mattermost.webex")
+			pluginConfigData["version_welcome_bot"] = pluginVersion(plugins, "com.mattermost.welcomebot")
+			pluginConfigData["version_zoom"] = pluginVersion(plugins, "zoom")
+		}
 	}
 
 	a.SendDiagnostic(TRACK_CONFIG_PLUGIN, pluginConfigData)

--- a/app/diagnostics_test.go
+++ b/app/diagnostics_test.go
@@ -201,7 +201,7 @@ func TestDiagnostics(t *testing.T) {
 	// Enable plugins for the remainder of the tests.
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = true })
 
-	t.Run("SendDailyDiagnosticsPlugins", func(t *testing.T) {
+	t.Run("SendDailyDiagnostics", func(t *testing.T) {
 		th.App.sendDailyDiagnostics(true)
 
 		var info []string

--- a/app/diagnostics_test.go
+++ b/app/diagnostics_test.go
@@ -68,7 +68,9 @@ func TestDiagnostics(t *testing.T) {
 		t.SkipNow()
 	}
 
-	th := Setup(t)
+	th := SetupWithCustomConfig(t, func(config *model.Config) {
+		*config.PluginSettings.Enable = false
+	})
 	defer th.TearDown()
 
 	type payload struct {
@@ -147,7 +149,59 @@ func TestDiagnostics(t *testing.T) {
 		}
 	})
 
-	t.Run("SendDailyDiagnostics", func(t *testing.T) {
+	// Plugins remain disabled at this point
+	t.Run("SendDailyDiagnosticsPluginsDisabled", func(t *testing.T) {
+		th.App.sendDailyDiagnostics(true)
+
+		var info []string
+		// Collect the info sent.
+	Loop:
+		for {
+			select {
+			case result := <-data:
+				assertPayload(t, result, "", nil)
+				info = append(info, result.Batch[0].Event)
+			case <-time.After(time.Second * 1):
+				break Loop
+			}
+		}
+
+		for _, item := range []string{
+			TRACK_CONFIG_SERVICE,
+			TRACK_CONFIG_TEAM,
+			TRACK_CONFIG_SQL,
+			TRACK_CONFIG_LOG,
+			TRACK_CONFIG_NOTIFICATION_LOG,
+			TRACK_CONFIG_FILE,
+			TRACK_CONFIG_RATE,
+			TRACK_CONFIG_EMAIL,
+			TRACK_CONFIG_PRIVACY,
+			TRACK_CONFIG_OAUTH,
+			TRACK_CONFIG_LDAP,
+			TRACK_CONFIG_COMPLIANCE,
+			TRACK_CONFIG_LOCALIZATION,
+			TRACK_CONFIG_SAML,
+			TRACK_CONFIG_PASSWORD,
+			TRACK_CONFIG_CLUSTER,
+			TRACK_CONFIG_METRICS,
+			TRACK_CONFIG_SUPPORT,
+			TRACK_CONFIG_NATIVEAPP,
+			TRACK_CONFIG_EXPERIMENTAL,
+			TRACK_CONFIG_ANALYTICS,
+			TRACK_CONFIG_PLUGIN,
+			TRACK_ACTIVITY,
+			TRACK_SERVER,
+			TRACK_CONFIG_MESSAGE_EXPORT,
+			// TRACK_PLUGINS,
+		} {
+			require.Contains(t, info, item)
+		}
+	})
+
+	// Enable plugins for the remainder of the tests.
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = true })
+
+	t.Run("SendDailyDiagnosticsPlugins", func(t *testing.T) {
 		th.App.sendDailyDiagnostics(true)
 
 		var info []string

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -33,7 +33,7 @@ type TestHelper struct {
 	tempWorkspace string
 }
 
-func setupTestHelper(enterprise bool, tb testing.TB) *TestHelper {
+func setupTestHelper(enterprise bool, tb testing.TB, configSet func(*model.Config)) *TestHelper {
 	store := mainHelper.GetStore()
 	store.DropAllTables()
 
@@ -48,6 +48,9 @@ func setupTestHelper(enterprise bool, tb testing.TB) *TestHelper {
 	}
 
 	config := memoryStore.Get()
+	if configSet != nil {
+		configSet(config)
+	}
 	*config.PluginSettings.Directory = filepath.Join(tempWorkspace, "plugins")
 	*config.PluginSettings.ClientDirectory = filepath.Join(tempWorkspace, "webapp")
 	memoryStore.Set(config)
@@ -105,11 +108,15 @@ func setupTestHelper(enterprise bool, tb testing.TB) *TestHelper {
 }
 
 func SetupEnterprise(tb testing.TB) *TestHelper {
-	return setupTestHelper(true, tb)
+	return setupTestHelper(true, tb, nil)
 }
 
 func Setup(tb testing.TB) *TestHelper {
-	return setupTestHelper(false, tb)
+	return setupTestHelper(false, tb, nil)
+}
+
+func SetupWithCustomConfig(tb testing.TB, configSet func(*model.Config)) *TestHelper {
+	return setupTestHelper(false, tb, configSet)
 }
 
 func (me *TestHelper) InitBasic() *TestHelper {


### PR DESCRIPTION
#### Summary
Check if plugins were disabled before attempting to collect metrics and emit telemetry for same.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-22619