### PR TITLE
MM-23747 fix Sprintf linter errors from new gosimple

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -811,8 +811,8 @@ func TestGetChannelMembersTimezones(t *testing.T) {
 func TestGetChannelsForUser(t *testing.T) {
 	th := Setup(t).InitBasic()
 	channel := &model.Channel{
-		DisplayName: fmt.Sprintf("Public"),
-		Name:        fmt.Sprintf("public"),
+		DisplayName: "Public",
+		Name:        "public",
 		Type:        model.CHANNEL_OPEN,
 		CreatorId:   th.BasicUser.Id,
 		TeamId:      th.BasicTeam.Id,

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -442,17 +442,17 @@ func TestMentionsToTeamMembers(t *testing.T) {
 		expectedMap model.UserMentionMap
 	}{
 		{
-			fmt.Sprintf(""),
+			"",
 			th.BasicTeam.Id,
 			model.UserMentionMap{},
 		},
 		{
-			fmt.Sprintf("/trigger"),
+			"/trigger",
 			th.BasicTeam.Id,
 			model.UserMentionMap{},
 		},
 		{
-			fmt.Sprintf("/trigger 0 mentions"),
+			"/trigger 0 mentions",
 			th.BasicTeam.Id,
 			model.UserMentionMap{},
 		},
@@ -527,17 +527,17 @@ func TestMentionsToPublicChannels(t *testing.T) {
 		expectedMap model.ChannelMentionMap
 	}{
 		{
-			fmt.Sprintf(""),
+			"",
 			th.BasicTeam.Id,
 			model.ChannelMentionMap{},
 		},
 		{
-			fmt.Sprintf("/trigger"),
+			"/trigger",
 			th.BasicTeam.Id,
 			model.ChannelMentionMap{},
 		},
 		{
-			fmt.Sprintf("/trigger 0 mentions"),
+			"/trigger 0 mentions",
 			th.BasicTeam.Id,
 			model.ChannelMentionMap{},
 		},

--- a/cmd/mattermost/commands/integrity.go
+++ b/cmd/mattermost/commands/integrity.go
@@ -25,8 +25,8 @@ func init() {
 }
 
 func printRelationalIntegrityCheckResult(data store.RelationalIntegrityCheckData, verbose bool) {
-	fmt.Println(fmt.Sprintf("Found %d records in relation %s orphans of relation %s",
-		len(data.Records), data.ChildName, data.ParentName))
+	fmt.Printf("Found %d records in relation %s orphans of relation %s\n",
+		len(data.Records), data.ChildName, data.ParentName)
 	if !verbose {
 		return
 	}
@@ -43,15 +43,15 @@ func printRelationalIntegrityCheckResult(data store.RelationalIntegrityCheckData
 
 		if record.ChildId != nil {
 			if parentId == "NULL" || parentId == "empty" {
-				fmt.Println(fmt.Sprintf("  Child %s (%s.%s) has %s ParentIdAttr (%s.%s)", *record.ChildId, data.ChildName, data.ChildIdAttr, parentId, data.ChildName, data.ParentIdAttr))
+				fmt.Printf("  Child %s (%s.%s) has %s ParentIdAttr (%s.%s)\n", *record.ChildId, data.ChildName, data.ChildIdAttr, parentId, data.ChildName, data.ParentIdAttr)
 			} else {
-				fmt.Println(fmt.Sprintf("  Child %s (%s.%s) is missing Parent %s (%s.%s)", *record.ChildId, data.ChildName, data.ChildIdAttr, parentId, data.ChildName, data.ParentIdAttr))
+				fmt.Printf("  Child %s (%s.%s) is missing Parent %s (%s.%s)\n", *record.ChildId, data.ChildName, data.ChildIdAttr, parentId, data.ChildName, data.ParentIdAttr)
 			}
 		} else {
 			if parentId == "NULL" || parentId == "empty" {
-				fmt.Println(fmt.Sprintf("  Child has %s ParentIdAttr (%s.%s)", parentId, data.ChildName, data.ParentIdAttr))
+				fmt.Printf("  Child has %s ParentIdAttr (%s.%s)\n", parentId, data.ChildName, data.ParentIdAttr)
 			} else {
-				fmt.Println(fmt.Sprintf("  Child is missing Parent %s (%s.%s)", parentId, data.ChildName, data.ParentIdAttr))
+				fmt.Printf("  Child is missing Parent %s (%s.%s)\n", parentId, data.ChildName, data.ParentIdAttr)
 			}
 		}
 	}

--- a/model/client4.go
+++ b/model/client4.go
@@ -133,7 +133,7 @@ func (c *Client4) ClearOAuthToken() {
 }
 
 func (c *Client4) GetUsersRoute() string {
-	return fmt.Sprintf("/users")
+	return "/users"
 }
 
 func (c *Client4) GetUserRoute(userId string) string {
@@ -157,7 +157,7 @@ func (c *Client4) GetUserByEmailRoute(email string) string {
 }
 
 func (c *Client4) GetBotsRoute() string {
-	return fmt.Sprintf("/bots")
+	return "/bots"
 }
 
 func (c *Client4) GetBotRoute(botUserId string) string {
@@ -165,7 +165,7 @@ func (c *Client4) GetBotRoute(botUserId string) string {
 }
 
 func (c *Client4) GetTeamsRoute() string {
-	return fmt.Sprintf("/teams")
+	return "/teams"
 }
 
 func (c *Client4) GetTeamRoute(teamId string) string {
@@ -197,7 +197,7 @@ func (c *Client4) GetTeamImportRoute(teamId string) string {
 }
 
 func (c *Client4) GetChannelsRoute() string {
-	return fmt.Sprintf("/channels")
+	return "/channels"
 }
 
 func (c *Client4) GetChannelsForTeamRoute(teamId string) string {
@@ -234,19 +234,19 @@ func (c *Client4) GetChannelMemberRoute(channelId, userId string) string {
 }
 
 func (c *Client4) GetPostsRoute() string {
-	return fmt.Sprintf("/posts")
+	return "/posts"
 }
 
 func (c *Client4) GetPostsEphemeralRoute() string {
-	return fmt.Sprintf("/posts/ephemeral")
+	return "/posts/ephemeral"
 }
 
 func (c *Client4) GetConfigRoute() string {
-	return fmt.Sprintf("/config")
+	return "/config"
 }
 
 func (c *Client4) GetLicenseRoute() string {
-	return fmt.Sprintf("/license")
+	return "/license"
 }
 
 func (c *Client4) GetPostRoute(postId string) string {
@@ -254,7 +254,7 @@ func (c *Client4) GetPostRoute(postId string) string {
 }
 
 func (c *Client4) GetFilesRoute() string {
-	return fmt.Sprintf("/files")
+	return "/files"
 }
 
 func (c *Client4) GetFileRoute(fileId string) string {
@@ -262,7 +262,7 @@ func (c *Client4) GetFileRoute(fileId string) string {
 }
 
 func (c *Client4) GetPluginsRoute() string {
-	return fmt.Sprintf("/plugins")
+	return "/plugins"
 }
 
 func (c *Client4) GetPluginRoute(pluginId string) string {
@@ -270,35 +270,35 @@ func (c *Client4) GetPluginRoute(pluginId string) string {
 }
 
 func (c *Client4) GetSystemRoute() string {
-	return fmt.Sprintf("/system")
+	return "/system"
 }
 
 func (c *Client4) GetTestEmailRoute() string {
-	return fmt.Sprintf("/email/test")
+	return "/email/test"
 }
 
 func (c *Client4) GetTestSiteURLRoute() string {
-	return fmt.Sprintf("/site_url/test")
+	return "/site_url/test"
 }
 
 func (c *Client4) GetTestS3Route() string {
-	return fmt.Sprintf("/file/s3_test")
+	return "/file/s3_test"
 }
 
 func (c *Client4) GetDatabaseRoute() string {
-	return fmt.Sprintf("/database")
+	return "/database"
 }
 
 func (c *Client4) GetCacheRoute() string {
-	return fmt.Sprintf("/caches")
+	return "/caches"
 }
 
 func (c *Client4) GetClusterRoute() string {
-	return fmt.Sprintf("/cluster")
+	return "/cluster"
 }
 
 func (c *Client4) GetIncomingWebhooksRoute() string {
-	return fmt.Sprintf("/hooks/incoming")
+	return "/hooks/incoming"
 }
 
 func (c *Client4) GetIncomingWebhookRoute(hookID string) string {
@@ -306,7 +306,7 @@ func (c *Client4) GetIncomingWebhookRoute(hookID string) string {
 }
 
 func (c *Client4) GetComplianceReportsRoute() string {
-	return fmt.Sprintf("/compliance/reports")
+	return "/compliance/reports"
 }
 
 func (c *Client4) GetComplianceReportRoute(reportId string) string {
@@ -314,7 +314,7 @@ func (c *Client4) GetComplianceReportRoute(reportId string) string {
 }
 
 func (c *Client4) GetOutgoingWebhooksRoute() string {
-	return fmt.Sprintf("/hooks/outgoing")
+	return "/hooks/outgoing"
 }
 
 func (c *Client4) GetOutgoingWebhookRoute(hookID string) string {
@@ -334,27 +334,27 @@ func (c *Client4) GetUserStatusesRoute() string {
 }
 
 func (c *Client4) GetSamlRoute() string {
-	return fmt.Sprintf("/saml")
+	return "/saml"
 }
 
 func (c *Client4) GetLdapRoute() string {
-	return fmt.Sprintf("/ldap")
+	return "/ldap"
 }
 
 func (c *Client4) GetBrandRoute() string {
-	return fmt.Sprintf("/brand")
+	return "/brand"
 }
 
 func (c *Client4) GetDataRetentionRoute() string {
-	return fmt.Sprintf("/data_retention")
+	return "/data_retention"
 }
 
 func (c *Client4) GetElasticsearchRoute() string {
-	return fmt.Sprintf("/elasticsearch")
+	return "/elasticsearch"
 }
 
 func (c *Client4) GetCommandsRoute() string {
-	return fmt.Sprintf("/commands")
+	return "/commands"
 }
 
 func (c *Client4) GetCommandRoute(commandId string) string {
@@ -366,7 +366,7 @@ func (c *Client4) GetCommandMoveRoute(commandId string) string {
 }
 
 func (c *Client4) GetEmojisRoute() string {
-	return fmt.Sprintf("/emoji")
+	return "/emoji"
 }
 
 func (c *Client4) GetEmojiRoute(emojiId string) string {
@@ -378,11 +378,11 @@ func (c *Client4) GetEmojiByNameRoute(name string) string {
 }
 
 func (c *Client4) GetReactionsRoute() string {
-	return fmt.Sprintf("/reactions")
+	return "/reactions"
 }
 
 func (c *Client4) GetOAuthAppsRoute() string {
-	return fmt.Sprintf("/oauth/apps")
+	return "/oauth/apps"
 }
 
 func (c *Client4) GetOAuthAppRoute(appId string) string {
@@ -390,19 +390,19 @@ func (c *Client4) GetOAuthAppRoute(appId string) string {
 }
 
 func (c *Client4) GetOpenGraphRoute() string {
-	return fmt.Sprintf("/opengraph")
+	return "/opengraph"
 }
 
 func (c *Client4) GetJobsRoute() string {
-	return fmt.Sprintf("/jobs")
+	return "/jobs"
 }
 
 func (c *Client4) GetRolesRoute() string {
-	return fmt.Sprintf("/roles")
+	return "/roles"
 }
 
 func (c *Client4) GetSchemesRoute() string {
-	return fmt.Sprintf("/schemes")
+	return "/schemes"
 }
 
 func (c *Client4) GetSchemeRoute(id string) string {
@@ -410,7 +410,7 @@ func (c *Client4) GetSchemeRoute(id string) string {
 }
 
 func (c *Client4) GetAnalyticsRoute() string {
-	return fmt.Sprintf("/analytics")
+	return "/analytics"
 }
 
 func (c *Client4) GetTimezonesRoute() string {
@@ -430,7 +430,7 @@ func (c *Client4) GetTotalUsersStatsRoute() string {
 }
 
 func (c *Client4) GetRedirectLocationRoute() string {
-	return fmt.Sprintf("/redirect_location")
+	return "/redirect_location"
 }
 
 func (c *Client4) GetServerBusyRoute() string {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR fixes errors from `make check-style` due to new `gosimple`.

The upgrade to Go 1.14.x, triggered VSCode to update tools, which included an updated `gosimple`.  The linter is now complaining about 
```
S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
```

- replace all instances of `fmt.Sprintf("whatever")` with simply "whatever".
- replace all instances of `fmt.Println(fmt.Sprintf("whatever %d", i))` with `fmt.Printf("whatever %d\n", i)`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23747