### PR TITLE
[MM-27746] Compare our current LRU cache with Ristretto

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/cznic/strutil v0.0.0-20181122101858-275e90344537 // indirect
+	github.com/dgraph-io/ristretto v0.0.3
 	github.com/dgryski/dgoogauth v0.0.0-20190221195224-5a805980a5f3
 	github.com/disintegration/imaging v1.6.2
 	github.com/dyatlov/go-opengraph v0.0.0-20180429202543-816b6608b3c8
@@ -53,7 +54,6 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20200412013138-3577fbdbcff7
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/jmoiron/sqlx v1.2.0
-	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/lib/pq v1.7.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/mailru/easyjson v0.7.1 // indirect
@@ -84,11 +84,10 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/poy/onpar v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.7.1
-	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237 // indirect
 	github.com/rs/cors v1.7.0
 	github.com/rudderlabs/analytics-go v3.2.1+incompatible
-	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7
+	github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7 // indirect
 	github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd
 	github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 // indirect
 	github.com/sirupsen/logrus v1.6.0
@@ -104,7 +103,6 @@ require (
 	github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c // indirect
 	github.com/throttled/throttled v2.2.4+incompatible
 	github.com/tinylib/msgp v1.1.2
-	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 // indirect
 	github.com/tylerb/graceful v1.2.15
 	github.com/uber/jaeger-client-go v2.24.0+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/Masterminds/squirrel v1.4.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZl
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
+github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PaulARoy/azurestoragecache v0.0.0-20170906084534-3c249a3ba788/go.mod h1:lY1dZd8HBzJ10eqKERHn3CU59tfhzcAVb2c0ZhIWSOk=
 github.com/RoaringBitmap/roaring v0.4.21 h1:WJ/zIlNX4wQZ9x8Ey33O1UaD9TCTakYsdLFSBcTwH+8=
@@ -128,9 +129,12 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
+github.com/dgraph-io/ristretto v0.0.3 h1:jh22xisGBjrEVnRZ1DVTpBVQm0Xndu8sMl0CWDzSIBI=
+github.com/dgraph-io/ristretto v0.0.3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/dgoogauth v0.0.0-20190221195224-5a805980a5f3 h1:AqeKSZIG/NIC75MNQlPy/LM3LxfpLwahICJBHwSMFNc=
 github.com/dgryski/dgoogauth v0.0.0-20190221195224-5a805980a5f3/go.mod h1:hEfFauPHz7+NnjR/yHJGhrKo1Za+zStgwUETx3yzqgY=
+github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/die-net/lrucache v0.0.0-20181227122439-19a39ef22a11/go.mod h1:ew0MSjCVDdtGMjF3kzLK9hwdgF5mOE8SbYVF3Rc7mkU=
@@ -667,6 +671,7 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.3.1 h1:GPTpEAuNr98px18yNQ66JllNil98wfRZ/5Ukny8FeQA=
@@ -719,8 +724,6 @@ github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDW
 github.com/tinylib/msgp v1.1.2 h1:gWmO7n0Ys2RBEb7GPYB9Ujq8Mk5p2U08lRnmMcGy6BQ=
 github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 h1:OXcKh35JaYsGMRzpvFkLv/MEyPuL49CThT1pZ8aSml4=
-github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/tylerb/graceful v1.2.15 h1:B0x01Y8fsJpogzZTkDg6BDi6eMf03s01lEKGdrv83oA=
 github.com/tylerb/graceful v1.2.15/go.mod h1:LPYTbOYmUTdabwRt0TGhLllQ0MUNbs0Y5q1WXJOI9II=

--- a/services/cache/lfu.go
+++ b/services/cache/lfu.go
@@ -20,7 +20,7 @@ type LFU struct {
 	invalidateClusterEvent string
 }
 
-// LFUOptions contains options for initializing LFU cache
+// LFUOptions contains options for initializing LFU cache.
 type LFUOptions struct {
 	config                 *ristretto.Config
 	Name                   string
@@ -50,8 +50,6 @@ func NewLFU(config *ristretto.Config) Cache {
 // 	if err != nil {
 // 		panic(err)
 // 	}
-
-// 	// fmt.Println(lfu)
 
 // 	return &LFU{
 // 		cache:                  lfu,
@@ -105,7 +103,6 @@ func (l *LFU) SetWithExpiry(key string, value interface{}, ttl time.Duration) er
 // return ErrKeyNotFound if the key is missing from the cache
 func (l *LFU) Get(key string, value interface{}) error {
 	val, found := l.cache.Get(key)
-	// fmt.Println(val)
 
 	if !found {
 		return ErrKeyNotFound
@@ -123,7 +120,7 @@ func (l *LFU) Get(key string, value interface{}) error {
 // Remove deletes the value for a key.
 func (l *LFU) Remove(key string) error {
 	l.cache.Del(key)
-	// l.len--
+	l.len--
 	return nil
 }
 

--- a/services/cache/lfu.go
+++ b/services/cache/lfu.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package cache
+
+import (
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+// LFU cache implementation using the Ristretto library.
+type LFU struct {
+	cache                  *ristretto.Cache
+	name                   string
+	size                   int
+	len                    int
+	defaultExpiry          time.Duration
+	invalidateClusterEvent string
+}
+
+// LFUOptions contains options for initializing LFU cache
+type LFUOptions struct {
+	config                 *ristretto.Config
+	Name                   string
+	Size                   int
+	DefaultExpiry          time.Duration
+	InvalidateClusterEvent string
+}
+
+// NewLFU creates an LFU using the Ristretto library.
+func NewLFU(config *ristretto.Config) Cache {
+	lfu, err := ristretto.NewCache(config)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &LFU{
+		cache: lfu,
+		name:  "testLFU",
+	}
+}
+
+// NewLFU creates an LFU using the Ristretto library.
+// func NewLFU(options *LFUOptions) Cache {
+// 	lfu, err := ristretto.NewCache(options.config)
+
+// 	if err != nil {
+// 		panic(err)
+// 	}
+
+// 	// fmt.Println(lfu)
+
+// 	return &LFU{
+// 		cache:                  lfu,
+// 		name:                   options.Name,
+// 		size:                   options.Size,
+// 		defaultExpiry:          options.DefaultExpiry,
+// 		invalidateClusterEvent: options.InvalidateClusterEvent,
+// 	}
+// }
+
+// Purge is used to completely clear the cache.
+func (l *LFU) Purge() error {
+	l.cache.Clear()
+	l.len = 0
+	return nil
+}
+
+// Set adds the given key and value to the store without an expiry. If the key already exists,
+// it will overwrite the previous value.
+func (l *LFU) Set(key string, value interface{}) error {
+	buf, err := msgpack.Marshal(value)
+
+	if err != nil {
+		return err
+	}
+
+	ok := l.cache.Set(key, buf, 1)
+
+	if !ok {
+		return ErrKeyNotFound
+	}
+
+	l.len++
+
+	return nil
+}
+
+// SetWithDefaultExpiry adds the given key and value to the store with the default expiry. If
+// the key already exists, it will overwrite the previoous value
+func (l *LFU) SetWithDefaultExpiry(key string, value interface{}) error {
+	return nil
+}
+
+// SetWithExpiry adds the given key and value to the cache with the given expiry. If the key
+// already exists, it will overwrite the previoous value
+func (l *LFU) SetWithExpiry(key string, value interface{}, ttl time.Duration) error {
+	return nil
+}
+
+// Get the content stored in the cache for the given key, and decode it into the value interface.
+// return ErrKeyNotFound if the key is missing from the cache
+func (l *LFU) Get(key string, value interface{}) error {
+	val, found := l.cache.Get(key)
+	// fmt.Println(val)
+
+	if !found {
+		return ErrKeyNotFound
+	}
+
+	err := msgpack.Unmarshal(val.([]byte), value)
+
+	if err != nil {
+		panic(err)
+	}
+
+	return nil
+}
+
+// Remove deletes the value for a key.
+func (l *LFU) Remove(key string) error {
+	l.cache.Del(key)
+	// l.len--
+	return nil
+}
+
+// Keys returns a slice of the keys in the cache.
+func (l *LFU) Keys() ([]string, error) {
+	keys := []string{"hello", "world"}
+	return keys, nil
+}
+
+// Len returns the number of items in the cache.
+func (l *LFU) Len() (int, error) {
+	return l.len, nil
+}
+
+// GetInvalidateClusterEvent returns the cluster event configured when this cache was created.
+func (l *LFU) GetInvalidateClusterEvent() string {
+	return l.invalidateClusterEvent
+}
+
+// Name returns the name of the cache
+func (l *LFU) Name() string {
+	return l.name
+}

--- a/services/cache/lfu_test.go
+++ b/services/cache/lfu_test.go
@@ -4,7 +4,6 @@
 package cache
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -13,14 +12,7 @@ import (
 )
 
 func TestLFU(t *testing.T) {
-	// l := NewLFU(&LFUOptions{
-	// 	Size:                   128,
-	// 	DefaultExpiry:          0,
-	// 	InvalidateClusterEvent: "",
-	// 	// NumCounters: 1e7,     // number of keys to track frequency of (10M).
-	// 	// MaxCost:     1 << 30, // maximum cost of cache (1GB).
-	// 	// BufferItems: 64,      // number of keys per Get buffer.
-	// })
+	assert := assert.New(t)
 
 	l := NewLFU(&ristretto.Config{
 		NumCounters: 1e7,     // number of keys to track frequency of (10M).
@@ -28,11 +20,11 @@ func TestLFU(t *testing.T) {
 		BufferItems: 64,      // number of keys per Get buffer.
 	})
 
-	name := l.Name()
-	fmt.Printf("name: %s\n", name)
+	// name := l.Name()
+	// t.Logf("name: %s\n", name)
 
 	len, _ := l.Len()
-	fmt.Printf("len: %d\n", len)
+	assert.Equal(0, len, "length should be 0 after cache is initialized.")
 
 	// set a value with a cost of 1
 	// l.Set("key", "value", 1)
@@ -42,7 +34,7 @@ func TestLFU(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	len, _ = l.Len()
-	fmt.Printf("len: %d\n", len)
+	assert.Equal(1, len, "length should be 1 after item is added to the cache.")
 
 	var value string
 
@@ -50,21 +42,16 @@ func TestLFU(t *testing.T) {
 		panic("missing value")
 	}
 
-	assert := assert.New(t)
+	// t.Logf("value: %s\n", value)
 
-	fmt.Printf("value: %s\n", value)
-
-	// expected := "value"
-	// actual := string(value)
-
-	assert.Equal(value, "value", "they should be equal")
+	assert.Equal(value, "value", "they should be equal.")
 
 	// l.Remove("key")
 
-	// fmt.Println(l.Keys())
+	// t.Logf(l.Keys())
 
 	_ = l.Purge()
 
 	len, _ = l.Len()
-	fmt.Printf("len: %d\n", len)
+	assert.Equal(0, len, "length should be 0 after cache is purged.")
 }

--- a/services/cache/lfu_test.go
+++ b/services/cache/lfu_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package cache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLFU(t *testing.T) {
+	// l := NewLFU(&LFUOptions{
+	// 	Size:                   128,
+	// 	DefaultExpiry:          0,
+	// 	InvalidateClusterEvent: "",
+	// 	// NumCounters: 1e7,     // number of keys to track frequency of (10M).
+	// 	// MaxCost:     1 << 30, // maximum cost of cache (1GB).
+	// 	// BufferItems: 64,      // number of keys per Get buffer.
+	// })
+
+	l := NewLFU(&ristretto.Config{
+		NumCounters: 1e7,     // number of keys to track frequency of (10M).
+		MaxCost:     1 << 30, // maximum cost of cache (1GB).
+		BufferItems: 64,      // number of keys per Get buffer.
+	})
+
+	name := l.Name()
+	fmt.Printf("name: %s\n", name)
+
+	len, _ := l.Len()
+	fmt.Printf("len: %d\n", len)
+
+	// set a value with a cost of 1
+	// l.Set("key", "value", 1)
+	l.Set("key", "value")
+
+	// wait for value to pass through buffers
+	time.Sleep(10 * time.Millisecond)
+
+	len, _ = l.Len()
+	fmt.Printf("len: %d\n", len)
+
+	var value string
+
+	if err := l.Get("key", &value); err != nil {
+		panic("missing value")
+	}
+
+	assert := assert.New(t)
+
+	fmt.Printf("value: %s\n", value)
+
+	// expected := "value"
+	// actual := string(value)
+
+	assert.Equal(value, "value", "they should be equal")
+
+	// l.Remove("key")
+
+	// fmt.Println(l.Keys())
+
+	_ = l.Purge()
+
+	len, _ = l.Len()
+	fmt.Printf("len: %d\n", len)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,6 +79,8 @@ github.com/blevesearch/zap/v13
 github.com/blevesearch/zap/v14
 # github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 ## explicit
+# github.com/cespare/xxhash v1.1.0
+github.com/cespare/xxhash
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
@@ -99,6 +101,10 @@ github.com/couchbase/vellum/utf8
 ## explicit
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
+# github.com/dgraph-io/ristretto v0.0.3
+## explicit
+github.com/dgraph-io/ristretto
+github.com/dgraph-io/ristretto/z
 # github.com/dgryski/dgoogauth v0.0.0-20190221195224-5a805980a5f3
 ## explicit
 github.com/dgryski/dgoogauth
@@ -240,7 +246,6 @@ github.com/jaytaylor/html2text
 github.com/jmoiron/sqlx
 github.com/jmoiron/sqlx/reflectx
 # github.com/jonboulle/clockwork v0.1.0
-## explicit
 github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
@@ -394,7 +399,6 @@ github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.2.0
-## explicit
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.10.0
 github.com/prometheus/common/expfmt
@@ -471,14 +475,7 @@ github.com/throttled/throttled
 github.com/throttled/throttled/store/memstore
 # github.com/tinylib/msgp v1.1.2
 ## explicit
-github.com/tinylib/msgp
-github.com/tinylib/msgp/gen
 github.com/tinylib/msgp/msgp
-github.com/tinylib/msgp/parse
-github.com/tinylib/msgp/printer
-# github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
-## explicit
-github.com/ttacon/chalk
 # github.com/tylerb/graceful v1.2.15
 ## explicit
 github.com/tylerb/graceful


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adds an LFU cache using the Ristretto library.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/15247
JIRA: `MM-27746`
