### PR TITLE
[MM-30981] Require Plugin name in manifest

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -147,7 +147,7 @@ type Manifest struct {
 	Id string `json:"id" yaml:"id"`
 
 	// The name to be displayed for the plugin.
-	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+	Name string `json:"name" yaml:"name"`
 
 	// A description of what your plugin is and does.
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
@@ -327,6 +327,10 @@ func (m *Manifest) MeetMinServerVersion(serverVersion string) (bool, error) {
 func (m *Manifest) IsValid() error {
 	if !IsValidPluginId(m.Id) {
 		return errors.New("invalid plugin ID")
+	}
+
+	if strings.TrimSpace(m.Name) == "" {
+		return errors.New("a plugin name is needed")
 	}
 
 	if m.HomepageURL != "" && !IsValidHttpUrl(m.HomepageURL) {

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -23,16 +23,17 @@ func TestIsValid(t *testing.T) {
 		manifest    *Manifest
 		ExpectError bool
 	}{
-		{"Invalid Id", &Manifest{Id: "some id"}, true},
-		{"Invalid homePageURL", &Manifest{Id: "com.company.test", HomepageURL: "some url"}, true},
-		{"Invalid supportURL", &Manifest{Id: "com.company.test", SupportURL: "some url"}, true},
-		{"Invalid ReleaseNotesURL", &Manifest{Id: "com.company.test", ReleaseNotesURL: "some url"}, true},
-		{"Invalid version", &Manifest{Id: "com.company.test", HomepageURL: "http://someurl.com", SupportURL: "http://someotherurl.com", Version: "version"}, true},
-		{"Invalid min version", &Manifest{Id: "com.company.test", HomepageURL: "http://someurl.com", SupportURL: "http://someotherurl.com", Version: "5.10.0", MinServerVersion: "version"}, true},
-		{"SettingSchema error", &Manifest{Id: "com.company.test", HomepageURL: "http://someurl.com", SupportURL: "http://someotherurl.com", Version: "5.10.0", MinServerVersion: "5.10.8", SettingsSchema: &PluginSettingsSchema{
+		{"Invalid Id", &Manifest{Id: "some id", Name: "some name"}, true},
+		{"Invalid Name", &Manifest{Id: "com.company.test", Name: "  "}, true},
+		{"Invalid homePageURL", &Manifest{Id: "com.company.test", Name: "some name", HomepageURL: "some url"}, true},
+		{"Invalid supportURL", &Manifest{Id: "com.company.test", Name: "some name", SupportURL: "some url"}, true},
+		{"Invalid ReleaseNotesURL", &Manifest{Id: "com.company.test", Name: "some name", ReleaseNotesURL: "some url"}, true},
+		{"Invalid version", &Manifest{Id: "com.company.test", Name: "some name", HomepageURL: "http://someurl.com", SupportURL: "http://someotherurl.com", Version: "version"}, true},
+		{"Invalid min version", &Manifest{Id: "com.company.test", Name: "some name", HomepageURL: "http://someurl.com", SupportURL: "http://someotherurl.com", Version: "5.10.0", MinServerVersion: "version"}, true},
+		{"SettingSchema error", &Manifest{Id: "com.company.test", Name: "some name", HomepageURL: "http://someurl.com", SupportURL: "http://someotherurl.com", Version: "5.10.0", MinServerVersion: "5.10.8", SettingsSchema: &PluginSettingsSchema{
 			Settings: []*PluginSetting{{Type: "Invalid"}},
 		}}, true},
-		{"Minimal valid manifest", &Manifest{Id: "com.company.test"}, false},
+		{"Minimal valid manifest", &Manifest{Id: "com.company.test", Name: "some name"}, false},
 		{"Happy case", &Manifest{
 			Id:               "com.company.test",
 			Name:             "thename",


### PR DESCRIPTION
#### Summary
Plugins without a name defined in the manifest are tricky to display in the webapp. This PR changes `IsValid` to enforce a name. Right now `IsValid` is not used, so this changes doesn't have a direct impact.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30981

#### Release Note
```release-note
NONE
```
