### PR TITLE
MM-22980 - Revert "server init order fixed"

### DIFF
--- a/app/server_app_adapters.go
+++ b/app/server_app_adapters.go
@@ -56,6 +56,8 @@ func (s *Server) RunOldAppInitialization() error {
 
 	mlog.Info("Server is initializing...")
 
+	s.initEnterprise()
+
 	if s.FakeApp().Srv().newStore == nil {
 		s.FakeApp().Srv().newStore = func() store.Store {
 			return store.NewTimerLayer(
@@ -74,8 +76,6 @@ func (s *Server) RunOldAppInitialization() error {
 
 	s.FakeApp().Srv().Store = s.FakeApp().Srv().newStore()
 	s.FakeApp().StartPushNotificationsHubWorkers()
-
-	s.initEnterprise()
 
 	if err := s.FakeApp().ensureAsymmetricSigningKey(); err != nil {
 		return errors.Wrapf(err, "unable to ensure asymmetric signing key")


### PR DESCRIPTION
#### Summary
This reverts commit daebc93d90958aa2831618f64e0ab2f667a1aa01.
The change in that commit caused Metrics not to be initialized properly
#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-22980