### PR TITLE
[MM-25408] Improve the grammar on Account Creation Screen

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2456,7 +2456,7 @@
   },
   {
     "id": "api.team.invite_members.invalid_email.app_error",
-    "translation": "The following email addresses do not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
+    "translation": "The email address you entered does not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
   },
   {
     "id": "api.team.invite_members.limit_reached.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2456,7 +2456,7 @@
   },
   {
     "id": "api.team.invite_members.invalid_email.app_error",
-    "translation": "The email address you entered does not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
+    "translation": "The email address you entered does not belong to an accepted domain: {{.Addresses}}. Please contact your System Admin for details."
   },
   {
     "id": "api.team.invite_members.limit_reached.app_error",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -1752,7 +1752,7 @@
   },
   {
     "id": "api.team.invite_members.invalid_email.app_error",
-    "translation": "The following email addresses do not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
+    "translation": "The email address you entered does not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
   },
   {
     "id": "api.team.invite_members.no_one.app_error",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -1752,7 +1752,7 @@
   },
   {
     "id": "api.team.invite_members.invalid_email.app_error",
-    "translation": "The email address you entered does not belong to an accepted domain: {{.Addresses}}. Please contact your System Administrator for details."
+    "translation": "The email address you entered does not belong to an accepted domain: {{.Addresses}}. Please contact your System Admin for details."
   },
   {
     "id": "api.team.invite_members.no_one.app_error",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR changes the error message that appears in the Account Creation Screen if the email address you entered does not belong to the accepted domain. This is the result after the change (see screenshot)

![mattermost](https://user-images.githubusercontent.com/6761059/96190231-e2448700-0f0f-11eb-9fde-1754b3784a32.png)


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fix: #15927 
JIRA: https://mattermost.atlassian.net/browse/MM-25408

```release-note
NONE
```
