### PR TITLE
MM-22831: Allow config keys which don't have a period to be overridden

### DIFF
--- a/config/unmarshal.go
+++ b/config/unmarshal.go
@@ -161,12 +161,12 @@ func unmarshalConfig(r io.Reader, allowEnvironmentOverrides bool) (*model.Config
 		preserveMap := make(map[string]map[string]interface{})
 		if plugins != nil {
 			pl := plugins.(map[string]interface{})
-			// Note the values which have a period in them.
 			for k, parentVal := range pl {
 				var castedVal map[string]interface{}
 				if _, ok := parentVal.(map[string]interface{}); ok {
 					castedVal = parentVal.(map[string]interface{})
 				}
+				// Note the values which don't have a period in them.
 				if !strings.Contains(k, ".") {
 					flattened := flattenStructToMap(config.PluginSettings.Plugins[k])
 					// This contains all flattened keys. We need to unflatten one-level.
@@ -248,7 +248,7 @@ func unmarshalConfig(r io.Reader, allowEnvironmentOverrides bool) (*model.Config
 		preserveMap := make(map[string]*model.PluginState)
 		if states != nil {
 			st := states.(map[string]interface{})
-			// Note the values which have a period in them.
+			// Note the values which don't have a period in them.
 			for k := range st {
 				if !strings.Contains(k, ".") {
 					preserveMap[k] = config.PluginSettings.PluginStates[k]

--- a/config/unmarshal.go
+++ b/config/unmarshal.go
@@ -153,13 +153,79 @@ func unmarshalConfig(r io.Reader, allowEnvironmentOverrides bool) (*model.Config
 	unmarshalErr := v.Unmarshal(&config)
 	// https://github.com/spf13/viper/issues/324
 	// https://github.com/spf13/viper/issues/348
+	// We preserve those values which don't have a period in them,
+	// so that atleast we can override them through environment variables.
 	if unmarshalErr == nil {
+		plugins := v.Get("pluginsettings.plugins")
+		preserveMap := make(map[string]map[string]interface{})
+		if plugins != nil {
+			pl := plugins.(map[string]interface{})
+			// Note the values which have a period in them.
+			for k := range pl {
+				if !strings.Contains(k, ".") {
+					flattened := flattenStructToMap(config.PluginSettings.Plugins[k])
+					// This contains all flattened keys. We need to unflatten one-level.
+					// We follow the same logic as the parent loop where we have a new map
+					// and we insert keys which don't have period in them. And for keys
+					// which do have periods, we unflatten them and keep in a separate map.
+					//
+					// Subtle gotcha: we could have nested maps of any depth here. But
+					// the current code is just able to handle maps of depth 1.
+					// Anything more than that, will be flattened. This is technically
+					// a regression, but such a case was never needed. So it suffices to
+					// make it work for the most common case.
+					expanded := make(map[string]interface{})
+					tmpMap := make(map[string]map[string]interface{})
+					for k, val := range flattened {
+						if !strings.Contains(k, ".") {
+							expanded[k] = val
+						} else {
+							parts := strings.Split(k, ".")
+							lastPart := parts[len(parts)-1]
+							rest := strings.Join(parts[:len(parts)-1], ".")
+							if _, ok := tmpMap[rest]; !ok {
+								tmpMap[rest] = map[string]interface{}{lastPart: val}
+							} else {
+								tmpMap[rest][lastPart] = val
+							}
+						}
+					}
+
+					// Now merge the 2 maps
+					for k, val := range tmpMap {
+						expanded[k] = val
+					}
+					preserveMap[k] = expanded
+				}
+			}
+		}
+
 		config.PluginSettings.Plugins = make(map[string]map[string]interface{})
 		unmarshalErr = v.UnmarshalKey("pluginsettings.plugins", &config.PluginSettings.Plugins)
+		// Now restore those values.
+		for k, val := range preserveMap {
+			config.PluginSettings.Plugins[k] = val
+		}
 	}
 	if unmarshalErr == nil {
+		states := v.Get("pluginsettings.pluginstates")
+		preserveMap := make(map[string]*model.PluginState)
+		if states != nil {
+			st := states.(map[string]interface{})
+			// Note the values which have a period in them.
+			for k := range st {
+				if !strings.Contains(k, ".") {
+					preserveMap[k] = config.PluginSettings.PluginStates[k]
+				}
+			}
+		}
+
 		config.PluginSettings.PluginStates = make(map[string]*model.PluginState)
 		unmarshalErr = v.UnmarshalKey("pluginsettings.pluginstates", &config.PluginSettings.PluginStates)
+		// Now restore those values.
+		for k, val := range preserveMap {
+			config.PluginSettings.PluginStates[k] = val
+		}
 	}
 
 	envConfig := v.EnvSettings()

--- a/config/unmarshal_test.go
+++ b/config/unmarshal_test.go
@@ -146,7 +146,9 @@ func TestConfigFromEnvVars(t *testing.T) {
 			"Plugins": {
 				"jira": {
 					"enabled": "true",
-					"secret": "config-secret"
+					"secret": "config-secret",
+					"int": 2,
+					"bool": true
 				}
 			},
 			"PluginStates": {
@@ -301,6 +303,8 @@ func TestConfigFromEnvVars(t *testing.T) {
 	t.Run("plugin specific settings except keys with a period should be overridden via environment", func(t *testing.T) {
 		os.Setenv("MM_PLUGINSETTINGS_PLUGINS_JIRA_ENABLED", "false")
 		os.Setenv("MM_PLUGINSETTINGS_PLUGINS_JIRA_SECRET", "env-secret")
+		os.Setenv("MM_PLUGINSETTINGS_PLUGINS_JIRA_INT", "5")
+		os.Setenv("MM_PLUGINSETTINGS_PLUGINS_JIRA_BOOL", "false")
 		os.Setenv("MM_PLUGINSETTINGS_PLUGINSTATES_JIRA_ENABLE", "false")
 		os.Setenv("MM_PLUGINSETTINGS_PLUGINS_COM_MATTERMOST_NPS_ENABLE", "false")
 		defer os.Unsetenv("MM_PLUGINSETTINGS_PLUGINS_JIRA_ENABLED")
@@ -320,6 +324,14 @@ func TestConfigFromEnvVars(t *testing.T) {
 		secret, ok := pluginsJira["secret"]
 		require.True(t, ok, "PluginSettings.Plugins.jira.secret is missing from config")
 		assert.Equal(t, "env-secret", secret)
+
+		intVal, ok := pluginsJira["int"]
+		require.True(t, ok, "PluginSettings.Plugins.jira.int is missing from config")
+		assert.Equal(t, int64(5), intVal)
+
+		boolVal, ok := pluginsJira["bool"]
+		require.True(t, ok, "PluginSettings.Plugins.jira.bool is missing from config")
+		assert.Equal(t, false, boolVal)
 
 		pluginStatesJira, ok := cfg.PluginSettings.PluginStates["jira"]
 		require.True(t, ok, "PluginSettings.PluginStates.jira is missing from config")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We get the original map from viper config. And then we populate the map
with those keys which do not have a period in them.
After we have unmarshalled the original values, we restore the original
values which did not have periods.

This allows us to atleast override values which don't have period in them.

But there is a subtle gotcha here, for the PluginSettings.Plugins section,
we can have nested maps of any depth. The current code is just able to handle
maps of depth 1. Anything more than that, will be flattened. This is technically
a regression, but I believe such a case was never needed.

Not a complete fix, because that needs to be done from within viper itself.
But it fixes the most common cases which don't have period in them.

Fixes #13963

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22831