### PR TITLE
[MM-30982] Add filter metadata to Marketplace response

### DIFF
--- a/model/marketplace_plugin.go
+++ b/model/marketplace_plugin.go
@@ -20,8 +20,12 @@ type BaseMarketplacePlugin struct {
 	IconData        string             `json:"icon_data"`
 	DownloadURL     string             `json:"download_url"`
 	ReleaseNotesURL string             `json:"release_notes_url"`
-	Labels          []MarketplaceLabel `json:"labels"`
-	Signature       string             `json:"signature"` // Signature represents a signature of a plugin saved in base64 encoding.
+	Labels          []MarketplaceLabel `json:"labels,omitempty"`
+	Hosting         string             `json:"hosting"`       // Indicated if the plugin is limited to a certain hosting type
+	AuthorType      string             `json:"author_type"`   // The maintainer of the plugin
+	ReleaseStage    string             `json:"release_stage"` // The stage in the software release cycle that the plugin is in
+	Enterprise      bool               `json:"enterprise"`    // Indicated if the plugin is an enterprise plugin
+	Signature       string             `json:"signature"`     // Signature represents a signature of a plugin saved in base64 encoding.
 	Manifest        *Manifest          `json:"manifest"`
 }
 


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-marketplace/pull/137 and other PRs added additional filter fields to the Marketplace. This PR adds `Hosting`, `AuthorType`, `ReleaseStage` and `Enterprise` to the Marketplace response send to the client. 

On the Marketplace some of these fields are typed. I opted for not doing this here as the MM server does just passes the data and doesn't look into it. 1/5

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30982

#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
