### PR TITLE
[MM-22734] Support different interactive message button styles

### DIFF
--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -47,6 +47,11 @@ type PostAction struct {
 	// If the action is disabled.
 	Disabled bool `json:"disabled,omitempty"`
 
+	// Style defines a text and border style.
+	// Supported values are "default", "primary", "success", "good", "warning", "danger"
+	// and any hex color.
+	Style string `json:"style,omitempty"`
+
 	// DataSource indicates the data source for the select action. If left
 	// empty, the select is populated from Options. Other supported values
 	// are "users" and "channels".


### PR DESCRIPTION
#### Summary
Add `Style` field to `model.PostAction`, which allows integrations to define a button style.

See https://github.com/mattermost/mattermost-webapp/pull/4993 for the webapp changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22734