### PR TITLE
MMCTL is not being included in the package

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -1,4 +1,3 @@
-
 dist: | check-style test package
 
 build-linux:
@@ -98,7 +97,7 @@ package:
 	cp -RL $(BUILD_WEBAPP_DIR)/dist/* $(DIST_PATH)/client
 
 	@#Download MMCTL
-	scripts/download_mmctl_release.sh
+	scripts/download_mmctl_release.sh "" $(DIST_PATH)/bin
 
 	@# Help files
 ifeq ($(BUILD_ENTERPRISE_READY),true)
@@ -137,7 +136,7 @@ else
 	cp $(GOBIN)/darwin_amd64/platform $(DIST_PATH)/bin # from cross-compiled bin dir
 endif
 	#Download MMCTL for OSX
-	scripts/download_mmctl_release.sh "Darwin"
+	scripts/download_mmctl_release.sh "Darwin" $(DIST_PATH)/bin
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="osx-amd64"; \
@@ -172,7 +171,7 @@ else
 	cp $(GOBIN)/windows_amd64/platform.exe $(DIST_PATH)/bin # from cross-compiled bin dir
 endif
 	#Download MMCTL for Windows
-	scripts/download_mmctl_release.sh "Windows"
+	scripts/download_mmctl_release.sh "Windows" $(DIST_PATH)/bin
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="windows-amd64"; \
@@ -207,7 +206,7 @@ else
 	cp $(GOBIN)/linux_amd64/platform $(DIST_PATH)/bin # from cross-compiled bin dir
 endif
 	#Download MMCTL for Linux
-	scripts/download_mmctl_release.sh "Linux"
+	scripts/download_mmctl_release.sh "Linux" $(DIST_PATH)/bin
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="linux-amd64"; \

--- a/scripts/download_mmctl_release.sh
+++ b/scripts/download_mmctl_release.sh
@@ -13,6 +13,8 @@ then
   OVERRIDE_OS=$1
 fi
 
+BIN_PATH=${2:-bin}
+
 # strip whitespace
 THIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$THIS_BRANCH" =~ 'release-'[0-9] ]];
@@ -34,15 +36,15 @@ fi
 case "$PLATFORM" in
 
 Linux)
-  MMCTL_FILE="linux_amd64.tar" && curl -f -O -L https://releases.mattermost.com/mmctl/"$RELEASE_TO_DOWNLOAD"/"$MMCTL_FILE" && tar -xvf "$MMCTL_FILE" -C bin && rm "$MMCTL_FILE";
+  MMCTL_FILE="linux_amd64.tar" && curl -f -O -L https://releases.mattermost.com/mmctl/"$RELEASE_TO_DOWNLOAD"/"$MMCTL_FILE" && tar -xvf "$MMCTL_FILE" -C "$BIN_PATH" && rm "$MMCTL_FILE";
   ;;
 
 Darwin)
-  MMCTL_FILE="darwin_amd64.tar" && curl -f -O -L https://releases.mattermost.com/mmctl/"$RELEASE_TO_DOWNLOAD"/"$MMCTL_FILE" && tar -xvf "$MMCTL_FILE" -C bin && rm "$MMCTL_FILE";
+  MMCTL_FILE="darwin_amd64.tar" && curl -f -O -L https://releases.mattermost.com/mmctl/"$RELEASE_TO_DOWNLOAD"/"$MMCTL_FILE" && tar -xvf "$MMCTL_FILE" -C "$BIN_PATH" && rm "$MMCTL_FILE";
   ;;
 
 Windows)
-  MMCTL_FILE="windows_amd64.zip" && curl -f -O -L https://releases.mattermost.com/mmctl/"$RELEASE_TO_DOWNLOAD"/"$MMCTL_FILE" && unzip -o "$MMCTL_FILE" -d bin && rm "$MMCTL_FILE";
+  MMCTL_FILE="windows_amd64.zip" && curl -f -O -L https://releases.mattermost.com/mmctl/"$RELEASE_TO_DOWNLOAD"/"$MMCTL_FILE" && unzip -o "$MMCTL_FILE" -d "$BIN_PATH" && rm "$MMCTL_FILE";
   ;;
 
 *)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

It's was including it in the bin folder but when we package we need to include it in the dist/bin so right now the download_mmctl script accepts a second parameter to define the path where the binary is going to be stored

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
