### PR TITLE
MM-26203: Fix TestChannelStore//SearchAllChannels flake

### DIFF
--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -5242,7 +5242,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 
 	o14 := model.Channel{
 		TeamId:      t2.Id,
-		DisplayName: "FOOBAR",
+		DisplayName: "FOOBARDISPLAYNAME",
 		Name:        "whatever",
 		Type:        model.CHANNEL_OPEN,
 	}
@@ -5255,9 +5255,9 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 		ExpectedResults *model.ChannelList
 		TotalCount      int
 	}{
-		{"Search FooBar by display name", "oob", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
-		{"Search FooBar by display name2", "foo", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
-		{"Search FooBar by display name3", "bar", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
+		{"Search FooBar by display name", "bardisplay", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
+		{"Search FooBar by display name2", "foobar", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
+		{"Search FooBar by display name3", "displayname", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
 		{"Search FooBar by name", "what", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
 		{"Search FooBar by name2", "ever", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o14}, 1},
 		{"ChannelA", "ChannelA", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o1, &o2, &o3}, 0},
@@ -5273,9 +5273,9 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 		{"pipe ignored", "town square |", store.ChannelSearchOpts{IncludeDeleted: false}, &model.ChannelList{&o9}, 0},
 		{"exclude defaults search 'off'", "off-", store.ChannelSearchOpts{IncludeDeleted: false, ExcludeChannelNames: []string{"off-topic"}}, &model.ChannelList{&o8, &o7}, 0},
 		{"exclude defaults search 'town'", "town", store.ChannelSearchOpts{IncludeDeleted: false, ExcludeChannelNames: []string{"town-square"}}, &model.ChannelList{}, 0},
-		{"exclude by group association", "off", store.ChannelSearchOpts{IncludeDeleted: false, NotAssociatedToGroup: group.Id}, &model.ChannelList{&o8, &o6}, 0},
-		{"paginate includes count", "off", store.ChannelSearchOpts{IncludeDeleted: false, PerPage: model.NewInt(100)}, &model.ChannelList{&o8, &o7, &o6}, 3},
-		{"paginate, page 2 correct entries and count", "off", store.ChannelSearchOpts{IncludeDeleted: false, PerPage: model.NewInt(2), Page: model.NewInt(1)}, &model.ChannelList{&o6}, 3},
+		{"exclude by group association", "off-", store.ChannelSearchOpts{IncludeDeleted: false, NotAssociatedToGroup: group.Id}, &model.ChannelList{&o8, &o6}, 0},
+		{"paginate includes count", "off-", store.ChannelSearchOpts{IncludeDeleted: false, PerPage: model.NewInt(100)}, &model.ChannelList{&o8, &o7, &o6}, 3},
+		{"paginate, page 2 correct entries and count", "off-", store.ChannelSearchOpts{IncludeDeleted: false, PerPage: model.NewInt(2), Page: model.NewInt(1)}, &model.ChannelList{&o6}, 3},
 	}
 
 	for _, testCase := range testCases {

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -449,7 +449,7 @@ func testTeamStoreSearchPrivate(t *testing.T, ss store.Store) {
 	require.Nil(t, err)
 
 	q := model.Team{}
-	q.DisplayName = "FOOBAR"
+	q.DisplayName = "FOOBARDISPLAYNAME"
 	q.Name = "whatever"
 	q.Email = MakeEmail()
 	q.Type = model.TEAM_OPEN
@@ -466,19 +466,19 @@ func testTeamStoreSearchPrivate(t *testing.T, ss store.Store) {
 	}{
 		{
 			"Search FooBar by display name from text in the middle of display name",
-			"ooba",
+			"oobardisplay",
 			1,
 			q.Id,
 		},
 		{
 			"Search FooBar by display name from text at the beginning of display name",
-			"foo",
+			"foobar",
 			1,
 			q.Id,
 		},
 		{
 			"Search FooBar by display name from text at the end of display name",
-			"bar",
+			"bardisplayname",
 			1,
 			q.Id,
 		},


### PR DESCRIPTION
Using random strings for channel names creates chances of collisions
when searching for specific strings.

We increase the search space increasing the size of the search string
to be searched. This reduces collisions and makes the tests more reliable.

For the "off-" family of tests, this probably needs more length. But
it would also need the tests to be changed slightly as the "off-" part
acts as a prefix. I accidentally stumbled upon it while running the test
50 times. Adding a "-" is probably good enough for now. We can revisit
if it fails again in CI.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-26203