### PR TITLE
[MM-28195] storetest/user_store: fix flaky test

### DIFF
--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -2321,7 +2321,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
 
 	u1, err := ss.User().Save(&model.User{
 		Email:    MakeEmail(),
-		Username: "c-u1" + model.NewId(),
+		Username: "Yuka",
 	})
 	require.Nil(t, err)
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u1.Id)) }()
@@ -2330,7 +2330,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
 
 	u2, err := ss.User().Save(&model.User{
 		Email:    MakeEmail(),
-		Username: "b-u2" + model.NewId(),
+		Username: "Leia",
 	})
 	require.Nil(t, err)
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u2.Id)) }()
@@ -2339,7 +2339,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
 
 	u3, err := ss.User().Save(&model.User{
 		Email:    MakeEmail(),
-		Username: "a-u3" + model.NewId(),
+		Username: "Ali",
 	})
 	require.Nil(t, err)
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u3.Id)) }()

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -2321,7 +2321,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
 
 	u1, err := ss.User().Save(&model.User{
 		Email:    MakeEmail(),
-		Username: "u1" + model.NewId(),
+		Username: "c-u1" + model.NewId(),
 	})
 	require.Nil(t, err)
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u1.Id)) }()
@@ -2330,7 +2330,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
 
 	u2, err := ss.User().Save(&model.User{
 		Email:    MakeEmail(),
-		Username: "u2" + model.NewId(),
+		Username: "b-u2" + model.NewId(),
 	})
 	require.Nil(t, err)
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u2.Id)) }()
@@ -2339,7 +2339,7 @@ func testUserStoreGetNewUsersForTeam(t *testing.T, ss store.Store) {
 
 	u3, err := ss.User().Save(&model.User{
 		Email:    MakeEmail(),
-		Username: "u3" + model.NewId(),
+		Username: "a-u3" + model.NewId(),
 	})
 	require.Nil(t, err)
 	defer func() { require.Nil(t, ss.User().PermanentDelete(u3.Id)) }()


### PR DESCRIPTION

#### Summary
Fix a flaky test; The `(UserStore).GetNewUsersForTeam()` method is sorting the users with 2 criteria.
a) Creation time (newest first)
b) Name (alphabetical order)
In the test we need to supply names in alphabetical order to cover if the user creation dates are same. 

How come the creation dates can be the same? We calculate the creation date with `time.Now().UnixNano() / int64(time.Millisecond)`. So if two users are created in the same `millisecond` we end up having same `user.CreateAt` field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28195
