### PR TITLE
[MM-27961] Fix panic on DB error in App.GetSidebarCategories()

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -2644,7 +2644,7 @@ func (a *App) createInitialSidebarCategories(userId, teamId string) *model.AppEr
 func (a *App) GetSidebarCategories(userId, teamId string) (*model.OrderedSidebarCategories, *model.AppError) {
 	categories, err := a.Srv().Store.Channel().GetSidebarCategories(userId, teamId)
 
-	if len(categories.Categories) == 0 && err == nil {
+	if err == nil && len(categories.Categories) == 0 {
 		// A user must always have categories, so migration must not have happened yet, and we should run it ourselves
 		nErr := a.createInitialSidebarCategories(userId, teamId)
 		if nErr != nil {


### PR DESCRIPTION
#### Summary

PR fixes a panic in `App.GetSidebarCategories()` when the underlying store method returns an error.

#### Ticket

https://mattermost.atlassian.net/browse/MM-27961