### PR TITLE
[MM-26881] Fix TestLinkMetadataStore test failing for some

### DIFF
--- a/model/link_metadata.go
+++ b/model/link_metadata.go
@@ -171,9 +171,9 @@ func (o *LinkMetadata) DeserializeDataToConcreteType() error {
 
 // FloorToNearestHour takes a timestamp (in milliseconds) and returns it rounded to the previous hour in UTC.
 func FloorToNearestHour(ms int64) int64 {
-	t := time.Unix(0, ms*int64(1000*1000))
+	t := time.Unix(0, ms*int64(1000*1000)).UTC()
 
-	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, t.Location()).UnixNano() / int64(time.Millisecond)
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond)
 }
 
 // isRoundedToNearestHour returns true if the given timestamp (in milliseconds) has been rounded to the nearest hour in UTC.

--- a/store/storetest/link_metadata_store.go
+++ b/store/storetest/link_metadata_store.go
@@ -19,7 +19,7 @@ import (
 var linkMetadataTimestamp int64 = 1546300800000
 
 func getNextLinkMetadataTimestamp() int64 {
-	linkMetadataTimestamp += int64(time.Hour) / 1000
+	linkMetadataTimestamp += int64(time.Hour) / (1000 * 1000)
 	return linkMetadataTimestamp
 }
 


### PR DESCRIPTION
#### Summary

PR fixes `TestLinkMetadataStore` failing locally for some.
The main issue was not forcing the time to be in UTC.
`model.FloorToNearestHour()` would fail for some particular timezones.

#### Ticket

https://mattermost.atlassian.net/browse/MM-26881
