### PR TITLE
MM-28882:ignore guest ldap sync

### DIFF
--- a/einterfaces/ldap.go
+++ b/einterfaces/ldap.go
@@ -20,7 +20,7 @@ type LdapInterface interface {
 	MigrateIDAttribute(toAttribute string) error
 	GetGroup(groupUID string) (*model.Group, *model.AppError)
 	GetAllGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError)
-	FirstLoginSync(userID, userAuthService, userAuthData, email string) *model.AppError
+	FirstLoginSync(user, userAuthService, userAuthData, email string) *model.AppError
 	UpdateProfilePictureIfNecessary(model.User, *model.Session)
 	GetADLdapIdFromSAMLId(authData string) string
 }

--- a/einterfaces/ldap.go
+++ b/einterfaces/ldap.go
@@ -20,7 +20,7 @@ type LdapInterface interface {
 	MigrateIDAttribute(toAttribute string) error
 	GetGroup(groupUID string) (*model.Group, *model.AppError)
 	GetAllGroupsPage(page int, perPage int, opts model.LdapGroupSearchOpts) ([]*model.Group, int, *model.AppError)
-	FirstLoginSync(user, userAuthService, userAuthData, email string) *model.AppError
+	FirstLoginSync(user *model.User, userAuthService, userAuthData, email string) *model.AppError
 	UpdateProfilePictureIfNecessary(model.User, *model.Session)
 	GetADLdapIdFromSAMLId(authData string) string
 }

--- a/model/config.go
+++ b/model/config.go
@@ -2188,6 +2188,7 @@ type SamlSettings struct {
 	Enable                        *bool `access:"authentication"`
 	EnableSyncWithLdap            *bool `access:"authentication"`
 	EnableSyncWithLdapIncludeAuth *bool `access:"authentication"`
+	IgnoreGuestsLdapSync          *bool `access:"authentication"`
 
 	Verify      *bool `access:"authentication"`
 	Encrypt     *bool `access:"authentication"`
@@ -2240,6 +2241,10 @@ func (s *SamlSettings) SetDefaults() {
 
 	if s.EnableSyncWithLdapIncludeAuth == nil {
 		s.EnableSyncWithLdapIncludeAuth = NewBool(false)
+	}
+
+	if s.IgnoreGuestsLdapSync == nil {
+		s.IgnoreGuestsLdapSync = NewBool(false)
 	}
 
 	if s.EnableAdminAttribute == nil {

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -649,6 +649,7 @@ func (ts *TelemetryService) trackConfig() {
 		"enable":                              *cfg.SamlSettings.Enable,
 		"enable_sync_with_ldap":               *cfg.SamlSettings.EnableSyncWithLdap,
 		"enable_sync_with_ldap_include_auth":  *cfg.SamlSettings.EnableSyncWithLdapIncludeAuth,
+		"ignore_guests_ldap_sync":             *cfg.SamlSettings.IgnoreGuestsLdapSync,
 		"enable_admin_attribute":              *cfg.SamlSettings.EnableAdminAttribute,
 		"verify":                              *cfg.SamlSettings.Verify,
 		"encrypt":                             *cfg.SamlSettings.Encrypt,


### PR DESCRIPTION
#### Summary
Adds a configuration setting for SAML to ignore Guests when Sync'ing LDAP users.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28882

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/6750
https://github.com/mattermost/enterprise/pull/801

```release-note
Added configuration setting to ignore Guests when using SAML and synchronizing with LDAP.
```