### PR TITLE
MM-24395: Set response header to be attachment for SVG images.

### DIFF
--- a/services/imageproxy/local.go
+++ b/services/imageproxy/local.go
@@ -75,18 +75,16 @@ type contentTypeRecorder struct {
 }
 
 func (rec *contentTypeRecorder) WriteHeader(code int) {
-	defer rec.ResponseWriter.WriteHeader(code)
-
 	hdr := rec.ResponseWriter.Header()
 	contentType := hdr.Get("Content-Type")
 	mediaType, _, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		mlog.Error("error in decoding media type", mlog.Err(err))
-		return
-	}
-	if mediaType == "image/svg+xml" {
+	// The error is caused by a malformed input and there's not much use logging it.
+	// Therefore, even in the error case we set it to attachment mode to be safe.
+	if err != nil || mediaType == "image/svg+xml" {
 		hdr.Set("Content-Disposition", fmt.Sprintf("attachment;filename=%q", rec.filename))
 	}
+
+	rec.ResponseWriter.WriteHeader(code)
 }
 
 func (backend *LocalBackend) GetImage(w http.ResponseWriter, r *http.Request, imageURL string) {

--- a/services/imageproxy/local_test.go
+++ b/services/imageproxy/local_test.go
@@ -168,7 +168,7 @@ func TestLocalBackend_GetImage(t *testing.T) {
 	t.Run("SVG attachment", func(t *testing.T) {
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Cache-Control", "max-age=2592000, private")
-			w.Header().Set("Content-Type", "image/png")
+			w.Header().Set("Content-Type", "image/svg+xml")
 			w.Header().Set("Content-Length", "10")
 
 			w.WriteHeader(http.StatusOK)

--- a/services/imageproxy/local_test.go
+++ b/services/imageproxy/local_test.go
@@ -181,15 +181,16 @@ func TestLocalBackend_GetImage(t *testing.T) {
 		proxy := makeTestLocalProxy()
 
 		recorder := httptest.NewRecorder()
-		request, _ := http.NewRequest(http.MethodGet, "", nil)
+		request, err := http.NewRequest(http.MethodGet, "", nil)
+		require.NoError(t, err)
 		proxy.GetImage(recorder, request, mock.URL+"/test.svg")
 		resp := recorder.Result()
 
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		require.Equal(t, "attachment;filename=\"test.svg\"", resp.Header.Get("Content-Disposition"))
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "attachment;filename=\"test.svg\"", resp.Header.Get("Content-Disposition"))
 
-		respBody, _ := ioutil.ReadAll(resp.Body)
-		assert.Equal(t, []byte("1111111111"), respBody)
+		_, err = ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
 	})
 }
 


### PR DESCRIPTION
We check the file extension and appropriately set the response header.
SVG images without a file extension aren't proxied at all. So there's no
problem with that.


#### Ticket link

https://mattermost.atlassian.net/browse/MM-24395