### PR TITLE
MM-25154: Fix data race in InvokeClusterLeaderChangedListener

### DIFF
--- a/app/cluster.go
+++ b/app/cluster.go
@@ -23,6 +23,10 @@ func (s *Server) RemoveClusterLeaderChangedListener(id string) {
 
 func (s *Server) InvokeClusterLeaderChangedListeners() {
 	s.Log.Info("Cluster leader changed. Invoking ClusterLeaderChanged listeners.")
+	// This needs to be run in a separate goroutine otherwise a recursive lock happens
+	// because the listener function eventually ends up calling .IsLeader().
+	// Fixing this would require the changed event to pass the leader directly, but that
+	// requires a lot of work.
 	s.Go(func() {
 		s.clusterLeaderListeners.Range(func(_, listener interface{}) bool {
 			listener.(func())()

--- a/app/server.go
+++ b/app/server.go
@@ -333,6 +333,9 @@ func NewServer(options ...Option) (*Server, error) {
 		mlog.Error("Error to reset the server status.", mlog.Err(err))
 	}
 
+	// Scheduler must be started before cluster.
+	s.initJobs()
+
 	if s.joinCluster && s.Cluster != nil {
 		s.FakeApp().registerAllClusterMessageHandlers()
 		s.Cluster.StartInterNodeCommunication()
@@ -356,8 +359,6 @@ func NewServer(options ...Option) (*Server, error) {
 			mlog.Error("Unable to deactivate guest accounts", mlog.Err(appErr))
 		}
 	}
-
-	s.initJobs()
 
 	if s.runjobs {
 		s.Go(func() {
@@ -471,6 +472,7 @@ func (s *Server) Shutdown() error {
 		s.Metrics.StopServer()
 	}
 
+	// This must be done after the cluster is stopped.
 	if s.Jobs != nil && s.runjobs {
 		s.Jobs.StopWorkers()
 		s.Jobs.StopSchedulers()

--- a/app/server_app_adapters.go
+++ b/app/server_app_adapters.go
@@ -114,7 +114,7 @@ func (s *Server) RunOldAppInitialization() error {
 
 	s.clusterLeaderListenerId = s.AddClusterLeaderChangedListener(func() {
 		mlog.Info("Cluster leader changed. Determining if job schedulers should be running:", mlog.Bool("isLeader", s.FakeApp().IsLeader()))
-		if s.Jobs != nil {
+		if s.Jobs != nil && s.Jobs.Schedulers != nil {
 			s.Jobs.Schedulers.HandleClusterLeaderChange(s.FakeApp().IsLeader())
 		}
 	})


### PR DESCRIPTION
The order of booting up a server should be
Job scheduler -> Cluster.

And shutdown should be the opposite. This is needed because the job scheduler
initializes certain data structures that are later called by ClusterLeaderChanged
event handlers. And the event handlers run in a separate goroutine.

Therefore, if the cluster initialization happens before the job scheduler,
then a race happens between accessing the jobs variable and setting it.

To prevent this race, we fix the order of startup, and add comments in both
places to prevent things from regressing again.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-25154