### PR TITLE
[MM-28157] Fix panic in api4.searchPosts()

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -466,7 +466,11 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := model.SearchParameterFromJson(r.Body)
+	params, jsonErr := model.SearchParameterFromJson(r.Body)
+	if jsonErr != nil {
+		c.Err = model.NewAppError("searchPosts", "api.post.search_posts.invalid_body.app_error", nil, jsonErr.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if params.Terms == nil || len(*params.Terms) == 0 {
 		c.SetInvalidParam("terms")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1791,6 +1791,10 @@
     "translation": "This channel is read-only. Only members with permission can pin or unpin posts here."
   },
   {
+    "id": "api.post.search_posts.invalid_body.app_error",
+    "translation": "Unable to parse the request body."
+  },
+  {
     "id": "api.post.send_notification_and_forget.push_channel_mention",
     "translation": " notified the channel."
   },

--- a/model/post.go
+++ b/model/post.go
@@ -497,15 +497,14 @@ func (o *SearchParameter) SearchParameterToJson() string {
 	return string(b)
 }
 
-func SearchParameterFromJson(data io.Reader) *SearchParameter {
+func SearchParameterFromJson(data io.Reader) (*SearchParameter, error) {
 	decoder := json.NewDecoder(data)
 	var searchParam SearchParameter
-	err := decoder.Decode(&searchParam)
-	if err != nil {
-		return nil
+	if err := decoder.Decode(&searchParam); err != nil {
+		return nil, err
 	}
 
-	return &searchParam
+	return &searchParam, nil
 }
 
 func (o *Post) ChannelMentions() []string {

--- a/model/post_test.go
+++ b/model/post_test.go
@@ -856,3 +856,31 @@ func TestPostPatchDisableMentionHighlights(t *testing.T) {
 		assert.Nil(t, patch.Message)
 	})
 }
+
+func TestSearchParameterFromJson(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		params, err := SearchParameterFromJson(strings.NewReader(""))
+		require.Nil(t, params)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		params, err := SearchParameterFromJson(strings.NewReader("invalid"))
+		require.Nil(t, params)
+		require.Error(t, err)
+	})
+
+	t.Run("valid empty input", func(t *testing.T) {
+		params, err := SearchParameterFromJson(strings.NewReader("{}"))
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		require.Equal(t, &SearchParameter{}, params)
+	})
+
+	t.Run("valid non-empty input", func(t *testing.T) {
+		params, err := SearchParameterFromJson(strings.NewReader("{\"terms\": \"test\"}"))
+		require.NoError(t, err)
+		require.NotNil(t, params)
+		require.Equal(t, "test", *params.Terms)
+	})
+}


### PR DESCRIPTION
#### Summary

PR fixes a panic in `api4.searchPosts()` happening in case the decoding of the JSON request body failed.

#### Ticket

https://mattermost.atlassian.net/browse/MM-28157