### PR TITLE
MM-31356: Add a minimum required version check for Postgres

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -330,7 +330,7 @@ func NewServer(options ...Option) (*Server, error) {
 					return nil, errors.Wrap(err2, "cannot parse DB version")
 				}
 				if intVer < sqlstore.MINIMUM_REQUIRED_POSTGRES_VERSION {
-					return nil, fmt.Errorf("minimum required postgres version is 10.0; found %s", ver)
+					return nil, fmt.Errorf("minimum required postgres version is %s; found %s", sqlstore.VersionString(sqlstore.MINIMUM_REQUIRED_POSTGRES_VERSION), sqlstore.VersionString(intVer))
 				}
 			}
 

--- a/app/server.go
+++ b/app/server.go
@@ -321,13 +321,13 @@ func NewServer(options ...Option) (*Server, error) {
 		s.newStore = func() (store.Store, error) {
 			s.sqlStore = sqlstore.New(s.Config().SqlSettings, s.Metrics)
 			if s.sqlStore.DriverName() == model.DATABASE_DRIVER_POSTGRES {
-				ver, err := s.sqlStore.GetDbVersion(true)
-				if err != nil {
-					return nil, errors.Wrap(err, "cannot get DB version")
+				ver, err2 := s.sqlStore.GetDbVersion(true)
+				if err2 != nil {
+					return nil, errors.Wrap(err2, "cannot get DB version")
 				}
-				intVer, err := strconv.Atoi(ver)
-				if err != nil {
-					return nil, errors.Wrap(err, "cannot parse DB version")
+				intVer, err2 := strconv.Atoi(ver)
+				if err2 != nil {
+					return nil, errors.Wrap(err2, "cannot parse DB version")
 				}
 				if intVer < sqlstore.MINIMUM_REQUIRED_POSTGRES_VERSION {
 					return nil, fmt.Errorf("minimum required postgres version is 10.0; found %s", ver)

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -896,7 +896,7 @@ func (ts *TelemetryService) trackServer() {
 		data["system_admins"] = scr
 	}
 
-	if scr, err := ts.dbStore.GetDbVersion(); err == nil {
+	if scr, err := ts.dbStore.GetDbVersion(false); err == nil {
 		data["database_version"] = scr
 	}
 

--- a/services/telemetry/telemetry_test.go
+++ b/services/telemetry/telemetry_test.go
@@ -70,7 +70,7 @@ func initializeMocks(cfg *model.Config) (*mocks.ServerIface, *storeMocks.Store, 
 	serverIfaceMock.On("HttpService").Return(httpservice.MakeHTTPService(configService))
 
 	storeMock := &storeMocks.Store{}
-	storeMock.On("GetDbVersion").Return("5.24.0", nil)
+	storeMock.On("GetDbVersion", false).Return("5.24.0", nil)
 
 	systemStore := storeMocks.SystemStore{}
 	props := model.StringMap{}

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1358,4 +1359,14 @@ func IsDuplicate(err error) bool {
 	}
 
 	return false
+}
+
+// VersionString converts an integer representation of a DB version
+// to a pretty-printed string.
+// Postgres doesn't follow three-part version numbers from 10.0 onwards:
+// https://www.postgresql.org/docs/13/libpq-status.html#LIBPQ-PQSERVERVERSION.
+func VersionString(v int) string {
+	minor := v % 10000
+	major := v / 10000
+	return strconv.Itoa(major) + "." + strconv.Itoa(minor)
 }

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -40,8 +40,9 @@ const (
 	DB_PING_ATTEMPTS           = 18
 	DB_PING_TIMEOUT_SECS       = 10
 	// This is a numerical version string by postgres. The format is
-	// 2 characters for major, minor, and patch version.
-	// 10.0.0 would be 100000.
+	// 2 characters for major, minor, and patch version prior to 10.
+	// After 10, it's major and minor only.
+	// 10.1 would be 100001.
 	// 9.6.3 would be 90603.
 	MINIMUM_REQUIRED_POSTGRES_VERSION = 100000
 )

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -369,7 +369,7 @@ func TestGetDbVersion(t *testing.T) {
 			settings := makeSqlSettings(driver)
 			store := New(*settings, nil)
 
-			version, err := store.GetDbVersion()
+			version, err := store.GetDbVersion(false)
 			require.Nil(t, err)
 			require.Regexp(t, regexp.MustCompile(`\d+\.\d+(\.\d+)?`), version)
 		})

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -471,6 +471,31 @@ func TestIsDuplicate(t *testing.T) {
 	}
 }
 
+func TestVersionString(t *testing.T) {
+	versions := []struct {
+		input  int
+		output string
+	}{
+		{
+			input:  100000,
+			output: "10.0",
+		},
+		{
+			input:  90603,
+			output: "9.603",
+		},
+		{
+			input:  120005,
+			output: "12.5",
+		},
+	}
+
+	for _, v := range versions {
+		out := VersionString(v.input)
+		assert.Equal(t, v.output, out)
+	}
+}
+
 func makeSqlSettings(driver string) *model.SqlSettings {
 	switch driver {
 	case model.DATABASE_DRIVER_POSTGRES:

--- a/store/store.go
+++ b/store/store.go
@@ -61,7 +61,7 @@ type Store interface {
 	DropAllTables()
 	RecycleDBConnections(d time.Duration)
 	GetCurrentSchemaVersion() string
-	GetDbVersion() (string, error)
+	GetDbVersion(numerical bool) (string, error)
 	TotalMasterDbConnections() int
 	TotalReadDbConnections() int
 	TotalSearchDbConnections() int

--- a/store/storetest/mocks/Store.go
+++ b/store/storetest/mocks/Store.go
@@ -236,20 +236,20 @@ func (_m *Store) GetCurrentSchemaVersion() string {
 	return r0
 }
 
-// GetDbVersion provides a mock function with given fields:
-func (_m *Store) GetDbVersion() (string, error) {
-	ret := _m.Called()
+// GetDbVersion provides a mock function with given fields: numerical
+func (_m *Store) GetDbVersion(numerical bool) (string, error) {
+	ret := _m.Called(numerical)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(bool) string); ok {
+		r0 = rf(numerical)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(bool) error); ok {
+		r1 = rf(numerical)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/storetest/store.go
+++ b/store/storetest/store.go
@@ -95,7 +95,7 @@ func (s *Store) Close()                                { /* do nothing */ }
 func (s *Store) LockToMaster()                         { /* do nothing */ }
 func (s *Store) UnlockFromMaster()                     { /* do nothing */ }
 func (s *Store) DropAllTables()                        { /* do nothing */ }
-func (s *Store) GetDbVersion() (string, error)         { return "", nil }
+func (s *Store) GetDbVersion(bool) (string, error)     { return "", nil }
 func (s *Store) RecycleDBConnections(time.Duration)    {}
 func (s *Store) TotalMasterDbConnections() int         { return 1 }
 func (s *Store) TotalReadDbConnections() int           { return 1 }


### PR DESCRIPTION
To keep conformance with our failing fast and obvious philosophy,
we add a check to prevent Mattermost server from starting
if the postgres version is below 10.0.

This gives customers a chance to upgrade their database before upgrading
their Mattermost version, than to run into weird compatibility issues
after they have finished the upgrade.

https://mattermost.atlassian.net/browse/MM-31356

```release-note
NONE
```
