### PR TITLE
Fix flaky TestPlugin

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -33,7 +33,8 @@ func TestPlugin(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	statesJson, _ := json.Marshal(th.App.Config().PluginSettings.PluginStates)
+	statesJson, err := json.Marshal(th.App.Config().PluginSettings.PluginStates)
+	require.Nil(t, err)
 	states := map[string]*model.PluginState{}
 	json.Unmarshal(statesJson, &states)
 	th.App.UpdateConfig(func(cfg *model.Config) {
@@ -66,6 +67,11 @@ func TestPlugin(t *testing.T) {
 	CheckNoError(t, resp)
 	assert.Equal(t, "testplugin", manifest.Id)
 
+	// Stored in File Store: Install Plugin from URL case
+	pluginStored, err := th.App.FileExists("./plugins/" + manifest.Id + ".tar.gz")
+	assert.Nil(t, err)
+	assert.True(t, pluginStored)
+
 	ok, resp := th.SystemAdminClient.RemovePlugin(manifest.Id)
 	CheckNoError(t, resp)
 	require.True(t, ok)
@@ -87,11 +93,6 @@ func TestPlugin(t *testing.T) {
 		CheckNoError(t, resp)
 		assert.Equal(t, "testplugin", manifest.Id)
 	})
-
-	// Stored in File Store: Install Plugin from URL case
-	pluginStored, err := th.App.FileExists("./plugins/" + manifest.Id + ".tar.gz")
-	assert.Nil(t, err)
-	assert.True(t, pluginStored)
 
 	th.App.RemovePlugin(manifest.Id)
 


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Fix panic due to not checking for JSON marshal error
- Reorder the FileExists check which would fail if we were to pass
the -short flag to bypass the slow URL test. In which case, the plugin
would have been removed from the filesystem.
So we move the check before we remove the plugin.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22666