### PR TITLE
MM-28890 Enable the gif picker, timezones, and viewing archived channels by default

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -626,7 +626,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.EnableGifPicker == nil {
-		s.EnableGifPicker = NewBool(false)
+		s.EnableGifPicker = NewBool(true)
 	}
 
 	if s.GfycatApiKey == nil || *s.GfycatApiKey == "" {
@@ -1899,7 +1899,7 @@ func (s *TeamSettings) SetDefaults() {
 	}
 
 	if s.ExperimentalViewArchivedChannels == nil {
-		s.ExperimentalViewArchivedChannels = NewBool(false)
+		s.ExperimentalViewArchivedChannels = NewBool(true)
 	}
 
 	if s.LockTeammateNameDisplay == nil {
@@ -2711,7 +2711,7 @@ func (s *DisplaySettings) SetDefaults() {
 	}
 
 	if s.ExperimentalTimezone == nil {
-		s.ExperimentalTimezone = NewBool(false)
+		s.ExperimentalTimezone = NewBool(true)
 	}
 }
 


### PR DESCRIPTION
Similar to the last PR to enable custom emoji by default, these are all ones we want turned on to help improve NPS for end users since admins tend not to customize stuff like this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28990