### PR TITLE
MM-27523: Remove ability to read/write admin filter settings.

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -1931,8 +1931,8 @@ type LdapSettings struct {
 	UserFilter        *string `access:"authentication"`
 	GroupFilter       *string `access:"authentication"`
 	GuestFilter       *string `access:"authentication"`
-	EnableAdminFilter *bool   `access:"authentication"`
-	AdminFilter       *string `access:"authentication"`
+	EnableAdminFilter *bool
+	AdminFilter       *string
 
 	// Group Mapping
 	GroupDisplayNameAttribute *string `access:"authentication"`


### PR DESCRIPTION
#### Summary

Prevents non-system-admins from viewing or updating the LDAP admin filter settings.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-27523