### PR TITLE
[MM-23727] Make channel validation consistent on the server

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -144,10 +144,6 @@ func (a *App) CreateChannelWithUser(channel *model.Channel, userId string) (*mod
 		return nil, model.NewAppError("CreateChannelWithUser", "api.channel.create_channel.direct_channel.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	if strings.Index(channel.Name, "__") > 0 {
-		return nil, model.NewAppError("CreateChannelWithUser", "api.channel.create_channel.invalid_character.app_error", nil, "", http.StatusBadRequest)
-	}
-
 	if len(channel.TeamId) == 0 {
 		return nil, model.NewAppError("CreateChannelWithUser", "app.channel.create_channel.no_team_id.app_error", nil, "", http.StatusBadRequest)
 	}
@@ -464,14 +460,6 @@ func (a *App) GetGroupChannel(userIds []string) (*model.Channel, *model.AppError
 
 // UpdateChannel updates a given channel by its Id. It also publishes the CHANNEL_UPDATED event.
 func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
-	userIds := strings.Split(channel.Name, "__")
-	if channel.Type != model.CHANNEL_DIRECT &&
-		len(userIds) == 2 &&
-		model.IsValidId(userIds[0]) &&
-		model.IsValidId(userIds[1]) {
-		return nil, model.NewAppError("UpdateChannel", "api.channel.update_channel.invalid_character.app_error", nil, "", http.StatusBadRequest)
-	}
-
 	_, err := a.Srv().Store.Channel().Update(channel)
 	if err != nil {
 		return nil, err

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -745,6 +745,14 @@ func TestRenameChannel(t *testing.T) {
 			"",
 		},
 		{
+			"Success on rename open channel with consecutive underscores in name",
+			th.createChannel(th.BasicTeam, model.CHANNEL_OPEN),
+			false,
+			"foo__bar",
+			"foo__bar",
+			"New Display Name",
+		},
+		{
 			"Fail on rename direct message channel",
 			th.CreateDmChannel(th.BasicUser2),
 			true,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4500,7 +4500,7 @@
   },
   {
     "id": "model.channel.is_valid.name.app_error",
-    "translation": "Invalid name. User ids are not permitted in channel name for non-direct message channels."
+    "translation": "Invalid channel name. User ids are not permitted in channel name for non-direct message channels."
   },
   {
     "id": "model.channel.is_valid.purpose.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -256,10 +256,6 @@
     "translation": "Must use createDirectChannel API service for direct message channel creation."
   },
   {
-    "id": "api.channel.create_channel.invalid_character.app_error",
-    "translation": "Invalid character '__' in channel name for non-direct channel."
-  },
-  {
     "id": "api.channel.create_channel.max_channel_limit.app_error",
     "translation": "Unable to create more than {{.MaxChannelsPerTeam}} channels for current team."
   },
@@ -422,10 +418,6 @@
   {
     "id": "api.channel.update_channel.deleted.app_error",
     "translation": "The channel has been archived or deleted."
-  },
-  {
-    "id": "api.channel.update_channel.invalid_character.app_error",
-    "translation": "Invalid channel name. User ids are not permitted in channel name for non-direct message channels."
   },
   {
     "id": "api.channel.update_channel.tried.app_error",
@@ -4505,6 +4497,10 @@
   {
     "id": "model.channel.is_valid.id.app_error",
     "translation": "Invalid Id."
+  },
+  {
+    "id": "model.channel.is_valid.name.app_error",
+    "translation": "Invalid name. User ids are not permitted in channel name for non-direct message channels."
   },
   {
     "id": "model.channel.is_valid.purpose.app_error",

--- a/model/channel.go
+++ b/model/channel.go
@@ -222,6 +222,11 @@ func (o *Channel) IsValid() *AppError {
 		return NewAppError("Channel.IsValid", "model.channel.is_valid.creator_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
+	userIds := strings.Split(o.Name, "__")
+	if o.Type != CHANNEL_DIRECT && len(userIds) == 2 && IsValidId(userIds[0]) && IsValidId(userIds[1]) {
+		return NewAppError("Channel.IsValid", "model.channel.is_valid.name.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
#### Summary
- ~Channel creation enforces that the channel URL must not contain `__` no matter which characters surround it so this PR changes the update and rename logic to match the create channel validations~

- This PR now removes the strict unnecessary validation (must not contain `__`) at the server level and ensures that it is consistent no matter where in the server a rename is done from.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23727

#### QA Test steps
- Attempt to rename a channel using the rename channel modal (or the CLI) and set the url to something like `channel__name`
- Ensure that it does not save