### PR TITLE
Automated cherry pick of #13894

### DIFF
--- a/app/user_agent.go
+++ b/app/user_agent.go
@@ -89,6 +89,11 @@ func getBrowserVersion(ua *uasurfer.UserAgent, userAgentString string) string {
 		return strings.Fields(afterVersion)[0]
 	}
 
+	if index := strings.Index(userAgentString, "mmctl/"); index != -1 {
+		afterVersion := userAgentString[index+len("mmctl/"):]
+		return strings.Fields(afterVersion)[0]
+	}
+
 	if index := strings.Index(userAgentString, "Franz/"); index != -1 {
 		afterVersion := userAgentString[index+len("Franz/"):]
 		return strings.Fields(afterVersion)[0]
@@ -120,6 +125,10 @@ func getBrowserName(ua *uasurfer.UserAgent, userAgentString string) string {
 
 	if strings.Contains(userAgentString, "Mattermost") {
 		return "Desktop App"
+	}
+
+	if strings.Contains(userAgentString, "mmctl") {
+		return "mmctl"
 	}
 
 	if browser == uasurfer.BrowserIE && ua.Browser.Version.Major > 11 {

--- a/app/user_agent_test.go
+++ b/app/user_agent_test.go
@@ -21,6 +21,7 @@ var testUserAgents = []testUserAgent{
 	{"Chrome 60", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.90 Safari/537.36"},
 	{"Chrome Mobile", "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Mobile Safari/537.36"},
 	{"MM Classic App", "Mozilla/5.0 (Linux; Android 8.0.0; Nexus 5X Build/OPR6.170623.013; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.81 Mobile Safari/537.36 Web-Atoms-Mobile-WebView"},
+	{"mmctl", "mmctl/5.20.0 (linux)"},
 	{"MM App 3.7.1", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.7.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36"},
 	{"Franz 4.0.4", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Franz/4.0.4 Chrome/52.0.2743.82 Electron/1.3.1 Safari/537.36"},
 	{"Edge 14", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393"},
@@ -38,6 +39,7 @@ func TestGetPlatformName(t *testing.T) {
 	expected := []string{
 		"Windows",
 		"Macintosh",
+		"Linux",
 		"Linux",
 		"Linux",
 		"Macintosh",
@@ -69,6 +71,7 @@ func TestGetOSName(t *testing.T) {
 		"Mac OS",
 		"Android",
 		"Android",
+		"Linux",
 		"Mac OS",
 		"Mac OS",
 		"Windows 10",
@@ -98,6 +101,7 @@ func TestGetBrowserName(t *testing.T) {
 		"Chrome",
 		"Chrome",
 		"Chrome",
+		"mmctl",
 		"Desktop App",
 		"Chrome",
 		"Edge",
@@ -127,6 +131,7 @@ func TestGetBrowserVersion(t *testing.T) {
 		"60.0.3112", // Doesn't report the fourth part of the version
 		"60.0.3112", // Doesn't report the fourth part of the version
 		"61.0.3163",
+		"5.20.0",
 		"3.7.1",
 		"4.0.4",
 		"14.14393",


### PR DESCRIPTION
Cherry pick of #13894 on release-5.22.

- #13894: Add mmctl to the User-Agent parser

/cc  @mgdelacroix