### PR TITLE
MM-31618: Bump golangci to 1.33.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
       - run:
           command: |
             echo "Installing golangci-lint"
-            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.31.0
+            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.33.2
             echo "Installing mattermost-govet"
             export GOBIN=${PWD}/mattermost-server/bin
             GO111MODULE=off go get -u github.com/mattermost/mattermost-govet

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,7 @@ empty:
     - echo "empty"
 
 #lint:
-#  image: $CI_REGISTRY/mattermost/ci/images/golangci-lint:v1.31.0-1
+#  image: $CI_REGISTRY/mattermost/ci/images/golangci-lint:v1.33.2-1
 #  stage: .pre
 #  script:
 #    - GO111MODULE=off GOBIN=$PWD/bin go get -u github.com/mattermost/mattermost-govet


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-31618

```release-note
NONE
```
