### PR TITLE
Automated cherry pick of #15334

### DIFF
--- a/app/plugin_commands.go
+++ b/app/plugin_commands.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -136,6 +137,11 @@ func (a *App) tryExecutePluginCommand(args *model.CommandArgs) (*model.Command, 
 		return nil, nil, nil
 	}
 
+	// Checking if plugin is working or not
+	if err := pluginsEnvironment.PerformHealthCheck(matched.PluginId); err != nil {
+		return matched.Command, nil, model.NewAppError("ExecutePluginCommand", "model.plugin_command_error.error.app_error", map[string]interface{}{"Command": trigger}, "err= Plugin has recently crashed: "+matched.PluginId, http.StatusInternalServerError)
+	}
+
 	pluginHooks, err := pluginsEnvironment.HooksForPlugin(matched.PluginId)
 	if err != nil {
 		return matched.Command, nil, model.NewAppError("ExecutePluginCommand", "model.plugin_command.error.app_error", nil, "err="+err.Error(), http.StatusInternalServerError)
@@ -150,5 +156,11 @@ func (a *App) tryExecutePluginCommand(args *model.CommandArgs) (*model.Command, 
 	}
 
 	response, appErr := pluginHooks.ExecuteCommand(a.PluginContext(), args)
+
+	// Checking if plugin crashed after running the command
+	if err := pluginsEnvironment.PerformHealthCheck(matched.PluginId); err != nil {
+		errMessage := fmt.Sprintf("err= Plugin %s crashed due to /%s command", matched.PluginId, trigger)
+		return matched.Command, nil, model.NewAppError("ExecutePluginCommand", "model.plugin_command_crash.error.app_error", map[string]interface{}{"Command": trigger, "PluginId": matched.PluginId}, errMessage, http.StatusInternalServerError)
+	}
 	return matched.Command, response, appErr
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7203,6 +7203,14 @@
     "translation": "An error occurred while trying to execute this command."
   },
   {
+    "id": "model.plugin_command_crash.error.app_error",
+    "translation": "/{{.Command}} command crashed the {{.PluginId}} plugin. Please contact your system administrator"
+  },
+  {
+    "id": "model.plugin_command_error.error.app_error",
+    "translation": "Plugin for /{{.Command}} is not working. Please contact your system administrator"
+  },
+  {
     "id": "model.plugin_key_value.is_valid.key.app_error",
     "translation": "Invalid key, must be more than {{.Min}} and a of maximum {{.Max}} characters long."
   },

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -472,8 +472,8 @@ func (env *Environment) RunMultiPluginHook(hookRunnerFunc func(hooks Hooks) bool
 	}
 }
 
-// performHealthCheck uses the active plugin's supervisor to verify if the plugin has crashed.
-func (env *Environment) performHealthCheck(id string) error {
+// PerformHealthCheck uses the active plugin's supervisor to verify if the plugin has crashed.
+func (env *Environment) PerformHealthCheck(id string) error {
 	p, ok := env.registeredPlugins.Load(id)
 	if !ok {
 		return nil

--- a/plugin/health_check.go
+++ b/plugin/health_check.go
@@ -51,7 +51,7 @@ func (job *PluginHealthCheckJob) run() {
 // If the plugin passes the health check, do nothing.
 // If the plugin fails the health check, the function either restarts or deactivates the plugin, based on the quantity and frequency of its failures.
 func (job *PluginHealthCheckJob) CheckPlugin(id string) {
-	err := job.env.performHealthCheck(id)
+	err := job.env.PerformHealthCheck(id)
 	if err == nil {
 		return
 	}


### PR DESCRIPTION
Cherry pick of #15334 on release-5.29.

/cc  @asimsedhain

```release-note
Added an informative error message to show when a slash command has crashed a plugin, rather than "command not found". Subsequent commands also now show that the plugin has crashed recently.
```