### PR TITLE
Migrate Update method from ChannelStore to return idiomatic plain error

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -532,7 +532,7 @@ func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppE
 		case errors.As(err, &appErr):
 			return nil, appErr
 		default:
-
+			return nil, model.NewAppError("UpdateChannel", "app.channel.update_channel.internal_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
 
@@ -2332,7 +2332,13 @@ func (a *App) MoveChannel(team *model.Team, channel *model.Channel, user *model.
 
 	channel.TeamId = team.Id
 	if _, err := a.Srv().Store.Channel().Update(channel); err != nil {
-		return err
+		var appErr *model.AppError
+		switch {
+		case errors.As(err, &appErr):
+			return appErr
+		default:
+			return model.NewAppError("MoveChannel", "app.channel.update_channel.internal_error", nil, err.Error(), http.StatusInternalServerError)
+		}
 	}
 	a.postChannelMoveMessage(user, channel, previousTeam)
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -527,7 +527,13 @@ func (a *App) GetGroupChannel(userIds []string) (*model.Channel, *model.AppError
 func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppError) {
 	_, err := a.Srv().Store.Channel().Update(channel)
 	if err != nil {
-		return nil, err
+		var appErr *model.AppError
+		switch {
+		case errors.As(err, &appErr):
+			return nil, appErr
+		default:
+
+		}
 	}
 
 	a.invalidateCacheForChannel(channel)

--- a/app/channel.go
+++ b/app/channel.go
@@ -528,7 +528,10 @@ func (a *App) UpdateChannel(channel *model.Channel) (*model.Channel, *model.AppE
 	_, err := a.Srv().Store.Channel().Update(channel)
 	if err != nil {
 		var appErr *model.AppError
+		var iErr *store.ErrInvalidInput
 		switch {
+		case errors.As(err, &iErr):
+			return nil, model.NewAppError("UpdateChannel", "app.channel.update.bad_id", nil, iErr.Error(), http.StatusBadRequest)
 		case errors.As(err, &appErr):
 			return nil, appErr
 		default:
@@ -2333,7 +2336,10 @@ func (a *App) MoveChannel(team *model.Team, channel *model.Channel, user *model.
 	channel.TeamId = team.Id
 	if _, err := a.Srv().Store.Channel().Update(channel); err != nil {
 		var appErr *model.AppError
+		var iErr *store.ErrInvalidInput
 		switch {
+		case errors.As(err, &iErr):
+			return model.NewAppError("MoveChannel", "app.channel.update.bad_id", nil, iErr.Error(), http.StatusBadRequest)
 		case errors.As(err, &appErr):
 			return appErr
 		default:

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2971,10 +2971,6 @@
     "translation": "Unable to save direct channel."
   },
   {
-    "id": "app.channel.update_channel.internal_error",
-    "translation": "Unable to update channel."
-  },
-  {
     "id": "app.channel.move_channel.members_do_not_match.error",
     "translation": "Unable to move a channel unless all its members are already members of the destination team."
   },
@@ -2997,6 +2993,14 @@
   {
     "id": "app.channel.post_update_channel_purpose_message.updated_to",
     "translation": "%s updated the channel purpose to: %s"
+  },
+  {
+    "id": "app.channel.update.bad_id",
+    "translation": "Unable to update the channel."
+  },
+  {
+    "id": "app.channel.update_channel.internal_error",
+    "translation": "Unable to update channel."
   },
   {
     "id": "app.cluster.404.app_error",
@@ -6265,38 +6269,6 @@
   {
     "id": "store.sql_channel.set_delete_at.update_public_channel.app_error",
     "translation": "Unable to update the materialized public channel."
-  },
-  {
-    "id": "store.sql_channel.update.app_error",
-    "translation": "Unable to update the channel."
-  },
-  {
-    "id": "store.sql_channel.update.archived_channel.app_error",
-    "translation": "You can not modify an archived channel."
-  },
-  {
-    "id": "store.sql_channel.update.commit_transaction.app_error",
-    "translation": "Unable to commit transaction."
-  },
-  {
-    "id": "app.channel.update.bad_id",
-    "translation": "Unable to update the channel."
-  },
-  {
-    "id": "store.sql_channel.update.open_transaction.app_error",
-    "translation": "Unable to open transaction."
-  },
-  {
-    "id": "store.sql_channel.update.previously.app_error",
-    "translation": "A channel with that handle was previously created."
-  },
-  {
-    "id": "store.sql_channel.update.updating.app_error",
-    "translation": "We encountered an error updating the channel."
-  },
-  {
-    "id": "store.sql_channel.update.upsert_public_channel.app_error",
-    "translation": "Unable to upsert materialized public channel."
   },
   {
     "id": "store.sql_channel.update_last_viewed_at.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6275,8 +6275,8 @@
     "translation": "Unable to commit transaction."
   },
   {
-    "id": "store.sql_channel.update.exists.app_error",
-    "translation": "A channel with that handle already exists."
+    "id": "app.channel.update.bad_id",
+    "translation": "Unable to update the channel."
   },
   {
     "id": "store.sql_channel.update.open_transaction.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2971,6 +2971,10 @@
     "translation": "Unable to save direct channel."
   },
   {
+    "id": "app.channel.update_channel.internal_error",
+    "translation": "Unable to update channel."
+  },
+  {
     "id": "app.channel.move_channel.members_do_not_match.error",
     "translation": "Unable to move a channel unless all its members are already members of the destination team."
   },

--- a/store/opentracing_layer.go
+++ b/store/opentracing_layer.go
@@ -1863,7 +1863,7 @@ func (s *OpenTracingLayerChannelStore) SetDeleteAt(channelId string, deleteAt in
 	return resultVar0
 }
 
-func (s *OpenTracingLayerChannelStore) Update(channel *model.Channel) (*model.Channel, *model.AppError) {
+func (s *OpenTracingLayerChannelStore) Update(channel *model.Channel) (*model.Channel, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.Update")
 	s.Root.Store.SetContext(newCtx)

--- a/store/searchlayer/channel_layer.go
+++ b/store/searchlayer/channel_layer.go
@@ -53,7 +53,7 @@ func (c *SearchChannelStore) Save(channel *model.Channel, maxChannels int64) (*m
 	return newChannel, err
 }
 
-func (c *SearchChannelStore) Update(channel *model.Channel) (*model.Channel, *model.AppError) {
+func (c *SearchChannelStore) Update(channel *model.Channel) (*model.Channel, error) {
 	updatedChannel, err := c.ChannelStore.Update(channel)
 	if err == nil {
 		c.indexChannel(updatedChannel)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -645,7 +645,7 @@ func (s SqlChannelStore) Update(channel *model.Channel) (*model.Channel, error) 
 
 	// Additionally propagate the write to the PublicChannels table.
 	if err := s.upsertPublicChannelT(transaction, updatedChannel); err != nil {
-		return nil, errors.Wrap(err, "failed to update public channels")
+		return nil, errors.Wrap(err, "upsertPublicChannelT: failed to upsert channel")
 	}
 
 	if err := transaction.Commit(); err != nil {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -12,14 +12,14 @@ import (
 	"strings"
 
 	"github.com/mattermost/gorp"
-	"github.com/pkg/errors"
-
-	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-server/v5/einterfaces"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/services/cache/lru"
 	"github.com/mattermost/mattermost-server/v5/store"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/store/store.go
+++ b/store/store.go
@@ -130,7 +130,7 @@ type ChannelStore interface {
 	Save(channel *model.Channel, maxChannelsPerTeam int64) (*model.Channel, error)
 	CreateDirectChannel(userId *model.User, otherUserId *model.User) (*model.Channel, error)
 	SaveDirectChannel(channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error)
-	Update(channel *model.Channel) (*model.Channel, *model.AppError)
+	Update(channel *model.Channel) (*model.Channel, error)
 	Get(id string, allowFromCache bool) (*model.Channel, *model.AppError)
 	InvalidateChannel(id string)
 	InvalidateChannelByName(teamId, name string)

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -6499,16 +6499,16 @@ func testGroupSyncedChannelCount(t *testing.T, ss store.Store) {
 	require.False(t, channel2.IsGroupConstrained())
 	defer ss.Channel().PermanentDelete(channel2.Id)
 
-	count, err := ss.Channel().GroupSyncedChannelCount()
-	require.Nil(t, err)
+	count, appErr := ss.Channel().GroupSyncedChannelCount()
+	require.Nil(t, appErr)
 	require.GreaterOrEqual(t, count, int64(1))
 
 	channel2.GroupConstrained = model.NewBool(true)
-	channel2, err = ss.Channel().Update(channel2)
+	channel2, err := ss.Channel().Update(channel2)
 	require.Nil(t, err)
 	require.True(t, channel2.IsGroupConstrained())
 
-	countAfter, err := ss.Channel().GroupSyncedChannelCount()
-	require.Nil(t, err)
+	countAfter, appErr := ss.Channel().GroupSyncedChannelCount()
+	require.Nil(t, appErr)
 	require.GreaterOrEqual(t, countAfter, count+1)
 }

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -1672,8 +1672,8 @@ func testChannelMembersToAdd(t *testing.T, ss store.Store) {
 
 	// reset state of channel and verify
 	channel.DeleteAt = 0
-	_, err = ss.Channel().Update(channel)
-	require.Nil(t, err)
+	_, nErr = ss.Channel().Update(channel)
+	require.Nil(t, nErr)
 	channelMembers, err = ss.Group().ChannelMembersToAdd(0, nil)
 	require.Nil(t, err)
 	require.Len(t, channelMembers, 1)

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -1691,7 +1691,7 @@ func (_m *ChannelStore) SetDeleteAt(channelId string, deleteAt int64, updateAt i
 }
 
 // Update provides a mock function with given fields: channel
-func (_m *ChannelStore) Update(channel *model.Channel) (*model.Channel, *model.AppError) {
+func (_m *ChannelStore) Update(channel *model.Channel) (*model.Channel, error) {
 	ret := _m.Called(channel)
 
 	var r0 *model.Channel
@@ -1703,13 +1703,11 @@ func (_m *ChannelStore) Update(channel *model.Channel) (*model.Channel, *model.A
 		}
 	}
 
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(*model.Channel) *model.AppError); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*model.Channel) error); ok {
 		r1 = rf(channel)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
+		r1 = ret.Error(1)
 	}
 
 	return r0, r1

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -3851,8 +3851,8 @@ func testUserStoreGetChannelGroupUsers(t *testing.T, ss store.Store) {
 
 	// update team to be group-constrained
 	channel.GroupConstrained = model.NewBool(true)
-	_, err = ss.Channel().Update(channel)
-	require.Nil(t, err)
+	_, nErr = ss.Channel().Update(channel)
+	require.Nil(t, nErr)
 
 	// still returns user (being group-constrained has no effect)
 	requireNUsers(1)

--- a/store/timer_layer.go
+++ b/store/timer_layer.go
@@ -1729,7 +1729,7 @@ func (s *TimerLayerChannelStore) SetDeleteAt(channelId string, deleteAt int64, u
 	return resultVar0
 }
 
-func (s *TimerLayerChannelStore) Update(channel *model.Channel) (*model.Channel, *model.AppError) {
+func (s *TimerLayerChannelStore) Update(channel *model.Channel) (*model.Channel, error) {
 	start := timemodule.Now()
 
 	resultVar0, resultVar1 := s.ChannelStore.Update(channel)


### PR DESCRIPTION
#### Summary

This is a proposal PR that migrates the method `ChannelStore.Update` to return idiomatic go error interface (when it applies).

Fixes https://github.com/mattermost/mattermost-server/issues/14689