### PR TITLE
MM-28984: Add fallback text to push notification

### DIFF
--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -164,7 +164,7 @@ func (a *App) getPushNotificationMessage(contentsConfig, postMessage string, exp
 	senderName, channelName, channelType, replyToThreadType string, userLocale i18n.TranslateFunc) string {
 
 	// If the post only has images then push an appropriate message
-	if len(postMessage) == 0 && hasFiles {
+	if postMessage == "" && hasFiles {
 		if channelType == model.CHANNEL_DIRECT {
 			return strings.Trim(userLocale("api.post.send_notifications_and_forget.push_image_only"), " ")
 		}
@@ -580,6 +580,10 @@ func (a *App) buildFullPushNotificationMessage(contentsConfig string, post *mode
 
 	if fw, ok := post.GetProp("from_webhook").(string); ok {
 		msg.FromWebhook = fw
+	}
+
+	for _, attachment := range post.Attachments() {
+		post.Message += "\n" + attachment.Fallback
 	}
 
 	userLocale := utils.GetUserTranslations(user.Locale)

--- a/app/notification_push_test.go
+++ b/app/notification_push_test.go
@@ -1407,6 +1407,29 @@ func TestPushNotificationRace(t *testing.T) {
 	})
 }
 
+func TestPushNotificationAttachment(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	post := &model.Post{
+		Message: "hello world",
+		Props: map[string]interface{}{
+			"attachments": []*model.SlackAttachment{
+				{
+					AuthorName: "testuser",
+					Text:       "test attachment",
+					Fallback:   "fallback text",
+				},
+			},
+		},
+	}
+	user := &model.User{}
+	ch := &model.Channel{}
+
+	pn := th.App.buildFullPushNotificationMessage("full", post, user, ch, ch.Name, "test", false, false, "")
+	assert.Equal(t, "test: hello world\nfallback text", pn.Message)
+}
+
 // Run it with | grep -v '{"level"' to prevent spamming the console.
 func BenchmarkPushNotificationThroughput(b *testing.B) {
 	th := SetupWithStoreMock(b)


### PR DESCRIPTION
We read the fallback text from message attachments and append that as part
of a push notification.

https://mattermost.atlassian.net/browse/MM-28984

```release-note
NONE
```
