### PR TITLE
Fix assertExpectedWebsocketEvent ignoring the passed event

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1756,13 +1756,13 @@ func assertExpectedWebsocketEvent(t *testing.T, client *model.WebSocketClient, e
 	for {
 		select {
 		case resp, ok := <-client.EventChannel:
-			require.Truef(t, ok, "channel closed before receiving expected event %s", model.WEBSOCKET_EVENT_USER_UPDATED)
-			if resp.EventType() == model.WEBSOCKET_EVENT_USER_UPDATED {
+			require.Truef(t, ok, "channel closed before receiving expected event %s", event)
+			if resp.EventType() == event {
 				test(resp)
 				return
 			}
 		case <-time.After(5 * time.Second):
-			require.Failf(t, "failed to receive expected event %s", model.WEBSOCKET_EVENT_USER_UPDATED)
+			require.Failf(t, "failed to receive expected event %s", event)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
Fix assertExpectedWebsocketEvent ignoring the passed event

#### Ticket Link
Discovered while working on #12609 https://mattermost.atlassian.net/browse/MM-18756