### PR TITLE
Add Jitsi plugin to diagnostics

### DIFF
--- a/app/diagnostics.go
+++ b/app/diagnostics.go
@@ -674,6 +674,7 @@ func (a *App) trackConfig() {
 		"enable_gitlab":                 pluginActivated(cfg.PluginSettings.PluginStates, "com.github.manland.mattermost-plugin-gitlab"),
 		"enable_jenkins":                pluginActivated(cfg.PluginSettings.PluginStates, "jenkins"),
 		"enable_jira":                   pluginActivated(cfg.PluginSettings.PluginStates, "jira"),
+		"enable_jitsi":                  pluginActivated(cfg.PluginSettings.PluginStates, "jitsi"),
 		"enable_nps":                    pluginActivated(cfg.PluginSettings.PluginStates, "com.mattermost.nps"),
 		"enable_webex":                  pluginActivated(cfg.PluginSettings.PluginStates, "com.mattermost.webex"),
 		"enable_welcome_bot":            pluginActivated(cfg.PluginSettings.PluginStates, "com.mattermost.welcomebot"),


### PR DESCRIPTION
Jitsi plugin: https://github.com/mattermost/mattermost-plugin-jitsi

@amyblais wondering if we can add to 5.24? This adds one telemetry, low risk.

cc @aaronrothschild FYI