### PR TITLE
add error type, so it can remove Back button in webclient

### DIFF
--- a/web/oauth.go
+++ b/web/oauth.go
@@ -144,7 +144,11 @@ func authorizeOAuthPage(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if !oauthApp.IsValidRedirectURL(authRequest.RedirectUri) {
 		err := model.NewAppError("authorizeOAuthPage", "api.oauth.allow_oauth.redirect_callback.app_error", nil, "", http.StatusBadRequest)
-		utils.RenderWebAppError(c.App.Config(), w, r, err, c.App.AsymmetricSigningKey())
+		utils.RenderWebError(c.App.Config(), w, r, err.StatusCode,
+			url.Values{
+				"type":    []string{"oauth_invalid_redirect_url"},
+				"message": []string{utils.T("api.oauth.allow_oauth.redirect_callback.app_error")},
+			}, c.App.AsymmetricSigningKey())
 		return
 	}
 


### PR DESCRIPTION

#### Summary
OAuth2.0: Incorrect Callback URL during authentication allows user to go "Back to Mattermost" in the authentication window

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23699

#### Related PRs
