### PR TITLE
Automated cherry pick of #14619

### DIFF
--- a/api4/group.go
+++ b/api4/group.go
@@ -778,7 +778,7 @@ func getGroups(c *Context, w http.ResponseWriter, r *http.Request) {
 	if parentTeam != nil && parentTeam.IsGroupConstrained() {
 		filteredGroups := []*model.Group{}
 
-		teamGroups, err := c.App.GetAllGroupsByTeam(parentTeam.Id)
+		teamGroups, err := c.App.Srv().Store.Group().GetGroupsByTeam(teamID, model.GroupSearchOpts{})
 		if err != nil {
 			c.Err = err
 			return
@@ -786,7 +786,7 @@ func getGroups(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		for _, group := range groups {
 			for _, teamGroup := range teamGroups {
-				if teamGroup.Id == group.Id {
+				if teamGroup.Group.Id == group.Id {
 					filteredGroups = append(filteredGroups, group)
 				}
 			}

--- a/api4/group_test.go
+++ b/api4/group_test.go
@@ -1052,7 +1052,7 @@ func TestGetGroupsGroupConstrainedParentTeam(t *testing.T) {
 	team, err = th.App.UpdateTeam(team)
 	require.Nil(t, err)
 
-	// team is not group-constrained but has no associated groups
+	// team is group-constrained but has no associated groups
 	apiGroups, response = th.SystemAdminClient.GetGroups(model.GroupSearchOpts{NotAssociatedToChannel: channel.Id})
 	require.Nil(t, response.Error)
 	require.Len(t, apiGroups, 0)

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -136,8 +136,6 @@ type AppIface interface {
 	// FilterNonGroupTeamMembers returns the subset of the given user IDs of the users who are not members of groups
 	// associated to the team excluding bots.
 	FilterNonGroupTeamMembers(userIds []string, team *model.Team) ([]string, error)
-	// GetAllGroupsByTeam iterates all pages of groups associated to the given team and returns them all.
-	GetAllGroupsByTeam(teamID string) ([]*model.Group, *model.AppError)
 	// GetAllLdapGroupsPage retrieves all LDAP groups under the configured base DN using the default or configured group
 	// filter.
 	GetAllLdapGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError)

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -136,6 +136,8 @@ type AppIface interface {
 	// FilterNonGroupTeamMembers returns the subset of the given user IDs of the users who are not members of groups
 	// associated to the team excluding bots.
 	FilterNonGroupTeamMembers(userIds []string, team *model.Team) ([]string, error)
+	// GetAllGroupsByTeam iterates all pages of groups associated to the given team and returns them all.
+	GetAllGroupsByTeam(teamID string) ([]*model.Group, *model.AppError)
 	// GetAllLdapGroupsPage retrieves all LDAP groups under the configured base DN using the default or configured group
 	// filter.
 	GetAllLdapGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError)
@@ -158,6 +160,8 @@ type AppIface interface {
 	GetEmojiStaticUrl(emojiName string) (string, *model.AppError)
 	// GetEnvironmentConfig returns a map of configuration keys whose values have been overridden by an environment variable.
 	GetEnvironmentConfig() map[string]interface{}
+	// GetGroupsByTeam returns the paged list and the total count of group associated to the given team.
+	GetGroupsByTeam(teamId string, opts model.GroupSearchOpts) ([]*model.GroupWithSchemeAdmin, int, *model.AppError)
 	// GetHubForUserId returns the hub for a given user id.
 	GetHubForUserId(userId string) *Hub
 	// GetKnownUsers returns the list of user ids of users with any direct
@@ -555,7 +559,6 @@ type AppIface interface {
 	GetGroupsByChannel(channelId string, opts model.GroupSearchOpts) ([]*model.GroupWithSchemeAdmin, int, *model.AppError)
 	GetGroupsByIDs(groupIDs []string) ([]*model.Group, *model.AppError)
 	GetGroupsBySource(groupSource model.GroupSource) ([]*model.Group, *model.AppError)
-	GetGroupsByTeam(teamId string, opts model.GroupSearchOpts) ([]*model.GroupWithSchemeAdmin, int, *model.AppError)
 	GetGroupsByUserId(userId string) ([]*model.Group, *model.AppError)
 	GetIncomingWebhook(hookId string) (*model.IncomingWebhook, *model.AppError)
 	GetIncomingWebhooksForTeamPage(teamId string, page, perPage int) ([]*model.IncomingWebhook, *model.AppError)

--- a/app/group.go
+++ b/app/group.go
@@ -118,6 +118,11 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 				return nil, model.NewAppError("App.UpsertGroupSyncable", "group_not_associated_to_synced_team", nil, "", http.StatusBadRequest)
 			}
 		}
+
+		_, err = a.UpsertGroupSyncable(model.NewGroupTeam(groupSyncable.GroupId, team.Id, groupSyncable.AutoAdd))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if gs == nil {

--- a/app/group.go
+++ b/app/group.go
@@ -4,6 +4,8 @@
 package app
 
 import (
+	"net/http"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
@@ -86,6 +88,36 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 		return nil, err
 	}
 
+	// reject the syncable creation if the group isn't already associated to the parent team
+	if groupSyncable.Type == model.GroupSyncableTypeChannel {
+		channel, err := a.Srv().Store.Channel().Get(groupSyncable.SyncableId, true)
+		if err != nil {
+			return nil, err
+		}
+
+		team, err := a.Srv().Store.Team().Get(channel.TeamId)
+		if err != nil {
+			return nil, err
+		}
+		if team.IsGroupConstrained() {
+			var teamGroups []*model.Group
+			teamGroups, err = a.GetAllGroupsByTeam(team.Id)
+			if err != nil {
+				return nil, err
+			}
+			var permittedGroup bool
+			for _, teamGroup := range teamGroups {
+				if teamGroup.Id == groupSyncable.GroupId {
+					permittedGroup = true
+					break
+				}
+			}
+			if !permittedGroup {
+				return nil, model.NewAppError("App.UpsertGroupSyncable", "group_not_associated_to_synced_team", nil, "", http.StatusBadRequest)
+			}
+		}
+	}
+
 	if gs == nil {
 		gs, err = a.Srv().Store.Group().CreateGroupSyncable(groupSyncable)
 		if err != nil {
@@ -93,23 +125,6 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 		}
 	} else {
 		gs, err = a.Srv().Store.Group().UpdateGroupSyncable(groupSyncable)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// if the type is channel, then upsert the associated GroupTeam [MM-14675]
-	if gs.Type == model.GroupSyncableTypeChannel {
-		channel, err := a.Srv().Store.Channel().Get(gs.SyncableId, true)
-		if err != nil {
-			return nil, err
-		}
-		_, err = a.UpsertGroupSyncable(&model.GroupSyncable{
-			GroupId:    gs.GroupId,
-			SyncableId: channel.TeamId,
-			Type:       model.GroupSyncableTypeTeam,
-			AutoAdd:    gs.AutoAdd,
-		})
 		if err != nil {
 			return nil, err
 		}
@@ -217,6 +232,7 @@ func (a *App) GetGroupsByChannel(channelId string, opts model.GroupSearchOpts) (
 	return groups, int(count), nil
 }
 
+// GetGroupsByTeam returns the paged list and the total count of group associated to the given team.
 func (a *App) GetGroupsByTeam(teamId string, opts model.GroupSearchOpts) ([]*model.GroupWithSchemeAdmin, int, *model.AppError) {
 	groups, err := a.Srv().Store.Group().GetGroupsByTeam(teamId, opts)
 	if err != nil {
@@ -371,4 +387,27 @@ func (a *App) UserIsInAdminRoleGroup(userID, syncableID string, syncableType mod
 	}
 
 	return true, nil
+}
+
+// GetAllGroupsByTeam iterates all pages of groups associated to the given team and returns them all.
+func (a *App) GetAllGroupsByTeam(teamID string) ([]*model.Group, *model.AppError) {
+	batchCount := 1
+	page := 0
+	var teamGroups []*model.Group
+
+	for batchCount > 0 {
+		batch, err := a.Srv().Store.Group().GetGroupsByTeam(teamID, model.GroupSearchOpts{PageOpts: &model.PageOpts{Page: page, PerPage: 100}})
+		if err != nil {
+			return nil, err
+		}
+
+		batchCount = len(batch)
+		page++
+
+		for _, item := range batch {
+			teamGroups = append(teamGroups, &item.Group)
+		}
+	}
+
+	return teamGroups, nil
 }

--- a/app/group.go
+++ b/app/group.go
@@ -103,7 +103,7 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 		}
 		if team.IsGroupConstrained() {
 			var teamGroups []*model.GroupWithSchemeAdmin
-			teamGroups, err := a.Srv().Store.Group().GetGroupsByTeam(channel.TeamId, model.GroupSearchOpts{})
+			teamGroups, err = a.Srv().Store.Group().GetGroupsByTeam(channel.TeamId, model.GroupSearchOpts{})
 			if err != nil {
 				return nil, err
 			}

--- a/app/group.go
+++ b/app/group.go
@@ -90,12 +90,14 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 
 	// reject the syncable creation if the group isn't already associated to the parent team
 	if groupSyncable.Type == model.GroupSyncableTypeChannel {
-		channel, err := a.Srv().Store.Channel().Get(groupSyncable.SyncableId, true)
+		var channel *model.Channel
+		channel, err = a.Srv().Store.Channel().Get(groupSyncable.SyncableId, true)
 		if err != nil {
 			return nil, err
 		}
 
-		team, err := a.Srv().Store.Team().Get(channel.TeamId)
+		var team *model.Team
+		team, err = a.Srv().Store.Team().Get(channel.TeamId)
 		if err != nil {
 			return nil, err
 		}

--- a/app/group.go
+++ b/app/group.go
@@ -117,12 +117,13 @@ func (a *App) UpsertGroupSyncable(groupSyncable *model.GroupSyncable) (*model.Gr
 			if !permittedGroup {
 				return nil, model.NewAppError("App.UpsertGroupSyncable", "group_not_associated_to_synced_team", nil, "", http.StatusBadRequest)
 			}
+		} else {
+			_, err = a.UpsertGroupSyncable(model.NewGroupTeam(groupSyncable.GroupId, team.Id, groupSyncable.AutoAdd))
+			if err != nil {
+				return nil, err
+			}
 		}
 
-		_, err = a.UpsertGroupSyncable(model.NewGroupTeam(groupSyncable.GroupId, team.Id, groupSyncable.AutoAdd))
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	if gs == nil {

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -158,6 +158,33 @@ func TestUpsertGroupSyncable(t *testing.T) {
 	require.Equal(t, int64(0), gs.DeleteAt)
 }
 
+func TestUpsertGroupSyncableTeamGroupConstrained(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	group1 := th.CreateGroup()
+	group2 := th.CreateGroup()
+
+	team := th.CreateTeam()
+	team.GroupConstrained = model.NewBool(true)
+	team, err := th.App.UpdateTeam(team)
+	require.Nil(t, err)
+	_, err = th.App.UpsertGroupSyncable(model.NewGroupTeam(group1.Id, team.Id, false))
+
+	channel := th.CreateChannel(team)
+
+	_, err = th.App.UpsertGroupSyncable(model.NewGroupChannel(group2.Id, channel.Id, false))
+	require.NotNil(t, err)
+	require.Equal(t, err.Id, "group_not_associated_to_synced_team")
+
+	gs, err := th.App.GetGroupSyncable(group2.Id, channel.Id, model.GroupSyncableTypeChannel)
+	require.Nil(t, gs)
+	require.NotNil(t, err)
+
+	_, err = th.App.UpsertGroupSyncable(model.NewGroupChannel(group1.Id, channel.Id, false))
+	require.Nil(t, err)
+}
+
 func TestGetGroupSyncable(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/app/opentracing_layer.go
+++ b/app/opentracing_layer.go
@@ -3765,28 +3765,6 @@ func (a *OpenTracingAppLayer) GetAllChannelsCount(opts model.ChannelSearchOpts) 
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetAllGroupsByTeam(teamID string) ([]*model.Group, *model.AppError) {
-	origCtx := a.ctx
-	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetAllGroupsByTeam")
-
-	a.ctx = newCtx
-	a.app.Srv().Store.SetContext(newCtx)
-	defer func() {
-		a.app.Srv().Store.SetContext(origCtx)
-		a.ctx = origCtx
-	}()
-
-	defer span.Finish()
-	resultVar0, resultVar1 := a.app.GetAllGroupsByTeam(teamID)
-
-	if resultVar1 != nil {
-		span.LogFields(spanlog.Error(resultVar1))
-		ext.Error.Set(span, true)
-	}
-
-	return resultVar0, resultVar1
-}
-
 func (a *OpenTracingAppLayer) GetAllLdapGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetAllLdapGroupsPage")

--- a/app/opentracing_layer.go
+++ b/app/opentracing_layer.go
@@ -3765,6 +3765,28 @@ func (a *OpenTracingAppLayer) GetAllChannelsCount(opts model.ChannelSearchOpts) 
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) GetAllGroupsByTeam(teamID string) ([]*model.Group, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetAllGroupsByTeam")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetAllGroupsByTeam(teamID)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetAllLdapGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetAllLdapGroupsPage")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4479,6 +4479,10 @@
     "translation": "SAML 2.0 is not configured or supported on this server."
   },
   {
+    "id": "group_not_associated_to_synced_team",
+    "translation": "Group cannot be associated to the channel until it is first associated to the parent group-synced team."
+  },
+  {
     "id": "groups.unsupported_syncable_type",
     "translation": "Unsupported syncable type '{{.Value}}'."
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -3777,13 +3777,14 @@ func (c *Client4) GetGroupsAssociatedToChannelsByTeam(teamId string, opts GroupS
 // GetGroups retrieves Mattermost Groups
 func (c *Client4) GetGroups(opts GroupSearchOpts) ([]*Group, *Response) {
 	path := fmt.Sprintf(
-		"%s?include_member_count=%v&not_associated_to_team=%v&not_associated_to_channel=%v&filter_allow_reference=%v&q=%v",
+		"%s?include_member_count=%v&not_associated_to_team=%v&not_associated_to_channel=%v&filter_allow_reference=%v&q=%v&filter_parent_team_permitted=%v",
 		c.GetGroupsRoute(),
 		opts.IncludeMemberCount,
 		opts.NotAssociatedToTeam,
 		opts.NotAssociatedToChannel,
 		opts.FilterAllowReference,
 		opts.Q,
+		opts.FilterParentTeamPermitted,
 	)
 	if opts.Since > 0 {
 		path = fmt.Sprintf("%s&since=%v", path, opts.Since)

--- a/model/group.go
+++ b/model/group.go
@@ -81,6 +81,12 @@ type GroupSearchOpts struct {
 	FilterAllowReference   bool
 	PageOpts               *PageOpts
 	Since                  int64
+
+	// FilterParentTeamPermitted filters the groups to the intersect of the
+	// set associated to the parent team and those returned by the query.
+	// If the parent team is not group-constrained or if NotAssociatedToChannel
+	// is not set then this option is ignored.
+	FilterParentTeamPermitted bool
 }
 
 type PageOpts struct {

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -2994,14 +2994,15 @@ func testGetGroupsByTeam(t *testing.T, ss store.Store) {
 func testGetGroups(t *testing.T, ss store.Store) {
 	// Create Team1
 	team1 := &model.Team{
-		DisplayName:     "Team1",
-		Description:     model.NewId(),
-		CompanyName:     model.NewId(),
-		AllowOpenInvite: false,
-		InviteId:        model.NewId(),
-		Name:            "zz" + model.NewId(),
-		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
-		Type:            model.TEAM_OPEN,
+		DisplayName:      "Team1",
+		Description:      model.NewId(),
+		CompanyName:      model.NewId(),
+		AllowOpenInvite:  false,
+		InviteId:         model.NewId(),
+		Name:             "zz" + model.NewId(),
+		Email:            "success+" + model.NewId() + "@simulator.amazonses.com",
+		Type:             model.TEAM_OPEN,
+		GroupConstrained: model.NewBool(true),
 	}
 	team1, err := ss.Team().Save(team1)
 	require.Nil(t, err)
@@ -3080,6 +3081,16 @@ func testGetGroups(t *testing.T, ss store.Store) {
 		Type:        model.CHANNEL_PRIVATE,
 	}
 	channel2, nErr = ss.Channel().Save(channel2, 9999)
+	require.Nil(t, nErr)
+
+	// Create Channel3
+	channel3 := &model.Channel{
+		TeamId:      team1.Id,
+		DisplayName: "Channel3",
+		Name:        model.NewId(),
+		Type:        model.CHANNEL_PRIVATE,
+	}
+	channel3, nErr = ss.Channel().Save(channel3, 9999)
 	require.Nil(t, nErr)
 
 	// Create Group3
@@ -3333,6 +3344,33 @@ func testGetGroups(t *testing.T, ss store.Store) {
 			PerPage: 100,
 			Resultf: func(groups []*model.Group) bool {
 				return len(groups) == 0
+			},
+		},
+		{
+			Name:    "Filter groups from group-constrained teams",
+			Opts:    model.GroupSearchOpts{NotAssociatedToChannel: channel3.Id, FilterParentTeamPermitted: true},
+			Page:    0,
+			PerPage: 100,
+			Resultf: func(groups []*model.Group) bool {
+				return len(groups) == 2 && groups[0].Id == group1.Id && groups[1].Id == group2.Id
+			},
+		},
+		{
+			Name:    "Filter groups from group-constrained page 0",
+			Opts:    model.GroupSearchOpts{NotAssociatedToChannel: channel3.Id, FilterParentTeamPermitted: true},
+			Page:    0,
+			PerPage: 1,
+			Resultf: func(groups []*model.Group) bool {
+				return groups[0].Id == group1.Id
+			},
+		},
+		{
+			Name:    "Filter groups from group-constrained page 1",
+			Opts:    model.GroupSearchOpts{NotAssociatedToChannel: channel3.Id, FilterParentTeamPermitted: true},
+			Page:    0,
+			PerPage: 1,
+			Resultf: func(groups []*model.Group) bool {
+				return groups[0].Id == group2.Id
 			},
 		},
 	}

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -3367,7 +3367,7 @@ func testGetGroups(t *testing.T, ss store.Store) {
 		{
 			Name:    "Filter groups from group-constrained page 1",
 			Opts:    model.GroupSearchOpts{NotAssociatedToChannel: channel3.Id, FilterParentTeamPermitted: true},
-			Page:    0,
+			Page:    1,
 			PerPage: 1,
 			Resultf: func(groups []*model.Group) bool {
 				return groups[0].Id == group2.Id

--- a/web/params.go
+++ b/web/params.go
@@ -23,59 +23,60 @@ const (
 )
 
 type Params struct {
-	UserId                 string
-	TeamId                 string
-	InviteId               string
-	TokenId                string
-	ChannelId              string
-	PostId                 string
-	FileId                 string
-	Filename               string
-	PluginId               string
-	CommandId              string
-	HookId                 string
-	ReportId               string
-	EmojiId                string
-	AppId                  string
-	Email                  string
-	Username               string
-	TeamName               string
-	ChannelName            string
-	PreferenceName         string
-	EmojiName              string
-	Category               string
-	Service                string
-	JobId                  string
-	JobType                string
-	ActionId               string
-	RoleId                 string
-	RoleName               string
-	SchemeId               string
-	Scope                  string
-	GroupId                string
-	Page                   int
-	PerPage                int
-	LogsPerPage            int
-	Permanent              bool
-	RemoteId               string
-	SyncableId             string
-	SyncableType           model.GroupSyncableType
-	BotUserId              string
-	Q                      string
-	IsLinked               *bool
-	IsConfigured           *bool
-	NotAssociatedToTeam    string
-	NotAssociatedToChannel string
-	Paginate               *bool
-	IncludeMemberCount     bool
-	NotAssociatedToGroup   string
-	ExcludeDefaultChannels bool
-	LimitAfter             int
-	LimitBefore            int
-	GroupIDs               string
-	IncludeTotalCount      bool
-	IncludeDeleted         bool
-	FilterAllowReference   bool
+	UserId                    string
+	TeamId                    string
+	InviteId                  string
+	TokenId                   string
+	ChannelId                 string
+	PostId                    string
+	FileId                    string
+	Filename                  string
+	PluginId                  string
+	CommandId                 string
+	HookId                    string
+	ReportId                  string
+	EmojiId                   string
+	AppId                     string
+	Email                     string
+	Username                  string
+	TeamName                  string
+	ChannelName               string
+	PreferenceName            string
+	EmojiName                 string
+	Category                  string
+	Service                   string
+	JobId                     string
+	JobType                   string
+	ActionId                  string
+	RoleId                    string
+	RoleName                  string
+	SchemeId                  string
+	Scope                     string
+	GroupId                   string
+	Page                      int
+	PerPage                   int
+	LogsPerPage               int
+	Permanent                 bool
+	RemoteId                  string
+	SyncableId                string
+	SyncableType              model.GroupSyncableType
+	BotUserId                 string
+	Q                         string
+	IsLinked                  *bool
+	IsConfigured              *bool
+	NotAssociatedToTeam       string
+	NotAssociatedToChannel    string
+	Paginate                  *bool
+	IncludeMemberCount        bool
+	NotAssociatedToGroup      string
+	ExcludeDefaultChannels    bool
+	LimitAfter                int
+	LimitBefore               int
+	GroupIDs                  string
+	IncludeTotalCount         bool
+	IncludeDeleted            bool
+	FilterAllowReference      bool
+	FilterParentTeamPermitted bool
 }
 
 func ParamsFromRequest(r *http.Request) *Params {
@@ -280,6 +281,10 @@ func ParamsFromRequest(r *http.Request) *Params {
 
 	if val, err := strconv.ParseBool(query.Get("filter_allow_reference")); err == nil {
 		params.FilterAllowReference = val
+	}
+
+	if val, err := strconv.ParseBool(query.Get("filter_parent_team_permitted")); err == nil {
+		params.FilterParentTeamPermitted = val
 	}
 
 	if val, err := strconv.ParseBool(query.Get("paginate")); err == nil {


### PR DESCRIPTION
Cherry pick of #14619 on release-5.24.

- #14619: MM-25040: Only return team-associated groups if the

/cc  @mkraft