### PR TITLE
[MM-24700] Add api endpoint to GetGroupsByUserIds

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -154,6 +154,8 @@ type AppIface interface {
 	GetEmojiStaticUrl(emojiName string) (string, *model.AppError)
 	// GetEnvironmentConfig returns a map of configuration keys whose values have been overridden by an environment variable.
 	GetEnvironmentConfig() map[string]interface{}
+	// GetGroupsByUserIds returns a slice of `GroupsByUser` which contain a user id and a slice of groups
+	GetGroupsByUserIds(userIDs []string) ([]*model.GroupsByUser, *model.AppError)
 	// GetHubForUserId returns the hub for a given user id.
 	GetHubForUserId(userId string) *Hub
 	// GetKnownUsers returns the list of user ids of users with any direct

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -384,9 +384,10 @@ func TestGetGroupsByUserIds(t *testing.T) {
 	user3 := th.CreateUser()
 	userIds := []string{user1.Id, user2.Id, user3.Id}
 	var groupsByUsers []*model.GroupsByUser
+	var err *model.AppError
 
 	t.Run("Returns an empty list of groups when users match no groups", func(t *testing.T) {
-		groupsByUsers, err := th.App.GetGroupsByUserIds(userIds)
+		groupsByUsers, err = th.App.GetGroupsByUserIds(userIds)
 		require.Nil(t, err)
 		require.Equal(t, groupsByUsers, []*model.GroupsByUser{})
 	})

--- a/app/opentracing_layer.go
+++ b/app/opentracing_layer.go
@@ -5487,6 +5487,28 @@ func (a *OpenTracingAppLayer) GetGroupsByUserId(userId string) ([]*model.Group, 
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) GetGroupsByUserIds(userIDs []string) ([]*model.GroupsByUser, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetGroupsByUserIds")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetGroupsByUserIds(userIDs)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetHubForUserId(userId string) *Hub {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetHubForUserId")

--- a/model/client4.go
+++ b/model/client4.go
@@ -5024,3 +5024,14 @@ func (c *Client4) GetChannelMemberCountsByGroup(channelID string, includeTimezon
 	defer closeBody(r)
 	return ChannelMemberCountsByGroupFromJson(r.Body), BuildResponse(r)
 }
+
+func (c *Client4) GetGroupsByUserIds(userIds []string) ([]*GroupsByUser, *Response) {
+	r, err := c.DoApiPost(c.GetGroupsRoute()+"/users/ids", ArrayToJson(userIds))
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	var groupsByUsers []*GroupsByUser
+	json.NewDecoder(r.Body).Decode(&groupsByUsers)
+	return groupsByUsers, BuildResponse(r)
+}

--- a/model/group.go
+++ b/model/group.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 )
 
 const (
@@ -57,6 +58,23 @@ type GroupsAssociatedToChannelWithSchemeAdmin struct {
 type GroupsAssociatedToChannel struct {
 	ChannelId string                  `json:"channel_id"`
 	Groups    []*GroupWithSchemeAdmin `json:"groups"`
+}
+
+type GroupsByUser struct {
+	UserId   string   `json:"user_id"`
+	GroupIDs *string  `json:"-"`
+	Groups   []*Group `json:"groups"`
+}
+
+func (g *GroupsByUser) GetGroupIDs() []string {
+	if g.GroupIDs == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*g.GroupIDs)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	return strings.Split(trimmed, ",")
 }
 
 type GroupPatch struct {

--- a/store/opentracing_layer.go
+++ b/store/opentracing_layer.go
@@ -3229,6 +3229,24 @@ func (s *OpenTracingLayerGroupStore) GetByUser(userId string) ([]*model.Group, *
 	return resultVar0, resultVar1
 }
 
+func (s *OpenTracingLayerGroupStore) GetByUsers(userIDs []string) ([]*model.GroupsByUser, *model.AppError) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "GroupStore.GetByUsers")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := s.GroupStore.GetByUsers(userIDs)
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (s *OpenTracingLayerGroupStore) GetGroupSyncable(groupID string, syncableID string, syncableType model.GroupSyncableType) (*model.GroupSyncable, *model.AppError) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "GroupStore.GetGroupSyncable")

--- a/store/store.go
+++ b/store/store.go
@@ -626,6 +626,7 @@ type GroupStore interface {
 	GetByRemoteID(remoteID string, groupSource model.GroupSource) (*model.Group, *model.AppError)
 	GetAllBySource(groupSource model.GroupSource) ([]*model.Group, *model.AppError)
 	GetByUser(userId string) ([]*model.Group, *model.AppError)
+	GetByUsers(userIDs []string) ([]*model.GroupsByUser, *model.AppError)
 	Update(group *model.Group) (*model.Group, *model.AppError)
 	Delete(groupID string) (*model.Group, *model.AppError)
 

--- a/store/storetest/mocks/GroupStore.go
+++ b/store/storetest/mocks/GroupStore.go
@@ -529,6 +529,31 @@ func (_m *GroupStore) GetByUser(userId string) ([]*model.Group, *model.AppError)
 	return r0, r1
 }
 
+// GetByUsers provides a mock function with given fields: userIDs
+func (_m *GroupStore) GetByUsers(userIDs []string) ([]*model.GroupsByUser, *model.AppError) {
+	ret := _m.Called(userIDs)
+
+	var r0 []*model.GroupsByUser
+	if rf, ok := ret.Get(0).(func([]string) []*model.GroupsByUser); ok {
+		r0 = rf(userIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.GroupsByUser)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func([]string) *model.AppError); ok {
+		r1 = rf(userIDs)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetGroupSyncable provides a mock function with given fields: groupID, syncableID, syncableType
 func (_m *GroupStore) GetGroupSyncable(groupID string, syncableID string, syncableType model.GroupSyncableType) (*model.GroupSyncable, *model.AppError) {
 	ret := _m.Called(groupID, syncableID, syncableType)

--- a/store/timer_layer.go
+++ b/store/timer_layer.go
@@ -2958,6 +2958,22 @@ func (s *TimerLayerGroupStore) GetByUser(userId string) ([]*model.Group, *model.
 	return resultVar0, resultVar1
 }
 
+func (s *TimerLayerGroupStore) GetByUsers(userIDs []string) ([]*model.GroupsByUser, *model.AppError) {
+	start := timemodule.Now()
+
+	resultVar0, resultVar1 := s.GroupStore.GetByUsers(userIDs)
+
+	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if resultVar1 == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("GroupStore.GetByUsers", success, elapsed)
+	}
+	return resultVar0, resultVar1
+}
+
 func (s *TimerLayerGroupStore) GetGroupSyncable(groupID string, syncableID string, syncableType model.GroupSyncableType) (*model.GroupSyncable, *model.AppError) {
 	start := timemodule.Now()
 


### PR DESCRIPTION
#### Summary
- Adds an endpoint to batch get all groups for a set of users to be used in the team and channel members block in the system console upon page load an action to load the groups for all the members loaded on the page will be dispatched. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24700