### PR TITLE
[MM-27293] Remove heap pre-allocation for file uploads

### DIFF
--- a/api4/file.go
+++ b/api4/file.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"crypto/subtle"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -51,8 +50,7 @@ var MEDIA_CONTENT_TYPES = [...]string{
 	"audio/wav",
 }
 
-const maxUploadDrainBytes = (10 * 1024 * 1024) // 10Mb
-const maxMultipartFormDataBytes = 10 * 1024    // 10Kb
+const maxMultipartFormDataBytes = 10 * 1024 // 10Kb
 
 func (api *API) InitFile() {
 	api.BaseRoutes.Files.Handle("", api.ApiSessionRequired(uploadFileStream)).Methods("POST")
@@ -97,9 +95,6 @@ func multipartReader(req *http.Request, stream io.Reader) (*multipart.Reader, er
 }
 
 func uploadFileStream(c *Context, w http.ResponseWriter, r *http.Request) {
-	// Drain any remaining bytes in the request body, up to a limit
-	defer io.CopyN(ioutil.Discard, r.Body, maxUploadDrainBytes)
-
 	if !*c.App.Config().FileSettings.EnableFileAttachments {
 		c.Err = model.NewAppError("uploadFileStream",
 			"api.file.attachments.disabled.app_error",
@@ -118,6 +113,13 @@ func uploadFileStream(c *Context, w http.ResponseWriter, r *http.Request) {
 				nil, err.Error(), http.StatusBadRequest)
 			return
 		}
+	}
+
+	if r.ContentLength == 0 {
+		c.Err = model.NewAppError("uploadFileStream",
+			"api.file.upload_file.read_request.app_error",
+			nil, "Content-Length should not be 0", http.StatusBadRequest)
+		return
 	}
 
 	timestamp := time.Now()

--- a/app/file.go
+++ b/app/file.go
@@ -61,7 +61,7 @@ const (
 	ImageThumbnailRatio  = float64(ImageThumbnailHeight) / float64(ImageThumbnailWidth)
 	ImagePreviewWidth    = 1920
 
-	UploadFileInitialBufferSize = 2 * 1024 * 1024 // 2Mb
+	maxUploadInitialBufferSize = 1024 * 1024 // 1Mb
 
 	// Deprecated
 	IMAGE_THUMBNAIL_PIXEL_WIDTH  = 120
@@ -549,6 +549,12 @@ func (t *UploadFileTask) init(a *App) {
 		t.limit = t.ContentLength
 	} else {
 		t.limit = t.maxFileSize
+	}
+
+	if t.ContentLength > 0 && t.ContentLength < maxUploadInitialBufferSize {
+		t.buf.Grow(int(t.ContentLength))
+	} else {
+		t.buf.Grow(maxUploadInitialBufferSize)
 	}
 
 	t.fileinfo = model.NewInfo(filepath.Base(t.Name))


### PR DESCRIPTION
#### Summary

- Added `Content-Length` validation for file uploads.
- Removed buffer allocation before the actual uploaded data gets in.

Since the [original code](https://github.com/mattermost/mattermost-server/pull/9835) was designed to address some performance issues I've run both the provided benchmarks and a load-test to verify that the proposed changes wouldn't cause a significant regression.

#### Benchmarks 

```
name                                                          old time/op    new time/op    delta
UploadFile/random-5Mb-gif-raw-ish_DoUploadFile-8                65.5ms ± 3%    67.9ms ± 3%    +3.64%  (p=0.032 n=5+5)
UploadFile/random-5Mb-gif-raw_UploadFileX_Content-Length-8      4.30ms ± 1%    7.50ms ± 2%   +74.32%  (p=0.008 n=5+5)
UploadFile/random-5Mb-gif-raw_UploadFileX_chunked-8             6.10ms ± 2%    7.55ms ± 1%   +23.78%  (p=0.008 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFiles-8                    563ms ± 2%     573ms ± 1%    +1.88%  (p=0.032 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFileX_Content-Length-8     492ms ± 1%     504ms ± 3%    +2.44%  (p=0.032 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFileX_chunked-8            500ms ± 1%     500ms ± 0%      ~     (p=0.690 n=5+5)
UploadFile/random-2Mb-jpg-raw-ish_DoUploadFile-8                2.35ms ± 3%    2.43ms ± 3%      ~     (p=0.056 n=5+5)
UploadFile/random-2Mb-jpg-raw_UploadFileX_Content-Length-8      1.66ms ± 4%    2.38ms ± 7%   +43.65%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-raw_UploadFileX_chunked-8             1.69ms ± 5%    2.40ms ± 6%   +42.22%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFiles-8                    571ms ± 2%     566ms ± 2%      ~     (p=0.421 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFileX_Content-Length-8     561ms ± 1%     558ms ± 1%      ~     (p=0.421 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFileX_chunked-8            559ms ± 1%     559ms ± 1%      ~     (p=1.000 n=4+5)
UploadFile/zero-10Mb-raw-ish_DoUploadFile-8                     11.1ms ± 3%    11.1ms ± 3%      ~     (p=0.690 n=5+5)
UploadFile/zero-10Mb-raw_UploadFileX_Content-Length-8           7.03ms ± 1%   11.14ms ± 2%   +58.49%  (p=0.008 n=5+5)
UploadFile/zero-10Mb-raw_UploadFileX_chunked-8                  11.9ms ± 9%    11.1ms ± 2%      ~     (p=0.222 n=5+5)
UploadFile/zero-10Mb-image_UploadFiles-8                        16.8ms ± 1%    16.8ms ± 2%      ~     (p=0.841 n=5+5)
UploadFile/zero-10Mb-image_UploadFileX_Content-Length-8         7.06ms ± 2%   11.01ms ± 2%   +55.89%  (p=0.008 n=5+5)
UploadFile/zero-10Mb-image_UploadFileX_chunked-8                7.10ms ± 2%   11.06ms ± 1%   +55.75%  (p=0.008 n=5+5)

name                                                          old alloc/op   new alloc/op   delta
UploadFile/random-5Mb-gif-raw-ish_DoUploadFile-8                4.44MB ± 0%    4.44MB ± 0%      ~     (p=1.000 n=5+5)
UploadFile/random-5Mb-gif-raw_UploadFileX_Content-Length-8      5.69MB ± 0%   16.80MB ± 0%  +195.46%  (p=0.008 n=5+5)
UploadFile/random-5Mb-gif-raw_UploadFileX_chunked-8             14.7MB ± 0%    16.8MB ± 0%   +14.12%  (p=0.008 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFiles-8                   82.0MB ± 0%    82.0MB ± 0%      ~     (p=0.460 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFileX_Content-Length-8    58.1MB ± 0%    69.0MB ± 0%   +18.69%  (p=0.016 n=5+4)
UploadFile/random-5Mb-gif-image_UploadFileX_chunked-8           58.1MB ± 0%    69.0MB ± 0%   +18.69%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-raw-ish_DoUploadFile-8                1.84MB ± 0%    1.84MB ± 0%      ~     (p=0.841 n=5+5)
UploadFile/random-2Mb-jpg-raw_UploadFileX_Content-Length-8      1.74MB ± 0%    4.21MB ± 0%  +141.71%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-raw_UploadFileX_chunked-8             2.11MB ± 0%    4.21MB ± 0%   +99.42%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFiles-8                   70.5MB ± 0%    70.5MB ± 0%      ~     (p=1.000 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFileX_Content-Length-8    57.9MB ± 0%    60.3MB ± 0%    +4.17%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFileX_chunked-8           57.9MB ± 0%    60.3MB ± 0%    +4.16%  (p=0.016 n=4+5)
UploadFile/zero-10Mb-raw-ish_DoUploadFile-8                     21.3MB ± 0%    21.3MB ± 0%      ~     (p=0.548 n=5+5)
UploadFile/zero-10Mb-raw_UploadFileX_Content-Length-8           10.5MB ± 0%    33.6MB ± 0%  +219.40%  (p=0.008 n=5+5)
UploadFile/zero-10Mb-raw_UploadFileX_chunked-8                  31.5MB ± 0%    33.6MB ± 0%    +6.58%  (p=0.008 n=5+5)
UploadFile/zero-10Mb-image_UploadFiles-8                        54.8MB ± 0%    54.8MB ± 0%      ~     (p=0.690 n=5+5)
UploadFile/zero-10Mb-image_UploadFileX_Content-Length-8         10.5MB ± 0%    33.6MB ± 0%  +219.40%  (p=0.008 n=5+5)
UploadFile/zero-10Mb-image_UploadFileX_chunked-8                10.5MB ± 0%    33.6MB ± 0%  +219.41%  (p=0.008 n=5+5)

name                                                          old allocs/op  new allocs/op  delta
UploadFile/random-5Mb-gif-raw-ish_DoUploadFile-8                 1.01k ± 0%     1.01k ± 0%      ~     (all equal)
UploadFile/random-5Mb-gif-raw_UploadFileX_Content-Length-8         144 ± 0%       159 ± 0%   +10.42%  (p=0.008 n=5+5)
UploadFile/random-5Mb-gif-raw_UploadFileX_chunked-8                148 ± 0%       159 ± 0%    +7.43%  (p=0.008 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFiles-8                    3.71M ± 0%     3.71M ± 0%      ~     (p=0.984 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFileX_Content-Length-8     3.70M ± 0%     3.70M ± 0%    +0.00%  (p=0.008 n=5+5)
UploadFile/random-5Mb-gif-image_UploadFileX_chunked-8            3.70M ± 0%     3.70M ± 0%    +0.00%  (p=0.016 n=4+5)
UploadFile/random-2Mb-jpg-raw-ish_DoUploadFile-8                 8.06k ± 0%     8.06k ± 0%      ~     (all equal)
UploadFile/random-2Mb-jpg-raw_UploadFileX_Content-Length-8         143 ± 0%       155 ± 0%    +8.39%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-raw_UploadFileX_chunked-8                143 ± 0%       155 ± 0%    +8.39%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFiles-8                    3.72M ± 0%     3.72M ± 0%      ~     (p=0.976 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFileX_Content-Length-8     3.71M ± 0%     3.71M ± 0%    +0.00%  (p=0.008 n=5+5)
UploadFile/random-2Mb-jpg-image_UploadFileX_chunked-8            3.71M ± 0%     3.71M ± 0%    +0.00%  (p=0.016 n=4+5)
UploadFile/zero-10Mb-raw-ish_DoUploadFile-8                      2.72k ± 0%     2.72k ± 0%      ~     (p=0.333 n=4+5)
UploadFile/zero-10Mb-raw_UploadFileX_Content-Length-8              144 ± 0%       162 ± 0%   +12.22%  (p=0.016 n=4+5)
UploadFile/zero-10Mb-raw_UploadFileX_chunked-8                     150 ± 0%       162 ± 0%    +8.00%  (p=0.029 n=4+4)
UploadFile/zero-10Mb-image_UploadFiles-8                         2.74k ± 0%     2.74k ± 0%      ~     (p=0.333 n=5+4)
UploadFile/zero-10Mb-image_UploadFileX_Content-Length-8            144 ± 0%       162 ± 0%   +12.19%  (p=0.016 n=5+4)
UploadFile/zero-10Mb-image_UploadFileX_chunked-8                   144 ± 0%       162 ± 0%   +12.22%  (p=0.008 n=5+5)
```

This is going to be a trade-off. The internal re-slicing is clearly causing over allocations.
One possible mitigation would be to implement a custom (dynamic) buffer with a maximum capacity (set to the content-length in this case) to make sure we never allocate a larger than needed byte slice. This is not perfect either since we would still incur in several allocations.

Also, the (hopefully) short-term plan is to move away from storing files in memory unless strictly needed.
https://mattermost.atlassian.net/browse/MM-27277 is tracking that effort.

#### Load-test results

![metrics](https://user-images.githubusercontent.com/1832946/88842932-94599600-d1e0-11ea-9859-46d9092d2d18.png)

As far as the load-test results I couldn't spot any significant difference between the two runs.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-27293
