### PR TITLE
Metrics operations shouldn't be inside goroutine

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -232,9 +232,7 @@ func (wc *WebConn) writePump() {
 				}
 
 				if wc.App.Metrics() != nil {
-					wc.App.Srv().Go(func() {
-						wc.App.Metrics().IncrementWebSocketBroadcast(msg.EventType())
-					})
+					wc.App.Metrics().IncrementWebSocketBroadcast(msg.EventType())
 				}
 			}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Metrics operations are done in memory so there is no need
to spawn a new goroutine

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-22714