### PR TITLE
MM-30862: Fix racy test RunComplianceReports

### DIFF
--- a/app/compliance.go
+++ b/app/compliance.go
@@ -43,8 +43,9 @@ func (a *App) SaveComplianceReport(job *model.Compliance) (*model.Compliance, *m
 		}
 	}
 
+	jCopy := job.DeepCopy()
 	a.Srv().Go(func() {
-		a.Compliance().RunComplianceJob(job)
+		a.Compliance().RunComplianceJob(jCopy)
 	})
 
 	return job, nil

--- a/model/compliance.go
+++ b/model/compliance.go
@@ -58,6 +58,11 @@ func (c *Compliance) PreSave() {
 	c.CreateAt = GetMillis()
 }
 
+func (c *Compliance) DeepCopy() *Compliance {
+	copy := *c
+	return &copy
+}
+
 func (c *Compliance) JobName() string {
 	jobName := c.Type
 	if c.Type == COMPLIANCE_TYPE_DAILY {


### PR DESCRIPTION
We pass a copy of the compliance object to the goroutine

https://mattermost.atlassian.net/browse/MM-30862

```release-note
NONE
```
