### PR TITLE
MM-27187: Use the correct page offset for cache clear methods

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -2589,7 +2589,7 @@ func (a *App) ClearChannelMembersCache(channelID string) {
 	page := 0
 
 	for {
-		channelMembers, err := a.Srv().Store.Channel().GetMembers(channelID, page, perPage)
+		channelMembers, err := a.Srv().Store.Channel().GetMembers(channelID, page*perPage, perPage)
 		if err != nil {
 			a.Log().Warn("error clearing cache for channel members", mlog.String("channel_id", channelID))
 			break

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -1877,6 +1877,28 @@ func TestMarkChannelsAsViewedPanic(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestClearChannelMembersCache(t *testing.T) {
+	th := SetupWithStoreMock(t)
+	defer th.TearDown()
+
+	mockStore := th.App.Srv().Store.(*mocks.Store)
+	mockChannelStore := mocks.ChannelStore{}
+	cms := model.ChannelMembers{}
+	for i := 0; i < 200; i++ {
+		cms = append(cms, model.ChannelMember{
+			ChannelId: "1",
+		})
+	}
+	mockChannelStore.On("GetMembers", "channelID", 0, 100).Return(&cms, nil)
+	mockChannelStore.On("GetMembers", "channelID", 100, 100).Return(&model.ChannelMembers{
+		model.ChannelMember{
+			ChannelId: "1",
+		}}, nil)
+	mockStore.On("Channel").Return(&mockChannelStore)
+
+	th.App.ClearChannelMembersCache("channelID")
+}
+
 func TestSidebarCategory(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/app/team.go
+++ b/app/team.go
@@ -1643,7 +1643,7 @@ func (a *App) ClearTeamMembersCache(teamID string) {
 	page := 0
 
 	for {
-		teamMembers, err := a.Srv().Store.Team().GetMembers(teamID, page, perPage, nil)
+		teamMembers, err := a.Srv().Store.Team().GetMembers(teamID, page*perPage, perPage, nil)
 		if err != nil {
 			a.Log().Warn("error clearing cache for team members", mlog.String("team_id", teamID), mlog.String("err", err.Error()))
 			break

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/store/storetest/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1135,4 +1137,25 @@ func TestInvalidateAllEmailInvites(t *testing.T) {
 
 	_, err = th.App.Srv().Store.Token().GetByToken(t3.Token)
 	require.Nil(t, err)
+}
+
+func TestClearTeamMembersCache(t *testing.T) {
+	th := SetupWithStoreMock(t)
+	defer th.TearDown()
+
+	mockStore := th.App.Srv().Store.(*mocks.Store)
+	mockTeamStore := mocks.TeamStore{}
+	tms := []*model.TeamMember{}
+	for i := 0; i < 200; i++ {
+		tms = append(tms, &model.TeamMember{
+			TeamId: "1",
+		})
+	}
+	mockTeamStore.On("GetMembers", "teamID", 0, 100, mock.Anything).Return(tms, nil)
+	mockTeamStore.On("GetMembers", "teamID", 100, 100, mock.Anything).Return([]*model.TeamMember{{
+		TeamId: "1",
+	}}, nil)
+	mockStore.On("Team").Return(&mockTeamStore)
+
+	th.App.ClearTeamMembersCache("teamID")
 }


### PR DESCRIPTION
We were just using page and incrementing by 1. This would fetch pages
one by one like (1-100, 2-102, 3-103) rather than (1-100,100-200,200-300).

We fix that to update the correct page offset.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-27187