### PR TITLE
[MM-27622] Publish messages as WarnMetricsBot when a user is required

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -324,6 +324,12 @@ func (a *App) getWarnMetricStatusAndDisplayTextsForId(warnMetricId string, T i18
 }
 
 func (a *App) notifyAdminsOfWarnMetricStatus(warnMetricId string, isE0Edition bool) *model.AppError {
+	// get warn metrics bot
+	warnMetricsBot, err := a.GetWarnMetricsBot()
+	if err != nil {
+		return err
+	}
+
 	perPage := 25
 	userOptions := &model.UserGetOptions{
 		Page:     0,
@@ -351,25 +357,12 @@ func (a *App) notifyAdminsOfWarnMetricStatus(warnMetricId string, isE0Edition bo
 		}
 	}
 
-	T := utils.GetUserTranslations(sysAdmins[0].Locale)
-	warnMetricsBot := &model.Bot{
-		Username:    model.BOT_WARN_METRIC_BOT_USERNAME,
-		DisplayName: T("app.system.warn_metric.bot_displayname"),
-		Description: "",
-		OwnerId:     sysAdmins[0].Id,
-	}
-
-	bot, err := a.getOrCreateWarnMetricsBot(warnMetricsBot)
-	if err != nil {
-		return err
-	}
-
 	for _, sysAdmin := range sysAdmins {
 		T := utils.GetUserTranslations(sysAdmin.Locale)
-		bot.DisplayName = T("app.system.warn_metric.bot_displayname")
-		bot.Description = T("app.system.warn_metric.bot_description")
+		warnMetricsBot.DisplayName = T("app.system.warn_metric.bot_displayname")
+		warnMetricsBot.Description = T("app.system.warn_metric.bot_description")
 
-		channel, appErr := a.GetOrCreateDirectChannel(bot.UserId, sysAdmin.Id)
+		channel, appErr := a.GetOrCreateDirectChannel(warnMetricsBot.UserId, sysAdmin.Id)
 		if appErr != nil {
 			mlog.Error("Cannot create channel for system bot notification!", mlog.String("Admin Id", sysAdmin.Id))
 			return appErr
@@ -381,7 +374,7 @@ func (a *App) notifyAdminsOfWarnMetricStatus(warnMetricId string, isE0Edition bo
 		}
 
 		botPost := &model.Post{
-			UserId:    bot.UserId,
+			UserId:    warnMetricsBot.UserId,
 			ChannelId: channel.Id,
 			Type:      model.POST_SYSTEM_WARN_METRIC_STATUS,
 			Message:   "",
@@ -417,7 +410,7 @@ func (a *App) notifyAdminsOfWarnMetricStatus(warnMetricId string, isE0Edition bo
 				},
 				Integration: &model.PostActionIntegration{
 					Context: model.StringInterface{
-						"bot_user_id": bot.UserId,
+						"bot_user_id": warnMetricsBot.UserId,
 						"force_ack":   false,
 					},
 					URL: postActionUrl,

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -196,6 +196,8 @@ type AppIface interface {
 	GetTeamSchemeChannelRoles(teamId string) (guestRoleName string, userRoleName string, adminRoleName string, err *model.AppError)
 	// GetTotalUsersStats is used for the DM list total
 	GetTotalUsersStats(viewRestrictions *model.ViewUsersRestrictions) (*model.UsersStats, *model.AppError)
+	// Gets or creates the Warn Metrics Bot
+	GetWarnMetricsBot() (*model.Bot, *model.AppError)
 	// HubRegister registers a connection to a hub.
 	HubRegister(webConn *WebConn)
 	// HubStart starts all the hubs.

--- a/app/bot.go
+++ b/app/bot.go
@@ -84,6 +84,36 @@ func (a *App) CreateBot(bot *model.Bot) (*model.Bot, *model.AppError) {
 	return savedBot, nil
 }
 
+// Gets or creates the Warn Metrics Bot
+func (a *App) GetWarnMetricsBot() (*model.Bot, *model.AppError) {
+	perPage := 1
+	userOptions := &model.UserGetOptions{
+		Page:     0,
+		PerPage:  perPage,
+		Role:     model.SYSTEM_ADMIN_ROLE_ID,
+		Inactive: false,
+	}
+
+	sysAdminList, err := a.GetUsers(userOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(sysAdminList) == 0 {
+		return nil, model.NewAppError("GetWarnMetricsBot", "app.bot.get_warn_metrics_bot.empty_admin_list.app_error", nil, "", http.StatusInternalServerError)
+	}
+
+	T := utils.GetUserTranslations(sysAdminList[0].Locale)
+	warnMetricsBot := &model.Bot{
+		Username:    model.BOT_WARN_METRIC_BOT_USERNAME,
+		DisplayName: T("app.system.warn_metric.bot_displayname"),
+		Description: "",
+		OwnerId:     sysAdminList[0].Id,
+	}
+
+	return a.getOrCreateWarnMetricsBot(warnMetricsBot)
+}
+
 func (a *App) getOrCreateWarnMetricsBot(botDef *model.Bot) (*model.Bot, *model.AppError) {
 	botUser, appErr := a.GetUserByUsername(botDef.Username)
 	if appErr != nil {

--- a/app/bot_test.go
+++ b/app/bot_test.go
@@ -912,6 +912,44 @@ func TestDeleteBotIconImage(t *testing.T) {
 	})
 }
 
+func TestGetWarnMetricsBot(t *testing.T) {
+	t.Run("An error should be returned if there are no sysadmins in the instance", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		require.Nil(t, th.App.PermanentDeleteAllUsers())
+
+		_, err := th.App.GetWarnMetricsBot()
+		require.NotNil(t, err)
+		require.Equal(t, "app.bot.get_warn_metrics_bot.empty_admin_list.app_error", err.Id)
+	})
+
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	t.Run("The bot should be created the first time it's retrieved", func(t *testing.T) {
+		// assert no bot with username exists
+		_, err := th.App.GetUserByUsername(model.BOT_WARN_METRIC_BOT_USERNAME)
+		require.NotNil(t, err)
+
+		bot, err := th.App.GetWarnMetricsBot()
+		require.Nil(t, err)
+		require.Equal(t, bot.Username, model.BOT_WARN_METRIC_BOT_USERNAME)
+	})
+
+	t.Run("The bot should be correctly retrieved if it exists already", func(t *testing.T) {
+		// assert that the bot is now present
+		botUser, err := th.App.GetUserByUsername(model.BOT_WARN_METRIC_BOT_USERNAME)
+		require.Nil(t, err)
+		require.True(t, botUser.IsBot)
+
+		bot, err := th.App.GetWarnMetricsBot()
+		require.Nil(t, err)
+		require.Equal(t, bot.Username, model.BOT_WARN_METRIC_BOT_USERNAME)
+		require.Equal(t, bot.UserId, botUser.Id)
+	})
+}
+
 func sToP(s string) *string {
 	return &s
 }

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -9328,6 +9328,28 @@ func (a *OpenTracingAppLayer) GetViewUsersRestrictions(userId string) (*model.Vi
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) GetWarnMetricsBot() (*model.Bot, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetWarnMetricsBot")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetWarnMetricsBot()
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetWarnMetricsStatus() (map[string]*model.WarnMetricStatus, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetWarnMetricsStatus")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3659,6 +3659,10 @@
     "translation": "{{if .disableBotsSetting}}{{if .printAllBots}}{{.UserName}} was deactivated. They managed the following bot accounts which have now been disabled.\n\n{{.BotNames}}{{else}}{{.UserName}} was deactivated. They managed {{.NumBots}} bot accounts which have now been disabled, including the following:\n\n{{.BotNames}}{{end}}You can take ownership of each bot by enabling it at **Integrations > Bot Accounts** and creating new tokens for the bot.\n\nFor more information, see our [documentation](https://docs.mattermost.com/developer/bot-accounts.html#what-happens-when-a-user-who-owns-bot-accounts-is-disabled).{{else}}{{if .printAllBots}}{{.UserName}} was deactivated. They managed the following bot accounts which are still enabled.\n\n{{.BotNames}}\n{{else}}{{.UserName}} was deactivated. They managed {{.NumBots}} bot accounts which are still enabled, including the following:\n\n{{.BotNames}}{{end}}We strongly recommend you to take ownership of each bot by re-enabling it at **Integrations > Bot Accounts** and creating new tokens for the bot.\n\nFor more information, see our [documentation](https://docs.mattermost.com/developer/bot-accounts.html#what-happens-when-a-user-who-owns-bot-accounts-is-disabled).\n\nIf you want bot accounts to disable automatically after owner deactivation, set “Disable bot accounts when owner is deactivated” in **System Console > Integrations > Bot Accounts** to true.{{end}}"
   },
   {
+    "id": "app.bot.get_warn_metrics_bot.empty_admin_list.app_error",
+    "translation": "List of admins is empty."
+  },
+  {
     "id": "app.bot.getbot.internal_error",
     "translation": "Unable to get the bot."
   },


### PR DESCRIPTION
#### Summary
This PR adds the channel restore and channel privacy endpoints to local mode using the Advisor Bot to post the relevant messages when the endpoints are used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24864
https://mattermost.atlassian.net/browse/MM-24600
https://mattermost.atlassian.net/browse/MM-27440

#### Release Note
```release-note
Added channel restore and channel privacy change endpoints to local mode using the advisor bot
```