### PR TITLE
[MM-28080] scripts/test: do not remove existing data directory

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,7 @@ PACKAGES_COMMA=$(echo $PACKAGES | tr ' ' ',')
 
 echo "Packages to test: $PACKAGES"
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
-find . -type d -name data -not -path './vendor/*' | xargs rm -rf
+find . -type d -name data -not -path './vendor/*' -not -path './data'| xargs rm -rf
 
 $GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=2000s -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,7 +14,7 @@ PACKAGES_COMMA=$(echo $PACKAGES | tr ' ' ',')
 
 echo "Packages to test: $PACKAGES"
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
-find . -type d -name data -not -path './vendor/*' -not -path './data'| xargs rm -rf
+find . -type d -name data -not -path './vendor/*' -not -path './data' | xargs rm -rf
 
 $GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=2000s -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?


### PR DESCRIPTION
#### Summary
This PR tweaks the `test.sh` file to not to remove `./data` directory before running the tests.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28080
