### PR TITLE
image: bump default MM package to use release 5.26.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.12
 ENV PATH="/mattermost/bin:${PATH}"
 ARG PUID=2000
 ARG PGID=2000
-ARG MM_PACKAGE="https://releases.mattermost.com/5.25.2/mattermost-5.25.2-linux-amd64.tar.gz?src=docker"
+ARG MM_PACKAGE="https://releases.mattermost.com/5.26.0/mattermost-5.26.0-linux-amd64.tar.gz?src=docker"
 
 
 # Install some needed packages


### PR DESCRIPTION
#### Summary
image: bump default MM package to use release 5.26.0

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
