### PR TITLE
MM-29979: make websocket writes zero-alloc

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -4,6 +4,8 @@
 package app
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -169,6 +171,11 @@ func (wc *WebConn) writePump() {
 		wc.WebSocket.Close()
 	}()
 
+	var buf bytes.Buffer
+	// 2k is seen to be a good heuristic under which 98.5% of message sizes remain.
+	buf.Grow(1024 * 2)
+	enc := json.NewEncoder(&buf)
+
 	for {
 		select {
 		case msg, ok := <-wc.send:
@@ -201,20 +208,20 @@ func (wc *WebConn) writePump() {
 				continue
 			}
 
-			var msgBytes []byte
+			buf.Reset()
 			if evtOk {
 				cpyEvt := evt.SetSequence(wc.Sequence)
-				msgBytes = []byte(cpyEvt.ToJson())
+				enc.Encode(cpyEvt)
 				wc.Sequence++
 			} else {
-				msgBytes = []byte(msg.ToJson())
+				enc.Encode(msg)
 			}
 
 			if len(wc.send) >= sendFullWarn {
 				logData := []mlog.Field{
 					mlog.String("user_id", wc.UserId),
 					mlog.String("type", msg.EventType()),
-					mlog.Int("size", len(msgBytes)),
+					mlog.Int("size", buf.Len()),
 				}
 				if evtOk {
 					logData = append(logData, mlog.String("channel_id", evt.GetBroadcast().ChannelId))
@@ -224,7 +231,7 @@ func (wc *WebConn) writePump() {
 			}
 
 			wc.WebSocket.SetWriteDeadline(time.Now().Add(writeWaitTime))
-			if err := wc.WebSocket.WriteMessage(websocket.TextMessage, msgBytes); err != nil {
+			if err := wc.WebSocket.WriteMessage(websocket.TextMessage, buf.Bytes()); err != nil {
 				wc.logSocketErr("websocket.send", err)
 				return
 			}

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -209,12 +209,17 @@ func (wc *WebConn) writePump() {
 			}
 
 			buf.Reset()
+			var err error
 			if evtOk {
 				cpyEvt := evt.SetSequence(wc.Sequence)
-				enc.Encode(cpyEvt)
+				err = enc.Encode(cpyEvt)
 				wc.Sequence++
 			} else {
-				enc.Encode(msg)
+				err = enc.Encode(msg)
+			}
+			if err != nil {
+				mlog.Warn("Error in encoding websocket message", mlog.Err(err))
+				continue
 			}
 
 			if len(wc.send) >= sendFullWarn {


### PR DESCRIPTION
Instead of allocating a new slice every time we write a message,
we create a json encoder for a byte buffer and then reset the buffer
every time we write a new message.

This allocates a buffer of a constant size per-connection, but gets rid
of a new allocation for every single write, reducing pressure on GC.

After taking a distrbution of message sizes from a load test, it was seen that
2k is a good enough buffer size within which 98.5% of messages remain.

Taking a look at the alloc profiles for (*webconn).writepump:
- master branch: 8.01% of total allocations totalling 64GB
- with this PR: 4.92% and 10GB.

CPU and Memory graphs

![wsreuse-cpi](https://user-images.githubusercontent.com/1774000/97335668-1c187480-18a4-11eb-9d68-9794d46e97a3.png)

![wsreuse-mem](https://user-images.githubusercontent.com/1774000/97335704-25094600-18a4-11eb-8f03-99b1a7cb9f70.png)

We can see that the new PR has marginally higher memory usage. That's expected. But CPU usage is not very prominently visible at that high a level. The alloc profiles are there as a measurable proof for that.

https://mattermost.atlassian.net/browse/MM-29979
