### PR TITLE
MM-18006: Fix flaky test CreateOrRestoreGroupMember (#14955)

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6675,12 +6675,12 @@
     "translation": "group syncable was already deleted"
   },
   {
-    "id": "store.sql_group.no_rows",
-    "translation": "no matching group found"
+    "id": "store.sql_group.more_than_one_row_changed",
+    "translation": "More than one row changed."
   },
   {
-    "id": "store.sql_group.no_rows_changed",
-    "translation": "no rows changed"
+    "id": "store.sql_group.no_rows",
+    "translation": "no matching group found"
   },
   {
     "id": "store.sql_group.permanent_delete_members_by_user.app_error",

--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -232,8 +232,8 @@ func (s *SqlGroupStore) Update(group *model.Group) (*model.Group, *model.AppErro
 		}
 		return nil, model.NewAppError("SqlGroupStore.GroupUpdate", "store.update_error", nil, err.Error(), http.StatusInternalServerError)
 	}
-	if rowsChanged != 1 {
-		return nil, model.NewAppError("SqlGroupStore.GroupUpdate", "store.sql_group.no_rows_changed", nil, "", http.StatusInternalServerError)
+	if rowsChanged > 1 {
+		return nil, model.NewAppError("SqlGroupStore.GroupUpdate", "store.sql_group.more_than_one_row_changed", nil, "", http.StatusInternalServerError)
 	}
 
 	return group, nil
@@ -427,8 +427,8 @@ func (s *SqlGroupStore) UpsertMember(groupID string, userID string) (*model.Grou
 		if rowsChanged, err = s.GetMaster().Update(member); err != nil {
 			return nil, model.NewAppError("SqlGroupStore.GroupCreateOrRestoreMember", "store.update_error", nil, "group_id="+member.GroupId+", user_id="+member.UserId+", "+err.Error(), http.StatusInternalServerError)
 		}
-		if rowsChanged != 1 {
-			return nil, model.NewAppError("SqlGroupStore.GroupCreateOrRestoreMember", "store.sql_group.no_rows_changed", nil, "", http.StatusInternalServerError)
+		if rowsChanged > 1 {
+			return nil, model.NewAppError("SqlGroupStore.GroupCreateOrRestoreMember", "store.sql_group.more_than_one_row_changed", nil, "", http.StatusInternalServerError)
 		}
 	}
 


### PR DESCRIPTION
Updating a Group or a GroupMember only changed the UpdateAt or CreateAt times
respectively. And it threw an error if number of rows changed was not 1.

However, it can happen that 2 calls happen so fast that 1 milisecond does not pass,
or even 2 concurrent calls at the same time might happen so that model.GetMillis
return the same timestamp. In those cases, the number of rows updated can be 0.

The error should just check if the number is greater than 1, instead of not equal to 1.
This makes it more robust and correct.

Co-authored-by: Mattermod <mattermod@users.noreply.github.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
