### PR TITLE
admin/logs: Check if the license allows the cluster mode

### DIFF
--- a/app/admin.go
+++ b/app/admin.go
@@ -22,7 +22,9 @@ import (
 
 func (s *Server) GetLogs(page, perPage int) ([]string, *model.AppError) {
 	var lines []string
-	if s.Cluster != nil && *s.Config().ClusterSettings.Enable {
+
+	license := s.License()
+	if license != nil && *license.Features.Cluster && s.Cluster != nil && *s.Config().ClusterSettings.Enable {
 		lines = append(lines, "-----------------------------------------------------------------------------------------------------------")
 		lines = append(lines, "-----------------------------------------------------------------------------------------------------------")
 		lines = append(lines, s.Cluster.GetMyClusterInfo().Hostname)


### PR DESCRIPTION
#### Summary
When accessing the logs via the System Console it prints a header with the name of the instance, if Mattermost is set to use the Cluster mode.
However, this is an E20 feature and if you enable the cluster mode either in team edition or with an E10 license this part will break and have a panic and not show the logs to the user.

This PR fixes this issue by checking if there is a valid license and if that allows the Cluster mode

Steps to test without this fix:

- Spin a mattermost with e10 or team edition and set the configuration `MM_CLUSTERSETTINGS_CLUSTERNAME=production` and `MM_CLUSTERSETTINGS_ENABLE=true`
- Open the system logs and go to the Server Logs option.
- No logs will appear and if you check the network or the console in the google dev tools you will see the request to `/api/v4/logs?page=0&logs_per_page=1000` retutns a `502 (Bad Gateway)`

To test with this fix:
- Spin a mattermost with e10 or team edition and set the configuration `MM_CLUSTERSETTINGS_CLUSTERNAME=production` and `MM_CLUSTERSETTINGS_ENABLE=true`
- Open the system logs and go to the Server Logs option.
- Logs will appear without the header

with an E20 license
- Spin a mattermost with e10 or team edition and set the configuration `MM_CLUSTERSETTINGS_CLUSTERNAME=production` and `MM_CLUSTERSETTINGS_ENABLE=true`
- Open the system logs and go to the Server Logs option.
- Logs will appear with the header which is something like
```
-----------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------------------------------------------------
HOSTNAME
-----------------------------------------------------------------------------------------------------------
-----------------------------------------------------------------------------------------------------------
```

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-27232
