### PR TITLE
Soft fail on cloud user limit warnings when creating user

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -156,11 +156,11 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// New user created, check cloud limits and send emails if needed
+	// Soft fail on error since user is already created
 	if ruser != nil {
 		err = c.App.CheckAndSendUserLimitWarningEmails()
 		if err != nil {
-			c.Err = err
-			return
+			mlog.Error(err.Error())
 		}
 	}
 


### PR DESCRIPTION
#### Summary
This is causing an issue on cloud where if this check fails then the CWS does not complete workspace setup since it thinks the user failed to create when in fact the user was created successfully.

#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
None
```
