### PR TITLE
MM-31401  Add Shared flag to Channels table

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -51,6 +51,7 @@ type Channel struct {
 	SchemeId         *string                `json:"scheme_id"`
 	Props            map[string]interface{} `json:"props" db:"-"`
 	GroupConstrained *bool                  `json:"group_constrained"`
+	Shared           *bool                  `json:"shared"`
 }
 
 type ChannelWithTeamData struct {
@@ -311,6 +312,10 @@ func (o *Channel) AddProp(key string, value interface{}) {
 
 func (o *Channel) IsGroupConstrained() bool {
 	return o.GroupConstrained != nil && *o.GroupConstrained
+}
+
+func (o *Channel) IsShared() bool {
+	return o.Shared != nil && *o.Shared
 }
 
 func (o *Channel) GetOtherUserIdForDM(userId string) string {

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -956,6 +956,7 @@ func upgradeDatabaseToVersion531(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, VERSION_5_30_0, VERSION_5_31_0) {
 	// allow 10 files per post
 	sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
+	sqlStore.CreateColumnIfNotExists("Channels", "Shared", "tinyint(1)", "boolean", "0")
 	// saveSchemaVersion(sqlStore, VERSION_5_31_0)
 	// }
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -956,7 +956,7 @@ func upgradeDatabaseToVersion531(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, VERSION_5_30_0, VERSION_5_31_0) {
 	// allow 10 files per post
 	sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
-	sqlStore.CreateColumnIfNotExists("Channels", "Shared", "tinyint(1)", "boolean", "0")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
 	// saveSchemaVersion(sqlStore, VERSION_5_31_0)
 	// }
 }


### PR DESCRIPTION
#### Summary
This PR adds a new flag to the Channels table `Shared`.  

This is in support of the upcoming Shared Channels feature and is needed to efficiently determine if a channel needs to sync after Post added/edited/deleted.  Values may be nil, false, true.  `(*Channel).IsShared` has been added as well.

The flag will not be set or queried until the Shared Channels feature branch is merged.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31401

#### Release Note
```release-note
NONE
```
