### PR TITLE
[MM-29731] Fix panic in saveUserTermsOfService

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -2423,8 +2423,16 @@ func saveUserTermsOfService(c *Context, w http.ResponseWriter, r *http.Request) 
 	props := model.StringInterfaceFromJson(r.Body)
 
 	userId := c.App.Session().UserId
-	termsOfServiceId := props["termsOfServiceId"].(string)
-	accepted := props["accepted"].(bool)
+	termsOfServiceId, ok := props["termsOfServiceId"].(string)
+	if !ok {
+		c.SetInvalidParam("termsOfServiceId")
+		return
+	}
+	accepted, ok := props["accepted"].(bool)
+	if !ok {
+		c.SetInvalidParam("accepted")
+		return
+	}
 
 	auditRec := c.MakeAuditRecord("saveUserTermsOfService", audit.Fail)
 	defer c.LogAuditRec(auditRec)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -829,7 +829,7 @@ func TestGetUserByUsernameWithAcceptedTermsOfService(t *testing.T) {
 }
 
 func TestSaveUserTermsOfService(t *testing.T) {
-	th := Setup(t).InitBasic()
+	th := Setup(t)
 	defer th.TearDown()
 
 	t.Run("Invalid data", func(t *testing.T) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -828,6 +828,17 @@ func TestGetUserByUsernameWithAcceptedTermsOfService(t *testing.T) {
 	require.Equal(t, tos.Id, ruser.TermsOfServiceId, "Terms of service ID should match")
 }
 
+func TestSaveUserTermsOfService(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	t.Run("Invalid data", func(t *testing.T) {
+		resp, err := th.Client.DoApiPost("/users/"+th.BasicUser.Id+"/terms_of_service", "{}")
+		require.NotNil(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+}
+
 func TestGetUserByEmail(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()


### PR DESCRIPTION
#### Summary

PR fixes a panic in `api4.saveUserTermsOfService` in case of bad/missing data in the request body.

#### Ticket

https://mattermost.atlassian.net/browse/MM-29731
