### PR TITLE
MM-30802: Enable GoSAML2 library support

### DIFF
--- a/app/enterprise.go
+++ b/app/enterprise.go
@@ -187,17 +187,9 @@ func (a *App) initEnterprise() {
 	if notificationInterface != nil {
 		a.srv.Notification = notificationInterface(a)
 	}
-	if samlInterface != nil {
-		if *a.Config().ExperimentalSettings.UseNewSAMLLibrary && samlInterfaceNew != nil {
-			mlog.Debug("Loading new SAML2 library")
-			a.srv.Saml = samlInterfaceNew(a)
-		} else if *a.Config().ExperimentalSettings.UseNewSAMLLibrary && samlInterfaceNew == nil {
-			mlog.Debug("Ignoring configuration setting to use the Experimental SAML library")
-			a.srv.Saml = samlInterface(a)
-		} else {
-			mlog.Debug("Loading original SAML library")
-			a.srv.Saml = samlInterface(a)
-		}
+	if samlInterfaceNew != nil {
+		mlog.Debug("Loading SAML2 library")
+		a.srv.Saml = samlInterfaceNew(a)
 		if err := a.srv.Saml.ConfigureSP(); err != nil {
 			mlog.Error("An error occurred while configuring SAML Service Provider", mlog.Err(err))
 		}

--- a/app/enterprise.go
+++ b/app/enterprise.go
@@ -138,12 +138,6 @@ func RegisterMetricsInterface(f func(*Server) einterfaces.MetricsInterface) {
 	metricsInterface = f
 }
 
-var samlInterface func(*App) einterfaces.SamlInterface
-
-func RegisterSamlInterface(f func(*App) einterfaces.SamlInterface) {
-	samlInterface = f
-}
-
 var samlInterfaceNew func(*App) einterfaces.SamlInterface
 
 func RegisterNewSamlInterface(f func(*App) einterfaces.SamlInterface) {

--- a/app/enterprise_test.go
+++ b/app/enterprise_test.go
@@ -17,7 +17,6 @@ import (
 func TestSAMLSettings(t *testing.T) {
 	tt := []struct {
 		name              string
-		setSAMLInterface  bool
 		setNewInterface   bool
 		useNewSAMLLibrary bool
 		isNil             bool
@@ -25,35 +24,18 @@ func TestSAMLSettings(t *testing.T) {
 	}{
 		{
 			name:              "No SAML Interfaces, default setting",
-			setSAMLInterface:  false,
 			setNewInterface:   false,
 			useNewSAMLLibrary: false,
 			isNil:             true,
 		},
 		{
 			name:              "No SAML Interfaces, set config true",
-			setSAMLInterface:  false,
-			setNewInterface:   false,
-			useNewSAMLLibrary: true,
-			isNil:             true,
-		},
-		{
-			name:              "Orignal SAML Interface, default setting",
-			setSAMLInterface:  true,
-			setNewInterface:   false,
-			useNewSAMLLibrary: false,
-			isNil:             true,
-		},
-		{
-			name:              "Orignal SAML Interface, config true",
-			setSAMLInterface:  true,
 			setNewInterface:   false,
 			useNewSAMLLibrary: true,
 			isNil:             true,
 		},
 		{
 			name:              "Both SAML Interfaces, default setting",
-			setSAMLInterface:  true,
 			setNewInterface:   true,
 			useNewSAMLLibrary: false,
 			isNil:             false,
@@ -61,7 +43,6 @@ func TestSAMLSettings(t *testing.T) {
 		},
 		{
 			name:              "Both SAML Interfaces, config true",
-			setSAMLInterface:  true,
 			setNewInterface:   true,
 			useNewSAMLLibrary: true,
 			isNil:             false,
@@ -71,17 +52,6 @@ func TestSAMLSettings(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			saml := &mocks.SamlInterface{}
-			saml.Mock.On("ConfigureSP").Return(nil)
-			saml.Mock.On("GetMetadata").Return("samlOne", nil)
-			if tc.setSAMLInterface {
-				RegisterSamlInterface(func(a *App) einterfaces.SamlInterface {
-					return saml
-				})
-			} else {
-				RegisterSamlInterface(nil)
-			}
-
 			saml2 := &mocks.SamlInterface{}
 			saml2.Mock.On("ConfigureSP").Return(nil)
 			saml2.Mock.On("GetMetadata").Return("samlTwo", nil)

--- a/app/enterprise_test.go
+++ b/app/enterprise_test.go
@@ -42,16 +42,14 @@ func TestSAMLSettings(t *testing.T) {
 			setSAMLInterface:  true,
 			setNewInterface:   false,
 			useNewSAMLLibrary: false,
-			isNil:             false,
-			metadata:          "samlOne",
+			isNil:             true,
 		},
 		{
 			name:              "Orignal SAML Interface, config true",
 			setSAMLInterface:  true,
 			setNewInterface:   false,
 			useNewSAMLLibrary: true,
-			isNil:             false,
-			metadata:          "samlOne",
+			isNil:             true,
 		},
 		{
 			name:              "Both SAML Interfaces, default setting",
@@ -59,7 +57,7 @@ func TestSAMLSettings(t *testing.T) {
 			setNewInterface:   true,
 			useNewSAMLLibrary: false,
 			isNil:             false,
-			metadata:          "samlOne",
+			metadata:          "samlTwo",
 		},
 		{
 			name:              "Both SAML Interfaces, config true",


### PR DESCRIPTION
#### Summary
ReEnables SAML2 library as the only library used, requires Enterprise related changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30802

#### Release Note
```release-note
Enable goSAML2 library as the only supported SAML Library.
```

#### Related PRs
https://github.com/mattermost/enterprise/pull/832
