### PR TITLE
[MM-30916]: Change receiver name for (me *LogoutProvider) in app/slashcommands/command_logout.go to be more idiomatic.

### DIFF
--- a/app/slashcommands/command_logout.go
+++ b/app/slashcommands/command_logout.go
@@ -20,11 +20,11 @@ func init() {
 	app.RegisterCommandProvider(&LogoutProvider{})
 }
 
-func (me *LogoutProvider) GetTrigger() string {
+func (lo *LogoutProvider) GetTrigger() string {
 	return CMD_LOGOUT
 }
 
-func (me *LogoutProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
+func (lo *LogoutProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
 	return &model.Command{
 		Trigger:          CMD_LOGOUT,
 		AutoComplete:     true,
@@ -34,7 +34,7 @@ func (me *LogoutProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.
 	}
 }
 
-func (me *LogoutProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
+func (lo *LogoutProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
 	// Actual logout is handled client side.
 	return &model.CommandResponse{GotoLocation: "/login"}
 }

--- a/app/slashcommands/command_logout.go
+++ b/app/slashcommands/command_logout.go
@@ -20,11 +20,11 @@ func init() {
 	app.RegisterCommandProvider(&LogoutProvider{})
 }
 
-func (lo *LogoutProvider) GetTrigger() string {
+func (*LogoutProvider) GetTrigger() string {
 	return CMD_LOGOUT
 }
 
-func (lo *LogoutProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
+func (*LogoutProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.Command {
 	return &model.Command{
 		Trigger:          CMD_LOGOUT,
 		AutoComplete:     true,
@@ -34,7 +34,7 @@ func (lo *LogoutProvider) GetCommand(a *app.App, T goi18n.TranslateFunc) *model.
 	}
 }
 
-func (lo *LogoutProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
+func (*LogoutProvider) DoCommand(a *app.App, args *model.CommandArgs, message string) *model.CommandResponse {
 	// Actual logout is handled client side.
 	return &model.CommandResponse{GotoLocation: "/login"}
 }


### PR DESCRIPTION
#### Summary 

Updated receiver name for (me *LogoutProvider) to be more idiomatic. 

#### Ticket Link

Fixes: #16375   
JIRA: https://mattermost.atlassian.net/browse/MM-30916

#### Release Note

```release-note
NONE
```