### PR TITLE
[MM-28883] Include cloud defaults in the EE release package

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -102,6 +102,7 @@ package:
 	@# Help files
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	cp $(BUILD_ENTERPRISE_DIR)/ENTERPRISE-EDITION-LICENSE.txt $(DIST_PATH)
+	cp -L $(BUILD_ENTERPRISE_DIR)/cloud/config/cloud_defaults.json $(DIST_PATH)/config
 else
 	cp build/MIT-COMPILED-LICENSE.md $(DIST_PATH)
 endif


### PR DESCRIPTION
That defaults file would be used in the cloud installations to set the
initial values for them

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR adds to the release process the new cloud defaults configuration file to be used by the cloud installations

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-28883

#### Screenshots
Here is the EE docker with the new configuration file in the /config folder

![Screenshot from 2020-11-16 12-33-02](https://user-images.githubusercontent.com/741240/99247895-e9f59500-2807-11eb-8022-f0851b9e8112.png)


#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
