### PR TITLE
MM-22056: defer close stream should be called before required assertions

### DIFF
--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -231,8 +231,8 @@ func TestUploadFiles(t *testing.T) {
 			clientIds:         []string{"1", "2", "3", "4", "5"},
 			expectedCreatorId: th.BasicUser.Id,
 		},
-		// // Upload a bunch of images. testgif.gif is an animated GIF,
-		// // so it does not have HasPreviewImage set.
+		// Upload a bunch of images. testgif.gif is an animated GIF,
+		// so it does not have HasPreviewImage set.
 		{
 			title:                   "Happy images",
 			names:                   []string{"test.png", "testgif.gif"},


### PR DESCRIPTION
#### Summary
This PR improves a test that has been flagged as flaky. I'm not a 100% sure that this was causing the issue, but in any case, 2 deferred function were defined after an assertion. In case of failure, this functions would never get called. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22056

Signed-off-by: Gabriel Linden Sagula <gsagula@gmail.com>