### PR TITLE
MM-27525: Sanitizes gifycat's and Oauth secrets.

### DIFF
--- a/config/utils.go
+++ b/config/utils.go
@@ -33,6 +33,14 @@ func desanitize(actual, target *model.Config) {
 		target.GitLabSettings.Secret = actual.GitLabSettings.Secret
 	}
 
+	if target.GoogleSettings.Secret != nil && *target.GoogleSettings.Secret == model.FAKE_SETTING {
+		target.GoogleSettings.Secret = actual.GoogleSettings.Secret
+	}
+
+	if target.Office365Settings.Secret != nil && *target.Office365Settings.Secret == model.FAKE_SETTING {
+		target.Office365Settings.Secret = actual.Office365Settings.Secret
+	}
+
 	if *target.SqlSettings.DataSource == model.FAKE_SETTING {
 		*target.SqlSettings.DataSource = *actual.SqlSettings.DataSource
 	}
@@ -56,6 +64,10 @@ func desanitize(actual, target *model.Config) {
 
 	if *target.MessageExportSettings.GlobalRelaySettings.SmtpPassword == model.FAKE_SETTING {
 		*target.MessageExportSettings.GlobalRelaySettings.SmtpPassword = *actual.MessageExportSettings.GlobalRelaySettings.SmtpPassword
+	}
+
+	if target.ServiceSettings.GfycatApiSecret != nil && *target.ServiceSettings.GfycatApiSecret == model.FAKE_SETTING {
+		*target.ServiceSettings.GfycatApiSecret = *actual.ServiceSettings.GfycatApiSecret
 	}
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -3504,6 +3504,14 @@ func (o *Config) Sanitize() {
 		*o.GitLabSettings.Secret = FAKE_SETTING
 	}
 
+	if o.GoogleSettings.Secret != nil && len(*o.GoogleSettings.Secret) > 0 {
+		*o.GoogleSettings.Secret = FAKE_SETTING
+	}
+
+	if o.Office365Settings.Secret != nil && len(*o.Office365Settings.Secret) > 0 {
+		*o.Office365Settings.Secret = FAKE_SETTING
+	}
+
 	*o.SqlSettings.DataSource = FAKE_SETTING
 	*o.SqlSettings.AtRestEncryptKey = FAKE_SETTING
 
@@ -3519,5 +3527,9 @@ func (o *Config) Sanitize() {
 
 	if o.MessageExportSettings.GlobalRelaySettings.SmtpPassword != nil && len(*o.MessageExportSettings.GlobalRelaySettings.SmtpPassword) > 0 {
 		*o.MessageExportSettings.GlobalRelaySettings.SmtpPassword = FAKE_SETTING
+	}
+
+	if o.ServiceSettings.GfycatApiSecret != nil && len(*o.ServiceSettings.GfycatApiSecret) > 0 {
+		*o.ServiceSettings.GfycatApiSecret = FAKE_SETTING
 	}
 }


### PR DESCRIPTION
#### Summary

In the future these will all be obfuscated via struct field tags, but for now here are a few missing sanitized passwords and secrets:

* gifycat API secret; and
* oauth app. secrets

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-27525