### PR TITLE
WIP MM-19341: Force telemetry intentions to be specified for all config settings

### DIFF
--- a/services/telemetry/config_telemetry.go
+++ b/services/telemetry/config_telemetry.go
@@ -4,8 +4,11 @@
 package telemetry
 
 import (
+	"fmt"
+	"reflect"
+
+	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
-	"github.com/mattermost/mattermost-server/v5/utils"
 )
 
 type ConfigTelemetryField struct {
@@ -16,16 +19,20 @@ type ConfigTelemetryField struct {
 
 type ConfigTelemetryMap map[string][]ConfigTelemetryField
 
-func makeConfigMap() ConfigTelemetryMap {
+// makeConfigTelemetryMap creates the telemetry map for mapping the Mattermost config to telemetry data
+func makeConfigTelemetryMap() ConfigTelemetryMap {
 	return ConfigTelemetryMap{
 		TRACK_CONFIG_TEAM: teamConfig(),
 	}
 }
 
+// teamConfig creates the "team config" telemetry map
 func teamConfig() []ConfigTelemetryField {
 	cfg := model.Config{}
 	cfg.SetDefaults()
+	cfg.TeamSettings.ExperimentalDefaultChannels = []string{"Foo", "Bar"}
 
+	// FIXME: This is just a few examples - would need to be implemented for *all* config settings in the full PR.
 	configMap := []ConfigTelemetryField{
 		{
 			"cfg.ServiceSettings.WebserverMode",
@@ -45,51 +52,108 @@ func teamConfig() []ConfigTelemetryField {
 		{
 			"TeamSettings.ExperimentalDefaultChannels",
 			"experimental_default_channels",
-			sendLength(),
+			sendStringListLength(),
 		},
 	}
 
 	return configMap
 }
 
+// sendFieldValue returns a mapping function that sends the config field value in full in the telemetry data
 func sendFieldValue() func(interface{}) interface{} {
 	return func(innerValue interface{}) interface{} {
 		return innerValue
 	}
 }
 
+// sendIsDefaultBoolean returns a mapping function that sends a boolean value in the telemetry data indicating whether
+// the config field is set to the specified default value or not
 func sendIsDefaultBoolean(defaultValue interface{}) func(interface{}) interface{} {
 	return func(value interface{}) interface{} {
 		return value == defaultValue
 	}
 }
 
-func sendLength() func(interface{}) interface{} {
+// sendStringListLength returns a mapping function that sends the length of a string list in the telemetry data
+func sendStringListLength() func(interface{}) interface{} {
 	return func(innerValue interface{}) interface{} {
-		return len(innerValue.([]interface{}))
+		return len(innerValue.([]string))
 	}
 }
 
+// sendNothing returns a mapping function returning nil, indicating that intentionally no telemetry data is collected
+// for the given Mattermost config field.
 func sendNothing() func(interface{}) interface{} {
 	return func(innerValue interface{}) interface{} {
 		return nil
 	}
 }
 
+// trackConfig prepares and sends the telemetry derived from the Mattermost config.
 func (ts *TelemetryService) trackConfig() {
 	cfg := ts.srv.Config()
-	telemetryMap := makeConfigMap()
-	configMap :=
+	telemetryMap := makeConfigTelemetryMap()
+	configMap := configToMap(*cfg, "")
 
-	for key, fields := range configMap {
-		ts.sendTelemetry(key, mapConfig(cfg, fields))
+	for key, fields := range telemetryMap {
+		ts.sendTelemetry(key, mapConfig(configMap, fields))
 	}
 }
 
+// mapConfig takes the config in map form, and a list of ConfigTelemetryField items and returns the telemetry data
 func mapConfig(configMap map[string]interface{}, fields []ConfigTelemetryField) map[string]interface{} {
 	data := map[string]interface{}{}
 
 	for _, field := range fields {
-
+		data[field.telemetryKey] = field.telemetryFunction(configMap[field.configField])
 	}
+
+	return data
+}
+
+// configToMap converts the config into a map keyed off the setting name in dot-notated form
+func configToMap(t interface{}, prefix string) map[string]interface{} {
+	defer func() {
+		if r := recover(); r != nil {
+			mlog.Error("Panicked in configToMap. This should never happen.", mlog.Any("recover", r))
+		}
+	}()
+
+	val := reflect.ValueOf(t)
+
+	if val.Kind() != reflect.Struct {
+		return nil
+	}
+
+	out := map[string]interface{}{}
+
+	for i := 0; i < val.NumField(); i++ {
+		field := val.Field(i)
+
+		var value interface{}
+
+		switch field.Kind() {
+		case reflect.Struct:
+			name := val.Type().Field(i).Name
+			data := configToMap(field.Interface(), prefix+name+".")
+			for key, val := range data {
+				out[key] = val
+			}
+		case reflect.Ptr:
+			indirectType := field.Elem()
+
+			if indirectType.Kind() == reflect.Struct {
+				value = configToMap(indirectType.Interface(), prefix)
+			} else if indirectType.Kind() != reflect.Invalid {
+				value = indirectType.Interface()
+				fmt.Println(prefix+val.Type().Field(i).Name)
+				out[prefix+val.Type().Field(i).Name] = value
+			}
+		default:
+			value = field.Interface()
+			out[prefix+val.Type().Field(i).Name] = value
+		}
+	}
+
+	return out
 }

--- a/services/telemetry/config_telemetry.go
+++ b/services/telemetry/config_telemetry.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package telemetry
+
+import (
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/utils"
+)
+
+type ConfigTelemetryField struct {
+	configField string
+	telemetryKey string
+	telemetryFunction func(interface{}) interface{}
+}
+
+type ConfigTelemetryMap map[string][]ConfigTelemetryField
+
+func makeConfigMap() ConfigTelemetryMap {
+	return ConfigTelemetryMap{
+		TRACK_CONFIG_TEAM: teamConfig(),
+	}
+}
+
+func teamConfig() []ConfigTelemetryField {
+	cfg := model.Config{}
+	cfg.SetDefaults()
+
+	configMap := []ConfigTelemetryField{
+		{
+			"cfg.ServiceSettings.WebserverMode",
+			"web_server_mode",
+			sendFieldValue(),
+		},
+		{
+			"ServiceSettings.GfycatApiKey",
+			"gfycat_api_key",
+			sendIsDefaultBoolean(model.SERVICE_SETTINGS_DEFAULT_GFYCAT_API_KEY),
+		},
+		{
+			"ServiceSettings.SiteURL",
+			"",
+			sendNothing(),
+		},
+		{
+			"TeamSettings.ExperimentalDefaultChannels",
+			"experimental_default_channels",
+			sendLength(),
+		},
+	}
+
+	return configMap
+}
+
+func sendFieldValue() func(interface{}) interface{} {
+	return func(innerValue interface{}) interface{} {
+		return innerValue
+	}
+}
+
+func sendIsDefaultBoolean(defaultValue interface{}) func(interface{}) interface{} {
+	return func(value interface{}) interface{} {
+		return value == defaultValue
+	}
+}
+
+func sendLength() func(interface{}) interface{} {
+	return func(innerValue interface{}) interface{} {
+		return len(innerValue.([]interface{}))
+	}
+}
+
+func sendNothing() func(interface{}) interface{} {
+	return func(innerValue interface{}) interface{} {
+		return nil
+	}
+}
+
+func (ts *TelemetryService) trackConfig() {
+	cfg := ts.srv.Config()
+	telemetryMap := makeConfigMap()
+	configMap :=
+
+	for key, fields := range configMap {
+		ts.sendTelemetry(key, mapConfig(cfg, fields))
+	}
+}
+
+func mapConfig(configMap map[string]interface{}, fields []ConfigTelemetryField) map[string]interface{} {
+	data := map[string]interface{}{}
+
+	for _, field := range fields {
+
+	}
+}

--- a/services/telemetry/config_telemetry_test.go
+++ b/services/telemetry/config_telemetry_test.go
@@ -2,9 +2,6 @@ package telemetry
 
 import (
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"reflect"
 	"testing"
 
@@ -13,6 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// This is the main test that illustrates the point of this change - if a config setting doesn't have it's telemetry
+// mapping specified this unit test will pass, forcing anyone who adds a new config setting to explicitly set what
+// telemetry is sent for it in order to pass CI.
 func TestMapConfig(t *testing.T) {
 	config := model.Config{}
 	config.SetDefaults()
@@ -36,6 +36,19 @@ func TestMapConfig(t *testing.T) {
 	}
 }
 
+// FIXME: WIP.
+func TestConfigToMap(t *testing.T) {
+	config := model.Config{}
+	config.SetDefaults()
+	config.TeamSettings.ExperimentalDefaultChannels = []string{"Foo", "Bar"}
+
+	data := configToMap(config, "")
+	for k, v := range data {
+		t.Log(fmt.Sprintf("%v: %v", k, v))
+	}
+}
+
+// FIXME: WIP.
 func recursiveBuildConfigList(val reflect.Value, prefix string) []string {
 	var fields []string
 	for i := 0; i < val.Type().NumField(); i++ {
@@ -50,9 +63,9 @@ func recursiveBuildConfigList(val reflect.Value, prefix string) []string {
 	return fields
 }
 
-/*
+// FIXME: WIP.
 func buildTelemetryList() []string {
-	cm := makeConfigMap()
+	cm := makeConfigTelemetryMap()
 	var fieldNames []string
 	for _, fields := range cm {
 		for _, field := range fields {
@@ -60,22 +73,4 @@ func buildTelemetryList() []string {
 		}
 	}
 	return fieldNames
-}
-*/
-
-func buildTelemetryList() []string {
-	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "config_telemetry.go", nil, parser.ParseComments)
-	if err != nil {
-		panic(err)
-	}
-
-	ast.Inspect(file, func(n ast.Node) bool {
-		tp, ok := n.(*ast.DeclStmt)
-		if ok {
-			fmt.Println(tp.Decl)
-		}
-		return true
-	})
-	return []string{}
 }

--- a/services/telemetry/config_telemetry_test.go
+++ b/services/telemetry/config_telemetry_test.go
@@ -1,0 +1,81 @@
+package telemetry
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapConfig(t *testing.T) {
+	config := model.Config{}
+	config.SetDefaults()
+
+	// Build the list of all config fields.
+	configFields := recursiveBuildConfigList(reflect.ValueOf(config), "")
+	_ = configFields
+
+	// Get the list of config fields that are covered by telemetry.
+	telemetryFields := buildTelemetryList()
+	_ = telemetryFields
+
+	// Check that all config fields are handled in the telemetry Fields.
+	for _, configField := range configFields {
+		assert.Contains(
+			t,
+			telemetryFields,
+			configField,
+			fmt.Sprintf("Telemetry for Config Field %v must be specified in services/telemetry/config_telemetry.go", configField),
+		)
+	}
+}
+
+func recursiveBuildConfigList(val reflect.Value, prefix string) []string {
+	var fields []string
+	for i := 0; i < val.Type().NumField(); i++ {
+		name := val.Type().Field(i).Name
+		newVal := val.Field(i)
+		if newVal.Kind() == reflect.Struct {
+			fields = append(fields, recursiveBuildConfigList(newVal, prefix+name+".")...)
+		} else {
+			fields = append(fields, prefix+name)
+		}
+	}
+	return fields
+}
+
+/*
+func buildTelemetryList() []string {
+	cm := makeConfigMap()
+	var fieldNames []string
+	for _, fields := range cm {
+		for _, field := range fields {
+			fieldNames = append(fieldNames, field.configField)
+		}
+	}
+	return fieldNames
+}
+*/
+
+func buildTelemetryList() []string {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "config_telemetry.go", nil, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		tp, ok := n.(*ast.DeclStmt)
+		if ok {
+			fmt.Println(tp.Decl)
+		}
+		return true
+	})
+	return []string{}
+}

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -5,7 +5,6 @@ package telemetry
 
 import (
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -321,7 +320,7 @@ func (ts *TelemetryService) trackActivity() {
 		"outgoing_webhooks":            outgoingWebhooksCount,
 	})
 }
-
+/*
 func (ts *TelemetryService) trackConfig() {
 	cfg := ts.srv.Config()
 	ts.sendTelemetry(TRACK_CONFIG_SERVICE, map[string]interface{}{
@@ -765,6 +764,7 @@ func (ts *TelemetryService) trackConfig() {
 		"bulk_indexing_time_window_seconds": *cfg.BleveSettings.BulkIndexingTimeWindowSeconds,
 	})
 }
+*/
 
 func (ts *TelemetryService) trackLicense() {
 	if license := ts.srv.License(); license != nil {

--- a/services/telemetry/telemetry_test.go
+++ b/services/telemetry/telemetry_test.go
@@ -278,7 +278,7 @@ func TestRudderTelemetry(t *testing.T) {
 			if event != "" {
 				assert.Equal(t, event, actual.Batch[0].Event)
 			}
-			assert.False(t, actual.Batch[0].Timestamp.IsZero(), "batch timestamp should not be the zero value")
+			assert.False(t, actual.Batch[0].Timestamp.IsZero(), "batch timestamp should not be the zero sendFieldValue")
 			if properties != nil {
 				assert.Equal(t, properties, actual.Batch[0].Properties)
 			}
@@ -322,7 +322,7 @@ func TestRudderTelemetry(t *testing.T) {
 	}
 
 	t.Run("Send", func(t *testing.T) {
-		testValue := "test-send-value-6789"
+		testValue := "test-send-sendFieldValue-6789"
 		telemetryService.sendTelemetry("Testing Telemetry", map[string]interface{}{
 			"hey": testValue,
 		})


### PR DESCRIPTION
This is a Work In Progress PR to get feedback on the approach and see if there's a better way of doing it.

The idea is to ensure through CI that the telemetry intentions for *every* `config.json` field are explicitly specified, or else to fail the CI. This will remove the need to manually check new settings for telemetry on every release, and move the requirement onto the developers adding new settings to explicitly specify their telemetry requirements.

Things I don't like about this approach:
- It uses reflection in the actual Mattermost code, not just the tests. I'd rather just have reflection magic going on in the tests.
- When building the `ConfigTelemetryMap`, the config settings are specified using strings, rather than using the variables directly. This feels nasty, and I'd rather they were properly strongly typed.
- There are probably some issues in the mapper functions around my lazy usage of `interface{}` but I'm sure they could be overcome with suitable effort.

Particularly interesting functions in this are:
* Building the map: https://github.com/mattermost/mattermost-server/pull/15570/files#diff-81ef8d3dd91b97cb7da6cfcb1d1d2345R30
* Ewww reflection: https://github.com/mattermost/mattermost-server/pull/15570/files#diff-81ef8d3dd91b97cb7da6cfcb1d1d2345R114
* The test case that is basically the entire point of this: https://github.com/mattermost/mattermost-server/pull/15570/files#diff-7d50d4a07d76a4dd1ffc3cc11729a657R13