### PR TITLE
cmd/version: skip server start to get the current mattermost version

### DIFF
--- a/cmd/mattermost/commands/version.go
+++ b/cmd/mattermost/commands/version.go
@@ -16,10 +16,18 @@ var VersionCmd = &cobra.Command{
 }
 
 func init() {
+	VersionCmd.Flags().Bool("skip-server-start", false, "Skip the server initialization and return the Mattermost version without the DB version.")
+
 	RootCmd.AddCommand(VersionCmd)
 }
 
 func versionCmdF(command *cobra.Command, args []string) error {
+	skipStart, _ := command.Flags().GetBool("skip-server-start")
+	if skipStart {
+		printVersionNoDB()
+		return nil
+	}
+
 	a, err := InitDBCommandContextCobra(command)
 	if err != nil {
 		return err
@@ -31,10 +39,14 @@ func versionCmdF(command *cobra.Command, args []string) error {
 }
 
 func printVersion(a *app.App) {
+	printVersionNoDB()
+	CommandPrintln("DB Version: " + a.Srv().Store.GetCurrentSchemaVersion())
+}
+
+func printVersionNoDB() {
 	CommandPrintln("Version: " + model.CurrentVersion)
 	CommandPrintln("Build Number: " + model.BuildNumber)
 	CommandPrintln("Build Date: " + model.BuildDate)
 	CommandPrintln("Build Hash: " + model.BuildHash)
 	CommandPrintln("Build Enterprise Ready: " + model.BuildEnterpriseReady)
-	CommandPrintln("DB Version: " + a.Srv().Store.GetCurrentSchemaVersion())
 }


### PR DESCRIPTION
#### Summary
Sometimes we need to know the version of the Mattermost but don't have/want to have it connected to a DB.
In the mattermost cloud context, we need to know which version is the docker image refers to, because we can use tags that do not have the version information in the tag like `mattermost/mattermost-team-edition:5.25.0` which is a 5.25.0 version, we can have something like: `mattermost/mattermost-team-edition:a8445a0` which we don't know which version it is.

In the mattermost-operator we need to know which version that image belongs to so we can enable/disable features that we need to set in the env vars.

this is a proposal to make the operation life a bit better and it is related to https://github.com/mattermost/mattermost-operator/pull/171 and not rely only in the image tag and become a bit more confident in which version the image is.


#### Ticket Link
related to jira: https://mattermost.atlassian.net/browse/MM-27649
