### PR TITLE
MM-24914 Fix updateCategory endpoint returning the wrong type

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -1927,7 +1927,7 @@ func updateCategoriesForTeamForUser(c *Context, w http.ResponseWriter, r *http.R
 	}
 
 	auditRec.Success()
-	w.Write(model.SidebarCategoryWithChannelsToJson(categories))
+	w.Write(model.SidebarCategoriesWithChannelsToJson(categories))
 }
 
 func validateUserChannels(operationName string, c *Context, teamId, userId string, channelIDs []string) *model.AppError {
@@ -1986,7 +1986,7 @@ func updateCategoryForTeamForUser(c *Context, w http.ResponseWriter, r *http.Req
 	}
 
 	auditRec.Success()
-	w.Write(model.SidebarCategoryWithChannelsToJson(categories))
+	w.Write(categories[0].ToJson())
 }
 
 func deleteCategoryForTeamForUser(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -3673,3 +3673,105 @@ func TestGetChannelMemberCountsByGroup(t *testing.T) {
 		require.ElementsMatch(t, expectedMemberCounts, memberCounts)
 	})
 }
+
+func TestUpdateCategoryForTeamForUser(t *testing.T) {
+	t.Run("should update the channel order of the Channels category", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		categories, resp := th.Client.GetSidebarCategoriesForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, "")
+		require.Nil(t, resp.Error)
+		require.Len(t, categories.Categories, 3)
+		require.Len(t, categories.Order, 3)
+
+		channelsCategory := categories.Categories[1]
+		require.Equal(t, model.SidebarCategoryChannels, channelsCategory.Type)
+		require.Len(t, channelsCategory.Channels, 5) // Town Square, Off Topic, and the 3 channels created by InitBasic
+
+		// Should return the correct values from the API
+		updatedCategory := &model.SidebarCategoryWithChannels{
+			SidebarCategory: channelsCategory.SidebarCategory,
+			Channels:        []string{channelsCategory.Channels[1], channelsCategory.Channels[0], channelsCategory.Channels[4], channelsCategory.Channels[3], channelsCategory.Channels[2]},
+		}
+
+		t.Log("UserId=" + th.BasicUser.Id)
+		t.Log("TeamId=" + th.BasicTeam.Id)
+		t.Log("category=" + channelsCategory.Id)
+
+		received, resp := th.Client.UpdateSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, channelsCategory.Id, updatedCategory)
+		assert.Nil(t, resp.Error)
+		assert.Equal(t, channelsCategory.Id, received.Id)
+		assert.Equal(t, updatedCategory.Channels, received.Channels)
+
+		// And when requesting the category later
+		received, resp = th.Client.GetSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, channelsCategory.Id, "")
+		assert.Nil(t, resp.Error)
+		assert.Equal(t, channelsCategory.Id, received.Id)
+		assert.Equal(t, updatedCategory.Channels, received.Channels)
+	})
+
+	t.Run("should update the sort order of the DM category", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		categories, resp := th.Client.GetSidebarCategoriesForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, "")
+		require.Nil(t, resp.Error)
+		require.Len(t, categories.Categories, 3)
+		require.Len(t, categories.Order, 3)
+
+		dmsCategory := categories.Categories[2]
+		require.Equal(t, model.SidebarCategoryDirectMessages, dmsCategory.Type)
+		require.Equal(t, model.SidebarCategorySortRecent, dmsCategory.Sorting)
+
+		// Should return the correct values from the API
+		updatedCategory := &model.SidebarCategoryWithChannels{
+			SidebarCategory: dmsCategory.SidebarCategory,
+			Channels:        dmsCategory.Channels,
+		}
+		updatedCategory.Sorting = model.SidebarCategorySortAlphabetical
+
+		received, resp := th.Client.UpdateSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, dmsCategory.Id, updatedCategory)
+		assert.Nil(t, resp.Error)
+		assert.Equal(t, dmsCategory.Id, received.Id)
+		assert.Equal(t, model.SidebarCategorySortAlphabetical, received.Sorting)
+
+		// And when requesting the category later
+		received, resp = th.Client.GetSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, dmsCategory.Id, "")
+		assert.Nil(t, resp.Error)
+		assert.Equal(t, dmsCategory.Id, received.Id)
+		assert.Equal(t, model.SidebarCategorySortAlphabetical, received.Sorting)
+	})
+
+	t.Run("should update the display name of a custom category", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		customCategory, resp := th.Client.CreateSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, &model.SidebarCategoryWithChannels{
+			SidebarCategory: model.SidebarCategory{
+				UserId:      th.BasicUser.Id,
+				TeamId:      th.BasicTeam.Id,
+				DisplayName: "custom123",
+			},
+		})
+		require.Nil(t, resp.Error)
+		require.Equal(t, "custom123", customCategory.DisplayName)
+
+		// Should return the correct values from the API
+		updatedCategory := &model.SidebarCategoryWithChannels{
+			SidebarCategory: customCategory.SidebarCategory,
+			Channels:        customCategory.Channels,
+		}
+		updatedCategory.DisplayName = "abcCustom"
+
+		received, resp := th.Client.UpdateSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, customCategory.Id, updatedCategory)
+		assert.Nil(t, resp.Error)
+		assert.Equal(t, customCategory.Id, received.Id)
+		assert.Equal(t, updatedCategory.DisplayName, received.DisplayName)
+
+		// And when requesting the category later
+		received, resp = th.Client.GetSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, customCategory.Id, "")
+		assert.Nil(t, resp.Error)
+		assert.Equal(t, customCategory.Id, received.Id)
+		assert.Equal(t, updatedCategory.DisplayName, received.DisplayName)
+	})
+}

