### PR TITLE
MM-23063: Fix flaky test TestTermsOfServiceStore

### DIFF
--- a/store/storetest/terms_of_service_store.go
+++ b/store/storetest/terms_of_service_store.go
@@ -13,25 +13,26 @@ import (
 )
 
 func TestTermsOfServiceStore(t *testing.T, ss store.Store) {
+	t.Run("TestSaveTermsOfService", func(t *testing.T) { testSaveTermsOfService(t, ss) })
+	t.Run("TestGetLatestTermsOfService", func(t *testing.T) { testGetLatestTermsOfService(t, ss) })
+	t.Run("TestGetTermsOfService", func(t *testing.T) { testGetTermsOfService(t, ss) })
+}
+
+func cleanUpTOS(t *testing.T, ss store.Store) {
 	supp, ok := ss.(SqlSupplier)
 	if !ok {
-		t.Fatal("store is not a SqlSupplier type underneath")
+		require.Fail(t, "store is not a SqlSupplier type underneath")
 	}
-	t.Run("TestSaveTermsOfService", func(t *testing.T) { testSaveTermsOfService(t, ss) })
-
 	// Clearing out the table before starting the test.
 	// Otherwise the row inserted by the previous Save call from testSaveTermsOfService
 	// gets picked up.
 	_, err := supp.GetMaster().Exec(`DELETE FROM TermsOfService`)
 	require.NoError(t, err)
-	t.Run("TestGetLatestTermsOfService", func(t *testing.T) { testGetLatestTermsOfService(t, ss) })
-
-	_, err = supp.GetMaster().Exec(`DELETE FROM TermsOfService`)
-	require.NoError(t, err)
-	t.Run("TestGetTermsOfService", func(t *testing.T) { testGetTermsOfService(t, ss) })
 }
 
 func testSaveTermsOfService(t *testing.T, ss store.Store) {
+	t.Cleanup(func() { cleanUpTOS(t, ss) })
+
 	u1 := model.User{}
 	u1.Username = model.NewId()
 	u1.Email = MakeEmail()
@@ -49,6 +50,8 @@ func testSaveTermsOfService(t *testing.T, ss store.Store) {
 }
 
 func testGetLatestTermsOfService(t *testing.T, ss store.Store) {
+	t.Cleanup(func() { cleanUpTOS(t, ss) })
+
 	u1 := model.User{}
 	u1.Username = model.NewId()
 	u1.Email = MakeEmail()
@@ -67,6 +70,8 @@ func testGetLatestTermsOfService(t *testing.T, ss store.Store) {
 }
 
 func testGetTermsOfService(t *testing.T, ss store.Store) {
+	t.Cleanup(func() { cleanUpTOS(t, ss) })
+
 	u1 := model.User{}
 	u1.Username = model.NewId()
 	u1.Email = MakeEmail()

--- a/store/storetest/terms_of_service_store.go
+++ b/store/storetest/terms_of_service_store.go
@@ -18,20 +18,18 @@ func TestTermsOfServiceStore(t *testing.T, ss store.Store) {
 	t.Run("TestGetTermsOfService", func(t *testing.T) { testGetTermsOfService(t, ss) })
 }
 
-func cleanUpTOS(t *testing.T, ss store.Store) {
-	supp, ok := ss.(SqlSupplier)
-	if !ok {
-		require.Fail(t, "store is not a SqlSupplier type underneath")
-	}
+func cleanUpTOS(ss store.Store) {
 	// Clearing out the table before starting the test.
 	// Otherwise the row inserted by the previous Save call from testSaveTermsOfService
 	// gets picked up.
-	_, err := supp.GetMaster().Exec(`DELETE FROM TermsOfService`)
-	require.NoError(t, err)
+	// We call DropAllTables but we actually need to delete only TermsOfService.
+	// However, there is no straightforward way to just clear that table without introducing
+	// new methods. So we use the hammer.
+	ss.DropAllTables()
 }
 
 func testSaveTermsOfService(t *testing.T, ss store.Store) {
-	t.Cleanup(func() { cleanUpTOS(t, ss) })
+	t.Cleanup(func() { cleanUpTOS(ss) })
 
 	u1 := model.User{}
 	u1.Username = model.NewId()
@@ -50,7 +48,7 @@ func testSaveTermsOfService(t *testing.T, ss store.Store) {
 }
 
 func testGetLatestTermsOfService(t *testing.T, ss store.Store) {
-	t.Cleanup(func() { cleanUpTOS(t, ss) })
+	t.Cleanup(func() { cleanUpTOS(ss) })
 
 	u1 := model.User{}
 	u1.Username = model.NewId()
@@ -70,7 +68,7 @@ func testGetLatestTermsOfService(t *testing.T, ss store.Store) {
 }
 
 func testGetTermsOfService(t *testing.T, ss store.Store) {
-	t.Cleanup(func() { cleanUpTOS(t, ss) })
+	t.Cleanup(func() { cleanUpTOS(ss) })
 
 	u1 := model.User{}
 	u1.Username = model.NewId()

--- a/store/storetest/terms_of_service_store.go
+++ b/store/storetest/terms_of_service_store.go
@@ -13,8 +13,21 @@ import (
 )
 
 func TestTermsOfServiceStore(t *testing.T, ss store.Store) {
+	supp, ok := ss.(SqlSupplier)
+	if !ok {
+		t.Fatal("store is not a SqlSupplier type underneath")
+	}
 	t.Run("TestSaveTermsOfService", func(t *testing.T) { testSaveTermsOfService(t, ss) })
+
+	// Clearing out the table before starting the test.
+	// Otherwise the row inserted by the previous Save call from testSaveTermsOfService
+	// gets picked up.
+	_, err := supp.GetMaster().Exec(`DELETE FROM TermsOfService`)
+	require.NoError(t, err)
 	t.Run("TestGetLatestTermsOfService", func(t *testing.T) { testGetLatestTermsOfService(t, ss) })
+
+	_, err = supp.GetMaster().Exec(`DELETE FROM TermsOfService`)
+	require.NoError(t, err)
 	t.Run("TestGetTermsOfService", func(t *testing.T) { testGetTermsOfService(t, ss) })
 }
 
@@ -43,7 +56,7 @@ func testGetLatestTermsOfService(t *testing.T, ss store.Store) {
 	_, appErr := ss.User().Save(&u1)
 	require.Nil(t, appErr)
 
-	termsOfService := &model.TermsOfService{Text: "terms of service", UserId: u1.Id}
+	termsOfService := &model.TermsOfService{Text: "terms of service 2", UserId: u1.Id}
 	_, err := ss.TermsOfService().Save(termsOfService)
 	require.Nil(t, err)
 


### PR DESCRIPTION
The call to testGetLatestTermsOfService would happen after testSaveTermsOfService
which would persist the data between calls. Therefore, if they were to happen under
a milisecond, there would be 2 rows with the same CreateAt timestamp and the DB
would randomly return any row.

If this were to happen, then the wrong row would not match the user id and would fail.

To fix this, we just clear the table data before proceeding with the test.

https://mattermost.atlassian.net/browse/MM-23063
