### PR TITLE
MM-31323: Fix racy test TestHandleCommandResponsePost

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -210,7 +210,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 	}
 
 	notification := &PostNotification{
-		Post:       post,
+		Post:       post.Clone(),
 		Channel:    channel,
 		ProfileMap: profileMap,
 		Sender:     sender,

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -583,7 +583,9 @@ func (a *App) buildFullPushNotificationMessage(contentsConfig string, post *mode
 	}
 
 	for _, attachment := range post.Attachments() {
-		post.Message += "\n" + attachment.Fallback
+		if attachment.Fallback != "" {
+			post.Message += "\n" + attachment.Fallback
+		}
 	}
 
 	userLocale := utils.GetUserTranslations(user.Locale)


### PR DESCRIPTION
In https://github.com/mattermost/mattermost-server/pull/16089,
we added logic to modify the notification text in the presence
of fallback text.

Unfortunately, that created a race condition during publishing
the post via websockets. To fix this, we create a clone of the post
before sending it off for push notifications.

https://mattermost.atlassian.net/browse/MM-31323

```release-note
NONE
```
