### PR TITLE
Add front wildcard search for users

### DIFF
--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1243,7 +1243,7 @@ func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string
 			} else {
 				searchFields = append(searchFields, fmt.Sprintf("%s LIKE ? escape '*' ", field))
 			}
-			termArgs = append(termArgs, fmt.Sprintf("%s%%", strings.TrimLeft(term, "@")))
+			termArgs = append(termArgs, fmt.Sprintf("%%%s%%", strings.TrimLeft(term, "@")))
 		}
 		query = query.Where(fmt.Sprintf("(%s)", strings.Join(searchFields, " OR ")), termArgs...)
 	}


### PR DESCRIPTION
Allow users to be searched with containing term instead of starting with.

This gives more convenience to users finding users from a large list.