### PR TITLE
MM-25281  Place new categories in the correct position

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -1739,7 +1739,14 @@ func TestSidebarCategory(t *testing.T) {
 	basicChannel2 := th.CreateChannel(th.BasicTeam)
 	defer th.App.PermanentDeleteChannel(basicChannel2)
 	user := th.CreateUser()
+	th.LinkUserToTeam(user, th.BasicTeam)
+	th.AddUserToChannel(user, basicChannel2)
+
 	var createdCategory *model.SidebarCategoryWithChannels
+	t.Run("MigrateSidebarCategories", func(t *testing.T) {
+		_, err := th.App.Srv().Store.Channel().MigrateSidebarCategories(strings.Repeat("0", 26), strings.Repeat("0", 26))
+		require.Nil(t, err, "Should finish initial migration")
+	})
 	t.Run("CreateSidebarCategory", func(t *testing.T) {
 		catData := model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{
@@ -1775,6 +1782,7 @@ func TestSidebarCategory(t *testing.T) {
 	t.Run("GetSidebarCategoryOrder", func(t *testing.T) {
 		catOrder, err := th.App.GetSidebarCategoryOrder(user.Id, th.BasicTeam.Id)
 		require.Nil(t, err, "Expected no error")
-		require.Len(t, catOrder, 1)
+		require.Len(t, catOrder, 4)
+		require.Equal(t, catOrder[1], createdCategory.Id, "the newly created category should be after favorites")
 	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When a new category is created, it should be placed as follows:
1. If the Favorites category is first, the new category should be placed after it
2. Otherwise, the new category should be placed first.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-25281
