### PR TITLE
MM-30918 Fix product notice check when user setting is missing

### DIFF
--- a/app/product_notices.go
+++ b/app/product_notices.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/pkg/errors"
-	"github.com/reflog/dateconstraints"
+	date_constraints "github.com/reflog/dateconstraints"
 )
 
 const MAX_REPEAT_VIEWINGS = 3
@@ -179,7 +179,7 @@ func validateUserConfigEntry(preferences store.PreferenceStore, userId string, k
 	}
 	pref, err := preferences.Get(userId, parts[0], parts[1])
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	return pref.Value == expectedValue, nil
 }


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
if user preference doesn't exist - don't throw error, just fail notice check
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30918
#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
