### PR TITLE
MM-22190: Add error checks to TestUnlinkGroupTeam

### DIFF
--- a/api4/group_test.go
+++ b/api4/group_test.go
@@ -236,10 +236,12 @@ func TestUnlinkGroupTeam(t *testing.T) {
 
 	response = th.Client.UnlinkGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam)
 	assert.NotNil(t, response.Error)
-
 	th.UpdateUserToTeamAdmin(th.BasicUser, th.BasicTeam)
-	th.Client.Logout()
-	th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+	ok, response := th.Client.Logout()
+	assert.True(t, ok)
+	CheckOKStatus(t, response)
+	_, response = th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
+	CheckOKStatus(t, response)
 
 	response = th.Client.UnlinkGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam)
 	CheckOKStatus(t, response)

--- a/app/team.go
+++ b/app/team.go
@@ -1602,7 +1602,7 @@ func (a *App) ClearTeamMembersCache(teamID string) {
 	for {
 		teamMembers, err := a.Srv().Store.Team().GetMembers(teamID, page, perPage, &model.ViewUsersRestrictions{})
 		if err != nil {
-			a.Log().Warn("error clearing cache for team members", mlog.String("team_id", teamID))
+			a.Log().Warn("error clearing cache for team members", mlog.String("team_id", teamID), mlog.String("err", err.Error()))
 			break
 		}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
I could not figure out the actual root cause for this.

But a possible area of concern is that somewhere in the call stack,
the login failed partially. Therefore, the session did not have the teamMembers
populated. And the permission check failed therefore. Since the errors from login are actually masked, unless we check them, we would never know what failed.

Adding the error checks should let us know in future if this is not the case.

Another possible case is the app.ClearTeamMembersCache which gets called in
the goroutine app.SyncRolesAndMembership. If this races with the session,
then it's possible that the teamMember is wiped off from the session. But this
happens after the permission check. So it's not very likely.

Also, while we are here, I found that (*app).ClearTeamMembersCache
does not log the internal error bubbled up. This prevents us from understanding
what actually happened. Added that logging.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22190