### PR TITLE
Remove unncessary recover() calls

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -246,10 +246,6 @@ func (me *TestHelper) TearDown() {
 	me.ShutdownApp()
 
 	utils.EnableDebugLogForTest()
-
-	if err := recover(); err != nil {
-		panic(err)
-	}
 }
 
 var initBasicOnce sync.Once

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -567,9 +567,6 @@ func (me *TestHelper) TearDown() {
 		me.App.InvalidateAllCaches()
 	}
 	me.ShutdownApp()
-	if err := recover(); err != nil {
-		panic(err)
-	}
 	if me.tempWorkspace != "" {
 		os.RemoveAll(me.tempWorkspace)
 	}

--- a/migrations/helper_test.go
+++ b/migrations/helper_test.go
@@ -250,9 +250,6 @@ func (me *TestHelper) TearDown() {
 	// Clean all the caches
 	me.App.InvalidateAllCaches()
 	me.Server.Shutdown()
-	if err := recover(); err != nil {
-		panic(err)
-	}
 	if me.tempWorkspace != "" {
 		os.RemoveAll(me.tempWorkspace)
 	}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -158,9 +158,6 @@ func (th *TestHelper) TearDown() {
 		th.App.InvalidateAllCaches()
 	}
 	th.Server.Shutdown()
-	if err := recover(); err != nil {
-		panic(err)
-	}
 }
 
 func TestStaticFilesRequest(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Recovering and immediately panicking does not make sense. So we just remove it.

This also fixes the bug of tempWorkspace not getting cleaned up in case of panics.
