### PR TITLE
[MM-26877] Fix flaky TestPluginAPIUpdateUserPreferences

### DIFF
--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -250,7 +250,7 @@ func TestPluginAPIUpdateUserPreferences(t *testing.T) {
 			assert.Equal(t, "0", pref.Value)
 		} else {
 			newTheme, _ := json.Marshal(map[string]string{"color": "#ff0000", "color2": "#faf"})
-			assert.Equal(t, string(newTheme), preferences[0].Value)
+			assert.Equal(t, string(newTheme), pref.Value)
 		}
 	}
 }


### PR DESCRIPTION
#### Summary

PR *attempts* to fix flaky `TestPluginAPIUpdateUserPreferences`.
I wasn't able to reproduce it locally but I suspect the problem was that the order of the returned preferences cannot be relied upon.
Feel free to give it a spin and check if this actually fixes it.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-26877