### PR TITLE
[MM-26390] Ensures the generated team name in sampledata is a valid one

### DIFF
--- a/cmd/mattermost/commands/sampledata.go
+++ b/cmd/mattermost/commands/sampledata.go
@@ -563,9 +563,18 @@ func createChannelMembership(channelName string, guest bool) app.UserChannelImpo
 	}
 }
 
+func getSampleTeamName(idx int) string {
+	for {
+		name := fmt.Sprintf("%s-%d", fake.Word(), idx)
+		if !model.IsReservedTeamName(name) {
+			return name
+		}
+	}
+}
+
 func createTeam(idx int) app.LineImportData {
 	displayName := fake.Word()
-	name := fmt.Sprintf("%s-%d", fake.Word(), idx)
+	name := getSampleTeamName(idx)
 	allowOpenInvite := rand.Intn(2) == 0
 
 	description := fake.Paragraph()

--- a/model/team.go
+++ b/model/team.go
@@ -234,7 +234,6 @@ func IsReservedTeamName(s string) bool {
 }
 
 func IsValidTeamName(s string) bool {
-
 	if !IsValidAlphaNum(s) {
 		return false
 	}


### PR DESCRIPTION
#### Summary
Sampledata is generating teams with invalid URLs that are using reserved words like `error` as a prefix. This PR validates the generated team name and creates a new one if it's invalid.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26390