### PR TITLE
IS-299: Checkout webapp over HTTPS on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - checkout
       - run: |
           cd ../
-          GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone git@github.com:mattermost/mattermost-webapp.git
+          git clone https://github.com/mattermost/mattermost-webapp.git
           cd mattermost-webapp
           git checkout $CIRCLE_BRANCH || git checkout master
           export WEBAPP_GIT_COMMIT=$(git rev-parse HEAD)


### PR DESCRIPTION
#### Summary
Checkout the webapp repo over HTTPS to avoid `StrictHostKeyChecking=no`.

#### Ticket Link
https://mattermost.atlassian.net/browse/IS-299