### PR TITLE
MM-26883/26884: properly identify interface name for test services (#…

### DIFF
--- a/utils/testutils/testutils.go
+++ b/utils/testutils/testutils.go
@@ -6,8 +6,13 @@ package testutils
 import (
 	"bytes"
 	"io"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
 
 	"github.com/mattermost/mattermost-server/v5/utils/fileutils"
 )
@@ -26,4 +31,45 @@ func ReadTestFile(name string) ([]byte, error) {
 	} else {
 		return data.Bytes(), nil
 	}
+}
+
+// GetInterface returns the best match of an interface that might be listening on a given port.
+// This is helpful when a test is being run in a CI environment under docker.
+func GetInterface(port int) string {
+	dial := func(iface string, port int) bool {
+		c, err := net.DialTimeout("tcp", iface+":"+strconv.Itoa(port), time.Second)
+		if err != nil {
+			return false
+		}
+		c.Close()
+		return true
+	}
+	// First, we check dockerhost
+	iface := "dockerhost"
+	if ok := dial(iface, port); ok {
+		return iface
+	}
+	// If not, we check localhost
+	iface = "localhost"
+	if ok := dial(iface, port); ok {
+		return iface
+	}
+	// If nothing works, we just attempt to use a hack and get the interface IP.
+	// https://stackoverflow.com/a/37212665/4962526.
+	cmdStr := ""
+	switch runtime.GOOS {
+	// Using ip address for Linux, ifconfig for Darwin.
+	case "linux":
+		cmdStr = `ip address | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | cut -f1 -d/ | head -n1`
+	case "darwin":
+		cmdStr = `ifconfig | grep -E "([0-9]{1,3}\.){3}[0-9]{1,3}" | grep -v 127.0.0.1 | awk '{ print $2 }' | cut -f2 -d: | head -n1`
+	default:
+		return ""
+	}
+	cmd := exec.Command("bash", "-c", cmdStr)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	return string(out)
 }


### PR DESCRIPTION
…15040)

* MM-26883/26884: properly identify interface name for test services

We were just hardcoding to dockerhost which would only work inside
a CI environment. This PR generalizes the logic to use fallbacks
if dockerhost is not available.

* Incorporate review comments

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
