### PR TITLE
MM-31082: Use a base path for test assets

### DIFF
--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -148,7 +148,7 @@ func (h *MainHelper) PreloadMigrations() {
 		if basePath != "" {
 			finalPath = filepath.Join(basePath, relPath, "postgres_migration_warmup.sql")
 		} else {
-			finalPath = filepath("mattermost-server", relPath, "postgres_migration_warmup.sql")
+			finalPath = filepath.Join("mattermost-server", relPath, "postgres_migration_warmup.sql")
 		}
 		buf, err = ioutil.ReadFile(finalPath)
 		if err != nil {
@@ -159,7 +159,7 @@ func (h *MainHelper) PreloadMigrations() {
 		if basePath != "" {
 			finalPath = filepath.Join(basePath, relPath, "mysql_migration_warmup.sql")
 		} else {
-			finalPath = filepath("mattermost-server", relPath, "mysql_migration_warmup.sql")
+			finalPath = filepath.Join("mattermost-server", relPath, "mysql_migration_warmup.sql")
 		}
 		buf, err = ioutil.ReadFile(finalPath)
 		if err != nil {

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -141,14 +141,27 @@ func (h *MainHelper) PreloadMigrations() {
 	var buf []byte
 	var err error
 	basePath := os.Getenv("MM_SERVER_PATH")
+	relPath := "testlib/testdata"
 	switch *h.Settings.DriverName {
 	case model.DATABASE_DRIVER_POSTGRES:
-		buf, err = ioutil.ReadFile(filepath.Join(basePath, "mattermost-server/testlib/testdata/postgres_migration_warmup.sql"))
+		var finalPath string
+		if basePath != "" {
+			finalPath = filepath.Join(basePath, relPath, "postgres_migration_warmup.sql")
+		} else {
+			finalPath = filepath("mattermost-server", relPath, "postgres_migration_warmup.sql")
+		}
+		buf, err = ioutil.ReadFile(finalPath)
 		if err != nil {
 			panic(fmt.Errorf("cannot read file: %v", err))
 		}
 	case model.DATABASE_DRIVER_MYSQL:
-		buf, err = ioutil.ReadFile(filepath.Join(basePath, "mattermost-server/testlib/testdata/mysql_migration_warmup.sql"))
+		var finalPath string
+		if basePath != "" {
+			finalPath = filepath.Join(basePath, relPath, "mysql_migration_warmup.sql")
+		} else {
+			finalPath = filepath("mattermost-server", relPath, "mysql_migration_warmup.sql")
+		}
+		buf, err = ioutil.ReadFile(finalPath)
 		if err != nil {
 			panic(fmt.Errorf("cannot read file: %v", err))
 		}

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
@@ -139,14 +140,15 @@ func (h *MainHelper) setupResources() {
 func (h *MainHelper) PreloadMigrations() {
 	var buf []byte
 	var err error
+	basePath := os.Getenv("MM_SERVER_PATH")
 	switch *h.Settings.DriverName {
 	case model.DATABASE_DRIVER_POSTGRES:
-		buf, err = ioutil.ReadFile("mattermost-server/testlib/testdata/postgres_migration_warmup.sql")
+		buf, err = ioutil.ReadFile(filepath.Join(basePath, "mattermost-server/testlib/testdata/postgres_migration_warmup.sql"))
 		if err != nil {
 			panic(fmt.Errorf("cannot read file: %v", err))
 		}
 	case model.DATABASE_DRIVER_MYSQL:
-		buf, err = ioutil.ReadFile("mattermost-server/testlib/testdata/mysql_migration_warmup.sql")
+		buf, err = ioutil.ReadFile(filepath.Join(basePath, "mattermost-server/testlib/testdata/mysql_migration_warmup.sql"))
 		if err != nil {
 			panic(fmt.Errorf("cannot read file: %v", err))
 		}


### PR DESCRIPTION
Tests can be run from other tools using a different base path.
We need to respect the MM_SERVER_PATH variable for that.

https://mattermost.atlassian.net/browse/MM-31082

```release-note
NONE
```
