### PR TITLE
MM-23185 - Markdown image hosted by plugins are not shown if local image proxy is enabled

### DIFF
--- a/api4/image.go
+++ b/api4/image.go
@@ -5,6 +5,9 @@ package api4
 
 import (
 	"net/http"
+	"net/url"
+
+	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 func (api *API) InitImage() {
@@ -12,11 +15,17 @@ func (api *API) InitImage() {
 }
 
 func getImage(c *Context, w http.ResponseWriter, r *http.Request) {
-	url := r.URL.Query().Get("url")
+	actualURL := r.URL.Query().Get("url")
+	parsedURL, err := url.Parse(actualURL)
+	if err != nil {
+		c.Err = model.NewAppError("getImage", "api.image.get.app_error", nil, err.Error(), http.StatusBadRequest)
+		return
+	}
 
-	if *c.App.Config().ImageProxySettings.Enable {
-		c.App.ImageProxy().GetImage(w, r, url)
+	// in case image proxy is enabled and we are fetching a remote image (NOT static or served by plugins), pass request to proxy
+	if *c.App.Config().ImageProxySettings.Enable && parsedURL.IsAbs() {
+		c.App.ImageProxy().GetImage(w, r, actualURL)
 	} else {
-		http.Redirect(w, r, url, http.StatusFound)
+		http.Redirect(w, r, actualURL, http.StatusFound)
 	}
 }

--- a/api4/image_test.go
+++ b/api4/image_test.go
@@ -91,5 +91,14 @@ func TestGetImage(t *testing.T) {
 		respBody, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, "success", string(respBody))
+
+		// local images should not be proxied, but forwarded
+		r, err = http.NewRequest("GET", th.Client.ApiUrl+"/image?url=/plugins/test/image.png", nil)
+		require.NoError(t, err)
+		r.Header.Set(model.HEADER_AUTH, th.Client.AuthType+" "+th.Client.AuthToken)
+
+		resp, err = th.Client.HttpClient.Do(r)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusFound, resp.StatusCode)
 	})
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1405,6 +1405,10 @@
     "translation": "Encountered an error writing to local server storage."
   },
   {
+    "id": "api.image.get.app_error",
+    "translation": "Requested image url cannot be parsed."
+  },
+  {
     "id": "api.incoming_webhook.disabled.app_error",
     "translation": "Incoming webhooks have been disabled by the system admin."
   },


### PR DESCRIPTION

#### Summary
Local images (like the ones provided by plugins) should not go through proxy.
This PR checks is URL being passed is an absolute one before passing it to proxy

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23185