### PR TITLE
Remove duplicated signal

### DIFF
--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -92,7 +92,7 @@ func runServer(configStore config.Store, disableConfigWatch bool, usedPlatform b
 
 	// wait for kill signal before attempting to gracefully shutdown
 	// the running service
-	signal.Notify(interruptChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(interruptChan, syscall.SIGINT, syscall.SIGTERM)
 	<-interruptChan
 
 	return nil


### PR DESCRIPTION
#### Summary

Just a minor fix to remove a duplicated reference to `syscall.SIGINT` when listening for interruptions

#### Ticket Link

There is no ticket
