### PR TITLE
Mm 16292 support command overrides

### DIFF
--- a/app/command.go
+++ b/app/command.go
@@ -77,21 +77,22 @@ func (a *App) CreateCommandPost(post *model.Post, teamId string, response *model
 func (a *App) ListAutocompleteCommands(teamId string, T goi18n.TranslateFunc) ([]*model.Command, *model.AppError) {
 	commands := make([]*model.Command, 0, 32)
 	seen := make(map[string]bool)
-	for _, value := range commandProviders {
-		if cmd := value.GetCommand(a, T); cmd != nil {
-			cpy := *cmd
-			if cpy.AutoComplete && !seen[cpy.Id] {
-				cpy.Sanitize()
-				seen[cpy.Trigger] = true
-				commands = append(commands, &cpy)
-			}
-		}
-	}
 
 	for _, cmd := range a.PluginCommandsForTeam(teamId) {
 		if cmd.AutoComplete && !seen[cmd.Trigger] {
 			seen[cmd.Trigger] = true
 			commands = append(commands, cmd)
+		}
+	}
+
+	for _, value := range commandProviders {
+		if cmd := value.GetCommand(a, T); cmd != nil {
+			cpy := *cmd
+			if cpy.AutoComplete && !seen[cpy.Trigger] {
+				cpy.Sanitize()
+				seen[cpy.Trigger] = true
+				commands = append(commands, &cpy)
+			}
 		}
 	}
 
@@ -102,7 +103,7 @@ func (a *App) ListAutocompleteCommands(teamId string, T goi18n.TranslateFunc) ([
 		}
 
 		for _, cmd := range teamCmds {
-			if cmd.AutoComplete && !seen[cmd.Id] {
+			if cmd.AutoComplete && !seen[cmd.Trigger] {
 				cmd.Sanitize()
 				seen[cmd.Trigger] = true
 				commands = append(commands, cmd)
@@ -183,12 +184,8 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 
 	args.TriggerId = triggerId
 
-	cmd, response := a.tryExecuteBuiltInCommand(args, trigger, message)
-	if cmd != nil && response != nil {
-		return a.HandleCommandResponse(cmd, args, response, true)
-	}
-
-	cmd, response, appErr = a.tryExecutePluginCommand(args)
+	// Plugins can override built in and custom commands
+	cmd, response, appErr := a.tryExecutePluginCommand(args)
 	if appErr != nil {
 		return nil, appErr
 	} else if cmd != nil && response != nil {
@@ -196,12 +193,18 @@ func (a *App) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *
 		return a.HandleCommandResponse(cmd, args, response, true)
 	}
 
+	// Custom commands can override built ins
 	cmd, response, appErr = a.tryExecuteCustomCommand(args, trigger, message)
 	if appErr != nil {
 		return nil, appErr
 	} else if cmd != nil && response != nil {
 		response.TriggerId = clientTriggerId
 		return a.HandleCommandResponse(cmd, args, response, false)
+	}
+
+	cmd, response = a.tryExecuteBuiltInCommand(args, trigger, message)
+	if cmd != nil && response != nil {
+		return a.HandleCommandResponse(cmd, args, response, true)
 	}
 
 	return nil, model.NewAppError("command", "api.command.execute_command.not_found.app_error", map[string]interface{}{"Trigger": trigger}, "", http.StatusNotFound)

--- a/app/command.go
+++ b/app/command.go
@@ -85,17 +85,6 @@ func (a *App) ListAutocompleteCommands(teamId string, T goi18n.TranslateFunc) ([
 		}
 	}
 
-	for _, value := range commandProviders {
-		if cmd := value.GetCommand(a, T); cmd != nil {
-			cpy := *cmd
-			if cpy.AutoComplete && !seen[cpy.Trigger] {
-				cpy.Sanitize()
-				seen[cpy.Trigger] = true
-				commands = append(commands, &cpy)
-			}
-		}
-	}
-
 	if *a.Config().ServiceSettings.EnableCommands {
 		teamCmds, err := a.Srv().Store.Command().GetByTeam(teamId)
 		if err != nil {
@@ -107,6 +96,17 @@ func (a *App) ListAutocompleteCommands(teamId string, T goi18n.TranslateFunc) ([
 				cmd.Sanitize()
 				seen[cmd.Trigger] = true
 				commands = append(commands, cmd)
+			}
+		}
+	}
+
+	for _, value := range commandProviders {
+		if cmd := value.GetCommand(a, T); cmd != nil {
+			cpy := *cmd
+			if cpy.AutoComplete && !seen[cpy.Trigger] {
+				cpy.Sanitize()
+				seen[cpy.Trigger] = true
+				commands = append(commands, &cpy)
 			}
 		}
 	}

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -90,10 +90,15 @@ func TestExecuteCommand(t *testing.T) {
 
 		for TestCase, result := range TestCases {
 			args := &model.CommandArgs{
-				Command: TestCase,
-				T:       func(s string, args ...interface{}) string { return s },
+				Command:   TestCase,
+				TeamId:    th.BasicTeam.Id,
+				ChannelId: th.BasicChannel.Id,
+				UserId:    th.BasicUser.Id,
+				T:         func(s string, args ...interface{}) string { return s },
 			}
-			resp, _ := th.App.ExecuteCommand(args)
+			resp, err := th.App.ExecuteCommand(args)
+			require.Nil(t, err)
+			require.NotNil(t, resp)
 
 			assert.Equal(t, resp.Text, result)
 		}

--- a/app/plugin_commands_test.go
+++ b/app/plugin_commands_test.go
@@ -53,7 +53,6 @@ func TestPluginCommand(t *testing.T) {
 			}
 
 			func (p *MyPlugin) OnConfigurationChange() error {
-				p.API.LogError("hello")
 				if err := p.API.LoadPluginConfiguration(&p.configuration); err != nil {
 					return err
 				}
@@ -62,7 +61,6 @@ func TestPluginCommand(t *testing.T) {
 			}
 
 			func (p *MyPlugin) OnActivate() error {
-				p.API.LogError("team", "team", p.configuration.TeamId)
 				err := p.API.RegisterCommand(&model.Command{
 					TeamId: p.configuration.TeamId,
 					Trigger: "plugin",
@@ -73,7 +71,6 @@ func TestPluginCommand(t *testing.T) {
 				if err != nil {
 					p.API.LogError("error", "err", err)
 				}
-				p.API.LogDebug("team", "team", p.configuration.TeamId)
 
 				return err
 			}
@@ -244,7 +241,6 @@ func TestPluginCommand(t *testing.T) {
 			}
 
 			func (p *MyPlugin) OnConfigurationChange() error {
-				p.API.LogError("hello")
 				if err := p.API.LoadPluginConfiguration(&p.configuration); err != nil {
 					return err
 				}
@@ -253,7 +249,6 @@ func TestPluginCommand(t *testing.T) {
 			}
 
 			func (p *MyPlugin) OnActivate() error {
-				p.API.LogError("team", "team", p.configuration.TeamId)
 				err := p.API.RegisterCommand(&model.Command{
 					TeamId: p.configuration.TeamId,
 					Trigger: "code",
@@ -264,7 +259,6 @@ func TestPluginCommand(t *testing.T) {
 				if err != nil {
 					p.API.LogError("error", "err", err)
 				}
-				p.API.LogDebug("team", "team", p.configuration.TeamId)
 
 				return err
 			}
@@ -289,16 +283,6 @@ func TestPluginCommand(t *testing.T) {
 		require.Nil(t, err)
 		require.Equal(t, model.COMMAND_RESPONSE_TYPE_EPHEMERAL, resp.ResponseType)
 		require.Equal(t, "text", resp.Text)
-
-		err2 := th.App.DisablePlugin(pluginIds[0])
-		require.Nil(t, err2)
-
-		commands, err3 := th.App.ListAutocompleteCommands(args.TeamId, utils.T)
-		require.Nil(t, err3)
-
-		for _, commands := range commands {
-			require.NotEqual(t, "plugin", commands.Trigger)
-		}
 
 		th.App.RemovePlugin(pluginIds[0])
 	})


### PR DESCRIPTION
#### Summary
Support command overrides. Built in commands can now be overridden by plugins and custom commands.
Also fixes a bug in slash command autocomplete where duplicate checking was done incorrectly. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26201
