### PR TITLE
MM-24197 - CI: API checks should take into account existing documentation branch (if exists)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,8 @@ jobs:
           command: |
             git clone https://github.com/mattermost/mattermost-api-reference.git
             cd mattermost-api-reference
+            echo "Trying to checkout the same branch on mattermost-api-reference as mattermost-server"
+            git checkout ${CIRCLE_BRANCH} || true
             make build
       - persist_to_workspace:
           root: ~/mattermost


### PR DESCRIPTION
#### Summary
Currently the API documentation check step in CircleCI uses `master` branch of mattermost-api-documentation.
This PR adds an attempt to use a branch that matches the `mattermost-server` branch name to avoid failing builds

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24197