### PR TITLE
MM-26015: ensure admin has permission after removal from team

### DIFF
--- a/app/authorization.go
+++ b/app/authorization.go
@@ -139,16 +139,8 @@ func (a *App) HasPermissionToTeam(askingUserId string, teamId string, permission
 		return false
 	}
 	teamMember, _ := a.GetTeamMember(teamId, askingUserId)
-	if teamMember != nil {
-		// If the team member has been deleted, they don't have permission.
-		// We still check if they have permissions from being an admin.
-		if teamMember.DeleteAt != 0 {
-			// Deleted TeamMember's roles are zeroed so we check permissions of user id
-			return a.HasPermissionTo(askingUserId, permission)
-		}
-
-		roles := teamMember.GetRoles()
-		return a.RolesGrantPermission(roles, permission.Id)
+	if teamMember != nil && teamMember.DeleteAt == 0 {
+		return a.RolesGrantPermission(teamMember.GetRoles(), permission.Id)
 	}
 	return a.HasPermissionTo(askingUserId, permission)
 }

--- a/app/authorization_test.go
+++ b/app/authorization_test.go
@@ -52,4 +52,10 @@ func TestHasPermissionToTeam(t *testing.T) {
 	th.RemoveUserFromTeam(th.BasicUser, th.BasicTeam)
 
 	assert.False(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
+
+	th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
+	assert.True(t, th.App.HasPermissionToTeam(th.SystemAdminUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
+	th.RemoveUserFromTeam(th.SystemAdminUser, th.BasicTeam)
+	// This used to fail before MM-26015
+	assert.True(t, th.App.HasPermissionToTeam(th.SystemAdminUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Ensure admin retains permissions to team after being removed from a team

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-26015