### PR TITLE
[MM-29215] config/envrionment: fix a panic where a setting is not defined in model.Config

### DIFF
--- a/config/environment.go
+++ b/config/environment.go
@@ -17,7 +17,10 @@ func removeEnvOverrides(cfg, cfgWithoutEnv *model.Config, envOverrides map[strin
 	newCfg := cfg.Clone()
 	for _, path := range paths {
 		originalVal := getVal(cfgWithoutEnv, path)
-		getVal(newCfg, path).Set(originalVal)
+		newVal := getVal(newCfg, path)
+		if newVal.CanSet() {
+			newVal.Set(originalVal)
+		}
 	}
 	return newCfg
 }

--- a/config/environment_test.go
+++ b/config/environment_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveEnvOverrides(t *testing.T) {
+	defaultCfg := &model.Config{}
+	defaultCfg.SetDefaults()
+
+	newCfg := defaultCfg.Clone()
+	newCfg.EmailSettings.EnableSignUpWithEmail = model.NewBool(false)
+
+	envOverrides := map[string]interface{}{
+		"EmailSettings": map[string]interface{}{
+			"EnableSignUpWithEmail": false,
+		},
+	}
+
+	updatedCfg := removeEnvOverrides(newCfg, defaultCfg, envOverrides)
+	require.NotNil(t, updatedCfg)
+	require.True(t, *updatedCfg.EmailSettings.EnableSignUpWithEmail)
+
+	envOverrides["ServiceSettings"] = map[string]interface{}{
+		"NonExistentConfig": true,
+	}
+
+	require.NotPanics(t, func() {
+		_ = removeEnvOverrides(defaultCfg, defaultCfg, envOverrides)
+	}, "invalid setting should not panic")
+}


### PR DESCRIPTION
#### Summary
This PR adds a check to `reflect.Value`if it is settable, in other words if it is not zero value. In cluster mode we can have at least 2 different versions of MM server running hence 2 different config structs. In order to prevent panics if we receive a undefined value we simply skip it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29215