### PR TITLE
MM-25039:Add function for converting ObjectGUID ID

### DIFF
--- a/einterfaces/ldap.go
+++ b/einterfaces/ldap.go
@@ -21,4 +21,5 @@ type LdapInterface interface {
 	GetGroup(groupUID string) (*model.Group, *model.AppError)
 	GetAllGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError)
 	FirstLoginSync(userID, userAuthService, userAuthData, email string) *model.AppError
+	GetADLdapIdFromSAMLId(authData string) string
 }


### PR DESCRIPTION
#### Summary
Adds function used in Enterprise to convert a Base64 Encoded GUID to a HEX Escaped string used for AD/LDAP

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25039

####Related PR
