### PR TITLE
[MM-31398] upgrade error level to critical in case of panic or os.Exit

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -609,7 +609,7 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -675,7 +675,7 @@ func (th *TestHelper) UpdateActiveUser(user *model.User, active bool) {
 
 	_, err := th.App.UpdateActive(user, active)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -689,7 +689,7 @@ func (th *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -703,7 +703,7 @@ func (th *TestHelper) AddUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -992,7 +992,7 @@ func (th *TestHelper) UpdateUserToTeamAdmin(user *model.User, team *model.Team) 
 		}
 	} else {
 		utils.EnableDebugLogForTest()
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -1012,7 +1012,7 @@ func (th *TestHelper) UpdateUserToNonTeamAdmin(user *model.User, team *model.Tea
 		}
 	} else {
 		utils.EnableDebugLogForTest()
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)

--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -609,9 +609,6 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -675,9 +672,6 @@ func (th *TestHelper) UpdateActiveUser(user *model.User, active bool) {
 
 	_, err := th.App.UpdateActive(user, active)
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -689,9 +683,6 @@ func (th *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -703,9 +694,6 @@ func (th *TestHelper) AddUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -992,9 +980,6 @@ func (th *TestHelper) UpdateUserToTeamAdmin(user *model.User, team *model.Team) 
 		}
 	} else {
 		utils.EnableDebugLogForTest()
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -1012,9 +997,6 @@ func (th *TestHelper) UpdateUserToNonTeamAdmin(user *model.User, team *model.Tea
 		}
 	} else {
 		utils.EnableDebugLogForTest()
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -239,7 +239,7 @@ func (th *TestHelper) CreateTeam() *model.Team {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if team, err = th.App.CreateTeam(team); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -271,14 +271,14 @@ func (th *TestHelper) CreateUserOrGuest(guest bool) *model.User {
 	var err *model.AppError
 	if guest {
 		if user, err = th.App.CreateGuest(user); err != nil {
-			mlog.Error(err.Error())
+			mlog.Critical(err.Error())
 
 			time.Sleep(time.Second)
 			panic(err)
 		}
 	} else {
 		if user, err = th.App.CreateUser(user); err != nil {
-			mlog.Error(err.Error())
+			mlog.Critical(err.Error())
 
 			time.Sleep(time.Second)
 			panic(err)
@@ -301,7 +301,7 @@ func (th *TestHelper) CreateBot() *model.Bot {
 	th.App.Log().SetConsoleLevel(mlog.LevelError)
 	bot, err := th.App.CreateBot(bot)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -332,7 +332,7 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string) *model
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -346,7 +346,7 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -360,7 +360,7 @@ func (th *TestHelper) CreateGroupChannel(user1 *model.User, user2 *model.User) *
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.CreateGroupChannel([]string{th.BasicUser.Id, user1.Id, user2.Id}, th.BasicUser.Id); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -382,7 +382,7 @@ func (th *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -402,7 +402,7 @@ func (th *TestHelper) CreateMessagePost(channel *model.Channel, message string) 
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -416,7 +416,7 @@ func (th *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -430,7 +430,7 @@ func (th *TestHelper) RemoveUserFromTeam(user *model.User, team *model.Team) {
 
 	err := th.App.RemoveUserFromTeam(team.Id, user.Id, "")
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -444,7 +444,7 @@ func (th *TestHelper) AddUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -509,7 +509,7 @@ func (th *TestHelper) CreateGroup() *model.Group {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if group, err = th.App.CreateGroup(group); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)

--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -239,9 +239,6 @@ func (th *TestHelper) CreateTeam() *model.Team {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if team, err = th.App.CreateTeam(team); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -271,16 +268,10 @@ func (th *TestHelper) CreateUserOrGuest(guest bool) *model.User {
 	var err *model.AppError
 	if guest {
 		if user, err = th.App.CreateGuest(user); err != nil {
-			mlog.Critical(err.Error())
-
-			time.Sleep(time.Second)
 			panic(err)
 		}
 	} else {
 		if user, err = th.App.CreateUser(user); err != nil {
-			mlog.Critical(err.Error())
-
-			time.Sleep(time.Second)
 			panic(err)
 		}
 	}
@@ -298,15 +289,10 @@ func (th *TestHelper) CreateBot() *model.Bot {
 		OwnerId:     th.BasicUser.Id,
 	}
 
-	th.App.Log().SetConsoleLevel(mlog.LevelError)
 	bot, err := th.App.CreateBot(bot)
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
-	th.App.Log().SetConsoleLevel(mlog.LevelDebug)
 	return bot
 }
 
@@ -332,9 +318,6 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string) *model
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -346,9 +329,6 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -360,9 +340,6 @@ func (th *TestHelper) CreateGroupChannel(user1 *model.User, user2 *model.User) *
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.CreateGroupChannel([]string{th.BasicUser.Id, user1.Id, user2.Id}, th.BasicUser.Id); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -382,9 +359,6 @@ func (th *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -402,9 +376,6 @@ func (th *TestHelper) CreateMessagePost(channel *model.Channel, message string) 
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -416,9 +387,6 @@ func (th *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -430,9 +398,6 @@ func (th *TestHelper) RemoveUserFromTeam(user *model.User, team *model.Team) {
 
 	err := th.App.RemoveUserFromTeam(team.Id, user.Id, "")
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -444,9 +409,6 @@ func (th *TestHelper) AddUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -509,9 +471,6 @@ func (th *TestHelper) CreateGroup() *model.Group {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if group, err = th.App.CreateGroup(group); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()

--- a/app/slashcommands/helper_test.go
+++ b/app/slashcommands/helper_test.go
@@ -187,9 +187,6 @@ func (th *TestHelper) createTeam() *model.Team {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if team, err = th.App.CreateTeam(team); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -219,16 +216,10 @@ func (th *TestHelper) createUserOrGuest(guest bool) *model.User {
 	var err *model.AppError
 	if guest {
 		if user, err = th.App.CreateGuest(user); err != nil {
-			mlog.Critical(err.Error())
-
-			time.Sleep(time.Second)
 			panic(err)
 		}
 	} else {
 		if user, err = th.App.CreateUser(user); err != nil {
-			mlog.Critical(err.Error())
-
-			time.Sleep(time.Second)
 			panic(err)
 		}
 	}
@@ -258,9 +249,6 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string) *model
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -281,9 +269,6 @@ func (th *TestHelper) createChannelWithAnotherUser(team *model.Team, channelType
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -295,9 +280,6 @@ func (th *TestHelper) createDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -309,9 +291,6 @@ func (th *TestHelper) createGroupChannel(user1 *model.User, user2 *model.User) *
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.CreateGroupChannel([]string{th.BasicUser.Id, user1.Id, user2.Id}, th.BasicUser.Id); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -331,9 +310,6 @@ func (th *TestHelper) createPost(channel *model.Channel) *model.Post {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -345,9 +321,6 @@ func (th *TestHelper) linkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -359,9 +332,6 @@ func (th *TestHelper) addUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 

--- a/app/slashcommands/helper_test.go
+++ b/app/slashcommands/helper_test.go
@@ -187,7 +187,7 @@ func (th *TestHelper) createTeam() *model.Team {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if team, err = th.App.CreateTeam(team); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -219,14 +219,14 @@ func (th *TestHelper) createUserOrGuest(guest bool) *model.User {
 	var err *model.AppError
 	if guest {
 		if user, err = th.App.CreateGuest(user); err != nil {
-			mlog.Error(err.Error())
+			mlog.Critical(err.Error())
 
 			time.Sleep(time.Second)
 			panic(err)
 		}
 	} else {
 		if user, err = th.App.CreateUser(user); err != nil {
-			mlog.Error(err.Error())
+			mlog.Critical(err.Error())
 
 			time.Sleep(time.Second)
 			panic(err)
@@ -258,7 +258,7 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string) *model
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -281,7 +281,7 @@ func (th *TestHelper) createChannelWithAnotherUser(team *model.Team, channelType
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -295,7 +295,7 @@ func (th *TestHelper) createDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -309,7 +309,7 @@ func (th *TestHelper) createGroupChannel(user1 *model.User, user2 *model.User) *
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.CreateGroupChannel([]string{th.BasicUser.Id, user1.Id, user2.Id}, th.BasicUser.Id); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -331,7 +331,7 @@ func (th *TestHelper) createPost(channel *model.Channel) *model.Post {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -345,7 +345,7 @@ func (th *TestHelper) linkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -359,7 +359,7 @@ func (th *TestHelper) addUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)

--- a/migrations/helper_test.go
+++ b/migrations/helper_test.go
@@ -120,7 +120,7 @@ func (th *TestHelper) CreateTeam() *model.Team {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if team, err = th.App.CreateTeam(team); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -143,7 +143,7 @@ func (th *TestHelper) CreateUser() *model.User {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if user, err = th.App.CreateUser(user); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -170,7 +170,7 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string) *model
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -184,7 +184,7 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -206,7 +206,7 @@ func (th *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -220,7 +220,7 @@ func (th *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)
@@ -234,7 +234,7 @@ func (th *TestHelper) AddUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Error(err.Error())
+		mlog.Critical(err.Error())
 
 		time.Sleep(time.Second)
 		panic(err)

--- a/migrations/helper_test.go
+++ b/migrations/helper_test.go
@@ -5,11 +5,9 @@ package migrations
 
 import (
 	"os"
-	"time"
 
 	"github.com/mattermost/mattermost-server/v5/app"
 	"github.com/mattermost/mattermost-server/v5/config"
-	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/store/localcachelayer"
 	"github.com/mattermost/mattermost-server/v5/utils"
@@ -120,9 +118,6 @@ func (th *TestHelper) CreateTeam() *model.Team {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if team, err = th.App.CreateTeam(team); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -143,9 +138,6 @@ func (th *TestHelper) CreateUser() *model.User {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if user, err = th.App.CreateUser(user); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -170,9 +162,6 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string) *model
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -184,9 +173,6 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 	var err *model.AppError
 	var channel *model.Channel
 	if channel, err = th.App.GetOrCreateDirectChannel(th.BasicUser.Id, user.Id); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -206,9 +192,6 @@ func (th *TestHelper) CreatePost(channel *model.Channel) *model.Post {
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if post, err = th.App.CreatePost(post, channel, false, true); err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 	utils.EnableDebugLogForTest()
@@ -220,9 +203,6 @@ func (th *TestHelper) LinkUserToTeam(user *model.User, team *model.Team) {
 
 	err := th.App.JoinUserToTeam(team, user, "")
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 
@@ -234,9 +214,6 @@ func (th *TestHelper) AddUserToChannel(user *model.User, channel *model.Channel)
 
 	member, err := th.App.AddUserToChannel(user, channel)
 	if err != nil {
-		mlog.Critical(err.Error())
-
-		time.Sleep(time.Second)
 		panic(err)
 	}
 

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -847,7 +847,7 @@ func upgradeDatabaseToVersion527(sqlStore *SqlStore) {
 func upgradeDatabaseToVersion528(sqlStore *SqlStore) {
 	if shouldPerformUpgrade(sqlStore, VERSION_5_27_0, VERSION_5_28_0) {
 		if err := precheckMigrationToVersion528(sqlStore); err != nil {
-			mlog.Error("Error upgrading DB schema to 5.28.0", mlog.Err(err))
+			mlog.Critical("Error upgrading DB schema to 5.28.0", mlog.Err(err))
 			os.Exit(EXIT_GENERIC_FAILURE)
 		}
 

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -169,7 +169,7 @@ func (h *MainHelper) PreloadMigrations() {
 	handle := h.SQLStore.GetMaster()
 	_, err = handle.Exec(string(buf))
 	if err != nil {
-		mlog.Error("Error preloading migrations. Check if you have &multiStatements=true in your DSN if you are using MySQL. Or perhaps the schema changed? If yes, then update the warmup files accordingly.")
+		mlog.Critical("Error preloading migrations. Check if you have &multiStatements=true in your DSN if you are using MySQL. Or perhaps the schema changed? If yes, then update the warmup files accordingly.")
 		panic(err)
 	}
 }

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -170,7 +170,7 @@ func (h *MainHelper) PreloadMigrations() {
 	handle := h.SQLStore.GetMaster()
 	_, err = handle.Exec(string(buf))
 	if err != nil {
-		panic(errors.Wrap(err, "error preloading migrations. check if you have &multiStatements=true in your DSN if you are using MySQL. or perhaps the schema changed? if yes, then update the warmup files accordingly"))
+		panic(errors.Wrap(err, "Error preloading migrations. Check if you have &multiStatements=true in your DSN if you are using MySQL. Or perhaps the schema changed? If yes, then update the warmup files accordingly"))
 	}
 }
 

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/store/sqlstore"
 	"github.com/mattermost/mattermost-server/v5/store/storetest"
 	"github.com/mattermost/mattermost-server/v5/utils"
+	"github.com/pkg/errors"
 )
 
 type MainHelper struct {
@@ -169,8 +170,7 @@ func (h *MainHelper) PreloadMigrations() {
 	handle := h.SQLStore.GetMaster()
 	_, err = handle.Exec(string(buf))
 	if err != nil {
-		mlog.Critical("Error preloading migrations. Check if you have &multiStatements=true in your DSN if you are using MySQL. Or perhaps the schema changed? If yes, then update the warmup files accordingly.")
-		panic(err)
+		panic(errors.Wrap(err, "error preloading migrations. check if you have &multiStatements=true in your DSN if you are using MySQL. or perhaps the schema changed? if yes, then update the warmup files accordingly"))
 	}
 }
 


### PR DESCRIPTION

#### Summary
We should use `mlog.Critical` if we are going to call `panic` or `os.Exit(>0)`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31398

#### Release Note

```release-note
NONE
```
