### PR TITLE
Send user updated websocket event on plugin.UpdateUser

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -1018,7 +1018,7 @@ type AppIface interface {
 	UpdateUserActive(userId string, active bool) *model.AppError
 	UpdateUserAsUser(user *model.User, asAdmin bool) (*model.User, *model.AppError)
 	UpdateUserAuth(userId string, userAuth *model.UserAuth) (*model.UserAuth, *model.AppError)
-	UpdateUserNotifyProps(userId string, props map[string]string) (*model.User, *model.AppError)
+	UpdateUserNotifyProps(userId string, props map[string]string, sendNotifications bool) (*model.User, *model.AppError)
 	UpdateUserRoles(userId string, newRoles string, sendWebSocketEvent bool) (*model.User, *model.AppError)
 	UploadData(us *model.UploadSession, rd io.Reader) (*model.FileInfo, *model.AppError)
 	UploadEmojiImage(id string, imageData *multipart.FileHeader) *model.AppError

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -493,7 +493,7 @@ func (a *App) importUser(data *UserImportData, dryRun bool) *model.AppError {
 			}
 		}
 		if hasNotifyPropsChanged {
-			if savedUser, err = a.UpdateUserNotifyProps(user.Id, user.NotifyProps); err != nil {
+			if savedUser, err = a.UpdateUserNotifyProps(user.Id, user.NotifyProps, false); err != nil {
 				return err
 			}
 		}

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -15622,7 +15622,7 @@ func (a *OpenTracingAppLayer) UpdateUserAuth(userId string, userAuth *model.User
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) UpdateUserNotifyProps(userId string, props map[string]string) (*model.User, *model.AppError) {
+func (a *OpenTracingAppLayer) UpdateUserNotifyProps(userId string, props map[string]string, sendNotifications bool) (*model.User, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.UpdateUserNotifyProps")
 
@@ -15634,7 +15634,7 @@ func (a *OpenTracingAppLayer) UpdateUserNotifyProps(userId string, props map[str
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.UpdateUserNotifyProps(userId, props)
+	resultVar0, resultVar1 := a.app.UpdateUserNotifyProps(userId, props, sendNotifications)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/app/user.go
+++ b/app/user.go
@@ -1174,8 +1174,6 @@ func (a *App) UpdateUserAsUser(user *model.User, asAdmin bool) (*model.User, *mo
 		return nil, err
 	}
 
-	a.sendUpdatedUserEvent(*updatedUser)
-
 	return updatedUser, nil
 }
 
@@ -1191,8 +1189,6 @@ func (a *App) PatchUser(userId string, patch *model.UserPatch, asAdmin bool) (*m
 	if err != nil {
 		return nil, err
 	}
-
-	a.sendUpdatedUserEvent(*updatedUser)
 
 	return updatedUser, nil
 }
@@ -1314,6 +1310,7 @@ func (a *App) UpdateUser(user *model.User, sendNotifications bool) (*model.User,
 	}
 
 	a.InvalidateCacheForUser(user.Id)
+	a.sendUpdatedUserEvent(*userUpdate.New)
 
 	return userUpdate.New, nil
 }

--- a/app/user.go
+++ b/app/user.go
@@ -1307,10 +1307,10 @@ func (a *App) UpdateUser(user *model.User, sendNotifications bool) (*model.User,
 				}
 			})
 		}
+		a.sendUpdatedUserEvent(*userUpdate.New)
 	}
 
 	a.InvalidateCacheForUser(user.Id)
-	a.sendUpdatedUserEvent(*userUpdate.New)
 
 	return userUpdate.New, nil
 }
@@ -1328,7 +1328,7 @@ func (a *App) UpdateUserActive(userId string, active bool) *model.AppError {
 	return nil
 }
 
-func (a *App) UpdateUserNotifyProps(userId string, props map[string]string) (*model.User, *model.AppError) {
+func (a *App) UpdateUserNotifyProps(userId string, props map[string]string, sendNotifications bool) (*model.User, *model.AppError) {
 	user, err := a.GetUser(userId)
 	if err != nil {
 		return nil, err
@@ -1336,7 +1336,7 @@ func (a *App) UpdateUserNotifyProps(userId string, props map[string]string) (*mo
 
 	user.NotifyProps = props
 
-	ruser, err := a.UpdateUser(user, true)
+	ruser, err := a.UpdateUser(user, sendNotifications)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### Summary

- Sends a WebSocket event when `plugin.UpdateUser` is called so it is updated immediately for all the users.

#### Release Note

```release-note
- UserUpdate WebSocket Event is now broadcast by 2 more APIs - plugin.UpdateUser and ConvertBotToUser
- Change in a User's NotifyProps during the user import process will not send an email notification. This is done to make it consistent with other parts of the import process where change in user's attributes would also not send any notifications.
```