### PR TITLE
Fixing race condition on status serialization

### DIFF
--- a/api4/status_test.go
+++ b/api4/status_test.go
@@ -15,44 +15,60 @@ func TestGetUserStatus(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	userStatus, resp := Client.GetUserStatus(th.BasicUser.Id, "")
-	CheckNoError(t, resp)
-	assert.Equal(t, "offline", userStatus.Status)
+	t.Run("offline status", func(t *testing.T) {
+		userStatus, resp := Client.GetUserStatus(th.BasicUser.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "offline", userStatus.Status)
+	})
 
-	th.App.SetStatusOnline(th.BasicUser.Id, true)
-	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
-	CheckNoError(t, resp)
-	assert.Equal(t, "online", userStatus.Status)
+	t.Run("online status", func(t *testing.T) {
+		th.App.SetStatusOnline(th.BasicUser.Id, true)
+		userStatus, resp := Client.GetUserStatus(th.BasicUser.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "online", userStatus.Status)
+	})
 
-	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
-	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
-	CheckNoError(t, resp)
-	assert.Equal(t, "away", userStatus.Status)
+	t.Run("away status", func(t *testing.T) {
+		th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
+		userStatus, resp := Client.GetUserStatus(th.BasicUser.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "away", userStatus.Status)
+	})
 
-	th.App.SetStatusDoNotDisturb(th.BasicUser.Id)
-	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
-	CheckNoError(t, resp)
-	assert.Equal(t, "dnd", userStatus.Status)
+	t.Run("dnd status", func(t *testing.T) {
+		th.App.SetStatusDoNotDisturb(th.BasicUser.Id)
+		userStatus, resp := Client.GetUserStatus(th.BasicUser.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "dnd", userStatus.Status)
+	})
 
-	th.App.SetStatusOffline(th.BasicUser.Id, true)
-	userStatus, resp = Client.GetUserStatus(th.BasicUser.Id, "")
-	CheckNoError(t, resp)
-	assert.Equal(t, "offline", userStatus.Status)
+	t.Run("back to offline status", func(t *testing.T) {
+		th.App.SetStatusOffline(th.BasicUser.Id, true)
+		userStatus, resp := Client.GetUserStatus(th.BasicUser.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "offline", userStatus.Status)
+	})
 
-	//Get user2 status logged as user1
-	userStatus, resp = Client.GetUserStatus(th.BasicUser2.Id, "")
-	CheckNoError(t, resp)
-	assert.Equal(t, "offline", userStatus.Status)
+	t.Run("get other user status", func(t *testing.T) {
+		//Get user2 status logged as user1
+		userStatus, resp := Client.GetUserStatus(th.BasicUser2.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "offline", userStatus.Status)
+	})
 
-	Client.Logout()
+	t.Run("get status from logged out user", func(t *testing.T) {
+		Client.Logout()
 
-	_, resp = Client.GetUserStatus(th.BasicUser2.Id, "")
-	CheckUnauthorizedStatus(t, resp)
+		_, resp := Client.GetUserStatus(th.BasicUser2.Id, "")
+		CheckUnauthorizedStatus(t, resp)
+	})
 
-	th.LoginBasic2()
-	userStatus, resp = Client.GetUserStatus(th.BasicUser2.Id, "")
-	CheckNoError(t, resp)
-	assert.Equal(t, "offline", userStatus.Status)
+	t.Run("get status from other user", func(t *testing.T) {
+		th.LoginBasic2()
+		userStatus, resp := Client.GetUserStatus(th.BasicUser2.Id, "")
+		CheckNoError(t, resp)
+		assert.Equal(t, "offline", userStatus.Status)
+	})
 }
 
 func TestGetUsersStatusesByIds(t *testing.T) {
@@ -62,40 +78,55 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 
 	usersIds := []string{th.BasicUser.Id, th.BasicUser2.Id}
 
-	usersStatuses, resp := Client.GetUsersStatusesByIds(usersIds)
-	CheckNoError(t, resp)
-	for _, userStatus := range usersStatuses {
-		assert.Equal(t, "offline", userStatus.Status)
-	}
+	t.Run("empty userIds list", func(t *testing.T) {
+		_, resp := Client.GetUsersStatusesByIds([]string{})
+		CheckBadRequestStatus(t, resp)
+	})
 
-	th.App.SetStatusOnline(th.BasicUser.Id, true)
-	th.App.SetStatusOnline(th.BasicUser2.Id, true)
-	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
-	CheckNoError(t, resp)
-	for _, userStatus := range usersStatuses {
-		assert.Equal(t, "online", userStatus.Status)
-	}
+	t.Run("offline status", func(t *testing.T) {
+		usersStatuses, resp := Client.GetUsersStatusesByIds(usersIds)
+		CheckNoError(t, resp)
+		for _, userStatus := range usersStatuses {
+			assert.Equal(t, "offline", userStatus.Status)
+		}
+	})
 
-	th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
-	th.App.SetStatusAwayIfNeeded(th.BasicUser2.Id, true)
-	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
-	CheckNoError(t, resp)
-	for _, userStatus := range usersStatuses {
-		assert.Equal(t, "away", userStatus.Status)
-	}
+	t.Run("online status", func(t *testing.T) {
+		th.App.SetStatusOnline(th.BasicUser.Id, true)
+		th.App.SetStatusOnline(th.BasicUser2.Id, true)
+		usersStatuses, resp := Client.GetUsersStatusesByIds(usersIds)
+		CheckNoError(t, resp)
+		for _, userStatus := range usersStatuses {
+			assert.Equal(t, "online", userStatus.Status)
+		}
+	})
 
-	th.App.SetStatusDoNotDisturb(th.BasicUser.Id)
-	th.App.SetStatusDoNotDisturb(th.BasicUser2.Id)
-	usersStatuses, resp = Client.GetUsersStatusesByIds(usersIds)
-	CheckNoError(t, resp)
-	for _, userStatus := range usersStatuses {
-		assert.Equal(t, "dnd", userStatus.Status)
-	}
+	t.Run("away status", func(t *testing.T) {
+		th.App.SetStatusAwayIfNeeded(th.BasicUser.Id, true)
+		th.App.SetStatusAwayIfNeeded(th.BasicUser2.Id, true)
+		usersStatuses, resp := Client.GetUsersStatusesByIds(usersIds)
+		CheckNoError(t, resp)
+		for _, userStatus := range usersStatuses {
+			assert.Equal(t, "away", userStatus.Status)
+		}
+	})
 
-	Client.Logout()
+	t.Run("dnd status", func(t *testing.T) {
+		th.App.SetStatusDoNotDisturb(th.BasicUser.Id)
+		th.App.SetStatusDoNotDisturb(th.BasicUser2.Id)
+		usersStatuses, resp := Client.GetUsersStatusesByIds(usersIds)
+		CheckNoError(t, resp)
+		for _, userStatus := range usersStatuses {
+			assert.Equal(t, "dnd", userStatus.Status)
+		}
+	})
 
-	_, resp = Client.GetUsersStatusesByIds(usersIds)
-	CheckUnauthorizedStatus(t, resp)
+	t.Run("get statuses from logged out user", func(t *testing.T) {
+		Client.Logout()
+
+		_, resp := Client.GetUsersStatusesByIds(usersIds)
+		CheckUnauthorizedStatus(t, resp)
+	})
 }
 
 func TestUpdateUserStatus(t *testing.T) {
@@ -103,40 +134,57 @@ func TestUpdateUserStatus(t *testing.T) {
 	defer th.TearDown()
 	Client := th.Client
 
-	toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser.Id}
-	updateUserStatus, resp := Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
-	CheckNoError(t, resp)
-	assert.Equal(t, "online", updateUserStatus.Status)
+	t.Run("set online status", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser.Id}
+		updateUserStatus, resp := Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
+		CheckNoError(t, resp)
+		assert.Equal(t, "online", updateUserStatus.Status)
+	})
 
