### PR TITLE
MM-30544 - Fix interactive dialogs called from post integration actions

### DIFF
--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -291,7 +291,14 @@ func (a *App) DoPostActionWithCookie(postId, actionId, userId, selectedOption st
 		a.SendEphemeralPost(userId, ephemeralPost)
 	}
 
-	return clientTriggerId, nil
+	// Allow the integration action to override the triggerId, e.g. when a plugin opens an
+	// interactive dialog and needs to return that triggerId to the client.
+	returnTriggerId := clientTriggerId
+	if response.TriggerId != "" {
+		returnTriggerId = response.TriggerId
+	}
+
+	return returnTriggerId, nil
 }
 
 // Perform an HTTP POST request to an integration's action endpoint.

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -188,6 +188,12 @@ type PostActionIntegrationResponse struct {
 	Update           *Post  `json:"update"`
 	EphemeralText    string `json:"ephemeral_text"`
 	SkipSlackParsing bool   `json:"skip_slack_parsing"` // Set to `true` to skip the Slack-compatibility handling of Text.
+
+	// Optional; set this when a plugin wants to return a trigger_id to the client that initiated
+	// the integration action (e.g., when a client clicked on a button, which called an integration
+	// action, which called a slash command, which opened an interactive dialog).
+	// Note: this will override the triggerId generated in DoPostActionWithCookie.
+	TriggerId string `json:"trigger_id"`
 }
 
 type PostActionAPIResponse struct {


### PR DESCRIPTION
#### Summary
- The Incident Management plugin has the following use case: We have a reminder post with a button `Update Status`, when the user clicks on it, it should call the slash command `/incident update` which opens an interactive dialog. However, the slash command is called from the plugin's code, and there is no way to return the `trigger_id` to the client. 
- This change allows an integration request to return a `trigger_id` field in the response. If the `DoPostActionWithCookie` method sees a `trigger_id` field returned, it will return that (instead of the `trigger_id` it generated).
- I am pretty sure this won't break anything, since the trigger_id is being used for what it's supposed to. And the plugin should only return a trigger_id when /it/ is the code that is creating the dialog. But please let me know if I've overlooked something.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-30544

#### Release Note
```release-note
NONE
```
