### PR TITLE
[MM-30914]: Change receiver name for (me *InviteProvider) in app/slashcommands/command_invite.go to be more idiomatic.

### DIFF
--- a/app/slashcommands/command_invite.go
+++ b/app/slashcommands/command_invite.go
@@ -24,11 +24,11 @@ func init() {
 	app.RegisterCommandProvider(&InviteProvider{})
 }
 
-func (inv *InviteProvider) GetTrigger() string {
+func (*InviteProvider) GetTrigger() string {
 	return CMD_INVITE
 }
 
-func (inv *InviteProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
+func (*InviteProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
 	return &model.Command{
 		Trigger:          CMD_INVITE,
 		AutoComplete:     true,
@@ -38,7 +38,7 @@ func (inv *InviteProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model
 	}
 }
 
-func (inv *InviteProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*InviteProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
 	if message == "" {
 		return &model.CommandResponse{
 			Text:         args.T("api.command_invite.missing_message.app_error"),

--- a/app/slashcommands/command_invite.go
+++ b/app/slashcommands/command_invite.go
@@ -24,11 +24,11 @@ func init() {
 	app.RegisterCommandProvider(&InviteProvider{})
 }
 
-func (me *InviteProvider) GetTrigger() string {
+func (inv *InviteProvider) GetTrigger() string {
 	return CMD_INVITE
 }
 
-func (me *InviteProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
+func (inv *InviteProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
 	return &model.Command{
 		Trigger:          CMD_INVITE,
 		AutoComplete:     true,
@@ -38,7 +38,7 @@ func (me *InviteProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.
 	}
 }
 
-func (me *InviteProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
+func (inv *InviteProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
 	if message == "" {
 		return &model.CommandResponse{
 			Text:         args.T("api.command_invite.missing_message.app_error"),


### PR DESCRIPTION
#### Summary 

Updated receiver name for (me *InviteProvider) to be more idiomatic. 

#### Ticket Link

Fixes: #16373  
JIRA: https://mattermost.atlassian.net/browse/MM-30914

#### Release Note

```release-note
NONE
```