### PR TITLE
Remove unused argument on runServer

### DIFF
--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -48,10 +48,10 @@ func serverCmdF(command *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to load configuration")
 	}
 
-	return runServer(configStore, disableConfigWatch, usedPlatform, interruptChan)
+	return runServer(configStore, usedPlatform, interruptChan)
 }
 
-func runServer(configStore *config.Store, disableConfigWatch bool, usedPlatform bool, interruptChan chan os.Signal) error {
+func runServer(configStore *config.Store, usedPlatform bool, interruptChan chan os.Signal) error {
 	// Setting the highest traceback level from the code.
 	// This is done to print goroutines from all threads (see golang.org/issue/13161)
 	// and also preserve a crash dump for later investigation.

--- a/cmd/mattermost/commands/server_test.go
+++ b/cmd/mattermost/commands/server_test.go
@@ -62,7 +62,7 @@ func TestRunServerSuccess(t *testing.T) {
 	// Use non-default listening port in case another server instance is already running.
 	*configStore.Get().ServiceSettings.ListenAddress = UnitTestListeningPort
 
-	err := runServer(configStore, th.disableConfigWatch, false, th.interruptChan)
+	err := runServer(configStore, false, th.interruptChan)
 	require.NoError(t, err)
 }
 
@@ -113,7 +113,7 @@ func TestRunServerSystemdNotification(t *testing.T) {
 	*configStore.Get().ServiceSettings.ListenAddress = UnitTestListeningPort
 
 	// Start and stop the server
-	err = runServer(configStore, th.disableConfigWatch, false, th.interruptChan)
+	err = runServer(configStore, false, th.interruptChan)
 	require.NoError(t, err)
 
 	// Ensure the notification has been sent on the socket and is correct
@@ -135,6 +135,6 @@ func TestRunServerNoSystemd(t *testing.T) {
 	// Use non-default listening port in case another server instance is already running.
 	*configStore.Get().ServiceSettings.ListenAddress = UnitTestListeningPort
 
-	err := runServer(configStore, th.disableConfigWatch, false, th.interruptChan)
+	err := runServer(configStore, false, th.interruptChan)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
#### Summary
It looks like that `runServer()` does not use the `disableConfigWatch` argument. Removes the unused argument.

#### Ticket Link
No associated ticket found

#### Release Note
```release-note
NONE
```
