### PR TITLE
MM-26584: Bump up Go patch version (#15156)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
 
   check-app-layers:
     docker:
-      - image: mattermost/mattermost-build-server:20200322_golang-1.14.1
+      - image: mattermost/mattermost-build-server:20200731_golang-1.14.6
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -114,7 +114,7 @@ jobs:
 
   check-store-layers:
     docker:
-      - image: mattermost/mattermost-build-server:20200322_golang-1.14.1
+      - image: mattermost/mattermost-build-server:20200731_golang-1.14.6
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -146,7 +146,7 @@ jobs:
 
   build:
     docker:
-      - image: mattermost/mattermost-build-server:20200322_golang-1.14.1
+      - image: mattermost/mattermost-build-server:20200731_golang-1.14.6
     resource_class: xlarge
     working_directory: ~/mattermost
     steps:
@@ -231,7 +231,7 @@ jobs:
               --env GOBIN=/mattermost/mattermost-server/bin \
               -v ~/mattermost:/mattermost \
               -w /mattermost/mattermost-server \
-              mattermost/mattermost-build-server:20200322_golang-1.14.1 \
+              mattermost/mattermost-build-server:20200731_golang-1.14.6 \
               bash -c 'ulimit -n 8096; make test-server BUILD_NUMBER="$CIRCLE_BRANCH-$CIRCLE_PREVIOUS_BUILD_NUM" TESTFLAGS= TESTFLAGSEE='
           no_output_timeout: 1h
       - run:
@@ -304,7 +304,7 @@ jobs:
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
               -v ~/mattermost:/mattermost \
               -w /mattermost/mattermost-server \
-              mattermost/mattermost-build-server:20200322_golang-1.14.1 \
+              mattermost/mattermost-build-server:20200731_golang-1.14.6 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="postgres://mmuser:mostest@postgres:5432/latest?sslmode=disable&connect_timeout=10" ARGS="version" run-cli'
             echo "Generating dump"
             docker-compose --no-ansi exec -T postgres pg_dump --schema-only -d migrated -U mmuser > migrated.sql
@@ -340,7 +340,7 @@ jobs:
               --env MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://elasticsearch:9200 \
               -v ~/mattermost:/mattermost \
               -w /mattermost/mattermost-server \
-              mattermost/mattermost-build-server:20200322_golang-1.14.1 \
+              mattermost/mattermost-build-server:20200731_golang-1.14.6 \
               bash -c 'ulimit -n 8096; make ARGS="version" run-cli && make MM_SQLSETTINGS_DATASOURCE="mmuser:mostest@tcp(mysql:3306)/latest?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s" ARGS="version" run-cli'
 
             echo "Ignoring known MySQL mismatch: ChannelMembers.SchemeGuest"

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -1,3 +1,3 @@
-FROM golang:1.14.1
+FROM golang:1.14.6
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq

--- a/build/Jenkinsfile.branch
+++ b/build/Jenkinsfile.branch
@@ -9,7 +9,7 @@ def platformStages = new org.mattermost.PlatformStages()
 
 def rndEE = UUID.randomUUID().toString()
 def rndTE = UUID.randomUUID().toString()
-def mmBuilderServer = 'mattermost/mattermost-build-server:20200322_golang-1.14.1'
+def mmBuilderServer = 'mattermost/mattermost-build-server:20200731_golang-1.14.6'
 def mmBuilderWebapp = 'mattermost/mattermost-build-webapp:oct-2-2018'
 
 pipeline {

--- a/build/Jenkinsfile.pr
+++ b/build/Jenkinsfile.pr
@@ -78,7 +78,7 @@ pipeline {
 			}
 
 			steps {
-				withDockerContainer(args: '-u root --privileged -v ${WORKSPACE}/src:/go/src/', image: 'mattermost/mattermost-build-server:20200322_golang-1.14.1') {
+				withDockerContainer(args: '-u root --privileged -v ${WORKSPACE}/src:/go/src/', image: 'mattermost/mattermost-build-server:20200731_golang-1.14.6') {
 					ansiColor('xterm') {
 						sh """
 							cd /go/src/github.com/mattermost/mattermost-server
@@ -98,7 +98,7 @@ pipeline {
 			}
 
 			steps {
-				withDockerContainer(args: '-u root --privileged -v ${WORKSPACE}/src:/go/src/', image: 'mattermost/mattermost-build-server:20200322_golang-1.14.1') {
+				withDockerContainer(args: '-u root --privileged -v ${WORKSPACE}/src:/go/src/', image: 'mattermost/mattermost-build-server:20200731_golang-1.14.6') {
 					ansiColor('xterm') {
 						sh """
 							cd /go/src/github.com/mattermost/mattermost-server
@@ -286,7 +286,7 @@ pipeline {
 							}
 						}
 
-						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src:/go/src/", image: 'mattermost/mattermost-build-server:20200322_golang-1.14.1') {
+						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src:/go/src/", image: 'mattermost/mattermost-build-server:20200731_golang-1.14.6') {
 							ansiColor('xterm') {
 								sh """
 									cd /go/src/github.com/mattermost/mattermost-server
@@ -333,7 +333,7 @@ pipeline {
 							}
 						}
 
-						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src:/go/src/", image: 'mattermost/mattermost-build-server:20200322_golang-1.14.1') {
+						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src:/go/src/", image: 'mattermost/mattermost-build-server:20200731_golang-1.14.6') {
 							ansiColor('xterm') {
 								sh """
 									cd /go/src/github.com/mattermost/mattermost-server
@@ -404,7 +404,7 @@ pipeline {
 							}
 						}
 
-						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src-copy:/go/src/", image: 'mattermost/mattermost-build-server:20200322_golang-1.14.1') {
+						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src-copy:/go/src/", image: 'mattermost/mattermost-build-server:20200731_golang-1.14.6') {
 							ansiColor('xterm') {
 								sh """
 									cd /go/src/github.com/mattermost/mattermost-server
@@ -448,7 +448,7 @@ pipeline {
 							}
 						}
 
-						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src-copy:/go/src/", image: 'mattermost/mattermost-build-server:20200322_golang-1.14.1') {
+						withDockerContainer(args: "-u root --privileged --net ${COMPOSE_PROJECT_NAME}_mm-test -v ${WORKSPACE}/src-copy:/go/src/", image: 'mattermost/mattermost-build-server:20200731_golang-1.14.6') {
 							ansiColor('xterm') {
 								sh """
 									cd /go/src/github.com/mattermost/mattermost-server

--- a/build/README.md
+++ b/build/README.md
@@ -18,3 +18,4 @@ In our Docker Hub Repository we have the following images:
 - `mattermost/mattermost-build-server:feb-28-2019` which is based on Go 1.12 you can use for MM versions >= `5.9.0` <= `5.15.0`
 - `mattermost/mattermost-build-server:sep-17-2019` which is based on Go 1.12.9 you can use for MM versions >= `5.16.0`
 - `mattermost/mattermost-build-server:20200322_golang-1.14.1` which is based on Go 1.14.1 you can use for MM versions >= `5.24.0`
+- `mattermost/mattermost-build-server:20200731_golang-1.14.6` which is based on Go 1.14.6 you can use for MM versions >= `5.26.0`

--- a/build/local-test-env.sh
+++ b/build/local-test-env.sh
@@ -43,7 +43,7 @@ up()
         -e MM_EMAILSETTINGS_SMTPSERVER="inbucket" \
         -e MM_EMAILSETTINGS_SMTPPORT="10025" \
         -e MM_ELASTICSEARCHSETTINGS_CONNECTIONURL="http://elasticsearch:9200" \
-        mattermost/mattermost-build-server:20200322_golang-1.14.1 /bin/bash
+        mattermost/mattermost-build-server:20200731_golang-1.14.6 /bin/bash
 }
 
 down()


### PR DESCRIPTION
* MM-26584: Bump up Go patch version

This contains a patch fix for https://github.com/golang/go/issues/38023
which have been encountered in our load tests and some users.

I have verified on such a stuck instance and the thread dump seem to match
with what is seen on the issue. All threads stuck on runtime.futex, except one,
which is at runtime.osyield.

And of all the times load tests were run which _did not_ show this issue,
it was run with a version greater than 1.14.1, which further points to the
theory that this bug is the culprit.

* Replace docker image versions.

* Update build/README.md

Co-authored-by: Elisabeth Kulzer <elikul@elikul.de>
Co-authored-by: Mattermod <mattermod@users.noreply.github.com>