### PR TITLE
Restrict the sampledata generation to not run without enough users for group channels

### DIFF
--- a/cmd/mattermost/commands/sampledata.go
+++ b/cmd/mattermost/commands/sampledata.go
@@ -240,6 +240,10 @@ func sampleDataCmdF(command *cobra.Command, args []string) error {
 		return errors.New("You can't have more channel memberships than channels per team.")
 	}
 
+	if users < 6 && groupChannels > 0 {
+		return errors.New("You can't have group channels generation with less than 6 users. Use --group-channels 0 or increase the number of users.")
+	}
+
 	var bulkFile *os.File
 	switch bulk {
 	case "":

--- a/cmd/mattermost/commands/sampledata_test.go
+++ b/cmd/mattermost/commands/sampledata_test.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,12 +15,35 @@ func TestSampledataBadParameters(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	// should fail because you need at least 1 worker
-	require.Error(t, th.RunCommand(t, "sampledata", "--workers", "0"))
+	t.Run("should fail because you need at least 1 worker", func(t *testing.T) {
+		require.Error(t, th.RunCommand(t, "sampledata", "--workers", "0"))
+	})
 
-	// should fail because you have more team memberships than teams
-	require.Error(t, th.RunCommand(t, "sampledata", "--teams", "10", "--teams-memberships", "11"))
+	t.Run("should fail because you have more team memberships than teams", func(t *testing.T) {
+		require.Error(t, th.RunCommand(t, "sampledata", "--teams", "10", "--teams-memberships", "11"))
+	})
 
-	// should fail because you have more channel memberships than channels per team
-	require.Error(t, th.RunCommand(t, "sampledata", "--channels-per-team", "10", "--channel-memberships", "11"))
+	t.Run("should fail because you have more channel memberships than channels per team", func(t *testing.T) {
+		require.Error(t, th.RunCommand(t, "sampledata", "--channels-per-team", "10", "--channel-memberships", "11"))
+	})
+
+	t.Run("should fail because you have group channels and don't have enough users (6 users)", func(t *testing.T) {
+		require.Error(t, th.RunCommand(t, "sampledata", "--group-channels", "1", "--users", "5"))
+	})
+
+	t.Run("should not fail with less than 6 users and no group channels", func(t *testing.T) {
+		f, err := ioutil.TempFile("", "*")
+		require.Nil(t, err)
+		f.Close()
+		defer os.Remove(f.Name())
+		require.NoError(t, th.RunCommand(t, "sampledata", "--group-channels", "0", "--users", "5", "--bulk", f.Name()))
+	})
+
+	t.Run("should not fail with less than 6 users and no group channels", func(t *testing.T) {
+		f, err := ioutil.TempFile("", "*")
+		require.Nil(t, err)
+		f.Close()
+		defer os.Remove(f.Name())
+		require.NoError(t, th.RunCommand(t, "sampledata", "--group-channels", "0", "--users", "5", "--bulk", f.Name()))
+	})
 }


### PR DESCRIPTION
#### Summary
Restrict the sampledata generation to not run without enough users for group channels

#### Ticket Link
[MM-27886](https://mattermost.atlassian.net/browse/MM-27886)