### PR TITLE
Allow 'mmctl channel move' to move private channels

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -1870,7 +1870,7 @@ func moveChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("team_id", team.Id)
 	auditRec.AddMeta("team_name", team.Name)
 
-	if channel.Type == model.CHANNEL_DIRECT || channel.Type == model.CHANNEL_GROUP || channel.Type == model.CHANNEL_PRIVATE {
+	if channel.Type == model.CHANNEL_DIRECT || channel.Type == model.CHANNEL_GROUP {
 		c.Err = model.NewAppError("moveChannel", "api.channel.move_channel.type.invalid", nil, "", http.StatusForbidden)
 		return
 	}

--- a/api4/channel_local.go
+++ b/api4/channel_local.go
@@ -246,7 +246,7 @@ func localMoveChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("team_id", team.Id)
 	auditRec.AddMeta("team_name", team.Name)
 
-	if channel.Type == model.CHANNEL_DIRECT || channel.Type == model.CHANNEL_GROUP || channel.Type == model.CHANNEL_PRIVATE {
+	if channel.Type == model.CHANNEL_DIRECT || channel.Type == model.CHANNEL_GROUP {
 		c.Err = model.NewAppError("moveChannel", "api.channel.move_channel.type.invalid", nil, "", http.StatusForbidden)
 		return
 	}


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
Currently `mmctl channel move someotherteam teamname:channelname` does not allow moving private channels. The error message only mentions direct message and group message channels that cannot be moved:
https://github.com/mattermost/mattermost-server/blob/15037a510a5da29bf16badb5ae4e6c69ee6fe946/i18n/en.json#L339-L340
While not being able to move direct message and group message channels makes sense, the same should not apply to private channels.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
None

#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
Fixed an issue where `mmctl channel move` did not allow moving private channels.
```
