### PR TITLE
Add an app-layers check to the server's CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,19 @@ jobs:
   #           make i18n-extract
   #           diff /tmp/en.json i18n/en.json
 
+  check-app-layers:
+    docker:
+      - image: mattermost/mattermost-build-server:oct-18-2019
+    working_directory: ~/mattermost
+    steps:
+      - attach_workspace:
+          at: ~/mattermost/
+      - run:
+          command: |
+            cd mattermost-server
+            make app-layers
+            if [[ -n $(git status --porcelain) ]]; then echo "Please update the app layers using make app-layers"; exit 1; fi
+
   build:
     docker:
       - image: mattermost/mattermost-build-server:oct-18-2019
@@ -342,9 +355,12 @@ workflows:
       # - check-i18n:
       #     requires:
       #       - setup
-      - build:
+      - check-app-layers:
           requires:
             - setup
+      - build:
+          requires:
+            - check-app-layers
       - upload-s3-sha:
           context: mattermost-ci-pr-builds-s3
           requires:
@@ -362,16 +378,16 @@ workflows:
           dbdriver: mysql
           dbsource: "mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8"
           requires:
-            - setup
+            - check-app-layers
       - test:
           name: test-postgres
           dbdriver: postgres
           dbsource: "postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10"
           requires:
-            - setup
+            - check-app-layers
       - test-schema:
           requires:
-            - setup
+            - check-app-layers
       - trigger-ee-tests:
           context: matterbuild-circleci-token
           requires:


### PR DESCRIPTION
#### Summary

This PR adds a build step that checks that the App layers are correctly generated. The step is run before the build/test steps to shortcircuit the build as soon as possible if there is any errors

![image](https://user-images.githubusercontent.com/223323/76005477-5b581680-5f0b-11ea-878e-4608004ec154.png)
