### PR TITLE
MM-28803 - Cloud settings defaults

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -209,6 +209,13 @@ func Setup(tb testing.TB) *TestHelper {
 	searchEngine := mainHelper.GetSearchEngine()
 	th := setupTestHelper(dbStore, searchEngine, false, true, nil)
 	th.InitLogin()
+
+	// Restoring defaults expected for tests
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ExperimentalSettings.RestrictSystemAdmin = false
+		*cfg.EmailSettings.RequireEmailVerification = false
+	})
+
 	return th
 }
 

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -197,6 +197,10 @@ func TestUpdateConfig(t *testing.T) {
 		siteURL := cfg.ServiceSettings.SiteURL
 		defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.SiteURL = siteURL })
 
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ExperimentalSettings.RestrictSystemAdmin = false
+		})
+
 		nonEmptyURL := "http://localhost"
 		cfg.ServiceSettings.SiteURL = &nonEmptyURL
 

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -116,8 +116,11 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ExperimentalSettings.RestrictSystemAdmin = false
 		*cfg.EmailSettings.RequireEmailVerification = false
+		*cfg.EmailSettings.ConnectionSecurity = ""
+
 		*cfg.ClusterSettings.UseExperimentalGossip = false
 		*cfg.ClusterSettings.UseExperimentalGossip = false
+
 	})
 
 	if enterprise {

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -112,6 +112,14 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 		*cfg.PasswordSettings.Number = false
 	})
 
