### PR TITLE
api4/bot: fix permission check in convert handler

### DIFF
--- a/api4/bot.go
+++ b/api4/bot.go
@@ -406,7 +406,7 @@ func convertBotToUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("userPatch", userPatch)
 	auditRec.AddMeta("set_system_admin", systemAdmin)
 
-	if c.Params.UserId != c.App.Session().UserId && !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
 		return
 	}


### PR DESCRIPTION

#### Summary
This PR fixes a permission check error for `convertBotToUser`. Only system administrators can perform this action.
