### PR TITLE
[MM-30141] Break out of loop early in ClearSessionCacheForUserSkipClusterSend

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -215,6 +215,7 @@ func (a *App) ClearSessionCacheForUserSkipClusterSend(userId string) {
 					if a.Metrics() != nil {
 						a.Metrics().IncrementMemCacheInvalidationCounterSession()
 					}
+					break
 				}
 			}
 		}


### PR DESCRIPTION
#### Summary

PR adds a `break` statement to exit the loop early in case a session is found. This avoids having to loop and get more keys which would result in some unnecessary locking.

#### Benchmarks

```go
func BenchmarkClearSessionCacheForUserSkipClusterSend(b *testing.B) {
	th := Setup(b)
	defer th.TearDown()

	n := 1000
	userIds := make([]string, n)
	for i := 0; i < n; i++ {
		userIds[i] = model.NewId()
		session := &model.Session{
			Id:     model.NewId(),
			Token:  model.NewId(),
			UserId: userIds[i],
		}
		err := th.App.Srv().sessionCache.Set(session.Token, session)
		require.NoError(b, err)
	}

	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		th.App.ClearSessionCacheForUserSkipClusterSend(userIds[rand.Intn(n)])
	}
}
```

```
~ » cat pre
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      9596 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      9210 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      9567 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      9289 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
~ » cat post
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      7939 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      7588 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      7662 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
BenchmarkClearSessionCacheForUserSkipClusterSend-8   	  100000	      7663 ns/op
--- BENCH: BenchmarkClearSessionCacheForUserSkipClusterSend-8
~ » benchstat pre post                 
name                                       old time/op  new time/op  delta
ClearSessionCacheForUserSkipClusterSend-8  9.42µs ± 2%  7.71µs ± 3%  -18.08%  (p=0.029 n=4+4)
```

Not much of a gain in absolute terms but still less work for the CPU.

#### Ticket

https://mattermost.atlassian.net/browse/MM-30141