### PR TITLE
MM-25744 Remove (*App).Shutdown and update all references.

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -117,14 +117,6 @@ func (a *App) InitServer() {
 	a.saml = a.srv.Saml
 }
 
-// DO NOT CALL THIS.
-// This is to avoid having to change all the code in cmd/mattermost/commands/* for now
-// shutdown should be called directly on the server
-func (a *App) Shutdown() {
-	a.Srv().Shutdown()
-	a.srv = nil
-}
-
 func (a *App) initJobs() {
 	if jobsLdapSyncInterface != nil {
 		a.srv.Jobs.LdapSync = jobsLdapSyncInterface(a)

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -83,10 +83,6 @@ type AppIface interface {
 	CreateUser(user *model.User) (*model.User, *model.AppError)
 	// Creates and stores FileInfos for a post created before the FileInfos table existed.
 	MigrateFilenamesToFileInfos(post *model.Post) []*model.FileInfo
-	// DO NOT CALL THIS.
-	// This is to avoid having to change all the code in cmd/mattermost/commands/* for now
-	// shutdown should be called directly on the server
-	Shutdown()
 	// DefaultChannelNames returns the list of system-wide default channel names.
 	//
 	// By default the list will be (not necessarily in this order):

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -24,7 +24,7 @@ func TestAppRace(t *testing.T) {
 		a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })
 		serverErr := a.StartServer()
 		require.NoError(t, serverErr)
-		a.Shutdown()
+		a.Srv().Shutdown()
 	}
 }
 */

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -13330,21 +13330,6 @@ func (a *OpenTracingAppLayer) SetTeamIconFromMultiPartFile(teamId string, file m
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) Shutdown() {
-	origCtx := a.ctx
-	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.Shutdown")
-
-	a.ctx = newCtx
-	a.app.Srv().Store.SetContext(newCtx)
-	defer func() {
-		a.app.Srv().Store.SetContext(origCtx)
-		a.ctx = origCtx
-	}()
-
-	defer span.Finish()
-	a.app.Shutdown()
-}
-
 func (a *OpenTracingAppLayer) SlackAddBotUser(teamId string, log *bytes.Buffer) *model.User {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.SlackAddBotUser")

--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -172,7 +172,7 @@ func createChannelCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	name, errn := command.Flags().GetString("name")
 	if errn != nil || name == "" {
@@ -231,7 +231,7 @@ func removeChannelUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	allUsers, _ := command.Flags().GetBool("all-users")
 
@@ -291,7 +291,7 @@ func addChannelUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
@@ -326,7 +326,7 @@ func archiveChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channels := getChannelsFromChannelArgs(a, args)
 	for i, channel := range channels {
@@ -350,7 +350,7 @@ func deleteChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	confirmFlag, _ := command.Flags().GetBool("confirm")
 	if !confirmFlag {
@@ -390,7 +390,7 @@ func moveChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -469,7 +469,7 @@ func listChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	teams := getTeamsFromTeamArgs(a, args)
 	for i, team := range teams {
@@ -501,7 +501,7 @@ func restoreChannelsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channels := getChannelsFromChannelArgs(a, args)
 	for i, channel := range channels {
@@ -531,7 +531,7 @@ func modifyChannelCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	username, erru := command.Flags().GetString("username")
 	if erru != nil || username == "" {
@@ -584,7 +584,7 @@ func renameChannelCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
@@ -616,7 +616,7 @@ func searchChannelCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to InitDBCommandContextCobra")
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	var channel *model.Channel
 

--- a/cmd/mattermost/commands/command.go
+++ b/cmd/mattermost/commands/command.go
@@ -116,7 +116,7 @@ func createCommandCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -191,7 +191,7 @@ func showCommandCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	slashCommand := getCommandFromCommandArg(a, args[0])
 	if slashCommand == nil {
@@ -209,7 +209,7 @@ func moveCommandCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Enter the destination team and at least one command to move.")
@@ -249,7 +249,7 @@ func listCommandCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	var teams []*model.Team
 	if len(args) < 1 {
@@ -285,7 +285,7 @@ func deleteCommandCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	slashCommand := getCommandFromCommandArg(a, args[0])
 	if slashCommand == nil {
@@ -310,7 +310,7 @@ func modifyCommandCmdF(command *cobra.Command, args []string) (cmdError error) {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	oldCommand := getCommandFromCommandArg(a, args[0])
 	if oldCommand == nil {

--- a/cmd/mattermost/commands/config.go
+++ b/cmd/mattermost/commands/config.go
@@ -123,7 +123,7 @@ func configSubpathCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	path, err := command.Flags().GetString("path")
 	if err != nil {
@@ -264,7 +264,7 @@ func configSetCmdF(command *cobra.Command, args []string) error {
 			auditRec.AddMeta("setting", configSetting)
 			auditRec.AddMeta("new_value", newVal)
 			a.LogAuditRec(auditRec, nil)
-			a.Shutdown()
+			a.Srv().Shutdown()
 		}
 	*/
 
@@ -480,7 +480,7 @@ func configResetCmdF(command *cobra.Command, args []string) error {
 		if errInit == nil {
 			auditRec := a.MakeAuditRecord("configReset", audit.Success)
 			a.LogAuditRec(auditRec, nil)
-			a.Shutdown()
+			a.Srv().Shutdown()
 		}
 	*/
 

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -88,7 +88,7 @@ func scheduleExportCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if !*a.Config().MessageExportSettings.EnableExport {
 		return errors.New("ERROR: The message export feature is not enabled")
@@ -149,7 +149,7 @@ func buildExportCmdF(format string) func(command *cobra.Command, args []string) 
 		if err != nil {
 			return err
 		}
-		defer a.Shutdown()
+		defer a.Srv().Shutdown()
 
 		startTime, err := command.Flags().GetInt64("exportFrom")
 		if err != nil {
@@ -187,7 +187,7 @@ func bulkExportCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	allTeams, err := command.Flags().GetBool("all-teams")
 	if err != nil {

--- a/cmd/mattermost/commands/group.go
+++ b/cmd/mattermost/commands/group.go
@@ -122,7 +122,7 @@ func channelGroupEnableCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
@@ -159,7 +159,7 @@ func channelGroupDisableCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
@@ -183,7 +183,7 @@ func channelGroupStatusCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
@@ -204,7 +204,7 @@ func channelGroupListCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	channel := getChannelFromChannelArg(a, args[0])
 	if channel == nil {
@@ -228,7 +228,7 @@ func teamGroupEnableCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -261,7 +261,7 @@ func teamGroupDisableCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -285,7 +285,7 @@ func teamGroupStatusCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -306,7 +306,7 @@ func teamGroupListCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {

--- a/cmd/mattermost/commands/import.go
+++ b/cmd/mattermost/commands/import.go
@@ -51,7 +51,7 @@ func slackImportCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) != 2 {
 		return errors.New("Incorrect number of arguments.")
@@ -101,7 +101,7 @@ func bulkImportCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	apply, err := command.Flags().GetBool("apply")
 	if err != nil {

--- a/cmd/mattermost/commands/integrity.go
+++ b/cmd/mattermost/commands/integrity.go
@@ -69,7 +69,7 @@ func integrityCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	confirmFlag, _ := command.Flags().GetBool("confirm")
 	if !confirmFlag {

--- a/cmd/mattermost/commands/jobserver.go
+++ b/cmd/mattermost/commands/jobserver.go
@@ -39,7 +39,7 @@ func jobserverCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	a.Srv().LoadLicense()
 	a.InitServer()

--- a/cmd/mattermost/commands/ldap.go
+++ b/cmd/mattermost/commands/ldap.go
@@ -44,7 +44,7 @@ func ldapSyncCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if ldapI := a.Ldap(); ldapI != nil {
 		job, err := ldapI.StartSynchronizeJob(true)
@@ -65,7 +65,7 @@ func ldapIdMigrateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	toAttribute := args[0]
 	if ldapI := a.Ldap(); ldapI != nil {

--- a/cmd/mattermost/commands/license.go
+++ b/cmd/mattermost/commands/license.go
@@ -34,7 +34,7 @@ func uploadLicenseCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) != 1 {
 		return errors.New("Enter one license file to upload")

--- a/cmd/mattermost/commands/permissions.go
+++ b/cmd/mattermost/commands/permissions.go
@@ -98,7 +98,7 @@ func exportPermissionsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if license := a.Srv().License(); license == nil {
 		return errors.New(utils.T("cli.license.critical"))
@@ -119,7 +119,7 @@ func importPermissionsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if license := a.Srv().License(); license == nil {
 		return errors.New(utils.T("cli.license.critical"))

--- a/cmd/mattermost/commands/plugin.go
+++ b/cmd/mattermost/commands/plugin.go
@@ -107,7 +107,7 @@ func pluginAddCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -137,7 +137,7 @@ func pluginDeleteCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -161,7 +161,7 @@ func pluginEnableCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -185,7 +185,7 @@ func pluginDisableCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -209,7 +209,7 @@ func pluginListCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	pluginsResp, appErr := a.GetPlugins()
 	if appErr != nil {
@@ -234,7 +234,7 @@ func pluginPublicKeysCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	verbose, err := command.Flags().GetBool("verbose")
 	if err != nil {
@@ -268,7 +268,7 @@ func pluginAddPublicKeyCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -299,7 +299,7 @@ func pluginDeletePublicKeyCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")

--- a/cmd/mattermost/commands/reset.go
+++ b/cmd/mattermost/commands/reset.go
@@ -29,7 +29,7 @@ func resetCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	confirmFlag, _ := command.Flags().GetBool("confirm")
 	if !confirmFlag {

--- a/cmd/mattermost/commands/roles.go
+++ b/cmd/mattermost/commands/roles.go
@@ -47,7 +47,7 @@ func makeSystemAdminCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one user.")
@@ -97,7 +97,7 @@ func makeMemberCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Enter at least one user.")

--- a/cmd/mattermost/commands/sampledata.go
+++ b/cmd/mattermost/commands/sampledata.go
@@ -143,7 +143,7 @@ func sampleDataCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	seed, err := command.Flags().GetInt64("seed")
 	if err != nil {

--- a/cmd/mattermost/commands/team.go
+++ b/cmd/mattermost/commands/team.go
@@ -144,7 +144,7 @@ func createTeamCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	name, errn := command.Flags().GetString("name")
 	if errn != nil || name == "" {
@@ -187,7 +187,7 @@ func removeUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -223,7 +223,7 @@ func addUsersCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -258,7 +258,7 @@ func deleteTeamsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	confirmFlag, _ := command.Flags().GetBool("confirm")
 	if !confirmFlag {
@@ -304,7 +304,7 @@ func listTeamsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	teams, err2 := a.GetAllTeams()
 	if err2 != nil {
@@ -327,7 +327,7 @@ func searchTeamCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	var teams []*model.Team
 
@@ -358,7 +358,7 @@ func restoreTeamsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	teams := getTeamsFromTeamArgs(a, args)
 	for i, team := range teams {
@@ -399,7 +399,7 @@ func archiveTeamCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	foundTeams := getTeamsFromTeamArgs(a, args)
 	for i, team := range foundTeams {
@@ -424,7 +424,7 @@ func renameTeamCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {
@@ -463,7 +463,7 @@ func modifyTeamCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	team := getTeamFromTeamArg(a, args[0])
 	if team == nil {

--- a/cmd/mattermost/commands/test.go
+++ b/cmd/mattermost/commands/test.go
@@ -50,7 +50,7 @@ func webClientTestsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	utils.InitTranslations(a.Config().LocalizationSettings)
 	serverErr := a.Srv().Start()
@@ -71,7 +71,7 @@ func serverForWebClientTestsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	utils.InitTranslations(a.Config().LocalizationSettings)
 	serverErr := a.Srv().Start()

--- a/cmd/mattermost/commands/user.go
+++ b/cmd/mattermost/commands/user.go
@@ -275,7 +275,7 @@ func userActivateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -322,7 +322,7 @@ func userDeactivateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -338,7 +338,7 @@ func userCreateCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	username, erru := command.Flags().GetString("username")
 	if erru != nil || username == "" {
@@ -556,7 +556,7 @@ func userConvertCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	toBot, err := command.Flags().GetBool("bot")
 	if err != nil {
@@ -589,7 +589,7 @@ func userInviteCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 2 {
 		return errors.New("Expected at least two arguments. See help text for details.")
@@ -639,7 +639,7 @@ func resetUserPasswordCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) != 2 {
 		return errors.New("Expected two arguments. See help text for details.")
@@ -667,7 +667,7 @@ func updateUserEmailCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) != 2 {
 		return errors.New("Expected two arguments. See help text for details.")
@@ -707,7 +707,7 @@ func resetUserMfaCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -736,7 +736,7 @@ func deleteUserCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -789,7 +789,7 @@ func deleteAllUsersCommandF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) > 0 {
 		return errors.New("Expected zero arguments.")
@@ -834,7 +834,7 @@ func migrateAuthToLdapCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	fromAuth := args[0]
 	matchField := args[2]
@@ -878,7 +878,7 @@ func migrateAuthToSamlCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	dryRunFlag, _ := command.Flags().GetBool("dryRun")
 	autoFlag, _ := command.Flags().GetBool("auto")
@@ -939,7 +939,7 @@ func verifyUserCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
@@ -965,7 +965,7 @@ func searchUserCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer a.Shutdown()
+	defer a.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")

--- a/cmd/mattermost/commands/webhook.go
+++ b/cmd/mattermost/commands/webhook.go
@@ -92,7 +92,7 @@ func listWebhookCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	var teams []*model.Team
 	if len(args) < 1 {
@@ -154,7 +154,7 @@ func createIncomingWebhookCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	channelArg, errChannel := command.Flags().GetString("channel")
 	if errChannel != nil || channelArg == "" {
@@ -209,7 +209,7 @@ func modifyIncomingWebhookCmdF(command *cobra.Command, args []string) (cmdError 
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("WebhookID is not specified")
@@ -267,7 +267,7 @@ func createOutgoingWebhookCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	teamArg, errTeam := command.Flags().GetString("team")
 	if errTeam != nil || teamArg == "" {
@@ -361,7 +361,7 @@ func modifyOutgoingWebhookCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("WebhookID is not specified")
@@ -451,7 +451,7 @@ func deleteWebhookCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	if len(args) < 1 {
 		return errors.New("WebhookID is not specified")
@@ -477,7 +477,7 @@ func showWebhookCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	webhookId := args[0]
 	if incomingWebhook, err := app.GetIncomingWebhook(webhookId); err == nil {
@@ -497,7 +497,7 @@ func moveOutgoingWebhookCmd(command *cobra.Command, args []string) (cmdError err
 	if err != nil {
 		return err
 	}
-	defer app.Shutdown()
+	defer app.Srv().Shutdown()
 
 	newTeamId := args[0]
 	_, teamError := app.GetTeam(newTeamId)


### PR DESCRIPTION
#### Summary
This PR removes `(*App).Shutdown()`, which forwarded the call to (*Server).Shutdown().  All references to it now call Shutdown on server directly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25744