### PR TITLE
Migrate Get/GetFromMaster methods from ChannelStore to return error interface

### DIFF
--- a/api4/group_test.go
+++ b/api4/group_test.go
@@ -707,7 +707,7 @@ func TestGetGroupsByChannel(t *testing.T) {
 	require.True(t, *groups[0].SchemeAdmin)
 
 	groups, _, response = th.SystemAdminClient.GetGroupsByChannel(model.NewId(), opts)
-	assert.Equal(t, "store.sql_channel.get.existing.app_error", response.Error.Id)
+	assert.Equal(t, "app.channel.get.existing.app_error", response.Error.Id)
 	assert.Empty(t, groups)
 }
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -1469,7 +1469,7 @@ func (a *App) GetChannel(channelId string) (*model.Channel, *model.AppError) {
 		case errors.As(err, &nfErr):
 			return nil, model.NewAppError("GetChannel", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
-			return nil, model.NewAppError("GetChannel", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return nil, model.NewAppError("GetChannel", "app.channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
 	return channel, nil
@@ -1793,7 +1793,7 @@ func (a *App) LeaveChannel(channelId string, userId string) *model.AppError {
 		case errors.As(uresult.NErr, &nfErr):
 			return model.NewAppError("LeaveChannel", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
-			return model.NewAppError("LeaveChannel", "store.sql_channel.get.find.app_error", nil, uresult.NErr.Error(), http.StatusInternalServerError)
+			return model.NewAppError("LeaveChannel", "app.channel.get.find.app_error", nil, uresult.NErr.Error(), http.StatusInternalServerError)
 		}
 	}
 	ccresult := <-mcc

--- a/app/channel.go
+++ b/app/channel.go
@@ -1467,7 +1467,7 @@ func (a *App) GetChannel(channelId string) (*model.Channel, *model.AppError) {
 		var nfErr *store.ErrNotFound
 		switch {
 		case errors.As(err, &nfErr):
-			return nil, model.NewAppError("GetChannel", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			return nil, model.NewAppError("GetChannel", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
 			return nil, model.NewAppError("GetChannel", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
@@ -1791,7 +1791,7 @@ func (a *App) LeaveChannel(channelId string, userId string) *model.AppError {
 		var nfErr *store.ErrNotFound
 		switch {
 		case errors.As(uresult.NErr, &nfErr):
-			return model.NewAppError("LeaveChannel", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			return model.NewAppError("LeaveChannel", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
 			return model.NewAppError("LeaveChannel", "store.sql_channel.get.find.app_error", nil, uresult.NErr.Error(), http.StatusInternalServerError)
 		}

--- a/app/channel.go
+++ b/app/channel.go
@@ -1764,7 +1764,7 @@ func (a *App) LeaveChannel(channelId string, userId string) *model.AppError {
 	sc := make(chan store.StoreResult, 1)
 	go func() {
 		channel, err := a.Srv().Store.Channel().Get(channelId, true)
-		sc <- store.StoreResult{Data: channel, NewErr: err}
+		sc <- store.StoreResult{Data: channel, NErr: err}
 		close(sc)
 	}()
 
@@ -1787,13 +1787,13 @@ func (a *App) LeaveChannel(channelId string, userId string) *model.AppError {
 		return cresult.Err
 	}
 	uresult := <-uc
-	if uresult.NewErr != nil {
+	if uresult.NErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
-		case errors.As(uresult.NewErr, &nfErr):
+		case errors.As(uresult.NErr, &nfErr):
 			return model.NewAppError("LeaveChannel", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
-			return model.NewAppError("LeaveChannel", "store.sql_channel.get.find.app_error", nil, uresult.NewErr.Error(), http.StatusInternalServerError)
+			return model.NewAppError("LeaveChannel", "store.sql_channel.get.find.app_error", nil, uresult.NErr.Error(), http.StatusInternalServerError)
 		}
 	}
 	ccresult := <-mcc

--- a/app/command.go
+++ b/app/command.go
@@ -387,7 +387,7 @@ func (a *App) tryExecuteCustomCommand(args *model.CommandArgs, trigger string, m
 		case errors.As(cr.NErr, &nfErr):
 			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
-			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "store.sql_channel.get.find.app_error", nil, cr.NErr.Error(), http.StatusInternalServerError)
+			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "app.channel.get.find.app_error", nil, cr.NErr.Error(), http.StatusInternalServerError)
 		}
 	}
 	channel := cr.Data.(*model.Channel)

--- a/app/command.go
+++ b/app/command.go
@@ -385,7 +385,7 @@ func (a *App) tryExecuteCustomCommand(args *model.CommandArgs, trigger string, m
 		var nfErr *store.ErrNotFound
 		switch {
 		case errors.As(cr.NErr, &nfErr):
-			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
 			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "store.sql_channel.get.find.app_error", nil, cr.NErr.Error(), http.StatusInternalServerError)
 		}

--- a/app/command.go
+++ b/app/command.go
@@ -345,7 +345,7 @@ func (a *App) tryExecuteCustomCommand(args *model.CommandArgs, trigger string, m
 	chanChan := make(chan store.StoreResult, 1)
 	go func() {
 		channel, err := a.Srv().Store.Channel().Get(args.ChannelId, true)
-		chanChan <- store.StoreResult{Data: channel, NewErr: err}
+		chanChan <- store.StoreResult{Data: channel, NErr: err}
 		close(chanChan)
 	}()
 
@@ -381,13 +381,13 @@ func (a *App) tryExecuteCustomCommand(args *model.CommandArgs, trigger string, m
 	user := ur.Data.(*model.User)
 
 	cr := <-chanChan
-	if cr.NewErr != nil {
+	if cr.NErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
-		case errors.As(cr.NewErr, &nfErr):
+		case errors.As(cr.NErr, &nfErr):
 			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
-			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "store.sql_channel.get.find.app_error", nil, cr.NewErr.Error(), http.StatusInternalServerError)
+			return nil, nil, model.NewAppError("tryExecuteCustomCommand", "store.sql_channel.get.find.app_error", nil, cr.NErr.Error(), http.StatusInternalServerError)
 		}
 	}
 	channel := cr.Data.(*model.Channel)

--- a/app/group.go
+++ b/app/group.go
@@ -93,7 +93,7 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 	// reject the syncable creation if the group isn't already associated to the parent team
 	if groupSyncable.Type == model.GroupSyncableTypeChannel {
 		channel, nErr := a.Srv().Store.Channel().Get(groupSyncable.SyncableId, true)
-		if err != nil {
+		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
 			case errors.As(nErr, &nfErr):

--- a/app/group.go
+++ b/app/group.go
@@ -99,7 +99,7 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 			case errors.As(nErr, &nfErr):
 				return nil, model.NewAppError("UpsertGroupSyncable", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
-				return nil, model.NewAppError("UpsertGroupSyncable", "store.sql_channel.get.find.app_error", nil, nErr.Error(), http.StatusInternalServerError)
+				return nil, model.NewAppError("UpsertGroupSyncable", "app.channel.get.find.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 			}
 		}
 

--- a/app/group.go
+++ b/app/group.go
@@ -4,9 +4,11 @@
 package app
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/store"
 )
 
 func (a *App) GetGroup(id string) (*model.Group, *model.AppError) {
@@ -90,10 +92,15 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 
 	// reject the syncable creation if the group isn't already associated to the parent team
 	if groupSyncable.Type == model.GroupSyncableTypeChannel {
-		var channel *model.Channel
-		channel, err = a.Srv().Store.Channel().Get(groupSyncable.SyncableId, true)
+		channel, nErr := a.Srv().Store.Channel().Get(groupSyncable.SyncableId, true)
 		if err != nil {
-			return nil, err
+			var nfErr *store.ErrNotFound
+			switch {
+			case errors.As(nErr, &nfErr):
+				return nil, model.NewAppError("UpsertGroupSyncable", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			default:
+				return nil, model.NewAppError("UpsertGroupSyncable", "store.sql_channel.get.find.app_error", nil, nErr.Error(), http.StatusInternalServerError)
+			}
 		}
 
 		var team *model.Team

--- a/app/group.go
+++ b/app/group.go
@@ -97,7 +97,7 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 			var nfErr *store.ErrNotFound
 			switch {
 			case errors.As(nErr, &nfErr):
-				return nil, model.NewAppError("UpsertGroupSyncable", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+				return nil, model.NewAppError("UpsertGroupSyncable", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
 				return nil, model.NewAppError("UpsertGroupSyncable", "store.sql_channel.get.find.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 			}

--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -20,6 +20,7 @@ package app
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -101,7 +102,13 @@ func (a *App) DoPostActionWithCookie(postId, actionId, userId, selectedOption st
 
 		channel, err := a.Srv().Store.Channel().Get(cookie.ChannelId, true)
 		if err != nil {
-			return "", err
+			var nfErr *store.ErrNotFound
+			switch {
+			case errors.As(err, &nfErr):
+				return "", model.NewAppError("DoPostActionWithCookie", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			default:
+				return "", model.NewAppError("DoPostActionWithCookie", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
 		}
 
 		upstreamRequest.ChannelId = cookie.ChannelId

--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -105,7 +105,7 @@ func (a *App) DoPostActionWithCookie(postId, actionId, userId, selectedOption st
 			var nfErr *store.ErrNotFound
 			switch {
 			case errors.As(err, &nfErr):
-				return "", model.NewAppError("DoPostActionWithCookie", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+				return "", model.NewAppError("DoPostActionWithCookie", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
 				return "", model.NewAppError("DoPostActionWithCookie", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}

--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -107,7 +107,7 @@ func (a *App) DoPostActionWithCookie(postId, actionId, userId, selectedOption st
 			case errors.As(err, &nfErr):
 				return "", model.NewAppError("DoPostActionWithCookie", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
-				return "", model.NewAppError("DoPostActionWithCookie", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+				return "", model.NewAppError("DoPostActionWithCookie", "app.channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}
 		}
 

--- a/app/post.go
+++ b/app/post.go
@@ -97,7 +97,7 @@ func (a *App) CreatePostMissingChannel(post *model.Post, triggerWebhooks bool) (
 		var nfErr *store.ErrNotFound
 		switch {
 		case errors.As(err, &nfErr):
-			return nil, model.NewAppError("CreatePostMissingChannel", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			return nil, model.NewAppError("CreatePostMissingChannel", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
 			return nil, model.NewAppError("CreatePostMissingChannel", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}

--- a/app/post.go
+++ b/app/post.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -93,7 +94,13 @@ func (a *App) CreatePostAsUser(post *model.Post, currentSessionId string, setOnl
 func (a *App) CreatePostMissingChannel(post *model.Post, triggerWebhooks bool) (*model.Post, *model.AppError) {
 	channel, err := a.Srv().Store.Channel().Get(post.ChannelId, true)
 	if err != nil {
-		return nil, err
+		var nfErr *store.ErrNotFound
+		switch {
+		case errors.As(err, &nfErr):
+			return nil, model.NewAppError("CreatePostMissingChannel", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+		default:
+			return nil, model.NewAppError("CreatePostMissingChannel", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
 	}
 
 	return a.CreatePost(post, channel, triggerWebhooks, true)

--- a/app/post.go
+++ b/app/post.go
@@ -99,7 +99,7 @@ func (a *App) CreatePostMissingChannel(post *model.Post, triggerWebhooks bool) (
 		case errors.As(err, &nfErr):
 			return nil, model.NewAppError("CreatePostMissingChannel", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 		default:
-			return nil, model.NewAppError("CreatePostMissingChannel", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return nil, model.NewAppError("CreatePostMissingChannel", "app.channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
 

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -418,7 +418,7 @@ func (a *App) CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.Outgoin
 			case errors.As(errCh, &nfErr):
 				return nil, model.NewAppError("CreateOutgoingWebhook", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
-				return nil, model.NewAppError("CreateOutgoingWebhook", "store.sql_channel.get.find.app_error", nil, errCh.Error(), http.StatusInternalServerError)
+				return nil, model.NewAppError("CreateOutgoingWebhook", "app.channel.get.find.app_error", nil, errCh.Error(), http.StatusInternalServerError)
 			}
 		}
 
@@ -648,7 +648,7 @@ func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookReq
 			case errors.As(err, &nfErr):
 				return model.NewAppError("HandleIncomingWebhook", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
-				return model.NewAppError("HandleIncomingWebhook", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+				return model.NewAppError("HandleIncomingWebhook", "app.channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}
 		}
 	}

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -416,7 +416,7 @@ func (a *App) CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.Outgoin
 			var nfErr *store.ErrNotFound
 			switch {
 			case errors.As(errCh, &nfErr):
-				return nil, model.NewAppError("CreateOutgoingWebhook", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+				return nil, model.NewAppError("CreateOutgoingWebhook", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
 				return nil, model.NewAppError("CreateOutgoingWebhook", "store.sql_channel.get.find.app_error", nil, errCh.Error(), http.StatusInternalServerError)
 			}
@@ -646,7 +646,7 @@ func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookReq
 			var nfErr *store.ErrNotFound
 			switch {
 			case errors.As(err, &nfErr):
-				return model.NewAppError("HandleIncomingWebhook", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+				return model.NewAppError("HandleIncomingWebhook", "app.channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
 				return model.NewAppError("HandleIncomingWebhook", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"regexp"
@@ -412,7 +413,13 @@ func (a *App) CreateOutgoingWebhook(hook *model.OutgoingWebhook) (*model.Outgoin
 	if len(hook.ChannelId) != 0 {
 		channel, errCh := a.Srv().Store.Channel().Get(hook.ChannelId, true)
 		if errCh != nil {
-			return nil, errCh
+			var nfErr *store.ErrNotFound
+			switch {
+			case errors.As(errCh, &nfErr):
+				return nil, model.NewAppError("CreateOutgoingWebhook", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			default:
+				return nil, model.NewAppError("CreateOutgoingWebhook", "store.sql_channel.get.find.app_error", nil, errCh.Error(), http.StatusInternalServerError)
+			}
 		}
 
 		if channel.Type != model.CHANNEL_OPEN {
@@ -633,10 +640,16 @@ func (a *App) HandleIncomingWebhook(hookId string, req *model.IncomingWebhookReq
 			}()
 		}
 	} else {
-		var err *model.AppError
+		var err error
 		channel, err = a.Srv().Store.Channel().Get(hook.ChannelId, true)
 		if err != nil {
-			return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel.app_error", nil, "err="+err.Message, err.StatusCode)
+			var nfErr *store.ErrNotFound
+			switch {
+			case errors.As(err, &nfErr):
+				return model.NewAppError("HandleIncomingWebhook", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			default:
+				return model.NewAppError("HandleIncomingWebhook", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
 		}
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2971,6 +2971,14 @@
     "translation": "Unable to save direct channel."
   },
   {
+    "id": "app.channel.get.existing.app_error",
+    "translation": "Unable to find the existing channel."
+  },
+  {
+    "id": "app.channel.get.find.app_error",
+    "translation": "We encountered an error finding the channel."
+  },
+  {
     "id": "app.channel.move_channel.members_do_not_match.error",
     "translation": "Unable to move a channel unless all its members are already members of the destination team."
   },
@@ -6007,11 +6015,11 @@
     "translation": "Unable to delete the channel."
   },
   {
-    "id": "app.channel.get.existing.app_error",
+    "id": "store.sql_channel.get.existing.app_error",
     "translation": "Unable to find the existing channel."
   },
   {
-    "id": "app.channel.get.find.app_error",
+    "id": "store.sql_channel.get.find.app_error",
     "translation": "We encountered an error finding the channel."
   },
   {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6007,7 +6007,7 @@
     "translation": "Unable to delete the channel."
   },
   {
-    "id": "store.sql_channel.get.existing.app_error",
+    "id": "app.channel.get.existing.app_error",
     "translation": "Unable to find the existing channel."
   },
   {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6011,7 +6011,7 @@
     "translation": "Unable to find the existing channel."
   },
   {
-    "id": "store.sql_channel.get.find.app_error",
+    "id": "app.channel.get.find.app_error",
     "translation": "We encountered an error finding the channel."
   },
   {

--- a/store/localcachelayer/channel_layer.go
+++ b/store/localcachelayer/channel_layer.go
@@ -150,7 +150,7 @@ func (s LocalCacheChannelStore) GetPinnedPostCount(channelId string, allowFromCa
 	return count, nil
 }
 
-func (s LocalCacheChannelStore) Get(id string, allowFromCache bool) (*model.Channel, *model.AppError) {
+func (s LocalCacheChannelStore) Get(id string, allowFromCache bool) (*model.Channel, error) {
 
 	if allowFromCache {
 		if cacheItem := s.rootStore.doStandardReadCache(s.rootStore.channelByIdCache, id); cacheItem != nil {

--- a/store/opentracing_layer.go
+++ b/store/opentracing_layer.go
@@ -630,7 +630,7 @@ func (s *OpenTracingLayerChannelStore) Delete(channelId string, time int64) *mod
 	return resultVar0
 }
 
-func (s *OpenTracingLayerChannelStore) Get(id string, allowFromCache bool) (*model.Channel, *model.AppError) {
+func (s *OpenTracingLayerChannelStore) Get(id string, allowFromCache bool) (*model.Channel, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.Get")
 	s.Root.Store.SetContext(newCtx)
@@ -1026,7 +1026,7 @@ func (s *OpenTracingLayerChannelStore) GetForPost(postId string) (*model.Channel
 	return resultVar0, resultVar1
 }
 
-func (s *OpenTracingLayerChannelStore) GetFromMaster(id string) (*model.Channel, *model.AppError) {
+func (s *OpenTracingLayerChannelStore) GetFromMaster(id string) (*model.Channel, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.GetFromMaster")
 	s.Root.Store.SetContext(newCtx)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -718,7 +718,7 @@ func (s SqlChannelStore) InvalidateChannelByName(teamId, name string) {
 	}
 }
 
-func (s SqlChannelStore) Get(id string, allowFromCache bool) (*model.Channel, *model.AppError) {
+func (s SqlChannelStore) Get(id string, allowFromCache bool) (*model.Channel, error) {
 	return s.get(id, false, allowFromCache)
 }
 
@@ -736,11 +736,11 @@ func (s SqlChannelStore) GetPinnedPosts(channelId string) (*model.PostList, *mod
 	return pl, nil
 }
 
-func (s SqlChannelStore) GetFromMaster(id string) (*model.Channel, *model.AppError) {
+func (s SqlChannelStore) GetFromMaster(id string) (*model.Channel, error) {
 	return s.get(id, true, false)
 }
 
-func (s SqlChannelStore) get(id string, master bool, allowFromCache bool) (*model.Channel, *model.AppError) {
+func (s SqlChannelStore) get(id string, master bool, allowFromCache bool) (*model.Channel, error) {
 	var db *gorp.DbMap
 
 	if master {
@@ -751,11 +751,11 @@ func (s SqlChannelStore) get(id string, master bool, allowFromCache bool) (*mode
 
 	obj, err := db.Get(model.Channel{}, id)
 	if err != nil {
-		return nil, model.NewAppError("SqlChannelStore.Get", "store.sql_channel.get.find.app_error", nil, "id="+id+", "+err.Error(), http.StatusInternalServerError)
+		return nil, errors.Wrapf(err, "failed to find channel with id = %s", id)
 	}
 
 	if obj == nil {
-		return nil, model.NewAppError("SqlChannelStore.Get", "store.sql_channel.get.existing.app_error", nil, "id="+id, http.StatusNotFound)
+		return nil, store.NewErrNotFound("Channel", id)
 	}
 
 	ch := obj.(*model.Channel)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -12,14 +12,14 @@ import (
 	"strings"
 
 	"github.com/mattermost/gorp"
-	"github.com/pkg/errors"
-
-	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/mattermost-server/v5/einterfaces"
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/services/cache/lru"
 	"github.com/mattermost/mattermost-server/v5/store"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/store"
@@ -480,7 +481,13 @@ func (s *SqlGroupStore) CreateGroupSyncable(groupSyncable *model.GroupSyncable) 
 		insertErr = s.GetMaster().Insert(groupSyncableToGroupTeam(groupSyncable))
 	case model.GroupSyncableTypeChannel:
 		if _, err := s.Channel().Get(groupSyncable.SyncableId, false); err != nil {
-			return nil, err
+			var nfErr *store.ErrNotFound
+			switch {
+			case errors.As(err, &nfErr):
+				return nil, model.NewAppError("CreateGroupSyncable", "store.sql_channel.get.existing.app_error", nil, nfErr.Error(), http.StatusNotFound)
+			default:
+				return nil, model.NewAppError("CreateGroupSyncable", "store.sql_channel.get.find.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
 		}
 
 		insertErr = s.GetMaster().Insert(groupSyncableToGroupChannel(groupSyncable))

--- a/store/store.go
+++ b/store/store.go
@@ -13,9 +13,9 @@ import (
 )
 
 type StoreResult struct {
-	Data   interface{}
-	Err    *model.AppError
-	NewErr error
+	Data interface{}
+	Err  *model.AppError
+	NErr error
 }
 
 type Store interface {

--- a/store/store.go
+++ b/store/store.go
@@ -15,6 +15,8 @@ import (
 type StoreResult struct {
 	Data interface{}
 	Err  *model.AppError
+
+	// NErr a temporary field used by the new code for the AppError migration. This will later become Err when the entire store is migrated.
 	NErr error
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -13,8 +13,9 @@ import (
 )
 
 type StoreResult struct {
-	Data interface{}
-	Err  *model.AppError
+	Data   interface{}
+	Err    *model.AppError
+	NewErr error
 }
 
 type Store interface {

--- a/store/store.go
+++ b/store/store.go
@@ -131,10 +131,10 @@ type ChannelStore interface {
 	CreateDirectChannel(userId *model.User, otherUserId *model.User) (*model.Channel, error)
 	SaveDirectChannel(channel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error)
 	Update(channel *model.Channel) (*model.Channel, *model.AppError)
-	Get(id string, allowFromCache bool) (*model.Channel, *model.AppError)
+	Get(id string, allowFromCache bool) (*model.Channel, error)
 	InvalidateChannel(id string)
 	InvalidateChannelByName(teamId, name string)
-	GetFromMaster(id string) (*model.Channel, *model.AppError)
+	GetFromMaster(id string) (*model.Channel, error)
 	Delete(channelId string, time int64) *model.AppError
 	Restore(channelId string, time int64) *model.AppError
 	SetDeleteAt(channelId string, deleteAt int64, updateAt int64) *model.AppError

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -195,7 +195,7 @@ func (_m *ChannelStore) Delete(channelId string, time int64) *model.AppError {
 }
 
 // Get provides a mock function with given fields: id, allowFromCache
-func (_m *ChannelStore) Get(id string, allowFromCache bool) (*model.Channel, *model.AppError) {
+func (_m *ChannelStore) Get(id string, allowFromCache bool) (*model.Channel, error) {
 	ret := _m.Called(id, allowFromCache)
 
 	var r0 *model.Channel
@@ -207,13 +207,11 @@ func (_m *ChannelStore) Get(id string, allowFromCache bool) (*model.Channel, *mo
 		}
 	}
 
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, bool) *model.AppError); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, bool) error); ok {
 		r1 = rf(id, allowFromCache)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
+		r1 = ret.Error(1)
 	}
 
 	return r0, r1
@@ -743,7 +741,7 @@ func (_m *ChannelStore) GetForPost(postId string) (*model.Channel, *model.AppErr
 }
 
 // GetFromMaster provides a mock function with given fields: id
-func (_m *ChannelStore) GetFromMaster(id string) (*model.Channel, *model.AppError) {
+func (_m *ChannelStore) GetFromMaster(id string) (*model.Channel, error) {
 	ret := _m.Called(id)
 
 	var r0 *model.Channel
@@ -755,13 +753,11 @@ func (_m *ChannelStore) GetFromMaster(id string) (*model.Channel, *model.AppErro
 		}
 	}
 
-	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(id)
 	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
+		r1 = ret.Error(1)
 	}
 
 	return r0, r1

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -450,8 +450,8 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	_, err = ss.Scheme().Delete(d5.Id)
 	assert.Nil(t, err)
 
-	c6, err := ss.Channel().Get(c5.Id, true)
-	assert.Nil(t, err)
+	c6, nErr := ss.Channel().Get(c5.Id, true)
+	assert.Nil(t, nErr)
 	assert.Equal(t, "", *c6.SchemeId)
 }
 

--- a/store/timer_layer.go
+++ b/store/timer_layer.go
@@ -600,7 +600,7 @@ func (s *TimerLayerChannelStore) Delete(channelId string, time int64) *model.App
 	return resultVar0
 }
 
-func (s *TimerLayerChannelStore) Get(id string, allowFromCache bool) (*model.Channel, *model.AppError) {
+func (s *TimerLayerChannelStore) Get(id string, allowFromCache bool) (*model.Channel, error) {
 	start := timemodule.Now()
 
 	resultVar0, resultVar1 := s.ChannelStore.Get(id, allowFromCache)
@@ -952,7 +952,7 @@ func (s *TimerLayerChannelStore) GetForPost(postId string) (*model.Channel, *mod
 	return resultVar0, resultVar1
 }
 
-func (s *TimerLayerChannelStore) GetFromMaster(id string) (*model.Channel, *model.AppError) {
+func (s *TimerLayerChannelStore) GetFromMaster(id string) (*model.Channel, error) {
 	start := timemodule.Now()
 
 	resultVar0, resultVar1 := s.ChannelStore.GetFromMaster(id)


### PR DESCRIPTION
#### Summary

This is a proposal PR that migrates the method `ChannelStore.Get` and `ChannelStore.GetFromMaster` to return idiomatic go error interface (when it applies).

Fixes https://github.com/mattermost/mattermost-server/issues/14690