### PR TITLE
MM-24644 fix infinite loop splitting post attachments

### DIFF
--- a/app/webhook.go
+++ b/app/webhook.go
@@ -219,7 +219,7 @@ func SplitWebhookPost(post *model.Post, maxPostSize int) ([]*model.Post, *model.
 			}
 
 			if len(origAttachments) > 0 {
-				newSplit := base
+				newSplit := base.Clone()
 				splits = append(splits, newSplit)
 				continue
 			}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR fixes an infinite loop when splitting post attachments into multiple posts.  This bug was due to performing an assignment copy of a model.Post instead of using model.Post.clone().  The Post.Props map was being inadvertently carried over to the copy.

Includes new unit tests for this case and a few others.

This is meant to be the minimum fix as it is likely to be cherry picked for a dot release.  I plan to revisit this implementation as it generates more posts than necessary when the message text and attachments need to be split.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-24644