### PR TITLE
Close store database connection on error

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -56,10 +56,12 @@ func NewDatabaseStore(dsn string) (ds *DatabaseStore, err error) {
 		db:             db,
 	}
 	if err = initializeConfigurationsTable(ds.db); err != nil {
+		ds.db.Close()
 		return nil, errors.Wrap(err, "failed to initialize")
 	}
 
 	if err = ds.Load(); err != nil {
+		ds.db.Close()
 		return nil, errors.Wrap(err, "failed to load")
 	}
 


### PR DESCRIPTION
When an error is encountered initializing the configuration table
of the database on server startup, the database connection is not
closed. This change ensures these connections are cleaned up.

```release-note
Close store database connection on error
```
