### PR TITLE
Added Websocket's broadcast queue load metrics

### DIFF
--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -344,7 +344,7 @@ func (h *Hub) Unregister(webConn *WebConn) {
 func (h *Hub) Broadcast(message *model.WebSocketEvent) {
 	if h != nil && h.broadcast != nil && message != nil {
 		if metrics := h.app.Metrics(); metrics != nil {
-			metrics.IncrementWebSocketBroadcastHubElements(strconv.Itoa(h.connectionIndex), 1)
+			metrics.IncrementWebSocketBroadcastBufferSize(strconv.Itoa(h.connectionIndex), 1)
 		}
 		select {
 		case h.broadcast <- message:
@@ -437,7 +437,7 @@ func (h *Hub) Start() {
 				}
 			case msg := <-h.broadcast:
 				if metrics := h.app.Metrics(); metrics != nil {
-					metrics.DecrementWebSocketBroadcastHubElements(strconv.Itoa(h.connectionIndex), 1)
+					metrics.DecrementWebSocketBroadcastBufferSize(strconv.Itoa(h.connectionIndex), 1)
 				}
 				candidates := connections.All()
 				if msg.GetBroadcast().UserId != "" {

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -343,6 +343,9 @@ func (h *Hub) Unregister(webConn *WebConn) {
 
 func (h *Hub) Broadcast(message *model.WebSocketEvent) {
 	if h != nil && h.broadcast != nil && message != nil {
+		if metrics := h.app.Metrics(); metrics != nil {
+			metrics.IncrementWebSocketBroadcastHubElements(strconv.Itoa(h.connectionIndex), 1)
+		}
 		select {
 		case h.broadcast <- message:
 		case <-h.didStop:
@@ -433,6 +436,9 @@ func (h *Hub) Start() {
 					}
 				}
 			case msg := <-h.broadcast:
+				if metrics := h.app.Metrics(); metrics != nil {
+					metrics.DecrementWebSocketBroadcastHubElements(strconv.Itoa(h.connectionIndex), 1)
+				}
 				candidates := connections.All()
 				if msg.GetBroadcast().UserId != "" {
 					candidates = connections.ForUser(msg.GetBroadcast().UserId)

--- a/einterfaces/metrics.go
+++ b/einterfaces/metrics.go
@@ -37,6 +37,8 @@ type MetricsInterface interface {
 
 	IncrementWebsocketEvent(eventType string)
 	IncrementWebSocketBroadcast(eventType string)
+	IncrementWebSocketBroadcastHubElements(hub string, amount float64)
+	DecrementWebSocketBroadcastHubElements(hub string, amount float64)
 
 	AddMemCacheHitCounter(cacheName string, amount float64)
 	AddMemCacheMissCounter(cacheName string, amount float64)

--- a/einterfaces/metrics.go
+++ b/einterfaces/metrics.go
@@ -37,8 +37,8 @@ type MetricsInterface interface {
 
 	IncrementWebsocketEvent(eventType string)
 	IncrementWebSocketBroadcast(eventType string)
-	IncrementWebSocketBroadcastHubElements(hub string, amount float64)
-	DecrementWebSocketBroadcastHubElements(hub string, amount float64)
+	IncrementWebSocketBroadcastBufferSize(hub string, amount float64)
+	DecrementWebSocketBroadcastBufferSize(hub string, amount float64)
 
 	AddMemCacheHitCounter(cacheName string, amount float64)
 	AddMemCacheMissCounter(cacheName string, amount float64)

--- a/einterfaces/mocks/MetricsInterface.go
+++ b/einterfaces/mocks/MetricsInterface.go
@@ -21,8 +21,8 @@ func (_m *MetricsInterface) AddMemCacheMissCounter(cacheName string, amount floa
 	_m.Called(cacheName, amount)
 }
 
-// DecrementWebSocketBroadcastHubElements provides a mock function with given fields: hub, amount
-func (_m *MetricsInterface) DecrementWebSocketBroadcastHubElements(hub string, amount float64) {
+// DecrementWebSocketBroadcastBufferSize provides a mock function with given fields: hub, amount
+func (_m *MetricsInterface) DecrementWebSocketBroadcastBufferSize(hub string, amount float64) {
 	_m.Called(hub, amount)
 }
 
@@ -146,8 +146,8 @@ func (_m *MetricsInterface) IncrementWebSocketBroadcast(eventType string) {
 	_m.Called(eventType)
 }
 
-// IncrementWebSocketBroadcastHubElements provides a mock function with given fields: hub, amount
-func (_m *MetricsInterface) IncrementWebSocketBroadcastHubElements(hub string, amount float64) {
+// IncrementWebSocketBroadcastBufferSize provides a mock function with given fields: hub, amount
+func (_m *MetricsInterface) IncrementWebSocketBroadcastBufferSize(hub string, amount float64) {
 	_m.Called(hub, amount)
 }
 

--- a/einterfaces/mocks/MetricsInterface.go
+++ b/einterfaces/mocks/MetricsInterface.go
@@ -21,6 +21,11 @@ func (_m *MetricsInterface) AddMemCacheMissCounter(cacheName string, amount floa
 	_m.Called(cacheName, amount)
 }
 
+// DecrementWebSocketBroadcastHubElements provides a mock function with given fields: hub, amount
+func (_m *MetricsInterface) DecrementWebSocketBroadcastHubElements(hub string, amount float64) {
+	_m.Called(hub, amount)
+}
+
 // IncrementChannelIndexCounter provides a mock function with given fields:
 func (_m *MetricsInterface) IncrementChannelIndexCounter() {
 	_m.Called()
@@ -139,6 +144,11 @@ func (_m *MetricsInterface) IncrementUserIndexCounter() {
 // IncrementWebSocketBroadcast provides a mock function with given fields: eventType
 func (_m *MetricsInterface) IncrementWebSocketBroadcast(eventType string) {
 	_m.Called(eventType)
+}
+
+// IncrementWebSocketBroadcastHubElements provides a mock function with given fields: hub, amount
+func (_m *MetricsInterface) IncrementWebSocketBroadcastHubElements(hub string, amount float64) {
+	_m.Called(hub, amount)
 }
 
 // IncrementWebhookPost provides a mock function with given fields:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Now we send metrics when the websocket's broadcast queue receive or
consume a message from the queue

![Screenshot from 2020-02-24 18-06-45](https://user-images.githubusercontent.com/741240/75176902-648bfb00-5735-11ea-9808-4e5f6f469c59.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-22046