### PR TITLE
Opentracing layer generator improvement

### DIFF
--- a/app/layer_generators/opentracing_layer.go.tmpl
+++ b/app/layer_generators/opentracing_layer.go.tmpl
@@ -58,9 +58,7 @@ func (a *{{$.Name}}) {{$index}}({{$element.Params | joinParamsWithType}}) {{$ele
 		a.ctx = origCtx 
 	}()
 	{{range $paramIdx, $param := $element.Params}}
-		{{if index $element.ParamsToTrace $param.Name}}
-			span.SetTag("{{$param.Name}}", {{$param.Name}})
-		{{end}}	
+		{{ shouldTrace $element.ParamsToTrace $param.Name }}
 	{{end}}
 	defer span.Finish()
 	{{- if $element.Results | len | eq 0}}


### PR DESCRIPTION
#### Summary
Opentracing layer generator supported annotations in form of:
```go
// @openTracingParams teamId, skipSlackParsing
	CreateCommandPost(post *model.Post, teamId string, response *model.CommandResponse, skipSlackParsing bool) (*model.Post, *model.AppError)
```

This allowed passing params to opentracing spans.
This PR improves that syntax to allow getting struct fields, i.e:

```go
// @openTracingParams post.Id, teamId, skipSlackParsing
	CreateCommandPost(post *model.Post, teamId string, response *model.CommandResponse, skipSlackParsing bool) (*model.Post, *model.AppError)
```

