### PR TITLE
MM-27648: Fix a hub deadlock while revoking session (#15293)

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -81,7 +81,19 @@ func (a *App) GetSession(token string) (*model.Session, *model.AppError) {
 
 		timeout := int64(*a.Config().ServiceSettings.SessionIdleTimeoutInMinutes) * 1000 * 60
 		if (model.GetMillis() - session.LastActivityAt) > timeout {
-			a.RevokeSessionById(session.Id)
+			// Revoking the session is an asynchronous task anyways since we are not checking
+			// for the return value of the call before returning the error.
+			// So moving this to a goroutine has 2 advantages:
+			// 1. We are treating this as a proper asynchronous task.
+			// 2. This also fixes a race condition in the web hub, where GetSession
+			// gets called from (*WebConn).isMemberOfTeam and revoking a session involves
+			// clearing the webconn cache, which needs the hub again.
+			a.Srv().Go(func() {
+				err := a.RevokeSessionById(session.Id)
+				if err != nil {
+					mlog.Warn("Error while revoking session", mlog.Err(err))
+				}
+			})
 			return nil, model.NewAppError("GetSession", "api.context.invalid_token.error", map[string]interface{}{"Token": token}, "idle timeout", http.StatusUnauthorized)
 		}
 	}


### PR DESCRIPTION
#### Summary
This is a cherry-pick of https://mattermost.atlassian.net/browse/MM-27648, modulo the unit tests which aren't compatible with the code in v5.25 (but [aren't strictly required](https://community.mattermost.com/core/pl/txynjirgr3yzfpm1tf9x4meiba)).

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-31201

#### Release Note
```release-note
Fix a relatively infrequent issue involving a hub deadlock while revoking session.
```
