### PR TITLE
MM-24547: Fix deadlock in pingTimeoutTimer

### DIFF
--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -271,15 +271,18 @@ func (wsc *WebSocketClient) pingHandler(appData string) error {
 }
 
 func (wsc *WebSocketClient) pingWatchdog() {
-	select {
-	case <-wsc.resetTimerChan:
-		if !wsc.pingTimeoutTimer.Stop() {
-			<-wsc.pingTimeoutTimer.C
-		}
+	for {
+		select {
+		case <-wsc.resetTimerChan:
+			if !wsc.pingTimeoutTimer.Stop() {
+				<-wsc.pingTimeoutTimer.C
+			}
 
-		wsc.pingTimeoutTimer.Reset(time.Second * (60 + PING_TIMEOUT_BUFFER_SECONDS))
-	case <-wsc.pingTimeoutTimer.C:
-		wsc.PingTimeoutChannel <- true
-	case <-wsc.quitPingWatchdog:
+			wsc.pingTimeoutTimer.Reset(time.Second * (60 + PING_TIMEOUT_BUFFER_SECONDS))
+		case <-wsc.pingTimeoutTimer.C:
+			wsc.PingTimeoutChannel <- true
+		case <-wsc.quitPingWatchdog:
+			return
+		}
 	}
 }

--- a/model/websocket_client.go
+++ b/model/websocket_client.go
@@ -277,10 +277,11 @@ func (wsc *WebSocketClient) pingWatchdog() {
 			if !wsc.pingTimeoutTimer.Stop() {
 				<-wsc.pingTimeoutTimer.C
 			}
-
 			wsc.pingTimeoutTimer.Reset(time.Second * (60 + PING_TIMEOUT_BUFFER_SECONDS))
+
 		case <-wsc.pingTimeoutTimer.C:
 			wsc.PingTimeoutChannel <- true
+			wsc.pingTimeoutTimer.Reset(time.Second * (60 + PING_TIMEOUT_BUFFER_SECONDS))
 		case <-wsc.quitPingWatchdog:
 			return
 		}


### PR DESCRIPTION
The read of the timer channel happened in 2 different goroutines
which created a race, and therefore if one was read before,
it would cause the other to deadlock.

To fix this, we use yet another channel to pass the message
and thereby make the reads happen in the same goroutine.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-24685
