### PR TITLE
MM-26425: Make URL parsing for image proxy more robust

### DIFF
--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -560,6 +560,8 @@ func TestPreparePostForClientWithImageProxy(t *testing.T) {
 			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
 		})
 
+		th.Server.ImageProxy = imageproxy.MakeImageProxy(th.Server, th.Server.HTTPService, th.Server.Log)
+
 		return th
 	}
 

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -475,59 +475,68 @@ func TestImageProxy(t *testing.T) {
 	th.Server.ImageProxy = imageproxy.MakeImageProxy(th.Server, th.Server.HTTPService, th.Server.Log)
 
 	for name, tc := range map[string]struct {
-		ProxyType       string
-		ProxyURL        string
-		ProxyOptions    string
-		ImageURL        string
-		ProxiedImageURL string
+		ProxyType              string
+		ProxyURL               string
+		ProxyOptions           string
+		ImageURL               string
+		ProxiedImageURL        string
+		ProxiedRemovedImageURL string
 	}{
 		"atmos/camo": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
-			ProxyURL:        "https://127.0.0.1",
-			ProxyOptions:    "foo",
-			ImageURL:        "http://mydomain.com/myimage",
-			ProxiedImageURL: "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage",
+			ProxyType:              model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
+			ProxyURL:               "https://127.0.0.1",
+			ProxyOptions:           "foo",
+			ImageURL:               "http://mydomain.com/myimage",
+			ProxiedRemovedImageURL: "http://mydomain.com/myimage",
+			ProxiedImageURL:        "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage",
 		},
 		"atmos/camo_SameSite": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
-			ProxyURL:        "https://127.0.0.1",
-			ProxyOptions:    "foo",
-			ImageURL:        "http://mymattermost.com/myimage",
-			ProxiedImageURL: "http://mymattermost.com/myimage",
+			ProxyType:              model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
+			ProxyURL:               "https://127.0.0.1",
+			ProxyOptions:           "foo",
+			ImageURL:               "http://mymattermost.com/myimage",
+			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
+			ProxiedImageURL:        "http://mymattermost.com/myimage",
 		},
 		"atmos/camo_PathOnly": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
-			ProxyURL:        "https://127.0.0.1",
-			ProxyOptions:    "foo",
-			ImageURL:        "/myimage",
-			ProxiedImageURL: "/myimage",
+			ProxyType:              model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
+			ProxyURL:               "https://127.0.0.1",
+			ProxyOptions:           "foo",
+			ImageURL:               "/myimage",
+			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
+			ProxiedImageURL:        "http://mymattermost.com/myimage",
 		},
 		"atmos/camo_EmptyImageURL": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
-			ProxyURL:        "https://127.0.0.1",
-			ProxyOptions:    "foo",
-			ImageURL:        "",
-			ProxiedImageURL: "",
+			ProxyType:              model.IMAGE_PROXY_TYPE_ATMOS_CAMO,
+			ProxyURL:               "https://127.0.0.1",
+			ProxyOptions:           "foo",
+			ImageURL:               "",
+			ProxiedRemovedImageURL: "",
+			ProxiedImageURL:        "",
 		},
 		"local": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_LOCAL,
-			ImageURL:        "http://mydomain.com/myimage",
-			ProxiedImageURL: "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage",
+			ProxyType:              model.IMAGE_PROXY_TYPE_LOCAL,
+			ImageURL:               "http://mydomain.com/myimage",
+			ProxiedRemovedImageURL: "http://mydomain.com/myimage",
+			ProxiedImageURL:        "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage",
 		},
 		"local_SameSite": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_LOCAL,
-			ImageURL:        "http://mymattermost.com/myimage",
-			ProxiedImageURL: "http://mymattermost.com/myimage",
+			ProxyType:              model.IMAGE_PROXY_TYPE_LOCAL,
+			ImageURL:               "http://mymattermost.com/myimage",
+			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
+			ProxiedImageURL:        "http://mymattermost.com/myimage",
 		},
 		"local_PathOnly": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_LOCAL,
