### PR TITLE
MM-26064 - ENV var license override

### DIFF
--- a/app/license.go
+++ b/app/license.go
@@ -17,12 +17,12 @@ import (
 
 const (
 	requestTrialURL = "https://customers.mattermost.com/api/v1/trials"
-	LicenseENV      = "MM_LICENSE"
+	LicenseEnv      = "MM_LICENSE"
 )
 
 func (s *Server) LoadLicense() {
 	// ENV var overrides all other sources of license.
-	licenseStr := os.Getenv(LicenseENV)
+	licenseStr := os.Getenv(LicenseEnv)
 	if licenseStr != "" {
 		if s.ValidateAndSetLicenseBytes([]byte(licenseStr)) {
 			mlog.Info("License key from ENV is valid, unlocking enterprise features.")

--- a/app/license.go
+++ b/app/license.go
@@ -25,7 +25,7 @@ func (s *Server) LoadLicense() {
 	licenseStr := os.Getenv(LicenseENV)
 	if licenseStr != "" {
 		if s.ValidateAndSetLicenseBytes([]byte(licenseStr)) {
-			mlog.Info("License key from ENV valid unlocking enterprise features.")
+			mlog.Info("License key from ENV is valid, unlocking enterprise features.")
 		}
 		return
 	}

--- a/app/license.go
+++ b/app/license.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -14,9 +15,21 @@ import (
 	"github.com/mattermost/mattermost-server/v5/utils"
 )
 
-const requestTrialURL = "https://customers.mattermost.com/api/v1/trials"
+const (
+	requestTrialURL = "https://customers.mattermost.com/api/v1/trials"
+	LicenseENV      = "MM_LICENSE"
+)
 
 func (s *Server) LoadLicense() {
+	// ENV var overrides all other sources of license.
+	licenseStr := os.Getenv(LicenseENV)
+	if licenseStr != "" {
+		if s.ValidateAndSetLicenseBytes([]byte(licenseStr)) {
+			mlog.Info("License key from ENV valid unlocking enterprise features.")
+		}
+		return
+	}
+
 	licenseId := ""
 	props, err := s.Store.System().Get()
 	if err == nil {
@@ -137,14 +150,15 @@ func (s *Server) SetLicense(license *model.License) bool {
 	return false
 }
 
-func (s *Server) ValidateAndSetLicenseBytes(b []byte) {
+func (s *Server) ValidateAndSetLicenseBytes(b []byte) bool {
 	if success, licenseStr := utils.ValidateLicense(b); success {
 		license := model.LicenseFromJson(strings.NewReader(licenseStr))
 		s.SetLicense(license)
-		return
+		return true
 	}
 
 	mlog.Warn("No valid enterprise license found")
+	return false
 }
 
 func (s *Server) SetClientLicense(m map[string]string) {


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR adds support for a new environment variable `MM_LICENSE` which can contain the contents of a license file.  When set, this license takes priority over all other license sources.  

- Database and file licenses are not overwritten but simply ignored while `MM_LICENSE` is set.

- If MM_LICENSE is set to a non-empty string, but the license is not valid, the server will be started without a license.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-26064