### PR TITLE
Remove jobServer from search engine

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -226,8 +226,8 @@ func NewServer(options ...Option) (*Server, error) {
 		return nil, errors.Wrapf(err, "unable to load Mattermost translation files")
 	}
 
-	searchEngine := searchengine.NewBroker(s.Config(), s.Jobs)
-	bleveEngine := bleveengine.NewBleveEngine(s.Config(), s.Jobs)
+	searchEngine := searchengine.NewBroker(s.Config())
+	bleveEngine := bleveengine.NewBleveEngine(s.Config())
 	if err := bleveEngine.Start(); err != nil {
 		return nil, err
 	}

--- a/services/searchengine/bleveengine/bleve.go
+++ b/services/searchengine/bleveengine/bleve.go
@@ -11,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/mattermost/mattermost-server/v5/jobs"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 
@@ -35,7 +34,6 @@ type BleveEngine struct {
 	Mutex        sync.RWMutex
 	ready        int32
 	cfg          *model.Config
-	jobServer    *jobs.JobServer
 	indexSync    bool
 }
 
@@ -97,11 +95,8 @@ func getUserIndexMapping() *mapping.IndexMappingImpl {
 	return indexMapping
 }
 
-func NewBleveEngine(cfg *model.Config, jobServer *jobs.JobServer) *BleveEngine {
-	return &BleveEngine{
-		cfg:       cfg,
-		jobServer: jobServer,
-	}
+func NewBleveEngine(cfg *model.Config) *BleveEngine {
+	return &BleveEngine{cfg: cfg}
 }
 
 func (b *BleveEngine) getIndexDir(indexName string) string {

--- a/services/searchengine/bleveengine/bleve_test.go
+++ b/services/searchengine/bleveengine/bleve_test.go
@@ -57,10 +57,10 @@ func (s *BleveEngineTestSuite) setupStore() {
 	cfg.BleveSettings.IndexDir = model.NewString(s.IndexDir)
 	cfg.SqlSettings.DisableDatabaseSearch = model.NewBool(true)
 
-	s.SearchEngine = searchengine.NewBroker(cfg, nil)
+	s.SearchEngine = searchengine.NewBroker(cfg)
 	s.Store = searchlayer.NewSearchLayer(&testlib.TestStore{Store: s.SQLSupplier}, s.SearchEngine, cfg)
 
-	bleveEngine := NewBleveEngine(cfg, nil)
+	bleveEngine := NewBleveEngine(cfg)
 	bleveEngine.indexSync = true
 	s.SearchEngine.RegisterBleveEngine(bleveEngine)
 	if err := bleveEngine.Start(); err != nil {

--- a/services/searchengine/searchengine.go
+++ b/services/searchengine/searchengine.go
@@ -4,14 +4,12 @@
 package searchengine
 
 import (
-	"github.com/mattermost/mattermost-server/v5/jobs"
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
-func NewBroker(cfg *model.Config, jobServer *jobs.JobServer) *Broker {
+func NewBroker(cfg *model.Config) *Broker {
 	return &Broker{
 		cfg:       cfg,
-		jobServer: jobServer,
 	}
 }
 
@@ -25,7 +23,6 @@ func (seb *Broker) RegisterBleveEngine(be SearchEngineInterface) {
 
 type Broker struct {
 	cfg                 *model.Config
-	jobServer           *jobs.JobServer
 	ElasticsearchEngine SearchEngineInterface
 	BleveEngine         SearchEngineInterface
 }

--- a/services/searchengine/searchengine.go
+++ b/services/searchengine/searchengine.go
@@ -9,7 +9,7 @@ import (
 
 func NewBroker(cfg *model.Config) *Broker {
 	return &Broker{
-		cfg:       cfg,
+		cfg: cfg,
 	}
 }
 

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -106,7 +106,7 @@ func (h *MainHelper) setupStore() {
 	config := &model.Config{}
 	config.SetDefaults()
 
-	h.SearchEngine = searchengine.NewBroker(config, nil)
+	h.SearchEngine = searchengine.NewBroker(config)
 	h.ClusterInterface = &FakeClusterInterface{}
 	h.SQLSupplier = sqlstore.NewSqlSupplier(*h.Settings, nil)
 	h.Store = searchlayer.NewSearchLayer(&TestStore{


### PR DESCRIPTION
#### Summary
We were passing the jobserver to the searchengine but not using it. This PR removes those unused bits of code

#### Related Pull Requests
 - [Has enterprise PR](https://github.com/mattermost/enterprise/pull/667)