### PR TITLE
MM-24547: Fix writer leak when connection closes

### DIFF
--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -183,10 +183,10 @@ func (wsc *WebSocketClient) Listen() {
 	// But if (1) happens, we set the closed bit, and close the rest of the stuff.
 	go func() {
 		defer func() {
-			// We CAS to 1 and proceed.
 			close(wsc.EventChannel)
 			close(wsc.ResponseChannel)
 			close(wsc.quitPingWatchdog)
+			// We CAS to 1 and proceed.
 			if !atomic.CompareAndSwapInt32(&wsc.closed, 0, 1) {
 				return
 			}

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -136,6 +136,8 @@ func (wsc *WebSocketClient) ConnectWithDialer(dialer *websocket.Dialer) *AppErro
 	return nil
 }
 
+// Close closes the websocket client. It is recommended that a closed client should not be
+// reused again. Rather a new client should be created anew.
 func (wsc *WebSocketClient) Close() {
 	// CAS to 1 and proceed. Return if already 1.
 	if !atomic.CompareAndSwapInt32(&wsc.closed, 0, 1) {
@@ -143,10 +145,9 @@ func (wsc *WebSocketClient) Close() {
 	}
 	wsc.quitWriterChan <- struct{}{}
 	close(wsc.writeChan)
+	// We close the connection, which breaks the reader loop.
+	// Then we let the defer block in the reader do further cleanup.
 	wsc.Conn.Close()
-	close(wsc.EventChannel)
-	close(wsc.ResponseChannel)
-	close(wsc.quitPingWatchdog)
 }
 
 // TODO: un-export the Conn so that Write methods go through the writer
@@ -166,9 +167,33 @@ func (wsc *WebSocketClient) writer() {
 	}
 }
 
+// Listen starts the read loop of the websocket client.
 func (wsc *WebSocketClient) Listen() {
+	// This loop can exit in 2 conditions:
+	// 1. Either the connection breaks naturally.
+	// 2. Close was explicitly called, which closes the connection manually.
+	//
+	// Due to the way the API is written, there is a requirement that a client may NOT
+	// call Listen at all and can still call Close and Connect.
+	// Therefore, we let the cleanup of the reader stuff rely on closing the connection
+	// and then we do the cleanup in the defer block.
+	//
+	// First, we close some channels and then CAS to 1 and proceed to close the writer chan also.
+	// This is needed because then the defer clause does not double-close the writer when (2) happens.
+	// But if (1) happens, we set the closed bit, and close the rest of the stuff.
 	go func() {
-		defer wsc.Close()
+		defer func() {
+			// We CAS to 1 and proceed.
+			close(wsc.EventChannel)
+			close(wsc.ResponseChannel)
+			close(wsc.quitPingWatchdog)
+			if !atomic.CompareAndSwapInt32(&wsc.closed, 0, 1) {
+				return
+			}
+			wsc.quitWriterChan <- struct{}{}
+			close(wsc.writeChan)
+			wsc.Conn.Close() // This can most likely be removed. Needs to be checked.
+		}()
 
 		var buf bytes.Buffer
 		buf.Grow(avgReadMsgSizeBytes)
@@ -207,7 +232,6 @@ func (wsc *WebSocketClient) Listen() {
 				wsc.ResponseChannel <- &response
 				continue
 			}
-
 		}
 	}()
 }

--- a/model/websocket_client_test.go
+++ b/model/websocket_client_test.go
@@ -84,7 +84,7 @@ func TestWebSocketClose(t *testing.T) {
 	checkWriteChan := func(writeChan chan writeMessage) {
 		defer func() {
 			if x := recover(); x == nil {
-				require.Fail(t, "should have panicked due to sending to a closed channel")
+				require.Fail(t, "should have panicked due to closing a closed channel")
 			}
 		}()
 		close(writeChan)

--- a/model/websocket_client_test.go
+++ b/model/websocket_client_test.go
@@ -87,7 +87,7 @@ func TestWebSocketClose(t *testing.T) {
 				require.Fail(t, "should have panicked due to sending to a closed channel")
 			}
 		}()
-		writeChan <- writeMessage{}
+		close(writeChan)
 	}
 
 	waitForResponses := func(doneChan chan struct{}, cli *WebSocketClient) {
@@ -103,7 +103,7 @@ func TestWebSocketClose(t *testing.T) {
 		}()
 	}
 
-	t.Run("ExplicitClose", func(t *testing.T) {
+	t.Run("SuddenClose", func(t *testing.T) {
 		cli, err := NewWebSocketClient4(url, "authToken")
 		require.Nil(t, err)
 
@@ -125,7 +125,7 @@ func TestWebSocketClose(t *testing.T) {
 		assert.Equal(t, "model.websocket_client.connect_fail.app_error", cli.ListenError.Id, "unexpected error id")
 	})
 
-	t.Run("SuddenClose", func(t *testing.T) {
+	t.Run("ExplicitClose", func(t *testing.T) {
 		cli, err := NewWebSocketClient4(url, "authToken")
 		require.Nil(t, err)
 

--- a/model/websocket_client_test.go
+++ b/model/websocket_client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,9 +34,6 @@ func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 				break
 			}
 		}
-		if _, ok := err.(*websocket.CloseError); !ok {
-			require.NoError(t, err)
-		}
 	}
 }
 
@@ -55,4 +53,93 @@ func TestWebSocketRace(t *testing.T) {
 		time.Sleep(500 * time.Millisecond)
 		cli.UserTyping("channel", "parentId")
 	}
+}
+
+func TestWebSocketClose(t *testing.T) {
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	url := strings.Replace(s.URL, "http://", "ws://", 1)
+
+	// Check whether the Event and Response channels
+	// have been closed or not.
+	waitClose := func(doneChan chan struct{}) int {
+		numClosed := 0
+		timeout := time.After(300 * time.Millisecond)
+		for {
+			select {
+			case <-doneChan:
+				numClosed++
+				if numClosed == 2 {
+					return numClosed
+				}
+			case <-timeout:
+				require.Fail(t, "timed out waiting for channels to be closed")
+				return numClosed
+			}
+		}
+	}
+
+	checkWriteChan := func(writeChan chan writeMessage) {
+		defer func() {
+			if x := recover(); x == nil {
+				require.Fail(t, "should have panicked due to sending to a closed channel")
+			}
+		}()
+		writeChan <- writeMessage{}
+	}
+
+	waitForResponses := func(doneChan chan struct{}, cli *WebSocketClient) {
+		go func() {
+			for range cli.EventChannel {
+			}
+			doneChan <- struct{}{}
+		}()
+		go func() {
+			for range cli.ResponseChannel {
+			}
+			doneChan <- struct{}{}
+		}()
+	}
+
+	t.Run("ExplicitClose", func(t *testing.T) {
+		cli, err := NewWebSocketClient4(url, "authToken")
+		require.Nil(t, err)
+
+		cli.Listen()
+
+		doneChan := make(chan struct{}, 2)
+		waitForResponses(doneChan, cli)
+
+		cli.UserTyping("channelId", "parentId")
+		cli.Conn.Close()
+
+		numClosed := waitClose(doneChan)
+		assert.Equal(t, 2, numClosed, "unexpected number of channels closed")
+
+		// Check whether the write channel was closed or not.
+		checkWriteChan(cli.writeChan)
+
+		require.NotNil(t, cli.ListenError, "non-nil listen error")
+		assert.Equal(t, "model.websocket_client.connect_fail.app_error", cli.ListenError.Id, "unexpected error id")
+	})
+
+	t.Run("SuddenClose", func(t *testing.T) {
+		cli, err := NewWebSocketClient4(url, "authToken")
+		require.Nil(t, err)
+
+		cli.Listen()
+
+		doneChan := make(chan struct{}, 2)
+		waitForResponses(doneChan, cli)
+
+		cli.UserTyping("channelId", "parentId")
+		cli.Close()
+
+		numClosed := waitClose(doneChan)
+		assert.Equal(t, 2, numClosed, "unexpected number of channels closed")
+
+		// Check whether the write channel was closed or not.
+		checkWriteChan(cli.writeChan)
+	})
 }

--- a/model/websocket_client_test.go
+++ b/model/websocket_client_test.go
@@ -22,6 +22,7 @@ func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 			WriteBufferSize: 1024,
 		}
 		conn, err := upgrader.Upgrade(w, req, nil)
+		require.Nil(t, err)
 		var buf []byte
 		for {
 			_, buf, err = conn.ReadMessage()


### PR DESCRIPTION
When the connection is closed, the exit path does not
shut down the writer goroutine. In which case, it will keep spinning forever.

Since we already have the CAS mechanism now, we can use that to close the writer
and guard from a double-close.

The problem with refactoring the writer closing to a common
function was that we needed to wait for the reader to exit
before closing the EventChannel and ResponseChannel.

But then there is another problem that the API can be used in such
a way that the client is liable to call Close without even calling
Listen. In that case, we cannot wait for Listen to quit.

So from Close, we can only close the connection. And therefore
we need to duplicate the writer closing in the read loop's
defer block.

This makes closing the websocket client idempotent from both perspective -
- Explicitly closing.
- Closing due to connection tear down.

There are still 2 races left:
- Using the exported Conn to directly write messages. We cannot do anything about
that as long as clients directly using that.
- Setting the wsc.pingTimeoutTimer field in a separate goroutine when calling
.Connect(). This will need to be seen later.

### Ticket link

https://mattermost.atlassian.net/browse/MM-24547