### PR TITLE
MM-27887: set traceback to crash from code

### DIFF
--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/mattermost/mattermost-server/v5/api4"
@@ -54,6 +55,11 @@ func serverCmdF(command *cobra.Command, args []string) error {
 }
 
 func runServer(configStore config.Store, disableConfigWatch bool, usedPlatform bool, interruptChan chan os.Signal) error {
+	// Setting the highest traceback level from the code.
+	// This is done to print goroutines from all threads (see golang.org/issue/13161)
+	// and also preserve a crash dump for later investigation.
+	debug.SetTraceback("crash")
+
 	options := []app.Option{
 		app.ConfigStore(configStore),
 		app.RunJobs,


### PR DESCRIPTION
Unless we set traceback level to crash, goroutines from all threads aren't printed.
See: https://github.com/golang/go/issues/13161.

This is important because SIGQUIT traces will miss on goroutines.

https://mattermost.atlassian.net/browse/MM-27887
