### PR TITLE
[MM-29937] Don't allow email and contact name to be updated from the MM app

### DIFF
--- a/model/cloud.go
+++ b/model/cloud.go
@@ -45,9 +45,9 @@ type CloudCustomer struct {
 // CloudCustomerInfo represents editable info of a customer.
 type CloudCustomerInfo struct {
 	Name             string `json:"name"`
-	Email            string `json:"email"`
-	ContactFirstName string `json:"contact_first_name"`
-	ContactLastName  string `json:"contact_last_name"`
+	Email            string `json:"-"`
+	ContactFirstName string `json:"-"`
+	ContactLastName  string `json:"-"`
 	NumEmployees     int    `json:"num_employees"`
 }
 

--- a/model/cloud.go
+++ b/model/cloud.go
@@ -45,9 +45,9 @@ type CloudCustomer struct {
 // CloudCustomerInfo represents editable info of a customer.
 type CloudCustomerInfo struct {
 	Name             string `json:"name"`
-	Email            string `json:"-"`
-	ContactFirstName string `json:"-"`
-	ContactLastName  string `json:"-"`
+	Email            string `json:"email,omitempty"`
+	ContactFirstName string `json:"contact_first_name,omitempty"`
+	ContactLastName  string `json:"contact_last_name,omitempty"`
 	NumEmployees     int    `json:"num_employees"`
 }
 


### PR DESCRIPTION
#### Summary
When updating the Company Information, the stripe implementation expected that unchanged fields would be `nil`, whereas the MM app would send up blank strings, thus resetting those fields.

This PR stops the fields that aren't modified by the MM app from being added to the struct at all, so that they can't be wiped out.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29937

#### Release Note
```release-note
NONE
```
