### PR TITLE
MM-28370: Fix send on closed channel

### DIFF
--- a/app/notification_push_test.go
+++ b/app/notification_push_test.go
@@ -11,8 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mattermost/mattermost-server/v5/config"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/store/storetest/mocks"
+	"github.com/mattermost/mattermost-server/v5/testlib"
 	"github.com/mattermost/mattermost-server/v5/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1360,6 +1362,48 @@ func TestAllPushNotifications(t *testing.T) {
 	assert.Equal(t, 8, numMessages)
 	assert.Equal(t, 3, numClears)
 	assert.Equal(t, 6, numUpdateBadges)
+}
+
+func TestPushNotificationRace(t *testing.T) {
+	memoryStore, err := config.NewMemoryStoreWithOptions(&config.MemoryStoreOptions{
+		IgnoreEnvironmentOverrides: true,
+	})
+	require.NoError(t, err, "failed to initialize memory store")
+	defer memoryStore.Close()
+
+	mockStore := testlib.GetMockStoreForSetupFunctions()
+	mockPreferenceStore := mocks.PreferenceStore{}
+	mockPreferenceStore.On("Get",
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("string"),
+		mock.AnythingOfType("string")).
+		Return(&model.Preference{Value: "test"}, nil)
+	mockStore.On("Preference").Return(&mockPreferenceStore)
+	s := &Server{
+		configStore: memoryStore,
+		Store:       mockStore,
+	}
+	app := New(ServerConnector(s))
+
+	s.createPushNotificationsHub()
+
+	s.StopPushNotificationsHubWorkers()
+
+	// Now we start sending messages after the PN hub is shut down.
+	// We test all 3 notification types.
+	app.clearPushNotification("currentSessionId", "userId", "channelId")
+
+	app.UpdateMobileAppBadge("userId")
+
+	notification := &PostNotification{
+		Post:    &model.Post{},
+		Channel: &model.Channel{},
+		ProfileMap: map[string]*model.User{
+			"userId": &model.User{},
+		},
+		Sender: &model.User{},
+	}
+	app.sendPushNotification(notification, &model.User{}, true, false, model.COMMENTS_NOTIFY_ANY)
 }
 
 // Run it with | grep -v '{"level"' to prevent spamming the console.

--- a/app/server.go
+++ b/app/server.go
@@ -711,6 +711,7 @@ func (s *Server) Shutdown() error {
 	s.StopHTTPServer()
 	s.stopLocalModeServer()
 	// Push notification hub needs to be shutdown after HTTP server
+	// to prevent stray requests from generating a push notification after it's shut down.
 	s.StopPushNotificationsHubWorkers()
 
 	s.WaitForGoroutines()


### PR DESCRIPTION
We check if the push notification hub is shutting down before sending
anything to the channel.

This is accomplished by closing the stopChan instead of sending struct{}{} to it,
and doing a non-blocking read of it before sending the message to the hub.

The primary reason for this strange pattern is that the shutdown of HTTP server is
partly asynchronous, and even after the server is shutdown, there is no guarantee
that any stray goroutines are active.

Alternatively, we could choose to _not_ close the notificationsChan at all, but then
the request will just get stuck and the server has to do an unclean shutdown.

This approach doesn't look so bad.

Admittedly, this is still racy because there is no guarantee in the order of instructions
executed in the goroutine that's closing the channel and the goroutine that's sending to the channel.
But this should atleast take care of the most common case.

https://mattermost.atlassian.net/browse/MM-28370
