### PR TITLE
MM-23399: Fix for old team schemes that have a blank guest role.

### DIFF
--- a/store/localcachelayer/role_layer_test.go
+++ b/store/localcachelayer/role_layer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestRoleStore(t *testing.T) {
-	StoreTest(t, storetest.TestRoleStore)
+	StoreTestWithSqlSupplier(t, storetest.TestRoleStore)
 }
 
 func TestRoleStoreCache(t *testing.T) {

--- a/store/sqlstore/role_store_test.go
+++ b/store/sqlstore/role_store_test.go
@@ -10,5 +10,5 @@ import (
 )
 
 func TestRoleStore(t *testing.T) {
-	StoreTest(t, storetest.TestRoleStore)
+	StoreTestWithSqlSupplier(t, storetest.TestRoleStore)
 }


### PR DESCRIPTION
#### Summary

Same reason as the channel moderations API changes: there are team schemes in the wild with blank `DefaultChannelGuestRoles` fields. This supports that in the query.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-23399