### PR TITLE
Revert "[MM-29224] Fix bug where markdown image link doesn't show preview (#15862)

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -318,10 +318,6 @@ func getFirstLinkAndImages(str string) (string, []string) {
 			if firstLink == "" {
 				firstLink = v.Destination()
 			}
-		case *markdown.InlineLink:
-			if firstLink == "" {
-				firstLink = v.Destination()
-			}
 		case *markdown.InlineImage:
 			images = append(images, v.Destination())
 		case *markdown.ReferenceImage:

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -1294,11 +1294,11 @@ func TestGetFirstLinkAndImages(t *testing.T) {
 			ExpectedFirstLink: "https://example.com",
 			ExpectedImages:    []string{"https://example.com/logo"},
 		},
-		"markdown links": {
+		"markdown links (not returned)": {
 			Input: `this is a [our page](http://example.com) and [another page][]
 
 [another page]: http://www.exaple.com/another_page`,
-			ExpectedFirstLink: "http://example.com",
+			ExpectedFirstLink: "",
 			ExpectedImages:    []string{},
 		},
 	} {


### PR DESCRIPTION
As discussed in SET, we're reverting this for the time being because of some conflicts with other integrations. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-29224

#### Release Note
```release-note
NONE
```
