### PR TITLE
[MM-15744] remove store from api4/user

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -116,7 +116,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	var ruser *model.User
 	var err *model.AppError
 	if len(tokenId) > 0 {
-		token, nErr := c.App.Srv().Store.Token().GetByToken(tokenId)
+		token, nErr := c.App.GetTokenFromTokenString(tokenId);
 		if nErr != nil {
 			var status int
 			switch nErr.(type) {

--- a/api4/user.go
+++ b/api4/user.go
@@ -116,7 +116,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	var ruser *model.User
 	var err *model.AppError
 	if len(tokenId) > 0 {
-		token, nErr := c.App.GetTokenFromTokenString(tokenId);
+		token, nErr := c.App.GetTokenFromTokenString(tokenId)
 		if nErr != nil {
 			var status int
 			switch nErr.(type) {

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -674,6 +674,7 @@ type AppIface interface {
 	GetTeamsForUser(userId string) ([]*model.Team, *model.AppError)
 	GetTeamsUnreadForUser(excludeTeamId string, userId string) ([]*model.TeamUnread, *model.AppError)
 	GetTermsOfService(id string) (*model.TermsOfService, *model.AppError)
+	GetTokenFromTokenString(token string) (*model.Token, error)
 	GetUploadSession(uploadId string) (*model.UploadSession, *model.AppError)
 	GetUploadSessionsForUser(userId string) ([]*model.UploadSession, *model.AppError)
 	GetUser(userId string) (*model.User, *model.AppError)

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -9086,6 +9086,28 @@ func (a *OpenTracingAppLayer) GetUsersWithoutTeamPage(options *model.UserGetOpti
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) GetTokenFromTokenString(token string) (*model.Token, error) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetTokenFromTokenString")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetTokenFromTokenString(token)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetVerifyEmailToken(token string) (*model.Token, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetVerifyEmailToken")

--- a/app/user.go
+++ b/app/user.go
@@ -1667,6 +1667,15 @@ func (a *App) GetVerifyEmailToken(token string) (*model.Token, *model.AppError) 
 	return rtoken, nil
 }
 
+func (a *App) GetTokenFromTokenString(token string) (*model.Token, error) {
+	rtoken, err := a.Srv().Store.Token().GetByToken(token)
+	if err != nil {
+		return nil, err
+	}
+
+	return rtoken, nil
+}
+
 // GetTotalUsersStats is used for the DM list total
 func (a *App) GetTotalUsersStats(viewRestrictions *model.ViewUsersRestrictions) (*model.UsersStats, *model.AppError) {
 	count, err := a.Srv().Store.User().Count(model.UserCountOptions{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This pull request adds a new function (`App.GetTokenFromString(string)`) to the App Interface in order to remove the Store call from `api4/user.go`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes [15477](https://github.com/mattermost/mattermost-server/issues/15744)
Otherwise, link the JIRA ticket.
-->
