### PR TITLE
[MM-23605] Create new team scheme updated socket event

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -188,7 +188,7 @@ func (a *App) UpdateTeamScheme(team *model.Team) (*model.Team, *model.AppError) 
 		return nil, err
 	}
 
-	a.sendTeamEvent(oldTeam, model.WEBSOCKET_EVENT_UPDATE_TEAM)
+	a.sendTeamEvent(oldTeam, model.WEBSOCKET_EVENT_UPDATE_TEAM_SCHEME)
 
 	return oldTeam, nil
 }

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -31,6 +31,7 @@ const (
 	WEBSOCKET_EVENT_UPDATE_TEAM             = "update_team"
 	WEBSOCKET_EVENT_DELETE_TEAM             = "delete_team"
 	WEBSOCKET_EVENT_RESTORE_TEAM            = "restore_team"
+	WEBSOCKET_EVENT_UPDATE_TEAM_SCHEME      = "update_team_scheme"
 	WEBSOCKET_EVENT_USER_ADDED              = "user_added"
 	WEBSOCKET_EVENT_USER_UPDATED            = "user_updated"
 	WEBSOCKET_EVENT_USER_ROLE_UPDATED       = "user_role_updated"


### PR DESCRIPTION
#### Summary
- Adds a new websocket event to be triggered when a scheme is assigned to a team 
- `update_team` which was previously being used only reloads the team in the state and not the memberships, so I created a new websocket event for a scheme being added/removed from a team

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23605