### PR TITLE
Update db schema version for MM-31401 and MM-27312

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	CURRENT_SCHEMA_VERSION   = VERSION_5_30_0
+	VERSION_5_32_0           = "5.32.0"
 	VERSION_5_31_0           = "5.31.0"
 	VERSION_5_30_0           = "5.30.0"
 	VERSION_5_29_0           = "5.29.0"
@@ -196,6 +197,7 @@ func upgradeDatabase(sqlStore *SqlStore, currentModelVersionString string) error
 	upgradeDatabaseToVersion529(sqlStore)
 	upgradeDatabaseToVersion530(sqlStore)
 	upgradeDatabaseToVersion531(sqlStore)
+	upgradeDatabaseToVersion532(sqlStore)
 
 	return nil
 }
@@ -954,9 +956,15 @@ func upgradeDatabaseToVersion530(sqlStore *SqlStore) {
 
 func upgradeDatabaseToVersion531(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, VERSION_5_30_0, VERSION_5_31_0) {
+	// saveSchemaVersion(sqlStore, VERSION_5_31_0)
+	// }
+}
+
+func upgradeDatabaseToVersion532(sqlStore *SqlStore) {
+	// if shouldPerformUpgrade(sqlStore, VERSION_5_31_0, VERSION_5_32_0) {
 	// allow 10 files per post
 	sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
 	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
-	// saveSchemaVersion(sqlStore, VERSION_5_31_0)
+	// saveSchemaVersion(sqlStore, VERSION_5_32_0)
 	// }
 }


### PR DESCRIPTION
#### Summary

Since both mentioned PRs were not included in 5.31 I've bumped the schema version for the DB upgrade steps so that those happen in the expected version.