### PR TITLE
MM-25369: Disable Brotli in 'dev' mode.

### DIFF
--- a/web/static.go
+++ b/web/static.go
@@ -126,11 +126,13 @@ func staticFilesHandler(handler http.Handler) http.Handler {
 
 func brotliFilesHandler(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		isRequestingBrotliFile, contentType := requestingBrotliFileExtension(r)
-		if isRequestingBrotliFile && acceptsEncodingBrotli(r) {
-			r.URL.Path = r.URL.Path + ".br"
-			w.Header().Set("Content-Encoding", "br")
-			w.Header().Set("Content-Type", contentType)
+		if model.BuildNumber != "dev" {
+			isRequestingBrotliFile, contentType := requestingBrotliFileExtension(r)
+			if isRequestingBrotliFile && acceptsEncodingBrotli(r) {
+				r.URL.Path = r.URL.Path + ".br"
+				w.Header().Set("Content-Encoding", "br")
+				w.Header().Set("Content-Type", contentType)
+			}
 		}
 
 		handler.ServeHTTP(w, r)


### PR DESCRIPTION

#### Summary

The front-end save-to-reload time went from about 13 to 40 seconds on my local machine, which is annoyingly slow, so I've disabled Brotli in "dev" mode.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-25369