### PR TITLE
WIP: Filter stop words when searching posts in mysql

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6671,6 +6671,10 @@
     "translation": "Searching has been disabled on this server. Please contact your System Administrator."
   },
   {
+    "id": "store.sql_post.search.app_error",
+    "translation": "We encountered an error searching posts."
+  },
+  {
     "id": "store.sql_post.update.app_error",
     "translation": "Unable to update the Post."
   },

--- a/store/searchtest/post_layer.go
+++ b/store/searchtest/post_layer.go
@@ -263,6 +263,11 @@ var searchPostStoreTests = []searchTest{
 		Fn:   testShouldBeAbleToFindPostsEvenIfStopWordsWhereGiven,
 		Tags: []string{ENGINE_MYSQL},
 	},
+	{
+		Name: "Should not go to database when searching with stopwords only",
+		Fn:   testShouldNotGoToDatabaseWhenSearchingWithStopWordsOnly,
+		Tags: []string{ENGINE_MYSQL},
+	},
 }
 
 func TestSearchPostStore(t *testing.T, s store.Store, testEngine *SearchTestEngine) {
@@ -1755,4 +1760,14 @@ func testShouldBeAbleToFindPostsEvenIfStopWordsWhereGiven(t *testing.T, th *Sear
 	require.Nil(t, apperr)
 	require.Len(t, posts.Posts, 1)
 	require.Equal(t, p1.Message, posts.Posts[p1.Id].Message)
+}
+
+func testShouldNotGoToDatabaseWhenSearchingWithStopWordsOnly(t *testing.T, th *SearchTestHelper) {
+	_, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "where is the car?", "", model.POST_DEFAULT, 0, false)
+	require.Nil(t, err)
+	defer th.deleteUserPosts(th.User.Id)
+
+	posts, apperr := th.Store.Post().Search(th.Team.Id, th.User.Id, &model.SearchParams{Terms: "where is the"})
+	require.Nil(t, apperr)
+	require.Len(t, posts.Posts, 0)
 }

--- a/store/searchtest/post_layer.go
+++ b/store/searchtest/post_layer.go
@@ -258,6 +258,11 @@ var searchPostStoreTests = []searchTest{
 		Fn:   testShouldNotReturnLinksEmbeddedInMarkdown,
 		Tags: []string{ENGINE_POSTGRES, ENGINE_ELASTICSEARCH},
 	},
+	{
+		Name: "Should be able to find post even if stop word where given",
+		Fn:   testShouldBeAbleToFindPostsEvenIfStopWordsWhereGiven,
+		Tags: []string{ENGINE_MYSQL},
+	},
 }
 
 func TestSearchPostStore(t *testing.T, s store.Store, testEngine *SearchTestEngine) {
@@ -1739,4 +1744,15 @@ func testShouldNotReturnLinksEmbeddedInMarkdown(t *testing.T, th *SearchTestHelp
 	require.Nil(t, apperr)
 
 	require.Len(t, results.Posts, 0)
+}
+
+func testShouldBeAbleToFindPostsEvenIfStopWordsWhereGiven(t *testing.T, th *SearchTestHelper) {
+	p1, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "where is the car?", "", model.POST_DEFAULT, 0, false)
+	require.Nil(t, err)
+	defer th.deleteUserPosts(th.User.Id)
+
+	posts, apperr := th.Store.Post().Search(th.Team.Id, th.User.Id, &model.SearchParams{Terms: "where is the car"})
+	require.Nil(t, apperr)
+	require.Len(t, posts.Posts, 1)
+	require.Equal(t, p1.Message, posts.Posts[p1.Id].Message)
 }

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1253,6 +1253,10 @@ func (s *SqlPostStore) search(teamId string, userId string, params *model.Search
 
 			terms = re.ReplaceAllString(terms, " ")
 			terms = strings.TrimSpace(terms)
+
+			if terms == "" {
+				return list, nil
+			}
 		}
 
 		searchClause := fmt.Sprintf("AND MATCH (%s) AGAINST (:Terms IN BOOLEAN MODE)", searchType)


### PR DESCRIPTION
#### Summary
This PR resolves partially #14439 by filtering stopwords from terms introduced in search field.

#### Ticket Link

Partially #14439 

JIRA: https://mattermost.atlassian.net/browse/MM-24523

**Notes**: It resolves only one point of three in the ticket, this is to remove all matching stopwords from the terms introduced by the user, for example having a post with the content `"where is the car"` and looking for `"the car"` will retrive the post. Before this changes when looking for a post with terms that containing a stopword, you always got empty list.

This is a WIP yet because currently stopwords are being retrived from Mysql in every search, and I think this could be stored in a variable in order to save an unnecessary and repeated query but not sure where to place that var.

Secondly, I think could be a bug when searching for a post with the terms `"where is my car"`, notice the `"my"` word, it is not an stopword but it is always getting empty results (assuming a post with `"where is my car"` already exists).

Finally for cases when looking with terms with hashtags that are stopwords (`#where`, `#the`, ...) I prefer to create another PR and analize it with more calm, I'm not sure to how to solve that, maybe using `REGEXP` as suggested by @ethervoid but I'm not sure about the performance of that.