--- a/model/channel_sidebar.go
+++ b/model/channel_sidebar.go
@@ -94,7 +94,7 @@ func (o SidebarCategoryWithChannels) ToJson() []byte {
 	return b
 }
 
-func SidebarCategoryWithChannelsToJson(o []*SidebarCategoryWithChannels) []byte {
+func SidebarCategoriesWithChannelsToJson(o []*SidebarCategoryWithChannels) []byte {
 	if b, err := json.Marshal(o); err != nil {
 		return []byte("[]")
 	} else {

--- a/model/client4.go
+++ b/model/client4.go
@@ -5169,7 +5169,7 @@ func (c *Client4) UpdateSidebarCategoryOrderForTeamForUser(userID, teamID string
 }
 
 func (c *Client4) GetSidebarCategoryForTeamForUser(userID, teamID, categoryID, etag string) (*SidebarCategoryWithChannels, *Response) {
-	route := c.GetUserCategoryRoute(userID, teamID) + categoryID
+	route := c.GetUserCategoryRoute(userID, teamID) + "/" + categoryID
 	r, appErr := c.DoApiGet(route, etag)
 	if appErr != nil {
 		return nil, BuildErrorResponse(r, appErr)
@@ -5185,7 +5185,7 @@ func (c *Client4) GetSidebarCategoryForTeamForUser(userID, teamID, categoryID, e
 
 func (c *Client4) UpdateSidebarCategoryForTeamForUser(userID, teamID, categoryID string, category *SidebarCategoryWithChannels) (*SidebarCategoryWithChannels, *Response) {
 	payload, _ := json.Marshal(category)
-	route := c.GetUserCategoryRoute(userID, teamID) + categoryID
+	route := c.GetUserCategoryRoute(userID, teamID) + "/" + categoryID
 	r, appErr := c.doApiPutBytes(route, payload)
 	if appErr != nil {
 		return nil, BuildErrorResponse(r, appErr)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3669,6 +3669,8 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 			category.DisplayName = categoryToUpdate.DisplayName
 		}
 
+		category.Sorting = categoryToUpdate.Sorting
+
 		if _, err = transaction.UpdateColumns(func(col *gorp.ColumnMap) bool {
 			return col.ColumnName == "DisplayName" || col.ColumnName == "Sorting"
 		}, category); err != nil {


### PR DESCRIPTION
The endpoint was returning an array of categories instead of just the one that was updated. I also fixed a couple cases where `model.Client4` constructed URLs wrong and a spot where I broke updating sorting method in my last PR.