### PR TITLE
[MM-27377] api4/team_local: add updateChannelPrivacy and restoreTeam to local mode

### DIFF
--- a/api4/team_local.go
+++ b/api4/team_local.go
@@ -22,6 +22,7 @@ func (api *API) InitTeamLocal() {
 	api.BaseRoutes.Team.Handle("/invite/email", api.ApiLocal(localInviteUsersToTeam)).Methods("POST")
 	api.BaseRoutes.Team.Handle("/patch", api.ApiLocal(patchTeam)).Methods("PUT")
 	api.BaseRoutes.Team.Handle("/privacy", api.ApiLocal(updateTeamPrivacy)).Methods("PUT")
+	api.BaseRoutes.Team.Handle("/restore", api.ApiLocal(restoreTeam)).Methods("POST")
 
 	api.BaseRoutes.TeamByName.Handle("", api.ApiLocal(getTeamByName)).Methods("GET")
 	api.BaseRoutes.TeamMembers.Handle("", api.ApiLocal(addTeamMember)).Methods("POST")

--- a/api4/team_local.go
+++ b/api4/team_local.go
@@ -21,6 +21,7 @@ func (api *API) InitTeamLocal() {
 	api.BaseRoutes.Team.Handle("", api.ApiLocal(localDeleteTeam)).Methods("DELETE")
 	api.BaseRoutes.Team.Handle("/invite/email", api.ApiLocal(localInviteUsersToTeam)).Methods("POST")
 	api.BaseRoutes.Team.Handle("/patch", api.ApiLocal(patchTeam)).Methods("PUT")
+	api.BaseRoutes.Team.Handle("/privacy", api.ApiLocal(updateTeamPrivacy)).Methods("PUT")
 
 	api.BaseRoutes.TeamByName.Handle("", api.ApiLocal(getTeamByName)).Methods("GET")
 	api.BaseRoutes.TeamMembers.Handle("", api.ApiLocal(addTeamMember)).Methods("POST")

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -507,29 +507,29 @@ func TestRestoreTeam(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
-	t.Run("restore archived public team", func(t *testing.T) {
+	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
 		team := createTeam(t, true, model.TEAM_OPEN)
-		team, resp := Client.RestoreTeam(team.Id)
+		team, resp := client.RestoreTeam(team.Id)
 		CheckOKStatus(t, resp)
 		require.Zero(t, team.DeleteAt)
 		require.Equal(t, model.TEAM_OPEN, team.Type)
-	})
+	}, "restore archived public team")
 
-	t.Run("restore archived private team", func(t *testing.T) {
+	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
 		team := createTeam(t, true, model.TEAM_INVITE)
-		team, resp := Client.RestoreTeam(team.Id)
+		team, resp := client.RestoreTeam(team.Id)
 		CheckOKStatus(t, resp)
 		require.Zero(t, team.DeleteAt)
 		require.Equal(t, model.TEAM_INVITE, team.Type)
-	})
+	}, "restore archived private team")
 
-	t.Run("restore active public team", func(t *testing.T) {
+	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
 		team := createTeam(t, false, model.TEAM_OPEN)
-		team, resp := Client.RestoreTeam(team.Id)
+		team, resp := client.RestoreTeam(team.Id)
 		CheckOKStatus(t, resp)
 		require.Zero(t, team.DeleteAt)
 		require.Equal(t, model.TEAM_OPEN, team.Type)
-	})
+	}, "restore active public team")
 
 	t.Run("not logged in", func(t *testing.T) {
 		Client.Logout()
@@ -541,6 +541,11 @@ func TestRestoreTeam(t *testing.T) {
 		th.LoginBasic2()
 		_, resp := Client.RestoreTeam(teamPublic.Id)
 		CheckForbiddenStatus(t, resp)
+	})
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
+		_, resp := client.RestoreTeam(teamPublic.Id)
+		CheckOKStatus(t, resp)
 	})
 }
 

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -651,6 +651,11 @@ func TestUpdateTeamPrivacy(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
+		_, resp := client.UpdateTeamPrivacy(model.NewId(), model.TEAM_INVITE)
+		CheckNotFoundStatus(t, resp)
+	}, "non-existent team for admins")
+
 	t.Run("not logged in", func(t *testing.T) {
 		Client.Logout()
 		_, resp := Client.UpdateTeamPrivacy(teamPublic.Id, model.TEAM_INVITE)


### PR DESCRIPTION
#### Summary
This PR adds `updateChannelPrivacy` and `restoreTeam` endpoints to local router.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27377
https://mattermost.atlassian.net/browse/MM-27378