### PR TITLE
cherry-pick #16567: revert "Temporary fix for oauth on cloud beta"

### DIFF
--- a/app/oauth.go
+++ b/app/oauth.go
@@ -810,8 +810,6 @@ func (a *App) AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service
 
 	teamId := stateProps["team_id"]
 
-	mlog.Debug("OAuth redirect uri: " + redirectUri)
-
 	p := url.Values{}
 	p.Set("client_id", *sso.Id)
 	p.Set("client_secret", *sso.Secret)

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -93,8 +93,6 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			mlog.String("method", r.Method),
 			mlog.String("url", r.URL.Path),
 			mlog.String("request_id", requestID),
-			mlog.String("host", r.Host),
-			mlog.String("scheme", r.Header.Get(model.HEADER_FORWARDED_PROTO)),
 		}
 		// Websockets are returning status code 0 to requests after closing the socket
 		if statusCode != "0" {
@@ -155,7 +153,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, *c.App.Config().FileSettings.MaxFileSize+bytes.MinRead)
 
 	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
-	siteURLHeader := *c.App.Config().ServiceSettings.SiteURL + subpath
+	siteURLHeader := app.GetProtocol(r) + "://" + r.Host + subpath
 	c.SetSiteURLHeader(siteURLHeader)
 
 	w.Header().Set(model.HEADER_REQUEST_ID, c.App.RequestId())


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
- This reverts commit ee931f5. Fixes oauth on servers running under a subpath.
- Cherry-pick of above fix onto the release-5.31 branch.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- Original ticket https://mattermost.atlassian.net/browse/MM-31394
- Related PR https://github.com/mattermost/mattermost-server/pull/16567

#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
