### PR TITLE
MM-22762: Deflake TestPlugin in cmd/mattermost/commands

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -230,6 +230,7 @@ func (a *App) SyncPlugins() *model.AppError {
 			}
 		}(plugin.Manifest.Id)
 	}
+	wg.Wait()
 
 	// Install plugins from the file store.
 	pluginSignaturePathMap, appErr := a.getPluginsFromFolder()
@@ -263,7 +264,6 @@ func (a *App) SyncPlugins() *model.AppError {
 				mlog.Error("Failed to sync plugin from file store", mlog.String("bundle", plugin.path), mlog.Err(err))
 			}
 		}(plugin)
-
 	}
 
 	wg.Wait()


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
There was a race in (*App).SyncPlugins where if the same plugin
existed in availablePlugins and pluginSignaturePathMap, then
we would try to add/remove at the same time.

This would lead to a possible removal / addition of a plugin directory
or even unable to remove a directory because it was already in use.

We fix this by first finishing the removal of availablePlugins
before syncing it with the file store.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-22762