### PR TITLE
MM-23281 - Continuously crashing plugin goes into infinite restart loop

### DIFF
--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -1026,10 +1026,10 @@ func TestActiveHooks(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, hooks)
 
-		// Should fail to find pluginId as it was deleted when deactivated
+		// Should not return any error as deactivated plugins still exist in registeredPlugins.
 		path, err := th.App.GetPluginsEnvironment().PublicFilesPath(pluginId)
-		require.Error(t, err)
-		require.Empty(t, path)
+		require.NoError(t, err)
+		require.NotEmpty(t, path)
 	})
 }
 

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -321,7 +321,8 @@ func (env *Environment) Deactivate(id string) bool {
 		rp.supervisor.Shutdown()
 	}
 
-	env.registeredPlugins.Delete(id)
+	// Do not remove this PluginID from env.registeredPlugins as PluginHealthCheckJob
+	// relies upon updating failTimeStamps externally when restarting plugins.
 
 	return true
 }


### PR DESCRIPTION
#### Summary
Do not remove pluginID from `Env.registeredPlugins` on `Deactivate()`. This is a bandaid fix to resolve https://mattermost.atlassian.net/browse/MM-23281, the underlying issue is how `PluginHealthCheckJob` is structured and communicates with the Plugin `Environment`. I tried to capture and provide the solution in https://mattermost.atlassian.net/browse/MM-23365 on how `PluginHealthCheckJob` should be structured to avoid bypassing public APIs to update `Environment`'s internal state.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-23281
