### PR TITLE
[MM-28630] Add ping endpoint to local mode

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -318,6 +318,7 @@ func InitLocal(configservice configservice.ConfigService, globalOptionsFunc app.
 	api.BaseRoutes.Groups = api.BaseRoutes.ApiRoot.PathPrefix("/groups").Subrouter()
 
 	api.BaseRoutes.LDAP = api.BaseRoutes.ApiRoot.PathPrefix("/ldap").Subrouter()
+	api.BaseRoutes.System = api.BaseRoutes.ApiRoot.PathPrefix("/system").Subrouter()
 	api.BaseRoutes.Posts = api.BaseRoutes.ApiRoot.PathPrefix("/posts").Subrouter()
 	api.BaseRoutes.Post = api.BaseRoutes.Posts.PathPrefix("/{post_id:[A-Za-z0-9]+}").Subrouter()
 	api.BaseRoutes.PostsForChannel = api.BaseRoutes.Channel.PathPrefix("/posts").Subrouter()

--- a/api4/system_local.go
+++ b/api4/system_local.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (api *API) InitSystemLocal() {
+	api.BaseRoutes.System.Handle("/ping", api.ApiLocal(getSystemPing)).Methods("GET")
 	api.BaseRoutes.ApiRoot.Handle("/logs", api.ApiLocal(getLogs)).Methods("GET")
 	api.BaseRoutes.ApiRoot.Handle("/server_busy", api.ApiLocal(setServerBusy)).Methods("POST")
 	api.BaseRoutes.ApiRoot.Handle("/server_busy", api.ApiLocal(getServerBusyExpires)).Methods("GET")


### PR DESCRIPTION
#### Summary
Adds the ping endpoint required for the `mmctl system version` command to local mode.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28630

#### Related Pull Requests
- [Has mmctl changes](https://github.com/mattermost/mmctl/pull/209)