### PR TITLE
[MM-27836] Fix possible panic when patching config

### DIFF
--- a/api4/config.go
+++ b/api4/config.go
@@ -79,7 +79,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	appCfg := c.App.Config()
-	if *appCfg.ServiceSettings.SiteURL != "" && *cfg.ServiceSettings.SiteURL == "" {
+	if *appCfg.ServiceSettings.SiteURL != "" && (cfg.ServiceSettings.SiteURL == nil || *cfg.ServiceSettings.SiteURL == "") {
 		c.Err = model.NewAppError("updateConfig", "api.config.update_config.clear_siteurl.app_error", nil, "", http.StatusBadRequest)
 		return
 	}
@@ -179,7 +179,7 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	appCfg := c.App.Config()
-	if *appCfg.ServiceSettings.SiteURL != "" && *cfg.ServiceSettings.SiteURL == "" {
+	if *appCfg.ServiceSettings.SiteURL != "" && (cfg.ServiceSettings.SiteURL == nil || *cfg.ServiceSettings.SiteURL == "") {
 		c.Err = model.NewAppError("patchConfig", "api.config.update_config.clear_siteurl.app_error", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/api4/config.go
+++ b/api4/config.go
@@ -79,7 +79,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	appCfg := c.App.Config()
-	if *appCfg.ServiceSettings.SiteURL != "" && (cfg.ServiceSettings.SiteURL == nil || *cfg.ServiceSettings.SiteURL == "") {
+	if *appCfg.ServiceSettings.SiteURL != "" && *cfg.ServiceSettings.SiteURL == "" {
 		c.Err = model.NewAppError("updateConfig", "api.config.update_config.clear_siteurl.app_error", nil, "", http.StatusBadRequest)
 		return
 	}

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -175,13 +175,6 @@ func TestUpdateConfig(t *testing.T) {
 		cfg, resp = th.SystemAdminClient.GetConfig()
 		CheckNoError(t, resp)
 		require.Equal(t, nonEmptyURL, *cfg.ServiceSettings.SiteURL)
-
-		// Check that sending a nil SiteURL returns an error.
-		cfg.ServiceSettings.SiteURL = nil
-		_, resp = th.SystemAdminClient.PatchConfig(cfg)
-		require.NotNil(t, resp.Error)
-		CheckBadRequestStatus(t, resp)
-		assert.Equal(t, "api.config.update_config.clear_siteurl.app_error", resp.Error.Id)
 	})
 }
 

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -175,6 +175,13 @@ func TestUpdateConfig(t *testing.T) {
 		cfg, resp = th.SystemAdminClient.GetConfig()
 		CheckNoError(t, resp)
 		require.Equal(t, nonEmptyURL, *cfg.ServiceSettings.SiteURL)
+
+		// Check that sending a nil SiteURL returns an error.
+		cfg.ServiceSettings.SiteURL = nil
+		_, resp = th.SystemAdminClient.PatchConfig(cfg)
+		require.NotNil(t, resp.Error)
+		CheckBadRequestStatus(t, resp)
+		assert.Equal(t, "api.config.update_config.clear_siteurl.app_error", resp.Error.Id)
 	})
 }
 
@@ -549,5 +556,11 @@ func TestPatchConfig(t *testing.T) {
 		cfg, resp = th.SystemAdminClient.GetConfig()
 		CheckNoError(t, resp)
 		require.Equal(t, nonEmptyURL, *cfg.ServiceSettings.SiteURL)
+
+		// Check that sending an empty config returns an error.
+		_, resp = th.SystemAdminClient.PatchConfig(&model.Config{})
+		require.NotNil(t, resp.Error)
+		CheckBadRequestStatus(t, resp)
+		assert.Equal(t, "api.config.update_config.clear_siteurl.app_error", resp.Error.Id)
 	})
 }


### PR DESCRIPTION
#### Summary

PR fixes two instances where sending an `nil` `SiteURL` could cause a panic when patching the config.

#### Ticket

https://mattermost.atlassian.net/browse/MM-27836