### PR TITLE
MM-29486: Fix racy test TestPatchChannelModeration

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -1828,15 +1828,15 @@ func TestPatchChannelModerationsForChannel(t *testing.T) {
 		wg.Add(20)
 		for i := 0; i < 10; i++ {
 			go func() {
-				th.App.PatchChannelModerationsForChannel(channel, addCreatePosts)
-				th.App.PatchChannelModerationsForChannel(channel, removeCreatePosts)
+				th.App.PatchChannelModerationsForChannel(channel.DeepCopy(), addCreatePosts)
+				th.App.PatchChannelModerationsForChannel(channel.DeepCopy(), removeCreatePosts)
 				wg.Done()
 			}()
 		}
 		for i := 0; i < 10; i++ {
 			go func() {
-				th.App.PatchChannelModerationsForChannel(channel, addCreatePosts)
-				th.App.PatchChannelModerationsForChannel(channel, removeCreatePosts)
+				th.App.PatchChannelModerationsForChannel(channel.DeepCopy(), addCreatePosts)
+				th.App.PatchChannelModerationsForChannel(channel.DeepCopy(), removeCreatePosts)
 				wg.Done()
 			}()
 		}

--- a/model/role.go
+++ b/model/role.go
@@ -484,12 +484,16 @@ func (r *Role) IsValidWithoutId() bool {
 
 	for _, permission := range r.Permissions {
 		permissionValidated := false
-		for _, p := range append(AllPermissions, DeprecatedPermissions...) {
-			if permission == p.Id {
-				permissionValidated = true
-				break
+		check := func(perms []*Permission) {
+			for _, p := range perms {
+				if permission == p.Id {
+					permissionValidated = true
+					break
+				}
 			}
 		}
+		check(AllPermissions)
+		check(DeprecatedPermissions)
 
 		if !permissionValidated {
 			return false

--- a/model/role.go
+++ b/model/role.go
@@ -482,21 +482,16 @@ func (r *Role) IsValidWithoutId() bool {
 		return false
 	}
 
-	for _, permission := range r.Permissions {
-		permissionValidated := false
-		check := func(perms []*Permission, permission string) bool {
-			for _, p := range perms {
-				if permission == p.Id {
-					return true
-				}
+	check := func(perms []*Permission, permission string) bool {
+		for _, p := range perms {
+			if permission == p.Id {
+				return true
 			}
-			return false
 		}
-		permissionValidated = check(AllPermissions, permission)
-		if !permissionValidated {
-			permissionValidated = check(DeprecatedPermissions, permission)
-		}
-
+		return false
+	}
+	for _, permission := range r.Permissions {
+		permissionValidated := check(AllPermissions, permission) || check(DeprecatedPermissions, permission)
 		if !permissionValidated {
 			return false
 		}

--- a/model/role.go
+++ b/model/role.go
@@ -484,16 +484,18 @@ func (r *Role) IsValidWithoutId() bool {
 
 	for _, permission := range r.Permissions {
 		permissionValidated := false
-		check := func(perms []*Permission, permission string) {
+		check := func(perms []*Permission, permission string) bool {
 			for _, p := range perms {
 				if permission == p.Id {
-					permissionValidated = true
-					break
+					return true
 				}
 			}
+			return false
 		}
-		check(AllPermissions, permission)
-		check(DeprecatedPermissions, permission)
+		permissionValidated = check(AllPermissions, permission)
+		if !permissionValidated {
+			permissionValidated = check(DeprecatedPermissions, permission)
+		}
 
 		if !permissionValidated {
 			return false

--- a/model/role.go
+++ b/model/role.go
@@ -484,7 +484,7 @@ func (r *Role) IsValidWithoutId() bool {
 
 	for _, permission := range r.Permissions {
 		permissionValidated := false
-		check := func(perms []*Permission) {
+		check := func(perms []*Permission, permission string) {
 			for _, p := range perms {
 				if permission == p.Id {
 					permissionValidated = true
@@ -492,8 +492,8 @@ func (r *Role) IsValidWithoutId() bool {
 				}
 			}
 		}
-		check(AllPermissions)
-		check(DeprecatedPermissions)
+		check(AllPermissions, permission)
+		check(DeprecatedPermissions, permission)
 
 		if !permissionValidated {
 			return false


### PR DESCRIPTION
- We avoid appending to the slice in `(r *Role) IsValidWithoutId`
by just iterating the 2 slices separately.
- We pass deep copies of channels to prevent racy modification.

https://mattermost.atlassian.net/browse/MM-29486

```release-note
NONE
```
