### PR TITLE
[MM-22343] Add set_online option for creating a post to client4.go

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -476,7 +476,7 @@ func (me *TestHelper) CreatePostWithClient(client *model.Client4, channel *model
 	}
 
 	utils.DisableDebugLogForTest()
-	rpost, resp := client.CreatePost(post)
+	rpost, resp := client.CreatePost(post, false)
 	if resp.Error != nil {
 		panic(resp.Error)
 	}
@@ -494,7 +494,7 @@ func (me *TestHelper) CreatePinnedPostWithClient(client *model.Client4, channel 
 	}
 
 	utils.DisableDebugLogForTest()
-	rpost, resp := client.CreatePost(post)
+	rpost, resp := client.CreatePost(post, false)
 	if resp.Error != nil {
 		panic(resp.Error)
 	}
@@ -509,7 +509,7 @@ func (me *TestHelper) CreateMessagePostWithClient(client *model.Client4, channel
 	}
 
 	utils.DisableDebugLogForTest()
-	rpost, resp := client.CreatePost(post)
+	rpost, resp := client.CreatePost(post, false)
 	if resp.Error != nil {
 		panic(resp.Error)
 	}

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1193,7 +1193,7 @@ func TestDeleteChannel(t *testing.T) {
 	require.True(t, err != nil || ch.DeleteAt != 0, "should have failed to get deleted channel, or returned one with a populated DeleteAt.")
 
 	post1 := &model.Post{ChannelId: publicChannel1.Id, Message: "a" + GenerateTestId() + "a"}
-	_, resp = Client.CreatePost(post1)
+	_, resp = Client.CreatePost(post1, false)
 	require.NotNil(t, resp, "expected response to not be nil")
 
 	// successful delete of private channel
@@ -2174,7 +2174,7 @@ func TestAddChannelMember(t *testing.T) {
 	require.Equal(t, user2.Id, cm.UserId, "should have returned exact user added to private channel")
 
 	post := &model.Post{ChannelId: publicChannel.Id, Message: "a" + GenerateTestId() + "a"}
-	rpost, err := Client.CreatePost(post)
+	rpost, err := Client.CreatePost(post, false)
 	require.NotNil(t, err)
 
 	Client.RemoveUserFromChannel(publicChannel.Id, user.Id)

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -99,14 +99,16 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("user status should be online", func(t *testing.T) {
-		p, resp := Client.CreatePost(&model.Post{
+		var p *model.Post
+		p, resp = Client.CreatePost(&model.Post{
 			ChannelId: th.BasicChannel.Id,
 			Message:   "i'm online",
 		}, true)
 		CheckNoError(t, resp)
 		CheckCreatedStatus(t, resp)
 
-		s, resp := Client.GetUserStatus(p.UserId, "")
+		var s *model.Status
+		s, resp = Client.GetUserStatus(p.UserId, "")
 		CheckNoError(t, resp)
 		assert.Equal(t, model.STATUS_ONLINE, s.Status)
 	})

--- a/api4/reaction_test.go
+++ b/api4/reaction_test.go
@@ -558,11 +558,11 @@ func TestGetBulkReactions(t *testing.T) {
 	post4 := &model.Post{UserId: user2Id, ChannelId: th.BasicChannel.Id, Message: "zz" + model.NewId() + "a"}
 	post5 := &model.Post{UserId: user2Id, ChannelId: th.BasicChannel.Id, Message: "zz" + model.NewId() + "a"}
 
-	post1, _ = Client.CreatePost(post1)
-	post2, _ = Client.CreatePost(post2)
-	post3, _ = Client.CreatePost(post3)
-	post4, _ = Client.CreatePost(post4)
-	post5, _ = Client.CreatePost(post5)
+	post1, _ = Client.CreatePost(post1, false)
+	post2, _ = Client.CreatePost(post2, false)
+	post3, _ = Client.CreatePost(post3, false)
+	post4, _ = Client.CreatePost(post4, false)
+	post5, _ = Client.CreatePost(post5, false)
 
 	expectedPostIdsReactionsMap := make(map[string][]*model.Reaction)
 	expectedPostIdsReactionsMap[post1.Id] = []*model.Reaction{}

--- a/app/auto_posts.go
+++ b/app/auto_posts.go
@@ -92,7 +92,7 @@ func (cfg *AutoPostCreator) CreateRandomPostNested(parentId, rootId string) (*mo
 		RootId:    rootId,
 		Message:   postText,
 		FileIds:   fileIds}
-	rpost, resp := cfg.client.CreatePost(post)
+	rpost, resp := cfg.client.CreatePost(post, false)
 	if resp != nil && resp.Error != nil {
 		return nil, false
 	}

--- a/app/command_loadtest.go
+++ b/app/command_loadtest.go
@@ -428,7 +428,7 @@ func (me *LoadTestProvider) PostCommand(a *App, args *model.CommandArgs, message
 		ChannelId: channel.Id,
 		Message:   textMessage,
 	}
-	_, resp = client.CreatePost(post)
+	_, resp = client.CreatePost(post, false)
 	if resp != nil && resp.Error != nil {
 		return &model.CommandResponse{Text: "Failed to create a post", ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL}
 	}

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,8 @@ github.com/mattermost/gosaml2 v0.3.2 h1:kq2dY5qUe6fPPHra171GVlgo+ycBsEog0gZMetxL
 github.com/mattermost/gosaml2 v0.3.2/go.mod h1:Z429EIOiEi9kbq6yHoApfzlcXpa6dzRDc6pO+Vy2Ksk=
 github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d h1:2DV7VIlEv6J5R5o6tUcb3ZMKJYeeZuWZL7Rv1m23TgQ=
 github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
+github.com/mattermost/mattermost-server v1.4.0 h1:bAN0zYgjyhXPy67VTiHLg+bu8mDJ2bhx109BKk2Ddos=
+github.com/mattermost/mattermost-server v5.11.1+incompatible h1:LPzKY0+2Tic/ik67qIg6VrydRCgxNXZQXOeaiJ2rMBY=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattermost/viper v1.0.4 h1:cMYOz4PhguscGSPxrSokUtib5HrG4gCpiUh27wyA3d0=

--- a/manualtesting/test_autolink.go
+++ b/manualtesting/test_autolink.go
@@ -31,6 +31,6 @@ func testAutoLink(env TestEnvironment) *model.AppError {
 	post := &model.Post{
 		ChannelId: channelID,
 		Message:   linkPostText}
-	_, resp := env.Client.CreatePost(post)
+	_, resp := env.Client.CreatePost(post, false)
 	return resp.Error
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -2551,8 +2551,12 @@ func (c *Client4) AutocompleteChannelsForTeamForSearch(teamId, name string) (*Ch
 // Post Section
 
 // CreatePost creates a post based on the provided post struct.
-func (c *Client4) CreatePost(post *Post) (*Post, *Response) {
-	r, err := c.DoApiPost(c.GetPostsRoute(), post.ToUnsanitizedJson())
+func (c *Client4) CreatePost(post *Post, online bool) (*Post, *Response) {
+	url := c.GetPostsRoute()
+	if !online {
+		url += "?set_online=false"
+	}
+	r, err := c.DoApiPost(url, post.ToUnsanitizedJson())
 	if err != nil {
 		return nil, BuildErrorResponse(r, err)
 	}

--- a/model/client4_test.go
+++ b/model/client4_test.go
@@ -54,7 +54,7 @@ func TestClient4CreatePost(t *testing.T) {
 	}))
 
 	client := NewAPIv4Client(server.URL)
-	_, resp := client.CreatePost(post)
+	_, resp := client.CreatePost(post, false)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 


### PR DESCRIPTION

#### Summary
This PR proposes to reflect the recent changes (https://github.com/mattermost/mattermost-server/pull/13538) made in the `CreatePost` method of the API. We can now set user status to offline while creating a post.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22343
