### PR TITLE
[MM-29273] Fix flaky test: TestUploadDataConcurrent

### DIFF
--- a/app/upload.go
+++ b/app/upload.go
@@ -98,6 +98,14 @@ func (a *App) UploadData(us *model.UploadSession, rd io.Reader) (*model.FileInfo
 		a.Srv().uploadLockMapMut.Unlock()
 	}()
 
+	// fetch the session from store to check for inconsistencies.
+	if storedSession, err := a.GetUploadSession(us.Id); err != nil {
+		return nil, err
+	} else if us.FileOffset != storedSession.FileOffset {
+		return nil, model.NewAppError("UploadData", "app.upload.upload_data.concurrent.app_error",
+			nil, "FileOffset mismatch", http.StatusBadRequest)
+	}
+
 	// make sure it's not possible to upload more data than what is expected.
 	lr := &io.LimitedReader{
 		R: rd,

--- a/app/upload_test.go
+++ b/app/upload_test.go
@@ -278,6 +278,7 @@ func TestUploadDataConcurrent(t *testing.T) {
 
 	// Verify that only 1 request was able to perform the upload.
 	require.Equal(t, int32(n-1), nErrs)
+	nErrs = 0
 
 	wg.Add(n)
 
@@ -300,7 +301,7 @@ func TestUploadDataConcurrent(t *testing.T) {
 	wg.Wait()
 
 	// Verify that only 1 request was able to finish the upload.
-	require.Equal(t, int32(n*2-2), nErrs)
+	require.Equal(t, int32(n-1), nErrs)
 
 	d, err := th.App.ReadFile(us.Path)
 	require.Nil(t, err)


### PR DESCRIPTION
#### Summary

PR adds a check to prevent possible inconsistencies in case of parallel upload requests.
While the code was correctly enforcing one request per session at any given time, there was still a case where concurrent requests for the same session could enter the function with an outdated `UploadSession` struct, causing the call to go through without errors.

#### Ticket

https://mattermost.atlassian.net/browse/MM-29273