### PR TITLE
Remove `cloud_restrictable` from `PluginSettings.Enabled`

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2585,7 +2585,7 @@ type PluginState struct {
 }
 
 type PluginSettings struct {
-	Enable                      *bool                             `access:"plugins,write_restrictable,cloud_restrictable"`
+	Enable                      *bool                             `access:"plugins,write_restrictable"`
 	EnableUploads               *bool                             `access:"plugins,write_restrictable,cloud_restrictable"`
 	AllowInsecureDownloadUrl    *bool                             `access:"plugins,write_restrictable,cloud_restrictable"`
 	EnableHealthCheck           *bool                             `access:"plugins,write_restrictable,cloud_restrictable"`


### PR DESCRIPTION
#### Summary

Removed `cloud_restrictable` tag for `PluginSettings.Enable` that was causing plugin configuration screens to now show in the System Console in cloud installations 

#### Ticket

[MM-29219](https://mattermost.atlassian.net/browse/MM-29219)