### PR TITLE
MM-23606: Fix role cache invalidation.

### DIFF
--- a/store/localcachelayer/layer.go
+++ b/store/localcachelayer/layer.go
@@ -297,6 +297,5 @@ func (s *LocalCacheStore) Invalidate() {
 	s.doClearCacheCluster(s.userProfileByIdsCache)
 	s.doClearCacheCluster(s.profilesInChannelCache)
 	s.doClearCacheCluster(s.teamAllTeamIdsForUserCache)
-	s.doClearCacheCluster(s.roleCache)
 	s.doClearCacheCluster(s.rolePermissionsCache)
 }

--- a/store/localcachelayer/role_layer.go
+++ b/store/localcachelayer/role_layer.go
@@ -35,7 +35,7 @@ func (s *LocalCacheRoleStore) handleClusterInvalidateRolePermissions(msg *model.
 func (s LocalCacheRoleStore) Save(role *model.Role) (*model.Role, *model.AppError) {
 	if len(role.Name) != 0 {
 		defer s.rootStore.doInvalidateCacheCluster(s.rootStore.roleCache, role.Name)
-		defer s.rootStore.doClearCacheCluster(s.rootStore.rolePermissionsCache) // TODO: This in other places?
+		defer s.rootStore.doClearCacheCluster(s.rootStore.rolePermissionsCache)
 	}
 	return s.RoleStore.Save(role)
 }

--- a/store/localcachelayer/scheme_layer.go
+++ b/store/localcachelayer/scheme_layer.go
@@ -53,6 +53,6 @@ func (s LocalCacheSchemeStore) Delete(schemeId string) (*model.Scheme, *model.Ap
 func (s LocalCacheSchemeStore) PermanentDeleteAll() *model.AppError {
 	defer s.rootStore.doClearCacheCluster(s.rootStore.schemeCache)
 	defer s.rootStore.doClearCacheCluster(s.rootStore.roleCache)
-
+	defer s.rootStore.doClearCacheCluster(s.rootStore.rolePermissionsCache)
 	return s.SchemeStore.PermanentDeleteAll()
 }

--- a/store/localcachelayer/scheme_layer.go
+++ b/store/localcachelayer/scheme_layer.go
@@ -46,7 +46,7 @@ func (s LocalCacheSchemeStore) Get(schemeId string) (*model.Scheme, *model.AppEr
 func (s LocalCacheSchemeStore) Delete(schemeId string) (*model.Scheme, *model.AppError) {
 	defer s.rootStore.doInvalidateCacheCluster(s.rootStore.schemeCache, schemeId)
 	defer s.rootStore.doClearCacheCluster(s.rootStore.roleCache)
-
+	defer s.rootStore.doClearCacheCluster(s.rootStore.rolePermissionsCache)
 	return s.SchemeStore.Delete(schemeId)
 }
 

--- a/store/localcachelayer/team_layer.go
+++ b/store/localcachelayer/team_layer.go
@@ -70,6 +70,7 @@ func (s LocalCacheTeamStore) Update(team *model.Team) (*model.Team, *model.AppEr
 	if err != nil {
 		return nil, err
 	}
+	defer s.rootStore.doClearCacheCluster(s.rootStore.rolePermissionsCache)
 
 	if oldTeam != nil && oldTeam.DeleteAt == 0 {
 		s.rootStore.doClearCacheCluster(s.rootStore.teamAllTeamIdsForUserCache)


### PR DESCRIPTION
#### Summary

The role cache must be invalidated when a team is associated or disassociated from a team scheme.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23606