### PR TITLE
MM-28530 - Changes are not automatically propagated to system console when a permission is added/removed from a role

### DIFF
--- a/app/role.go
+++ b/app/role.go
@@ -171,7 +171,7 @@ func (a *App) UpdateRole(role *model.Role) (*model.Role, *model.AppError) {
 		model.CHANNEL_ADMIN_ROLE_ID,
 	}
 
-	builtInRolesMinusChannelRoles := utils.RemoveStringsFromSlice(model.BuiltInSchemeManagedRoleIDs, builtInChannelRoles...)
+	builtInRolesMinusChannelRoles := append(utils.RemoveStringsFromSlice(model.BuiltInSchemeManagedRoleIDs, builtInChannelRoles...), model.NewSystemRoleIDs...)
 
 	if utils.StringInSlice(savedRole.Name, builtInRolesMinusChannelRoles) {
 		return savedRole, nil
@@ -211,7 +211,9 @@ func (a *App) UpdateRole(role *model.Role) (*model.Role, *model.AppError) {
 	}
 
 	for _, ir := range impactedRoles {
-		a.sendUpdatedRoleEvent(ir)
+		if ir.Name != role.Name {
+			a.sendUpdatedRoleEvent(ir)
+		}
 	}
 
 	return savedRole, nil

--- a/app/role.go
+++ b/app/role.go
@@ -125,6 +125,8 @@ func (a *App) PatchRole(role *model.Role, patch *model.RolePatch) (*model.Role, 
 		return nil, err
 	}
 
+	a.sendUpdatedRoleEvent(role)
+
 	return role, err
 }
 


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
When a role is patched, no websocket event is sent (so we need referesh on webapp).
This PR sends the websocket event and that means you don't need to refresh on front end to see the role take effect.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-28530