### PR TITLE
MM-28687:Handle empty returns with invalid certificates 

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5748,7 +5748,7 @@
   },
   {
     "id": "ent.ldap.no.users.checkcertificate",
-    "translation": "No LDAP users found. Check user filter or if using certificate authentication, verify certificates are correct."
+    "translation": "No LDAP users found, check your user filter and certificates."
   },
   {
     "id": "ent.ldap.save_user.email_exists.ldap_app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5747,6 +5747,10 @@
     "translation": "Error creating key pair"
   },
   {
+    "id": "ent.ldap.no.users.checkcertificate",
+    "translation": "No LDAP users found. Check user filter or if using certificate authentication, verify certificates are correct."
+  },
+  {
     "id": "ent.ldap.save_user.email_exists.ldap_app_error",
     "translation": "This account does not use AD/LDAP authentication. Please sign in using email and password."
   },

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -101,7 +101,7 @@ func (srv *JobServer) SetJobError(job *model.Job, jobError *model.AppError) *mod
 	if job.Data == nil {
 		job.Data = make(map[string]string)
 	}
-	job.Data["error"] = jobError.Message 
+	job.Data["error"] = jobError.Message
 	if len(jobError.DetailedError) > 0 {
 		job.Data["error"] += " — " + jobError.DetailedError
 	}

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -101,8 +101,10 @@ func (srv *JobServer) SetJobError(job *model.Job, jobError *model.AppError) *mod
 	if job.Data == nil {
 		job.Data = make(map[string]string)
 	}
-	job.Data["error"] = jobError.Message + " — " + jobError.DetailedError
-
+	job.Data["error"] = jobError.Message 
+	if len(jobError.DetailedError) > 0 {
+		job.Data["error"] += " — " + jobError.DetailedError
+	}
 	updated, err := srv.Store.Job().UpdateOptimistically(job, model.JOB_STATUS_IN_PROGRESS)
 	if err != nil {
 		return model.NewAppError("SetJobError", "app.job.update.app_error", nil, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
#### Summary
After implementing LDAP certificate authorization, when connecting or searching with invalid or missing certificates. No error is thrown neither on connection nor search.
The real changes are in the related PR. The changes here are in support of that PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28687

#### Relate PRs
https://github.com/mattermost/enterprise/pull/771