### PR TITLE
[MM-28945] api4/file: add missing return statement

### DIFF
--- a/api4/file.go
+++ b/api4/file.go
@@ -674,6 +674,7 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.Err = err
 		c.Err.StatusCode = http.StatusNotFound
+		return
 	}
 	defer fileReader.Close()
 

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -984,5 +984,6 @@ func TestGetPublicFile(t *testing.T) {
 	th.cleanupTestFile(info)
 	link = th.App.GeneratePublicLink(Client.Url, info)
 	resp, err = http.Get(link)
+	require.Nil(t, err)
 	require.Equal(t, http.StatusNotFound, resp.StatusCode, "should've failed to get file after it is deleted")
 }

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -980,5 +980,9 @@ func TestGetPublicFile(t *testing.T) {
 	fileInfo, err := th.App.Srv().Store.FileInfo().Get(fileId)
 	require.Nil(t, err)
 	require.Nil(t, th.cleanupTestFile(fileInfo))
+
 	th.cleanupTestFile(info)
+	link = th.App.GeneratePublicLink(Client.Url, info)
+	resp, err = http.Get(link)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode, "should've failed to get file after it is deleted")
 }


### PR DESCRIPTION
#### Summary
Add a missing `return` statement in case of an error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28945