### PR TITLE
MM-29525: Strip path_prefix from ListDirectory

### DIFF
--- a/services/filesstore/s3store.go
+++ b/services/filesstore/s3store.go
@@ -354,7 +354,15 @@ func (b *S3FileBackend) ListDirectory(path string) (*[]string, *model.AppError) 
 		if object.Err != nil {
 			return nil, model.NewAppError("ListDirectory", "utils.file.list_directory.s3.app_error", nil, object.Err.Error(), http.StatusInternalServerError)
 		}
-		paths = append(paths, strings.Trim(object.Key, "/"))
+		// We strip the path prefix that gets applied,
+		// so that it remains transparent to the application.
+		if strings.HasPrefix(object.Key, b.pathPrefix) {
+			object.Key = strings.TrimPrefix(object.Key, b.pathPrefix)
+		}
+		trimmed := strings.Trim(object.Key, "/")
+		if trimmed != "" {
+			paths = append(paths, trimmed)
+		}
 	}
 
 	return &paths, nil

--- a/services/filesstore/s3store.go
+++ b/services/filesstore/s3store.go
@@ -356,9 +356,7 @@ func (b *S3FileBackend) ListDirectory(path string) (*[]string, *model.AppError) 
 		}
 		// We strip the path prefix that gets applied,
 		// so that it remains transparent to the application.
-		if strings.HasPrefix(object.Key, b.pathPrefix) {
-			object.Key = strings.TrimPrefix(object.Key, b.pathPrefix)
-		}
+		object.Key = strings.TrimPrefix(object.Key, b.pathPrefix)
 		trimmed := strings.Trim(object.Key, "/")
 		if trimmed != "" {
 			paths = append(paths, trimmed)


### PR DESCRIPTION
An AWS path prefix is meant to be an implementation detail
which the calling application should not be aware of. Hence, we should
strip the path prefix when returning objects in a directory
because they anyways get applied while using the other APIs

https://mattermost.atlassian.net/browse/MM-29525
