### PR TITLE
[MM-23690] Not showing updated / correct roles when searching for user in the team members modal after their role has been updated

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -464,7 +464,7 @@ func getTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	sort := r.URL.Query().Get("sort")
-	searchTerm := r.URL.Query().Get("search_term")
+	term := r.URL.Query().Get("term")
 	excludeDeletedUsers := r.URL.Query().Get("exclude_deleted_users")
 	excludeDeletedUsersBool, _ := strconv.ParseBool(excludeDeletedUsers)
 
@@ -483,7 +483,7 @@ func getTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		Sort:                sort,
 		ExcludeDeletedUsers: excludeDeletedUsersBool,
 		ViewRestrictions:    restrictions,
-		SearchTerm: searchTerm,
+		Term: term,
 	}
 
 	members, err := c.App.GetTeamMembers(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage, teamMembersGetOptions)

--- a/api4/team.go
+++ b/api4/team.go
@@ -464,6 +464,7 @@ func getTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	sort := r.URL.Query().Get("sort")
+	searchTerm := r.URL.Query().Get("search_term")
 	excludeDeletedUsers := r.URL.Query().Get("exclude_deleted_users")
 	excludeDeletedUsersBool, _ := strconv.ParseBool(excludeDeletedUsers)
 
@@ -482,6 +483,7 @@ func getTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		Sort:                sort,
 		ExcludeDeletedUsers: excludeDeletedUsersBool,
 		ViewRestrictions:    restrictions,
+		SearchTerm: searchTerm,
 	}
 
 	members, err := c.App.GetTeamMembers(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage, teamMembersGetOptions)

--- a/api4/team.go
+++ b/api4/team.go
@@ -483,7 +483,7 @@ func getTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		Sort:                sort,
 		ExcludeDeletedUsers: excludeDeletedUsersBool,
 		ViewRestrictions:    restrictions,
-		Term: term,
+		Term:                term,
 	}
 
 	members, err := c.App.GetTeamMembers(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage, teamMembersGetOptions)

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -58,6 +58,7 @@ type TeamMembersGetOptions struct {
 	// Restrict to search in a list of teams and channels
 	ViewRestrictions *ViewUsersRestrictions
 
+	// The term which we match for on a team members email, username, nickname, or full name.
 	SearchTerm string
 }
 

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -57,6 +57,8 @@ type TeamMembersGetOptions struct {
 
 	// Restrict to search in a list of teams and channels
 	ViewRestrictions *ViewUsersRestrictions
+
+	SearchTerm string
 }
 
 func (o *TeamMember) ToJson() string {

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -59,7 +59,7 @@ type TeamMembersGetOptions struct {
 	ViewRestrictions *ViewUsersRestrictions
 
 	// The term which we search for on a team members email, username, nickname, or full name.
-	SearchTerm string
+	Term string
 }
 
 func (o *TeamMember) ToJson() string {

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -58,7 +58,7 @@ type TeamMembersGetOptions struct {
 	// Restrict to search in a list of teams and channels
 	ViewRestrictions *ViewUsersRestrictions
 
-	// The term which we match for on a team members email, username, nickname, or full name.
+	// The term which we search for on a team members email, username, nickname, or full name.
 	SearchTerm string
 }
 

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -881,6 +881,11 @@ func (s SqlTeamStore) GetMembers(teamId string, offset int, limit int, teamMembe
 			query = query.OrderBy(model.USERNAME)
 		}
 
+		if (teamMembersGetOptions.SearchTerm != "") {
+			isPostgreSQL := s.DriverName() == model.DATABASE_DRIVER_POSTGRES
+			query = generateSearchQuery(query, strings.Fields(teamMembersGetOptions.SearchTerm), USER_SEARCH_TYPE_ALL, isPostgreSQL)
+		}
+
 		query = applyTeamMemberViewRestrictionsFilter(query, teamId, teamMembersGetOptions.ViewRestrictions)
 	}
 

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -869,7 +869,7 @@ func (s SqlTeamStore) GetMembers(teamId string, offset int, limit int, teamMembe
 	}
 
 	if teamMembersGetOptions != nil {
-		if teamMembersGetOptions.Sort == model.USERNAME || teamMembersGetOptions.ExcludeDeletedUsers {
+		if teamMembersGetOptions.Sort == model.USERNAME || teamMembersGetOptions.ExcludeDeletedUsers || teamMembersGetOptions.SearchTerm != "" {
 			query = query.LeftJoin("Users ON TeamMembers.UserId = Users.Id")
 		}
 

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -869,7 +869,7 @@ func (s SqlTeamStore) GetMembers(teamId string, offset int, limit int, teamMembe
 	}
 
 	if teamMembersGetOptions != nil {
-		if teamMembersGetOptions.Sort == model.USERNAME || teamMembersGetOptions.ExcludeDeletedUsers || teamMembersGetOptions.SearchTerm != "" {
+		if teamMembersGetOptions.Sort == model.USERNAME || teamMembersGetOptions.ExcludeDeletedUsers || teamMembersGetOptions.Term != "" {
 			query = query.LeftJoin("Users ON TeamMembers.UserId = Users.Id")
 		}
 
@@ -881,9 +881,9 @@ func (s SqlTeamStore) GetMembers(teamId string, offset int, limit int, teamMembe
 			query = query.OrderBy(model.USERNAME)
 		}
 
-		if (teamMembersGetOptions.SearchTerm != "") {
+		if (teamMembersGetOptions.Term != "") {
 			isPostgreSQL := s.DriverName() == model.DATABASE_DRIVER_POSTGRES
-			query = generateSearchQuery(query, strings.Fields(teamMembersGetOptions.SearchTerm), USER_SEARCH_TYPE_ALL, isPostgreSQL)
+			query = generateSearchQuery(query, strings.Fields(teamMembersGetOptions.Term), USER_SEARCH_TYPE_ALL, isPostgreSQL)
 		}
 
 		query = applyTeamMemberViewRestrictionsFilter(query, teamId, teamMembersGetOptions.ViewRestrictions)

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -881,7 +881,7 @@ func (s SqlTeamStore) GetMembers(teamId string, offset int, limit int, teamMembe
 			query = query.OrderBy(model.USERNAME)
 		}
 
-		if (teamMembersGetOptions.Term != "") {
+		if teamMembersGetOptions.Term != "" {
 			isPostgreSQL := s.DriverName() == model.DATABASE_DRIVER_POSTGRES
 			query = generateSearchQuery(query, strings.Fields(teamMembersGetOptions.Term), USER_SEARCH_TYPE_ALL, isPostgreSQL)
 		}

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1239,9 +1239,9 @@ func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string
 		termArgs := []interface{}{}
 		for _, field := range fields {
 			if isPostgreSQL {
-				searchFields = append(searchFields, fmt.Sprintf("lower(%s) LIKE lower(?) escape '*' ", field))
+				searchFields = append(searchFields, fmt.Sprintf("lower(Users.%s) LIKE lower(?) escape '*' ", field))
 			} else {
-				searchFields = append(searchFields, fmt.Sprintf("%s LIKE ? escape '*' ", field))
+				searchFields = append(searchFields, fmt.Sprintf("Users.%s LIKE ? escape '*' ", field))
 			}
 			termArgs = append(termArgs, fmt.Sprintf("%s%%", strings.TrimLeft(term, "@")))
 		}


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
If you search for a particular member in the team members modal on chat facing side after a user has had their role updated, it will show an incorrect / out of date role. This PR aims to fix this problem.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23690