### PR TITLE
MM-27512: Use an authenticated user to bump up request rate limit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,10 @@ prepackaged-plugins: ## Populate the prepackaged-plugins directory
 	done
 
 prepackaged-binaries: ## Populate the prepackaged-binaries to the bin directory
+ifeq ($(MMCTL_REL_TO_DOWNLOAD),)
+	@echo "An error has occured trying to get the latest mmctl release. Aborting. Perhaps api.github.com is down?"
+	@exit 1
+endif
 # Externally built binaries
 ifeq ($(shell test -f bin/mmctl && printf "yes"),yes)
 	@echo mmctl installed

--- a/build/release.mk
+++ b/build/release.mk
@@ -66,7 +66,10 @@ build-client:
 
 package:
 	@ echo Packaging mattermost
-
+ifeq ($(MMCTL_REL_TO_DOWNLOAD),)
+	@echo "An error has occured trying to get the latest mmctl release. Aborting. Perhaps api.github.com is down?"
+	@exit 1
+endif
 	@# Remove any old files
 	rm -Rf $(DIST_ROOT)
 

--- a/scripts/get_latest_release.sh
+++ b/scripts/get_latest_release.sh
@@ -29,7 +29,7 @@ THIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ $(echo "$THIS_BRANCH" | grep -c ^"$BRANCH_TO_USE") == 1 ]];
 then
     VERSION_REL=${THIS_BRANCH//$BRANCH_TO_USE/v}
-    REL_TO_USE=$(curl --silent --user $BASIC_AUTH "https://api.github.com/repos/$REPO_TO_USE/releases" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed -n "/$VERSION_REL/p" | sort -rV | head -n 1)
+    REL_TO_USE=$(curl --silent $BASIC_AUTH "https://api.github.com/repos/$REPO_TO_USE/releases" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed -n "/$VERSION_REL/p" | sort -rV | head -n 1)
 else
     REL_TO_USE=$LATEST_REL
 fi

--- a/scripts/get_latest_release.sh
+++ b/scripts/get_latest_release.sh
@@ -7,7 +7,21 @@
 REPO_TO_USE=$1
 BRANCH_TO_USE=$2
 
-LATEST_REL=$(curl --silent "https://api.github.com/repos/$REPO_TO_USE/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+BASIC_AUTH=""
+
+# If we find a github username and token, we use that.
+# In CI, these variables are available and useful to avoid rate limits which is
+# much more strict for unauthenticated requests.
+if [[ $GITHUB_USERNAME != "" && $GITHUB_TOKEN != "" ]];
+then
+	BASIC_AUTH="--user $GITHUB_USERNAME:$GITHUB_TOKEN"
+fi
+
+LATEST_REL=$(curl \
+	--silent \
+	$BASIC_AUTH \
+	"https://api.github.com/repos/$REPO_TO_USE/releases/latest" \
+	| grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # Check if this is a release branch
 THIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -15,9 +29,9 @@ THIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ $(echo "$THIS_BRANCH" | grep -c ^"$BRANCH_TO_USE") == 1 ]];
 then
     VERSION_REL=${THIS_BRANCH//$BRANCH_TO_USE/v}
-    REL_TO_USE=$(curl --silent "https://api.github.com/repos/$REPO_TO_USE/releases" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed -n "/$VERSION_REL/p" | sort -rV | head -n 1)
+    REL_TO_USE=$(curl --silent --user $BASIC_AUTH "https://api.github.com/repos/$REPO_TO_USE/releases" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | sed -n "/$VERSION_REL/p" | sort -rV | head -n 1)
 else
-    REL_TO_USE=$(echo "$THIS_BRANCH" | sed "s/\(.*\)/$LATEST_REL/")
+    REL_TO_USE=$LATEST_REL
 fi
 
 echo "$REL_TO_USE"


### PR DESCRIPTION
An unauthenticated user can only make 60 requests per hour which means 1
request every minute. This can lead to frequent rate limit errors while
getting the latest release.

We change that to use an authenticated user which is already available
in the CI. This moves us to make 5000 requests per hour.

We also add additional logging in the Makefile targets in case
the command fails again so that it's clear what has happened, and not return
cryptic 404 errors again.

Ideally, we should be able to inspect the output of the curl command, but since
the output value of the entire bash script is fed into the variable, it is a bit
difficult to print debug output.

If this still gives error, then we need to either use a cached artifact somehow
or add additional logging and add a retry logic on top of it.

https://mattermost.atlassian.net/browse/MM-27512