### PR TITLE
Restricted cloud settings

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -270,6 +270,11 @@ func getLogs(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec := c.MakeAuditRecord("getLogs", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 
+	if *c.App.Config().ExperimentalSettings.RestrictSystemAdmin {
+		c.Err = model.NewAppError("getLogs", "api.restricted_system_admin", nil, "", http.StatusForbidden)
+		return
+	}
+
 	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_READ_REPORTING) {
 		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_READ_REPORTING)
 		return

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -277,6 +277,12 @@ func TestGetLogs(t *testing.T) {
 		require.NotEmpty(t, logs, "should not be empty")
 	})
 
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ExperimentalSettings.RestrictSystemAdmin = true })
+		_, resp := th.Client.GetLogs(0, 10)
+		CheckForbiddenStatus(t, resp)
+	})
+
 	_, resp := th.Client.GetLogs(0, 10)
 	CheckForbiddenStatus(t, resp)
 

--- a/model/config.go
+++ b/model/config.go
@@ -2536,7 +2536,7 @@ type PluginState struct {
 }
 
 type PluginSettings struct {
-	Enable                      *bool                             `access:"plugins"`
+	Enable                      *bool                             `access:"plugins,write_restrictable"`
 	EnableUploads               *bool                             `access:"plugins,write_restrictable"`
 	AllowInsecureDownloadUrl    *bool                             `access:"plugins,write_restrictable"`
 	EnableHealthCheck           *bool                             `access:"plugins,write_restrictable"`
@@ -2544,11 +2544,11 @@ type PluginSettings struct {
 	ClientDirectory             *string                           `access:"plugins,write_restrictable"`
 	Plugins                     map[string]map[string]interface{} `access:"plugins"`
 	PluginStates                map[string]*PluginState           `access:"plugins"`
-	EnableMarketplace           *bool                             `access:"plugins"`
-	EnableRemoteMarketplace     *bool                             `access:"plugins"`
-	AutomaticPrepackagedPlugins *bool                             `access:"plugins"`
-	RequirePluginSignature      *bool                             `access:"plugins"`
-	MarketplaceUrl              *string                           `access:"plugins"`
+	EnableMarketplace           *bool                             `access:"plugins,write_restrictable"`
+	EnableRemoteMarketplace     *bool                             `access:"plugins,write_restrictable"`
+	AutomaticPrepackagedPlugins *bool                             `access:"plugins,write_restrictable"`
+	RequirePluginSignature      *bool                             `access:"plugins,write_restrictable"`
+	MarketplaceUrl              *string                           `access:"plugins,write_restrictable"`
 	SignaturePublicKeyFiles     []string                          `access:"plugins"`
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -2549,7 +2549,7 @@ type PluginSettings struct {
 	AutomaticPrepackagedPlugins *bool                             `access:"plugins,write_restrictable"`
 	RequirePluginSignature      *bool                             `access:"plugins,write_restrictable"`
 	MarketplaceUrl              *string                           `access:"plugins,write_restrictable"`
-	SignaturePublicKeyFiles     []string                          `access:"plugins"`
+	SignaturePublicKeyFiles     []string                          `access:"plugins,write_restrictable"`
 }
 
 func (s *PluginSettings) SetDefaults(ls LogSettings) {


### PR DESCRIPTION
#### Summary

- Added checks on `RestrictedSystemAdmin` for system logs endpoint. 
- Added `write_restrictable` tag that will guard updates for `RestrictedSystemAdmin` to plugin settings not applicable for cloud. 

#### Related PR
Webapp: https://github.com/mattermost/mattermost-webapp/pull/6481

#### Ticket Link
[MM-28834](https://mattermost.atlassian.net/browse/MM-28834)
