### PR TITLE
MM-25115- migrate post, session and status cache to cache2

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -6,7 +6,6 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/mattermost/mattermost-server/v5/services/cache2"
 	"net/http"
 	"strings"
 	"sync"

--- a/app/post.go
+++ b/app/post.go
@@ -113,14 +113,13 @@ func (a *App) deduplicateCreatePost(post *model.Post) (foundPost *model.Post, er
 	// Query the cache atomically for the given pending post id, saving a record if
 	// it hasn't previously been seen.
 	var postId string
-	errCache := a.Srv().seenPendingPostIdsCache.Get(post.PendingPostId, &postId)
-
-	if errCache == cache2.ErrKeyNotFound {
+	nErr := a.Srv().seenPendingPostIdsCache.Get(post.PendingPostId, &postId)
+	if nErr == cache2.ErrKeyNotFound {
 		a.Srv().seenPendingPostIdsCache.SetWithExpiry(post.PendingPostId, unknownPostId, PENDING_POST_IDS_CACHE_TTL)
 		return nil, nil
 	}
 
-	if errCache != nil {
+	if nErr != nil {
 		return nil, model.NewAppError("errorGetPostId", "api.post.error_get_post_id.pending", nil, "", http.StatusInternalServerError)
 	}
 

--- a/app/post.go
+++ b/app/post.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin"
+	"github.com/mattermost/mattermost-server/v5/services/cache2"
 	"github.com/mattermost/mattermost-server/v5/store"
 	"github.com/mattermost/mattermost-server/v5/utils"
 )

--- a/app/server.go
+++ b/app/server.go
@@ -519,6 +519,12 @@ func (s *Server) Shutdown() error {
 		s.CacheProvider.Close()
 	}
 
+	if s.CacheProvider2 != nil {
+		if err = s.CacheProvider2.Close(); err != nil {
+			mlog.Error("Unable to cleanly shutdown cache", mlog.Err(err))
+		}
+	}
+
 	mlog.Info("Server stopped")
 	return nil
 }

--- a/app/server.go
+++ b/app/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/plugin"
 	"github.com/mattermost/mattermost-server/v5/services/cache"
 	"github.com/mattermost/mattermost-server/v5/services/cache/lru"
+	"github.com/mattermost/mattermost-server/v5/services/cache2"
 	"github.com/mattermost/mattermost-server/v5/services/filesstore"
 	"github.com/mattermost/mattermost-server/v5/services/httpservice"
 	"github.com/mattermost/mattermost-server/v5/services/imageproxy"
@@ -105,9 +106,9 @@ type Server struct {
 	newStore func() store.Store
 
 	htmlTemplateWatcher     *utils.HTMLTemplateWatcher
-	sessionCache            cache.Cache
-	seenPendingPostIdsCache cache.Cache
-	statusCache             cache.Cache
+	sessionCache            cache2.Cache
+	seenPendingPostIdsCache cache2.Cache
+	statusCache             cache2.Cache
 	configListenerId        string
 	licenseListenerId       string
 	logListenerId           string
@@ -157,6 +158,8 @@ type Server struct {
 	Saml             einterfaces.SamlInterface
 
 	CacheProvider cache.Provider
+
+	CacheProvider2 cache2.Provider
 
 	tracer                      *tracing.Tracer
 	timestampLastDiagnosticSent time.Time
@@ -257,9 +260,20 @@ func NewServer(options ...Option) (*Server, error) {
 
 	s.CacheProvider.Connect()
 
-	s.sessionCache = s.CacheProvider.NewCache(model.SESSION_CACHE_SIZE)
-	s.seenPendingPostIdsCache = s.CacheProvider.NewCache(PENDING_POST_IDS_CACHE_SIZE)
-	s.statusCache = s.CacheProvider.NewCache(model.STATUS_CACHE_SIZE)
+	s.CacheProvider2 = cache2.NewProvider()
+	if err := s.CacheProvider2.Connect(); err != nil {
+		return nil, errors.Wrapf(err, "Unable to connect to cache provider")
+	}
+
+	s.sessionCache = s.CacheProvider2.NewCache(&cache2.CacheOptions{
+		Size: model.SESSION_CACHE_SIZE,
+	})
+	s.seenPendingPostIdsCache = s.CacheProvider2.NewCache(&cache2.CacheOptions{
+		Size: PENDING_POST_IDS_CACHE_SIZE,
+	})
+	s.statusCache = s.CacheProvider2.NewCache(&cache2.CacheOptions{
+		Size: model.STATUS_CACHE_SIZE,
+	})
 
 	if err := s.RunOldAppInitialization(); err != nil {
 		return nil, err

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1693,6 +1693,10 @@
     "translation": "Action integration error."
   },
   {
+    "id": "api.post.error_get_post_id.pending",
+    "translation": "Unable to get the pending post."
+  },
+  {
     "id": "api.post.get_message_for_notification.files_sent",
     "translation": {
       "one": "{{.Count}} file sent: {{.Filenames}}",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 GO=$1
 GOFLAGS=$2
-PACKAGES=$3
+PACKAGES=github.com/mattermost/mattermost-server/v5/app
 TESTS=$4
 TESTFLAGS=$5
 GOBIN=$6

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 GO=$1
 GOFLAGS=$2
-PACKAGES=github.com/mattermost/mattermost-server/v5/app
+PACKAGES=$3
 TESTS=$4
 TESTFLAGS=$5
 GOBIN=$6


### PR DESCRIPTION

#### Summary
<!--
A description of what this pull request does.
-->

This CR is a continuation from [#14496](https://github.com/mattermost/mattermost-server/pull/14496). 

- It migrates post, session and status cache to cache2 package, by using the new cache `Provider` interface. 

- This CR also provides a new field called `CacheProvider2` in struct `app/server`. This facilitates further migration as there are many existing usages of the `server.CacheProvider` which are based on the old cache interface.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-25115
