### PR TITLE
[MM-26532] Support "active" filter on profile search

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -532,6 +532,7 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	groupConstrained := r.URL.Query().Get("group_constrained")
 	withoutTeam := r.URL.Query().Get("without_team")
 	inactive := r.URL.Query().Get("inactive")
+	active := r.URL.Query().Get("active")
 	role := r.URL.Query().Get("role")
 	sort := r.URL.Query().Get("sort")
 
@@ -559,6 +560,11 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	withoutTeamBool, _ := strconv.ParseBool(withoutTeam)
 	groupConstrainedBool, _ := strconv.ParseBool(groupConstrained)
 	inactiveBool, _ := strconv.ParseBool(inactive)
+	activeBool, _ := strconv.ParseBool(active)
+
+	if inactiveBool && activeBool {
+		c.SetInvalidUrlParam("inactive")
+	}
 
 	restrictions, err := c.App.GetViewUsersRestrictions(c.App.Session().UserId)
 	if err != nil {
@@ -575,6 +581,7 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		GroupConstrained: groupConstrainedBool,
 		WithoutTeam:      withoutTeamBool,
 		Inactive:         inactiveBool,
+		Active:           activeBool,
 		Role:             role,
 		Sort:             sort,
 		Page:             c.Params.Page,

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2172,6 +2172,35 @@ func TestGetRecentlyActiveUsersInTeam(t *testing.T) {
 	CheckUnauthorizedStatus(t, resp)
 }
 
+func TestGetActiveUsersInTeam(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	teamId := th.BasicTeam.Id
+
+	th.SystemAdminClient.UpdateUserActive(th.BasicUser2.Id, false)
+	rusers, resp := th.Client.GetActiveUsersInTeam(teamId, 0, 60, "")
+	CheckNoError(t, resp)
+
+	require.NotZero(t, len(rusers))
+	for _, u := range rusers {
+		require.Zero(t, u.DeleteAt, "should not be deleted")
+		require.NotEqual(t, th.BasicUser2.Id, "should not include deactivated user")
+		CheckUserSanitization(t, u)
+	}
+
+	rusers, resp = th.Client.GetActiveUsersInTeam(teamId, 0, 1, "")
+	CheckNoError(t, resp)
+	require.Len(t, rusers, 1, "should be 1 per page")
+
+	// Check case where we have supplied both active and inactive flags
+	_, err := th.Client.DoApiGet("/users?inactive=true&active=true", "")
+	require.NotNil(t, err)
+
+	th.Client.Logout()
+	_, resp = th.Client.GetActiveUsersInTeam(teamId, 0, 1, "")
+	CheckUnauthorizedStatus(t, resp)
+}
+
 func TestGetUsersWithoutTeam(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/model/client4.go
+++ b/model/client4.go
@@ -939,6 +939,17 @@ func (c *Client4) GetRecentlyActiveUsersInTeam(teamId string, page int, perPage 
 	return UserListFromJson(r.Body), BuildResponse(r)
 }
 
+// GetActiveUsersInTeam returns a page of users on a team. Page counting starts at 0.
+func (c *Client4) GetActiveUsersInTeam(teamId string, page int, perPage int, etag string) ([]*User, *Response) {
+	query := fmt.Sprintf("?active=true&in_team=%v&page=%v&per_page=%v", teamId, page, perPage)
+	r, err := c.DoApiGet(c.GetUsersRoute()+query, etag)
+	if err != nil {
+		return nil, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	return UserListFromJson(r.Body), BuildResponse(r)
+}
+
 // GetUsersNotInTeam returns a page of users who are not in a team. Page counting starts at 0.
 func (c *Client4) GetUsersNotInTeam(teamId string, page int, perPage int, etag string) ([]*User, *Response) {
 	query := fmt.Sprintf("?not_in_team=%v&page=%v&per_page=%v", teamId, page, perPage)

--- a/model/user_get.go
+++ b/model/user_get.go
@@ -20,6 +20,8 @@ type UserGetOptions struct {
 	WithoutTeam bool
 	// Filters the inactive users
 	Inactive bool
+	// Filters the active users
+	Active bool
 	// Filters for the given role
 	Role string
 	// Sorting option

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -526,6 +526,8 @@ func (us SqlUserStore) GetProfiles(options *model.UserGetOptions) ([]*model.User
 
 	if options.Inactive {
 		query = query.Where("u.DeleteAt != 0")
+	} else if options.Active {
+		query = query.Where("u.DeleteAt = 0")
 	}
 
 	queryString, args, err := query.ToSql()

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -422,6 +422,8 @@ func (us SqlUserStore) GetAllProfiles(options *model.UserGetOptions) ([]*model.U
 
 	if options.Inactive {
 		query = query.Where("u.DeleteAt != 0")
+	} else if options.Active {
+		query = query.Where("u.DeleteAt = 0")
 	}
 
 	queryString, args, err := query.ToSql()
@@ -713,6 +715,8 @@ func (us SqlUserStore) GetProfilesWithoutTeam(options *model.UserGetOptions) ([]
 
 	if options.Inactive {
 		query = query.Where("u.DeleteAt != 0")
+	} else if options.Active {
+		query = query.Where("u.DeleteAt = 0")
 	}
 
 	queryString, args, err := query.ToSql()

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -516,6 +516,36 @@ func testUserStoreGetAllProfiles(t *testing.T, ss store.Store) {
 			sanitized(u7),
 		}, actual)
 	})
+
+	t.Run("filter to active", func(t *testing.T) {
+		actual, err := ss.User().GetAllProfiles(&model.UserGetOptions{
+			Page:    0,
+			PerPage: 10,
+			Active:  true,
+		})
+		require.Nil(t, err)
+		require.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u2),
+			sanitized(u3),
+			sanitized(u4),
+			sanitized(u5),
+		}, actual)
+	})
+
+	t.Run("try to filter to active and inactive", func(t *testing.T) {
+		actual, err := ss.User().GetAllProfiles(&model.UserGetOptions{
+			Page:     0,
+			PerPage:  10,
+			Inactive: true,
+			Active:   true,
+		})
+		require.Nil(t, err)
+		require.Equal(t, []*model.User{
+			sanitized(u6),
+			sanitized(u7),
+		}, actual)
+	})
 }
 
 func testUserStoreGetProfiles(t *testing.T, ss store.Store) {
@@ -649,6 +679,36 @@ func testUserStoreGetProfiles(t *testing.T, ss store.Store) {
 			Page:     0,
 			PerPage:  10,
 			Inactive: true,
+		})
+		require.Nil(t, err)
+		require.Equal(t, []*model.User{
+			sanitized(u5),
+		}, actual)
+	})
+
+	t.Run("filter to active", func(t *testing.T) {
+		actual, err := ss.User().GetProfiles(&model.UserGetOptions{
+			InTeamId: teamId,
+			Page:     0,
+			PerPage:  10,
+			Active:   true,
+		})
+		require.Nil(t, err)
+		require.Equal(t, []*model.User{
+			sanitized(u1),
+			sanitized(u2),
+			sanitized(u3),
+			sanitized(u4),
+		}, actual)
+	})
+
+	t.Run("try to filter to active and inactive", func(t *testing.T) {
+		actual, err := ss.User().GetProfiles(&model.UserGetOptions{
+			InTeamId: teamId,
+			Page:     0,
+			PerPage:  10,
+			Inactive: true,
+			Active:   true,
 		})
 		require.Nil(t, err)
 		require.Equal(t, []*model.User{


### PR DESCRIPTION
#### Summary

In the webapp's Team Members modal, there is an inconsistency where the frontend assumes it is getting a page of users that are all active. It filters the inactive ones out client-side, but then the page is not full. This PR allows the frontend to request profiles using the query `api/v4/users?active=true`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-26532
https://mattermost.atlassian.net/browse/MM-26022

#### Related Pull Requests

https://github.com/mattermost/mattermost-webapp/pull/5798