### PR TITLE
MM-29522:fix typo in constant name

### DIFF
--- a/app/ldap.go
+++ b/app/ldap.go
@@ -199,12 +199,12 @@ func (a *App) writeLdapFile(filename string, fileData *multipart.FileHeader) *mo
 }
 
 func (a *App) AddLdapPublicCertificate(fileData *multipart.FileHeader) *model.AppError {
-	if err := a.writeLdapFile(model.LDAP_PUBIC_CERTIFICATE_NAME, fileData); err != nil {
+	if err := a.writeLdapFile(model.LDAP_PUBLIC_CERTIFICATE_NAME, fileData); err != nil {
 		return err
 	}
 
 	cfg := a.Config().Clone()
-	*cfg.LdapSettings.PublicCertificateFile = model.LDAP_PUBIC_CERTIFICATE_NAME
+	*cfg.LdapSettings.PublicCertificateFile = model.LDAP_PUBLIC_CERTIFICATE_NAME
 
 	if err := cfg.IsValid(); err != nil {
 		return err

--- a/model/client4.go
+++ b/model/client4.go
@@ -4094,7 +4094,7 @@ func (c *Client4) MigrateAuthToSaml(fromAuthService string, usersMap map[string]
 
 // UploadLdapPublicCertificate will upload a public certificate for LDAP and set the config to use it.
 func (c *Client4) UploadLdapPublicCertificate(data []byte) (bool, *Response) {
-	body, writer, err := fileToMultipart(data, LDAP_PUBIC_CERTIFICATE_NAME)
+	body, writer, err := fileToMultipart(data, LDAP_PUBLIC_CERTIFICATE_NAME)
 	if err != nil {
 		return false, &Response{Error: NewAppError("UploadLdapPublicCertificate", "model.client.upload_ldap_cert.app_error", nil, err.Error(), http.StatusBadRequest)}
 	}

--- a/model/ldap.go
+++ b/model/ldap.go
@@ -4,7 +4,7 @@
 package model
 
 const (
-	USER_AUTH_SERVICE_LDAP      = "ldap"
+	USER_AUTH_SERVICE_LDAP       = "ldap"
 	LDAP_PUBLIC_CERTIFICATE_NAME = "ldap-public.crt"
-	LDAP_PRIVATE_KEY_NAME       = "ldap-private.key"
+	LDAP_PRIVATE_KEY_NAME        = "ldap-private.key"
 )

--- a/model/ldap.go
+++ b/model/ldap.go
@@ -5,6 +5,6 @@ package model
 
 const (
 	USER_AUTH_SERVICE_LDAP      = "ldap"
-	LDAP_PUBIC_CERTIFICATE_NAME = "ldap-public.crt"
+	LDAP_PUBLIC_CERTIFICATE_NAME = "ldap-public.crt"
 	LDAP_PRIVATE_KEY_NAME       = "ldap-private.key"
 )


### PR DESCRIPTION
#### Summary
Fixes a typo in constant name. Updates all references.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29547