### PR TITLE
MM-25737: Fix for groups list not returning results.

### DIFF
--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -1225,7 +1225,16 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 
 	if opts.FilterParentTeamPermitted && len(opts.NotAssociatedToChannel) == 26 {
 		groupsQuery = groupsQuery.Where(`
-			g.Id IN (
+			CASE
+			WHEN (
+				SELECT
+					Teams.GroupConstrained
+				FROM
+					Teams
+					JOIN Channels ON Channels.TeamId = Teams.Id
+				WHERE
+					Channels.Id = ?
+			) THEN g.Id IN (
 				SELECT
 					GroupId
 				FROM
@@ -1241,7 +1250,9 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts)
 							Id = ?
 					)
 			)
-		`, opts.NotAssociatedToChannel)
+			ELSE TRUE
+		END
+		`, opts.NotAssociatedToChannel, opts.NotAssociatedToChannel)
 	}
 
 	queryString, args, err := groupsQuery.ToSql()

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -3163,6 +3163,29 @@ func testGetGroups(t *testing.T, ss store.Store) {
 
 	endCreateTime := u2Update.New.UpdateAt + 1
 
+	// Create Team3
+	team3 := &model.Team{
+		DisplayName:     "Team3",
+		Description:     model.NewId(),
+		CompanyName:     model.NewId(),
+		AllowOpenInvite: false,
+		InviteId:        model.NewId(),
+		Name:            "zz" + model.NewId(),
+		Email:           "success+" + model.NewId() + "@simulator.amazonses.com",
+		Type:            model.TEAM_INVITE,
+	}
+	team3, err = ss.Team().Save(team3)
+	require.Nil(t, err)
+
+	channel4 := &model.Channel{
+		TeamId:      team3.Id,
+		DisplayName: "Channel4",
+		Name:        model.NewId(),
+		Type:        model.CHANNEL_PRIVATE,
+	}
+	channel4, nErr = ss.Channel().Save(channel4, 9999)
+	require.Nil(t, nErr)
+
 	testCases := []struct {
 		Name    string
 		Page    int
@@ -3371,6 +3394,15 @@ func testGetGroups(t *testing.T, ss store.Store) {
 			PerPage: 1,
 			Resultf: func(groups []*model.Group) bool {
 				return groups[0].Id == group2.Id
+			},
+		},
+		{
+			Name:    "Non-group constrained team with no associated groups still returns groups for the child channel",
+			Opts:    model.GroupSearchOpts{NotAssociatedToChannel: channel4.Id, FilterParentTeamPermitted: true},
+			Page:    0,
+			PerPage: 100,
+			Resultf: func(groups []*model.Group) bool {
+				return len(groups) > 0
 			},
 		},
 	}


### PR DESCRIPTION
#### Summary

Fixes incorrect SQL query that filters groups even if the parent team is not group-constrained.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-25737
