### PR TITLE
MM-29354 - Remove pre-packaged incident response for v5.28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ PLUGIN_PACKAGES += mattermost-plugin-antivirus-v0.1.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v2.3.2
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-incident-response-v0.6.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)

--- a/go.tools.mod
+++ b/go.tools.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200915114419-f4421bc07461 // indirect
+	github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20201001222518-66764584f346 // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/reflog/struct2interface v0.6.1 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect

--- a/go.tools.sum
+++ b/go.tools.sum
@@ -68,6 +68,8 @@ github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200828152206-519b99
 github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200828152206-519b99a4e51e/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
 github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200915114419-f4421bc07461 h1:dn2/HZjzUY5PQmKDmH95vgwVqpbR84FiU/t060g7rqg=
 github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20200915114419-f4421bc07461/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
+github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20201001222518-66764584f346 h1:ByexaM3lb5ZdHGtcB1QwRkDXDxt/2MUTvI8+LjwhDXg=
+github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20201001222518-66764584f346/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5555,6 +5555,30 @@
     "translation": "Timed out waiting for cluster response"
   },
   {
+    "id": "ent.compliance.actiance.attachment.copy.appError",
+    "translation": ""
+  },
+  {
+    "id": "ent.compliance.actiance.file.creation.appError",
+    "translation": ""
+  },
+  {
+    "id": "ent.compliance.actiance.warning.creation.appError",
+    "translation": ""
+  },
+  {
+    "id": "ent.compliance.actiance.warning.write.appError",
+    "translation": ""
+  },
+  {
+    "id": "ent.compliance.actiance.xml.creation.appError",
+    "translation": ""
+  },
+  {
+    "id": "ent.compliance.actiance.xml.write.appError",
+    "translation": ""
+  },
+  {
     "id": "ent.compliance.bad_export_type.appError",
     "translation": "Unknown output format {{.ExportType}}"
   },

--- a/model/config.go
+++ b/model/config.go
@@ -2615,11 +2615,6 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates["com.mattermost.nps"] = &PluginState{Enable: ls.EnableDiagnostics == nil || *ls.EnableDiagnostics}
 	}
 
-	if s.PluginStates["com.mattermost.plugin-incident-response"] == nil {
-		// Enable the incident response plugin by default
-		s.PluginStates["com.mattermost.plugin-incident-response"] = &PluginState{Enable: true}
-	}
-
 	if s.EnableMarketplace == nil {
 		s.EnableMarketplace = NewBool(PLUGIN_SETTINGS_DEFAULT_ENABLE_MARKETPLACE)
 	}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -307,31 +307,6 @@ func TestConfigDefaultNPSPluginState(t *testing.T) {
 	})
 }
 
-func TestConfigDefaultIncidentResponsePluginState(t *testing.T) {
-	t.Run("should enable IncidentResponse plugin by default", func(t *testing.T) {
-		c1 := Config{}
-		c1.SetDefaults()
-
-		assert.True(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-response"].Enable)
-	})
-
-	t.Run("should not re-enable IncidentResponse plugin after it has been disabled", func(t *testing.T) {
-		c1 := Config{
-			PluginSettings: PluginSettings{
-				PluginStates: map[string]*PluginState{
-					"com.mattermost.plugin-incident-response": {
-						Enable: false,
-					},
-				},
-			},
-		}
-
-		c1.SetDefaults()
-
-		assert.False(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-response"].Enable)
-	})
-}
-
 func TestTeamSettingsIsValidSiteNameEmpty(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()


### PR DESCRIPTION
#### Summary
- (from ticket): We have been using pre-packaging as a means to distribute incident response automatically to cloud, but the version currently available is not final and should not be included in v5.28 proper. Let's remove it, as we intend to list in the marketplace first for on-premise customers.
- Revert of #15608 

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-29354