### PR TITLE
MM-26231: Reverts plugin API breaking change.

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -471,8 +471,8 @@ func (api *PluginAPI) GetGroup(groupId string) (*model.Group, *model.AppError) {
 	return api.app.GetGroup(groupId)
 }
 
-func (api *PluginAPI) GetGroupByName(name string, opts model.GroupSearchOpts) (*model.Group, *model.AppError) {
-	return api.app.GetGroupByName(name, opts)
+func (api *PluginAPI) GetGroupByName(name string) (*model.Group, *model.AppError) {
+	return api.app.GetGroupByName(name, model.GroupSearchOpts{})
 }
 
 func (api *PluginAPI) GetGroupsForUser(userId string) ([]*model.Group, *model.AppError) {

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -511,8 +511,8 @@ type API interface {
 	// GetGroupByName gets a group by name.
 	//
 	// @tag Group
-	// Minimum server version: 5.24
-	GetGroupByName(name string, opts model.GroupSearchOpts) (*model.Group, *model.AppError)
+	// Minimum server version: 5.18
+	GetGroupByName(name string) (*model.Group, *model.AppError)
 
 	// GetGroupsForUser gets the groups a user is in.
 	//

--- a/plugin/api_timer_layer_generated.go
+++ b/plugin/api_timer_layer_generated.go
@@ -553,9 +553,9 @@ func (api *apiTimerLayer) GetGroup(groupId string) (*model.Group, *model.AppErro
 	return _returnsA, _returnsB
 }
 
-func (api *apiTimerLayer) GetGroupByName(name string, opts model.GroupSearchOpts) (*model.Group, *model.AppError) {
+func (api *apiTimerLayer) GetGroupByName(name string) (*model.Group, *model.AppError) {
 	startTime := timePkg.Now()
-	_returnsA, _returnsB := api.apiImpl.GetGroupByName(name, opts)
+	_returnsA, _returnsB := api.apiImpl.GetGroupByName(name)
 	api.recordTime(startTime, "GetGroupByName", _returnsB == nil)
 	return _returnsA, _returnsB
 }
@@ -1019,6 +1019,6 @@ func (api *apiTimerLayer) PluginHTTP(request *http.Request) *http.Response {
 func (api *apiTimerLayer) PublishUserTyping(userId, channelId, parentId string) *model.AppError {
 	startTime := timePkg.Now()
 	_returnsA := api.apiImpl.PublishUserTyping(userId, channelId, parentId)
-	api.recordTime(startTime, "PublishUserTyping", true)
+	api.recordTime(startTime, "PublishUserTyping", _returnsA == nil)
 	return _returnsA
 }

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -2638,7 +2638,6 @@ func (s *apiRPCServer) GetGroup(args *Z_GetGroupArgs, returns *Z_GetGroupReturns
 
 type Z_GetGroupByNameArgs struct {
 	A string
-	B model.GroupSearchOpts
 }
 
 type Z_GetGroupByNameReturns struct {
@@ -2646,8 +2645,8 @@ type Z_GetGroupByNameReturns struct {
 	B *model.AppError
 }
 
-func (g *apiRPCClient) GetGroupByName(name string, opts model.GroupSearchOpts) (*model.Group, *model.AppError) {
-	_args := &Z_GetGroupByNameArgs{name, opts}
+func (g *apiRPCClient) GetGroupByName(name string) (*model.Group, *model.AppError) {
+	_args := &Z_GetGroupByNameArgs{name}
 	_returns := &Z_GetGroupByNameReturns{}
 	if err := g.client.Call("Plugin.GetGroupByName", _args, _returns); err != nil {
 		log.Printf("RPC call to GetGroupByName API failed: %s", err.Error())
@@ -2657,9 +2656,9 @@ func (g *apiRPCClient) GetGroupByName(name string, opts model.GroupSearchOpts) (
 
 func (s *apiRPCServer) GetGroupByName(args *Z_GetGroupByNameArgs, returns *Z_GetGroupByNameReturns) error {
 	if hook, ok := s.impl.(interface {
-		GetGroupByName(name string, opts model.GroupSearchOpts) (*model.Group, *model.AppError)
+		GetGroupByName(name string) (*model.Group, *model.AppError)
 	}); ok {
-		returns.A, returns.B = hook.GetGroupByName(args.A, args.B)
+		returns.A, returns.B = hook.GetGroupByName(args.A)
 	} else {
 		return encodableError(fmt.Errorf("API GetGroupByName called but not implemented."))
 	}

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1089,13 +1089,13 @@ func (_m *API) GetGroup(groupId string) (*model.Group, *model.AppError) {
 	return r0, r1
 }
 
-// GetGroupByName provides a mock function with given fields: name, opts
-func (_m *API) GetGroupByName(name string, opts model.GroupSearchOpts) (*model.Group, *model.AppError) {
-	ret := _m.Called(name, opts)
+// GetGroupByName provides a mock function with given fields: name
+func (_m *API) GetGroupByName(name string) (*model.Group, *model.AppError) {
+	ret := _m.Called(name)
 
 	var r0 *model.Group
-	if rf, ok := ret.Get(0).(func(string, model.GroupSearchOpts) *model.Group); ok {
-		r0 = rf(name, opts)
+	if rf, ok := ret.Get(0).(func(string) *model.Group); ok {
+		r0 = rf(name)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Group)
@@ -1103,8 +1103,8 @@ func (_m *API) GetGroupByName(name string, opts model.GroupSearchOpts) (*model.G
 	}
 
 	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, model.GroupSearchOpts) *model.AppError); ok {
-		r1 = rf(name, opts)
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(name)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)


### PR DESCRIPTION
#### Summary

Reverts plugin API breaking change. 

The only field from `model.GroupSearchOpts` that is being used is `FilterAllowReference`, which defaults to the original behaviour when `false`. By invoking `(*App).GetGroupByName` with `model.GroupSearchOpts{}` there should be no changes to the response received by plugins. 

In the future, consideration can be made to adding that field to the plugin API in a SemVer-compatible way, and I don't see that requiring the whole `model.GroupSearchOpts` struct.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-26231