### PR TITLE
Include dejavu in docker compose

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -53,5 +53,10 @@ services:
       - mm-test
     environment:
       http.host: "0.0.0.0"
+      http.port: 9200
+      http.cors.enabled: "true"
+      http.cors.allow-origin: "http://localhost:1358,http://127.0.0.1:1358"
+      http.cors.allow-headers: "X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization"
+      http.cors.allow-credentials: "true"
       transport.host: "127.0.0.1"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"

--- a/build/docker-compose.optional.yml
+++ b/build/docker-compose.optional.yml
@@ -1,0 +1,6 @@
+version: '2.4'
+services:
+  dejavu:
+    image: "appbaseio/dejavu:latest"
+    networks:
+      - mm-test

--- a/build/docker-compose.optional.yml
+++ b/build/docker-compose.optional.yml
@@ -1,6 +1,6 @@
 version: '2.4'
 services:
   dejavu:
-    image: "appbaseio/dejavu:latest"
+    image: "appbaseio/dejavu:3.4.2"
     networks:
       - mm-test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,14 @@ services:
     extends:
         file: build/docker-compose.common.yml
         service: elasticsearch
+  dejavu:
+    container_name: mattermost-dejavu
+    ports:
+      - "1358:1358"
+    extends:
+        file: build/docker-compose.optional.yml
+        service: dejavu
+
   start_dependencies:
     image: mattermost/mattermost-wait-for-dep:latest
     networks:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at another repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Proposal to add [dejavu](https://github.com/appbaseio/dejavu), an Elasticsearch UI, to our docker-compose as an optional tool. So it's configured but you can run it if needed

It's a proposal because when you need to check or edit the ES data or indexes is painful so this tool helps a lot in that task

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
