### PR TITLE
[MM-24560] Always clear channel cache when scheme is deleted

### DIFF
--- a/store/sqlstore/scheme_store.go
+++ b/store/sqlstore/scheme_store.go
@@ -287,10 +287,10 @@ func (s *SqlSchemeStore) Delete(schemeId string) (*model.Scheme, error) {
 		if _, err := s.GetMaster().Exec("UPDATE Channels SET SchemeId = '' WHERE SchemeId = :SchemeId", map[string]interface{}{"SchemeId": schemeId}); err != nil {
 			return nil, errors.Wrapf(err, "failed to update Channels with schemeId=%s", schemeId)
 		}
-
-		// Blow away the channel caches.
-		s.Channel().ClearCaches()
 	}
+
+	// Blow away the channel caches.
+	s.Channel().ClearCaches()
 
 	// Delete the roles belonging to the scheme.
 	roleNames := []string{scheme.DefaultChannelGuestRole, scheme.DefaultChannelUserRole, scheme.DefaultChannelAdminRole}


### PR DESCRIPTION
#### Summary
- Since a team scheme always has channel level role names also cached both channel and team caches have to be cleared... my previous PR cleared the Team cache but the channel cache was still only cleared when the scheme was a channel scheme, this fixes that.

- For 5.26 I will add a unit test to ensure that this behaviour always works as expected but for now this needs to go for 5.25 release

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-24560