### PR TITLE
Limit configuration database connections

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -47,6 +47,9 @@ func NewDatabaseStore(dsn string) (ds *DatabaseStore, err error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to connect to %s database", driverName)
 	}
+	// Set conservative connection configuration for configuration database.
+	db.SetMaxIdleConns(0)
+	db.SetMaxOpenConns(2)
 
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
When configuration is backed by a database, a separate pool of
connections is used for access from the primary database. This
change sets sensible config DB connection limits in order to
reduce database resource usage at scale.

Fixes https://mattermost.atlassian.net/browse/MM-31158

```release-note
NONE
```
