### PR TITLE
[MM-22212] Add channel scheme update event

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -753,6 +753,9 @@ func (a *App) PatchChannelModerationsForChannel(channel *model.Channel, channelM
 		if _, err = a.CreateChannelScheme(channel); err != nil {
 			return nil, err
 		}
+
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_SCHEME_UPDATED, "", channel.Id, "", nil)
+		a.Publish(message)
 	}
 
 	guestRoleName, memberRoleName, _, _ := a.GetSchemeRolesForChannel(channel.Id)
@@ -776,6 +779,10 @@ func (a *App) PatchChannelModerationsForChannel(channel *model.Channel, channelM
 		if _, err = a.DeleteChannelScheme(channel); err != nil {
 			return nil, err
 		}
+
+		message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_SCHEME_UPDATED, "", channel.Id, "", nil)
+		a.Publish(message)
+
 		memberRole = higherScopedMemberRole
 		guestRole = higherScopedGuestRole
 	} else {

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -22,6 +22,7 @@ const (
 	WEBSOCKET_EVENT_CHANNEL_RESTORED        = "channel_restored"
 	WEBSOCKET_EVENT_CHANNEL_UPDATED         = "channel_updated"
 	WEBSOCKET_EVENT_CHANNEL_MEMBER_UPDATED  = "channel_member_updated"
+	WEBSOCKET_EVENT_CHANNEL_SCHEME_UPDATED  = "channel_scheme_updated"
 	WEBSOCKET_EVENT_DIRECT_ADDED            = "direct_added"
 	WEBSOCKET_EVENT_GROUP_ADDED             = "group_added"
 	WEBSOCKET_EVENT_NEW_USER                = "new_user"


### PR DESCRIPTION
#### Summary
Sends a websocket event when a channel scheme is created or deleted from patching channel moderations 

#### Ticket Link
Fixes issue 1 on this PR https://github.com/mattermost/mattermost-server/pull/13813
