### PR TITLE
avoid panic in search channel store

### DIFF
--- a/store/searchlayer/channel_layer.go
+++ b/store/searchlayer/channel_layer.go
@@ -67,7 +67,7 @@ func (c *SearchChannelStore) UpdateMember(cm *model.ChannelMember) (*model.Chann
 		c.rootStore.indexUserFromID(cm.UserId)
 		channel, channelErr := c.ChannelStore.Get(member.ChannelId, true)
 		if channelErr != nil {
-			mlog.Error("Encountered error indexing user in channel", mlog.String("channel_id", member.ChannelId), mlog.Err(err))
+			mlog.Error("Encountered error indexing user in channel", mlog.String("channel_id", member.ChannelId), mlog.Err(channelErr))
 		} else {
 			c.rootStore.indexUserFromID(channel.CreatorId)
 		}
@@ -81,7 +81,7 @@ func (c *SearchChannelStore) SaveMember(cm *model.ChannelMember) (*model.Channel
 		c.rootStore.indexUserFromID(cm.UserId)
 		channel, channelErr := c.ChannelStore.Get(member.ChannelId, true)
 		if channelErr != nil {
-			mlog.Error("Encountered error indexing user in channel", mlog.String("channel_id", member.ChannelId), mlog.Err(err))
+			mlog.Error("Encountered error indexing user in channel", mlog.String("channel_id", member.ChannelId), mlog.Err(channelErr))
 		} else {
 			c.rootStore.indexUserFromID(channel.CreatorId)
 		}


### PR DESCRIPTION
#### Summary
Seen in Kibana logs. I took a look through the related files and couldn't find a parallel instance that needed to be fixed beyond these two.

Note also that I haven't found a place to add unit tests to help cover this bug.

Original panic:
```
http: panic serving 10.128.148.31:47536: runtime error: invalid memory address or nil pointer dereference
goroutine 1063732 [running]:
net/http.(*conn).serve.func1(0xc0042995e0)
	net/http/server.go:1767 +0x139
panic(0x1a4e080, 0x2edab40)
	runtime/panic.go:679 +0x1b2
github.com/mattermost/mattermost-server/v5/model.(*AppError).Error(0x0, 0xc000032000, 0x1a618c0)
	github.com/mattermost/mattermost-server/v5@/model/utils.go:73 +0x26
go.uber.org/zap/zapcore.encodeError(0x1c9c1d0, 0x5, 0x1fd6cc0, 0x0, 0x2028c60, 0xc0089fdfb0, 0xc0089fdfb0, 0x34)
	go.uber.org/zap@v1.13.0/zapcore/error.go:46 +0x3b
go.uber.org/zap/zapcore.Field.AddTo(0x1c9c1d0, 0x5, 0x19, 0x0, 0x0, 0x0, 0x1aa8c00, 0x0, 0x2028c60, 0xc0089fdfb0)
	go.uber.org/zap@v1.13.0/zapcore/field.go:165 +0xc8c
go.uber.org/zap/zapcore.addFields(0x2028c60, 0xc0089fdfb0, 0xc001df0800, 0x2, 0x2)
	go.uber.org/zap@v1.13.0/zapcore/field.go:199 +0xcf
go.uber.org/zap/zapcore.(*jsonEncoder).EncodeEntry(0xc00167d200, 0x2, 0xbf9678532a114ede, 0x3d02c134ae83, 0x2f284e0, 0x0, 0x0, 0x1d0d926, 0x2a, 0x1, ...)
	go.uber.org/zap@v1.13.0/zapcore/json_encoder.go:376 +0x1e4
go.uber.org/zap/zapcore.(*ioCore).Write(0xc00167d230, 0x2, 0xbf9678532a114ede, 0x3d02c134ae83, 0x2f284e0, 0x0, 0x0, 0x1d0d926, 0x2a, 0x1, ...)
	go.uber.org/zap@v1.13.0/zapcore/core.go:86 +0xa9
go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc004b2e8f0, 0xc001df0800, 0x2, 0x2)
	go.uber.org/zap@v1.13.0/zapcore/entry.go:216 +0x117
go.uber.org/zap.(*Logger).Error(0xc001fc4f00, 0x1d0d926, 0x2a, 0xc001df0800, 0x2, 0x2)
	go.uber.org/zap@v1.13.0/logger.go:203 +0x7f
github.com/mattermost/mattermost-server/v5/mlog.(*Logger).Error(...)
	github.com/mattermost/mattermost-server/v5@/mlog/log.go:184
github.com/mattermost/mattermost-server/v5/store/searchlayer.(*SearchChannelStore).SaveMember(0xc0009749c0, 0xc003e69a40, 0x2f284e0, 0x0)
	github.com/mattermost/mattermost-server/v5@/store/searchlayer/channel_layer.go:84 +0x2ed
github.com/mattermost/mattermost-server/v5/store.(*TimerLayerChannelStore).SaveMember(0xc000974ae0, 0xc003e69a40, 0xc000974ae0, 0xc)
	github.com/mattermost/mattermost-server/v5@/store/timer_layer.go:1559 +0x66
github.com/mattermost/mattermost-server/v5/app.(*App).createGroupChannel(0xc006d54f00, 0xc0085d1740, 0x3, 0x4, 0xc00a7396a0, 0x1a, 0xc008a319a0, 0xc0089fd2c0)
	github.com/mattermost/mattermost-server/v5@/app/channel.go:431 +0x6de
github.com/mattermost/mattermost-server/v5/app.(*App).CreateGroupChannel(0xc006d54f00, 0xc0085d1740, 0x3, 0x4, 0xc00a7396a0, 0x1a, 0x0, 0x1710a4516c7)
	github.com/mattermost/mattermost-server/v5@/app/channel.go:371 +0x81
github.com/mattermost/mattermost-server/v5/api4.createGroupChannel(0xc0085d1640, 0x1ff94a0, 0xc003e698f0, 0xc004dfae00)
	github.com/mattermost/mattermost-server/v5@/api4/channel.go:551 +0x437
github.com/mattermost/mattermost-server/v5/web.Handler.ServeHTTP(0xc0050cb6f0, 0x1da88d8, 0x2b0cb00, 0x12, 0x10001, 0x0, 0x0, 0x1ff94a0, 0xc003e698f0, 0xc004dfae00)
	github.com/mattermost/mattermost-server/v5@/web/handlers.go:212 +0x1e9a
github.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1(0x1ff8f20, 0xc0060882a0, 0xc004dfae00)
	github.com/NYTimes/gziphandler@v1.1.1/gzip.go:336 +0x23f
net/http.HandlerFunc.ServeHTTP(0xc004024120, 0x1ff8f20, 0xc0060882a0, 0xc004dfae00)
	net/http/server.go:2007 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc001680180, 0x1ff8f20, 0xc0060882a0, 0xc004dfac00)
	github.com/gorilla/mux@v1.7.3/mux.go:212 +0xe2
net/http.serverHandler.ServeHTTP(0xc00140c540, 0x1ff8f20, 0xc0060882a0, 0xc004dfac00)
	net/http/server.go:2802 +0xa4
net/http.(*conn).serve(0xc0042995e0, 0x1ffeee0, 0xc0063ee780)
	net/http/server.go:1890 +0x875
created by net/http.(*Server).Serve
	net/http/server.go:2927 +0x38e
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23521