### PR TITLE
MM-20934: Fixing int overflow in 32 bits on MaxImageSize check

### DIFF
--- a/app/brand.go
+++ b/app/brand.go
@@ -38,6 +38,9 @@ func (a *App) SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
+	// This casting is done to prevent overflow on 32 bit systems (not needed
+	// in 64 bits systems because images can have more than 32 bits height or
+	// width)
 	if int64(config.Width)*int64(config.Height) > model.MaxImageSize {
 		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.too_large.app_error", nil, "", http.StatusBadRequest)
 	}

--- a/app/brand.go
+++ b/app/brand.go
@@ -38,7 +38,7 @@ func (a *App) SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
-	if config.Width*config.Height > model.MaxImageSize {
+	if int64(config.Width)*int64(config.Height) > model.MaxImageSize {
 		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.too_large.app_error", nil, "", http.StatusBadRequest)
 	}
 

--- a/app/file.go
+++ b/app/file.go
@@ -728,6 +728,9 @@ func (t *UploadFileTask) preprocessImage() *model.AppError {
 	t.fileinfo.Height = config.Height
 
 	// Check dimensions before loading the whole thing into memory later on.
+	// This casting is done to prevent overflow on 32 bit systems (not needed
+	// in 64 bits systems because images can have more than 32 bits height or
+	// width)
 	if int64(t.fileinfo.Width)*int64(t.fileinfo.Height) > MaxImageSize {
 		return t.newAppError("api.file.upload_file.large_image_detailed.app_error",
 			"", http.StatusBadRequest)
@@ -911,6 +914,9 @@ func (a *App) DoUploadFileExpectModification(now time.Time, rawTeamId string, ra
 
 	if info.IsImage() {
 		// Check dimensions before loading the whole thing into memory later on
+		// This casting is done to prevent overflow on 32 bit systems (not needed
+		// in 64 bits systems because images can have more than 32 bits height or
+		// width)
 		if int64(info.Width)*int64(info.Height) > MaxImageSize {
 			err := model.NewAppError("uploadFile", "api.file.upload_file.large_image.app_error", map[string]interface{}{"Filename": filename}, "", http.StatusBadRequest)
 			return nil, data, err

--- a/app/file.go
+++ b/app/file.go
@@ -55,7 +55,7 @@ const (
 	RotatedCCWMirrored = 7
 	RotatedCW          = 8
 
-	MaxImageSize         = 6048 * 4032 // 24 megapixels, roughly 36MB as a raw image
+	MaxImageSize         = int64(6048 * 4032) // 24 megapixels, roughly 36MB as a raw image
 	ImageThumbnailWidth  = 120
 	ImageThumbnailHeight = 100
 	ImageThumbnailRatio  = float64(ImageThumbnailHeight) / float64(ImageThumbnailWidth)
@@ -728,7 +728,7 @@ func (t *UploadFileTask) preprocessImage() *model.AppError {
 	t.fileinfo.Height = config.Height
 
 	// Check dimensions before loading the whole thing into memory later on.
-	if t.fileinfo.Width*t.fileinfo.Height > MaxImageSize {
+	if int64(t.fileinfo.Width)*int64(t.fileinfo.Height) > MaxImageSize {
 		return t.newAppError("api.file.upload_file.large_image_detailed.app_error",
 			"", http.StatusBadRequest)
 	}
@@ -911,7 +911,7 @@ func (a *App) DoUploadFileExpectModification(now time.Time, rawTeamId string, ra
 
 	if info.IsImage() {
 		// Check dimensions before loading the whole thing into memory later on
-		if info.Width*info.Height > MaxImageSize {
+		if int64(info.Width)*int64(info.Height) > MaxImageSize {
 			err := model.NewAppError("uploadFile", "api.file.upload_file.large_image.app_error", map[string]interface{}{"Filename": filename}, "", http.StatusBadRequest)
 			return nil, data, err
 		}

--- a/app/team.go
+++ b/app/team.go
@@ -1510,7 +1510,7 @@ func (a *App) SetTeamIconFromMultiPartFile(teamId string, file multipart.File) *
 	if err != nil {
 		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
-	if config.Width*config.Height > model.MaxImageSize {
+	if int64(config.Width)*int64(config.Height) > model.MaxImageSize {
 		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.too_large.app_error", nil, "", http.StatusBadRequest)
 	}
 

--- a/app/team.go
+++ b/app/team.go
@@ -1510,6 +1510,10 @@ func (a *App) SetTeamIconFromMultiPartFile(teamId string, file multipart.File) *
 	if err != nil {
 		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
+
+	// This casting is done to prevent overflow on 32 bit systems (not needed
+	// in 64 bits systems because images can have more than 32 bits height or
+	// width)
 	if int64(config.Width)*int64(config.Height) > model.MaxImageSize {
 		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.too_large.app_error", nil, "", http.StatusBadRequest)
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -833,6 +833,9 @@ func (a *App) SetProfileImageFromMultiPartFile(userId string, file multipart.Fil
 	if err != nil {
 		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
+	// This casting is done to prevent overflow on 32 bit systems (not needed
+	// in 64 bits systems because images can have more than 32 bits height or
+	// width)
 	if int64(config.Width)*int64(config.Height) > model.MaxImageSize {
 		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.too_large.app_error", nil, "", http.StatusBadRequest)
 	}

--- a/app/user.go
+++ b/app/user.go
@@ -833,7 +833,7 @@ func (a *App) SetProfileImageFromMultiPartFile(userId string, file multipart.Fil
 	if err != nil {
 		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.decode_config.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
-	if config.Width*config.Height > model.MaxImageSize {
+	if int64(config.Width)*int64(config.Height) > model.MaxImageSize {
 		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.too_large.app_error", nil, "", http.StatusBadRequest)
 	}
 

--- a/model/file.go
+++ b/model/file.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	MaxImageSize = 6048 * 4032 // 24 megapixels, roughly 36MB as a raw image
+	MaxImageSize = int64(6048 * 4032) // 24 megapixels, roughly 36MB as a raw image
 )
 
 var (

--- a/store/opentracing_layer.go
+++ b/store/opentracing_layer.go
@@ -3247,6 +3247,24 @@ func (s *OpenTracingLayerGroupStore) GetGroups(page int, perPage int, opts model
 	return resultVar0, resultVar1
 }
 
+func (s *OpenTracingLayerGroupStore) GetGroupsAssociatedToChannelsByTeam(teamId string, opts model.GroupSearchOpts) (map[string][]*model.GroupWithSchemeAdmin, *model.AppError) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "GroupStore.GetGroupsAssociatedToChannelsByTeam")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := s.GroupStore.GetGroupsAssociatedToChannelsByTeam(teamId, opts)
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (s *OpenTracingLayerGroupStore) GetGroupsByChannel(channelId string, opts model.GroupSearchOpts) ([]*model.GroupWithSchemeAdmin, *model.AppError) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "GroupStore.GetGroupsByChannel")

--- a/store/timer_layer.go
+++ b/store/timer_layer.go
@@ -2974,22 +2974,6 @@ func (s *TimerLayerGroupStore) GetGroups(page int, perPage int, opts model.Group
 	return resultVar0, resultVar1
 }
 
-func (s *TimerLayerGroupStore) GetGroupsByChannel(channelId string, opts model.GroupSearchOpts) ([]*model.GroupWithSchemeAdmin, *model.AppError) {
-	start := timemodule.Now()
-
-	resultVar0, resultVar1 := s.GroupStore.GetGroupsByChannel(channelId, opts)
-
-	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
-	if s.Root.Metrics != nil {
-		success := "false"
-		if resultVar1 == nil {
-			success = "true"
-		}
-		s.Root.Metrics.ObserveStoreMethodDuration("GroupStore.GetGroupsByChannel", success, elapsed)
-	}
-	return resultVar0, resultVar1
-}
-
 func (s *TimerLayerGroupStore) GetGroupsAssociatedToChannelsByTeam(teamId string, opts model.GroupSearchOpts) (map[string][]*model.GroupWithSchemeAdmin, *model.AppError) {
 	start := timemodule.Now()
 
@@ -3002,6 +2986,22 @@ func (s *TimerLayerGroupStore) GetGroupsAssociatedToChannelsByTeam(teamId string
 			success = "true"
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("GroupStore.GetGroupsAssociatedToChannelsByTeam", success, elapsed)
+	}
+	return resultVar0, resultVar1
+}
+
+func (s *TimerLayerGroupStore) GetGroupsByChannel(channelId string, opts model.GroupSearchOpts) ([]*model.GroupWithSchemeAdmin, *model.AppError) {
+	start := timemodule.Now()
+
+	resultVar0, resultVar1 := s.GroupStore.GetGroupsByChannel(channelId, opts)
+
+	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if resultVar1 == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("GroupStore.GetGroupsByChannel", success, elapsed)
 	}
 	return resultVar0, resultVar1
 }


### PR DESCRIPTION
#### Summary
Fixing int overflow in 32 bits on MaxImageSize check. The width/heigh was
working with big-enough numbers for handling huge images in 64 bits, but in 32
bits, there were using 32 bits to represent the width and the height (what is
enough) but not when you multiple them. This was generating and overflow that
can lead to allow you to upload images bigger than the allowed ones.

I tested the solution in ARM and 386 architectures (only the overflow situation, not whole upload image process).

#### Ticket Link
[MM-20934](https://mattermost.atlassian.net/browse/MM-20934)