### PR TITLE
Thread hotfix for 5.29

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -160,24 +160,31 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 	mentionedUsersList := make([]string, 0, len(mentions.Mentions))
 	updateMentionChans := []chan *model.AppError{}
 	mentionAutofollowChans := []chan *model.AppError{}
+	threadParticipants := []string{post.UserId}
+	if *a.Config().ServiceSettings.ThreadAutoFollow && post.RootId != "" {
+		if parentPostList != nil {
+			threadParticipants = append(threadParticipants, parentPostList.Posts[parentPostList.Order[0]].UserId)
+		}
+		for id := range mentions.Mentions {
+			threadParticipants = append(threadParticipants, id)
+		}
+		// for each mention, make sure to update thread autofollow
+		for _, id := range threadParticipants {
+			mac := make(chan *model.AppError, 1)
+			go func(userId string) {
+				defer close(mac)
 
-	// for each mention, make sure to update thread autofollow
-	for id := range mentions.Mentions {
-		mac := make(chan *model.AppError, 1)
-		go func(userId string) {
-			defer close(mac)
-			if *a.Config().ServiceSettings.ThreadAutoFollow && post.RootId != "" {
 				nErr := a.Srv().Store.Thread().CreateMembershipIfNeeded(userId, post.RootId)
 				if nErr != nil {
 					mac <- model.NewAppError("SendNotifications", "app.channel.autofollow.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 					return
 				}
-			}
-			mac <- nil
-		}(id)
-		mentionAutofollowChans = append(mentionAutofollowChans, mac)
-	}
 
+				mac <- nil
+			}(id)
+			mentionAutofollowChans = append(mentionAutofollowChans, mac)
+		}
+	}
 	for id := range mentions.Mentions {
 		mentionedUsersList = append(mentionedUsersList, id)
 

--- a/model/config.go
+++ b/model/config.go
@@ -344,7 +344,6 @@ type ServiceSettings struct {
 	LocalModeSocketLocation                           *string
 	EnableAWSMetering                                 *bool
 	ThreadAutoFollow                                  *bool   `access:"experimental"`
-	CollapsedThreads                                  *bool   `access:"experimental"`
 	ManagedResourcePaths                              *string `access:"environment,write_restrictable,cloud_restrictable"`
 }
 
@@ -766,10 +765,6 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.ThreadAutoFollow == nil {
 		s.ThreadAutoFollow = NewBool(true)
-	}
-
-	if s.CollapsedThreads == nil {
-		s.CollapsedThreads = NewBool(false)
 	}
 
 	if s.ManagedResourcePaths == nil {

--- a/model/config.go
+++ b/model/config.go
@@ -344,6 +344,7 @@ type ServiceSettings struct {
 	LocalModeSocketLocation                           *string
 	EnableAWSMetering                                 *bool
 	ThreadAutoFollow                                  *bool   `access:"experimental"`
+	CollapsedThreads                                  *bool   `access:"experimental"`
 	ManagedResourcePaths                              *string `access:"environment,write_restrictable,cloud_restrictable"`
 }
 
@@ -765,6 +766,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.ThreadAutoFollow == nil {
 		s.ThreadAutoFollow = NewBool(true)
+	}
+
+	if s.CollapsedThreads == nil {
+		s.CollapsedThreads = NewBool(false)
 	}
 
 	if s.ManagedResourcePaths == nil {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1978,7 +1978,7 @@ func (s *SqlPostStore) updateThreadsFromPosts(transaction *gorp.Transaction, pos
 		if thread, found := threadByRoot[rootId]; !found {
 			// calculate participants
 			var participants model.StringArray
-			if _, err := transaction.Select(&participants, "SELECT DISTINCT UserId FROM Posts WHERE RootId=:RootId", map[string]interface{}{"RootId": rootId}); err != nil {
+			if _, err := transaction.Select(&participants, "SELECT DISTINCT UserId FROM Posts WHERE RootId=:RootId OR Id=:RootId", map[string]interface{}{"RootId": rootId}); err != nil {
 				return err
 			}
 			// calculate reply count

--- a/store/storetest/thread_store.go
+++ b/store/storetest/thread_store.go
@@ -221,7 +221,7 @@ func testThreadStorePopulation(t *testing.T, ss store.Store) {
 		thread1, err := ss.Thread().Get(newPosts1[0].Id)
 		require.Nil(t, err)
 		require.EqualValues(t, thread1.ReplyCount, 1)
-		require.Len(t, thread1.Participants, 1)
+		require.Len(t, thread1.Participants, 2)
 
 		err = ss.Post().Delete(rootPost.Id, 123, model.NewId())
 		require.Nil(t, err)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Participants were not counted properly for collapsed threads, this PR fixes it and adds a config switch that will be used in the future.

Related PR : https://github.com/mattermost/mattermost-server/pull/16234
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
Added config setting 'CollapsedThreads'. Off by default. For future use.
```
