### PR TITLE
MM-29488: Fix racy test TestScheduler

### DIFF
--- a/jobs/schedulers.go
+++ b/jobs/schedulers.go
@@ -197,7 +197,7 @@ func (schedulers *Schedulers) scheduleJob(cfg *model.Config, scheduler model.Sch
 	return scheduler.ScheduleJob(cfg, pendingJobs, lastSuccessfulJob)
 }
 
-func (schedulers *Schedulers) handleConfigChange(oldConfig *model.Config, newConfig *model.Config) {
+func (schedulers *Schedulers) handleConfigChange(_ *model.Config, newConfig *model.Config) {
 	mlog.Debug("Schedulers received config change.")
 	schedulers.configChanged <- newConfig
 }

--- a/jobs/schedulers.go
+++ b/jobs/schedulers.go
@@ -197,7 +197,7 @@ func (schedulers *Schedulers) scheduleJob(cfg *model.Config, scheduler model.Sch
 	return scheduler.ScheduleJob(cfg, pendingJobs, lastSuccessfulJob)
 }
 
-func (schedulers *Schedulers) handleConfigChange(_ *model.Config, newConfig *model.Config) {
+func (schedulers *Schedulers) handleConfigChange(oldConfig, newConfig *model.Config) {
 	mlog.Debug("Schedulers received config change.")
 	schedulers.configChanged <- newConfig
 }

--- a/jobs/schedulers_test.go
+++ b/jobs/schedulers_test.go
@@ -78,28 +78,40 @@ func TestScheduler(t *testing.T) {
 	exportInterface.On("MakeScheduler").Return(new(MockScheduler))
 	jobServer.MessageExportJob = exportInterface
 
-	schedulers := jobServer.InitSchedulers()
-	schedulers.Start()
-	time.Sleep(1 * time.Second)
+	t.Run("Base", func(t *testing.T) {
+		schedulers := jobServer.InitSchedulers()
+		schedulers.Start()
+		time.Sleep(time.Second)
 
-	// They should be all on here
-	for _, element := range schedulers.nextRunTimes {
-		assert.NotNil(t, element)
-	}
+		schedulers.Stop()
+		// They should be all on here
+		for _, element := range schedulers.nextRunTimes {
+			assert.NotNil(t, element)
+		}
+	})
 
-	schedulers.HandleClusterLeaderChange(false)
-	time.Sleep(1 * time.Second)
-	// They should be turned off
-	for _, element := range schedulers.nextRunTimes {
-		assert.Nil(t, element)
-	}
+	t.Run("ClusterLeaderChanged", func(t *testing.T) {
+		schedulers := jobServer.InitSchedulers()
+		schedulers.Start()
+		time.Sleep(time.Second)
+		schedulers.HandleClusterLeaderChange(false)
+		schedulers.Stop()
+		// They should be turned off
+		for _, element := range schedulers.nextRunTimes {
+			assert.Nil(t, element)
+		}
+	})
 
-	// After running a config change, they should stay off
-	schedulers.handleConfigChange(nil, nil)
-	for _, element := range schedulers.nextRunTimes {
-		assert.Nil(t, element)
-	}
-
-	schedulers.Stop()
-
+	t.Run("ConfigChanged", func(t *testing.T) {
+		schedulers := jobServer.InitSchedulers()
+		schedulers.Start()
+		time.Sleep(time.Second)
+		schedulers.HandleClusterLeaderChange(false)
+		// After running a config change, they should stay off
+		schedulers.handleConfigChange(nil, nil)
+		schedulers.Stop()
+		for _, element := range schedulers.nextRunTimes {
+			assert.Nil(t, element)
+		}
+	})
 }


### PR DESCRIPTION
We iterate the nextRunTimes slice only after stopping the
scheduler.

And since we are checking the slice 3 times, we split
the test into 3 sub-tests, every time starting a new scheduler
and running the same steps again.

https://mattermost.atlassian.net/browse/MM-29488

```release-note
NONE
```
