### PR TITLE
Release 5.29 cherrypick fix

### DIFF
--- a/model/file_info.go
+++ b/model/file_info.go
@@ -36,22 +36,23 @@ type GetFileInfosOptions struct {
 }
 
 type FileInfo struct {
-	Id              string `json:"id"`
-	CreatorId       string `json:"user_id"`
-	PostId          string `json:"post_id,omitempty"`
-	CreateAt        int64  `json:"create_at"`
-	UpdateAt        int64  `json:"update_at"`
-	DeleteAt        int64  `json:"delete_at"`
-	Path            string `json:"-"` // not sent back to the client
-	ThumbnailPath   string `json:"-"` // not sent back to the client
-	PreviewPath     string `json:"-"` // not sent back to the client
-	Name            string `json:"name"`
-	Extension       string `json:"extension"`
-	Size            int64  `json:"size"`
-	MimeType        string `json:"mime_type"`
-	Width           int    `json:"width,omitempty"`
-	Height          int    `json:"height,omitempty"`
-	HasPreviewImage bool   `json:"has_preview_image,omitempty"`
+	Id              string  `json:"id"`
+	CreatorId       string  `json:"user_id"`
+	PostId          string  `json:"post_id,omitempty"`
+	CreateAt        int64   `json:"create_at"`
+	UpdateAt        int64   `json:"update_at"`
+	DeleteAt        int64   `json:"delete_at"`
+	Path            string  `json:"-"` // not sent back to the client
+	ThumbnailPath   string  `json:"-"` // not sent back to the client
+	PreviewPath     string  `json:"-"` // not sent back to the client
+	Name            string  `json:"name"`
+	Extension       string  `json:"extension"`
+	Size            int64   `json:"size"`
+	MimeType        string  `json:"mime_type"`
+	Width           int     `json:"width,omitempty"`
+	Height          int     `json:"height,omitempty"`
+	HasPreviewImage bool    `json:"has_preview_image,omitempty"`
+	MiniPreview     *[]byte `json:"mini_preview"` // declared as *[]byte to avoid postgres/mysql differences in deserialization
 }
 
 func (fi *FileInfo) ToJson() string {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
A migration was cherrypicked into 5.29 without the code behind the actual feature (mini previews). This PR adds a field to the struct (still unused, code is in master) to avoid CI issues.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
