### PR TITLE
Additional Config Store Cleanup

### DIFF
--- a/cmd/mattermost/commands/channel.go
+++ b/cmd/mattermost/commands/channel.go
@@ -611,7 +611,6 @@ func renameChannelCmdF(command *cobra.Command, args []string) error {
 }
 
 func searchChannelCmdF(command *cobra.Command, args []string) error {
-
 	a, err := InitDBCommandContextCobra(command)
 	if err != nil {
 		return errors.Wrap(err, "failed to InitDBCommandContextCobra")

--- a/cmd/mattermost/commands/init.go
+++ b/cmd/mattermost/commands/init.go
@@ -17,7 +17,6 @@ func InitDBCommandContextCobra(command *cobra.Command) (*app.App, error) {
 		// Returning an error just prints the usage message, so actually panic
 		panic(err)
 	}
-	defer a.Srv().Shutdown()
 
 	a.InitPlugins(*a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
 	a.DoAppMigrations()

--- a/cmd/mattermost/commands/init.go
+++ b/cmd/mattermost/commands/init.go
@@ -13,11 +13,11 @@ import (
 
 func InitDBCommandContextCobra(command *cobra.Command) (*app.App, error) {
 	a, err := InitDBCommandContext(getConfigDSN(command, config.GetEnvironment()))
-
 	if err != nil {
 		// Returning an error just prints the usage message, so actually panic
 		panic(err)
 	}
+	defer a.Srv().Shutdown()
 
 	a.InitPlugins(*a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
 	a.DoAppMigrations()

--- a/cmd/mattermost/commands/permissions.go
+++ b/cmd/mattermost/commands/permissions.go
@@ -62,6 +62,7 @@ func resetPermissionsCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Srv().Shutdown()
 
 	confirmFlag, _ := command.Flags().GetBool("confirm")
 	if !confirmFlag {

--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -97,6 +97,7 @@ func runServer(configStore *config.Store, usedPlatform bool, interruptChan chan 
 	}
 	server, err := app.NewServer(options...)
 	if err != nil {
+		configStore.Close()
 		mlog.Critical(err.Error())
 		return err
 	}

--- a/cmd/mattermost/commands/server.go
+++ b/cmd/mattermost/commands/server.go
@@ -78,6 +78,7 @@ func serverCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to load configuration")
 	}
+	defer configStore.Close()
 
 	return runServer(configStore, usedPlatform, interruptChan)
 }
@@ -97,7 +98,6 @@ func runServer(configStore *config.Store, usedPlatform bool, interruptChan chan 
 	}
 	server, err := app.NewServer(options...)
 	if err != nil {
-		configStore.Close()
 		mlog.Critical(err.Error())
 		return err
 	}

--- a/cmd/mattermost/commands/version.go
+++ b/cmd/mattermost/commands/version.go
@@ -32,6 +32,7 @@ func versionCmdF(command *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer a.Srv().Shutdown()
 
 	printVersion(a)
 

--- a/config/database.go
+++ b/config/database.go
@@ -55,6 +55,7 @@ func NewDatabaseStore(dsn string) (ds *DatabaseStore, err error) {
 		db:             db,
 	}
 	if err = initializeConfigurationsTable(ds.db); err != nil {
+		ds.Close()
 		return nil, errors.Wrap(err, "failed to initialize")
 	}
 

--- a/config/database.go
+++ b/config/database.go
@@ -48,6 +48,12 @@ func NewDatabaseStore(dsn string) (ds *DatabaseStore, err error) {
 		return nil, errors.Wrapf(err, "failed to connect to %s database", driverName)
 	}
 
+	defer func() {
+		if err != nil {
+			db.Close()
+		}
+	}()
+
 	ds = &DatabaseStore{
 		driverName:     driverName,
 		originalDsn:    dsn,
@@ -55,8 +61,8 @@ func NewDatabaseStore(dsn string) (ds *DatabaseStore, err error) {
 		db:             db,
 	}
 	if err = initializeConfigurationsTable(ds.db); err != nil {
-		ds.Close()
-		return nil, errors.Wrap(err, "failed to initialize")
+		err = errors.Wrap(err, "failed to initialize")
+		return nil, err
 	}
 
 	return ds, nil

--- a/config/store.go
+++ b/config/store.go
@@ -54,7 +54,13 @@ func NewStore(dsn string, watch bool, customDefaults *model.Config) (*Store, err
 		return nil, err
 	}
 
-	return NewStoreFromBacking(backingStore, customDefaults)
+	store, err := NewStoreFromBacking(backingStore, customDefaults)
+	if err != nil {
+		backingStore.Close()
+		return store, errors.Wrap(err, "failed to create store")
+	}
+
+	return store, nil
 }
 
 func NewStoreFromBacking(backingStore BackingStore, customDefaults *model.Config) (*Store, error) {

--- a/config/store.go
+++ b/config/store.go
@@ -57,7 +57,7 @@ func NewStore(dsn string, watch bool, customDefaults *model.Config) (*Store, err
 	store, err := NewStoreFromBacking(backingStore, customDefaults)
 	if err != nil {
 		backingStore.Close()
-		return store, errors.Wrap(err, "failed to create store")
+		return nil, errors.Wrap(err, "failed to create store")
 	}
 
 	return store, nil


### PR DESCRIPTION
This change addresses a few issues where config stores were not
properly closed when an error was encountered on server startup.
This could result in leaked database connections when dealing with
a database config store.

Fixes https://mattermost.atlassian.net/browse/MM-30345

```release-note
Cleanup config store on server initialization errors
```
