### PR TITLE
MM-29548: remove ability to update SAML admin filter settings

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2212,8 +2212,8 @@ type SamlSettings struct {
 	// User Mapping
 	IdAttribute          *string `access:"authentication"`
 	GuestAttribute       *string `access:"authentication"`
-	EnableAdminAttribute *bool   `access:"authentication"`
-	AdminAttribute       *string `access:"authentication"`
+	EnableAdminAttribute *bool
+	AdminAttribute       *string
 	FirstNameAttribute   *string `access:"authentication"`
 	LastNameAttribute    *string `access:"authentication"`
 	EmailAttribute       *string `access:"authentication"`


### PR DESCRIPTION
#### Summary
Prevents non-system-admins from viewing or updating the SAML admin filter settings.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29548
