### PR TITLE
Remove database read check from enhanced ping endpoint

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -79,7 +79,7 @@ func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {
 		dbStatusKey := "database_status"
 		s[dbStatusKey] = model.STATUS_OK
 
-		// Database Write/Read Check
+		// Database Write Check
 		currentTime := fmt.Sprintf("%d", time.Now().Unix())
 		healthCheckKey := fmt.Sprintf("health_check_%s", c.App.GetClusterId())
 
@@ -91,27 +91,17 @@ func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {
 			mlog.Warn("Unable to write to database.", mlog.Err(writeErr))
 			s[dbStatusKey] = model.STATUS_UNHEALTHY
 			s[model.STATUS] = model.STATUS_UNHEALTHY
-		} else {
-			healthCheck, readErr := c.App.Srv().Store.System().GetByName(healthCheckKey)
-			if readErr != nil {
-				mlog.Warn("Unable to read from database.", mlog.Err(readErr))
-				s[dbStatusKey] = model.STATUS_UNHEALTHY
-				s[model.STATUS] = model.STATUS_UNHEALTHY
-			} else if healthCheck.Value != currentTime {
-				mlog.Warn("Incorrect healthcheck value", mlog.String("expected", currentTime), mlog.String("got", healthCheck.Value))
-				s[dbStatusKey] = model.STATUS_UNHEALTHY
-				s[model.STATUS] = model.STATUS_UNHEALTHY
-			}
-			_, writeErr = c.App.Srv().Store.System().PermanentDeleteByName(healthCheckKey)
-			if writeErr != nil {
-				mlog.Warn("Unable to remove ping health check value from database", mlog.Err(writeErr))
-				s[dbStatusKey] = model.STATUS_UNHEALTHY
-				s[model.STATUS] = model.STATUS_UNHEALTHY
-			}
+		}
 
-			if s[dbStatusKey] == model.STATUS_OK {
-				mlog.Debug("Able to write/read files to database")
-			}
+		_, writeErr = c.App.Srv().Store.System().PermanentDeleteByName(healthCheckKey)
+		if writeErr != nil {
+			mlog.Warn("Unable to remove ping health check value from database.", mlog.Err(writeErr))
+			s[dbStatusKey] = model.STATUS_UNHEALTHY
+			s[model.STATUS] = model.STATUS_UNHEALTHY
+		}
+
+		if s[dbStatusKey] == model.STATUS_OK {
+			mlog.Debug("Able to write to database.")
 		}
 
 		filestoreStatusKey := "filestore_status"


### PR DESCRIPTION
The enhanced ping endpoint can return an unhealthy database read
result if the database read replicas have a high-enough replication
delay. Instead of adding the complexity and delay of retry logic,
we are opting to remove the read check for now and will re-add it
in the future in a separate health check flow.

https://mattermost.atlassian.net/browse/MM-25428