### PR TITLE
[MM-25388] Add telemetry for default picture attribute

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -560,7 +560,7 @@ func (a *App) trackConfig() {
 		"isdefault_group_id_attribute":           isDefault(*cfg.LdapSettings.GroupIdAttribute, model.LDAP_SETTINGS_DEFAULT_GROUP_ID_ATTRIBUTE),
 		"isempty_guest_filter":                   isDefault(*cfg.LdapSettings.GuestFilter, ""),
 		"isempty_admin_filter":                   isDefault(*cfg.LdapSettings.AdminFilter, ""),
-		"isdefault_picture_attribute":            isDefault(*cfg.LdapSettings.PictureAttribute, model.LDAP_SETTINGS_DEFAULT_PICTURE_ATTRIBUTE),
+		"isempty_picture_attribute":              isDefault(*cfg.LdapSettings.PictureAttribute, ""),
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_COMPLIANCE, map[string]interface{}{

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -560,7 +560,7 @@ func (a *App) trackConfig() {
 		"isdefault_group_id_attribute":           isDefault(*cfg.LdapSettings.GroupIdAttribute, model.LDAP_SETTINGS_DEFAULT_GROUP_ID_ATTRIBUTE),
 		"isempty_guest_filter":                   isDefault(*cfg.LdapSettings.GuestFilter, ""),
 		"isempty_admin_filter":                   isDefault(*cfg.LdapSettings.AdminFilter, ""),
-		"isempty_picture_attribute":              isDefault(*cfg.LdapSettings.PictureAttribute, ""),
+		"isnotempty_picture_attribute":           !isDefault(*cfg.LdapSettings.PictureAttribute, ""),
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_COMPLIANCE, map[string]interface{}{

--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -560,6 +560,7 @@ func (a *App) trackConfig() {
 		"isdefault_group_id_attribute":           isDefault(*cfg.LdapSettings.GroupIdAttribute, model.LDAP_SETTINGS_DEFAULT_GROUP_ID_ATTRIBUTE),
 		"isempty_guest_filter":                   isDefault(*cfg.LdapSettings.GuestFilter, ""),
 		"isempty_admin_filter":                   isDefault(*cfg.LdapSettings.AdminFilter, ""),
+		"isdefault_picture_attribute":            isDefault(*cfg.LdapSettings.PictureAttribute, model.LDAP_SETTINGS_DEFAULT_PICTURE_ATTRIBUTE),
 	})
 
 	a.SendDiagnostic(TRACK_CONFIG_COMPLIANCE, map[string]interface{}{


### PR DESCRIPTION
#### Summary
- Adds an attribute to the ldap telemetry to determine if the picture attribute has been set to something other than the default (empty) 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-25388