### PR TITLE
MM-25014:set group name when group is created

### DIFF
--- a/api4/group.go
+++ b/api4/group.go
@@ -141,25 +141,12 @@ func patchGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 			tmp := strings.ReplaceAll(strings.ToLower(group.DisplayName), " ", "-")
 			groupPatch.Name = &tmp
 		} else {
-			if *groupPatch.Name == model.USER_NOTIFY_ALL || *groupPatch.Name == model.CHANNEL_MENTIONS_NOTIFY_PROP || *groupPatch.Name == model.USER_NOTIFY_HERE {
-				c.Err = model.NewAppError("Api4.patchGroup", "api.ldap_groups.existing_reserved_name_error", nil, "", http.StatusNotImplemented)
+			err = c.App.ValidateGroupName(*groupPatch.Name)
+			if err != nil {
+				c.Err = err
 				return
 			}
-			//check if a user already has this group name
-			user, _ := c.App.GetUserByUsername(*groupPatch.Name)
-			if user != nil {
-				c.Err = model.NewAppError("Api4.patchGroup", "api.ldap_groups.existing_user_name_error", nil, "", http.StatusNotImplemented)
-				return
-			}
-			//check if a mentionable group already has this name
-			searchOpts := model.GroupSearchOpts{
-				FilterAllowReference: true,
-			}
-			existingGroup, _ := c.App.GetGroupByName(*groupPatch.Name, searchOpts)
-			if existingGroup != nil {
-				c.Err = model.NewAppError("Api4.patchGroup", "api.ldap_groups.existing_group_name_error", nil, "", http.StatusNotImplemented)
-				return
-			}
+
 		}
 	}
 

--- a/api4/ldap.go
+++ b/api4/ldap.go
@@ -203,7 +203,7 @@ func linkLdapGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		// Only try a finite number of times, then give up.
 		baseName := strings.ReplaceAll(strings.ToLower(displayName), " ", "-")
 		validName := ""
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 10; i++ {
 			checkName := baseName
 			if i > 0 {
 				checkName = baseName + "-" + strconv.Itoa(i)

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -325,6 +325,8 @@ type AppIface interface {
 	// UserIsInAdminRoleGroup returns true at least one of the user's groups are configured to set the members as
 	// admins in the given syncable.
 	UserIsInAdminRoleGroup(userID, syncableID string, syncableType model.GroupSyncableType) (bool, *model.AppError)
+	// Validates the group name is unique from all other potential tag values.
+	ValidateGroupName(groupName string) *model.AppError
 	// VerifyPlugin checks that the given signature corresponds to the given plugin and matches a trusted certificate.
 	VerifyPlugin(plugin, signature io.ReadSeeker) *model.AppError
 	//GetUserStatusesByIds used by apiV4

--- a/app/group.go
+++ b/app/group.go
@@ -4,6 +4,8 @@
 package app
 
 import (
+	"net/http"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
@@ -53,6 +55,23 @@ func (a *App) DeleteGroup(groupID string) (*model.Group, *model.AppError) {
 	}
 
 	return deletedGroup, err
+}
+
+// Validates the group name is unique from all other potential tag values.
+func (a *App) ValidateGroupName(groupName string) *model.AppError {
+	if groupName == model.USER_NOTIFY_ALL || groupName == model.CHANNEL_MENTIONS_NOTIFY_PROP || groupName == model.USER_NOTIFY_HERE {
+		return model.NewAppError("validateGroupName", "api.ldap_groups.existing_reserved_name_error", nil, "", http.StatusNotImplemented)
+	}
+	//check if a user already has this group name
+	user, _ := a.GetUserByUsername(groupName)
+	if user != nil {
+		return model.NewAppError("validateGroupName", "api.ldap_groups.existing_user_name_error", nil, "", http.StatusNotImplemented)
+	}
+	existingGroup, _ := a.GetGroupByName(groupName, model.GroupSearchOpts{})
+	if existingGroup != nil {
+		return model.NewAppError("validateGroupName", "api.ldap_groups.existing_group_name_error", nil, "", http.StatusNotImplemented)
+	}
+	return nil
 }
 
 func (a *App) GetGroupMemberUsers(groupID string) ([]*model.User, *model.AppError) {

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -101,6 +101,40 @@ func TestDeleteGroup(t *testing.T) {
 	require.Nil(t, g)
 }
 
+func TestValidateGroup(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	// Test reserved names
+	err := th.App.ValidateGroupName("all")
+	require.NotNil(t, err)
+
+	err = th.App.ValidateGroupName("here")
+	require.NotNil(t, err)
+	err = th.App.ValidateGroupName("channel")
+	require.NotNil(t, err)
+
+	// Test existing group name
+	group := th.CreateGroup()
+	err = th.App.ValidateGroupName(group.Name)
+	require.NotNil(t, err)
+	g, err := th.App.DeleteGroup(group.Id)
+	require.Nil(t, err)
+	require.NotNil(t, g)
+	err = th.App.ValidateGroupName(group.Name)
+	require.NotNil(t, err)
+
+	// Test existing group name
+	user := th.CreateUser()
+	err = th.App.ValidateGroupName(user.Username)
+	require.NotNil(t, err)
+	err = th.App.PermanentDeleteUser(user)
+	require.Nil(t, err)
+
+	err = th.App.ValidateGroupName("new-group-name")
+	require.Nil(t, err)
+}
+
 func TestCreateOrRestoreGroupMember(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/app/opentracing_layer.go
+++ b/app/opentracing_layer.go
@@ -15094,6 +15094,28 @@ func (a *OpenTracingAppLayer) ValidateAndSetLicenseBytes(b []byte) {
 	a.app.ValidateAndSetLicenseBytes(b)
 }
 
+func (a *OpenTracingAppLayer) ValidateGroupName(groupName string) *model.AppError {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.ValidateGroupName")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.ValidateGroupName(groupName)
+
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0
+}
+
 func (a *OpenTracingAppLayer) VerifyEmailFromToken(userSuppliedTokenString string) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.VerifyEmailFromToken")


### PR DESCRIPTION
#### Summary
When a group link gets created it is being created with a "NewId()" as the name value. That value is then used in the WebApp as the token or slug. This PR creates the slug name when the group is created.

Although group mentions may never be turned on for that group, the Name field is indexed and must be unique. Therefore, we may append a duplicate breaker. When a group is patched, we must also check for uniqueness. The patch results in a thrown error for the user to modify. When it is being created, we must have a unique identifier. If a unique name base on Display Name cannot be found, default is the NewId().

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25014