### PR TITLE
Normalize plugin path when s3 prefix is present

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -756,12 +756,20 @@ func (a *App) getPluginsFromFolder() (map[string]*pluginSignaturePath, *model.Ap
 		return nil, model.NewAppError("getPluginsFromDir", "app.plugin.sync.list_filestore.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 	}
 
-	return getPluginsFromFilePaths(fileStorePaths), nil
+	return a.getPluginsFromFilePaths(fileStorePaths), nil
 }
 
-func getPluginsFromFilePaths(fileStorePaths []string) map[string]*pluginSignaturePath {
+func (a *App) getPluginsFromFilePaths(fileStorePaths []string) map[string]*pluginSignaturePath {
 	pluginSignaturePathMap := make(map[string]*pluginSignaturePath)
+
+	fsPrefix := ""
+	ptr := a.Config().FileSettings.AmazonS3PathPrefix
+	if ptr != nil {
+		fsPrefix = *ptr
+	}
+
 	for _, path := range fileStorePaths {
+		path = strings.TrimPrefix(path, fsPrefix+"/")
 		if strings.HasSuffix(path, ".tar.gz") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz")
 			helper := &pluginSignaturePath{
@@ -773,6 +781,7 @@ func getPluginsFromFilePaths(fileStorePaths []string) map[string]*pluginSignatur
 		}
 	}
 	for _, path := range fileStorePaths {
+		path = strings.TrimPrefix(path, fsPrefix+"/")
 		if strings.HasSuffix(path, ".tar.gz.sig") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz.sig")
 			if val, ok := pluginSignaturePathMap[id]; !ok {
@@ -802,7 +811,7 @@ func (a *App) processPrepackagedPlugins(pluginsDir string) []*plugin.Prepackaged
 		return nil
 	}
 
-	pluginSignaturePathMap := getPluginsFromFilePaths(fileStorePaths)
+	pluginSignaturePathMap := a.getPluginsFromFilePaths(fileStorePaths)
 	plugins := make([]*plugin.PrepackagedPlugin, 0, len(pluginSignaturePathMap))
 	prepackagedPlugins := make(chan *plugin.PrepackagedPlugin, len(pluginSignaturePathMap))
 

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -763,13 +763,15 @@ func (a *App) getPluginsFromFilePaths(fileStorePaths []string) map[string]*plugi
 	pluginSignaturePathMap := make(map[string]*pluginSignaturePath)
 
 	fsPrefix := ""
-	ptr := a.Config().FileSettings.AmazonS3PathPrefix
-	if ptr != nil {
-		fsPrefix = *ptr
+	if *a.Config().FileSettings.DriverName == model.IMAGE_DRIVER_S3 {
+		ptr := a.Config().FileSettings.AmazonS3PathPrefix
+		if ptr != nil && *ptr != "" {
+			fsPrefix = *ptr + "/"
+		}
 	}
 
 	for _, path := range fileStorePaths {
-		path = strings.TrimPrefix(path, fsPrefix+"/")
+		path = strings.TrimPrefix(path, fsPrefix)
 		if strings.HasSuffix(path, ".tar.gz") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz")
 			helper := &pluginSignaturePath{
@@ -781,7 +783,7 @@ func (a *App) getPluginsFromFilePaths(fileStorePaths []string) map[string]*plugi
 		}
 	}
 	for _, path := range fileStorePaths {
-		path = strings.TrimPrefix(path, fsPrefix+"/")
+		path = strings.TrimPrefix(path, fsPrefix)
 		if strings.HasSuffix(path, ".tar.gz.sig") {
 			id := strings.TrimSuffix(filepath.Base(path), ".tar.gz.sig")
 			if val, ok := pluginSignaturePathMap[id]; !ok {


### PR DESCRIPTION
#### Summary

When syncing plugins from the file store on startup, the full path to each plugin is used to fetch the plugins. When using a prefix path on s3, the `a.FileReader` automatically prepends the prefix on every request to s3. The automatic prepending of the prefix results in `my_prefix/my_prefix/antivirus.tar.gz`. This PR makes it so the prefix is stripped if this is the case.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-29521