### PR TITLE
MM-28115: Add env var for telemetry installation type.

### DIFF
--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -29,6 +29,8 @@ const (
 	RUDDER_KEY           = "placeholder_rudder_key"
 	RUDDER_DATAPLANE_URL = "placeholder_rudder_dataplane_url"
 
+	ENV_VAR_INSTALL_TYPE = "MM_INSTALL_TYPE"
+
 	TRACK_CONFIG_SERVICE            = "config_service"
 	TRACK_CONFIG_TEAM               = "config_team"
 	TRACK_CONFIG_CLIENT_REQ         = "config_client_requirements"
@@ -848,10 +850,11 @@ func (ts *TelemetryService) trackPlugins() {
 
 func (ts *TelemetryService) trackServer() {
 	data := map[string]interface{}{
-		"edition":          model.BuildEnterpriseReady,
-		"version":          model.CurrentVersion,
-		"database_type":    *ts.srv.Config().SqlSettings.DriverName,
-		"operating_system": runtime.GOOS,
+		"edition":           model.BuildEnterpriseReady,
+		"version":           model.CurrentVersion,
+		"database_type":     *ts.srv.Config().SqlSettings.DriverName,
+		"operating_system":  runtime.GOOS,
+		"installation_type": os.Getenv(ENV_VAR_INSTALL_TYPE),
 	}
 
 	if scr, err := ts.dbStore.User().AnalyticsGetSystemAdminCount(); err == nil {

--- a/services/telemetry/telemetry_test.go
+++ b/services/telemetry/telemetry_test.go
@@ -473,4 +473,30 @@ func TestRudderTelemetry(t *testing.T) {
 			// Did not receive telemetry
 		}
 	})
+
+	t.Run("TestInstallationType", func(t *testing.T) {
+		os.Unsetenv(ENV_VAR_INSTALL_TYPE)
+		telemetryService.sendDailyTelemetry(true)
+
+		var batches []batch
+		collectBatches(&batches)
+
+		for _, b := range batches {
+			if b.Event == TRACK_SERVER {
+				assert.Equal(t, b.Properties["installation_type"], "")
+			}
+		}
+
+		os.Setenv(ENV_VAR_INSTALL_TYPE, "docker")
+		defer os.Unsetenv(ENV_VAR_INSTALL_TYPE)
+
+		batches = []batch{}
+		collectBatches(&batches)
+
+		for _, b := range batches {
+			if b.Event == TRACK_SERVER {
+				assert.Equal(t, b.Properties["installation_type"], "docker")
+			}
+		}
+	})
 }


### PR DESCRIPTION
#### Summary
Add an env var to indicate the installation type for telemetry. Various installers will set this appropriately, and the default is an empty string (i.e. en var unset).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28115
