### PR TITLE
Change SidebarCategoryType enums to use full names

### DIFF
--- a/model/channel_sidebar.go
+++ b/model/channel_sidebar.go
@@ -14,10 +14,10 @@ type SidebarCategorySorting string
 const (
 	// Each sidebar category has a 'type'. System categories are Channels, Favorites and DMs
 	// All user-created categories will have type Custom
-	SidebarCategoryChannels       SidebarCategoryType = "C"
-	SidebarCategoryDirectMessages SidebarCategoryType = "D"
-	SidebarCategoryFavorites      SidebarCategoryType = "F"
-	SidebarCategoryCustom         SidebarCategoryType = "U"
+	SidebarCategoryChannels       SidebarCategoryType = "custom"
+	SidebarCategoryDirectMessages SidebarCategoryType = "direct_messages"
+	SidebarCategoryFavorites      SidebarCategoryType = "favorites"
+	SidebarCategoryCustom         SidebarCategoryType = "custom"
 	// Increment to use when adding/reordering things in the sidebar
 	MinimalSidebarSortDistance = 10
 	// Default Sort Orders for categories


### PR DESCRIPTION
We have some code on the client that relies on these using the old, full names for generating the correct translation strings, so they need to be changed from the single-letter versions.