### PR TITLE
[MM-30126] User friendly invoice filenames in-app

### DIFF
--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -303,14 +302,14 @@ func getSubscriptionInvoicePDF(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	pdfData, appErr := c.App.Cloud().GetInvoicePDF(c.Params.InvoiceId)
+	pdfData, filename, appErr := c.App.Cloud().GetInvoicePDF(c.Params.InvoiceId)
 	if appErr != nil {
 		c.Err = model.NewAppError("Api4.getSuscriptionInvoicePDF", "api.cloud.request_error", nil, appErr.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	err := writeFileResponse(
-		fmt.Sprintf("%s.pdf", c.Params.InvoiceId),
+		filename,
 		"application/pdf",
 		int64(binary.Size(pdfData)),
 		time.Now(),

--- a/einterfaces/cloud.go
+++ b/einterfaces/cloud.go
@@ -19,5 +19,5 @@ type CloudInterface interface {
 
 	GetSubscription() (*model.Subscription, *model.AppError)
 	GetInvoicesForSubscription() ([]*model.Invoice, *model.AppError)
-	GetInvoicePDF(invoiceID string) ([]byte, *model.AppError)
+	GetInvoicePDF(invoiceID string) ([]byte, string, *model.AppError)
 }


### PR DESCRIPTION
#### Summary
A change was made to CWS to name invoices in a more user friendly way. Mattermost-server would receive that invoice and then rename it to the old way. This PR along with: https://github.com/mattermost/enterprise/pull/817 will pass along the filename returned by CWS instead of renaming it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30126


#### Release Note
```release-note
None
```
