### PR TITLE
[MM-29725] Add websocket event for when user activation status changes

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1346,6 +1346,9 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 			}
 		})
 	}
+
+	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_USER_ACTIVATION_STATUS_CHANGE, "", "", "", nil)
+	c.App.Publish(message)
 	ReturnStatusOK(w)
 }
 

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -57,6 +57,7 @@ const (
 	WEBSOCKET_EVENT_CONFIG_CHANGED                           = "config_changed"
 	WEBSOCKET_EVENT_OPEN_DIALOG                              = "open_dialog"
 	WEBSOCKET_EVENT_GUESTS_DEACTIVATED                       = "guests_deactivated"
+	WEBSOCKET_EVENT_USER_ACTIVATION_STATUS_CHANGE            = "user_activation_status_change"
 	WEBSOCKET_EVENT_RECEIVED_GROUP                           = "received_group"
 	WEBSOCKET_EVENT_RECEIVED_GROUP_ASSOCIATED_TO_TEAM        = "received_group_associated_to_team"
 	WEBSOCKET_EVENT_RECEIVED_GROUP_NOT_ASSOCIATED_TO_TEAM    = "received_group_not_associated_to_team"


### PR DESCRIPTION
#### Summary
In cloud, admins will be able to activate and deactivate users to go over/under the user limit for the free tier. The number of users is important to the front end because it can trigger quite a few different warning banners, so we want the front-end to always be up to date. This PR adds a websocket event for when a users activation state changes, so that the front end can update its user count.



#### Ticket Link
**This doesn't apply directly to this ticket, but would be a logical next bug report I figured I'd fix now.
https://mattermost.atlassian.net/browse/MM-29725
