### PR TITLE
Enable cloud billing

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2807,6 +2807,7 @@ func TestInviteUsersToTeam(t *testing.T) {
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableEmailInvitations = &enableEmailInvitations })
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.RestrictCreationToDomains = restrictCreationToDomains })
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ExperimentalSettings.CloudUserLimit = model.NewInt64(0) })
 	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableEmailInvitations = false })

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2807,10 +2807,11 @@ func TestInviteUsersToTeam(t *testing.T) {
 	defer func() {
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableEmailInvitations = &enableEmailInvitations })
 		th.App.UpdateConfig(func(cfg *model.Config) { cfg.TeamSettings.RestrictCreationToDomains = restrictCreationToDomains })
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ExperimentalSettings.CloudUserLimit = model.NewInt64(0) })
 	}()
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableEmailInvitations = false })
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.ExperimentalSettings.CloudUserLimit = model.NewInt64(0) })
+
 	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
 		_, resp := client.InviteUsersToTeam(th.BasicTeam.Id, emailList)
 		require.NotNil(t, resp.Error, "Should be disabled")

--- a/model/config.go
+++ b/model/config.go
@@ -868,8 +868,8 @@ type ExperimentalSettings struct {
 	LinkMetadataTimeoutMilliseconds *int64  `access:"experimental,write_restrictable,cloud_restrictable"`
 	RestrictSystemAdmin             *bool   `access:"experimental,write_restrictable"`
 	UseNewSAMLLibrary               *bool   `access:"experimental,cloud_restrictable"`
-	CloudUserLimit                  *int64  `access:"experimental,write_restrictable,cloud_restrictable"`
-	CloudBilling                    *bool   `access:"experimental,write_restrictable,cloud_restrictable"`
+	CloudUserLimit                  *int64  `access:"experimental,write_restrictable"`
+	CloudBilling                    *bool   `access:"experimental,write_restrictable"`
 	EnableSharedChannels            *bool   `access:"experimental"`
 }
 
@@ -896,11 +896,11 @@ func (s *ExperimentalSettings) SetDefaults() {
 
 	if s.CloudUserLimit == nil {
 		// User limit 0 is treated as no limit
-		s.CloudUserLimit = NewInt64(0)
+		s.CloudUserLimit = NewInt64(10)
 	}
 
 	if s.CloudBilling == nil {
-		s.CloudBilling = NewBool(false)
+		s.CloudBilling = NewBool(true)
 	}
 
 	if s.UseNewSAMLLibrary == nil {


### PR DESCRIPTION
#### Summary

- Enable billing by defaulting the feature flag `CloudBilling` to `true` **only for `cloud-ga`** branch. 
- Set `CloudUserLimit` to 10.