### PR TITLE
MM-29572: Add Bifrost support to codebase

### DIFF
--- a/services/filesstore/s3_overrides.go
+++ b/services/filesstore/s3_overrides.go
@@ -52,5 +52,5 @@ func (cp customProvider) Retrieve() (credentials.Value, error) {
 	}, nil
 }
 
-// IsExpired just returns true always.
+// IsExpired always returns false.
 func (cp customProvider) IsExpired() bool { return false }

--- a/services/filesstore/s3_overrides.go
+++ b/services/filesstore/s3_overrides.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package filesstore
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// customTransport is used to point the request to a different server.
+// This is helpful in situations where a different service is handling AWS S3 requests
+// from multiple Mattermost applications, and the Mattermost service itself does not
+// have any S3 credentials.
+type customTransport struct {
+	base   http.RoundTripper
+	host   string
+	scheme string
+	cli    http.Client
+}
+
+// RoundTrip implements the transport's roundtripper implementation.
+func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Rountrippers should not modify the original request.
+	newReq := req.Clone(context.Background())
+	*newReq.URL = *req.URL
+	req.URL.Scheme = t.scheme
+	req.URL.Host = t.host
+	return t.cli.Do(req)
+}
+
+// customProvider is a dummy credentials provider for the minio client to work
+// without actually providing credentials. This is needed with a custom transport
+// in cases where the minio client does not actually have credentials with itself,
+// rather needs responses from another entity.
+//
+// It satisfies the credentials.Provider interface.
+type customProvider struct {
+	isSignV2 bool
+}
+
+// Retrieve just returns empty credentials.
+func (cp customProvider) Retrieve() (credentials.Value, error) {
+	sign := credentials.SignatureV4
+	if cp.isSignV2 {
+		sign = credentials.SignatureV2
+	}
+	return credentials.Value{
+		AccessKeyID:     "",
+		SecretAccessKey: "",
+		SessionToken:    "",
+		SignerType:      sign,
+	}, nil
+}
+
+// IsExpired just returns true always.
+func (cp customProvider) IsExpired() bool { return false }

--- a/services/filesstore/s3_overrides.go
+++ b/services/filesstore/s3_overrides.go
@@ -18,17 +18,17 @@ type customTransport struct {
 	base   http.RoundTripper
 	host   string
 	scheme string
-	cli    http.Client
+	client http.Client
 }
 
-// RoundTrip implements the transport's roundtripper implementation.
+// RoundTrip implements the http.Roundtripper interface.
 func (t *customTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Rountrippers should not modify the original request.
 	newReq := req.Clone(context.Background())
 	*newReq.URL = *req.URL
 	req.URL.Scheme = t.scheme
 	req.URL.Host = t.host
-	return t.cli.Do(req)
+	return t.client.Do(req)
 }
 
 // customProvider is a dummy credentials provider for the minio client to work
@@ -48,10 +48,7 @@ func (cp customProvider) Retrieve() (credentials.Value, error) {
 		sign = credentials.SignatureV2
 	}
 	return credentials.Value{
-		AccessKeyID:     "",
-		SecretAccessKey: "",
-		SessionToken:    "",
-		SignerType:      sign,
+		SignerType: sign,
 	}, nil
 }
 

--- a/services/filesstore/s3store.go
+++ b/services/filesstore/s3store.go
@@ -47,7 +47,7 @@ const (
 func (b *S3FileBackend) s3New() (*s3.Client, error) {
 	var creds *credentials.Credentials
 
-	isCloud := os.Getenv("MM_CLOUD_INSTALLATION_ID") != ""
+	isCloud := os.Getenv("MM_CLOUD_FILESTORE_BIFROST") != ""
 	if isCloud {
 		creds = credentials.New(customProvider{isSignV2: b.signV2})
 	} else if b.accessKey == "" && b.secretKey == "" {


### PR DESCRIPTION
We use a custom transport for minio when an environment variable
indicates that Mattermost is running in cloud.

The transport is used to redirect the request to the S3 endpoint set
in the config. And the scheme is set depending on if S3SSL is set.

A custom credentials provider is needed to return empty credentials
which will be overridden by the service anyways. This is just to allow
the minio client library to work transparently without knowing that
there is something else in the middle intercepting requests.

https://mattermost.atlassian.net/browse/MM-29572
