### PR TITLE
[MM-25677] Content-Type is optional

### DIFF
--- a/web/webhook.go
+++ b/web/webhook.go
@@ -29,8 +29,10 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var err *model.AppError
 	incomingWebhookPayload := &model.IncomingWebhookRequest{}
-	mediaType, _, mimeErr := mime.ParseMediaType(r.Header.Get("Content-Type"))
-	if mimeErr != nil && mimeErr != mime.ErrInvalidMediaParameter {
+	contentType := r.Header.Get("Content-Type")
+	mediaType, _, mimeErr := mime.ParseMediaType(contentType)
+	// Having an empty content-type is fine given that is an optional header
+	if contentType != "" && mimeErr != nil && mimeErr != mime.ErrInvalidMediaParameter {
 		c.Err = model.NewAppError("incomingWebhook", "api.webhook.incoming.error", nil, mimeErr.Error(), http.StatusBadRequest)
 		return
 	}

--- a/web/webhook.go
+++ b/web/webhook.go
@@ -33,7 +33,12 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	mediaType, _, mimeErr := mime.ParseMediaType(contentType)
 	// Having an empty content-type is fine given that is an optional header
 	if contentType != "" && mimeErr != nil && mimeErr != mime.ErrInvalidMediaParameter {
-		c.Err = model.NewAppError("incomingWebhook", "api.webhook.incoming.error", nil, mimeErr.Error(), http.StatusBadRequest)
+		c.Err = model.NewAppError("incomingWebhook",
+			"api.webhook.incoming.error",
+			nil,
+			"webhook_id="+id+" - error: "+mimeErr.Error(),
+			http.StatusBadRequest,
+		)
 		return
 	}
 
@@ -60,7 +65,12 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		err := decoder.Decode(incomingWebhookPayload, r.PostForm)
 
 		if err != nil {
-			c.Err = model.NewAppError("incomingWebhook", "api.webhook.incoming.error", nil, err.Error(), http.StatusBadRequest)
+			c.Err = model.NewAppError("incomingWebhook",
+				"api.webhook.incoming.error",
+				nil,
+				"webhook_id="+id+" - error: "+err.Error(),
+				http.StatusBadRequest,
+			)
 			return
 		}
 	} else {

--- a/web/webhook.go
+++ b/web/webhook.go
@@ -36,7 +36,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewAppError("incomingWebhook",
 			"api.webhook.incoming.error",
 			nil,
-			"webhook_id="+id+" - error: "+mimeErr.Error(),
+ 			"webhook_id="+id+", error: "+mimeErr.Error(), 
 			http.StatusBadRequest,
 		)
 		return
@@ -68,7 +68,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewAppError("incomingWebhook",
 				"api.webhook.incoming.error",
 				nil,
-				"webhook_id="+id+" - error: "+err.Error(),
+ 				"webhook_id="+id+", error: "+err.Error(), 
 				http.StatusBadRequest,
 			)
 			return

--- a/web/webhook.go
+++ b/web/webhook.go
@@ -28,18 +28,22 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 	r.ParseForm()
 
 	var err *model.AppError
+	var mediaType string
 	incomingWebhookPayload := &model.IncomingWebhookRequest{}
 	contentType := r.Header.Get("Content-Type")
-	mediaType, _, mimeErr := mime.ParseMediaType(contentType)
-	// Having an empty content-type is fine given that is an optional header
-	if contentType != "" && mimeErr != nil && mimeErr != mime.ErrInvalidMediaParameter {
-		c.Err = model.NewAppError("incomingWebhook",
-			"api.webhook.incoming.error",
-			nil,
- 			"webhook_id="+id+", error: "+mimeErr.Error(), 
-			http.StatusBadRequest,
-		)
-		return
+	// Content-Type header is optional so could be empty
+	if contentType != "" {
+		var mimeErr error
+		mediaType, _, mimeErr = mime.ParseMediaType(contentType)
+		if mimeErr != nil && mimeErr != mime.ErrInvalidMediaParameter {
+			c.Err = model.NewAppError("incomingWebhook",
+				"api.webhook.incoming.error",
+				nil,
+				"webhook_id="+id+", error: "+mimeErr.Error(),
+				http.StatusBadRequest,
+			)
+			return
+		}
 	}
 
 	defer func() {
@@ -68,7 +72,7 @@ func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewAppError("incomingWebhook",
 				"api.webhook.incoming.error",
 				nil,
- 				"webhook_id="+id+", error: "+err.Error(), 
+				"webhook_id="+id+", error: "+err.Error(),
 				http.StatusBadRequest,
 			)
 			return

--- a/web/webhook_test.go
+++ b/web/webhook_test.go
@@ -40,89 +40,89 @@ func TestIncomingWebhook(t *testing.T) {
 		payload := "payload={\"text\": \"test text\"}"
 		resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		payload = "payload={\"text\": \"\"}"
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode != http.StatusOK, "should have errored - no text to post")
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode, "should have errored - no text post")
 
 		payload = "payload={\"text\": \"test text\", \"channel\": \"junk\"}"
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode != http.StatusOK, "should have errored - bad channel")
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode, "should have errored - bad channel")
 
 		payload = "payload={\"text\": \"test text\"}"
 		resp, err = http.Post(ApiClient.Url+"/hooks/abc123", "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode != http.StatusOK, "should have errored - bad hook")
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode, "should have errored - bad hook")
 
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\"this is a test\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		text := `this is a \"test\"
 	that contains a newline and a tab`
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\""+text+"\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader(fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"%s\"}", th.BasicChannel.Name)))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader(fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"#%s\"}", th.BasicChannel.Name)))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader(fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"@%s\"}", th.BasicUser.Username)))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader("payload={\"text\":\"this is a test\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "AppLicaTion/x-www-Form-urlencoded", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded;charset=utf-8", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded; charset=utf-8", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded wrongtext", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\""+tooLongText+"\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader("{\"text\":\""+tooLongText+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		payloadMultiPart := "------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"username\"\r\n\r\nwebhook-bot\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"text\"\r\n\r\nthis is a test :tada:\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW--"
 		resp, err = http.Post(ApiClient.Url+"/hooks/"+hook.Id, "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW", strings.NewReader(payloadMultiPart))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "mimetype/wrong", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = http.Post(url, "", strings.NewReader("{\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)

--- a/web/webhook_test.go
+++ b/web/webhook_test.go
@@ -123,6 +123,10 @@ func TestIncomingWebhook(t *testing.T) {
 		resp, err = http.Post(url, "mimetype/wrong", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
 		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+
+		resp, err = http.Post(url, "", strings.NewReader("{\"text\":\""+text+"\"}"))
+		assert.Nil(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("WebhookExperimentalReadOnly", func(t *testing.T) {

--- a/web/webhook_test.go
+++ b/web/webhook_test.go
@@ -105,7 +105,7 @@ func TestIncomingWebhook(t *testing.T) {
 
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\""+tooLongText+"\"}"))
 		require.Nil(t, err)
-		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader("{\"text\":\""+tooLongText+"\"}"))
 		assert.Nil(t, err)
@@ -122,7 +122,7 @@ func TestIncomingWebhook(t *testing.T) {
 
 		resp, err = http.Post(url, "mimetype/wrong", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = http.Post(url, "", strings.NewReader("{\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

mime.ParseMimeType returns and "no media type" error if the passed
string is empty.

Given that the Content-Type header is optional we shouldn't return error
in that case so we're fixing that allowing the users to call the webhook
without passing that header

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-25677