### PR TITLE
Fix build failure.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,7 +15,7 @@ echo "Packages to test: $PACKAGES"
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
 find . -type d -name data -not -path './vendor/*' | xargs rm -rf
 
-$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=2000s -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 | tee output
+$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=2000s -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?
 
 cat output | $GOPATH/bin/go-junit-report > report.xml

--- a/store/storetest/settings.go
+++ b/store/storetest/settings.go
@@ -225,7 +225,7 @@ func CleanupSqlSettings(settings *model.SqlSettings) {
 		panic("unsupported driver " + driver)
 	}
 
-	if err := execAsRoot(settings, "DROP DATABASE "+dbName); err != nil {
+	if err := execAsRoot(settings, "DROP DATABASE IF EXISTS "+dbName); err != nil {
 		panic("failed to drop temporary database " + dbName + ": " + err.Error())
 	}
 


### PR DESCRIPTION
#### Summary
```
panic: failed to drop temporary database dbxssrb7uhnb8o384mprrxg4fo1r: failed to execute `DROP DATABASE dbxssrb7uhnb8o384mprrxg4fo1r` against mysql database as root: Error 1008: Can't drop database 'dbxssrb7uhnb8o384mprrxg4fo1r'; database doesn't exist
goroutine 1 [running]:
github.com/mattermost/mattermost-server/v5/store/storetest.CleanupSqlSettings(0xc000152150)
/go/src/github.com/mattermost/mattermost-server/store/storetest/settings.go:229 +0x234
```

#### Ticket Link
