### PR TITLE
MM-25641: Check if member was deleted in HasPermissionToTeam

### DIFF
--- a/app/authorization.go
+++ b/app/authorization.go
@@ -136,6 +136,11 @@ func (a *App) HasPermissionToTeam(askingUserId string, teamId string, permission
 		return false
 	}
 
+	// If the team member has been deleted, they don't have permission.
+	if teamMember.DeleteAt != 0 {
+		return false
+	}
+
 	roles := teamMember.GetRoles()
 
 	if a.RolesGrantPermission(roles, permission.Id) {

--- a/app/authorization_test.go
+++ b/app/authorization_test.go
@@ -6,6 +6,7 @@ package app
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -40,4 +41,15 @@ func TestChannelRolesGrantPermission(t *testing.T) {
 	testPermissionInheritance(t, func(t *testing.T, th *TestHelper, testData permissionInheritanceTestData) {
 		require.Equal(t, testData.shouldHavePermission, th.App.RolesGrantPermission([]string{testData.channelRole.Name}, testData.permission.Id), "row: %+v\n", testData.truthTableRow)
 	})
+}
+
+func TestHasPermissionToTeam(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	assert.True(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
+
+	th.RemoveUserFromTeam(th.BasicUser, th.BasicTeam)
+
+	assert.False(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
 }

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -439,6 +439,20 @@ func (me *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 	utils.EnableDebugLogForTest()
 }
 
+func (me *TestHelper) RemoveUserFromTeam(user *model.User, team *model.Team) {
+	utils.DisableDebugLogForTest()
+
+	err := me.App.RemoveUserFromTeam(team.Id, user.Id, "")
+	if err != nil {
+		mlog.Error(err.Error())
+
+		time.Sleep(time.Second)
+		panic(err)
+	}
+
+	utils.EnableDebugLogForTest()
+}
+
 func (me *TestHelper) AddUserToChannel(user *model.User, channel *model.Channel) *model.ChannelMember {
 	utils.DisableDebugLogForTest()
 


### PR DESCRIPTION
This PR adds a check to verify if a team member got deleted in HasPermissionToTeam,
and accordingly returns false.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-25641