### PR TITLE
Fix dependency alerting

### DIFF
--- a/scripts/depcheck-alert.sh
+++ b/scripts/depcheck-alert.sh
@@ -5,7 +5,7 @@
 # Get artifacts from CircleCI
 report_artifacts=$(curl -s https://circleci.com/api/v1.1/project/gh/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM/artifacts)
 json_url=$(echo $report_artifacts | jq -r 'map(select(.path == "Reports/OWASP/dependency-check-report.json").url)[0]')
-json_report=$(curl -s $json_url)
+json_report=$(curl -sL $json_url)
 
 # Anything new?
 vulnerability_count=$(echo $json_report | jq '[.dependencies[]?.vulnerabilities[]?.name]|length')


### PR DESCRIPTION
#### Summary
CircleCI changed their API for artifact downloads: the URL now redirects to S3. Because of this, alerting is currently broken. This change enables redirections in the alerting script.

#### Ticket Link
