### PR TITLE
Remove localDeleteUser in 5.26

### DIFF
--- a/api4/user_local.go
+++ b/api4/user_local.go
@@ -200,38 +200,6 @@ func localGetUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(user.ToJson()))
 }
 
-func localDeleteUser(c *Context, w http.ResponseWriter, r *http.Request) {
-	c.RequireUserId()
-	if c.Err != nil {
-		return
-	}
-
-	userId := c.Params.UserId
-
-	auditRec := c.MakeAuditRecord("localDeleteUser", audit.Fail)
-	defer c.LogAuditRec(auditRec)
-
-	user, err := c.App.GetUser(userId)
-	if err != nil {
-		c.Err = err
-		return
-	}
-	auditRec.AddMeta("user", user)
-
-	if c.Params.Permanent {
-		err = c.App.PermanentDeleteUser(user)
-	} else {
-		_, err = c.App.UpdateActive(user, false)
-	}
-	if err != nil {
-		c.Err = err
-		return
-	}
-
-	auditRec.Success()
-	ReturnStatusOK(w)
-}
-
 func localPermanentDeleteAllUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec := c.MakeAuditRecord("localPermanentDeleteAllUsers", audit.Fail)
 	defer c.LogAuditRec(auditRec)


### PR DESCRIPTION
This is a 5.28 feature and was mistakenly included in a cherry-pick PR
https://github.com/mattermost/mattermost-server/commit/88586bff05814c37b971f5058b6c3806bac957a1.

More discussion here: https://community-daily.mattermost.com/core/channels/developers-server/qpt6gcfz5pdxpf7gxwbpd9a6aw
