### PR TITLE
container: update container image name to use another registry for PR testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,9 +404,9 @@ jobs:
             export TAG="${CIRCLE_SHA1:0:7}"
             cd mattermost-server
             export MM_PACKAGE=https://pr-builds.mattermost.com/mattermost-server/commit/${CIRCLE_SHA1}/mattermost-team-linux-amd64.tar.gz
-            docker build --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mattermost-team-edition:${TAG} build
+            docker build --build-arg MM_PACKAGE=$MM_PACKAGE -t mattermost/mattermost-test-team:${TAG} build
             echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin
-            docker push mattermost/mattermost-team-edition:${TAG}
+            docker push mattermost/mattermost-test-team:${TAG}
 
 workflows:
   version: 2

--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -228,8 +228,8 @@ pipeline {
 					withCredentials([usernamePassword(credentialsId: 'matterbuild-docker-hub', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
 						sh 'docker login --username ${DOCKER_USER} --password ${DOCKER_PASS}'
 						sh """
-							docker build --no-cache --build-arg MM_PACKAGE=https://pr-builds.mattermost.com/mattermost-server/${CHANGE_ID}/mattermost-enterprise-linux-amd64.tar.gz -t mattermost/mattermost-enterprise-edition:${GIT_COMMIT_SHORT} build
-							docker push mattermost/mattermost-enterprise-edition:${GIT_COMMIT_SHORT}
+							docker build --no-cache --build-arg MM_PACKAGE=https://pr-builds.mattermost.com/mattermost-server/${CHANGE_ID}/mattermost-enterprise-linux-amd64.tar.gz -t mattermost/mattermost-test-enterprise:${GIT_COMMIT_SHORT} build
+							docker push mattermost/mattermost-test-enterprise:${GIT_COMMIT_SHORT}
 							docker logout
 						"""
 					}


### PR DESCRIPTION
#### Summary
Currently, we have two official container registry to hold our enterprise and team releases. 
They are and are stored in https://hub.docker.com/
 - `mattermost/mattermost-enterprise-edition`
 - `mattermost/mattermost-team-edition`

This holds not only the official releases but all images that we generate in the PRs for testing. This makes the repository polluted and confusing for people that are looking for the releases images.

As agreed in the Mattermost Developer Meeting and mentioned [here](https://community.mattermost.com/core/pl/nzjud8scnpgmdfrqqt4eyqfpkw) we are creating two new docker repositories to hold the testing images for all PR and any other testing for Mattermost application (server and webapp), they will be:
 - `mattermost/mattermost-test-enterprise`
- `mattermost/mattermost-test-team`

This PR update the container push to the new repositories for all testing things, for release branches and master branch it will continuing push to the official repo.

Other related PRs:
- [x] https://github.com/mattermost/mattermost-cloud/pull/165 -- This needs to be merged first
- [ ] https://github.com/mattermost/mattermost-webapp/pull/5048

#### Ticket Link
N/A

Notes:

adding @jasonblais as a reviewer to be aware of the changes, and this is part of the discussion we had to make the container registry more clear