### PR TITLE
MM-30823: Change to idiomatic receiver names for model.PushResponse

### DIFF
--- a/model/push_response.go
+++ b/model/push_response.go
@@ -37,8 +37,8 @@ func NewErrorPushResponse(message string) PushResponse {
 	return m
 }
 
-func (me *PushResponse) ToJson() string {
-	b, _ := json.Marshal(me)
+func (pr *PushResponse) ToJson() string {
+	b, _ := json.Marshal(pr)
 	return string(b)
 }
 


### PR DESCRIPTION
#### Summary
Updated the receiver names in methods to be more idiomatic and removed receiver names where it were not being used.
#### Ticket Link
JIRA - https://mattermost.atlassian.net/browse/MM-30823
Issue - Fixes #16335

#### Release Note
```release-note
NONE
```