### PR TITLE
MM24459: Implement ldap picture sync

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -267,6 +267,8 @@ type AppIface interface {
 	// This function deviates from other authorization checks in returning an error instead of just
 	// a boolean, allowing the permission failure to be exposed with more granularity.
 	SessionHasPermissionToManageBot(session model.Session, botUserId string) *model.AppError
+	// SessionIsRegistered determines if a specific session has been registered
+	SessionIsRegistered(session model.Session) bool
 	// SetBotIconImage sets LHS icon for a bot.
 	SetBotIconImage(botUserId string, file io.ReadSeeker) *model.AppError
 	// SetBotIconImageFromMultiPartFile sets LHS icon for a bot.
@@ -350,6 +352,7 @@ type AppIface interface {
 	AddUserToTeamByInviteId(inviteId string, userId string) (*model.Team, *model.AppError)
 	AddUserToTeamByTeamId(teamId string, user *model.User) *model.AppError
 	AddUserToTeamByToken(userId string, tokenId string) (*model.Team, *model.AppError)
+	AdjustImage(file io.Reader) ([]byte, *model.AppError)
 	AllowOAuthAppAccessToUser(userId string, authRequest *model.AuthorizeRequest) (string, *model.AppError)
 	AsymmetricSigningKey() *ecdsa.PrivateKey
 	AttachDeviceId(sessionId string, deviceId string, expiresAt int64) *model.AppError

--- a/app/login.go
+++ b/app/login.go
@@ -165,6 +165,12 @@ func (a *App) DoLogin(w http.ResponseWriter, r *http.Request, user *model.User, 
 
 	a.SetSession(session)
 
+	if user.AuthService == model.USER_AUTH_SERVICE_LDAP && a.Ldap() != nil {
+		a.Srv().Go(func() {
+			a.Ldap().UpdateProfilePictureIfNecessary(user, session)
+		})
+	}
+
 	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
 		a.Srv().Go(func() {
 			pluginContext := a.PluginContext()

--- a/app/opentracing_layer.go
+++ b/app/opentracing_layer.go
@@ -541,6 +541,28 @@ func (a *OpenTracingAppLayer) AddUserToTeamByToken(userId string, tokenId string
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) AdjustImage(file io.Reader) ([]byte, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AdjustImage")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.AdjustImage(file)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) AllowOAuthAppAccessToUser(userId string, authRequest *model.AuthorizeRequest) (string, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AllowOAuthAppAccessToUser")
@@ -12742,6 +12764,23 @@ func (a *OpenTracingAppLayer) SessionHasPermissionToUserOrBot(session model.Sess
 
 	defer span.Finish()
 	resultVar0 := a.app.SessionHasPermissionToUserOrBot(session, userId)
+
+	return resultVar0
+}
+
+func (a *OpenTracingAppLayer) SessionIsRegistered(session model.Session) bool {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.SessionIsRegistered")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.SessionIsRegistered(session)
 
 	return resultVar0
 }

--- a/app/user.go
+++ b/app/user.go
@@ -891,6 +891,7 @@ func (a *App) SetProfileImageFromFile(userId string, file io.Reader) *model.AppE
 	if err := a.Srv().Store.User().UpdateLastPictureUpdate(userId); err != nil {
 		mlog.Error("Error with updating last picture update", mlog.Err(err))
 	}
+	mlog.Debug("invalidate cache")
 	a.invalidateUserCacheAndPublish(userId)
 
 	return nil
@@ -2088,6 +2089,7 @@ func (a *App) invalidateUserCacheAndPublish(userId string) {
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
 	message.Add("user", user)
+	mlog.Debug("Publish")
 	a.Publish(message)
 }
 

--- a/app/user.go
+++ b/app/user.go
@@ -891,7 +891,6 @@ func (a *App) SetProfileImageFromFile(userId string, file io.Reader) *model.AppE
 	if err := a.Srv().Store.User().UpdateLastPictureUpdate(userId); err != nil {
 		mlog.Error("Error with updating last picture update", mlog.Err(err))
 	}
-	mlog.Debug("invalidate cache")
 	a.invalidateUserCacheAndPublish(userId)
 
 	return nil
@@ -2089,7 +2088,6 @@ func (a *App) invalidateUserCacheAndPublish(userId string) {
 
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_UPDATED, "", "", "", nil)
 	message.Add("user", user)
-	mlog.Debug("Publish")
 	a.Publish(message)
 }
 

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/einterfaces"
 	"github.com/mattermost/mattermost-server/v5/model"
 	oauthgitlab "github.com/mattermost/mattermost-server/v5/model/gitlab"
+	"github.com/mattermost/mattermost-server/v5/utils/testutils"
 )
 
 func TestIsUsernameTaken(t *testing.T) {
@@ -119,6 +120,31 @@ func TestSetDefaultProfileImage(t *testing.T) {
 
 	user = getUserFromDB(th.App, user.Id, t)
 	assert.Equal(t, int64(0), user.LastPictureUpdate)
+}
+
+func TestAdjustProfileImage(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	_, err := th.App.AdjustImage(bytes.NewReader([]byte{}))
+	require.Error(t, err)
+
+	// test image isn't the correct dimensions
+	// it should be adjusted
+	testjpg, error := testutils.ReadTestFile("testjpg.jpg")
+	require.Nil(t, error)
+	adjusted, err := th.App.AdjustImage(bytes.NewReader(testjpg))
+	require.Nil(t, err)
+	assert.True(t, len(adjusted) > 0)
+	assert.NotEqual(t, testjpg, adjusted)
+
+	// default image should require adjustement
+	user := th.BasicUser
+	image, err := th.App.GetDefaultProfileImage(user)
+	require.Nil(t, err)
+	image2, err := th.App.AdjustImage(bytes.NewReader(image))
+	require.Nil(t, err)
+	assert.Equal(t, image, image2)
 }
 
 func TestUpdateUserToRestrictedDomain(t *testing.T) {

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -29,6 +29,12 @@ type webConnDirectMessage struct {
 	msg  model.WebSocketMessage
 }
 
+type webConnSessionMessage struct {
+	userId       string
+	sessionToken string
+	isRegistered chan bool
+}
+
 // Hub is the central place to manage all websocket connections in the server.
 // It handles different websocket events and sending messages to individual
 // user connections.
@@ -47,20 +53,22 @@ type Hub struct {
 	activity        chan *webConnActivityMessage
 	directMsg       chan *webConnDirectMessage
 	explicitStop    bool
+	checkRegistered chan *webConnSessionMessage
 }
 
 // NewWebHub creates a new Hub.
 func (a *App) NewWebHub() *Hub {
 	return &Hub{
-		app:            a,
-		register:       make(chan *WebConn, 1),
-		unregister:     make(chan *WebConn, 1),
-		broadcast:      make(chan *model.WebSocketEvent, broadcastQueueSize),
-		stop:           make(chan struct{}),
-		didStop:        make(chan struct{}),
-		invalidateUser: make(chan string),
-		activity:       make(chan *webConnActivityMessage),
-		directMsg:      make(chan *webConnDirectMessage),
+		app:             a,
+		register:        make(chan *WebConn, 1),
+		unregister:      make(chan *WebConn, 1),
+		broadcast:       make(chan *model.WebSocketEvent, broadcastQueueSize),
+		stop:            make(chan struct{}),
+		didStop:         make(chan struct{}),
+		invalidateUser:  make(chan string),
+		activity:        make(chan *webConnActivityMessage),
+		directMsg:       make(chan *webConnDirectMessage),
+		checkRegistered: make(chan *webConnSessionMessage),
 	}
 }
 
@@ -289,6 +297,15 @@ func (a *App) UpdateWebConnUserActivity(session model.Session, activityAt int64)
 	}
 }
 
+// SessionIsRegistered determines if a specific session has been registered
+func (a *App) SessionIsRegistered(session model.Session) bool {
+	hub := a.GetHubForUserId(session.UserId)
+	if hub != nil {
+		return hub.IsRegistered(session.UserId, session.Token)
+	}
+	return false
+}
+
 // Register registers a connection to the hub.
 func (h *Hub) Register(webConn *WebConn) {
 	select {
@@ -303,6 +320,21 @@ func (h *Hub) Unregister(webConn *WebConn) {
 	case h.unregister <- webConn:
 	case <-h.stop:
 	}
+}
+
+// Determines if a user's session is registered a connection from the hub.
+func (h *Hub) IsRegistered(userId, sessionToken string) bool {
+	ws := &webConnSessionMessage{
+		userId:       userId,
+		sessionToken: sessionToken,
+		isRegistered: make(chan bool),
+	}
+	select {
+	case h.checkRegistered <- ws:
+		return <-ws.isRegistered
+	case <-h.stop:
+	}
+	return false
 }
 
 // Broadcast broadcasts the message to all connections in the hub.
@@ -375,6 +407,15 @@ func (h *Hub) Start() {
 
 		for {
 			select {
+			case webSessionMessage := <-h.checkRegistered:
+				conns := connIndex.ForUser(webSessionMessage.userId)
+				var isRegistered bool
+				for _, item := range conns {
+					if item.sessionToken.Load().(string) == webSessionMessage.sessionToken {
+						isRegistered = true
+					}
+				}
+				webSessionMessage.isRegistered <- isRegistered
 			case webConn := <-h.register:
 				connIndex.Add(webConn)
 				atomic.StoreInt64(&h.connectionCount, int64(len(connIndex.All())))

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -15,11 +15,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		mlog.Debug("dummyWebsocketHandler")
 		upgrader := &websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
@@ -28,9 +30,11 @@ func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 		for err == nil {
 			_, _, err = conn.ReadMessage()
 		}
+		mlog.Debug(err.Error())
 		if _, ok := err.(*websocket.CloseError); !ok {
 			require.NoError(t, err)
 		}
+		mlog.Debug("Made IT")
 	}
 }
 

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -12,13 +12,16 @@ import (
 
 	"github.com/gorilla/websocket"
 	goi18n "github.com/mattermost/go-i18n/i18n"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
+		mlog.Debug("dummyWebsocketHandler")
 		upgrader := &websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
@@ -27,9 +30,11 @@ func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 		for err == nil {
 			_, _, err = conn.ReadMessage()
 		}
+		mlog.Debug(err.Error())
 		if _, ok := err.(*websocket.CloseError); !ok {
 			require.NoError(t, err)
 		}
+		mlog.Debug("Made IT")
 	}
 }
 
@@ -105,4 +110,32 @@ func TestHubStopRaceCondition(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		require.FailNow(t, "hub call did not return within 15 seconds after stop")
 	}
+}
+
+func TestHubIsRegistered(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	th.App.HubStart()
+	wc1 := registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
+	wc2 := registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
+	wc3 := registerDummyWebConn(t, th.App, s.Listener.Addr(), th.BasicUser.Id)
+	defer wc1.Close()
+	defer wc2.Close()
+	defer wc3.Close()
+
+	session1 := wc1.session.Load().(*model.Session)
+
+	assert.True(t, th.App.SessionIsRegistered(*session1))
+	assert.True(t, th.App.SessionIsRegistered(*wc2.session.Load().(*model.Session)))
+	assert.True(t, th.App.SessionIsRegistered(*wc3.session.Load().(*model.Session)))
+
+	session4, appErr := th.App.CreateSession(&model.Session{
+		UserId: th.BasicUser2.Id,
+	})
+	require.Nil(t, appErr)
+	assert.False(t, th.App.SessionIsRegistered(*session4))
 }

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -15,13 +15,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		mlog.Debug("dummyWebsocketHandler")
 		upgrader := &websocket.Upgrader{
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
@@ -30,11 +28,9 @@ func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
 		for err == nil {
 			_, _, err = conn.ReadMessage()
 		}
-		mlog.Debug(err.Error())
 		if _, ok := err.(*websocket.CloseError); !ok {
 			require.NoError(t, err)
 		}
-		mlog.Debug("Made IT")
 	}
 }
 

--- a/config/client.go
+++ b/config/client.go
@@ -99,6 +99,7 @@ func GenerateClientConfig(c *model.Config, diagnosticID string, license *model.L
 	props["LdapNicknameAttributeSet"] = "false"
 	props["LdapFirstNameAttributeSet"] = "false"
 	props["LdapLastNameAttributeSet"] = "false"
+	props["LdapPictureAttributeSet"] = "false"
 	props["LdapPositionAttributeSet"] = "false"
 	props["EnableCompliance"] = "false"
 	props["EnableMobileFileDownload"] = "true"
@@ -144,6 +145,7 @@ func GenerateClientConfig(c *model.Config, diagnosticID string, license *model.L
 			props["LdapNicknameAttributeSet"] = strconv.FormatBool(*c.LdapSettings.NicknameAttribute != "")
 			props["LdapFirstNameAttributeSet"] = strconv.FormatBool(*c.LdapSettings.FirstNameAttribute != "")
 			props["LdapLastNameAttributeSet"] = strconv.FormatBool(*c.LdapSettings.LastNameAttribute != "")
+			props["LdapPictureAttributeSet"] = strconv.FormatBool(*c.LdapSettings.PictureAttribute != "")
 			props["LdapPositionAttributeSet"] = strconv.FormatBool(*c.LdapSettings.PositionAttribute != "")
 		}
 

--- a/einterfaces/ldap.go
+++ b/einterfaces/ldap.go
@@ -21,4 +21,5 @@ type LdapInterface interface {
 	GetGroup(groupUID string) (*model.Group, *model.AppError)
 	GetAllGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError)
 	FirstLoginSync(userID, userAuthService, userAuthData, email string) *model.AppError
+	UpdateProfilePictureIfNecessary(*model.User, *model.Session)
 }

--- a/model/config.go
+++ b/model/config.go
@@ -130,6 +130,7 @@ const (
 	LDAP_SETTINGS_DEFAULT_LOGIN_FIELD_NAME             = ""
 	LDAP_SETTINGS_DEFAULT_GROUP_DISPLAY_NAME_ATTRIBUTE = ""
 	LDAP_SETTINGS_DEFAULT_GROUP_ID_ATTRIBUTE           = ""
+	LDAP_SETTINGS_DEFAULT_PICTURE_ATTRIBUTE            = ""
 
 	SAML_SETTINGS_DEFAULT_ID_ATTRIBUTE         = ""
 	SAML_SETTINGS_DEFAULT_GUEST_ATTRIBUTE      = ""
@@ -1884,6 +1885,7 @@ type LdapSettings struct {
 	IdAttribute        *string
 	PositionAttribute  *string
 	LoginIdAttribute   *string
+	PictureAttribute   *string
 
 	// Synchronization
 	SyncIntervalMinutes *int
@@ -1991,6 +1993,10 @@ func (s *LdapSettings) SetDefaults() {
 
 	if s.PositionAttribute == nil {
 		s.PositionAttribute = NewString(LDAP_SETTINGS_DEFAULT_POSITION_ATTRIBUTE)
+	}
+
+	if s.PictureAttribute == nil {
+		s.PictureAttribute = NewString(LDAP_SETTINGS_DEFAULT_PICTURE_ATTRIBUTE)
 	}
 
 	// For those upgrading to the version when LoginIdAttribute was added


### PR DESCRIPTION
#### Summary
When updating the ldap picture, that go routine starts before the current session had connected its websocket. Therefore, we need to check and loop while waiting for the websocket to connect. The loop will try a fixed number of times before continuing and placing a message on the websocket. It is necessary to handle this update via the current user's websocket because the client caches the users image. Therefore even a refresh won't update the photo until the cache expires (24 hours).
Also split out the adjustments made when saving an image, so that they can be applied to an image being used to compare to the existing image. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24459

#### Related PRs
https://github.com/mattermost/enterprise/pull/648