### PR TITLE
MM-26167: improve CreatePostCheckOnlineStatus

### DIFF
--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -609,11 +609,7 @@ func TestCreatePostCheckOnlineStatus(t *testing.T) {
 			select {
 			case ev := <-wsClient.EventChannel:
 				if ev.EventType() == model.WEBSOCKET_EVENT_POSTED {
-					if isSetOnline {
-						assert.True(t, ev.GetData()["set_online"].(bool))
-					} else {
-						assert.False(t, ev.GetData()["set_online"].(bool))
-					}
+					assert.True(t, ev.GetData()["set_online"].(bool) == isSetOnline)
 					return
 				}
 			case <-timeout:

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"sort"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -598,40 +597,30 @@ func TestCreatePostCheckOnlineStatus(t *testing.T) {
 	_, loginResp := cli.Login(th.BasicUser2.Username, th.BasicUser2.Password)
 	require.Nil(t, loginResp.Error)
 
-	var wg sync.WaitGroup
 	wsClient, err := th.CreateWebSocketClientWithClient(cli)
 	require.Nil(t, err)
-	defer func() {
-		wg.Wait()
-		wsClient.Close()
-	}()
+	defer wsClient.Close()
 
 	wsClient.Listen()
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		timeout := time.After(2 * time.Second)
-		cnt := true
-		i := 0
-		for cnt {
+	waitForEvent := func(isSetOnline bool) {
+		timeout := time.After(5 * time.Second)
+		for {
 			select {
 			case ev := <-wsClient.EventChannel:
 				if ev.EventType() == model.WEBSOCKET_EVENT_POSTED {
-					if i == 0 {
-						assert.False(t, ev.GetData()["set_online"].(bool))
-					} else {
+					if isSetOnline {
 						assert.True(t, ev.GetData()["set_online"].(bool))
+					} else {
+						assert.False(t, ev.GetData()["set_online"].(bool))
 					}
-					i++
+					return
 				}
-				cnt = i != 2
 			case <-timeout:
-				cnt = false
+				require.Fail(t, "timed out waiting for event")
 			}
 		}
-		assert.Equal(t, 2, i, "unexpected number of posted events")
-	}()
+	}
 
 	handler := api.ApiHandler(createPost)
 	resp := httptest.NewRecorder()
@@ -645,6 +634,7 @@ func TestCreatePostCheckOnlineStatus(t *testing.T) {
 
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusCreated, resp.Code)
+	waitForEvent(false)
 
 	_, err = th.App.GetStatus(th.BasicUser.Id)
 	require.NotNil(t, err)
@@ -655,6 +645,7 @@ func TestCreatePostCheckOnlineStatus(t *testing.T) {
 
 	handler.ServeHTTP(resp, req)
 	assert.Equal(t, http.StatusCreated, resp.Code)
+	waitForEvent(true)
 
 	st, err := th.App.GetStatus(th.BasicUser.Id)
 	require.Nil(t, err)


### PR DESCRIPTION
We improve the flakyness of the test by making the websocket
status checks synchronous after making each request.

This makes the status responses more reliable because in very
busy CI environments the goroutine scheduler can indeed send
the response which is made by a later HTTP request before the first one.

### Ticket link

https://mattermost.atlassian.net/browse/MM-26167