### PR TITLE
MM-26891: return error if option not set instead of soft delete for permanent team deletion

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -367,8 +367,12 @@ func deleteTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	var err *model.AppError
-	if c.Params.Permanent && *c.App.Config().ServiceSettings.EnableAPITeamDeletion {
-		err = c.App.PermanentDeleteTeamId(c.Params.TeamId)
+	if c.Params.Permanent {
+		if *c.App.Config().ServiceSettings.EnableAPITeamDeletion {
+			err = c.App.PermanentDeleteTeamId(c.Params.TeamId)
+		} else {
+			err = model.NewAppError("deleteTeam", "api.user.delete_team.not_enabled.app_error", nil, "teamId="+c.Params.TeamId, http.StatusUnauthorized)
+		}
 	} else {
 		err = c.App.SoftDeleteTeam(c.Params.TeamId)
 	}

--- a/api4/team_local.go
+++ b/api4/team_local.go
@@ -18,13 +18,42 @@ func (api *API) InitTeamLocal() {
 
 	api.BaseRoutes.Team.Handle("", api.ApiLocal(getTeam)).Methods("GET")
 	api.BaseRoutes.Team.Handle("", api.ApiLocal(updateTeam)).Methods("PUT")
-	api.BaseRoutes.Team.Handle("", api.ApiLocal(deleteTeam)).Methods("DELETE")
+	api.BaseRoutes.Team.Handle("", api.ApiLocal(localDeleteTeam)).Methods("DELETE")
 	api.BaseRoutes.Team.Handle("/invite/email", api.ApiLocal(localInviteUsersToTeam)).Methods("POST")
 	api.BaseRoutes.Team.Handle("/patch", api.ApiLocal(patchTeam)).Methods("PUT")
 
 	api.BaseRoutes.TeamByName.Handle("", api.ApiLocal(getTeamByName)).Methods("GET")
 	api.BaseRoutes.TeamMembers.Handle("", api.ApiLocal(addTeamMember)).Methods("POST")
 	api.BaseRoutes.TeamMember.Handle("", api.ApiLocal(removeTeamMember)).Methods("DELETE")
+}
+
+func localDeleteTeam(c *Context, w http.ResponseWriter, r *http.Request) {
+	c.RequireTeamId()
+	if c.Err != nil {
+		return
+	}
+
+	auditRec := c.MakeAuditRecord("localDeleteTeam", audit.Fail)
+	defer c.LogAuditRec(auditRec)
+
+	if team, err := c.App.GetTeam(c.Params.TeamId); err == nil {
+		auditRec.AddMeta("team", team)
+	}
+
+	var err *model.AppError
+	if c.Params.Permanent {
+		err = c.App.PermanentDeleteTeamId(c.Params.TeamId)
+	} else {
+		err = c.App.SoftDeleteTeam(c.Params.TeamId)
+	}
+
+	if err != nil {
+		c.Err = err
+		return
+	}
+
+	auditRec.Success()
+	ReturnStatusOK(w)
 }
 
 func localInviteUsersToTeam(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -773,45 +773,52 @@ func TestPermanentDeleteTeam(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
-		team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN}
-		team, _ = client.CreateTeam(team)
+	enableAPITeamDeletion := *th.App.Config().ServiceSettings.EnableAPITeamDeletion
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableAPITeamDeletion = &enableAPITeamDeletion })
+	}()
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableAPITeamDeletion = false })
 
-		enableAPITeamDeletion := *th.App.Config().ServiceSettings.EnableAPITeamDeletion
+	t.Run("Permanent deletion not available through API if EnableAPITeamDeletion is not set", func(t *testing.T) {
+		team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN}
+		team, _ = th.Client.CreateTeam(team)
+
+		_, resp := th.Client.PermanentDeleteTeam(team.Id)
+		CheckUnauthorizedStatus(t, resp)
+
+		_, resp = th.SystemAdminClient.PermanentDeleteTeam(team.Id)
+		CheckUnauthorizedStatus(t, resp)
+	})
+
+	t.Run("Permanent deletion available through local mode even if EnableAPITeamDeletion is not set", func(t *testing.T) {
+		team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN}
+		team, _ = th.Client.CreateTeam(team)
+
+		ok, resp := th.LocalClient.PermanentDeleteTeam(team.Id)
+		CheckNoError(t, resp)
+		assert.True(t, ok)
+	})
+
+	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
 		defer func() {
 			th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableAPITeamDeletion = &enableAPITeamDeletion })
 		}()
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableAPITeamDeletion = true })
 
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableAPITeamDeletion = false })
-
-		// Does not error when deletion is disabled, just soft deletes
+		team := &model.Team{DisplayName: "DisplayName", Name: GenerateTestTeamName(), Email: th.GenerateTestEmail(), Type: model.TEAM_OPEN}
+		team, _ = client.CreateTeam(team)
 		ok, resp := client.PermanentDeleteTeam(team.Id)
 		CheckNoError(t, resp)
 		assert.True(t, ok)
 
-		rteam, err := th.App.GetTeam(team.Id)
-		assert.Nil(t, err)
-		assert.True(t, rteam.DeleteAt > 0)
-
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableAPITeamDeletion = true })
-
-		ok, resp = client.PermanentDeleteTeam(team.Id)
-		CheckNoError(t, resp)
-		assert.True(t, ok)
-
-		_, err = th.App.GetTeam(team.Id)
+		_, err := th.App.GetTeam(team.Id)
 		assert.NotNil(t, err)
 
 		ok, resp = client.PermanentDeleteTeam("junk")
 		CheckBadRequestStatus(t, resp)
 
 		require.False(t, ok, "should have returned false")
-	})
-
-	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		_, resp := client.PermanentDeleteTeam(th.BasicTeam.Id)
-		CheckNoError(t, resp)
-	})
+	}, "Permanent deletion with EnableAPITeamDeletion set")
 }
 
 func TestGetAllTeams(t *testing.T) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2615,6 +2615,10 @@
     "translation": "The signup link does not appear to be valid."
   },
   {
+    "id": "api.user.delete_team.not_enabled.app_error",
+    "translation": "Permanent team deletion feature is not enabled. Please contact your System Administrator."
+  },
+  {
     "id": "api.user.demote_user_to_guest.already_guest.app_error",
     "translation": "Unable to convert the user to guest because is already a guest."
   },


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- If the `EnableAPITeamDeletion` option is not set, then PermanentDeleteTeam returns an error instead of falling back to soft delete. This change was made to bring the behaviour into alignment with admin expectations and docs - https://docs.mattermost.com/administration/config-settings.html#enable-api-team-deletion

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-26891