### PR TITLE
[MM-24097] app/diagnostics: add telemetry for smtp_server_timeout

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -447,6 +447,7 @@ func (a *App) trackConfig() {
 		"isdefault_login_button_color":         isDefault(*cfg.EmailSettings.LoginButtonColor, ""),
 		"isdefault_login_button_border_color":  isDefault(*cfg.EmailSettings.LoginButtonBorderColor, ""),
 		"isdefault_login_button_text_color":    isDefault(*cfg.EmailSettings.LoginButtonTextColor, ""),
+		"smtp_server_timeout":                  *cfg.EmailSettings.SMTPServerTimeout,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_RATE, map[string]interface{}{


### PR DESCRIPTION
#### Summary
This PR adds telemetry for the `SMTPServerTimeout` configuration.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24097
