### PR TITLE
MM-27953: Fix flaky test TestTeamStore//SearchPrivate

### DIFF
--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -511,7 +511,7 @@ func testTeamStoreSearchPrivate(t *testing.T, ss store.Store) {
 
 	q := model.Team{}
 	q.DisplayName = "FOOBARDISPLAYNAME"
-	q.Name = "whatever"
+	q.Name = "averylongname"
 	q.Email = MakeEmail()
 	q.Type = model.TEAM_OPEN
 	q.AllowOpenInvite = false
@@ -545,13 +545,13 @@ func testTeamStoreSearchPrivate(t *testing.T, ss store.Store) {
 		},
 		{
 			"Search FooBar by  name from text at the beginning name",
-			"what",
+			"averyl",
 			1,
 			q.Id,
 		},
 		{
 			"Search FooBar by  name from text at the end of name",
-			"ever",
+			"ongname",
 			1,
 			q.Id,
 		},


### PR DESCRIPTION
We got hit by yet another random text search issue, but this was
on the more extreme end because this was a string of length 4 and still
it collided.

I am not sure if there is a fool proof solution to this than just
going for a larger string.

https://mattermost.atlassian.net/browse/MM-27953
