### PR TITLE
MM-30826: Sentry crash: nil deference in model.AuthorizeRequest

### DIFF
--- a/web/oauth.go
+++ b/web/oauth.go
@@ -46,6 +46,7 @@ func authorizeOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 	authRequest := model.AuthorizeRequestFromJson(r.Body)
 	if authRequest == nil {
 		c.SetInvalidParam("authorize_request")
+		return
 	}
 
 	if err := authRequest.IsValid(); err != nil {

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -129,6 +129,16 @@ func TestAuthorizeOAuthApp(t *testing.T) {
 	CheckNotFoundStatus(t, resp)
 }
 
+func TestNilAuthorizeOAuthApp(t *testing.T) {
+	th := Setup(t).InitBasic()
+	th.Login(ApiClient, th.SystemAdminUser)
+	defer th.TearDown()
+
+	_, resp := ApiClient.AuthorizeOAuthApp(nil)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, "api.context.invalid_body_param.app_error", resp.Error.Id)
+}
+
 func TestDeauthorizeOAuthApp(t *testing.T) {
 	th := Setup(t).InitBasic()
 	th.Login(ApiClient, th.SystemAdminUser)


### PR DESCRIPTION
The return statement after setting c.InvalidParam was missing

https://mattermost.atlassian.net/browse/MM-30826

```release-note
NONE
```
