### PR TITLE
[MM-27535] Change ExperimentalCloudUserLimit config to be base 10 

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -52,7 +52,7 @@ func GenerateClientConfig(c *model.Config, diagnosticID string, license *model.L
 	props["ExperimentalEnablePostMetadata"] = "true"
 	props["ExperimentalEnableClickToReply"] = strconv.FormatBool(*c.ExperimentalSettings.EnableClickToReply)
 
-	props["ExperimentalCloudUserLimit"] = strconv.FormatInt(*c.ExperimentalSettings.CloudUserLimit, 8)
+	props["ExperimentalCloudUserLimit"] = strconv.FormatInt(*c.ExperimentalSettings.CloudUserLimit, 10)
 	if *c.ServiceSettings.ExperimentalChannelOrganization || *c.ServiceSettings.ExperimentalGroupUnreadChannels != model.GROUP_UNREAD_CHANNELS_DISABLED {
 		props["ExperimentalChannelOrganization"] = strconv.FormatBool(true)
 	} else {


### PR DESCRIPTION
#### Summary
Might have done a bad copy + paste here. This number should be base 10, not base 8. Base 8 meant that the CloudUserLimit was always higher than the backend has set.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27535
