### PR TITLE
build: push git commit hash as tags as well

### DIFF
--- a/build/Jenkinsfile.branch
+++ b/build/Jenkinsfile.branch
@@ -128,14 +128,16 @@ pipeline {
           withCredentials([usernamePassword(credentialsId: 'matterbuild-docker-hub', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
             sh 'docker login --username ${DOCKER_USER} --password ${DOCKER_PASS}'
             sh """
+            export GIT_COMMIT=$(git rev-parse --short HEAD)
             export TAG='${env.BRANCH_NAME}'
-            docker build --no-cache --build-arg MM_PACKAGE=https://releases.mattermost.com/mattermost-platform/${env.BRANCH_NAME}/mattermost-enterprise-linux-amd64.tar.gz -t mattermost/mattermost-enterprise-edition:\${TAG} build
-            docker push mattermost/mattermost-enterprise-edition:\${TAG}
+            docker build --no-cache --build-arg MM_PACKAGE=https://releases.mattermost.com/mattermost-platform/${env.BRANCH_NAME}/mattermost-enterprise-linux-amd64.tar.gz -t mattermost/mattermost-enterprise-edition:\${TAG} -t mattermost/mattermost-enterprise-edition:\${GIT_COMMIT} build
+            docker push mattermost/mattermost-enterprise-edition:\${TAG} mattermost/mattermost-enterprise-edition:\${GIT_COMMIT}
             """
             sh """
+            export GIT_COMMIT=$(git rev-parse --short HEAD)
             export TAG='${env.BRANCH_NAME}'
-            docker build --no-cache --build-arg MM_PACKAGE=https://releases.mattermost.com/mattermost-platform/${env.BRANCH_NAME}/mattermost-team-linux-amd64.tar.gz -t mattermost/mattermost-team-edition:\${TAG} build
-            docker push mattermost/mattermost-team-edition:\${TAG}
+            docker build --no-cache --build-arg MM_PACKAGE=https://releases.mattermost.com/mattermost-platform/${env.BRANCH_NAME}/mattermost-team-linux-amd64.tar.gz -t mattermost/mattermost-team-edition:\${TAG} -t mattermost/mattermost-team-edition:\${GIT_COMMIT} build
+            docker push mattermost/mattermost-team-edition:\${TAG} mattermost/mattermost-team-edition:\${GIT_COMMIT}
             docker logout
             """
           }


### PR DESCRIPTION
#### Summary
build: push git commit hash as tags as well

This is useful to debug issues in the images when and if we have

#### Ticket Link
NONE


#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
