### PR TITLE
MM-23261 plugin stderr debug logs

### DIFF
--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -666,7 +666,7 @@ func TestPluginPanicLogs(t *testing.T) {
 		_, err := th.App.CreatePost(post, th.BasicChannel, false)
 		assert.Nil(t, err)
 
-		testlib.AssertLog(t, th.LogBuffer, mlog.LevelError, "panic: some text from panic")
+		testlib.AssertLog(t, th.LogBuffer, mlog.LevelDebug, "panic: some text from panic")
 	})
 }
 

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -21,8 +20,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v5/testlib"
 	"github.com/mattermost/mattermost-server/v5/utils"
 	"github.com/mattermost/mattermost-server/v5/utils/fileutils"
 )
@@ -665,8 +666,7 @@ func TestPluginPanicLogs(t *testing.T) {
 		_, err := th.App.CreatePost(post, th.BasicChannel, false)
 		assert.Nil(t, err)
 
-		logs := th.LogBuffer.String()
-		assert.True(t, strings.Contains(logs, "some text from panic"))
+		testlib.AssertLog(t, th.LogBuffer, mlog.LevelError, "panic: some text from panic")
 	})
 }
 

--- a/mlog/log.go
+++ b/mlog/log.go
@@ -144,15 +144,6 @@ func (l *Logger) StdLogWriter() io.Writer {
 	return &loggerWriter{f}
 }
 
-// StdErrPanicLogWriter returns a writer that can be hooked up to the output of a golang standard logger
-// all of the stderr will be interpreted as log entry.
-func (l *Logger) StdErrPanicLogWriter() io.Writer {
-	newLogger := *l
-	newLogger.zap = newLogger.zap.WithOptions(zap.AddCallerSkip(4), getStdLogOption())
-	f := newLogger.Error
-	return &panicLoggerWriter{f}
-}
-
 func (l *Logger) WithCallerSkip(skip int) *Logger {
 	newlogger := *l
 	newlogger.zap = newlogger.zap.WithOptions(zap.AddCallerSkip(skip))

--- a/mlog/stdlog.go
+++ b/mlog/stdlog.go
@@ -85,13 +85,3 @@ func (l *loggerWriter) Write(p []byte) (int, error) {
 	}
 	return len(p), nil
 }
-
-type panicLoggerWriter struct {
-	logFunc func(msg string, fields ...Field)
-}
-
-func (l *panicLoggerWriter) Write(p []byte) (int, error) {
-	trimmed := string(bytes.TrimSpace(p))
-	l.logFunc(trimmed)
-	return len(p), nil
-}

--- a/plugin/supervisor.go
+++ b/plugin/supervisor.go
@@ -63,7 +63,6 @@ func newSupervisor(pluginInfo *model.BundleInfo, apiImpl API, parentLogger *mlog
 		HandshakeConfig: handshake,
 		Plugins:         pluginMap,
 		Cmd:             cmd,
-		Stderr:          wrappedLogger.With(mlog.String("source", "plugin_stderr_panic")).StdErrPanicLogWriter(),
 		SyncStdout:      wrappedLogger.With(mlog.String("source", "plugin_stdout")).StdLogWriter(),
 		SyncStderr:      wrappedLogger.With(mlog.String("source", "plugin_stderr")).StdLogWriter(),
 		Logger:          hclogAdaptedLogger,

--- a/testlib/assertions.go
+++ b/testlib/assertions.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package testlib
 
 import (

--- a/testlib/assertions.go
+++ b/testlib/assertions.go
@@ -1,0 +1,30 @@
+package testlib
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+// AssertLog asserts that a JSON-encoded buffer of logs contains one with the given level and message.
+func AssertLog(t *testing.T, logs *bytes.Buffer, level, message string) {
+	dec := json.NewDecoder(logs)
+	for {
+		var log struct {
+			Level string
+			Msg   string
+		}
+		if err := dec.Decode(&log); err == io.EOF {
+			break
+		} else if err != nil {
+			continue
+		}
+
+		if log.Level == level && log.Msg == message {
+			return
+		}
+	}
+
+	t.Fatalf("failed to find %s log message: %s", level, message)
+}


### PR DESCRIPTION
#### Summary
This change effectively reverts https://mattermost.atlassian.net/browse/MM-18150, since plugins emit other logs over STDERR that ended up spamming the ERROR logs. 

It turned out we were already logging panics as debug logs even without those changes (thanks to the `SyncStderr` configuration), so I reverted the core of the changes but kept the tests to assert the required behaviour (now at the debug level). I'll reopen the original ticket to revisit the idea of surfacing just the panics as error logs.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-23261