### PR TITLE
MM-26346: check for nil Message in DisableMentionHighlights

### DIFF
--- a/model/post.go
+++ b/model/post.go
@@ -521,6 +521,9 @@ func (o *Post) DisableMentionHighlights() string {
 
 // DisableMentionHighlights disables mention highlighting for a post patch if required.
 func (o *PostPatch) DisableMentionHighlights() {
+	if o.Message == nil {
+		return
+	}
 	if _, hasMentions := findAtChannelMention(*o.Message); hasMentions {
 		if o.Props == nil {
 			o.Props = &StringInterface{}

--- a/model/post_test.go
+++ b/model/post_test.go
@@ -848,4 +848,11 @@ func TestPostPatchDisableMentionHighlights(t *testing.T) {
 			patch.Props = nil
 		})
 	}
+
+	t.Run("TestNilMessage", func(t *testing.T) {
+		patch.Message = nil
+		patch.DisableMentionHighlights()
+		// Useless assertion to prevent compiler elision.
+		assert.Nil(t, patch.Message)
+	})
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Sometimes a PostPatch may not contain the message field. For example,
while pinning a post, only the IsPinned field is set, and everything
else is nil. In that case, DisableMentionHighlights would throw a panic.
    
We handle that case by checking for nil first.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-26346
