### PR TITLE
[MM-31555] Print golang version on server startup

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -224,7 +224,7 @@ func NewServer(options ...Option) (*Server, error) {
 	}
 
 	// This is called after initLogging() to avoid a race condition.
-	mlog.Info("Server is initializing...", mlog.String(" Go version", runtime.Version()))
+	mlog.Info("Server is initializing...", mlog.String("go_version", runtime.Version()))
 
 	// It is important to initialize the hub only after the global logger is set
 	// to avoid race conditions while logging from inside the hub.

--- a/app/server.go
+++ b/app/server.go
@@ -224,7 +224,7 @@ func NewServer(options ...Option) (*Server, error) {
 	}
 
 	// This is called after initLogging() to avoid a race condition.
-	mlog.Info("Server is initializing with Go version " + runtime.Version())
+	mlog.Info("Server is initializing...", mlog.String(" Go version", runtime.Version()))
 
 	// It is important to initialize the hub only after the global logger is set
 	// to avoid race conditions while logging from inside the hub.

--- a/app/server.go
+++ b/app/server.go
@@ -223,7 +223,7 @@ func NewServer(options ...Option) (*Server, error) {
 		mlog.Error(err.Error())
 	}
 
-	mlog.Info("Go Version Detected: " +  runtime.Version())
+	mlog.Info("Go Version Detected: " + runtime.Version())
 
 	// This is called after initLogging() to avoid a race condition.
 	mlog.Info("Server is initializing...")

--- a/app/server.go
+++ b/app/server.go
@@ -223,10 +223,8 @@ func NewServer(options ...Option) (*Server, error) {
 		mlog.Error(err.Error())
 	}
 
-	mlog.Info("Go Version Detected: " + runtime.Version())
-
 	// This is called after initLogging() to avoid a race condition.
-	mlog.Info("Server is initializing...")
+	mlog.Info("Server is initializing with Go version " + runtime.Version())
 
 	// It is important to initialize the hub only after the global logger is set
 	// to avoid race conditions while logging from inside the hub.

--- a/app/server.go
+++ b/app/server.go
@@ -223,6 +223,8 @@ func NewServer(options ...Option) (*Server, error) {
 		mlog.Error(err.Error())
 	}
 
+	mlog.Info("Go Version Detected: " +  runtime.Version())
+
 	// This is called after initLogging() to avoid a race condition.
 	mlog.Info("Server is initializing...")
 


### PR DESCRIPTION
#### Summary
Add logging to Print Golang Version before server

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost-server/issues/16609
JIRA: https://mattermost.atlassian.net/browse/MM-31555

#### Release Note
<!--
If no release notes are required, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your past-tense release note in the block below.
-->
```release-note
NONE
```
