### PR TITLE
MM-30900 - Dropped condition of RestrictAdmin for filtering cloud_restrictable

### DIFF
--- a/api4/config.go
+++ b/api4/config.go
@@ -65,7 +65,7 @@ func getConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.Success()
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud && *cfg.ExperimentalSettings.RestrictSystemAdmin {
+	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
 		w.Write([]byte(cfg.ToJsonFiltered(model.ConfigAccessTagType, model.ConfigAccessTagCloudRestrictable)))
 	} else {
 		w.Write([]byte(cfg.ToJson()))
@@ -160,7 +160,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.LogAudit("updateConfig")
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud && *cfg.ExperimentalSettings.RestrictSystemAdmin {
+	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
 		w.Write([]byte(cfg.ToJsonFiltered(model.ConfigAccessTagType, model.ConfigAccessTagCloudRestrictable)))
 	} else {
 		w.Write([]byte(cfg.ToJson()))
@@ -267,7 +267,7 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
-	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud && *cfg.ExperimentalSettings.RestrictSystemAdmin {
+	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
 		w.Write([]byte(cfg.ToJsonFiltered(model.ConfigAccessTagType, model.ConfigAccessTagCloudRestrictable)))
 	} else {
 		w.Write([]byte(cfg.ToJson()))


### PR DESCRIPTION
#### Summary

5.30 introduces new System Roles (i.e. System Manager) that by default don't have read/write permissions to `ExperimentalSettings`. For cloud servers, when getting and updating the config, we were checking `ExperimentalSettings.RestrictedAdmin` to filter out `cloud_restrictable` settings. This was causing a panic for these new roles. See related bug. 

This PR drops the check for `RestrictedAdmin` and just filters `cloud_restrictable` for any cloud server to avoid these cases where roles can be granted/removed the Experimental Settings by admins in the System Console. 

#### Ticket Link
[MM-30900](https://mattermost.atlassian.net/browse/MM-30900)

#### Release Note
```release-note
NONE
```
