### PR TITLE
MM-24467: Add configuration setting for ServiceProviderIdentifier

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2075,6 +2075,7 @@ type SamlSettings struct {
 	IdpUrl                      *string
 	IdpDescriptorUrl            *string
 	IdpMetadataUrl              *string
+	ServiceProviderIdentifier   *string
 	AssertionConsumerServiceURL *string
 
 	SignatureAlgorithm *string
@@ -2150,6 +2151,10 @@ func (s *SamlSettings) SetDefaults() {
 
 	if s.IdpDescriptorUrl == nil {
 		s.IdpDescriptorUrl = NewString("")
+	}
+
+	if s.ServiceProviderIdentifier == nil {
+		s.ServiceProviderIdentifier = NewString("")
 	}
 
 	if s.IdpMetadataUrl == nil {


### PR DESCRIPTION
#### Summary
Adding a new configuration setting `ServiceProviderIdentifier`.

The <ISSUER> tag in the AuthnRequest is being created incorrectly. This PR uses a new configuration setting to set the <ISSUER>. If the new configuration setting is empty, then the current logic is used. This will allow existing installations to continue to work.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24467

####Related PRs
https://github.com/mattermost/enterprise/pull/633
https://github.com/mattermost/mattermost-webapp/pull/5420