### PR TITLE
Cherry pick 5.23 - [MM-25677] Content-Type is optional (#14705)

### DIFF
--- a/web/webhook_test.go
+++ b/web/webhook_test.go
@@ -40,89 +40,93 @@ func TestIncomingWebhook(t *testing.T) {
 		payload := "payload={\"text\": \"test text\"}"
 		resp, err := http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		payload = "payload={\"text\": \"\"}"
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode != http.StatusOK, "should have errored - no text to post")
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode, "should have errored - no text post")
 
 		payload = "payload={\"text\": \"test text\", \"channel\": \"junk\"}"
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode != http.StatusOK, "should have errored - bad channel")
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode, "should have errored - bad channel")
 
 		payload = "payload={\"text\": \"test text\"}"
 		resp, err = http.Post(ApiClient.Url+"/hooks/abc123", "application/x-www-form-urlencoded", strings.NewReader(payload))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode != http.StatusOK, "should have errored - bad hook")
+		assert.NotEqual(t, http.StatusOK, resp.StatusCode, "should have errored - bad hook")
 
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\"this is a test\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		text := `this is a \"test\"
 	that contains a newline and a tab`
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\""+text+"\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader(fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"%s\"}", th.BasicChannel.Name)))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader(fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"#%s\"}", th.BasicChannel.Name)))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader(fmt.Sprintf("{\"text\":\"this is a test\", \"channel\":\"@%s\"}", th.BasicUser.Username)))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader("payload={\"text\":\"this is a test\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "AppLicaTion/x-www-Form-urlencoded", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded;charset=utf-8", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded; charset=utf-8", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded wrongtext", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader("{\"text\":\""+tooLongText+"\"}"))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/x-www-form-urlencoded", strings.NewReader("{\"text\":\""+tooLongText+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = http.Post(url, "application/json", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		payloadMultiPart := "------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"username\"\r\n\r\nwebhook-bot\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW\r\nContent-Disposition: form-data; name=\"text\"\r\n\r\nthis is a test :tada:\r\n------WebKitFormBoundary7MA4YWxkTrZu0gW--"
 		resp, err = http.Post(ApiClient.Url+"/hooks/"+hook.Id, "multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW", strings.NewReader(payloadMultiPart))
 		require.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		resp, err = http.Post(url, "mimetype/wrong", strings.NewReader("payload={\"text\":\""+text+"\"}"))
 		assert.Nil(t, err)
-		assert.True(t, resp.StatusCode == http.StatusBadRequest)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		resp, err = http.Post(url, "", strings.NewReader("{\"text\":\""+text+"\"}"))
+		assert.Nil(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("WebhookExperimentalReadOnly", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

* Content-Type is optional

mime.ParseMimeType returns and "no media type" error if the passed
string is empty.

Given that the Content-Type header is optional we shouldn't return an error
in that case, so we're fixing that allowing the users to call the webhook
without passing that header

* Include webhook id in the error message

Given that the number of webhooks could be big the user could
need the id to check which one of the multiple webhooks are failing
so include the id aids in that part

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-25677