### PR TITLE
Revert "Updating to use a different network cidr for the mm-test network"

### DIFF
--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -45,11 +45,3 @@ services:
 networks:
   mm-test:
     driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.254.0/24
-          ip_range: 192.168.254.0/24
-          gateway: 192.168.254.1
-
-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,9 +62,3 @@ services:
 networks:
   mm-test:
     driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 192.168.254.0/24
-          ip_range: 192.168.254.0/24
-          gateway: 192.168.254.1


### PR DESCRIPTION
Reverts mattermost/mattermost-server#14223

This PR resulted into jenkins build issues. 