### PR TITLE
MM-23508 Fix plugin API's GetPostsForChannel

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -521,7 +521,7 @@ func (api *PluginAPI) GetPostsBefore(channelId, postId string, page, perPage int
 }
 
 func (api *PluginAPI) GetPostsForChannel(channelId string, page, perPage int) (*model.PostList, *model.AppError) {
-	return api.app.GetPostsPage(model.GetPostsOptions{ChannelId: channelId, Page: perPage, PerPage: page})
+	return api.app.GetPostsPage(model.GetPostsOptions{ChannelId: channelId, Page: page, PerPage: perPage})
 }
 
 func (api *PluginAPI) UpdatePost(post *model.Post) (*model.Post, *model.AppError) {


### PR DESCRIPTION
#### Summary

`GetPostsForChannel` called `GetPostsPage` with the `page` and `perPage` parameters swapped. This PR fixes this and adds a test checking the basic behaviour of the function.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23508