-	toUpdateUserStatus.Status = "away"
-	updateUserStatus, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
-	CheckNoError(t, resp)
-	assert.Equal(t, "away", updateUserStatus.Status)
+	t.Run("set away status", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "away", UserId: th.BasicUser.Id}
+		updateUserStatus, resp := Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
+		CheckNoError(t, resp)
+		assert.Equal(t, "away", updateUserStatus.Status)
+	})
 
-	toUpdateUserStatus.Status = "dnd"
-	updateUserStatus, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
-	CheckNoError(t, resp)
-	assert.Equal(t, "dnd", updateUserStatus.Status)
+	t.Run("set dnd status", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "dnd", UserId: th.BasicUser.Id}
+		updateUserStatus, resp := Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
+		CheckNoError(t, resp)
+		assert.Equal(t, "dnd", updateUserStatus.Status)
+	})
 
-	toUpdateUserStatus.Status = "offline"
-	updateUserStatus, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
-	CheckNoError(t, resp)
-	assert.Equal(t, "offline", updateUserStatus.Status)
+	t.Run("set offline status", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "offline", UserId: th.BasicUser.Id}
+		updateUserStatus, resp := Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
+		CheckNoError(t, resp)
+		assert.Equal(t, "offline", updateUserStatus.Status)
+	})
 
