### PR TITLE
license: dropping PhoneNumber field from the license

### DIFF
--- a/app/license.go
+++ b/app/license.go
@@ -204,7 +204,6 @@ func (a *App) GetSanitizedClientLicense() map[string]string {
 	delete(sanitizedLicense, "Id")
 	delete(sanitizedLicense, "Name")
 	delete(sanitizedLicense, "Email")
-	delete(sanitizedLicense, "PhoneNumber")
 	delete(sanitizedLicense, "IssuedAt")
 	delete(sanitizedLicense, "StartsAt")
 	delete(sanitizedLicense, "ExpiresAt")

--- a/model/license.go
+++ b/model/license.go
@@ -32,11 +32,10 @@ type License struct {
 }
 
 type Customer struct {
-	Id          string `json:"id"`
-	Name        string `json:"name"`
-	Email       string `json:"email"`
-	Company     string `json:"company"`
-	PhoneNumber string `json:"phone_number"`
+	Id      string `json:"id"`
+	Name    string `json:"name"`
+	Email   string `json:"email"`
+	Company string `json:"company"`
 }
 
 type Features struct {

--- a/model/license_test.go
+++ b/model/license_test.go
@@ -136,11 +136,10 @@ func TestLicenseToFromJson(t *testing.T) {
 		StartsAt:  GetMillis(),
 		ExpiresAt: GetMillis(),
 		Customer: &Customer{
-			Id:          NewId(),
-			Name:        NewId(),
-			Email:       NewId(),
-			Company:     NewId(),
-			PhoneNumber: NewId(),
+			Id:      NewId(),
+			Name:    NewId(),
+			Email:   NewId(),
+			Company: NewId(),
 		},
 		Features: &f,
 	}
@@ -159,7 +158,6 @@ func TestLicenseToFromJson(t *testing.T) {
 	CheckString(t, l1.Customer.Name, l.Customer.Name)
 	CheckString(t, l1.Customer.Email, l.Customer.Email)
 	CheckString(t, l1.Customer.Company, l.Customer.Company)
-	CheckString(t, l1.Customer.PhoneNumber, l.Customer.PhoneNumber)
 
 	f1 := l1.Features
 

--- a/utils/license.go
+++ b/utils/license.go
@@ -151,7 +151,6 @@ func GetClientLicense(l *model.License) map[string]string {
 		props["Name"] = l.Customer.Name
 		props["Email"] = l.Customer.Email
 		props["Company"] = l.Customer.Company
-		props["PhoneNumber"] = l.Customer.PhoneNumber
 		props["EmailNotificationContents"] = strconv.FormatBool(*l.Features.EmailNotificationContents)
 		props["MessageExport"] = strconv.FormatBool(*l.Features.MessageExport)
 		props["CustomPermissionsSchemes"] = strconv.FormatBool(*l.Features.CustomPermissionsSchemes)


### PR DESCRIPTION
#### Summary
Per request of the biz team and checking the code this field `PhoneNumber` is not used
in any place and also is one information that is not needed at all.

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-24297
GH: https://github.com/mattermost/license-generator/issues/1