### PR TITLE
[MM-31357] Avoid returning empty appError when autocompleting users

### DIFF
--- a/store/searchlayer/user_layer.go
+++ b/store/searchlayer/user_layer.go
@@ -216,7 +216,7 @@ func (s *SearchUserStore) AutocompleteUsersInChannel(teamId, channelId, term str
 				continue
 			}
 			mlog.Debug("Using the first available search engine", mlog.String("search_engine", engine.GetName()))
-			return autocomplete, err
+			return autocomplete, nil
 		}
 	}
 


### PR DESCRIPTION
#### Summary
As part of the `UserStore` error migration, we started returning `error` from the `searchlayer`, inadvertently returning an empty `AppError` instance in the user autocomplete function, that was then caught as `!= nil` by the caller, causing a panic.

`AppError` strikes yet again.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31357

#### Release Note
```release-note
NONE
```
