### PR TITLE
MM-26750: Remove instances of InitBasic when it's not required

### DIFF
--- a/app/auto_responder_test.go
+++ b/app/auto_responder_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestSetAutoResponderStatus(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	user := th.CreateUser()
@@ -51,7 +51,7 @@ func TestSetAutoResponderStatus(t *testing.T) {
 }
 
 func TestDisableAutoResponder(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	user := th.CreateUser()

--- a/app/bot_test.go
+++ b/app/bot_test.go
@@ -267,7 +267,7 @@ func TestGetBot(t *testing.T) {
 }
 
 func TestGetBots(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	OwnerId1 := model.NewId()
@@ -519,7 +519,7 @@ func TestPermanentDeleteBot(t *testing.T) {
 }
 
 func TestDisableUserBots(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	ownerId1 := model.NewId()
@@ -576,7 +576,7 @@ func TestDisableUserBots(t *testing.T) {
 }
 
 func TestNotifySysadminsBotOwnerDisabled(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	userBots := []*model.Bot{}

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -345,7 +345,7 @@ func TestCreateGroupChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 }
 
 func TestCreateDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	user1 := th.CreateUser()
@@ -371,7 +371,7 @@ func TestCreateDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 }
 
 func TestGetDirectChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	user1 := th.CreateUser()

--- a/app/command_autocomplete_test.go
+++ b/app/command_autocomplete_test.go
@@ -198,7 +198,7 @@ func TestParseNamedArguments(t *testing.T) {
 }
 
 func TestSuggestions(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	jira := createJiraAutocompleteData()
@@ -324,7 +324,7 @@ func TestSuggestions(t *testing.T) {
 }
 
 func TestCommandWithOptionalArgs(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	command := createCommandWithOptionalArgs()

--- a/app/command_me_test.go
+++ b/app/command_me_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestMeProviderDoCommand(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	mp := MeProvider{}

--- a/app/command_test.go
+++ b/app/command_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMoveCommand(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	sourceTeam := th.CreateTeam()
@@ -338,7 +338,7 @@ func TestHandleCommandResponse(t *testing.T) {
 }
 
 func TestDoCommandRequest(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) {

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestConfigListener(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	originalSiteName := th.App.Config().TeamSettings.SiteName

--- a/app/download_test.go
+++ b/app/download_test.go
@@ -5,15 +5,17 @@ package app
 
 import (
 	"fmt"
-	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestDownloadFromURL(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	app := th.App

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -155,7 +155,7 @@ func TestCopyEmojiImages(t *testing.T) {
 }
 
 func TestExportCustomEmoji(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	filePath := "../demo.json"
@@ -173,7 +173,7 @@ func TestExportCustomEmoji(t *testing.T) {
 }
 
 func TestExportAllUsers(t *testing.T) {
-	th1 := Setup(t).InitBasic()
+	th1 := Setup(t)
 	defer th1.TearDown()
 
 	// Adding a user and deactivating it to check whether it gets included in bulk export

--- a/app/file_test.go
+++ b/app/file_test.go
@@ -270,7 +270,7 @@ func TestMigrateFilenamesToFileInfos(t *testing.T) {
 }
 
 func TestCopyFileInfos(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	teamId := model.NewId()

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestGetGroup(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	group := th.CreateGroup()
 
@@ -26,7 +26,7 @@ func TestGetGroup(t *testing.T) {
 }
 
 func TestGetGroupByRemoteID(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	group := th.CreateGroup()
 
@@ -40,7 +40,7 @@ func TestGetGroupByRemoteID(t *testing.T) {
 }
 
 func TestGetGroupsByType(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	th.CreateGroup()
 	th.CreateGroup()
@@ -56,7 +56,7 @@ func TestGetGroupsByType(t *testing.T) {
 }
 
 func TestCreateGroup(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	id := model.NewId()
@@ -77,7 +77,7 @@ func TestCreateGroup(t *testing.T) {
 }
 
 func TestUpdateGroup(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	group := th.CreateGroup()
 	group.DisplayName = model.NewId()
@@ -88,7 +88,7 @@ func TestUpdateGroup(t *testing.T) {
 }
 
 func TestDeleteGroup(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	group := th.CreateGroup()
 
@@ -338,7 +338,7 @@ func TestGetGroupsByTeam(t *testing.T) {
 }
 
 func TestGetGroups(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	group := th.CreateGroup()
 

--- a/app/integration_action_test.go
+++ b/app/integration_action_test.go
@@ -956,7 +956,7 @@ func TestPostActionRelativePluginURL(t *testing.T) {
 }
 
 func TestDoPluginRequest(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -2220,7 +2220,7 @@ func TestGetNotificationNameFormat(t *testing.T) {
 }
 
 func TestUserAllowsEmail(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t.Run("should return true", func(t *testing.T) {

--- a/app/permissions_test.go
+++ b/app/permissions_test.go
@@ -23,7 +23,7 @@ func (tw testWriter) Write(p []byte) (int, error) {
 }
 
 func TestExportPermissions(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	var scheme *model.Scheme
@@ -91,7 +91,7 @@ func TestExportPermissions(t *testing.T) {
 }
 
 func TestImportPermissions(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	name := model.NewId()
@@ -171,7 +171,7 @@ func TestImportPermissions(t *testing.T) {
 }
 
 func TestImportPermissions_idempotentScheme(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	name := model.NewId()
@@ -214,7 +214,7 @@ func TestImportPermissions_idempotentScheme(t *testing.T) {
 }
 
 func TestImportPermissions_schemeDeletedOnRoleFailure(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	name := model.NewId()

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -343,7 +343,7 @@ func TestPluginAPIGetUsers(t *testing.T) {
 }
 
 func TestPluginAPIGetUsersInTeam(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	api := th.SetupPluginAPI()
 
@@ -847,7 +847,7 @@ func TestInstallPlugin(t *testing.T) {
 		}, pluginDir
 	}
 
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	// start an http server to serve plugin's tarball to the test.
@@ -1070,7 +1070,7 @@ func TestBasicAPIPlugins(t *testing.T) {
 }
 
 func TestPluginAPIKVCompareAndSet(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	api := th.SetupPluginAPI()
 
@@ -1166,7 +1166,7 @@ func TestPluginAPIKVCompareAndSet(t *testing.T) {
 }
 
 func TestPluginAPIKVCompareAndDelete(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	api := th.SetupPluginAPI()
 
@@ -1274,7 +1274,7 @@ func TestPluginCreatePostWithUploadedFile(t *testing.T) {
 }
 
 func TestPluginAPIGetConfig(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	api := th.SetupPluginAPI()
 
@@ -1311,7 +1311,7 @@ func TestPluginAPIGetConfig(t *testing.T) {
 }
 
 func TestPluginAPIGetUnsanitizedConfig(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 	api := th.SetupPluginAPI()
 
@@ -1360,7 +1360,7 @@ func TestPluginAddUserToChannel(t *testing.T) {
 }
 
 func TestInterpluginPluginHTTP(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	setupMultiPluginApiTest(t,
@@ -1460,7 +1460,7 @@ func TestInterpluginPluginHTTP(t *testing.T) {
 }
 
 func TestApiMetrics(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t.Run("", func(t *testing.T) {
@@ -1584,7 +1584,7 @@ func TestPluginAPIGetPostsForChannel(t *testing.T) {
 }
 
 func TestPluginHTTPConnHijack(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	testFolder, found := fileutils.FindDir("mattermost-server/app/plugin_api_tests")
@@ -1619,7 +1619,7 @@ func TestPluginHTTPConnHijack(t *testing.T) {
 }
 
 func TestPluginHTTPUpgradeWebSocket(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	testFolder, found := fileutils.FindDir("mattermost-server/app/plugin_api_tests")

--- a/app/plugin_health_check_test.go
+++ b/app/plugin_health_check_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestHealthCheckJob(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -788,7 +788,7 @@ func TestUserHasLoggedIn(t *testing.T) {
 }
 
 func TestUserHasBeenCreated(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,
@@ -834,7 +834,7 @@ func TestUserHasBeenCreated(t *testing.T) {
 }
 
 func TestErrorString(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t.Run("errors.New", func(t *testing.T) {
@@ -963,7 +963,7 @@ func TestHookContext(t *testing.T) {
 }
 
 func TestActiveHooks(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t.Run("", func(t *testing.T) {
@@ -1034,7 +1034,7 @@ func TestActiveHooks(t *testing.T) {
 }
 
 func TestHookMetrics(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t.Run("", func(t *testing.T) {

--- a/app/plugin_install_test.go
+++ b/app/plugin_install_test.go
@@ -65,7 +65,7 @@ func (b byBundleInfoId) Less(i, j int) bool { return b[i].Manifest.Id < b[j].Man
 
 func TestInstallPluginLocally(t *testing.T) {
 	t.Run("invalid tar", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		actualManifest, appErr := th.App.installPluginLocally(&nilReadSeeker{}, nil, installPluginLocallyOnlyIfNew)
@@ -75,7 +75,7 @@ func TestInstallPluginLocally(t *testing.T) {
 	})
 
 	t.Run("missing manifest", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		reader := makeInMemoryGzipTarFile(t, []testFile{
@@ -108,7 +108,7 @@ func TestInstallPluginLocally(t *testing.T) {
 	}
 
 	t.Run("invalid plugin id", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		actualManifest, appErr := installPlugin(t, th, "invalid#plugin#id", "version", installPluginLocallyOnlyIfNew)
@@ -149,7 +149,7 @@ func TestInstallPluginLocally(t *testing.T) {
 	}
 
 	t.Run("no plugins already installed", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 		cleanExistingBundles(t, th)
 
@@ -161,7 +161,7 @@ func TestInstallPluginLocally(t *testing.T) {
 	})
 
 	t.Run("different plugin already installed", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 		cleanExistingBundles(t, th)
 
@@ -178,7 +178,7 @@ func TestInstallPluginLocally(t *testing.T) {
 
 	t.Run("same plugin already installed", func(t *testing.T) {
 		t.Run("install only if new", func(t *testing.T) {
-			th := Setup(t).InitBasic()
+			th := Setup(t)
 			defer th.TearDown()
 			cleanExistingBundles(t, th)
 
@@ -195,7 +195,7 @@ func TestInstallPluginLocally(t *testing.T) {
 		})
 
 		t.Run("install if upgrade, but older", func(t *testing.T) {
-			th := Setup(t).InitBasic()
+			th := Setup(t)
 			defer th.TearDown()
 			cleanExistingBundles(t, th)
 
@@ -211,7 +211,7 @@ func TestInstallPluginLocally(t *testing.T) {
 		})
 
 		t.Run("install if upgrade, but same version", func(t *testing.T) {
-			th := Setup(t).InitBasic()
+			th := Setup(t)
 			defer th.TearDown()
 			cleanExistingBundles(t, th)
 
@@ -227,7 +227,7 @@ func TestInstallPluginLocally(t *testing.T) {
 		})
 
 		t.Run("install if upgrade, newer version", func(t *testing.T) {
-			th := Setup(t).InitBasic()
+			th := Setup(t)
 			defer th.TearDown()
 			cleanExistingBundles(t, th)
 
@@ -243,7 +243,7 @@ func TestInstallPluginLocally(t *testing.T) {
 		})
 
 		t.Run("install always, old version", func(t *testing.T) {
-			th := Setup(t).InitBasic()
+			th := Setup(t)
 			defer th.TearDown()
 			cleanExistingBundles(t, th)
 

--- a/app/plugin_shutdown_test.go
+++ b/app/plugin_shutdown_test.go
@@ -15,7 +15,7 @@ func TestPluginShutdownTest(t *testing.T) {
 		t.Skip("skipping test to verify forced shutdown of slow plugin")
 	}
 
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	tearDown, _, _ := SetAppEnvironmentWithPlugins(t,

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -35,7 +35,7 @@ func getHashedKey(key string) string {
 }
 
 func TestPluginKeyValueStore(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	pluginId := "testpluginid"
@@ -135,7 +135,7 @@ func TestPluginKeyValueStore(t *testing.T) {
 }
 
 func TestPluginKeyValueStoreCompareAndSet(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	pluginId := "testpluginid"
@@ -195,7 +195,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 	pluginId := "testpluginid"
 
 	t.Run("storing a value without providing options works", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		result, err := th.App.SetPluginKeyWithOptions(pluginId, "key", []byte("value-1"), model.PluginKVSetOptions{})
@@ -209,7 +209,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 	})
 
 	t.Run("test that setting it atomic when it doesn't match doesn't change anything", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		err := th.App.SetPluginKey(pluginId, "key", []byte("value-1"))
@@ -229,7 +229,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 	})
 
 	t.Run("test the atomic change with the proper old value", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		err := th.App.SetPluginKey(pluginId, "key", []byte("value-2"))
@@ -249,7 +249,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 	})
 
 	t.Run("when new value is nil and old value matches with the current, it should delete the currently set value", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		// first set a value.
@@ -271,7 +271,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 	})
 
 	t.Run("when new value is nil and there is a value set for the key already, it should delete the currently set value", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		// first set a value.
@@ -296,7 +296,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 	})
 
 	t.Run("when old value is nil and there is no value set for the key before, it should set the new value", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		result, err := th.App.SetPluginKeyWithOptions(pluginId, "nil-test-key-4", []byte("value-1"), model.PluginKVSetOptions{
@@ -312,7 +312,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 	})
 
 	t.Run("test that value is set and unset with ExpireInSeconds", func(t *testing.T) {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 		defer th.TearDown()
 
 		result, err := th.App.SetPluginKeyWithOptions(pluginId, "key", []byte("value-1"), model.PluginKVSetOptions{
@@ -336,7 +336,7 @@ func TestPluginKeyValueStoreSetWithOptionsJSON(t *testing.T) {
 }
 
 func TestServePluginRequest(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.PluginSettings.Enable = false })
@@ -348,7 +348,7 @@ func TestServePluginRequest(t *testing.T) {
 }
 
 func TestPrivateServePluginRequest(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	testCases := []struct {
@@ -441,7 +441,7 @@ func TestHandlePluginRequest(t *testing.T) {
 }
 
 func TestGetPluginStatusesDisabled(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
@@ -454,7 +454,7 @@ func TestGetPluginStatusesDisabled(t *testing.T) {
 }
 
 func TestGetPluginStatuses(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
@@ -467,7 +467,7 @@ func TestGetPluginStatuses(t *testing.T) {
 }
 
 func TestPluginSync(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	testCases := []struct {
@@ -672,7 +672,7 @@ func TestPluginPanicLogs(t *testing.T) {
 }
 
 func TestProcessPrepackagedPlugins(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	testsPath, _ := fileutils.FindDir("tests")

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -30,7 +30,7 @@ import (
 func TestPreparePostListForClient(t *testing.T) {
 	// Most of this logic is covered by TestPreparePostForClient, so this just tests handling of multiple posts
 
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	postList := model.NewPostList()
@@ -1492,7 +1492,7 @@ func TestGetImagesInMessageAttachments(t *testing.T) {
 
 func TestGetLinkMetadata(t *testing.T) {
 	setup := func(t *testing.T) *TestHelper {
-		th := Setup(t).InitBasic()
+		th := Setup(t)
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "127.0.0.1"
@@ -2076,7 +2076,7 @@ func TestResolveMetadataURL(t *testing.T) {
 }
 
 func TestParseLinkMetadata(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	imageURL := "http://example.com/test.png"

--- a/app/session_test.go
+++ b/app/session_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	session := &model.Session{
@@ -51,7 +51,7 @@ func TestCache(t *testing.T) {
 }
 
 func TestGetSessionIdleTimeoutInMinutes(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	session := &model.Session{
@@ -187,7 +187,7 @@ const hourMillis int64 = 60 * 60 * 1000
 const dayMillis int64 = 24 * hourMillis
 
 func TestApp_GetSessionLengthInMillis(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.SessionLengthMobileInDays = 3 })
@@ -273,7 +273,7 @@ func TestApp_GetSessionLengthInMillis(t *testing.T) {
 }
 
 func TestApp_ExtendExpiryIfNeeded(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ExtendSessionLengthWithActivity = true })

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -710,7 +710,7 @@ func TestSanitizeTeams(t *testing.T) {
 }
 
 func TestJoinUserToTeam(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	id := model.NewId()
@@ -1094,7 +1094,7 @@ func TestUpdateTeamMemberRolesChangingGuest(t *testing.T) {
 }
 
 func TestInvalidateAllEmailInvites(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t1 := model.Token{

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -109,7 +109,7 @@ func TestHubStopRaceCondition(t *testing.T) {
 }
 
 func TestHubConnIndex(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	connIndex := newHubConnectionIndex()

--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -724,7 +724,7 @@ func (r InfiniteReader) Read(p []byte) (n int, err error) {
 }
 
 func TestDoOutgoingWebhookRequest(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	th.App.UpdateConfig(func(cfg *model.Config) {


### PR DESCRIPTION
`th.InitBasic` initializes users, channels, and teams. But a lot of
tests don't use it at all, causing unncessary delays. A single `InitBasic`
call takes around 400ms. This PR removes 71 of them, approximately shaving
off 28 seconds. Arguably, this would be more because some tests run in loops.

#### Ticket link

https://mattermost.atlassian.net/browse/MM-26750