### PR TITLE
MM-28815: Message export query optimization

### DIFF
--- a/store/sqlstore/compliance_store.go
+++ b/store/sqlstore/compliance_store.go
@@ -209,7 +209,7 @@ func (s SqlComplianceStore) ComplianceExport(job *model.Compliance) ([]*model.Co
 }
 
 func (s SqlComplianceStore) MessageExport(after int64, limit int) ([]*model.MessageExport, error) {
-	props := map[string]interface{}{"StartTime": after, "Limit": limit}
+	props := map[string]interface{}{"StartTime": after, "Limit": limit / 2}
 
 	var explictDeleteAtIndex, explictUpdateAtIndex string
 


### PR DESCRIPTION
#### Summary

About a 5x performance improvement on the `(*SqlComplianceStore).ComplianceExport` query. Does remove the `Posts.CreateAt > :StartTime` part of the `WHERE` condition since `UpdateAt` is set when posts are created.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-28815