### PR TITLE
MM-24575 Error in logs when sending DM to same account

### DIFF
--- a/app/auto_responder.go
+++ b/app/auto_responder.go
@@ -18,6 +18,10 @@ func (a *App) SendAutoResponseIfNecessary(channel *model.Channel, sender *model.
 	}
 
 	receiverId := channel.GetOtherUserIdForDM(sender.Id)
+	if receiverId == "" {
+		// User direct messaged themself, let them test their auto-responder.
+		receiverId = sender.Id
+	}
 
 	receiver, err := a.GetUser(receiverId)
 	if err != nil {

--- a/app/post.go
+++ b/app/post.go
@@ -419,12 +419,14 @@ func (a *App) handlePostEvents(post *model.Post, user *model.User, channel *mode
 		return err
 	}
 
-	a.Srv().Go(func() {
-		_, err := a.SendAutoResponseIfNecessary(channel, user)
-		if err != nil {
-			mlog.Error("Failed to send auto response", mlog.String("user_id", user.Id), mlog.String("post_id", post.Id), mlog.Err(err))
-		}
-	})
+	if post.Type != model.POST_AUTO_RESPONDER { // don't respond to an auto-responder
+		a.Srv().Go(func() {
+			_, err := a.SendAutoResponseIfNecessary(channel, user)
+			if err != nil {
+				mlog.Error("Failed to send auto response", mlog.String("user_id", user.Id), mlog.String("post_id", post.Id), mlog.Err(err))
+			}
+		})
+	}
 
 	if triggerWebhooks {
 		a.Srv().Go(func() {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes the issue where an error was appearing in the logs any time a user sends a DM to themself.  `GetUser` was being called with a blank id.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-24575