### PR TITLE
Add toolkit team as owner of plugin package

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/plugin/ @mattermost/toolkit


### PR DESCRIPTION
#### Summary

This PR sets @mattermost/toolkit as the code owner of `/plugin`. I wasn't able to verify the changes as it seams like `master` is always used as the source of information about code owners.

See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-file-location for a syntax guide.

#### Ticket Link
https://community-daily.mattermost.com/core/pl/gzmrhtowspnsxyr1ik6ur84cka
