### PR TITLE
MM-30090 Add ManagedResourcePaths setting

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -47,6 +47,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["EnableMarketplace"] = strconv.FormatBool(*c.PluginSettings.EnableMarketplace)
 	props["EnableLatex"] = strconv.FormatBool(*c.ServiceSettings.EnableLatex)
 	props["ExtendSessionLengthWithActivity"] = strconv.FormatBool(*c.ServiceSettings.ExtendSessionLengthWithActivity)
+	props["ManagedResourcePaths"] = *c.ServiceSettings.ManagedResourcePaths
 
 	// This setting is only temporary, so keep using the old setting name for the mobile and web apps
 	props["ExperimentalEnablePostMetadata"] = "true"

--- a/model/config.go
+++ b/model/config.go
@@ -351,6 +351,7 @@ type ServiceSettings struct {
 	FeatureFlagSyncIntervalSeconds                    *int    `access:"environment,write_restrictable"`
 	DebugSplit                                        *bool   `access:"environment,write_restrictable"`
 	ThreadAutoFollow                                  *bool   `access:"experimental"`
+	ManagedResourcePaths                              *string `access:"environment,write_restrictable,cloud_restrictable"`
 }
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {
@@ -783,6 +784,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.ThreadAutoFollow == nil {
 		s.ThreadAutoFollow = NewBool(true)
+	}
+
+	if s.ManagedResourcePaths == nil {
+		s.ManagedResourcePaths = NewString("")
 	}
 }
 


### PR DESCRIPTION
Due to some changes in 5.28 around the internal/external link handling in the web app, we broke the newly added [Desktop Managed Resources](https://docs.mattermost.com/install/desktop-managed-resources.html) feature which basically lets non-MM services host stuff at certain routes under the MM server.

Since most paths in the server could be a team URL, the new link handling is correct for anyone not using that feature, so instead of reverting the link handling changes, we're adding a way to the server to manually specify these paths that should not be handled by the web app.

Hopefully I'm setting the correct struct tags on this. I've set it as environment because it affects the web server, and it's not something that would be turned on without making changes to the proxy to intercept requests to certain paths.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30090

#### Related Pull Requests
https://github.com/mattermost/mattermost-redux/pull/1282
https://github.com/mattermost/mattermost-webapp/pull/7024
https://github.com/mattermost/docs/pull/4089

#### Release Note
```release-note
Added the ManagedResourcePaths setting for use with the Desktop Managed Resources feature
```
