### PR TITLE
[MM-30562] Indicate deleteBy in post_deleted websocket event

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -1041,9 +1041,18 @@ func (a *App) DeletePost(postId, deleteByID string) (*model.Post, *model.AppErro
 		}
 	}
 
-	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", post.ChannelId, "", nil)
-	message.Add("post", a.PreparePostForClient(post, false, false).ToJson())
-	a.Publish(message)
+	postData := a.PreparePostForClient(post, false, false).ToJson()
+
+	userMessage := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", post.ChannelId, "", nil)
+	userMessage.Add("post", postData)
+	userMessage.GetBroadcast().ContainsSanitizedData = true
+	a.Publish(userMessage)
+
+	adminMessage := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_DELETED, "", post.ChannelId, "", nil)
+	adminMessage.Add("post", postData)
+	adminMessage.Add("delete_by", deleteByID)
+	adminMessage.GetBroadcast().ContainsSensitiveData = true
+	a.Publish(adminMessage)
 
 	a.Srv().Go(func() {
 		a.DeletePostFiles(post)


### PR DESCRIPTION
This lets the client know who deleted the post. This information is stored in the database, but cannot be retrieved from an API endpoint because the API does not return information about deleted post.

The motivation for the change is to improve bridges to other chat platforms, which want to know who performed the deletion, but I can see this being useful in general.
```release-note
In post_deleted websocket event, notify system administrators of the user initiating the deletion.
```

#### Ticket

https://mattermost.atlassian.net/browse/MM-30562