### PR TITLE
MM-25126 Add a separate default sorting method for categories

### DIFF
--- a/model/channel_sidebar.go
+++ b/model/channel_sidebar.go
@@ -25,8 +25,10 @@ const (
 	DefaultSidebarSortOrderChannels  = DefaultSidebarSortOrderFavorites + MinimalSidebarSortDistance
 	DefaultSidebarSortOrderDMs       = DefaultSidebarSortOrderChannels + MinimalSidebarSortDistance
 	// Sorting modes
-	// default for all categories except DMs
-	SidebarCategorySortManual SidebarCategorySorting = ""
+	// default for all categories except DMs (behaves like manual)
+	SidebarCategorySortDefault SidebarCategorySorting = ""
+	// sort manually
+	SidebarCategorySortManual SidebarCategorySorting = "manual"
 	// sort by recency (default for DMs)
 	SidebarCategorySortRecent SidebarCategorySorting = "recent"
 	// sort by display name alphabetically

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -458,7 +458,7 @@ func (s SqlChannelStore) MigrateSidebarCategories(fromTeamId, fromUserId string)
 			Id:          model.NewId(),
 			UserId:      u.UserId,
 			TeamId:      u.TeamId,
-			Sorting:     model.SidebarCategorySortManual,
+			Sorting:     model.SidebarCategorySortDefault,
 			SortOrder:   model.DefaultSidebarSortOrderFavorites,
 			Type:        model.SidebarCategoryFavorites,
 		}); err != nil && !IsUniqueConstraintError(err, []string{"UserId"}) {
@@ -470,7 +470,7 @@ func (s SqlChannelStore) MigrateSidebarCategories(fromTeamId, fromUserId string)
 			Id:          model.NewId(),
 			UserId:      u.UserId,
 			TeamId:      u.TeamId,
-			Sorting:     model.SidebarCategorySortManual,
+			Sorting:     model.SidebarCategorySortDefault,
 			SortOrder:   model.DefaultSidebarSortOrderChannels,
 			Type:        model.SidebarCategoryChannels,
 		}); err != nil && !IsUniqueConstraintError(err, []string{"UserId"}) {
@@ -3450,7 +3450,7 @@ func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategor
 		Id:          categoryId,
 		UserId:      userId,
 		TeamId:      teamId,
-		Sorting:     model.SidebarCategorySortManual,
+		Sorting:     model.SidebarCategorySortDefault,
 		SortOrder:   maxOrder + model.MinimalSidebarSortDistance,
 		Type:        model.SidebarCategoryCustom,
 	}


### PR DESCRIPTION
Just in case we decide to change how categories are sorted by default, having separate values for the default sorting method and for manual sorting lets us keep track of whether or not a user has actually used manual ordering. The client will treat them the same for now.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25126