### PR TITLE
MM-27041: Do not run tests against both DBs in CI

### DIFF
--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -4,6 +4,7 @@
 package sqlstore
 
 import (
+	"os"
 	"sync"
 	"testing"
 
@@ -80,14 +81,31 @@ func initStores() {
 	if testing.Short() {
 		return
 	}
-	storeTypes = append(storeTypes, &storeType{
-		Name:        "MySQL",
-		SqlSettings: storetest.MakeSqlSettings(model.DATABASE_DRIVER_MYSQL),
-	})
-	storeTypes = append(storeTypes, &storeType{
-		Name:        "PostgreSQL",
-		SqlSettings: storetest.MakeSqlSettings(model.DATABASE_DRIVER_POSTGRES),
-	})
+	// In CI, we already run the entire test suite for both mysql and postgres in parallel.
+	// So we just run the tests for the current database set.
+	if os.Getenv("IS_CI") == "true" {
+		switch os.Getenv("IS_CI") {
+		case "mysql":
+			storeTypes = append(storeTypes, &storeType{
+				Name:        "MySQL",
+				SqlSettings: storetest.MakeSqlSettings(model.DATABASE_DRIVER_MYSQL),
+			})
+		case "postgres":
+			storeTypes = append(storeTypes, &storeType{
+				Name:        "PostgreSQL",
+				SqlSettings: storetest.MakeSqlSettings(model.DATABASE_DRIVER_POSTGRES),
+			})
+		}
+	} else {
+		storeTypes = append(storeTypes, &storeType{
+			Name:        "MySQL",
+			SqlSettings: storetest.MakeSqlSettings(model.DATABASE_DRIVER_MYSQL),
+		})
+		storeTypes = append(storeTypes, &storeType{
+			Name:        "PostgreSQL",
+			SqlSettings: storetest.MakeSqlSettings(model.DATABASE_DRIVER_POSTGRES),
+		})
+	}
 
 	defer func() {
 		if err := recover(); err != nil {

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -84,7 +84,7 @@ func initStores() {
 	// In CI, we already run the entire test suite for both mysql and postgres in parallel.
 	// So we just run the tests for the current database set.
 	if os.Getenv("IS_CI") == "true" {
-		switch os.Getenv("IS_CI") {
+		switch os.Getenv("MM_SQLSETTINGS_DRIVERNAME") {
 		case "mysql":
 			storeTypes = append(storeTypes, &storeType{
 				Name:        "MySQL",


### PR DESCRIPTION
We already run the entire test suite for both mysql and postgres in parallel in CI.
So we just run the tests for the current database set.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-27041