### PR TITLE
[MM-25405] Fix client4.GetPluginStatuses()

### DIFF
--- a/model/client4.go
+++ b/model/client4.go
@@ -4725,7 +4725,7 @@ func (c *Client4) GetPlugins() (*PluginsResponse, *Response) {
 // to the administrator via the system console.
 // WARNING: PLUGINS ARE STILL EXPERIMENTAL. THIS FUNCTION IS SUBJECT TO CHANGE.
 func (c *Client4) GetPluginStatuses() (PluginStatuses, *Response) {
-	r, err := c.DoApiGet(c.GetPluginsRoute(), "/statuses")
+	r, err := c.DoApiGet(c.GetPluginsRoute()+"/statuses", "")
 	if err != nil {
 		return nil, BuildErrorResponse(r, err)
 	}


### PR DESCRIPTION
#### Summary

PR fixes `client4.GetPluginStatuses()` which cause of an error in passing the arguments was essentially behaving like `client4.GetPlugins()`.

Tested with (assuming there's at least one plugin enabled):

```go
package main

import (
	"fmt"
	"os"

	"github.com/mattermost/mattermost-server/model"
)

func main() {
	client := model.NewAPIv4Client("http://localhost:8065")
	if _, res := client.Login("sysadmin", "adminpass"); res.Error != nil {
		fmt.Println(res.Error)
		os.Exit(-1)
	}

	plugins, res := client.GetPlugins()
	if res.Error != nil {
		fmt.Println(res.Error)
		os.Exit(-1)
	}
	fmt.Printf("%+v\n", plugins.Active[0])

	statuses, res := client.GetPluginStatuses()
	if res.Error != nil {
		fmt.Println(res.Error)
		os.Exit(-1)
	}
	fmt.Printf("%+v\n", statuses[0])
}

```

#### Ticket

https://mattermost.atlassian.net/browse/MM-25405