### PR TITLE
MM-26514: Fix ALTER PRIMARY KEY migration for Postgres <9.3

### DIFF
--- a/store/sqlstore/supplier.go
+++ b/store/sqlstore/supplier.go
@@ -805,7 +805,7 @@ func (ss *SqlSupplier) AlterPrimaryKey(tableName string, columnNames []string) b
 		FROM
 			pg_constraint AS c
 		CROSS JOIN
-			(SELECT unnest(conkey) FROM pg_constraint WHERE conrelid='` + strings.ToLower(tableName) + `'::REGCLASS) AS cols(colnum)
+			(SELECT unnest(conkey) FROM pg_constraint WHERE conrelid='` + strings.ToLower(tableName) + `'::REGCLASS AND contype='p') AS cols(colnum)
 		INNER JOIN
 			pg_attribute AS a ON a.attrelid = c.conrelid
 		AND cols.colnum = a.attnum

--- a/store/sqlstore/supplier.go
+++ b/store/sqlstore/supplier.go
@@ -786,7 +786,8 @@ func (ss *SqlSupplier) AlterPrimaryKey(tableName string, columnNames []string) b
 	var currentPrimaryKey string
 	var err error
 	// get the current primary key as a comma separated list of columns
-	if ss.DriverName() == model.DATABASE_DRIVER_MYSQL {
+	switch ss.DriverName() {
+	case model.DATABASE_DRIVER_MYSQL:
 		query := `
 			SELECT GROUP_CONCAT(column_name ORDER BY seq_in_index) AS PK
 		FROM
@@ -798,13 +799,13 @@ func (ss *SqlSupplier) AlterPrimaryKey(tableName string, columnNames []string) b
 		GROUP BY
 			index_name`
 		currentPrimaryKey, err = ss.GetMaster().SelectStr(query, tableName)
-	} else if ss.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+	case model.DATABASE_DRIVER_POSTGRES:
 		query := `
 			SELECT string_agg(a.attname, ',') AS pk
 		FROM
 			pg_constraint AS c
-		CROSS JOIN LATERAL
-			UNNEST(c.conkey) AS cols(colnum)
+		CROSS JOIN
+			(SELECT unnest(conkey) FROM pg_constraint WHERE conrelid='` + strings.ToLower(tableName) + `'::REGCLASS) AS cols(colnum)
 		INNER JOIN
 			pg_attribute AS a ON a.attrelid = c.conrelid
 		AND cols.colnum = a.attnum
@@ -812,7 +813,7 @@ func (ss *SqlSupplier) AlterPrimaryKey(tableName string, columnNames []string) b
 			c.contype = 'p'
 		AND c.conrelid = '` + strings.ToLower(tableName) + `'::REGCLASS`
 		currentPrimaryKey, err = ss.GetMaster().SelectStr(query)
-	} else if ss.DriverName() == model.DATABASE_DRIVER_SQLITE {
+	case model.DATABASE_DRIVER_SQLITE:
 		// SQLite doesn't support altering primary key
 		return true
 	}


### PR DESCRIPTION
We work around the lack of LATERAL keyword by making the query separately.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-26514