### PR TITLE
MM-24481: Use atomics for load/store of client configs

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -72,15 +72,15 @@ func (a *App) ReloadConfig() error {
 }
 
 func (a *App) ClientConfig() map[string]string {
-	return a.Srv().clientConfig
+	return a.Srv().clientConfig.Load().(map[string]string)
 }
 
 func (a *App) ClientConfigHash() string {
-	return a.Srv().clientConfigHash
+	return a.Srv().clientConfigHash.Load().(string)
 }
 
 func (a *App) LimitedClientConfig() map[string]string {
-	return a.Srv().limitedClientConfig
+	return a.Srv().limitedClientConfig.Load().(map[string]string)
 }
 
 // Registers a function with a given listener to be called when the config is reloaded and may have changed. The function
@@ -319,9 +319,9 @@ func (a *App) regenerateClientConfig() {
 	}
 
 	clientConfigJSON, _ := json.Marshal(clientConfig)
-	a.Srv().clientConfig = clientConfig
-	a.Srv().limitedClientConfig = limitedClientConfig
-	a.Srv().clientConfigHash = fmt.Sprintf("%x", md5.Sum(clientConfigJSON))
+	a.Srv().clientConfig.Store(clientConfig)
+	a.Srv().limitedClientConfig.Store(limitedClientConfig)
+	a.Srv().clientConfigHash.Store(fmt.Sprintf("%x", md5.Sum(clientConfigJSON)))
 }
 
 func (a *App) GetCookieDomain() string {

--- a/app/server.go
+++ b/app/server.go
@@ -121,9 +121,9 @@ type Server struct {
 	pluginCommands     []*PluginCommand
 	pluginCommandsLock sync.RWMutex
 
-	clientConfig        map[string]string
-	clientConfigHash    string
-	limitedClientConfig map[string]string
+	clientConfig        atomic.Value
+	clientConfigHash    atomic.Value
+	limitedClientConfig atomic.Value
 
 	diagnosticId     string
 	diagnosticClient analytics.Client
@@ -171,7 +171,6 @@ func NewServer(options ...Option) (*Server, error) {
 		RootRouter:          rootRouter,
 		LocalRouter:         localRouter,
 		licenseListeners:    map[string]func(*model.License, *model.License){},
-		clientConfig:        make(map[string]string),
 	}
 
 	for _, option := range options {


### PR DESCRIPTION
There are 3 client config related variables which are set in regenerateClientConfig
but can be read from public methods in the App struct.

We use the same approach as the license fields in the App struct and use atomic.Value
for modifying them.

### Ticket link

https://mattermost.atlassian.net/browse/MM-24481