### PR TITLE
app: outdent skipSend condition

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -187,7 +187,7 @@ func (wc *WebConn) writePump() {
 				case model.WEBSOCKET_EVENT_TYPING,
 					model.WEBSOCKET_EVENT_STATUS_CHANGE,
 					model.WEBSOCKET_EVENT_CHANNEL_VIEWED:
-					mlog.Info(
+					mlog.Warn(
 						"websocket.slow: dropping message",
 						mlog.String("user_id", wc.UserId),
 						mlog.String("type", msg.EventType()),
@@ -197,40 +197,41 @@ func (wc *WebConn) writePump() {
 				}
 			}
 
-			if !skipSend {
-				var msgBytes []byte
-				if evtOk {
-					cpyEvt := evt.SetSequence(wc.Sequence)
-					msgBytes = []byte(cpyEvt.ToJson())
-					wc.Sequence++
-				} else {
-					msgBytes = []byte(msg.ToJson())
-				}
-
-				if len(wc.send) >= sendFullWarn {
-					logData := []mlog.Field{
-						mlog.String("user_id", wc.UserId),
-						mlog.String("type", msg.EventType()),
-						mlog.Int("size", len(msgBytes)),
-					}
-					if evtOk {
-						logData = append(logData, mlog.String("channel_id", evt.GetBroadcast().ChannelId))
-					}
-
-					mlog.Warn("websocket.full", logData...)
-				}
-
-				wc.WebSocket.SetWriteDeadline(time.Now().Add(writeWaitTime))
-				if err := wc.WebSocket.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
-					wc.logSocketErr("websocket.send", err)
-					return
-				}
-
-				if wc.App.Metrics() != nil {
-					wc.App.Metrics().IncrementWebSocketBroadcast(msg.EventType())
-				}
+			if skipSend {
+				continue
 			}
 
+			var msgBytes []byte
+			if evtOk {
+				cpyEvt := evt.SetSequence(wc.Sequence)
+				msgBytes = []byte(cpyEvt.ToJson())
+				wc.Sequence++
+			} else {
+				msgBytes = []byte(msg.ToJson())
+			}
+
+			if len(wc.send) >= sendFullWarn {
+				logData := []mlog.Field{
+					mlog.String("user_id", wc.UserId),
+					mlog.String("type", msg.EventType()),
+					mlog.Int("size", len(msgBytes)),
+				}
+				if evtOk {
+					logData = append(logData, mlog.String("channel_id", evt.GetBroadcast().ChannelId))
+				}
+
+				mlog.Warn("websocket.full", logData...)
+			}
+
+			wc.WebSocket.SetWriteDeadline(time.Now().Add(writeWaitTime))
+			if err := wc.WebSocket.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+				wc.logSocketErr("websocket.send", err)
+				return
+			}
+
+			if wc.App.Metrics() != nil {
+				wc.App.Metrics().IncrementWebSocketBroadcast(msg.EventType())
+			}
 		case <-ticker.C:
 			wc.WebSocket.SetWriteDeadline(time.Now().Add(writeWaitTime))
 			if err := wc.WebSocket.WriteMessage(websocket.PingMessage, []byte{}); err != nil {


### PR DESCRIPTION
We invert the skipSend condition and outdent the remaining block
to make the code a bit more idiomatic.

While here, we also change the dropping message level from info to
warn because that's what it should be.
