### PR TITLE
prepackage incident management v1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ PLUGIN_PACKAGES += mattermost-plugin-antivirus-v0.1.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v2.3.2
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-incident-response-v1.0.0
+PLUGIN_PACKAGES += mattermost-plugin-incident-management-v1.1.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)

--- a/model/config.go
+++ b/model/config.go
@@ -2634,9 +2634,9 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates["com.mattermost.nps"] = &PluginState{Enable: ls.EnableDiagnostics == nil || *ls.EnableDiagnostics}
 	}
 
-	if s.PluginStates["com.mattermost.plugin-incident-response"] == nil {
-		// Enable the incident response plugin by default
-		s.PluginStates["com.mattermost.plugin-incident-response"] = &PluginState{Enable: true}
+	if s.PluginStates["com.mattermost.plugin-incident-management"] == nil {
+		// Enable the incident management plugin by default
+		s.PluginStates["com.mattermost.plugin-incident-management"] = &PluginState{Enable: true}
 	}
 
 	if s.EnableMarketplace == nil {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -308,19 +308,19 @@ func TestConfigDefaultNPSPluginState(t *testing.T) {
 	})
 }
 
-func TestConfigDefaultIncidentResponsePluginState(t *testing.T) {
-	t.Run("should enable IncidentResponse plugin by default", func(t *testing.T) {
+func TestConfigDefaultIncidentManagementPluginState(t *testing.T) {
+	t.Run("should enable IncidentManagement plugin by default", func(t *testing.T) {
 		c1 := Config{}
 		c1.SetDefaults()
 
-		assert.True(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-response"].Enable)
+		assert.True(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-management"].Enable)
 	})
 
-	t.Run("should not re-enable IncidentResponse plugin after it has been disabled", func(t *testing.T) {
+	t.Run("should not re-enable IncidentManagement plugin after it has been disabled", func(t *testing.T) {
 		c1 := Config{
 			PluginSettings: PluginSettings{
 				PluginStates: map[string]*PluginState{
-					"com.mattermost.plugin-incident-response": {
+					"com.mattermost.plugin-incident-management": {
 						Enable: false,
 					},
 				},
@@ -329,7 +329,7 @@ func TestConfigDefaultIncidentResponsePluginState(t *testing.T) {
 
 		c1.SetDefaults()
 
-		assert.False(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-response"].Enable)
+		assert.False(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-management"].Enable)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Handle the transition from "incident response" to "incident management", automatically enabling the latter now. When the new version of the plugin starts, it will automatically uninstall the old version of the plugin while maintaining backwards compatibility with the underlying data.

```release-note
Pre-package Incident Management v1.1
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30204