### PR TITLE
MM-26339 - Add context and CommandArgs to dynamic autocomplete calls

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -382,7 +382,8 @@ func listCommandAutocompleteSuggestions(c *Context, w http.ResponseWriter, r *ht
 		roleId = model.SYSTEM_ADMIN_ROLE_ID
 	}
 
-	userInput := r.URL.Query().Get("user_input")
+	query := r.URL.Query()
+	userInput := query.Get("user_input")
 	if userInput == "" {
 		c.SetInvalidParam("userInput")
 		return
@@ -395,7 +396,19 @@ func listCommandAutocompleteSuggestions(c *Context, w http.ResponseWriter, r *ht
 		return
 	}
 
-	suggestions := c.App.GetSuggestions(commands, userInput, roleId)
+	commandArgs := &model.CommandArgs{
+		ChannelId: query.Get("channel_id"),
+		TeamId:    c.Params.TeamId,
+		RootId:    query.Get("root_id"),
+		ParentId:  query.Get("parent_id"),
+		UserId:    c.App.Session().UserId,
+		T:         c.App.T,
+		Session:   *c.App.Session(),
+		SiteURL:   c.GetSiteURLHeader(),
+		Command:   userInput,
+	}
+
+	suggestions := c.App.GetSuggestions(commandArgs, commands, roleId)
 
 	w.Write(model.AutocompleteSuggestionsToJSON(suggestions))
 }

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -190,7 +190,7 @@ type AppIface interface {
 	// based on the type of session (Mobile, SSO, Web/LDAP).
 	GetSessionLengthInMillis(session *model.Session) int64
 	// GetSuggestions returns suggestions for user input.
-	GetSuggestions(commands []*model.Command, userInput, roleID string) []model.AutocompleteSuggestion
+	GetSuggestions(commandArgs *model.CommandArgs, commands []*model.Command, roleID string) []model.AutocompleteSuggestion
 	// GetTeamGroupUsers returns the users who are associated to the team via GroupTeams and GroupMembers.
 	GetTeamGroupUsers(teamID string) ([]*model.User, *model.AppError)
 	// GetTeamSchemeChannelRoles Checks if a team has an override scheme and returns the scheme channel role names or default channel role names.

--- a/app/command_autocomplete_test.go
+++ b/app/command_autocomplete_test.go
@@ -202,22 +202,23 @@ func TestSuggestions(t *testing.T) {
 	defer th.TearDown()
 
 	jira := createJiraAutocompleteData()
+	emptyCmdArgs := &model.CommandArgs{}
 
-	suggestions := th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "ji", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions := th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "ji", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, jira.Trigger, suggestions[0].Complete)
 	assert.Equal(t, jira.Trigger, suggestions[0].Suggestion)
 	assert.Equal(t, "[command]", suggestions[0].Hint)
 	assert.Equal(t, jira.HelpText, suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira crea", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira crea", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira create", suggestions[0].Complete)
 	assert.Equal(t, "create", suggestions[0].Suggestion)
 	assert.Equal(t, "[issue text]", suggestions[0].Hint)
 	assert.Equal(t, "Create a new Issue", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira c", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira c", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 2)
 	assert.Equal(t, "jira create", suggestions[1].Complete)
 	assert.Equal(t, "create", suggestions[1].Suggestion)
@@ -228,27 +229,27 @@ func TestSuggestions(t *testing.T) {
 	assert.Equal(t, "[url]", suggestions[0].Hint)
 	assert.Equal(t, "Connect your Mattermost account to your Jira account", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira create ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira create ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira create ", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "[text]", suggestions[0].Hint)
 	assert.Equal(t, "This text is optional, will be inserted into the description field", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira create some", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira create some", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira create some", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "[text]", suggestions[0].Hint)
 	assert.Equal(t, "This text is optional, will be inserted into the description field", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira create some text ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira create some text ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 0)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "invalid command", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "invalid command", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 0)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira settings notifications o", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira settings notifications o", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 2)
 	assert.Equal(t, "jira settings notifications On", suggestions[0].Complete)
 	assert.Equal(t, "On", suggestions[0].Suggestion)
@@ -259,48 +260,48 @@ func TestSuggestions(t *testing.T) {
 	assert.Equal(t, "Turn notifications off", suggestions[1].Hint)
 	assert.Equal(t, "", suggestions[1].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 11)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira ", model.SYSTEM_USER_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira ", model.SYSTEM_USER_ROLE_ID)
 	assert.Len(t, suggestions, 9)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira create \"some issue text", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira create \"some issue text", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira create \"some issue text", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "[text]", suggestions[0].Hint)
 	assert.Equal(t, "This text is optional, will be inserted into the description field", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira timezone ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira timezone ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira timezone --zone ", suggestions[0].Complete)
 	assert.Equal(t, "--zone", suggestions[0].Suggestion)
 	assert.Equal(t, "", suggestions[0].Hint)
 	assert.Equal(t, "Set timezone", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira timezone --", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira timezone --", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira timezone --zone ", suggestions[0].Complete)
 	assert.Equal(t, "--zone", suggestions[0].Suggestion)
 	assert.Equal(t, "", suggestions[0].Hint)
 	assert.Equal(t, "Set timezone", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira timezone --zone ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira timezone --zone ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira timezone --zone ", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "[UTC+07:00]", suggestions[0].Hint)
 	assert.Equal(t, "Set timezone", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira timezone --zone bla", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira timezone --zone bla", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "jira timezone --zone bla", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "[UTC+07:00]", suggestions[0].Hint)
 	assert.Equal(t, "Set timezone", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{jira}, "", "jira timezone bla", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{jira}, "", "jira timezone bla", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 0)
 
 	commandA := &model.Command{
@@ -315,7 +316,7 @@ func TestSuggestions(t *testing.T) {
 		Trigger:          "charles",
 		AutocompleteData: model.NewAutocompleteData("charles", "", ""),
 	}
-	suggestions = th.App.GetSuggestions([]*model.Command{commandB, commandC, commandA}, "", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.GetSuggestions(emptyCmdArgs, []*model.Command{commandB, commandC, commandA}, model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 3)
 	assert.Equal(t, "alice", suggestions[0].Complete)
 	assert.Equal(t, "bob", suggestions[1].Complete)
@@ -327,15 +328,16 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	defer th.TearDown()
 
 	command := createCommandWithOptionalArgs()
+	emptyCmdArgs := &model.CommandArgs{}
 
-	suggestions := th.App.getSuggestions([]*model.AutocompleteData{command}, "", "comm", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions := th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "comm", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, command.Trigger, suggestions[0].Complete)
 	assert.Equal(t, command.Trigger, suggestions[0].Suggestion)
 	assert.Equal(t, "", suggestions[0].Hint)
 	assert.Equal(t, command.HelpText, suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 4)
 	assert.Equal(t, "command subcommand1", suggestions[0].Complete)
 	assert.Equal(t, "subcommand1", suggestions[0].Suggestion)
@@ -350,7 +352,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[2].Hint)
 	assert.Equal(t, "", suggestions[2].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand1 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand1 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 2)
 	assert.Equal(t, "command subcommand1 item1", suggestions[0].Complete)
 	assert.Equal(t, "item1", suggestions[0].Suggestion)
@@ -361,21 +363,21 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[1].Hint)
 	assert.Equal(t, "", suggestions[1].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand1 item1 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand1 item1 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "command subcommand1 item1 --name2 ", suggestions[0].Complete)
 	assert.Equal(t, "--name2", suggestions[0].Suggestion)
 	assert.Equal(t, "", suggestions[0].Hint)
 	assert.Equal(t, "arg2", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand1 item1 --name2 bla", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand1 item1 --name2 bla", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "command subcommand1 item1 --name2 bla", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "", suggestions[0].Hint)
 	assert.Equal(t, "arg2", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand2 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand2 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 2)
 	assert.Equal(t, "command subcommand2 --name1 ", suggestions[0].Complete)
 	assert.Equal(t, "--name1", suggestions[0].Suggestion)
@@ -386,7 +388,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[1].Hint)
 	assert.Equal(t, "arg2", suggestions[1].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand2 -", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand2 -", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 2)
 	assert.Equal(t, "command subcommand2 --name1 ", suggestions[0].Complete)
 	assert.Equal(t, "--name1", suggestions[0].Suggestion)
@@ -397,7 +399,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[1].Hint)
 	assert.Equal(t, "arg2", suggestions[1].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand2 --name1 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand2 --name1 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 3)
 	assert.Equal(t, "command subcommand2 --name1 item1", suggestions[0].Complete)
 	assert.Equal(t, "item1", suggestions[0].Suggestion)
@@ -412,7 +414,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[2].Hint)
 	assert.Equal(t, "arg3", suggestions[2].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand2 --name1 item", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand2 --name1 item", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 3)
 	assert.Equal(t, "command subcommand2 --name1 item1", suggestions[0].Complete)
 	assert.Equal(t, "item1", suggestions[0].Suggestion)
@@ -427,24 +429,24 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[2].Hint)
 	assert.Equal(t, "arg3", suggestions[2].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand2 --name1 item1 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand2 --name1 item1 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "command subcommand2 --name1 item1 ", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "", suggestions[0].Hint)
 	assert.Equal(t, "arg2", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand2 --name1 item1 bla ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand2 --name1 item1 bla ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "command subcommand2 --name1 item1 bla ", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)
 	assert.Equal(t, "", suggestions[0].Hint)
 	assert.Equal(t, "arg3", suggestions[0].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand2 --name1 item1 bla bla ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand2 --name1 item1 bla bla ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 0)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand3 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand3 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 3)
 	assert.Equal(t, "command subcommand3 --name1 ", suggestions[0].Complete)
 	assert.Equal(t, "--name1", suggestions[0].Suggestion)
