### PR TITLE
MM-31369: Fix racy test TestFileStoreWatcher

### DIFF
--- a/config/file_test.go
+++ b/config/file_test.go
@@ -884,10 +884,9 @@ func TestFileStoreWatcherEmitter(t *testing.T) {
 
 	t.Parallel()
 
-	path, tearDown := setupConfigFile(t, emptyConfig)
-	defer tearDown()
-
 	t.Run("disabled", func(t *testing.T) {
+		path, tearDown := setupConfigFile(t, emptyConfig)
+		defer tearDown()
 		fsInner, err := config.NewFileStore(path, false)
 		require.NoError(t, err)
 		fs, err := config.NewStoreFromBacking(fsInner, nil)
@@ -912,6 +911,8 @@ func TestFileStoreWatcherEmitter(t *testing.T) {
 	})
 
 	t.Run("enabled", func(t *testing.T) {
+		path, tearDown := setupConfigFile(t, emptyConfig)
+		defer tearDown()
 		fsInner, err := config.NewFileStore(path, true)
 		require.NoError(t, err)
 		fs, err := config.NewStoreFromBacking(fsInner, nil)


### PR DESCRIPTION
Since this test had t.Parallel set, it would run the sub-tests
in parallel. The issue was that the same file path was being written
from the 2 sub-tests causing duplicate firing of the event handlers.

This would cause a race where the store would be closing, and at the same time,
an event handler would fire, trying to read the fs.watcher field.

Having two separate file paths resolves this.

https://mattermost.atlassian.net/browse/MM-31369

```release-note
NONE
```
