### PR TITLE
Fix webapp checkout part 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,9 @@ jobs:
           export WEBAPP_GIT_COMMIT=$(git rev-parse HEAD)
           echo "$WEBAPP_GIT_COMMIT"
 
+          trap 'npm ci && make build' ERR
           curl -f -o ./dist.tar.gz https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz
           mkdir ./dist && tar -xvf ./dist.tar.gz -C ./dist --strip-components=1
-      - run:
-          name: Run when s3 download fails
-          command: npm ci && make build
-          when: on_fail
       - persist_to_workspace:
           root: ~/mattermost
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           trap 'npm ci && make build' ERR
           curl -f -o ./dist.tar.gz https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz
           mkdir ./dist && tar -xvf ./dist.tar.gz -C ./dist --strip-components=1
+          trap - ERR
       - persist_to_workspace:
           root: ~/mattermost
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,11 @@ jobs:
           echo "$WEBAPP_GIT_COMMIT"
 
           curl -f -o ./dist.tar.gz https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz
-          if [[ $? == 0 ]]
-          then
-            mkdir ./dist && tar -xvf ./dist.tar.gz -C ./dist --strip-components=1
-          else
-            npm ci && make build
-          fi
+          mkdir ./dist && tar -xvf ./dist.tar.gz -C ./dist --strip-components=1
+      - run:
+          name: Run when s3 download fails
+          command: npm ci && make build
+          when: on_fail
       - persist_to_workspace:
           root: ~/mattermost
           paths:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The pipeline errors if the commit for the webapp does not yet exist in the bucket for uploading the webapp PRs. 
Which means the if else did not work as expected. Instead now we use `when: on_fail`, which basically uses `trap` underneath so it still errors, but initiates the npm commands (so part of the webapp pipeline). 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
