### PR TITLE
MM-26571: Move the semaphore creation before hub start

### DIFF
--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -255,14 +255,13 @@ func (s *Server) createPushNotificationsHub() {
 		notificationsChan: make(chan PushNotification, buffer),
 		app:               fakeApp,
 		wg:                new(sync.WaitGroup),
+		sema:              make(chan struct{}, runtime.NumCPU()*8), // numCPU * 8 is a good amount of concurrency.
 	}
 	go hub.start()
 	s.PushNotificationsHub = hub
 }
 
 func (hub *PushNotificationsHub) start() {
-	hub.sema = make(chan struct{}, runtime.NumCPU()*8) // numCPU * 8 is a good amount of concurrency.
-
 	for notification := range hub.notificationsChan {
 		// Adding to the waitgroup first.
 		hub.wg.Add(1)


### PR DESCRIPTION
This avoids the race of assigning the sema field from the start method
which runs in a goroutine.

The race that happens is

```
==================

WARNING: DATA RACE
Write at 0x00c003a9d1b0 by goroutine 67:
  github.com/mattermost/mattermost-server/v5/app.(*PushNotificationsHub).start()
      /home/agniva/mattermost/mattermost-server/app/notification_push.go:264 +0x90

Previous read at 0x00c003a9d1b0 by goroutine 69:
  github.com/mattermost/mattermost-server/v5/app.(*Server).createPushNotificationsHub()
      /home/agniva/mattermost/mattermost-server/app/notification_push.go:260 +0x1d5
```