### PR TITLE
MM-30800: prepackage incident management 1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ PLUGIN_PACKAGES += mattermost-plugin-antivirus-v0.1.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v2.3.2
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-incident-management-v1.1.0
+PLUGIN_PACKAGES += mattermost-plugin-incident-management-v1.1.1
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ PLUGIN_PACKAGES += mattermost-plugin-antivirus-v0.1.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v2.3.2
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.0.0
-PLUGIN_PACKAGES += mattermost-plugin-incident-response-v0.6.0
+PLUGIN_PACKAGES += mattermost-plugin-incident-management-v1.1.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)

--- a/model/config.go
+++ b/model/config.go
@@ -2669,9 +2669,9 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates["com.mattermost.nps"] = &PluginState{Enable: ls.EnableDiagnostics == nil || *ls.EnableDiagnostics}
 	}
 
-	if s.PluginStates["com.mattermost.plugin-incident-response"] == nil {
-		// Enable the incident response plugin by default
-		s.PluginStates["com.mattermost.plugin-incident-response"] = &PluginState{Enable: true}
+	if s.PluginStates["com.mattermost.plugin-incident-management"] == nil {
+		// Enable the incident management plugin by default
+		s.PluginStates["com.mattermost.plugin-incident-management"] = &PluginState{Enable: true}
 	}
 
 	if s.EnableMarketplace == nil {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -308,19 +308,19 @@ func TestConfigDefaultNPSPluginState(t *testing.T) {
 	})
 }
 
-func TestConfigDefaultIncidentResponsePluginState(t *testing.T) {
-	t.Run("should enable IncidentResponse plugin by default", func(t *testing.T) {
+func TestConfigDefaultIncidentManagementPluginState(t *testing.T) {
+	t.Run("should enable IncidentManagement plugin by default", func(t *testing.T) {
 		c1 := Config{}
 		c1.SetDefaults()
 
-		assert.True(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-response"].Enable)
+		assert.True(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-management"].Enable)
 	})
 
-	t.Run("should not re-enable IncidentResponse plugin after it has been disabled", func(t *testing.T) {
+	t.Run("should not re-enable IncidentManagement plugin after it has been disabled", func(t *testing.T) {
 		c1 := Config{
 			PluginSettings: PluginSettings{
 				PluginStates: map[string]*PluginState{
-					"com.mattermost.plugin-incident-response": {
+					"com.mattermost.plugin-incident-management": {
 						Enable: false,
 					},
 				},
@@ -329,7 +329,7 @@ func TestConfigDefaultIncidentResponsePluginState(t *testing.T) {
 
 		c1.SetDefaults()
 
-		assert.False(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-response"].Enable)
+		assert.False(t, c1.PluginSettings.PluginStates["com.mattermost.plugin-incident-management"].Enable)
 	})
 }
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -1282,7 +1282,7 @@ func (ts *TelemetryService) trackPluginConfig(cfg *model.Config, marketplaceURL 
 		"com.mattermost.custom-attributes",
 		"com.mattermost.mscalendar",
 		"com.mattermost.nps",
-		"com.mattermost.plugin-incident-response",
+		"com.mattermost.plugin-incident-management",
 		"com.mattermost.plugin-todo",
 		"com.mattermost.webex",
 		"com.mattermost.welcomebot",


### PR DESCRIPTION
#### Summary
A few releases back, we pre-packaged incident _response_ v0.6, cherry-picking those changes into the `cloud-beta` branch for an early rollout. v5.28 and v5.29 did not pre-package incident response, since they were cut just after that commit in `master`, and we had intentions to revisit this prior to v5.30.

Since that time, we renamed the product, released a few more versions, and cherry-picked into `cloud-ga`. All of these changes have been in "production" for a while now, but we need to bring `master` back up-to-date, since a new `cloud` branch is pending release to production but it's still pointing at IR v0.6 instead of IM v1.1.

When IM v1.2 is released, we'll bump the version again, but this commit is important to include in the upcoming release of the `cloud` branch on Tuesday, November 24th.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30800

#### Release Note
```release-note
Pre-package and enable incident management v1.1.1
```
