### PR TITLE
[MM-28420] Fix possible panic during plugin installation

### DIFF
--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -376,6 +376,8 @@ func (a *App) installExtractedPlugin(manifest *model.Manifest, fromPluginDir str
 		updatedManifest, _, err := pluginsEnvironment.Activate(manifest.Id)
 		if err != nil {
 			return nil, model.NewAppError("installExtractedPlugin", "app.plugin.restart.app_error", nil, err.Error(), http.StatusInternalServerError)
+		} else if updatedManifest == nil {
+			return nil, model.NewAppError("installExtractedPlugin", "app.plugin.restart.app_error", nil, "failed to activate plugin: plugin already active", http.StatusInternalServerError)
 		}
 		manifest = updatedManifest
 	}


### PR DESCRIPTION
#### Summary

PR fixes a possible panic during plugin installation. The main issue is that `Environment.Activate()` can return both a `nil` manifest and no error in case of an already active plugin. During the installation process this case was not handled and would cause a `nil` dereference panic.

I've added a test to reproduce this: a plugin is installed and activated, then its installation folder is removed. A second attempt to install the same plugin would fail to remove it and de-activate it since the directory would not be found anymore (apparently we don't check for active plugins during installation, but only if the bundle exists). The installation would go ahead but the plugin's activation would fail, returning the `nil` manifest.

#### Ticket

https://mattermost.atlassian.net/browse/MM-28420
