### PR TITLE
Remove `cloud_restrictable` for cloud billing settings

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -898,8 +898,8 @@ type ExperimentalSettings struct {
 	LinkMetadataTimeoutMilliseconds *int64  `access:"experimental,write_restrictable,cloud_restrictable"`
 	RestrictSystemAdmin             *bool   `access:"experimental,write_restrictable"`
 	UseNewSAMLLibrary               *bool   `access:"experimental,cloud_restrictable"`
-	CloudUserLimit                  *int64  `access:"experimental,write_restrictable,cloud_restrictable"`
-	CloudBilling                    *bool   `access:"experimental,write_restrictable,cloud_restrictable"`
+	CloudUserLimit                  *int64  `access:"experimental,write_restrictable"`
+	CloudBilling                    *bool   `access:"experimental,write_restrictable"`
 	EnableSharedChannels            *bool   `access:"experimental"`
 }
 


### PR DESCRIPTION
#### Summary

Removed `cloud_restrictable` from `CloudBilling` and `CloudUserLimit` settings that was causing it to not be returned in the System Console seeing the related bug. 

This was fixed in the `cloud-ga` branch https://github.com/mattermost/mattermost-server/pull/15908 and not enabled in `master`.

#### Ticket Link
[MM-30746](https://mattermost.atlassian.net/browse/MM-30746)

#### Release Note

```release-note
NONE
```
