### PR TITLE
MM-30821: Change to idiomatic receiver names for slashcommands.msgProvider

### DIFF
--- a/app/slashcommands/command_msg.go
+++ b/app/slashcommands/command_msg.go
@@ -25,11 +25,11 @@ func init() {
 	app.RegisterCommandProvider(&msgProvider{})
 }
 
-func (me *msgProvider) GetTrigger() string {
+func (*msgProvider) GetTrigger() string {
 	return CMD_MSG
 }
 
-func (me *msgProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
+func (*msgProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
 	return &model.Command{
 		Trigger:          CMD_MSG,
 		AutoComplete:     true,
@@ -39,7 +39,7 @@ func (me *msgProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Com
 	}
 }
 
-func (me *msgProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*msgProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
 	splitMessage := strings.SplitN(message, " ", 2)
 
 	parsedMessage := ""


### PR DESCRIPTION
#### Summary
Updated the receiver names in methods to be more idiomatic and removed receiver names where it were not being used.
#### Ticket Link
JIRA - https://mattermost.atlassian.net/browse/MM-30821
Issue - Fixes #16333

#### Release Note
```release-note
NONE
```