### PR TITLE
[MM-28447] Avoid "ghost mentions" when "First Name" is not set, but "First Name trigger mention" setting is set

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -873,7 +873,7 @@ func addMentionKeywordsForUser(keywords map[string][]string, profile *model.User
 	}
 
 	// If turned on, add the user's case sensitive first name
-	if profile.NotifyProps[model.FIRST_NAME_NOTIFY_PROP] == "true" {
+	if profile.NotifyProps[model.FIRST_NAME_NOTIFY_PROP] == "true" && profile.FirstName != "" {
 		keywords[profile.FirstName] = append(keywords[profile.FirstName], profile.Id)
 	}
 

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1424,6 +1424,24 @@ func TestAddMentionKeywordsForUser(t *testing.T) {
 		assert.NotContains(t, keywords["Robert"], user.Id)
 	})
 
+	t.Run("should not add case sensitive first name if enabled but empty First Name", func(t *testing.T) {
+		user := &model.User{
+			Id:        model.NewId(),
+			Username:  "user",
+			FirstName: "",
+			LastName:  "Robert",
+			NotifyProps: map[string]string{
+				model.FIRST_NAME_NOTIFY_PROP: "true",
+			},
+		}
+		channelNotifyProps := map[string]string{}
+
+		keywords := map[string][]string{}
+		addMentionKeywordsForUser(keywords, user, channelNotifyProps, nil, false)
+
+		assert.NotContains(t, keywords[""], user.Id)
+	})
+
 	t.Run("should not add case sensitive first name if disabled", func(t *testing.T) {
 		user := &model.User{
 			Id:        model.NewId(),


### PR DESCRIPTION
#### Summary
If we have the "First name trigger mention" setting set, but we don't have a "First Name" set, we start receiving "ghost mentions" (we get the mention, but when we get to the channel, nothing is highlighted as a mention).

The easiest way to reproduce this was using the dot (`.`) or the underscore (`_`), which apparently always trigger the mention. Not sure if there are other characters or compositions that trigger mentions.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28447
Fix #15245 
