### PR TITLE
MM-29479: Fix racy test TestSidebarCategory

### DIFF
--- a/app/channel_category_test.go
+++ b/app/channel_category_test.go
@@ -62,6 +62,8 @@ func TestSidebarCategory(t *testing.T) {
 		err = th.App.UpdateSidebarCategoryOrder(user.Id, th.BasicTeam.Id, actualOrder)
 		require.Nil(t, err, "Should update order successfully")
 
+		// We create a copy of actualOrder to prevent racy read
+		// of the slice when the broadcast message is sent from webhub.
 		newOrder := make([]string, len(actualOrder))
 		copy(newOrder, actualOrder)
 		newOrder[2] = "asd"

--- a/app/channel_category_test.go
+++ b/app/channel_category_test.go
@@ -62,8 +62,10 @@ func TestSidebarCategory(t *testing.T) {
 		err = th.App.UpdateSidebarCategoryOrder(user.Id, th.BasicTeam.Id, actualOrder)
 		require.Nil(t, err, "Should update order successfully")
 
-		actualOrder[2] = "asd"
-		err = th.App.UpdateSidebarCategoryOrder(user.Id, th.BasicTeam.Id, actualOrder)
+		newOrder := make([]string, len(actualOrder))
+		copy(newOrder, actualOrder)
+		newOrder[2] = "asd"
+		err = th.App.UpdateSidebarCategoryOrder(user.Id, th.BasicTeam.Id, newOrder)
 		require.NotNil(t, err, "Should return error due to invalid id")
 	})
 


### PR DESCRIPTION
We create a copy of the slice to prevent racy
modification from the hub goroutine.

https://mattermost.atlassian.net/browse/MM-29479

```release-note
NONE
```
