### PR TITLE
WIP: Fix Wrong validation message when Bot username is absent

### DIFF
--- a/app/bot.go
+++ b/app/bot.go
@@ -18,6 +18,10 @@ import (
 
 // CreateBot creates the given bot and corresponding user.
 func (a *App) CreateBot(bot *model.Bot) (*model.Bot, *model.AppError) {
+	if !model.IsValidUsername(bot.Username) {
+		return nil, model.NewAppError("Bot.IsValid", "model.bot.is_valid.username.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	user, err := a.Srv().Store.User().Save(model.UserFromBot(bot))
 	if err != nil {
 		return nil, err

--- a/app/bot_test.go
+++ b/app/bot_test.go
@@ -99,6 +99,19 @@ func TestCreateBot(t *testing.T) {
 		require.NotNil(t, err)
 		require.Equal(t, "store.sql_user.save.username_exists.app_error", err.Id)
 	})
+
+	t.Run("create bot, without username", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		_, err := th.App.CreateBot(&model.Bot{
+			Username:    "",
+			Description: "a bot",
+			OwnerId:     th.BasicUser.Id,
+		})
+		require.NotNil(t, err)
+		require.Equal(t, "model.bot.is_valid.username.app_error", err.Id)
+	})
 }
 
 func TestPatchBot(t *testing.T) {


### PR DESCRIPTION
#### Summary
Add pre-flight `IsValidUsername` check to prevent wrong validation error on email instead of username for bot creation api.

#### Ticket Link
Fixes #13908 
