### PR TITLE
MM-25016 Send group Name to in out of channel group users message

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -411,7 +411,7 @@ func (a *App) sendNoUsersNotifiedByGroupInChannel(sender *model.User, post *mode
 		RootId:    post.RootId,
 		ParentId:  post.ParentId,
 		ChannelId: channel.Id,
-		Message:   T("api.post.check_for_out_of_channel_group_users.message.none", model.StringInterface{"GroupDisplayName": group.DisplayName}),
+		Message:   T("api.post.check_for_out_of_channel_group_users.message.none", model.StringInterface{"GroupName": group.Name}),
 	}
 	a.SendEphemeralPost(post.UserId, ephemeralPost)
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1602,7 +1602,7 @@
   },
   {
     "id": "api.post.check_for_out_of_channel_group_users.message.none",
-    "translation": "@{{.GroupDisplayName}} has no members on this team"
+    "translation": "@{{.GroupName}} has no members on this team"
   },
   {
     "id": "api.post.check_for_out_of_channel_groups_mentions.message.multiple",


### PR DESCRIPTION
#### Summary
- This attribute returned should be `group.Name` not `group.DisplayName`

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25016

![Screen Shot 2020-05-11 at 1 18 22 PM](https://user-images.githubusercontent.com/3207297/81591103-e7fad700-9389-11ea-91fc-4a393ed65e3c.png)