### PR TITLE
MM-24707 fix bug when bulk importing post replies

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -1267,8 +1267,6 @@ func (a *App) importMultiplePosts(data []*PostImportData, dryRun bool) *model.Ap
 		return err
 	}
 
-	var lastPostWithData *postAndData
-	repliesBulk := []ReplyImportData{}
 	for _, postWithData := range postsWithData {
 		postWithData := postWithData
 		if postWithData.postData.FlaggedBy != nil {
@@ -1301,27 +1299,14 @@ func (a *App) importMultiplePosts(data []*PostImportData, dryRun bool) *model.Ap
 			}
 		}
 
-		if postWithData.postData.Replies != nil {
-			repliesBulk = append(repliesBulk, *postWithData.postData.Replies...)
-			if len(repliesBulk) >= importMultiplePostsThreshold {
-				err := a.importReplies(repliesBulk, postWithData.post, postWithData.team.Id, dryRun)
-				if err != nil {
-					return err
-				}
-				repliesBulk = []ReplyImportData{}
+		if postWithData.postData.Replies != nil && len(*postWithData.postData.Replies) > 0 {
+			err := a.importReplies(*postWithData.postData.Replies, postWithData.post, postWithData.team.Id, dryRun)
+			if err != nil {
+				return err
 			}
 		}
 		a.updateFileInfoWithPostId(postWithData.post)
-		lastPostWithData = &postWithData
 	}
-
-	if len(repliesBulk) >= 0 && lastPostWithData != nil {
-		err := a.importReplies(repliesBulk, lastPostWithData.post, lastPostWithData.team.Id, dryRun)
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes a bug where replies to posts were not importing during bulk import.

Root cause is an optimization added in 5.22 which batch adds the replies.  Unfortunately the logic is in error and mismatches the replies with the posts.  Occasionally this will result in no error but the reply will appear under the wrong post.  More often the reply will generate the error above, depending on the time stamp of the last post in every 1000 post batch.  

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-24707