### PR TITLE
MM-30988 - Fix racy test ServerSystemdNotification

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -198,6 +198,8 @@ func NewServer(options ...Option) (*Server, error) {
 		uploadLockMap:       map[string]bool{},
 	}
 
+	model.AppErrorInit(utils.T)
+
 	for _, option := range options {
 		if err := option(s); err != nil {
 			return nil, errors.Wrap(err, "failed to apply option")
@@ -449,8 +451,6 @@ func NewServer(options ...Option) (*Server, error) {
 	if appErr != nil {
 		mlog.Error("Problem with file storage settings", mlog.Err(appErr))
 	}
-
-	model.AppErrorInit(utils.T)
 
 	s.timezones = timezones.New()
 	// Start email batching because it's not like the other jobs

--- a/app/server.go
+++ b/app/server.go
@@ -198,8 +198,6 @@ func NewServer(options ...Option) (*Server, error) {
 		uploadLockMap:       map[string]bool{},
 	}
 
-	model.AppErrorInit(utils.T)
-
 	for _, option := range options {
 		if err := option(s); err != nil {
 			return nil, errors.Wrap(err, "failed to apply option")
@@ -271,6 +269,7 @@ func NewServer(options ...Option) (*Server, error) {
 	if err := utils.TranslationsPreInit(); err != nil {
 		return nil, errors.Wrapf(err, "unable to load Mattermost translation files")
 	}
+	model.AppErrorInit(utils.T)
 
 	searchEngine := searchengine.NewBroker(s.Config(), s.Jobs)
 	bleveEngine := bleveengine.NewBleveEngine(s.Config(), s.Jobs)

--- a/model/utils.go
+++ b/model/utils.go
@@ -73,9 +73,12 @@ func (sa StringArray) Equals(input StringArray) bool {
 }
 
 var translateFunc goi18n.TranslateFunc
+var translateFuncOnce sync.Once
 
 func AppErrorInit(t goi18n.TranslateFunc) {
-	translateFunc = t
+	translateFuncOnce.Do(func() {
+		translateFunc = t
+	})
 }
 
 type AppError struct {

--- a/model/utils.go
+++ b/model/utils.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 

--- a/model/utils.go
+++ b/model/utils.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -72,10 +73,10 @@ func (sa StringArray) Equals(input StringArray) bool {
 	return true
 }
 
-var translateFunc goi18n.TranslateFunc = nil
+var translateFunc atomic.Value
 
 func AppErrorInit(t goi18n.TranslateFunc) {
-	translateFunc = t
+	translateFunc.Store(t)
 }
 
 type AppError struct {
@@ -148,7 +149,7 @@ func NewAppError(where string, id string, params map[string]interface{}, details
 	ap.DetailedError = details
 	ap.StatusCode = status
 	ap.IsOAuth = false
-	ap.Translate(translateFunc)
+	ap.Translate(translateFunc.Load().(goi18n.TranslateFunc))
 	return ap
 }
 

--- a/model/utils.go
+++ b/model/utils.go
@@ -18,7 +18,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -73,10 +72,10 @@ func (sa StringArray) Equals(input StringArray) bool {
 	return true
 }
 
-var translateFunc atomic.Value
+var translateFunc goi18n.TranslateFunc
 
 func AppErrorInit(t goi18n.TranslateFunc) {
-	translateFunc.Store(t)
+	translateFunc = t
 }
 
 type AppError struct {
@@ -149,11 +148,7 @@ func NewAppError(where string, id string, params map[string]interface{}, details
 	ap.DetailedError = details
 	ap.StatusCode = status
 	ap.IsOAuth = false
-	if fn, ok := translateFunc.Load().(goi18n.TranslateFunc); ok {
-		ap.Translate(fn)
-	} else {
-		ap.Translate(nil)
-	}
+	ap.Translate(translateFunc)
 	return ap
 }
 

--- a/model/utils.go
+++ b/model/utils.go
@@ -149,7 +149,11 @@ func NewAppError(where string, id string, params map[string]interface{}, details
 	ap.DetailedError = details
 	ap.StatusCode = status
 	ap.IsOAuth = false
-	ap.Translate(translateFunc.Load().(goi18n.TranslateFunc))
+	if fn, ok := translateFunc.Load().(goi18n.TranslateFunc); ok {
+		ap.Translate(fn)
+	} else {
+		ap.Translate(nil)
+	}
 	return ap
 }
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,7 +16,7 @@ echo "Packages to test: $PACKAGES"
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
 find . -type d -name data -not -path './vendor/*' -not -path './data' | xargs rm -rf
 
-$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=2000s -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
+$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -race -timeout=5000s -covermode=atomic -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?
 
 cat output | $GOBIN/go-junit-report > report.xml

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,7 +16,7 @@ echo "Packages to test: $PACKAGES"
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
 find . -type d -name data -not -path './vendor/*' -not -path './data' | xargs rm -rf
 
-$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -race -timeout=5000s -covermode=atomic -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
+$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=1000s -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?
 
 cat output | $GOBIN/go-junit-report > report.xml

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -16,7 +16,7 @@ echo "Packages to test: $PACKAGES"
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
 find . -type d -name data -not -path './vendor/*' -not -path './data' | xargs rm -rf
 
-$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=1000s -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
+$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=20m -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?
 
 cat output | $GOBIN/go-junit-report > report.xml


### PR DESCRIPTION
The translateFunc is a global variable which was unguarded. This wasn't a problem from the code,
but when consecutive tests were run, one test would still be writing to it while the other would be reading.
We wrap the write with a sync.Once so that consecutive tests don't write to it again.

https://mattermost.atlassian.net/browse/MM-30988

```release-note
NONE
```
