### PR TITLE
bump incident response to v0.7.0 in cloud

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ PLUGIN_PACKAGES += mattermost-plugin-antivirus-v0.1.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v2.3.2
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-incident-response-v0.6.0
+PLUGIN_PACKAGES += mattermost-plugin-incident-response-v0.7.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)


### PR DESCRIPTION
#### Summary
v0.7.0 was intended to be released as part of https://github.com/mattermost/mattermost-server/pull/15608, but we only made the change to the `cloud-beta` branch, and not in `master`, so it was lost when `cloud-ga` was later cut directly from `master`.

We can't upgrade directly to v1.0.0 at this time, since there was transient migration code in v0.7.0 to move from the KV store to the SQL store. Once this version successfully updates across the cloud, we'll follow on with prepackaging v1.0.0.

```release-note
Pre-package Incident Response v0.7.0
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29746