### PR TITLE
[Reliability-improvement-POC] Make app initialisation tolerant to database failures

### DIFF
--- a/app/options.go
+++ b/app/options.go
@@ -4,6 +4,8 @@
 package app
 
 import (
+	"context"
+
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/pkg/errors"
 
@@ -76,6 +78,13 @@ func StartMetrics(s *Server) error {
 	s.startMetrics = true
 
 	return nil
+}
+
+func SetContext(ctx context.Context) Option {
+	return func(s *Server) error {
+		s.context = ctx
+		return nil
+	}
 }
 
 func StartSearchEngine(s *Server) error {

--- a/app/server.go
+++ b/app/server.go
@@ -184,6 +184,8 @@ type Server struct {
 	featureFlagStop              chan struct{}
 	featureFlagStopped           chan struct{}
 	featureFlagSynchronizerMutex sync.Mutex
+
+	context context.Context
 }
 
 func NewServer(options ...Option) (*Server, error) {
@@ -306,7 +308,7 @@ func NewServer(options ...Option) (*Server, error) {
 
 	if s.newStore == nil {
 		s.newStore = func() store.Store {
-			s.sqlStore = sqlstore.NewSqlSupplier(s.Config().SqlSettings, s.Metrics)
+			s.sqlStore = sqlstore.NewSqlSupplier(s.Config().SqlSettings, s.Metrics, s.context, s.Config())
 			searchStore := searchlayer.NewSearchLayer(
 				localcachelayer.NewLocalCacheLayer(
 					retrylayer.New(s.sqlStore),

--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -47,10 +47,10 @@ func serverCmdF(command *cobra.Command, args []string) error {
 		return errors.Wrap(err, "failed to load configuration")
 	}
 
-	return runServer(configStore, disableConfigWatch, usedPlatform)
+	return runServer(configStore, usedPlatform)
 }
 
-func runServer(configStore *config.Store, disableConfigWatch bool, usedPlatform bool) error {
+func runServer(configStore *config.Store, usedPlatform bool) error {
 	// Setting the highest traceback level from the code.
 	// This is done to print goroutines from all threads (see golang.org/issue/13161)
 	// and also preserve a crash dump for later investigation.

--- a/cmd/mattermost/commands/server_test.go
+++ b/cmd/mattermost/commands/server_test.go
@@ -62,7 +62,7 @@ func TestRunServerSuccess(t *testing.T) {
 	// Use non-default listening port in case another server instance is already running.
 	*configStore.Get().ServiceSettings.ListenAddress = UnitTestListeningPort
 
-	err := runServer(configStore, false, th.interruptChan)
+	err := runServer(configStore, false)
 	require.NoError(t, err)
 }
 
@@ -113,7 +113,7 @@ func TestRunServerSystemdNotification(t *testing.T) {
 	*configStore.Get().ServiceSettings.ListenAddress = UnitTestListeningPort
 
 	// Start and stop the server
-	err = runServer(configStore, false, th.interruptChan)
+	err = runServer(configStore, false)
 	require.NoError(t, err)
 
 	// Ensure the notification has been sent on the socket and is correct
@@ -135,6 +135,6 @@ func TestRunServerNoSystemd(t *testing.T) {
 	// Use non-default listening port in case another server instance is already running.
 	*configStore.Get().ServiceSettings.ListenAddress = UnitTestListeningPort
 
-	err := runServer(configStore, false, th.interruptChan)
+	err := runServer(configStore, false)
 	require.NoError(t, err)
 }

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -6,15 +6,15 @@ package model
 type FeatureFlags struct {
 	// Exists only for unit and manual testing.
 	// When set to a value, will be returned by the ping endpoint.
-	TestFeature              string
-	EnsureDatabaseConnection string
-
+	TestFeature string
 	// Toggle on and off scheduled jobs for cloud user limit emails see MM-29999
 	CloudDelinquentEmailJobsEnabled bool
+	// Feature that toggles between long pinging vs finite pinging of the database
+	EnsureDatabaseConnectionEnabled bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
 	f.TestFeature = "off"
-	f.EnsureDatabaseConnection = "off"
+	f.EnsureDatabaseConnectionEnabled = false
 	f.CloudDelinquentEmailJobsEnabled = false
 }

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -6,9 +6,11 @@ package model
 type FeatureFlags struct {
 	// Exists only for unit and manual testing.
 	// When set to a value, will be returned by the ping endpoint.
-	TestFeature string
+	TestFeature              string
+	EnsureDatabaseConnection string
 }
 
 func (f *FeatureFlags) SetDefaults() {
 	f.TestFeature = "off"
+	f.EnsureDatabaseConnection = "off"
 }

--- a/services/searchengine/bleveengine/bleve_test.go
+++ b/services/searchengine/bleveengine/bleve_test.go
@@ -4,6 +4,7 @@
 package bleveengine
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -45,12 +46,15 @@ func (s *BleveEngineTestSuite) setupIndexes() {
 }
 
 func (s *BleveEngineTestSuite) setupStore() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	driverName := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
 	if driverName == "" {
 		driverName = model.DATABASE_DRIVER_POSTGRES
 	}
 	s.SQLSettings = storetest.MakeSqlSettings(driverName)
-	s.SQLSupplier = sqlstore.NewSqlSupplier(*s.SQLSettings, nil)
+	s.SQLSupplier = sqlstore.NewSqlSupplier(*s.SQLSettings, nil, ctx, nil)
 
 	cfg := &model.Config{}
 	cfg.SetDefaults()

--- a/store/localcachelayer/layer_test.go
+++ b/store/localcachelayer/layer_test.go
@@ -97,7 +97,7 @@ func initStores() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			st.SqlSupplier = sqlstore.NewSqlSupplier(*st.SqlSettings, nil, nil)
+			st.SqlSupplier = sqlstore.NewSqlSupplier(*st.SqlSettings, nil, nil, nil)
 			st.Store = NewLocalCacheLayer(st.SqlSupplier, nil, nil, getMockCacheProvider())
 			st.Store.DropAllTables()
 			st.Store.MarkSystemRanUnitTests()

--- a/store/localcachelayer/layer_test.go
+++ b/store/localcachelayer/layer_test.go
@@ -97,7 +97,7 @@ func initStores() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			st.SqlSupplier = sqlstore.NewSqlSupplier(*st.SqlSettings, nil)
+			st.SqlSupplier = sqlstore.NewSqlSupplier(*st.SqlSettings, nil, nil)
 			st.Store = NewLocalCacheLayer(st.SqlSupplier, nil, nil, getMockCacheProvider())
 			st.Store.DropAllTables()
 			st.Store.MarkSystemRanUnitTests()

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -4,6 +4,7 @@
 package sqlstore
 
 import (
+	"context"
 	"os"
 	"sync"
 	"testing"
@@ -114,7 +115,7 @@ func initStores() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			st.SqlSupplier = NewSqlSupplier(*st.SqlSettings, nil)
+			st.SqlSupplier = NewSqlSupplier(*st.SqlSettings, nil, context.Background(), nil)
 			st.Store = st.SqlSupplier
 			st.Store.DropAllTables()
 			st.Store.MarkSystemRanUnitTests()

--- a/store/sqlstore/supplier.go
+++ b/store/sqlstore/supplier.go
@@ -230,7 +230,7 @@ func NewSqlSupplier(settings model.SqlSettings, metrics einterfaces.MetricsInter
 func setupConnection(connType string, dataSource string, settings *model.SqlSettings, ctx context.Context, config *model.Config) *gorp.DbMap {
 	var db *dbsql.DB
 
-	if config != nil && config.FeatureFlags.EnsureDatabaseConnection != "off" {
+	if config != nil && config.FeatureFlags.EnsureDatabaseConnectionEnabled {
 		db = ensureDatabaseConnection(settings, dataSource, connType, ctx)
 	} else {
 		db = checkDatabaseConnection(settings, dataSource, connType)

--- a/store/sqlstore/supplier.go
+++ b/store/sqlstore/supplier.go
@@ -1339,10 +1339,10 @@ func checkDatabaseConnection(settings *model.SqlSettings, dataSource, connType s
 func ensureDatabaseConnection(settings *model.SqlSettings, dataSource, connType string, lifecycleContext context.Context) *dbsql.DB {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), DB_PING_TIMEOUT_SECS*time.Second)
+		defer cancel()
 
 		select {
 		case <-lifecycleContext.Done():
-			cancel()
 			os.Exit(EXIT_DB_OPEN)
 		default:
 			db, err := dbsql.Open(*settings.DriverName, dataSource)

--- a/store/sqlstore/supplier_test.go
+++ b/store/sqlstore/supplier_test.go
@@ -4,6 +4,7 @@
 package sqlstore_test
 
 import (
+	"context"
 	"regexp"
 	"sync"
 	"testing"
@@ -25,7 +26,7 @@ func TestSupplierLicenseRace(t *testing.T) {
 	settings := makeSqlSettings(model.DATABASE_DRIVER_SQLITE)
 	settings.DataSourceReplicas = []string{":memory:"}
 	settings.DataSourceSearchReplicas = []string{":memory:"}
-	supplier := sqlstore.NewSqlSupplier(*settings, nil)
+	supplier := sqlstore.NewSqlSupplier(*settings, nil, context.Background(), nil)
 
 	wg := sync.WaitGroup{}
 	wg.Add(3)
@@ -110,7 +111,7 @@ func TestGetReplica(t *testing.T) {
 			settings := makeSqlSettings(model.DATABASE_DRIVER_SQLITE)
 			settings.DataSourceReplicas = testCase.DataSourceReplicas
 			settings.DataSourceSearchReplicas = testCase.DataSourceSearchReplicas
-			supplier := sqlstore.NewSqlSupplier(*settings, nil)
+			supplier := sqlstore.NewSqlSupplier(*settings, nil, context.Background(), nil)
 			supplier.UpdateLicense(&model.License{})
 
 			replicas := make(map[*gorp.DbMap]bool)
@@ -167,7 +168,7 @@ func TestGetReplica(t *testing.T) {
 			settings := makeSqlSettings(model.DATABASE_DRIVER_SQLITE)
 			settings.DataSourceReplicas = testCase.DataSourceReplicas
 			settings.DataSourceSearchReplicas = testCase.DataSourceSearchReplicas
-			supplier := sqlstore.NewSqlSupplier(*settings, nil)
+			supplier := sqlstore.NewSqlSupplier(*settings, nil, context.Background(), nil)
 
 			replicas := make(map[*gorp.DbMap]bool)
 			for i := 0; i < 5; i++ {
@@ -227,7 +228,7 @@ func TestGetDbVersion(t *testing.T) {
 		t.Run("Should return db version for "+driver, func(t *testing.T) {
 			t.Parallel()
 			settings := makeSqlSettings(driver)
-			supplier := sqlstore.NewSqlSupplier(*settings, nil)
+			supplier := sqlstore.NewSqlSupplier(*settings, nil, context.Background(), nil)
 
 			version, err := supplier.GetDbVersion()
 			require.Nil(t, err)
@@ -307,7 +308,7 @@ func TestGetAllConns(t *testing.T) {
 			settings := makeSqlSettings(model.DATABASE_DRIVER_SQLITE)
 			settings.DataSourceReplicas = testCase.DataSourceReplicas
 			settings.DataSourceSearchReplicas = testCase.DataSourceSearchReplicas
-			supplier := sqlstore.NewSqlSupplier(*settings, nil)
+			supplier := sqlstore.NewSqlSupplier(*settings, nil, context.Background(), nil)
 
 			assert.Len(t, supplier.GetAllConns(), testCase.ExpectedNumConnections)
 		})

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -4,6 +4,7 @@
 package testlib
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -108,7 +109,7 @@ func (h *MainHelper) setupStore() {
 
 	h.SearchEngine = searchengine.NewBroker(config, nil)
 	h.ClusterInterface = &FakeClusterInterface{}
-	h.SQLSupplier = sqlstore.NewSqlSupplier(*h.Settings, nil)
+	h.SQLSupplier = sqlstore.NewSqlSupplier(*h.Settings, nil, context.Background(), nil)
 	h.Store = searchlayer.NewSearchLayer(&TestStore{
 		h.SQLSupplier,
 	}, h.SearchEngine, config)


### PR DESCRIPTION
## Summary

Currently, when the app gets through its initialization phase it tries to establish a connection with the storage. Then it tries for 3 minutes to ping in order to assess storage health(1 try every 10 seconds for a total of 18 tries). As soon as the max ping tries are exceeded, the process is exited, which will lead to pods being restarted and the whole cycle begins all over.

In the above situation, we know that storage availability is degraded, so restarting the app layer is not going to give us much value in solving or improving the problem at hand.

On the other hand, as soon as the app is initialized and connections are established, in the case of storage degradation, the app is resilient and just returns `500`s back to the web app.

### Proposal

Make storage access semantics homogeneous between the different stages of the app(initialization vs normal operation), by locking on an infinite loop while waiting for the storage to come up online vs having finite tries.

#### Benefits

- Focusing on fixing the issue at hand, which is storage unavailability.
- App restarts during storage unavailability can be risky.
- Reduces worst-case time to recovery, after the storage availability is restored. from previously `time taken for pods to restart` to now fixed `10s(time between pings)`.

@jwilander @crspeller will love your thoughts on this, cc'ed since I could see you two were part of some initial PRs around this part of the code.

Looked at some PRs for historical context but I couldn't build up any actionable context:
- https://github.com/mattermost/mattermost-server/pull/6693
- https://github.com/mattermost/mattermost-server/pull/6810

## Ticket Link
No associated ticket found.

## Release Note
```release-note
Remove max ping retries logic, when assessing storage health.
```
