### PR TITLE
[MM-27967] api4/config_test: fix flaky test if siteurl is already set

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -117,6 +117,7 @@ func setupTestHelper(dbStore store.Store, searchEngine *searchengine.Broker, ent
 		*cfg.TeamSettings.MaxUsersPerTeam = 50
 		*cfg.RateLimitSettings.Enable = false
 		*cfg.EmailSettings.SendEmailNotifications = true
+		*cfg.ServiceSettings.SiteURL = ""
 
 		// Disable sniffing, otherwise elastic client fails to connect to docker node
 		// More details: https://github.com/olivere/elastic/wiki/Sniffing

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -4,7 +4,6 @@
 package api4
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -146,7 +145,7 @@ func TestUpdateConfig(t *testing.T) {
 		require.Equal(t, SiteName, cfg.TeamSettings.SiteName, "It should update the SiteName")
 
 		t.Run("Should set defaults for missing fields", func(t *testing.T) {
-			_, appErr := th.SystemAdminClient.DoApiPut(th.SystemAdminClient.GetConfigRoute(), fmt.Sprintf(`{"ServiceSettings":{"SiteURL":"%s"}}`, *cfg.ServiceSettings.SiteURL))
+			_, appErr := th.SystemAdminClient.DoApiPut(th.SystemAdminClient.GetConfigRoute(), `{"ServiceSettings":{"SiteURL":""}}`)
 			require.Nil(t, appErr)
 		})
 

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -145,7 +145,7 @@ func TestUpdateConfig(t *testing.T) {
 		require.Equal(t, SiteName, cfg.TeamSettings.SiteName, "It should update the SiteName")
 
 		t.Run("Should set defaults for missing fields", func(t *testing.T) {
-			_, appErr := th.SystemAdminClient.DoApiPut(th.SystemAdminClient.GetConfigRoute(), `{"ServiceSettings":{"SiteURL":""}}`)
+			_, appErr := th.SystemAdminClient.DoApiPut(th.SystemAdminClient.GetConfigRoute(), "{}")
 			require.Nil(t, appErr)
 		})
 


### PR DESCRIPTION
#### Summary
If `MM_SERVICESETTINGS_SITEURL` is set in evironment variables, the test fails on updating to the default values since the condition in `api4/config` is not satisfied. (`*old.ServiceSettings.SiteURL == "" || *new.ServiceSettings.SiteURL != ""`) . We can pass an empty string to be able to set default values in the test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27967