-			ImageURL:        "/myimage",
-			ProxiedImageURL: "/myimage",
+			ProxyType:              model.IMAGE_PROXY_TYPE_LOCAL,
+			ImageURL:               "/myimage",
+			ProxiedRemovedImageURL: "http://mymattermost.com/myimage",
+			ProxiedImageURL:        "http://mymattermost.com/myimage",
 		},
 		"local_EmptyImageURL": {
-			ProxyType:       model.IMAGE_PROXY_TYPE_LOCAL,
-			ImageURL:        "",
-			ProxiedImageURL: "",
+			ProxyType:              model.IMAGE_PROXY_TYPE_LOCAL,
+			ImageURL:               "",
+			ProxiedRemovedImageURL: "",
+			ProxiedImageURL:        "",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -550,14 +559,14 @@ func TestImageProxy(t *testing.T) {
 
 			assert.Equal(t, "![foo]("+tc.ImageURL+")", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
 			post.Message = "![foo](" + tc.ProxiedImageURL + ")"
-			assert.Equal(t, "![foo]("+tc.ImageURL+")", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
+			assert.Equal(t, "![foo]("+tc.ProxiedRemovedImageURL+")", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
 
 			if tc.ImageURL != "" {
 				post.Message = "![foo](" + tc.ImageURL + " =500x200)"
 				assert.Equal(t, "![foo]("+tc.ProxiedImageURL+" =500x200)", th.App.PostWithProxyAddedToImageURLs(post).Message)
 				assert.Equal(t, "![foo]("+tc.ImageURL+" =500x200)", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
 				post.Message = "![foo](" + tc.ProxiedImageURL + " =500x200)"
-				assert.Equal(t, "![foo]("+tc.ImageURL+" =500x200)", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
+				assert.Equal(t, "![foo]("+tc.ProxiedRemovedImageURL+" =500x200)", th.App.PostWithProxyRemovedFromImageURLs(post).Message)
 			}
 		})
 	}

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/plugin/plugintest/mock"
+	"github.com/mattermost/mattermost-server/v5/services/imageproxy"
 	"github.com/mattermost/mattermost-server/v5/services/searchengine/mocks"
 	"github.com/mattermost/mattermost-server/v5/store/storetest"
 	storemocks "github.com/mattermost/mattermost-server/v5/store/storetest/mocks"
@@ -471,6 +472,8 @@ func TestImageProxy(t *testing.T) {
 		*cfg.ServiceSettings.SiteURL = "http://mymattermost.com"
 	})
 
+	th.Server.ImageProxy = imageproxy.MakeImageProxy(th.Server, th.Server.HTTPService, th.Server.Log)
+
 	for name, tc := range map[string]struct {
 		ProxyType       string
 		ProxyURL        string
@@ -675,6 +678,8 @@ func TestCreatePost(t *testing.T) {
 			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
 		})
 
+		th.Server.ImageProxy = imageproxy.MakeImageProxy(th.Server, th.Server.HTTPService, th.Server.Log)
+
 		imageURL := "http://mydomain.com/myimage"
 		proxiedImageURL := "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage"
 
@@ -754,6 +759,8 @@ func TestPatchPost(t *testing.T) {
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
 			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
 		})
+
+		th.Server.ImageProxy = imageproxy.MakeImageProxy(th.Server, th.Server.HTTPService, th.Server.Log)
 
 		imageURL := "http://mydomain.com/myimage"
 		proxiedImageURL := "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage"
@@ -974,6 +981,8 @@ func TestUpdatePost(t *testing.T) {
 			*cfg.ImageProxySettings.RemoteImageProxyURL = "https://127.0.0.1"
 			*cfg.ImageProxySettings.RemoteImageProxyOptions = "foo"
 		})
+
+		th.Server.ImageProxy = imageproxy.MakeImageProxy(th.Server, th.Server.HTTPService, th.Server.Log)
 
 		imageURL := "http://mydomain.com/myimage"
 		proxiedImageURL := "http://mymattermost.com/api/v4/image?url=http%3A%2F%2Fmydomain.com%2Fmyimage"

--- a/services/imageproxy/atmos_camo.go
+++ b/services/imageproxy/atmos_camo.go
@@ -61,8 +61,9 @@ func (backend *AtmosCamoBackend) getAtmosCamoImageURL(imageURL string) string {
 	}
 
 	// Parse url, return siteURL in case of failure.
+	// Also if the URL is opaque.
 	parsedURL, err := url.Parse(imageURL)
-	if err != nil {
+	if err != nil || parsedURL.Opaque != "" {
 		return backend.siteURL.String()
 	}
 

--- a/services/imageproxy/atmos_camo.go
+++ b/services/imageproxy/atmos_camo.go
@@ -60,20 +60,26 @@ func (backend *AtmosCamoBackend) getAtmosCamoImageURL(imageURL string) string {
 		return imageURL
 	}
 
-	// Parse url, bypass if error in parsing.
+	// Parse url, return siteURL in case of failure.
 	parsedURL, err := url.Parse(imageURL)
 	if err != nil {
-		return imageURL
+		return backend.siteURL.String()
 	}
 
-	// If host is same as siteURL host/ remoteURL host, or it's a relative URL, return.
-	if parsedURL.Host == backend.siteURL.Host || parsedURL.Host == "" || parsedURL.Host == backend.remoteURL.Host {
-		return imageURL
+	// If host is same as siteURL host/ remoteURL host, return.
+	if parsedURL.Host == backend.siteURL.Host || parsedURL.Host == backend.remoteURL.Host {
+		return parsedURL.String()
 	}
 
 	// Handle protocol-relative URLs.
 	if parsedURL.Scheme == "" {
 		parsedURL.Scheme = backend.siteURL.Scheme
+	}
+
+	// If it's a relative URL, fill up the hostname and scheme and return.
+	if parsedURL.Host == "" {
+		parsedURL.Host = backend.siteURL.Host
+		return parsedURL.String()
 	}
 
 	urlBytes := []byte(parsedURL.String())

--- a/services/imageproxy/atmos_camo_test.go
+++ b/services/imageproxy/atmos_camo_test.go
@@ -122,7 +122,7 @@ func TestGetAtmosCamoImageURL(t *testing.T) {
 			Name:     "should not proxy a relative image",
 			Input:    "/static/logo.png",
 			SiteURL:  defaultSiteURL,
-			Expected: "/static/logo.png",
+			Expected: "https://mattermost.example.com/static/logo.png",
 		},
 		{
 			Name:     "should not proxy an image on the Mattermost server",

--- a/services/imageproxy/atmos_camo_test.go
+++ b/services/imageproxy/atmos_camo_test.go
@@ -125,6 +125,12 @@ func TestGetAtmosCamoImageURL(t *testing.T) {
 			Expected: "https://mattermost.example.com/static/logo.png",
 		},
 		{
+			Name:     "should bypass opaque URLs",
+			Input:    "http:xyz123?query",
+			SiteURL:  defaultSiteURL,
+			Expected: defaultSiteURL,
+		},
+		{
 			Name:     "should not proxy an image on the Mattermost server",
 			Input:    "https://mattermost.example.com/static/logo.png",
 			SiteURL:  defaultSiteURL,

--- a/services/imageproxy/atmos_camo_test.go
+++ b/services/imageproxy/atmos_camo_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -64,9 +65,19 @@ func TestAtmosCamoBackend_GetImageDirect(t *testing.T) {
 	defer mock.Close()
 
 	proxy := makeTestAtmosCamoProxy()
-	proxy.ConfigService.(*testutils.StaticConfigService).Cfg.ImageProxySettings.RemoteImageProxyURL = model.NewString(mock.URL)
+	parsedURL, err := url.Parse(*proxy.ConfigService.Config().ServiceSettings.SiteURL)
+	require.NoError(t, err)
 
-	body, contentType, err := proxy.GetImageDirect("https://example.com/image.png")
+	remoteURL, err := url.Parse(mock.URL)
+	require.NoError(t, err)
+
+	backend := &AtmosCamoBackend{
+		proxy:     proxy,
+		siteURL:   parsedURL,
+		remoteURL: remoteURL,
+	}
+
+	body, contentType, err := backend.GetImageDirect("https://example.com/image.png")
 
 	assert.Nil(t, err)
 	assert.Equal(t, "image/png", contentType)
@@ -82,7 +93,6 @@ func TestGetAtmosCamoImageURL(t *testing.T) {
 
 	defaultSiteURL := "https://mattermost.example.com"
 	proxyURL := "http://images.example.com"
-	options := "7e5f3fab20b94782b43cdb022a66985ef28ba355df2c5d5da3c9a05e4b697bac"
 
 	for _, test := range []struct {
 		Name     string
@@ -132,9 +142,39 @@ func TestGetAtmosCamoImageURL(t *testing.T) {
 			SiteURL:  defaultSiteURL,
 			Expected: proxiedURL,
 		},
+		{
+			Name:     "should not bypass protocol relative URLs",
+			Input:    "//www.mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png",
+			SiteURL:  "http://mattermost.example.com",
+			Expected: proxiedURL,
+		},
+		{
+			Name:     "should not bypass if the host prefix is same",
+			Input:    "http://www.mattermost.org.example.com/wp-content/uploads/2016/03/logoHorizontal.png",
+			SiteURL:  defaultSiteURL,
+			Expected: "http://images.example.com/99dcf38b8e6110d6e3ebcfb7a2db9ce875bc5c03/687474703a2f2f7777772e6d61747465726d6f73742e6f72672e6578616d706c652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323031362f30332f6c6f676f486f72697a6f6e74616c2e706e67",
+		},
+		{
+			Name:     "should not bypass for user auth URLs",
+			Input:    "http://www.mattermost.org@example.com/wp-content/uploads/2016/03/logoHorizontal.png",
+			SiteURL:  defaultSiteURL,
+			Expected: "http://images.example.com/19deedea7c0b75369f8d2162ee4e7ab36e26ca50/687474703a2f2f7777772e6d61747465726d6f73742e6f7267406578616d706c652e636f6d2f77702d636f6e74656e742f75706c6f6164732f323031362f30332f6c6f676f486f72697a6f6e74616c2e706e67",
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			assert.Equal(t, test.Expected, getAtmosCamoImageURL(test.Input, test.SiteURL, proxyURL, options))
+			parsedURL, err := url.Parse(test.SiteURL)
+			require.NoError(t, err)
+
+			remoteURL, err := url.Parse(proxyURL)
+			require.NoError(t, err)
+
+			backend := &AtmosCamoBackend{
+				proxy:     makeTestAtmosCamoProxy(),
+				siteURL:   parsedURL,
+				remoteURL: remoteURL,
+			}
+
+			assert.Equal(t, test.Expected, backend.getAtmosCamoImageURL(test.Input))
 		})
 	}
 

--- a/services/imageproxy/imageproxy.go
+++ b/services/imageproxy/imageproxy.go
@@ -127,18 +127,25 @@ func (proxy *ImageProxy) GetProxiedImageURL(imageURL string) string {
 	if imageURL == "" || proxy.siteURL == nil {
 		return imageURL
 	}
-	// Parse url, bypass if error in parsing.
+	// Parse url, return siteURL in case of failure.
 	parsedURL, err := url.Parse(imageURL)
 	if err != nil {
-		return imageURL
+		return proxy.siteURL.String()
 	}
-	// If host is same as siteURL host, or it's a relative URL, return.
-	if parsedURL.Host == proxy.siteURL.Host || parsedURL.Host == "" {
-		return imageURL
+	// If host is same as siteURL host, return.
+	if parsedURL.Host == proxy.siteURL.Host {
+		return parsedURL.String()
 	}
+
 	// Handle protocol-relative URLs.
 	if parsedURL.Scheme == "" {
 		parsedURL.Scheme = proxy.siteURL.Scheme
+	}
+
+	// If it's a relative URL, fill up the hostname and return.
+	if parsedURL.Host == "" {
+		parsedURL.Host = proxy.siteURL.Host
+		return parsedURL.String()
 	}
 
 	return proxy.siteURL.String() + "/api/v4/image?url=" + url.QueryEscape(parsedURL.String())

--- a/services/imageproxy/imageproxy.go
+++ b/services/imageproxy/imageproxy.go
@@ -128,8 +128,9 @@ func (proxy *ImageProxy) GetProxiedImageURL(imageURL string) string {
 		return imageURL
 	}
 	// Parse url, return siteURL in case of failure.
+	// Also if the URL is opaque.
 	parsedURL, err := url.Parse(imageURL)
-	if err != nil {
+	if err != nil || parsedURL.Opaque != "" {
 		return proxy.siteURL.String()
 	}
 	// If host is same as siteURL host, return.

--- a/services/imageproxy/imageproxy_test.go
+++ b/services/imageproxy/imageproxy_test.go
@@ -37,6 +37,11 @@ func TestGetProxiedImageURL(t *testing.T) {
 			Expected: "https://mattermost.example.com/static/logo.png",
 		},
 		{
+			Name:     "should bypass opaque URLs",
+			Input:    "http:xyz123?query",
+			Expected: siteURL,
+		},
+		{
 			Name:     "should not proxy an image on the Mattermost server",
 			Input:    "https://mattermost.example.com/static/logo.png",
 			Expected: "https://mattermost.example.com/static/logo.png",

--- a/services/imageproxy/imageproxy_test.go
+++ b/services/imageproxy/imageproxy_test.go
@@ -4,16 +4,22 @@
 package imageproxy
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetProxiedImageURL(t *testing.T) {
 	siteURL := "https://mattermost.example.com"
+	parsedURL, err := url.Parse(siteURL)
+	require.NoError(t, err)
 
 	imageURL := "http://www.mattermost.org/wp-content/uploads/2016/03/logoHorizontal.png"
 	proxiedURL := "https://mattermost.example.com/api/v4/image?url=http%3A%2F%2Fwww.mattermost.org%2Fwp-content%2Fuploads%2F2016%2F03%2FlogoHorizontal.png"
+
+	proxy := ImageProxy{siteURL: parsedURL}
 
 	for _, test := range []struct {
 		Name     string
@@ -40,9 +46,24 @@ func TestGetProxiedImageURL(t *testing.T) {
 			Input:    proxiedURL,
 			Expected: proxiedURL,
 		},
+		{
+			Name:     "should not bypass protocol relative URLs",
+			Input:    "//mattermost.org/static/logo.png",
+			Expected: "https://mattermost.example.com/api/v4/image?url=https%3A%2F%2Fmattermost.org%2Fstatic%2Flogo.png",
+		},
+		{
+			Name:     "should not bypass if the host prefix is same",
+			Input:    "https://mattermost.example.com.anothersite.com/static/logo.png",
+			Expected: "https://mattermost.example.com/api/v4/image?url=https%3A%2F%2Fmattermost.example.com.anothersite.com%2Fstatic%2Flogo.png",
+		},
+		{
+			Name:     "should not bypass for user auth URLs",
+			Input:    "https://mattermost.example.com@anothersite.com/static/logo.png",
+			Expected: "https://mattermost.example.com/api/v4/image?url=https%3A%2F%2Fmattermost.example.com%40anothersite.com%2Fstatic%2Flogo.png",
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
-			assert.Equal(t, test.Expected, getProxiedImageURL(test.Input, siteURL))
+			assert.Equal(t, test.Expected, proxy.GetProxiedImageURL(test.Input))
 		})
 	}
 }

--- a/services/imageproxy/imageproxy_test.go
+++ b/services/imageproxy/imageproxy_test.go
@@ -34,7 +34,7 @@ func TestGetProxiedImageURL(t *testing.T) {
 		{
 			Name:     "should not proxy a relative image",
 			Input:    "/static/logo.png",
-			Expected: "/static/logo.png",
+			Expected: "https://mattermost.example.com/static/logo.png",
 		},
 		{
 			Name:     "should not proxy an image on the Mattermost server",


### PR DESCRIPTION
- We don't bypass protocol relative URLs.
- We don't bypass hostnames with a similar prefix.

https://mattermost.atlassian.net/browse/MM-26425

```release-note
NONE
```
