### PR TITLE
MM-24094  EnableOpenTracing config setting missing from telemetry

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -325,6 +325,7 @@ func (a *App) trackConfig() {
 		"enable_bot_account_creation":                             *cfg.ServiceSettings.EnableBotAccountCreation,
 		"enable_svgs":                                             *cfg.ServiceSettings.EnableSVGs,
 		"enable_latex":                                            *cfg.ServiceSettings.EnableLatex,
+		"enable_opentracing":                                      *cfg.ServiceSettings.EnableOpenTracing,
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_TEAM, map[string]interface{}{


### PR DESCRIPTION
#### Summary
added enable_opentracing to diagnostics
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24094
Docs PR: https://github.com/mattermost/docs/pull/3534