### PR TITLE
MM-3124: Fix racy test TestPluginPanicLogs

### DIFF
--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -715,7 +715,6 @@ func TestPluginPanicLogs(t *testing.T) {
 		}
 		`,
 		}, th.App, th.App.NewPluginAPI)
-		defer tearDown()
 
 		post := &model.Post{
 			UserId:    th.BasicUser.Id,
@@ -725,6 +724,9 @@ func TestPluginPanicLogs(t *testing.T) {
 		}
 		_, err := th.App.CreatePost(post, th.BasicChannel, false, true)
 		assert.Nil(t, err)
+		// We shutdown plugins first so that the read on the log buffer is race-free.
+		th.App.Srv().ShutDownPlugins()
+		tearDown()
 
 		testlib.AssertLog(t, th.LogBuffer, mlog.LevelDebug, "panic: some text from panic")
 	})


### PR DESCRIPTION
We shutdown all plugins prior to checking the log buffer
so that there are no active plugins writing to the buffer
when we read the contents.

https://mattermost.atlassian.net/browse/MM-31324

```release-note
NONE
```
