### PR TITLE
MM-27868 cherry pick

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -82,7 +82,7 @@ func (a *App) JoinDefaultChannels(teamId string, user *model.User, shouldBeAdmin
 			case errors.As(err, &nfErr):
 				err = model.NewAppError("JoinDefaultChannels", "app.channel.get_by_name.missing.app_error", nil, nfErr.Error(), http.StatusNotFound)
 			default:
-				err = model.NewAppError("JoinDefaultChannels", "app.channel.get_by_name.existing.app_error", nil, err.Error(), http.StatusInternalServerError)
+				err = model.NewAppError("JoinDefaultChannels", "app.channel.get_by_name.existing.app_error", nil, channelErr.Error(), http.StatusInternalServerError)
 			}
 			continue
 		}


### PR DESCRIPTION
#### Summary
Server panics when user joins team and one of the default channels has been archived.

This can be triggered by archiving "Off-Topic" or any of the channels listed in `TeamSettings.ExperimentalDefaultChannels`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27868