### PR TITLE
Fix telemetry initialization problem on placeholder usage

### DIFF
--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -104,7 +104,6 @@ func New(srv ServerIface, dbStore store.Store, searchEngine *searchengine.Broker
 		log:          log,
 	}
 	service.ensureTelemetryID()
-	service.initRudder(RUDDER_DATAPLANE_URL, RUDDER_KEY)
 	return service
 }
 
@@ -129,7 +128,7 @@ func (ts *TelemetryService) ensureTelemetryID() {
 }
 
 func (ts *TelemetryService) sendDailyTelemetry(override bool) {
-	if *ts.srv.Config().LogSettings.EnableDiagnostics && ts.srv.IsLeader() && ((!strings.Contains(RUDDER_KEY, "placeholder") && !strings.Contains(RUDDER_DATAPLANE_URL, "placeholder")) || override) {
+	if *ts.srv.Config().LogSettings.EnableDiagnostics && ts.srv.IsLeader() && ((!strings.HasPrefix(RUDDER_KEY, "placeholder") && !strings.HasPrefix(RUDDER_DATAPLANE_URL, "placeholder")) || override) {
 		ts.initRudder(RUDDER_DATAPLANE_URL, RUDDER_KEY)
 		ts.trackActivity()
 		ts.trackConfig()


### PR DESCRIPTION
#### Summary
The initialization of rudder should happen only before the telemetry is sent, and have checked that the placeholders are not used.

#### Ticket Link
[MM-28529](https://mattermost.atlassian.net/browse/MM-28529)