### PR TITLE
MM-23503: Fix race in websocket_client writer

### DIFF
--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -134,7 +134,7 @@ func (wsc *WebSocketClient) ConnectWithDialer(dialer *websocket.Dialer) *AppErro
 }
 
 func (wsc *WebSocketClient) Close() {
-	// CAS to 1 and proceed. Return if already 0.
+	// CAS to 1 and proceed. Return if already 1.
 	if !atomic.CompareAndSwapInt32(&wsc.closed, 0, 1) {
 		return
 	}

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -243,6 +243,9 @@ func (wsc *WebSocketClient) configurePingHandling() {
 }
 
 func (wsc *WebSocketClient) pingHandler(appData string) error {
+	if atomic.LoadInt32(&wsc.closed) == 1 {
+		return nil
+	}
 	if !wsc.pingTimeoutTimer.Stop() {
 		<-wsc.pingTimeoutTimer.C
 	}

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -134,6 +134,9 @@ func (wsc *WebSocketClient) ConnectWithDialer(dialer *websocket.Dialer) *AppErro
 }
 
 func (wsc *WebSocketClient) Close() {
+	if wsc.closed {
+		return
+	}
 	wsc.quitWriterChan <- struct{}{}
 	close(wsc.writeChan)
 	wsc.closed = true

--- a/model/websocket_client_test.go
+++ b/model/websocket_client_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		upgrader := &websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		}
+		conn, err := upgrader.Upgrade(w, req, nil)
+		var buf []byte
+		for {
+			_, buf, err = conn.ReadMessage()
+			if err != nil {
+				break
+			}
+			t.Logf("%s\n", buf)
+			err = conn.WriteMessage(websocket.PingMessage, []byte("ping"))
+			if err != nil {
+				break
+			}
+		}
+		if _, ok := err.(*websocket.CloseError); !ok {
+			require.NoError(t, err)
+		}
+	}
+}
+
+// TestWebSocketRace needs to be run with -race to verify that
+// there is no race.
+func TestWebSocketRace(t *testing.T) {
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	url := strings.Replace(s.URL, "http://", "ws://", 1)
+	cli, err := NewWebSocketClient4(url, "authToken")
+	require.Nil(t, err)
+
+	cli.Listen()
+
+	for i := 0; i < 10; i++ {
+		time.Sleep(500 * time.Millisecond)
+		cli.UserTyping("channel", "parentId")
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We create a separate writer goroutine where all the writes happen.
And we also clean up a lot of things related to the reader goroutine.

Now all cleanup related activities happen inside the Close method.

We also fix a bug where pingWatchdog would not have been initialized
if ConnectWithDialer was called after initializing a WebSocketClient
struct manually.

The code has been decorated with a lot of comments to explain the flow
of events. Overall, there are still a lot of edge conditions
which cannot be removed due to compatibility reasons. This entire
client is due for an overhaul in v6.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23503