### PR TITLE
MM-27508 - Fix slash commands

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	CURRENT_SCHEMA_VERSION   = VERSION_5_26_0
+	VERSION_5_28_0           = "5.28.0"
 	VERSION_5_27_0           = "5.27.0"
 	VERSION_5_26_0           = "5.26.0"
 	VERSION_5_25_0           = "5.25.0"
@@ -185,6 +186,7 @@ func upgradeDatabase(sqlStore SqlStore, currentModelVersionString string) error 
 	upgradeDatabaseToVersion525(sqlStore)
 	upgradeDatabaseToVersion526(sqlStore)
 	upgradeDatabaseToVersion527(sqlStore)
+	upgradeDatabaseToVersion528(sqlStore)
 
 	return nil
 }
@@ -828,8 +830,17 @@ func upgradeDatabaseToVersion526(sqlStore SqlStore) {
 func upgradeDatabaseToVersion527(sqlStore SqlStore) {
 	// TODO: uncomment when the time arrive to upgrade the DB for 5.27
 	// if shouldPerformUpgrade(sqlStore, VERSION_5_26_0, VERSION_5_27_0) {
-	sqlStore.CreateColumnIfNotExistsNoDefault("Commands", "PluginId", "VARCHAR(190)", "VARCHAR(190)")
 
 	// 	saveSchemaVersion(sqlStore, VERSION_5_27_0)
 	// }
+}
+
+func upgradeDatabaseToVersion528(sqlStore SqlStore) {
+	// TODO: uncomment when the time arrive to upgrade the DB for 5.28
+	//if shouldPerformUpgrade(sqlStore, VERSION_5_27_0, VERSION_5_28_0) {
+	sqlStore.CreateColumnIfNotExistsNoDefault("Commands", "PluginId", "VARCHAR(190)", "VARCHAR(190)")
+	sqlStore.GetMaster().Exec("UPDATE Commands SET PluginId = '' WHERE PluginId IS NULL")
+
+	// saveSchemaVersion(sqlStore, VERSION_5_28_0)
+	//}
 }


### PR DESCRIPTION
#### Summary
- slash commands will fail if `PluginId` is null in the database. So set all `PluginId`s to a blank string.
- move the new `PluginId` field to the 5.28 migration (which is when it will appear)

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-27508