### PR TITLE
[MM-23651] No more than 256 members are allowed to be invited 

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	MAX_ADD_MEMBERS_BATCH    = 20
+	MAX_ADD_MEMBERS_BATCH    = 256
 	MAXIMUM_BULK_IMPORT_SIZE = 10 * 1024 * 1024
 	groupIDsParamPattern     = "[^a-zA-Z0-9,]*"
 )

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2161,7 +2161,7 @@ func TestAddTeamMembers(t *testing.T) {
 	CheckNotFoundStatus(t, resp)
 
 	// Test with many users.
-	for i := 0; i < 25; i++ {
+	for i := 0; i < 260; i++ {
 		testUserList = append(testUserList, GenerateTestId())
 	}
 	_, resp = Client.AddTeamMembers(team.Id, testUserList)


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->

If more than 256 members are added to the list of invite members, then we throw an error. 
This is per comments within the Jira ticket which discussion in the comments lead to this limit being increased from the current 20 to 256.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-23651

**UNBLOCKS**
https://github.com/mattermost/mattermost-webapp/pull/6405