### PR TITLE
[MM-24059] Rename ExperimentalChannelSidebarOrganization to ExperimentalSidebarFeatures

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -318,7 +318,7 @@ func (a *App) trackConfig() {
 		"experimental_strict_csrf_enforcement":                    *cfg.ServiceSettings.ExperimentalStrictCSRFEnforcement,
 		"enable_email_invitations":                                *cfg.ServiceSettings.EnableEmailInvitations,
 		"experimental_channel_organization":                       *cfg.ServiceSettings.ExperimentalChannelOrganization,
-		"experimental_channel_sidebar_organization":               *cfg.ServiceSettings.ExperimentalChannelSidebarOrganization,
+		"experimental_sidebar_features":               			   *cfg.ServiceSettings.ExperimentalSidebarFeatures,
 		"disable_bots_when_owner_is_deactivated":                  *cfg.ServiceSettings.DisableBotsWhenOwnerIsDeactivated,
 		"enable_bot_account_creation":                             *cfg.ServiceSettings.EnableBotAccountCreation,
 		"enable_svgs":                                             *cfg.ServiceSettings.EnableSVGs,

--- a/config/client.go
+++ b/config/client.go
@@ -57,7 +57,7 @@ func GenerateClientConfig(c *model.Config, diagnosticID string, license *model.L
 		props["ExperimentalChannelOrganization"] = strconv.FormatBool(false)
 	}
 
-	props["ExperimentalChannelSidebarOrganization"] = *c.ServiceSettings.ExperimentalChannelSidebarOrganization
+	props["ExperimentalSidebarFeatures"] = *c.ServiceSettings.ExperimentalSidebarFeatures
 	props["ExperimentalEnableAutomaticReplies"] = strconv.FormatBool(*c.TeamSettings.ExperimentalEnableAutomaticReplies)
 	props["ExperimentalTimezone"] = strconv.FormatBool(*c.DisplaySettings.ExperimentalTimezone)
 

--- a/model/config.go
+++ b/model/config.go
@@ -314,7 +314,7 @@ type ServiceSettings struct {
 	ExperimentalEnableDefaultChannelLeaveJoinMessages *bool
 	ExperimentalGroupUnreadChannels                   *string
 	ExperimentalChannelOrganization                   *bool
-	ExperimentalChannelSidebarOrganization            *string
+	ExperimentalSidebarFeatures            			  *string
 	DEPRECATED_DO_NOT_USE_ImageProxyType              *string `json:"ImageProxyType" mapstructure:"ImageProxyType"`       // This field is deprecated and must not be used.
 	DEPRECATED_DO_NOT_USE_ImageProxyURL               *string `json:"ImageProxyURL" mapstructure:"ImageProxyURL"`         // This field is deprecated and must not be used.
 	DEPRECATED_DO_NOT_USE_ImageProxyOptions           *string `json:"ImageProxyOptions" mapstructure:"ImageProxyOptions"` // This field is deprecated and must not be used.
@@ -652,8 +652,8 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 		s.ExperimentalChannelOrganization = NewBool(experimentalUnreadEnabled)
 	}
 
-	if s.ExperimentalChannelSidebarOrganization == nil {
-		s.ExperimentalChannelSidebarOrganization = NewString("disabled")
+	if s.ExperimentalSidebarFeatures == nil {
+		s.ExperimentalSidebarFeatures = NewString("disabled")
 	}
 
 	if s.DEPRECATED_DO_NOT_USE_ImageProxyType == nil {


### PR DESCRIPTION
#### Summary
Renaming the setting to be less confused with the older ExperimentalChannelOrganization.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24059

#### Related PRs
Redux: https://github.com/mattermost/mattermost-redux/pull/1126
Webapp: https://github.com/mattermost/mattermost-webapp/pull/5318