+	// Restoring defaults expected for tests
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ExperimentalSettings.RestrictSystemAdmin = false
+		*cfg.EmailSettings.RequireEmailVerification = false
+		*cfg.ClusterSettings.UseExperimentalGossip = false
+		*cfg.ClusterSettings.UseExperimentalGossip = false
+	})
+
 	if enterprise {
 		th.App.Srv().SetLicense(model.NewTestLicense())
 	} else {

--- a/cmd/mattermost/commands/cmdtestlib.go
+++ b/cmd/mattermost/commands/cmdtestlib.go
@@ -53,6 +53,11 @@ func Setup(t testing.TB) *testHelper {
 
 	config := &model.Config{}
 	config.SetDefaults()
+
+	// Restoring defaults expected for tests
+	*config.ExperimentalSettings.RestrictSystemAdmin = false
+	*config.EmailSettings.RequireEmailVerification = false
+
 	testHelper.SetConfig(config)
 
 	return testHelper

--- a/model/config.go
+++ b/model/config.go
@@ -344,12 +344,7 @@ type ServiceSettings struct {
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	if s.EnableEmailInvitations == nil {
-		// If the site URL is also not present then assume this is a clean install
-		if s.SiteURL == nil {
-			s.EnableEmailInvitations = NewBool(false)
-		} else {
-			s.EnableEmailInvitations = NewBool(true)
-		}
+		s.EnableEmailInvitations = NewBool(true)
 	}
 
 	if s.SiteURL == nil {

--- a/model/config.go
+++ b/model/config.go
@@ -102,7 +102,7 @@ const (
 	SERVICE_SETTINGS_DEFAULT_GFYCAT_API_SECRET  = "3wLVZPiswc3DnaiaFoLkDvB4X0IV6CpMkj4tf2inJRsBY6-FnkT08zGmppWFgeof"
 
 	TEAM_SETTINGS_DEFAULT_SITE_NAME                = "Mattermost"
-	TEAM_SETTINGS_DEFAULT_MAX_USERS_PER_TEAM       = 50
+	TEAM_SETTINGS_DEFAULT_MAX_USERS_PER_TEAM       = 1000
 	TEAM_SETTINGS_DEFAULT_CUSTOM_BRAND_TEXT        = ""
 	TEAM_SETTINGS_DEFAULT_CUSTOM_DESCRIPTION_TEXT  = ""
 	TEAM_SETTINGS_DEFAULT_USER_STATUS_AWAY_TIMEOUT = 300
@@ -618,7 +618,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.EnableCustomEmoji == nil {
-		s.EnableCustomEmoji = NewBool(false)
+		s.EnableCustomEmoji = NewBool(true)
 	}
 
 	if s.EnableEmojiPicker == nil {
@@ -679,7 +679,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.ExperimentalChannelSidebarOrganization == nil {
-		s.ExperimentalChannelSidebarOrganization = NewString("disabled")
+		s.ExperimentalChannelSidebarOrganization = NewString("default_on")
 	}
 
 	if s.ExperimentalDataPrefetch == nil {
@@ -727,7 +727,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.EnableBotAccountCreation == nil {
-		s.EnableBotAccountCreation = NewBool(false)
+		s.EnableBotAccountCreation = NewBool(true)
 	}
 
 	if s.EnableSVGs == nil {
@@ -803,11 +803,11 @@ func (s *ClusterSettings) SetDefaults() {
 	}
 
 	if s.UseExperimentalGossip == nil {
-		s.UseExperimentalGossip = NewBool(false)
+		s.UseExperimentalGossip = NewBool(true)
 	}
 
 	if s.EnableExperimentalGossipEncryption == nil {
-		s.EnableExperimentalGossipEncryption = NewBool(false)
+		s.EnableExperimentalGossipEncryption = NewBool(true)
 	}
 
 	if s.ReadOnlyConfig == nil {
@@ -884,7 +884,7 @@ func (s *ExperimentalSettings) SetDefaults() {
 	}
 
 	if s.RestrictSystemAdmin == nil {
-		s.RestrictSystemAdmin = NewBool(false)
+		s.RestrictSystemAdmin = NewBool(true)
 	}
 
 	if s.CloudUserLimit == nil {
@@ -1050,11 +1050,11 @@ func (s *SqlSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.MaxIdleConns == nil {
-		s.MaxIdleConns = NewInt(20)
+		s.MaxIdleConns = NewInt(10)
 	}
 
 	if s.MaxOpenConns == nil {
-		s.MaxOpenConns = NewInt(300)
+		s.MaxOpenConns = NewInt(100)
 	}
 
 	if s.ConnMaxLifetimeMilliseconds == nil {
@@ -1418,7 +1418,7 @@ func (s *EmailSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.RequireEmailVerification == nil {
-		s.RequireEmailVerification = NewBool(false)
+		s.RequireEmailVerification = NewBool(true)
 	}
 
 	if s.FeedbackName == nil {
@@ -1426,11 +1426,11 @@ func (s *EmailSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.FeedbackEmail == nil {
-		s.FeedbackEmail = NewString("test@example.com")
+		s.FeedbackEmail = NewString("feedback@mattermost.com")
 	}
 
 	if s.ReplyToAddress == nil {
-		s.ReplyToAddress = NewString("test@example.com")
+		s.ReplyToAddress = NewString("noreply@mattermost.com")
 	}
 
 	if s.FeedbackOrganization == nil {
@@ -1466,7 +1466,7 @@ func (s *EmailSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.ConnectionSecurity == nil || *s.ConnectionSecurity == CONN_SECURITY_PLAIN {
-		s.ConnectionSecurity = NewString(CONN_SECURITY_NONE)
+		s.ConnectionSecurity = NewString(CONN_SECURITY_TLS)
 	}
 
 	if s.SendPushNotifications == nil {
@@ -1889,7 +1889,7 @@ func (s *TeamSettings) SetDefaults() {
 	}
 
 	if s.ExperimentalViewArchivedChannels == nil {
-		s.ExperimentalViewArchivedChannels = NewBool(false)
+		s.ExperimentalViewArchivedChannels = NewBool(true)
 	}
 
 	if s.LockTeammateNameDisplay == nil {
@@ -2699,7 +2699,7 @@ type GuestAccountsSettings struct {
 
 func (s *GuestAccountsSettings) SetDefaults() {
 	if s.Enable == nil {
-		s.Enable = NewBool(false)
+		s.Enable = NewBool(true)
 	}
 
 	if s.AllowEmailAccounts == nil {
@@ -2870,11 +2870,7 @@ func (o *Config) SetDefaults() {
 	o.SamlSettings.SetDefaults()
 
 	if o.TeamSettings.TeammateNameDisplay == nil {
-		o.TeamSettings.TeammateNameDisplay = NewString(SHOW_USERNAME)
-
-		if *o.SamlSettings.Enable || *o.LdapSettings.Enable {
-			*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
-		}
+		*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
 	}
 
 	o.SqlSettings.SetDefaults(isUpdate)

--- a/model/config.go
+++ b/model/config.go
@@ -2865,7 +2865,7 @@ func (o *Config) SetDefaults() {
 	o.SamlSettings.SetDefaults()
 
 	if o.TeamSettings.TeammateNameDisplay == nil {
-		o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
+		o.TeamSettings.TeammateNameDisplay = NewString(SHOW_FULLNAME)
 	}
 
 	o.SqlSettings.SetDefaults(isUpdate)

--- a/model/config.go
+++ b/model/config.go
@@ -2870,7 +2870,7 @@ func (o *Config) SetDefaults() {
 	o.SamlSettings.SetDefaults()
 
 	if o.TeamSettings.TeammateNameDisplay == nil {
-		*o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
+		o.TeamSettings.TeammateNameDisplay = SHOW_FULLNAME
 	}
 
 	o.SqlSettings.SetDefaults(isUpdate)

--- a/services/mailservice/mail_test.go
+++ b/services/mailservice/mail_test.go
@@ -31,6 +31,8 @@ func TestMailConnectionFromConfig(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg := fs.Get()
+	*cfg.EmailSettings.ConnectionSecurity = ""
+
 	conn, err := ConnectToSMTPServer(cfg)
 	require.Nil(t, err, "Should connect to the SMTP Server %v", err)
 
@@ -38,7 +40,6 @@ func TestMailConnectionFromConfig(t *testing.T) {
 
 	require.Nil(t, err, "Should get new SMTP client")
 
-	*cfg.EmailSettings.ConnectionSecurity = ""
 	*cfg.EmailSettings.SMTPServer = "wrongServer"
 	*cfg.EmailSettings.SMTPPort = "553"
 

--- a/services/mailservice/mail_test.go
+++ b/services/mailservice/mail_test.go
@@ -38,6 +38,7 @@ func TestMailConnectionFromConfig(t *testing.T) {
 
 	require.Nil(t, err, "Should get new SMTP client")
 
+	*cfg.EmailSettings.ConnectionSecurity = ""
 	*cfg.EmailSettings.SMTPServer = "wrongServer"
 	*cfg.EmailSettings.SMTPPort = "553"
 
@@ -51,6 +52,7 @@ func TestMailConnectionAdvanced(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg := fs.Get()
+	*cfg.EmailSettings.ConnectionSecurity = ""
 
 	conn, err := ConnectToSMTPServerAdvanced(
 		&SmtpConnectionInfo{
@@ -134,6 +136,7 @@ func TestSendMailUsingConfig(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg := fs.Get()
+	*cfg.EmailSettings.ConnectionSecurity = ""
 
 	var emailTo = "test@example.com"
 	var emailSubject = "Testing this email"
@@ -173,6 +176,7 @@ func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg := fs.Get()
+	*cfg.EmailSettings.ConnectionSecurity = ""
 
 	var emailTo = "test@example.com"
 	var emailSubject = "Testing this email"
@@ -218,6 +222,7 @@ func TestSendMailUsingConfigAdvanced(t *testing.T) {
 	require.Nil(t, err)
 
 	cfg := fs.Get()
+	*cfg.EmailSettings.ConnectionSecurity = ""
 
 	//Delete all the messages before check the sample email
 	DeleteMailBox("test2@example.com")


### PR DESCRIPTION
#### Summary
Update settings defaults specifically for cloud **ONLY on `cloud_beta` branch**. Ticket for the server to support setting defaults based on license [MM-28883](https://mattermost.atlassian.net/browse/MM-28883). 

**Settings changed:**
- Max Users for team: `1000`
- EnableCustomEmoji: `true`
- ExperimentalSideBar: `default_on`
- EnableBotAccountCreation: `true`
- RequireEmailVerification: `true`
- RestrictSystemAdmin: `true`
- TeammateNameDisplay: `FullName`

- ExperimentalGossip:
	- UseExperimentalGossip: `true`
	- EnableExperimentalGossipEncryption: `true`
- SqlSettings:
	- MaxIdleConns:`10`
	- MaxOpenConns `100`
- Email:
	- FeedbackEmail: `feedback@mattermost.com`
	- ReplyToAddress: `noreply@mattermost.com`
	- ConnectionSecurity: `TLS`

#### Ticket Link
[MM-28803](https://mattermost.atlassian.net/browse/MM-28803)
