### PR TITLE
MM-31171 Fork OpenGraph library to handle bad HTML from YouTube

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,3 +139,5 @@ require (
 )
 
 replace github.com/NYTimes/gziphandler v1.1.1 => github.com/agnivade/gziphandler v1.1.2-0.20200815170021-7481835cb745
+
+replace github.com/dyatlov/go-opengraph => github.com/hmhealey/go-opengraph v0.0.0-20201209151214-f2d823730dba

--- a/go.sum
+++ b/go.sum
@@ -413,6 +413,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce h1:7UnVY3T/ZnHUrfviiAgIUjg2PXxsQfs5bphsG8F7Keo=
 github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hmhealey/go-opengraph v0.0.0-20201209151214-f2d823730dba h1:2vMJwzNFzJcB6OSIZWNcjTGn4fWDcZTDv3DNPWL/OrA=
+github.com/hmhealey/go-opengraph v0.0.0-20201209151214-f2d823730dba/go.mod h1:IRzuuhgRxsskfZk1qE3U0gStYsrnZR3wPpntC5Dkv5g=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428 h1:Mo9W14pwbO9VfRe+ygqZ8dFbPpoIK1HFrG/zjTuQ+nc=

--- a/vendor/github.com/dyatlov/go-opengraph/opengraph/opengraph.go
+++ b/vendor/github.com/dyatlov/go-opengraph/opengraph/opengraph.go
@@ -17,7 +17,7 @@ type Image struct {
 	Type      string `json:"type"`
 	Width     uint64 `json:"width"`
 	Height    uint64 `json:"height"`
-	draft     bool    `json:"-"`
+	draft     bool   `json:"-"`
 }
 
 // Video defines Open Graph Video type
@@ -27,7 +27,7 @@ type Video struct {
 	Type      string `json:"type"`
 	Width     uint64 `json:"width"`
 	Height    uint64 `json:"height"`
-	draft     bool    `json:"-"`
+	draft     bool   `json:"-"`
 }
 
 // Audio defines Open Graph Audio Type
@@ -35,7 +35,7 @@ type Audio struct {
 	URL       string `json:"url"`
 	SecureURL string `json:"secure_url"`
 	Type      string `json:"type"`
-	draft     bool    `json:"-"`
+	draft     bool   `json:"-"`
 }
 
 // Article contain Open Graph Article structure
@@ -119,9 +119,6 @@ func (og *OpenGraph) ProcessHTML(buffer io.Reader) error {
 			return z.Err()
 		case html.StartTagToken, html.SelfClosingTagToken, html.EndTagToken:
 			name, hasAttr := z.TagName()
-			if atom.Lookup(name) == atom.Body {
-				return nil // OpenGraph is only in head, so we don't need body
-			}
 			if atom.Lookup(name) != atom.Meta || !hasAttr {
 				continue
 			}
@@ -185,7 +182,7 @@ func (og *OpenGraph) ProcessMeta(metaAttrs map[string]string) {
 	case "og:locale:alternate":
 		og.LocalesAlternate = append(og.LocalesAlternate, metaAttrs["content"])
 	case "og:audio":
-		if len(og.Audios)>0 && og.Audios[len(og.Audios)-1].draft {
+		if len(og.Audios) > 0 && og.Audios[len(og.Audios)-1].draft {
 			og.Audios[len(og.Audios)-1].URL = metaAttrs["content"]
 			og.Audios[len(og.Audios)-1].draft = false
 		} else {
@@ -198,7 +195,7 @@ func (og *OpenGraph) ProcessMeta(metaAttrs map[string]string) {
 		og.ensureHasAudio()
 		og.Audios[len(og.Audios)-1].Type = metaAttrs["content"]
 	case "og:image":
-		if len(og.Images)>0 && og.Images[len(og.Images)-1].draft {
+		if len(og.Images) > 0 && og.Images[len(og.Images)-1].draft {
 			og.Images[len(og.Images)-1].URL = metaAttrs["content"]
 			og.Images[len(og.Images)-1].draft = false
 		} else {
@@ -226,7 +223,7 @@ func (og *OpenGraph) ProcessMeta(metaAttrs map[string]string) {
 			og.Images[len(og.Images)-1].Height = h
 		}
 	case "og:video":
-		if len(og.Videos)>0 && og.Videos[len(og.Videos)-1].draft {
+		if len(og.Videos) > 0 && og.Videos[len(og.Videos)-1].draft {
 			og.Videos[len(og.Videos)-1].URL = metaAttrs["content"]
 			og.Videos[len(og.Videos)-1].draft = false
 		} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -176,7 +176,7 @@ github.com/dsnet/compress/bzip2/internal/sais
 github.com/dsnet/compress/internal
 github.com/dsnet/compress/internal/errors
 github.com/dsnet/compress/internal/prefix
-# github.com/dyatlov/go-opengraph v0.0.0-20180429202543-816b6608b3c8
+# github.com/dyatlov/go-opengraph v0.0.0-20180429202543-816b6608b3c8 => github.com/hmhealey/go-opengraph v0.0.0-20201209151214-f2d823730dba
 ## explicit
 github.com/dyatlov/go-opengraph/opengraph
 # github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c
@@ -919,3 +919,4 @@ willnorris.com/go/gifresize
 ## explicit
 willnorris.com/go/imageproxy
 willnorris.com/go/imageproxy/third_party/http
+# github.com/dyatlov/go-opengraph => github.com/hmhealey/go-opengraph v0.0.0-20201209151214-f2d823730dba


### PR DESCRIPTION
YouTube previews are currently broken sporadically on different servers because they started sending HTML with the OpenGraph metadata in the wrong place as well as some other invalid bits. It seems like it's a rolling change being propagated through all their servers since previews went from working on community to working sometimes to not working at all. Their HTML is actually invalid now, so I assume they'll fix it, but I've forked the OpenGraph library to be more relaxed.

The changes to the fork are here: https://github.com/dyatlov/go-opengraph/compare/master...hmhealey:master
In particular, it's these lines: https://github.com/dyatlov/go-opengraph/compare/master...hmhealey:master#diff-47ab48a2396307d97df39eabbd77905aad8cb1b808acfcab8a7a3b5523f08a6fL122-L124

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31171

#### Release Note
```release-note
Fixed YouTube previews not being displayed sometimes
```
