### PR TITLE
MM-30836: Use feature flags for RemoteClusterService

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -729,7 +729,7 @@ func (s *Server) startInterClusterServices(license *model.License) {
 	var err error
 
 	// TODO: check remote cluster service license (MM-30838)
-	if *s.Config().ExperimentalSettings.EnableRemoteClusterService {
+	if *s.Config().ExperimentalSettings.EnableRemoteClusterService && s.Config().FeatureFlags.EnableRemoteClusterService {
 		s.remoteClusterService, err = remotecluster.NewRemoteClusterService(s)
 		if err != nil {
 			mlog.Error("Error initializing Remote Cluster Service", mlog.Err(err))

--- a/config/client.go
+++ b/config/client.go
@@ -202,7 +202,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 
 		if *license.Features.SharedChannels {
 			props["ExperimentalSharedChannels"] = strconv.FormatBool(*c.ExperimentalSettings.EnableSharedChannels)
-			props["ExperimentalRemoteClusterService"] = strconv.FormatBool(*c.ExperimentalSettings.EnableRemoteClusterService)
+			props["ExperimentalRemoteClusterService"] = strconv.FormatBool(c.FeatureFlags.EnableRemoteClusterService && *c.ExperimentalSettings.EnableRemoteClusterService)
 		}
 	}
 

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -13,10 +13,14 @@ type FeatureFlags struct {
 
 	// Toggle on and off scheduled jobs for cloud user limit emails see MM-29999
 	CloudDelinquentEmailJobsEnabled bool
+
+	// Enable the remote cluster service for shared channels.
+	EnableRemoteClusterService bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
 	f.TestFeature = "off"
 	f.TestBoolFeature = false
 	f.CloudDelinquentEmailJobsEnabled = false
+	f.EnableRemoteClusterService = false
 }

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -711,7 +711,7 @@ func (ts *TelemetryService) trackConfig() {
 		"cloud_billing":                      *cfg.ExperimentalSettings.CloudBilling,
 		"cloud_user_limit":                   *cfg.ExperimentalSettings.CloudUserLimit,
 		"enable_shared_channels":             *cfg.ExperimentalSettings.EnableSharedChannels,
-		"enable_remote_cluster_service":      *cfg.ExperimentalSettings.EnableRemoteClusterService,
+		"enable_remote_cluster_service":      *cfg.ExperimentalSettings.EnableRemoteClusterService && cfg.FeatureFlags.EnableRemoteClusterService,
 	})
 
 	ts.sendTelemetry(TRACK_CONFIG_ANALYTICS, map[string]interface{}{


### PR DESCRIPTION
We use a proper feature flag for toggling this feature.
