### PR TITLE
[MM-31149] check for manage members before switching roles

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -5,6 +5,7 @@ package api4
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -1382,6 +1383,20 @@ func updateChannelMemberSchemeRoles(c *Context, w http.ResponseWriter, r *http.R
 
 	if !c.App.SessionHasPermissionToChannel(*c.App.Session(), c.Params.ChannelId, model.PERMISSION_MANAGE_CHANNEL_ROLES) {
 		c.SetPermissionError(model.PERMISSION_MANAGE_CHANNEL_ROLES)
+		return
+	}
+
+	channel, err := c.App.Srv().Store.Channel().Get(c.Params.ChannelId, true)
+	if err != nil {
+		c.LogError(model.NewAppError("Failed to retrieve channel", "app.update_member_role.channel_not_found", map[string]interface{}{"channelId": c.Params.ChannelId}, fmt.Sprintf("Couldn't find channel %s", c.Params.ChannelId), http.StatusNotFound))
+		return
+	}
+	if channel.Type == model.CHANNEL_OPEN && !c.App.SessionHasPermissionToChannel(*c.App.Session(), channel.Id, model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS)
+		return
+	}
+	if channel.Type == model.CHANNEL_PRIVATE && !c.App.SessionHasPermissionToChannel(*c.App.Session(), channel.Id, model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS) {
+		c.SetPermissionError(model.PERMISSION_MANAGE_PRIVATE_CHANNEL_MEMBERS)
 		return
 	}
 

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2468,6 +2468,13 @@ func TestUpdateChannelMemberSchemeRoles(t *testing.T) {
 	_, resp = SystemAdminClient.UpdateChannelMemberSchemeRoles(th.BasicChannel.Id, "ASDF", s4)
 	CheckBadRequestStatus(t, resp)
 
+	th.RemovePermissionFromRole(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS.Id, model.CHANNEL_USER_ROLE_ID)
+
+	_, resp = th.Client.UpdateChannelMemberSchemeRoles(th.BasicChannel.Id, th.BasicUser2.Id, s4)
+	CheckForbiddenStatus(t, resp)
+
+	th.AddPermissionToRole(model.PERMISSION_MANAGE_PUBLIC_CHANNEL_MEMBERS.Id, model.CHANNEL_ADMIN_ROLE_ID)
+
 	th.LoginBasic2()
 	_, resp = th.Client.UpdateChannelMemberSchemeRoles(th.BasicChannel.Id, th.BasicUser.Id, s4)
 	CheckForbiddenStatus(t, resp)
@@ -2475,6 +2482,7 @@ func TestUpdateChannelMemberSchemeRoles(t *testing.T) {
 	SystemAdminClient.Logout()
 	_, resp = SystemAdminClient.UpdateChannelMemberSchemeRoles(th.BasicChannel.Id, th.SystemAdminUser.Id, s4)
 	CheckUnauthorizedStatus(t, resp)
+
 }
 
 func TestUpdateChannelNotifyProps(t *testing.T) {


### PR DESCRIPTION
#### Summary

Add the same requirements in the server as in https://github.com/mattermost/mattermost-webapp/pull/7200

#### Ticket Link

[MM-31149](https://mattermost.atlassian.net/browse/MM-31149)

#### Release Note
```release-note
Prevent channel creator from changin other users channel roles if he has lost the manage members permission.
```
