### PR TITLE
MM-28549: Bump up postgres version

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -17,7 +17,7 @@ services:
       timeout: 10s
       retries: 3
   postgres:
-    image: "postgres:9.4"
+    image: "postgres:10"
     restart: always
     networks:
       - mm-test


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-28549

```release-notes
Mattermost does not support Postgres 9.4 anymore. The minimum
required version for Postgres will be 10.
```
