### PR TITLE
[MM-24987] Dont call GetSchemeRolesForChannel and instead load the scheme from channel

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -494,8 +494,10 @@ func (a *App) CreateChannelScheme(channel *model.Channel) (*model.Scheme, *model
 
 // DeleteChannelScheme deletes a channels scheme and sets its SchemeId to nil.
 func (a *App) DeleteChannelScheme(channel *model.Channel) (*model.Channel, *model.AppError) {
-	if _, err := a.DeleteScheme(*channel.SchemeId); err != nil {
-		return nil, err
+	if channel.SchemeId != nil && len(*channel.SchemeId) != 0 {
+		if _, err := a.DeleteScheme(*channel.SchemeId); err != nil {
+			return nil, err
+		}
 	}
 	channel.SchemeId = nil
 	return a.UpdateChannelScheme(channel)

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -1660,56 +1660,41 @@ func TestPatchChannelModerationsForChannel(t *testing.T) {
 	}
 
 	t.Run("Handles concurrent patch requests gracefully", func(t *testing.T) {
+		addCreatePosts := []*model.ChannelModerationPatch{
+			{
+				Name: &createPosts,
+				Roles: &model.ChannelModeratedRolesPatch{
+					Members: model.NewBool(false),
+					Guests:  model.NewBool(false),
+				},
+			},
+		}
+		removeCreatePosts := []*model.ChannelModerationPatch{
+			{
+				Name: &createPosts,
+				Roles: &model.ChannelModeratedRolesPatch{
+					Members: model.NewBool(false),
+					Guests:  model.NewBool(false),
+				},
+			},
+		}
+
 		wg := sync.WaitGroup{}
 		wg.Add(20)
 		for i := 0; i < 10; i++ {
 			go func() {
-				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
-					{
-						Name: &createPosts,
-						Roles: &model.ChannelModeratedRolesPatch{
-							Members: model.NewBool(true),
-							Guests:  model.NewBool(true),
-						},
-					},
-				})
-				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
-					{
-						Name: &createPosts,
-						Roles: &model.ChannelModeratedRolesPatch{
-							Members: model.NewBool(false),
-							Guests:  model.NewBool(false),
-						},
-					},
-				})
+				th.App.PatchChannelModerationsForChannel(channel, addCreatePosts)
+				th.App.PatchChannelModerationsForChannel(channel, removeCreatePosts)
 				wg.Done()
 			}()
 		}
-
 		for i := 0; i < 10; i++ {
 			go func() {
-				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
-					{
-						Name: &createPosts,
-						Roles: &model.ChannelModeratedRolesPatch{
-							Members: model.NewBool(true),
-							Guests:  model.NewBool(true),
-						},
-					},
-				})
-				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
-					{
-						Name: &createPosts,
-						Roles: &model.ChannelModeratedRolesPatch{
-							Members: model.NewBool(false),
-							Guests:  model.NewBool(false),
-						},
-					},
-				})
+				th.App.PatchChannelModerationsForChannel(channel, addCreatePosts)
+				th.App.PatchChannelModerationsForChannel(channel, removeCreatePosts)
 				wg.Done()
 			}()
 		}
-
 		wg.Wait()
 
 		higherScopedGuestRoleName, higherScopedMemberRoleName, _, _ := th.App.GetTeamSchemeChannelRoles(channel.TeamId)

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1657,6 +1658,67 @@ func TestPatchChannelModerationsForChannel(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Handles concurrent patch requests gracefully", func(t *testing.T) {
+		wg := sync.WaitGroup{}
+		wg.Add(20)
+		for i := 0; i < 10; i++ {
+			go func() {
+				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
+					{
+						Name: &createPosts,
+						Roles: &model.ChannelModeratedRolesPatch{
+							Members: model.NewBool(true),
+							Guests:  model.NewBool(true),
+						},
+					},
+				})
+				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
+					{
+						Name: &createPosts,
+						Roles: &model.ChannelModeratedRolesPatch{
+							Members: model.NewBool(false),
+							Guests:  model.NewBool(false),
+						},
+					},
+				})
+				wg.Done()
+			}()
+		}
+
+		for i := 0; i < 10; i++ {
+			go func() {
+				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
+					{
+						Name: &createPosts,
+						Roles: &model.ChannelModeratedRolesPatch{
+							Members: model.NewBool(true),
+							Guests:  model.NewBool(true),
+						},
+					},
+				})
+				th.App.PatchChannelModerationsForChannel(channel, []*model.ChannelModerationPatch{
+					{
+						Name: &createPosts,
+						Roles: &model.ChannelModeratedRolesPatch{
+							Members: model.NewBool(false),
+							Guests:  model.NewBool(false),
+						},
+					},
+				})
+				wg.Done()
+			}()
+		}
+
+		wg.Wait()
+
+		higherScopedGuestRoleName, higherScopedMemberRoleName, _, _ := th.App.GetTeamSchemeChannelRoles(channel.TeamId)
+		higherScopedMemberRole, _ := th.App.GetRoleByName(higherScopedMemberRoleName)
+		higherScopedGuestRole, _ := th.App.GetRoleByName(higherScopedGuestRoleName)
+		assert.Contains(t, higherScopedMemberRole.Permissions, createPosts)
+		assert.Contains(t, higherScopedGuestRole.Permissions, createPosts)
+	})
+
 }
 
 // TestMarkChannelsAsViewedPanic verifies that returning an error from a.GetUser


### PR DESCRIPTION
#### Summary
- Instead of always calling `GetSchemeRolesForChannel` modify this block to load use the scheme returned from create (if one is created) or call `GetScheme` directly using the channel struct already loaded into memory.
- This is required since there were cases where retrieving the channel from store would return a channel with an outdated scheme id resulting in the function `GetSchemeRolesForChannel` returning the team scheme roles (or system scheme roles) 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24987

#### Test steps
- Apply label `Setup HA Cloud Test Server`
- Create a team scheme and set all permissions to true
- Open channel moderation for a channel in that team and enable / disable create posts multiple times 
- Eventually it will say "Create posts is disabled in the team scheme" and you will be unable to add create posts back to the channel (as it gets disabled on the team level)  