### PR TITLE
MM-29420: Adds missing access to the global relay config settings.

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2734,7 +2734,7 @@ type MessageExportSettings struct {
 	DownloadExportResults *bool   `access:"compliance"`
 
 	// formatter-specific settings - these are only expected to be non-nil if ExportFormat is set to the associated format
-	GlobalRelaySettings *GlobalRelayMessageExportSettings
+	GlobalRelaySettings *GlobalRelayMessageExportSettings `access:"compliance"`
 }
 
 func (s *MessageExportSettings) SetDefaults() {


### PR DESCRIPTION
#### Summary

Adds missing `access` tag to nested struct to grant read and/or write access to the Global Relay config settings per the permissions.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-29420

#### Release Note
```release-note
Fixed bug where permissions did not grant read and/or write access to the Global Relay configuration settings.
```
