### PR TITLE
MM-23770: Fix for blank DefaultChannelGuestRole on team schemes.

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/plugin/plugintest/mock"
 	"github.com/mattermost/mattermost-server/v5/store/storetest/mocks"
 	"github.com/mattermost/mattermost-server/v5/utils"
 	"github.com/stretchr/testify/assert"
@@ -3146,7 +3147,7 @@ func TestGetChannelModerations(t *testing.T) {
 
 		mockStore := mocks.Store{}
 		mockSchemeStore := mocks.SchemeStore{}
-		mockSchemeStore.On("Get", scheme.Id).Return(scheme, nil)
+		mockSchemeStore.On("Get", mock.Anything).Return(scheme, nil)
 		mockStore.On("Scheme").Return(&mockSchemeStore)
 		mockStore.On("Team").Return(th.App.Srv().Store.Team())
 		mockStore.On("Channel").Return(th.App.Srv().Store.Channel())

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/store/storetest/mocks"
 	"github.com/mattermost/mattermost-server/v5/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3137,6 +3138,34 @@ func TestGetChannelModerations(t *testing.T) {
 				require.Equal(t, moderation.Roles.Members.Value, true)
 			}
 		}
+	})
+
+	t.Run("Does not return an error if the team scheme has a blank DefaultChannelGuestRole field", func(t *testing.T) {
+		scheme := th.SetupTeamScheme()
+		scheme.DefaultChannelGuestRole = ""
+
+		mockStore := mocks.Store{}
+		mockSchemeStore := mocks.SchemeStore{}
+		mockSchemeStore.On("Get", scheme.Id).Return(scheme, nil)
+		mockStore.On("Scheme").Return(&mockSchemeStore)
+		mockStore.On("Team").Return(th.App.Srv().Store.Team())
+		mockStore.On("Channel").Return(th.App.Srv().Store.Channel())
+		mockStore.On("User").Return(th.App.Srv().Store.User())
+		mockStore.On("Post").Return(th.App.Srv().Store.Post())
+		mockStore.On("FileInfo").Return(th.App.Srv().Store.FileInfo())
+		mockStore.On("Webhook").Return(th.App.Srv().Store.Webhook())
+		mockStore.On("System").Return(th.App.Srv().Store.System())
+		mockStore.On("License").Return(th.App.Srv().Store.License())
+		mockStore.On("Role").Return(th.App.Srv().Store.Role())
+		mockStore.On("Close").Return(nil)
+		th.App.Srv().Store = &mockStore
+
+		team.SchemeId = &scheme.Id
+		_, err := th.App.UpdateTeamScheme(team)
+		require.Nil(t, err)
+
+		_, res := th.SystemAdminClient.GetChannelModerations(channel.Id, "")
+		require.Nil(t, res.Error)
 	})
 }
 


### PR DESCRIPTION
#### Summary

There are cases where `Schemes` records exist without a `DefaultChannelGuestRole` value and this change handles those.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23770
