### PR TITLE
MM-25011: Remove concurrent write to websocket connection

### DIFF
--- a/api4/websocket_test.go
+++ b/api4/websocket_test.go
@@ -47,13 +47,6 @@ func TestWebSocket(t *testing.T) {
 	resp = <-WebSocketClient.ResponseChannel
 	require.Equal(t, resp.Error.Id, "api.web_socket_router.bad_action.app_error", "should have been bad action response")
 
-	req := &model.WebSocketRequest{}
-	req.Seq = 0
-	req.Action = "ping"
-	WebSocketClient.Conn.WriteJSON(req)
-	resp = <-WebSocketClient.ResponseChannel
-	require.Equal(t, resp.Error.Id, "api.web_socket_router.bad_seq.app_error", "should have been bad action response")
-
 	WebSocketClient.UserTyping("", "")
 	resp = <-WebSocketClient.ResponseChannel
 	require.Equal(t, resp.Error.Id, "api.websocket_handler.invalid_param.app_error", "should have been invalid param response")


### PR DESCRIPTION
This test writes directly to a connection
which causes panics and more frustration in an already fragile CI.

Since this anyways checks an edge condition, and will anyways be
removed in v6, let's remove this for now and let CI be happy.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-25011
