### PR TITLE
MM-25039: Update LDAP Auth Data

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -824,8 +824,8 @@ func upgradeDatabaseToVersion526(sqlStore SqlStore) {
 			if err != nil {
 				continue
 			}
-			*user.AuthData = base64.StdEncoding.EncodeToString(originBytes)
-			sqlStore.User().Update(user, false)
+			authData := base64.StdEncoding.EncodeToString(originBytes)
+			sqlStore.User().UpdateAuthData(user.Id, user.AuthService, &authData, user.Email, false)
 		}
 	}
 	// 	saveSchemaVersion(sqlStore, VERSION_5_26_0)


### PR DESCRIPTION
#### Summary
Updates the AD/LDAP AuthData field to match a normal base64 encoded GUID. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25039

#### Related PRs
