### PR TITLE
MM-24397: Reusing the read buffer while reading messages from websockets

### DIFF
--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -175,7 +175,6 @@ func (wsc *WebSocketClient) Listen() {
 		for {
 			// Reset buffer.
 			buf.Reset()
-			var rawMsg json.RawMessage
 			_, r, err := wsc.Conn.NextReader()
 			if err != nil {
 				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
@@ -193,7 +192,6 @@ func (wsc *WebSocketClient) Listen() {
 				return
 			}
 
-			rawMsg = buf.Bytes()
 			event := WebSocketEventFromJson(&buf)
 			if event == nil {
 				continue
@@ -204,7 +202,7 @@ func (wsc *WebSocketClient) Listen() {
 			}
 
 			var response WebSocketResponse
-			if err := json.Unmarshal(rawMsg, &response); err == nil && response.IsValid() {
+			if err := json.Unmarshal(buf.Bytes(), &response); err == nil && response.IsValid() {
 				wsc.ResponseChannel <- &response
 				continue
 			}

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -173,6 +173,8 @@ func (wsc *WebSocketClient) Listen() {
 		buf.Grow(avgReadMsgSizeBytes)
 
 		for {
+			// Reset buffer.
+			buf.Reset()
 			var rawMsg json.RawMessage
 			_, r, err := wsc.Conn.NextReader()
 			if err != nil {
@@ -193,8 +195,6 @@ func (wsc *WebSocketClient) Listen() {
 
 			rawMsg = buf.Bytes()
 			event := WebSocketEventFromJson(&buf)
-			// Reset buffer.
-			buf.Reset()
 			if event == nil {
 				continue
 			}

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -6,7 +6,6 @@ package model
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -175,9 +174,7 @@ func (wsc *WebSocketClient) Listen() {
 
 		for {
 			var rawMsg json.RawMessage
-			var err error
-			var r io.Reader
-			_, r, err = wsc.Conn.NextReader()
+			_, r, err := wsc.Conn.NextReader()
 			if err != nil {
 				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
 					wsc.ListenError = NewAppError("NewWebSocketClient", "model.websocket_client.connect_fail.app_error", nil, err.Error(), http.StatusInternalServerError)
@@ -195,7 +192,7 @@ func (wsc *WebSocketClient) Listen() {
 			}
 
 			rawMsg = buf.Bytes()
-			event := WebSocketEventFromJson(bytes.NewReader(rawMsg))
+			event := WebSocketEventFromJson(&buf)
 			// Reset buffer.
 			buf.Reset()
 			if event == nil {

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -175,6 +175,7 @@ func (wsc *WebSocketClient) Listen() {
 		for {
 			// Reset buffer.
 			buf.Reset()
+			var rawBytes []byte
 			_, r, err := wsc.Conn.NextReader()
 			if err != nil {
 				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
@@ -192,6 +193,8 @@ func (wsc *WebSocketClient) Listen() {
 				return
 			}
 
+			// This needs to be called before WebSocketEventFromJson consumes the buffer.
+			rawBytes = buf.Bytes()
 			event := WebSocketEventFromJson(&buf)
 			if event == nil {
 				continue
@@ -202,7 +205,7 @@ func (wsc *WebSocketClient) Listen() {
 			}
 
 			var response WebSocketResponse
-			if err := json.Unmarshal(buf.Bytes(), &response); err == nil && response.IsValid() {
+			if err := json.Unmarshal(rawBytes, &response); err == nil && response.IsValid() {
 				wsc.ResponseChannel <- &response
 				continue
 			}

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -175,7 +175,6 @@ func (wsc *WebSocketClient) Listen() {
 		for {
 			// Reset buffer.
 			buf.Reset()
-			var rawBytes []byte
 			_, r, err := wsc.Conn.NextReader()
 			if err != nil {
 				if !websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
@@ -193,9 +192,7 @@ func (wsc *WebSocketClient) Listen() {
 				return
 			}
 
-			// This needs to be called before WebSocketEventFromJson consumes the buffer.
-			rawBytes = buf.Bytes()
-			event := WebSocketEventFromJson(&buf)
+			event := WebSocketEventFromJson(bytes.NewReader(buf.Bytes()))
 			if event == nil {
 				continue
 			}
@@ -205,7 +202,7 @@ func (wsc *WebSocketClient) Listen() {
 			}
 
 			var response WebSocketResponse
-			if err := json.Unmarshal(rawBytes, &response); err == nil && response.IsValid() {
+			if err := json.Unmarshal(buf.Bytes(), &response); err == nil && response.IsValid() {
 				wsc.ResponseChannel <- &response
 				continue
 			}


### PR DESCRIPTION
#### Summary

The core problem was that conn.ReadMessage allocated a buffer every time it was read.
This created heavy amount of allocations every single time we read a message from the websocket.

To avoid this, we bypass the ReadMessage which was more of a helper method,
and actually call the NextReader which returns a reader object.
We can then reuse a single byte.Buffer instance to read the object unmarshal
into a WebSocketEvent object. This gets rid of the allocation in the read path completly
and allows GC more time to do other tasks.

As we can see from the alloc_space profile here:

Before:
![baseheap](https://user-images.githubusercontent.com/1774000/80229652-5f342980-866e-11ea-8fd6-d826bcaa4efb.png)

After:
![reusedheap](https://user-images.githubusercontent.com/1774000/80229664-622f1a00-866e-11ea-909d-6017e2999f6b.png)

There were 2 big boxes in the original profile. Not there's just one. So effectively 10GB of allocation is gone.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-24397
