### PR TITLE
Syncronize access when updating config on search layer

### DIFF
--- a/store/searchlayer/layer.go
+++ b/store/searchlayer/layer.go
@@ -4,6 +4,8 @@
 package searchlayer
 
 import (
+	"sync"
+
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/services/searchengine"
@@ -18,6 +20,7 @@ type SearchStore struct {
 	channel      *SearchChannelStore
 	post         *SearchPostStore
 	config       *model.Config
+	configLock   sync.RWMutex
 }
 
 func NewSearchLayer(baseStore store.Store, searchEngine *searchengine.Broker, cfg *model.Config) *SearchStore {
@@ -35,7 +38,15 @@ func NewSearchLayer(baseStore store.Store, searchEngine *searchengine.Broker, cf
 }
 
 func (s *SearchStore) UpdateConfig(cfg *model.Config) {
+	s.configLock.Lock()
+	defer s.configLock.Unlock()
 	s.config = cfg
+}
+
+func (s *SearchStore) GetConfig() *model.Config {
+	s.configLock.Lock()
+	defer s.configLock.Unlock()
+	return s.config
 }
 
 func (s *SearchStore) Channel() store.ChannelStore {

--- a/store/searchlayer/layer.go
+++ b/store/searchlayer/layer.go
@@ -4,7 +4,7 @@
 package searchlayer
 
 import (
-	"sync"
+	"sync/atomic"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -19,16 +19,15 @@ type SearchStore struct {
 	team         *SearchTeamStore
 	channel      *SearchChannelStore
 	post         *SearchPostStore
-	config       *model.Config
-	configLock   sync.RWMutex
+	configValue  atomic.Value
 }
 
 func NewSearchLayer(baseStore store.Store, searchEngine *searchengine.Broker, cfg *model.Config) *SearchStore {
 	searchStore := &SearchStore{
 		Store:        baseStore,
 		searchEngine: searchEngine,
-		config:       cfg,
 	}
+	searchStore.configValue.Store(cfg)
 	searchStore.channel = &SearchChannelStore{ChannelStore: baseStore.Channel(), rootStore: searchStore}
 	searchStore.post = &SearchPostStore{PostStore: baseStore.Post(), rootStore: searchStore}
 	searchStore.team = &SearchTeamStore{TeamStore: baseStore.Team(), rootStore: searchStore}
@@ -38,9 +37,11 @@ func NewSearchLayer(baseStore store.Store, searchEngine *searchengine.Broker, cf
 }
 
 func (s *SearchStore) UpdateConfig(cfg *model.Config) {
-	defer s.configLock.Unlock()
-	s.configLock.Lock()
-	s.config = cfg
+	s.configValue.Store(cfg)
+}
+
+func (s *SearchStore) getConfig() *model.Config {
+	return s.configValue.Load().(*model.Config)
 }
 
 func (s *SearchStore) Channel() store.ChannelStore {

--- a/store/searchlayer/layer.go
+++ b/store/searchlayer/layer.go
@@ -38,15 +38,9 @@ func NewSearchLayer(baseStore store.Store, searchEngine *searchengine.Broker, cf
 }
 
 func (s *SearchStore) UpdateConfig(cfg *model.Config) {
-	s.configLock.Lock()
 	defer s.configLock.Unlock()
+	s.configLock.Lock()
 	s.config = cfg
-}
-
-func (s *SearchStore) GetConfig() *model.Config {
-	s.configLock.Lock()
-	defer s.configLock.Unlock()
-	return s.config
 }
 
 func (s *SearchStore) Channel() store.ChannelStore {

--- a/store/searchlayer/layer_test.go
+++ b/store/searchlayer/layer_test.go
@@ -1,0 +1,56 @@
+package searchlayer_test
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/store/searchlayer"
+
+	"github.com/mattermost/mattermost-server/v5/services/searchengine"
+	"github.com/mattermost/mattermost-server/v5/store/sqlstore"
+	"github.com/mattermost/mattermost-server/v5/store/storetest"
+	"github.com/mattermost/mattermost-server/v5/testlib"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+func TestUpdateConfigRacePartA(t *testing.T) {
+	driverName := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
+	if driverName == "" {
+		driverName = model.DATABASE_DRIVER_POSTGRES
+	}
+	settings := storetest.MakeSqlSettings(driverName)
+	store := sqlstore.NewSqlSupplier(*settings, nil)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	cfg.ClusterSettings.MaxIdleConns = model.NewInt(1)
+	searchEngine := searchengine.NewBroker(cfg, nil)
+	layer := searchlayer.NewSearchLayer(&testlib.TestStore{Store: store}, searchEngine, cfg)
+	var wg sync.WaitGroup
+	values := make(chan int, 5)
+	defer close(values)
+
+	wg.Add(5)
+	for i := 0; i < 5; i++ {
+		go func(num int) {
+			defer wg.Done()
+			dupConfig := cfg.Clone()
+			*dupConfig.ClusterSettings.MaxIdleConns = num
+			values <- *dupConfig.ClusterSettings.MaxIdleConns
+			layer.UpdateConfig(dupConfig)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < 4; i++ {
+		<-values
+	}
+
+	assert.Equal(t, <-values, *layer.GetConfig().ClusterSettings.MaxIdleConns)
+
+}

--- a/store/searchlayer/layer_test.go
+++ b/store/searchlayer/layer_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package searchlayer_test
 
 import (

--- a/store/searchlayer/post_layer.go
+++ b/store/searchlayer/post_layer.go
@@ -186,7 +186,7 @@ func (s SearchPostStore) SearchPostsInTeamForUser(paramsList []*model.SearchPara
 		}
 	}
 
-	if *s.rootStore.config.SqlSettings.DisableDatabaseSearch {
+	if *s.rootStore.getConfig().SqlSettings.DisableDatabaseSearch {
 		mlog.Debug("Returning empty results for post SearchPostsInTeam as the database search is disabled")
 		return &model.PostSearchResults{PostList: model.NewPostList(), Matches: model.PostSearchMatches{}}, nil
 	}


### PR DESCRIPTION
#### Summary
Fixes a race condition due to a non synchronized access of a critical section, in our case updating the config of the search layer. 

Solution: synchronise access via making config to be an `atomic.Value`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30868

#### Release Note

```release-note
Fix race condition when updating config on search layer.
```
