### PR TITLE
Don't try to migrate empty setttings filenames

### DIFF
--- a/config/migrate.go
+++ b/config/migrate.go
@@ -28,6 +28,9 @@ func Migrate(from, to string) error {
 	files = append(files, sourceConfig.PluginSettings.SignaturePublicKeyFiles...)
 
 	for _, file := range files {
+		if file == "" {
+			continue
+		}
 		err = migrateFile(file, source, destination)
 
 		if err != nil {
@@ -38,6 +41,9 @@ func Migrate(from, to string) error {
 }
 
 func migrateFile(name string, source Store, destination Store) error {
+	if name == "" {
+		return nil
+	}
 	fileExists, err := source.HasFile(name)
 	if err != nil {
 		return errors.Wrapf(err, "failed to check existence of %s", name)

--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -29,11 +29,13 @@ func TestMigrateDatabaseToFile(t *testing.T) {
 	files := []string{"IdpCertificateFile", "PublicCertificateFile", "PrivateKeyFile"}
 	data := []byte("aaaaa")
 	ds, err := NewDatabaseStore(getDsn(*sqlSettings.DriverName, *sqlSettings.DataSource))
+	require.Nil(t, err)
 	defer ds.Close()
 	defer func() {
 		defaultCfg := &model.Config{}
 		defaultCfg.SetDefaults()
-		ds.Set(defaultCfg)
+		_, err = ds.Set(defaultCfg)
+		require.Nil(t, err)
 	}()
 	require.NoError(t, err)
 	config := ds.Get()
@@ -73,11 +75,13 @@ func TestMigrateDatabaseToFileWithEmptyFiles(t *testing.T) {
 	fileDSN := "config.json"
 	files := []string{"", "", ""}
 	ds, err := NewDatabaseStore(getDsn(*sqlSettings.DriverName, *sqlSettings.DataSource))
+	require.Nil(t, err)
 	defer ds.Close()
 	defer func() {
 		defaultCfg := &model.Config{}
 		defaultCfg.SetDefaults()
-		ds.Set(defaultCfg)
+		_, err = ds.Set(defaultCfg)
+		require.Nil(t, err)
 	}()
 	require.NoError(t, err)
 	config := ds.Get()

--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -72,7 +72,6 @@ func TestMigrateDatabaseToFileWithEmptyFiles(t *testing.T) {
 	sqlSettings := helper.GetSQLSettings()
 	fileDSN := "config.json"
 	files := []string{"", "", ""}
-	data := []byte("aaaaa")
 	ds, err := NewDatabaseStore(getDsn(*sqlSettings.DriverName, *sqlSettings.DataSource))
 	defer ds.Close()
 	defer func() {
@@ -88,10 +87,6 @@ func TestMigrateDatabaseToFileWithEmptyFiles(t *testing.T) {
 	_, err = ds.Set(config)
 	require.NoError(t, err)
 
-	for _, file := range files {
-		err = ds.SetFile(file, data)
-		require.NoError(t, err)
-	}
 	err = Migrate(getDsn(*sqlSettings.DriverName, *sqlSettings.DataSource), fileDSN)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Inside the migration logic for the config command, we're not checking if settings value that hold file path are empty and that makes the process to fail.

For example, if `SamlSettings.IdpCertificateFile` property is empty, which means not having a path as value of that setting, we're trying to migrate it anyway even reaching the database to check for it

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-22726