### PR TITLE
[MM-28536] [MM-28535] sysconsole_write_authentication bug fixes 

### DIFF
--- a/api4/saml.go
+++ b/api4/saml.go
@@ -62,8 +62,8 @@ func parseSamlCertificateRequest(r *http.Request, maxFileSize int64) (*multipart
 }
 
 func addSamlPublicCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 
@@ -86,8 +86,8 @@ func addSamlPublicCertificate(c *Context, w http.ResponseWriter, r *http.Request
 }
 
 func addSamlPrivateCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 
@@ -110,8 +110,8 @@ func addSamlPrivateCertificate(c *Context, w http.ResponseWriter, r *http.Reques
 }
 
 func addSamlIdpCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 
@@ -163,8 +163,8 @@ func addSamlIdpCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func removeSamlPublicCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 
@@ -181,8 +181,8 @@ func removeSamlPublicCertificate(c *Context, w http.ResponseWriter, r *http.Requ
 }
 
 func removeSamlPrivateCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 
@@ -199,8 +199,8 @@ func removeSamlPrivateCertificate(c *Context, w http.ResponseWriter, r *http.Req
 }
 
 func removeSamlIdpCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 
@@ -217,8 +217,8 @@ func removeSamlIdpCertificate(c *Context, w http.ResponseWriter, r *http.Request
 }
 
 func getSamlCertificateStatus(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 
@@ -227,8 +227,8 @@ func getSamlCertificateStatus(c *Context, w http.ResponseWriter, r *http.Request
 }
 
 func getSamlMetadataFromIdp(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 

--- a/api4/team.go
+++ b/api4/team.go
@@ -1324,8 +1324,8 @@ func getInviteInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func invalidateAllEmailInvites(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_MANAGE_SYSTEM) {
-		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+	if !c.App.SessionHasPermissionTo(*c.App.Session(), model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION) {
+		c.SetPermissionError(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION)
 		return
 	}
 

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -3352,19 +3352,22 @@ func TestInvalidateAllEmailInvites(t *testing.T) {
 	defer th.TearDown()
 
 	t.Run("Forbidden when request performed by system user", func(t *testing.T) {
-		_, res := th.Client.InvalidateAllEmailInvites()
+		ok, res := th.Client.InvalidateEmailInvites()
+		require.Equal(t, ok, false)
 		CheckForbiddenStatus(t, res)
 	})
 
 	t.Run("OK when request performed by system user with requisite system permission", func(t *testing.T) {
 		th.AddPermissionToRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
 		defer th.RemovePermissionFromRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
-		_, res := th.Client.InvalidateAllEmailInvites()
+		ok, res := th.Client.InvalidateEmailInvites()
+		require.Equal(t, ok, true)
 		CheckOKStatus(t, res)
 	})
 
 	t.Run("OK when request performed by system admin", func(t *testing.T) {
-		_, res := th.SystemAdminClient.InvalidateAllEmailInvites()
+		ok, res := th.SystemAdminClient.InvalidateEmailInvites()
+		require.Equal(t, ok, true)
 		CheckOKStatus(t, res)
 	})
 }

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -3356,7 +3356,7 @@ func TestInvalidateAllEmailInvites(t *testing.T) {
 		CheckForbiddenStatus(t, res)
 	})
 
-	t.Run("OK when request performed by system admin with requisite system permission", func(t *testing.T) {
+	t.Run("OK when request performed by system user with requisite system permission", func(t *testing.T) {
 		th.AddPermissionToRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
 		defer th.RemovePermissionFromRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
 		_, res := th.Client.InvalidateAllEmailInvites()

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -3346,3 +3346,25 @@ func TestTeamMembersMinusGroupMembers(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidateAllEmailInvites(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	t.Run("Forbidden when request performed by system user", func(t *testing.T) {
+		_, res := th.Client.InvalidateAllEmailInvites()
+		CheckForbiddenStatus(t, res)
+	})
+
+	t.Run("OK when request performed by system admin with requisite system permission", func(t *testing.T) {
+		th.AddPermissionToRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
+		defer th.RemovePermissionFromRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
+		_, res := th.Client.InvalidateAllEmailInvites()
+		CheckOKStatus(t, res)
+	})
+
+	t.Run("OK when request performed by system admin", func(t *testing.T) {
+		_, res := th.SystemAdminClient.InvalidateAllEmailInvites()
+		CheckOKStatus(t, res)
+	})
+}

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -3348,7 +3348,7 @@ func TestTeamMembersMinusGroupMembers(t *testing.T) {
 }
 
 func TestInvalidateAllEmailInvites(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t.Run("Forbidden when request performed by system user", func(t *testing.T) {

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -3353,7 +3353,7 @@ func TestInvalidateAllEmailInvites(t *testing.T) {
 
 	t.Run("Forbidden when request performed by system user", func(t *testing.T) {
 		ok, res := th.Client.InvalidateEmailInvites()
-		require.Equal(t, ok, false)
+		require.Equal(t, false, ok)
 		CheckForbiddenStatus(t, res)
 	})
 
@@ -3361,13 +3361,13 @@ func TestInvalidateAllEmailInvites(t *testing.T) {
 		th.AddPermissionToRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
 		defer th.RemovePermissionFromRole(model.PERMISSION_SYSCONSOLE_WRITE_AUTHENTICATION.Id, model.SYSTEM_USER_ROLE_ID)
 		ok, res := th.Client.InvalidateEmailInvites()
-		require.Equal(t, ok, true)
+		require.Equal(t, true, ok)
 		CheckOKStatus(t, res)
 	})
 
 	t.Run("OK when request performed by system admin", func(t *testing.T) {
 		ok, res := th.SystemAdminClient.InvalidateEmailInvites()
-		require.Equal(t, ok, true)
+		require.Equal(t, true, ok)
 		CheckOKStatus(t, res)
 	})
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -5605,3 +5605,13 @@ func (c *Client4) UploadData(uploadId string, data io.Reader) (*FileInfo, *Respo
 	defer closeBody(r)
 	return FileInfoFromJson(r.Body), BuildResponse(r)
 }
+
+// InvalidateAllEmailInvites invalidates all email invites.
+func (c *Client4) InvalidateAllEmailInvites() (bool, *Response) {
+	r, err := c.DoApiDelete(c.GetTeamsRoute() + "/invites/email")
+	if err != nil {
+		return false, BuildErrorResponse(r, err)
+	}
+	defer closeBody(r)
+	return CheckStatusOK(r), BuildResponse(r)
+}

--- a/model/client4.go
+++ b/model/client4.go
@@ -5605,13 +5605,3 @@ func (c *Client4) UploadData(uploadId string, data io.Reader) (*FileInfo, *Respo
 	defer closeBody(r)
 	return FileInfoFromJson(r.Body), BuildResponse(r)
 }
-
-// InvalidateAllEmailInvites invalidates all email invites.
-func (c *Client4) InvalidateAllEmailInvites() (bool, *Response) {
-	r, err := c.DoApiDelete(c.GetTeamsRoute() + "/invites/email")
-	if err != nil {
-		return false, BuildErrorResponse(r, err)
-	}
-	defer closeBody(r)
-	return CheckStatusOK(r), BuildResponse(r)
-}


### PR DESCRIPTION
#### Summary
- These endpoints should not require manage_system instead they should just check `sysconsole_write_auth...` 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-28536
- https://mattermost.atlassian.net/browse/MM-28535