@@ -459,7 +461,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[2].Hint)
 	assert.Equal(t, "arg3", suggestions[2].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand3 --name", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand3 --name", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 3)
 	assert.Equal(t, "command subcommand3 --name1 ", suggestions[0].Complete)
 	assert.Equal(t, "--name1", suggestions[0].Suggestion)
@@ -474,7 +476,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[2].Hint)
 	assert.Equal(t, "arg3", suggestions[2].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand3 --name1 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand3 --name1 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 2)
 	assert.Equal(t, "command subcommand3 --name1 item1", suggestions[0].Complete)
 	assert.Equal(t, "item1", suggestions[0].Suggestion)
@@ -485,7 +487,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "", suggestions[1].Hint)
 	assert.Equal(t, "", suggestions[1].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand4 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand4 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 2)
 	assert.Equal(t, "command subcommand4 item1", suggestions[0].Complete)
 	assert.Equal(t, "item1", suggestions[0].Suggestion)
@@ -496,7 +498,7 @@ func TestCommandWithOptionalArgs(t *testing.T) {
 	assert.Equal(t, "message", suggestions[1].Hint)
 	assert.Equal(t, "help4", suggestions[1].Description)
 
-	suggestions = th.App.getSuggestions([]*model.AutocompleteData{command}, "", "command subcommand4 item1 ", model.SYSTEM_ADMIN_ROLE_ID)
+	suggestions = th.App.getSuggestions(emptyCmdArgs, []*model.AutocompleteData{command}, "", "command subcommand4 item1 ", model.SYSTEM_ADMIN_ROLE_ID)
 	assert.Len(t, suggestions, 1)
 	assert.Equal(t, "command subcommand4 item1 ", suggestions[0].Complete)
 	assert.Equal(t, "", suggestions[0].Suggestion)

--- a/app/opentracing_layer.go
+++ b/app/opentracing_layer.go
@@ -7617,7 +7617,7 @@ func (a *OpenTracingAppLayer) GetStatusesByIds(userIds []string) (map[string]int
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetSuggestions(commands []*model.Command, userInput string, roleID string) []model.AutocompleteSuggestion {
+func (a *OpenTracingAppLayer) GetSuggestions(commandArgs *model.CommandArgs, commands []*model.Command, roleID string) []model.AutocompleteSuggestion {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetSuggestions")
 
@@ -7629,7 +7629,7 @@ func (a *OpenTracingAppLayer) GetSuggestions(commands []*model.Command, userInpu
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.GetSuggestions(commands, userInput, roleID)
+	resultVar0 := a.app.GetSuggestions(commandArgs, commands, roleID)
 
 	return resultVar0
 }


### PR DESCRIPTION
#### Summary
- This basically just treats each call to `doPluginRequest` like it is a plugin's `ExecuteCommand` hook. The `ExecuteCommand` takes a `plugin.Context` and a `model.CommandArgs`, so I am stuffing all of that information into the url params of the `doPluginRequest` call. The plugin can decide what it wants to parse, but it should have all the context it needs. If you can think of anything else you want to send, let me know.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-26339

#### Related Pull Requests:
- Redux: https://github.com/mattermost/mattermost-redux/pull/1181
- Webapp: https://github.com/mattermost/mattermost-webapp/pull/5816
