### PR TITLE
MM-26793 Fix accidentally removing other users' favorites

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3846,6 +3846,7 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 			// Remove any old favorites
 			sql, args, _ := s.getQueryBuilder().Delete("Preferences").Where(
 				sq.Eq{
+					"UserId":   userId,
 					"Name":     originalCategory.Channels,
 					"Category": model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL,
 				},


### PR DESCRIPTION
The missing where case made it so that, when one user favourites a channel, others have it removed from their Favorites. Gotta fight for those favourites!

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26793