### PR TITLE
Bump app version to 5.24

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -13,6 +13,8 @@ import (
 // It should be maintained in chronological order with most current
 // release at the front of the list.
 var versions = []string{
+	"5.24.0",
+	"5.23.0",
 	"5.22.0",
 	"5.21.0",
 	"5.20.0",


### PR DESCRIPTION
#### Summary
Given that the release branch for 5.22 has been cut, we can safely bump the app version to 5.24 now.