### PR TITLE
Updated the deleted_at timestamp for deactivated direct message channel

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -233,6 +233,7 @@ type ChannelStore interface {
 	RemoveAllDeactivatedMembers(channelId string) *model.AppError
 	GetChannelsBatchForIndexing(startTime, endTime int64, limit int) ([]*model.Channel, *model.AppError)
 	UserBelongsToChannels(userId string, channelIds []string) (bool, *model.AppError)
+	GetDirectChannelsForUser(userId string) ([]*model.Channel, *model.AppError)
 
 	// UpdateMembersRole sets all of the given team members to admins and all of the other members of the team to
 	// non-admin members.

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -2109,3 +2109,28 @@ func (_m *ChannelStore) UserBelongsToChannels(userId string, channelIds []string
 
 	return r0, r1
 }
+
+// GetDirectChannelsForUser provides a mock function with given fields: userId
+func (_m *ChannelStore) GetDirectChannelsForUser(userId string) ([]*model.Channel, *model.AppError) {
+	ret := _m.Called(userId)
+
+	var r0 []*model.Channel
+	if rf, ok := ret.Get(0).(func(string) []*model.Channel); ok {
+		r0 = rf(userId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Channel)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string) *model.AppError); ok {
+		r1 = rf(userId)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When the user account is deactivated, direct message channels are not updated with deleted time


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-26941