### PR TITLE
MM-25256 don't logout mobile users via Session Idle Timeout

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -75,7 +75,7 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 	}
 
 	if *a.Config().ServiceSettings.SessionIdleTimeoutInMinutes > 0 &&
-		!session.IsOAuth &&
+		!session.IsOAuth && !session.IsMobileApp() &&
 		session.Props[model.SESSION_PROP_TYPE] != model.SESSION_TYPE_USER_ACCESS_TOKEN &&
 		!*a.Config().ServiceSettings.ExtendSessionLengthWithActivity {
 


### PR DESCRIPTION
#### Summary

This PR fixes a bug where mobile clients were being logged out via Session Idle Timeout.  This setting only applies to desktop app and browsers.  See system console text.

![session_idle_tmeout](https://user-images.githubusercontent.com/5024605/82083460-c0707b00-96b7-11ea-99d7-57fe38463493.png)

Original ticket with "doesn't apply to mobile" here:  https://mattermost.atlassian.net/browse/MM-7481

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25256