### PR TITLE
[MM-30014] storetest/user_store: fix flaky test

### DIFF
--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -1423,6 +1423,7 @@ func testUserStoreGetProfilesByIds(t *testing.T, ss store.Store) {
 	_, nErr = ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: u2.Id}, -1)
 	require.Nil(t, nErr)
 
+	time.Sleep(time.Millisecond)
 	u3, err := ss.User().Save(&model.User{
 		Email:    MakeEmail(),
 		Username: "u3" + model.NewId(),


### PR DESCRIPTION

#### Summary
Fix a flaky test where two users can be created in the same millisecond.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30014

#### Release Note

```release-note
NONE
```
