### PR TITLE
MM-29478: Fix race in TestNotifyClusterPluginEvent

### DIFF
--- a/testlib/cluster.go
+++ b/testlib/cluster.go
@@ -4,12 +4,15 @@
 package testlib
 
 import (
+	"sync"
+
 	"github.com/mattermost/mattermost-server/v5/einterfaces"
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 type FakeClusterInterface struct {
 	clusterMessageHandler einterfaces.ClusterMessageHandler
+	mut                   sync.RWMutex
 	messages              []*model.ClusterMessage
 }
 
@@ -34,6 +37,8 @@ func (c *FakeClusterInterface) GetMyClusterInfo() *model.ClusterInfo { return ni
 func (c *FakeClusterInterface) GetClusterInfos() []*model.ClusterInfo { return nil }
 
 func (c *FakeClusterInterface) SendClusterMessage(message *model.ClusterMessage) {
+	c.mut.Lock()
+	defer c.mut.Unlock()
 	c.messages = append(c.messages, message)
 }
 
@@ -64,9 +69,13 @@ func (c *FakeClusterInterface) GetPluginStatuses() (model.PluginStatuses, *model
 }
 
 func (c *FakeClusterInterface) GetMessages() []*model.ClusterMessage {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
 	return c.messages
 }
 
 func (c *FakeClusterInterface) ClearMessages() {
+	c.mut.Lock()
+	defer c.mut.Unlock()
 	c.messages = nil
 }


### PR DESCRIPTION
The messages slice was accessed in a race manner. We protect it
with a mutex

```release-note
NONE
```

https://mattermost.atlassian.net/browse/MM-29478