-	toUpdateUserStatus.Status = "online"
-	toUpdateUserStatus.UserId = th.BasicUser2.Id
-	_, resp = Client.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
-	CheckForbiddenStatus(t, resp)
+	t.Run("set status for other user as regular user", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser2.Id}
+		_, resp := Client.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
+		CheckForbiddenStatus(t, resp)
+	})
 
-	toUpdateUserStatus.Status = "online"
-	updateUserStatus, _ = th.SystemAdminClient.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
-	assert.Equal(t, "online", updateUserStatus.Status)
+	t.Run("set status for other user as admin user", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser2.Id}
+		updateUserStatus, _ := th.SystemAdminClient.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
+		assert.Equal(t, "online", updateUserStatus.Status)
+	})
 
-	_, resp = Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
-	CheckBadRequestStatus(t, resp)
+	t.Run("not matching status user id and the user id passed in the function", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser2.Id}
+		_, resp := Client.UpdateUserStatus(th.BasicUser.Id, toUpdateUserStatus)
+		CheckBadRequestStatus(t, resp)
+	})
 
-	Client.Logout()
+	t.Run("get statuses from logged out user", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser2.Id}
+		Client.Logout()
 
-	_, resp = Client.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
-	CheckUnauthorizedStatus(t, resp)
+		_, resp := Client.UpdateUserStatus(th.BasicUser2.Id, toUpdateUserStatus)
+		CheckUnauthorizedStatus(t, resp)
+	})
 }

--- a/model/status.go
+++ b/model/status.go
@@ -28,10 +28,9 @@ type Status struct {
 }
 
 func (o *Status) ToJson() string {
-	tempChannelId := o.ActiveChannel
-	o.ActiveChannel = ""
-	b, _ := json.Marshal(o)
-	o.ActiveChannel = tempChannelId
+	oCopy := *o
+	oCopy.ActiveChannel = ""
+	b, _ := json.Marshal(oCopy)
 	return string(b)
 }
 
@@ -47,18 +46,14 @@ func StatusFromJson(data io.Reader) *Status {
 }
 
 func StatusListToJson(u []*Status) string {
-	activeChannels := make([]string, len(u))
-	for index, s := range u {
-		activeChannels[index] = s.ActiveChannel
-		s.ActiveChannel = ""
+	uCopy := make([]Status, len(u))
+	for i, s := range u {
+		sCopy := *s
+		sCopy.ActiveChannel = ""
+		uCopy[i] = sCopy
 	}
 
-	b, _ := json.Marshal(u)
-
-	for index, s := range u {
-		s.ActiveChannel = activeChannels[index]
-	}
-
+	b, _ := json.Marshal(uCopy)
 	return string(b)
 }
 


### PR DESCRIPTION
#### Summary
During status serialization the serialized object could be modified while is
been serialized, so I copied the object before serializing it.

#### Ticket Link
[MM-23505](https://mattermost.atlassian.net/browse/MM-23505)