### PR TITLE
MM-30041: Return correct error message for user save

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -875,7 +875,7 @@ func CheckErrorMessage(t *testing.T, resp *model.Response, errorId string) {
 	t.Helper()
 
 	require.NotNilf(t, resp.Error, "should have errored with message: %s", errorId)
-	require.Equalf(t, resp.Error.Id, errorId, "incorrect error message, actual: %s, expected: %s", resp.Error.Id, errorId)
+	require.Equalf(t, errorId, resp.Error.Id, "incorrect error message, actual: %s, expected: %s", resp.Error.Id, errorId)
 }
 
 func CheckStartsWith(t *testing.T, value, prefix, message string) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -53,13 +53,13 @@ func TestCreateUser(t *testing.T) {
 	ruser.Username = GenerateTestUsername()
 	ruser.Password = "passwd1"
 	_, resp = th.Client.CreateUser(ruser)
-	CheckErrorMessage(t, resp, "app.user.save.existing.app_error")
+	CheckErrorMessage(t, resp, "app.user.save.email_exists.app_error")
 	CheckBadRequestStatus(t, resp)
 
 	ruser.Email = th.GenerateTestEmail()
 	ruser.Username = user.Username
 	_, resp = th.Client.CreateUser(ruser)
-	CheckErrorMessage(t, resp, "app.user.save.existing.app_error")
+	CheckErrorMessage(t, resp, "app.user.save.username_exists.app_error")
 	CheckBadRequestStatus(t, resp)
 
 	ruser.Email = ""

--- a/app/bot.go
+++ b/app/bot.go
@@ -26,7 +26,16 @@ func (a *App) CreateBot(bot *model.Bot) (*model.Bot, *model.AppError) {
 		case errors.As(nErr, &appErr):
 			return nil, appErr
 		case errors.As(nErr, &invErr):
-			return nil, model.NewAppError("CreateBot", "app.user.save.existing.app_error", nil, invErr.Error(), http.StatusBadRequest)
+			code := ""
+			switch invErr.Field {
+			case "email":
+				code = "app.user.save.email_exists.app_error"
+			case "username":
+				code = "app.user.save.username_exists.app_error"
+			default:
+				code = "app.user.save.existing.app_error"
+			}
+			return nil, model.NewAppError("CreateBot", code, nil, invErr.Error(), http.StatusBadRequest)
 		default:
 			return nil, model.NewAppError("CreateBot", "app.user.save.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 		}
@@ -93,7 +102,16 @@ func (a *App) getOrCreateWarnMetricsBot(botDef *model.Bot) (*model.Bot, *model.A
 			case errors.As(nErr, &appError):
 				return nil, appError
 			case errors.As(nErr, &invErr):
-				return nil, model.NewAppError("getOrCreateWarnMetricsBot", "app.user.save.existing.app_error", nil, invErr.Error(), http.StatusBadRequest)
+				code := ""
+				switch invErr.Field {
+				case "email":
+					code = "app.user.save.email_exists.app_error"
+				case "username":
+					code = "app.user.save.username_exists.app_error"
+				default:
+					code = "app.user.save.existing.app_error"
+				}
+				return nil, model.NewAppError("getOrCreateWarnMetricsBot", code, nil, invErr.Error(), http.StatusBadRequest)
 			default:
 				return nil, model.NewAppError("getOrCreateWarnMetricsBot", "app.user.save.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 			}

--- a/app/bot_test.go
+++ b/app/bot_test.go
@@ -97,7 +97,7 @@ func TestCreateBot(t *testing.T) {
 			OwnerId:     th.BasicUser.Id,
 		})
 		require.NotNil(t, err)
-		require.Equal(t, "app.user.save.existing.app_error", err.Id)
+		require.Equal(t, "app.user.save.username_exists.app_error", err.Id)
 	})
 }
 

--- a/app/user.go
+++ b/app/user.go
@@ -306,7 +306,14 @@ func (a *App) createUser(user *model.User) (*model.User, *model.AppError) {
 		case errors.As(nErr, &appErr):
 			return nil, appErr
 		case errors.As(nErr, &invErr):
-			return nil, model.NewAppError("createUser", "app.user.save.existing.app_error", nil, invErr.Error(), http.StatusBadRequest)
+			switch invErr.Field {
+			case "email":
+				return nil, model.NewAppError("createUser", "app.user.save.email_exists.app_error", nil, invErr.Error(), http.StatusBadRequest)
+			case "username":
+				return nil, model.NewAppError("createUser", "app.user.save.username_exists.app_error", nil, invErr.Error(), http.StatusBadRequest)
+			default:
+				return nil, model.NewAppError("createUser", "app.user.save.existing.app_error", nil, invErr.Error(), http.StatusBadRequest)
+			}
 		default:
 			return nil, model.NewAppError("createUser", "app.user.save.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 		}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5467,8 +5467,16 @@
     "translation": "Unable to save the account."
   },
   {
+    "id": "app.user.save.email_exists.app_error",
+    "translation": "An account with that email already exists."
+  },
+  {
     "id": "app.user.save.existing.app_error",
     "translation": "Must call update for existing user."
+  },
+  {
+    "id": "app.user.save.username_exists.app_error",
+    "translation": "An account with that username already exists."
   },
   {
     "id": "app.user.search.app_error",


### PR DESCRIPTION
We were collapsing all types of user conflict into a single
error message. Fixed it by inspecting the field of the invalidError type
and returning the correct message.

https://mattermost.atlassian.net/browse/MM-30041

```release-note
NONE
```
