### PR TITLE
MM-27572 permissions regression

### DIFF
--- a/app/authorization.go
+++ b/app/authorization.go
@@ -147,7 +147,7 @@ func (a *App) HasPermissionToTeam(askingUserId string, teamId string, permission
 		return false
 	}
 	teamMember, _ := a.GetTeamMember(teamId, askingUserId)
-	if teamMember != nil && teamMember.DeleteAt == 0 {
+	if teamMember != nil {
 		if a.RolesGrantPermission(teamMember.GetRoles(), permission.Id) {
 			return true
 		}

--- a/app/authorization.go
+++ b/app/authorization.go
@@ -148,7 +148,9 @@ func (a *App) HasPermissionToTeam(askingUserId string, teamId string, permission
 	}
 	teamMember, _ := a.GetTeamMember(teamId, askingUserId)
 	if teamMember != nil && teamMember.DeleteAt == 0 {
-		return a.RolesGrantPermission(teamMember.GetRoles(), permission.Id)
+		if a.RolesGrantPermission(teamMember.GetRoles(), permission.Id) {
+			return true
+		}
 	}
 	return a.HasPermissionTo(askingUserId, permission)
 }

--- a/app/authorization.go
+++ b/app/authorization.go
@@ -147,7 +147,7 @@ func (a *App) HasPermissionToTeam(askingUserId string, teamId string, permission
 		return false
 	}
 	teamMember, _ := a.GetTeamMember(teamId, askingUserId)
-	if teamMember != nil {
+	if teamMember != nil && teamMember.DeleteAt == 0 {
 		if a.RolesGrantPermission(teamMember.GetRoles(), permission.Id) {
 			return true
 		}

--- a/app/authorization_test.go
+++ b/app/authorization_test.go
@@ -48,15 +48,14 @@ func TestHasPermissionToTeam(t *testing.T) {
 	defer th.TearDown()
 
 	assert.True(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
-
 	th.RemoveUserFromTeam(th.BasicUser, th.BasicTeam)
+	assert.False(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
 
-	// This should be true because system admins have all permissions
-	assert.True(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
-
+	assert.True(t, th.App.HasPermissionToTeam(th.SystemAdminUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
 	th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
 	assert.True(t, th.App.HasPermissionToTeam(th.SystemAdminUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
+	th.RemovePermissionFromRole(model.PERMISSION_LIST_TEAM_CHANNELS.Id, model.TEAM_USER_ROLE_ID)
+	assert.True(t, th.App.HasPermissionToTeam(th.SystemAdminUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
 	th.RemoveUserFromTeam(th.SystemAdminUser, th.BasicTeam)
-	// This used to fail before MM-26015
 	assert.True(t, th.App.HasPermissionToTeam(th.SystemAdminUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
 }

--- a/app/authorization_test.go
+++ b/app/authorization_test.go
@@ -51,7 +51,8 @@ func TestHasPermissionToTeam(t *testing.T) {
 
 	th.RemoveUserFromTeam(th.BasicUser, th.BasicTeam)
 
-	assert.False(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
+	// This should be true because system admins have all permissions
+	assert.True(t, th.App.HasPermissionToTeam(th.BasicUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))
 
 	th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)
 	assert.True(t, th.App.HasPermissionToTeam(th.SystemAdminUser.Id, th.BasicTeam.Id, model.PERMISSION_LIST_TEAM_CHANNELS))


### PR DESCRIPTION
#### Summary
Fixes a regression caused by https://github.com/mattermost/mattermost-server/pull/14961
Permissions where not cascading properly to check for system admin level permissions if the system admin was a member of the team. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27572
