### PR TITLE
MM-30802: Enable GoSAML2 library support (#16361)

### DIFF
--- a/app/enterprise.go
+++ b/app/enterprise.go
@@ -108,12 +108,6 @@ func RegisterMetricsInterface(f func(*Server) einterfaces.MetricsInterface) {
 	metricsInterface = f
 }
 
-var samlInterface func(*App) einterfaces.SamlInterface
-
-func RegisterSamlInterface(f func(*App) einterfaces.SamlInterface) {
-	samlInterface = f
-}
-
 var samlInterfaceNew func(*App) einterfaces.SamlInterface
 
 func RegisterNewSamlInterface(f func(*App) einterfaces.SamlInterface) {
@@ -145,17 +139,9 @@ func (s *Server) initEnterprise() {
 	if notificationInterface != nil {
 		s.Notification = notificationInterface(s.FakeApp())
 	}
-	if samlInterface != nil {
-		if *s.FakeApp().Config().ExperimentalSettings.UseNewSAMLLibrary && samlInterfaceNew != nil {
-			mlog.Debug("Loading new SAML2 library")
-			s.Saml = samlInterfaceNew(s.FakeApp())
-		} else if *s.FakeApp().Config().ExperimentalSettings.UseNewSAMLLibrary && samlInterfaceNew == nil {
-			mlog.Debug("Ignoring configuration setting to use the Experimental SAML library")
-			s.Saml = samlInterface(s.FakeApp())
-		} else {
-			mlog.Debug("Loading original SAML library")
-			s.Saml = samlInterface(s.FakeApp())
-		}
+	if samlInterfaceNew != nil {
+		mlog.Debug("Loading SAML2 library")
+		s.Saml = samlInterfaceNew(s.FakeApp())
 		s.AddConfigListener(func(_, cfg *model.Config) {
 			if err := s.Saml.ConfigureSP(); err != nil {
 				mlog.Error("An error occurred while configuring SAML Service Provider", mlog.Err(err))

--- a/app/enterprise_test.go
+++ b/app/enterprise_test.go
@@ -17,7 +17,6 @@ import (
 func TestSAMLSettings(t *testing.T) {
 	tt := []struct {
 		name              string
-		setSAMLInterface  bool
 		setNewInterface   bool
 		useNewSAMLLibrary bool
 		isNil             bool
@@ -25,45 +24,25 @@ func TestSAMLSettings(t *testing.T) {
 	}{
 		{
 			name:              "No SAML Interfaces, default setting",
-			setSAMLInterface:  false,
 			setNewInterface:   false,
 			useNewSAMLLibrary: false,
 			isNil:             true,
 		},
 		{
 			name:              "No SAML Interfaces, set config true",
-			setSAMLInterface:  false,
 			setNewInterface:   false,
 			useNewSAMLLibrary: true,
 			isNil:             true,
 		},
 		{
-			name:              "Orignal SAML Interface, default setting",
-			setSAMLInterface:  true,
-			setNewInterface:   false,
-			useNewSAMLLibrary: false,
-			isNil:             false,
-			metadata:          "samlOne",
-		},
-		{
-			name:              "Orignal SAML Interface, config true",
-			setSAMLInterface:  true,
-			setNewInterface:   false,
-			useNewSAMLLibrary: true,
-			isNil:             false,
-			metadata:          "samlOne",
-		},
-		{
 			name:              "Both SAML Interfaces, default setting",
-			setSAMLInterface:  true,
 			setNewInterface:   true,
 			useNewSAMLLibrary: false,
 			isNil:             false,
-			metadata:          "samlOne",
+			metadata:          "samlTwo",
 		},
 		{
 			name:              "Both SAML Interfaces, config true",
-			setSAMLInterface:  true,
 			setNewInterface:   true,
 			useNewSAMLLibrary: true,
 			isNil:             false,
@@ -73,17 +52,6 @@ func TestSAMLSettings(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			saml := &mocks.SamlInterface{}
-			saml.Mock.On("ConfigureSP").Return(nil)
-			saml.Mock.On("GetMetadata").Return("samlOne", nil)
-			if tc.setSAMLInterface {
-				RegisterSamlInterface(func(a *App) einterfaces.SamlInterface {
-					return saml
-				})
-			} else {
-				RegisterSamlInterface(nil)
-			}
-
 			saml2 := &mocks.SamlInterface{}
 			saml2.Mock.On("ConfigureSP").Return(nil)
 			saml2.Mock.On("GetMetadata").Return("samlTwo", nil)


### PR DESCRIPTION
* update saml to always use new library

* remove unused variable

* Update tests

Co-authored-by: Mattermod <mattermod@users.noreply.github.com>
(cherry picked from commit e014de0a6599063627b7183d59733afc0628dbdd)

#### Release Note
```release-note
Enable goSAML2 library as the only supported SAML Library.
```
