### PR TITLE
dockerfile: set 5.22.0 version

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.11
 ENV PATH="/mattermost/bin:${PATH}"
 ARG PUID=2000
 ARG PGID=2000
-ARG MM_PACKAGE="https://releases.mattermost.com/5.21.0/mattermost-5.21.0-linux-amd64.tar.gz"
+ARG MM_PACKAGE="https://releases.mattermost.com/5.22.0/mattermost-5.22.0-linux-amd64.tar.gz"
 
 
 # Install some needed packages


### PR DESCRIPTION
#### Summary
Default the dockerfile to use the release 5.22.0


will be good to cherry pick this to the release 5.22 branch as well to default there as well