### PR TITLE
[MM-22122] Fix manage channel members edge case for public and private channels

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -781,7 +781,7 @@ func (a *App) GetChannelModerationsForChannel(channel *model.Channel) ([]*model.
 		return nil, err
 	}
 
-	return buildChannelModerations(memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
+	return buildChannelModerations(channel.Type, memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
 }
 
 // PatchChannelModerationsForChannel Updates a channels scheme roles based on a given ChannelModerationPatch, if the permissions match the higher scoped role the scheme is deleted.
@@ -797,8 +797,8 @@ func (a *App) PatchChannelModerationsForChannel(channel *model.Channel, channelM
 		return nil, err
 	}
 
-	higherScopedMemberPermissions := higherScopedMemberRole.GetChannelModeratedPermissions()
-	higherScopedGuestPermissions := higherScopedGuestRole.GetChannelModeratedPermissions()
+	higherScopedMemberPermissions := higherScopedMemberRole.GetChannelModeratedPermissions(channel.Type)
+	higherScopedGuestPermissions := higherScopedGuestRole.GetChannelModeratedPermissions(channel.Type)
 
 	for _, moderationPatch := range channelModerationsPatch {
 		if moderationPatch.Roles.Members != nil && *moderationPatch.Roles.Members && !higherScopedMemberPermissions[*moderationPatch.Name] {
@@ -850,14 +850,14 @@ func (a *App) PatchChannelModerationsForChannel(channel *model.Channel, channelM
 		}
 	}
 
-	return buildChannelModerations(memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
+	return buildChannelModerations(channel.Type, memberRole, guestRole, higherScopedMemberRole, higherScopedGuestRole), nil
 }
 
-func buildChannelModerations(memberRole *model.Role, guestRole *model.Role, higherScopedMemberRole *model.Role, higherScopedGuestRole *model.Role) []*model.ChannelModeration {
-	memberPermissions := memberRole.GetChannelModeratedPermissions()
-	guestPermissions := guestRole.GetChannelModeratedPermissions()
-	higherScopedMemberPermissions := higherScopedMemberRole.GetChannelModeratedPermissions()
-	higherScopedGuestPermissions := higherScopedGuestRole.GetChannelModeratedPermissions()
+func buildChannelModerations(channelType string, memberRole *model.Role, guestRole *model.Role, higherScopedMemberRole *model.Role, higherScopedGuestRole *model.Role) []*model.ChannelModeration {
+	memberPermissions := memberRole.GetChannelModeratedPermissions(channelType)
+	guestPermissions := guestRole.GetChannelModeratedPermissions(channelType)
+	higherScopedMemberPermissions := higherScopedMemberRole.GetChannelModeratedPermissions(channelType)
+	higherScopedGuestPermissions := higherScopedGuestRole.GetChannelModeratedPermissions(channelType)
 
 	var channelModerations []*model.ChannelModeration
 	for _, permissionKey := range model.CHANNEL_MODERATED_PERMISSIONS {

--- a/model/role_test.go
+++ b/model/role_test.go
@@ -231,16 +231,19 @@ func TestGetChannelModeratedPermissions(t *testing.T) {
 	tests := []struct {
 		Name        string
 		Permissions []string
+		ChannelType string
 		Expected    map[string]bool
 	}{
 		{
 			"Filters non moderated permissions",
 			[]string{PERMISSION_CREATE_BOT.Id},
+			CHANNEL_OPEN,
 			map[string]bool{},
 		},
 		{
 			"Returns a map of moderated permissions",
 			[]string{PERMISSION_CREATE_POST.Id, PERMISSION_ADD_REACTION.Id, PERMISSION_REMOVE_REACTION.Id, PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS.Id, PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS.Id, PERMISSION_USE_CHANNEL_MENTIONS.Id},
+			CHANNEL_OPEN,
 			map[string]bool{
 				CHANNEL_MODERATED_PERMISSIONS[0]: true,
 				CHANNEL_MODERATED_PERMISSIONS[1]: true,
@@ -251,6 +254,7 @@ func TestGetChannelModeratedPermissions(t *testing.T) {
 		{
 			"Returns a map of moderated permissions when non moderated present",
 			[]string{PERMISSION_CREATE_POST.Id, PERMISSION_CREATE_DIRECT_CHANNEL.Id},
+			CHANNEL_OPEN,
 			map[string]bool{
 				CHANNEL_MODERATED_PERMISSIONS[0]: true,
 			},
@@ -258,13 +262,14 @@ func TestGetChannelModeratedPermissions(t *testing.T) {
 		{
 			"Returns a nothing when no permissions present",
 			[]string{},
+			CHANNEL_OPEN,
 			map[string]bool{},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.Name, func(t *testing.T) {
 			role := &Role{Permissions: tc.Permissions}
-			moderatedPermissions := role.GetChannelModeratedPermissions()
+			moderatedPermissions := role.GetChannelModeratedPermissions(tc.ChannelType)
 			for permission := range moderatedPermissions {
 				assert.Equal(t, moderatedPermissions[permission], tc.Expected[permission])
 			}


### PR DESCRIPTION
#### Summary
- This fixes the edge case where `manage_members` needs to defer to `manage_public_channel_members` for public channels and `manage_private_channel_members` for private channels to the
- I made the change in `role.GetChannelModeratedPermissions` which is used in both patch channel moderations and get channel moderations 

- TODO: Add some more tests
