### PR TITLE
MM-31061: Remove pointers to slice

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -218,7 +218,7 @@ func (a *App) ListDirectory(path string) ([]string, *model.AppError) {
 		return nil, model.NewAppError("ListDirectory", "api.file.list_directory.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 	}
 
-	return *paths, nil
+	return paths, nil
 }
 
 func (a *App) RemoveDirectory(path string) *model.AppError {

--- a/services/filesstore/filesstore.go
+++ b/services/filesstore/filesstore.go
@@ -29,7 +29,7 @@ type FileBackend interface {
 	AppendFile(fr io.Reader, path string) (int64, error)
 	RemoveFile(path string) error
 
-	ListDirectory(path string) (*[]string, error)
+	ListDirectory(path string) ([]string, error)
 	RemoveDirectory(path string) error
 }
 

--- a/services/filesstore/filesstore_test.go
+++ b/services/filesstore/filesstore_test.go
@@ -249,7 +249,7 @@ func (s *FileBackendTestSuite) TestListDirectory() {
 
 	paths, err := s.backend.ListDirectory("19700101")
 	s.Nil(err)
-	s.Len(*paths, 0)
+	s.Len(paths, 0)
 
 	written, err := s.backend.WriteFile(bytes.NewReader(b), path1)
 	s.Nil(err)
@@ -261,20 +261,20 @@ func (s *FileBackendTestSuite) TestListDirectory() {
 
 	paths, err = s.backend.ListDirectory("19700101")
 	s.Nil(err)
-	s.Len(*paths, 1)
-	s.Equal(path1, (*paths)[0])
+	s.Len(paths, 1)
+	s.Equal(path1, (paths)[0])
 
 	paths, err = s.backend.ListDirectory("19700101/")
 	s.Nil(err)
-	s.Len(*paths, 1)
-	s.Equal(path1, (*paths)[0])
+	s.Len(paths, 1)
+	s.Equal(path1, (paths)[0])
 
 	paths, err = s.backend.ListDirectory("")
 	s.Nil(err)
 
 	found1 := false
 	found2 := false
-	for _, path := range *paths {
+	for _, path := range paths {
 		if path == "19700101" {
 			found1 = true
 		} else if path == "19800101" {

--- a/services/filesstore/localstore.go
+++ b/services/filesstore/localstore.go
@@ -135,19 +135,19 @@ func (b *LocalFileBackend) RemoveFile(path string) error {
 	return nil
 }
 
-func (b *LocalFileBackend) ListDirectory(path string) (*[]string, error) {
+func (b *LocalFileBackend) ListDirectory(path string) ([]string, error) {
 	var paths []string
 	fileInfos, err := ioutil.ReadDir(filepath.Join(b.directory, path))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return &paths, nil
+			return paths, nil
 		}
 		return nil, errors.Wrapf(err, "unable to list the directory %s", path)
 	}
 	for _, fileInfo := range fileInfos {
 		paths = append(paths, filepath.Join(path, fileInfo.Name()))
 	}
-	return &paths, nil
+	return paths, nil
 }
 
 func (b *LocalFileBackend) RemoveDirectory(path string) error {

--- a/services/filesstore/mocks/FileBackend.go
+++ b/services/filesstore/mocks/FileBackend.go
@@ -73,16 +73,37 @@ func (_m *FileBackend) FileExists(path string) (bool, error) {
 	return r0, r1
 }
 
-// ListDirectory provides a mock function with given fields: path
-func (_m *FileBackend) ListDirectory(path string) (*[]string, error) {
+// FileSize provides a mock function with given fields: path
+func (_m *FileBackend) FileSize(path string) (int64, error) {
 	ret := _m.Called(path)
 
-	var r0 *[]string
-	if rf, ok := ret.Get(0).(func(string) *[]string); ok {
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListDirectory provides a mock function with given fields: path
+func (_m *FileBackend) ListDirectory(path string) ([]string, error) {
+	ret := _m.Called(path)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(string) []string); ok {
 		r0 = rf(path)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*[]string)
+			r0 = ret.Get(0).([]string)
 		}
 	}
 

--- a/services/filesstore/s3store.go
+++ b/services/filesstore/s3store.go
@@ -338,7 +338,7 @@ func getPathsFromObjectInfos(in <-chan s3.ObjectInfo) <-chan s3.ObjectInfo {
 	return out
 }
 
-func (b *S3FileBackend) ListDirectory(path string) (*[]string, error) {
+func (b *S3FileBackend) ListDirectory(path string) ([]string, error) {
 	path = filepath.Join(b.pathPrefix, path)
 	if !strings.HasSuffix(path, "/") && len(path) > 0 {
 		// s3Clnt returns only the path itself when "/" is not present
@@ -363,7 +363,7 @@ func (b *S3FileBackend) ListDirectory(path string) (*[]string, error) {
 		}
 	}
 
-	return &paths, nil
+	return paths, nil
 }
 
 func (b *S3FileBackend) RemoveDirectory(path string) error {


### PR DESCRIPTION
This PR removes instances of pointers
to slices in the codebase. There are some other instances in app/import_functions.go
but that's necessary to prevent empty arrays from appearing in the JSON output.

```release-note
NONE
```

https://mattermost.atlassian.net/browse/MM-31061
