### PR TITLE
[MM-31249] Add /exports API endpoint

### DIFF
--- a/api4/api.go
+++ b/api4/api.go
@@ -125,6 +125,7 @@ type Routes struct {
 	Cloud *mux.Router // 'api/v4/cloud'
 
 	Imports *mux.Router // 'api/v4/imports'
+	Exports *mux.Router // 'api/v4/exports'
 }
 
 type API struct {
@@ -238,6 +239,7 @@ func Init(configservice configservice.ConfigService, globalOptionsFunc app.AppOp
 	api.BaseRoutes.Cloud = api.BaseRoutes.ApiRoot.PathPrefix("/cloud").Subrouter()
 
 	api.BaseRoutes.Imports = api.BaseRoutes.ApiRoot.PathPrefix("/imports").Subrouter()
+	api.BaseRoutes.Exports = api.BaseRoutes.ApiRoot.PathPrefix("/exports").Subrouter()
 
 	api.InitUser()
 	api.InitBot()
@@ -276,6 +278,7 @@ func Init(configservice configservice.ConfigService, globalOptionsFunc app.AppOp
 	api.InitAction()
 	api.InitCloud()
 	api.InitImport()
+	api.InitExport()
 
 	root.Handle("/api/v4/{anything:.*}", http.HandlerFunc(api.Handle404))
 
@@ -344,6 +347,7 @@ func InitLocal(configservice configservice.ConfigService, globalOptionsFunc app.
 	api.BaseRoutes.Upload = api.BaseRoutes.Uploads.PathPrefix("/{upload_id:[A-Za-z0-9]+}").Subrouter()
 
 	api.BaseRoutes.Imports = api.BaseRoutes.ApiRoot.PathPrefix("/imports").Subrouter()
+	api.BaseRoutes.Exports = api.BaseRoutes.ApiRoot.PathPrefix("/exports").Subrouter()
 
 	api.BaseRoutes.Jobs = api.BaseRoutes.ApiRoot.PathPrefix("/jobs").Subrouter()
 
@@ -363,6 +367,7 @@ func InitLocal(configservice configservice.ConfigService, globalOptionsFunc app.
 	api.InitRoleLocal()
 	api.InitUploadLocal()
 	api.InitImportLocal()
+	api.InitExportLocal()
 	api.InitJobLocal()
 
 	root.Handle("/api/v4/{anything:.*}", http.HandlerFunc(api.Handle404))

--- a/api4/api.go
+++ b/api4/api.go
@@ -126,6 +126,7 @@ type Routes struct {
 
 	Imports *mux.Router // 'api/v4/imports'
 	Exports *mux.Router // 'api/v4/exports'
+	Export  *mux.Router // 'api/v4/exports/{export_name:.+\\.zip}'
 }
 
 type API struct {
@@ -240,6 +241,7 @@ func Init(configservice configservice.ConfigService, globalOptionsFunc app.AppOp
 
 	api.BaseRoutes.Imports = api.BaseRoutes.ApiRoot.PathPrefix("/imports").Subrouter()
 	api.BaseRoutes.Exports = api.BaseRoutes.ApiRoot.PathPrefix("/exports").Subrouter()
+	api.BaseRoutes.Export = api.BaseRoutes.Exports.PathPrefix("/{export_name:.+\\.zip}").Subrouter()
 
 	api.InitUser()
 	api.InitBot()
@@ -348,6 +350,7 @@ func InitLocal(configservice configservice.ConfigService, globalOptionsFunc app.
 
 	api.BaseRoutes.Imports = api.BaseRoutes.ApiRoot.PathPrefix("/imports").Subrouter()
 	api.BaseRoutes.Exports = api.BaseRoutes.ApiRoot.PathPrefix("/exports").Subrouter()
+	api.BaseRoutes.Export = api.BaseRoutes.Exports.PathPrefix("/{export_name:.+\\.zip}").Subrouter()
 
 	api.BaseRoutes.Jobs = api.BaseRoutes.ApiRoot.PathPrefix("/jobs").Subrouter()
 

--- a/api4/export.go
+++ b/api4/export.go
@@ -15,8 +15,8 @@ import (
 
 func (api *API) InitExport() {
 	api.BaseRoutes.Exports.Handle("", api.ApiSessionRequired(listExports)).Methods("GET")
-	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiSessionRequired(deleteExport)).Methods("DELETE")
-	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiSessionRequired(downloadExport)).Methods("GET")
+	api.BaseRoutes.Export.Handle("", api.ApiSessionRequired(deleteExport)).Methods("DELETE")
+	api.BaseRoutes.Export.Handle("", api.ApiSessionRequired(downloadExport)).Methods("GET")
 }
 
 func listExports(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/export.go
+++ b/api4/export.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api4
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/mattermost/mattermost-server/v5/audit"
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+func (api *API) InitExport() {
+	api.BaseRoutes.Exports.Handle("", api.ApiSessionRequired(listExports)).Methods("GET")
+	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiSessionRequired(deleteExport)).Methods("DELETE")
+	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiSessionRequired(downloadExport)).Methods("GET")
+}
+
+func listExports(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !c.IsSystemAdmin() {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	exports, appErr := c.App.ListExports()
+	if appErr != nil {
+		c.Err = appErr
+		return
+	}
+
+	data, err := json.Marshal(exports)
+	if err != nil {
+		c.Err = model.NewAppError("listImports", "app.export.marshal.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(data)
+}
+
+func deleteExport(c *Context, w http.ResponseWriter, r *http.Request) {
+	auditRec := c.MakeAuditRecord("deleteExport", audit.Fail)
+	defer c.LogAuditRec(auditRec)
+	auditRec.AddMeta("export_name", c.Params.ExportName)
+
+	if !c.IsSystemAdmin() {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	if err := c.App.DeleteExport(c.Params.ExportName); err != nil {
+		c.Err = err
+		return
+	}
+
+	auditRec.Success()
+	ReturnStatusOK(w)
+}
+
+func downloadExport(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !c.IsSystemAdmin() {
+		c.SetPermissionError(model.PERMISSION_MANAGE_SYSTEM)
+		return
+	}
+
+	filePath := filepath.Join(*c.App.Config().ExportSettings.Directory, c.Params.ExportName)
+	if ok, err := c.App.FileExists(filePath); err != nil {
+		c.Err = err
+		return
+	} else if !ok {
+		c.Err = model.NewAppError("downloadExport", "api.export.export_not_found.app_error", nil, "", http.StatusNotFound)
+		return
+	}
+
+	file, err := c.App.FileReader(filePath)
+	if err != nil {
+		c.Err = err
+		return
+	}
+	defer file.Close()
+
+	w.Header().Set("Content-Type", "application/zip")
+	http.ServeContent(w, r, c.Params.ExportName, time.Time{}, file)
+}

--- a/api4/export_local.go
+++ b/api4/export_local.go
@@ -5,6 +5,6 @@ package api4
 
 func (api *API) InitExportLocal() {
 	api.BaseRoutes.Exports.Handle("", api.ApiLocal(listExports)).Methods("GET")
-	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiLocal(deleteExport)).Methods("DELETE")
-	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiLocal(downloadExport)).Methods("GET")
+	api.BaseRoutes.Export.Handle("", api.ApiLocal(deleteExport)).Methods("DELETE")
+	api.BaseRoutes.Export.Handle("", api.ApiLocal(downloadExport)).Methods("GET")
 }

--- a/api4/export_local.go
+++ b/api4/export_local.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api4
+
+func (api *API) InitExportLocal() {
+	api.BaseRoutes.Exports.Handle("", api.ApiLocal(listExports)).Methods("GET")
+	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiLocal(deleteExport)).Methods("DELETE")
+	api.BaseRoutes.Exports.Handle("/{export_name:.+\\.zip}", api.ApiLocal(downloadExport)).Methods("GET")
+}

--- a/api4/export_test.go
+++ b/api4/export_test.go
@@ -1,0 +1,213 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api4
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/utils/fileutils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestListExports(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	t.Run("no permissions", func(t *testing.T) {
+		exports, resp := th.Client.ListExports()
+		require.Error(t, resp.Error)
+		require.Equal(t, "api.context.permissions.app_error", resp.Error.Id)
+		require.Nil(t, exports)
+	})
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		exports, resp := c.ListExports()
+		require.Nil(t, resp.Error)
+		require.Empty(t, exports)
+	}, "no exports")
+
+	dataDir, found := fileutils.FindDir("data")
+	require.True(t, found)
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		exportDir := filepath.Join(dataDir, *th.App.Config().ExportSettings.Directory)
+		err := os.Mkdir(exportDir, 0700)
+		require.Nil(t, err)
+		defer os.RemoveAll(exportDir)
+
+		f, err := os.Create(filepath.Join(exportDir, "export.zip"))
+		require.Nil(t, err)
+		f.Close()
+
+		exports, resp := c.ListExports()
+		require.Nil(t, resp.Error)
+		require.Len(t, exports, 1)
+		require.Equal(t, exports[0], "export.zip")
+	}, "expected exports")
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		value := *th.App.Config().ExportSettings.Directory
+		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ExportSettings.Directory = value + "new" })
+		defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ExportSettings.Directory = value })
+
+		exportDir := filepath.Join(dataDir, value+"new")
+		err := os.Mkdir(exportDir, 0700)
+		require.Nil(t, err)
+		defer os.RemoveAll(exportDir)
+
+		exports, resp := c.ListExports()
+		require.Nil(t, resp.Error)
+		require.Empty(t, exports)
+
+		f, err := os.Create(filepath.Join(exportDir, "export.zip"))
+		require.Nil(t, err)
+		f.Close()
+
+		exports, resp = c.ListExports()
+		require.Nil(t, resp.Error)
+		require.Len(t, exports, 1)
+		require.Equal(t, "export.zip", exports[0])
+	}, "change export directory")
+}
+
+func TestDeleteExport(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	t.Run("no permissions", func(t *testing.T) {
+		ok, resp := th.Client.DeleteExport("export.zip")
+		require.Error(t, resp.Error)
+		require.Equal(t, "api.context.permissions.app_error", resp.Error.Id)
+		require.False(t, ok)
+	})
+
+	dataDir, found := fileutils.FindDir("data")
+	require.True(t, found)
+	exportDir := filepath.Join(dataDir, *th.App.Config().ExportSettings.Directory)
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		err := os.Mkdir(exportDir, 0700)
+		require.Nil(t, err)
+		defer os.RemoveAll(exportDir)
+		exportName := "export.zip"
+		f, err := os.Create(filepath.Join(exportDir, exportName))
+		require.Nil(t, err)
+		f.Close()
+
+		exports, resp := c.ListExports()
+		require.Nil(t, resp.Error)
+		require.Len(t, exports, 1)
+		require.Equal(t, exports[0], exportName)
+
+		ok, resp := c.DeleteExport(exportName)
+		require.Nil(t, resp.Error)
+		require.True(t, ok)
+
+		exports, resp = c.ListExports()
+		require.Nil(t, resp.Error)
+		require.Empty(t, exports)
+
+		// verify idempotence
+		ok, resp = c.DeleteExport(exportName)
+		require.Nil(t, resp.Error)
+		require.True(t, ok)
+	}, "successfully delete export")
+}
+
+func TestDownloadExport(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	t.Run("no permissions", func(t *testing.T) {
+		var buf bytes.Buffer
+		n, resp := th.Client.DownloadExport("export.zip", &buf, 0)
+		require.Error(t, resp.Error)
+		require.Equal(t, "api.context.permissions.app_error", resp.Error.Id)
+		require.Zero(t, n)
+	})
+
+	dataDir, found := fileutils.FindDir("data")
+	require.True(t, found)
+	exportDir := filepath.Join(dataDir, *th.App.Config().ExportSettings.Directory)
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		var buf bytes.Buffer
+		n, resp := c.DownloadExport("export.zip", &buf, 0)
+		require.Error(t, resp.Error)
+		require.Equal(t, "api.export.export_not_found.app_error", resp.Error.Id)
+		require.Zero(t, n)
+	}, "not found")
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		err := os.Mkdir(exportDir, 0700)
+		require.Nil(t, err)
+		defer os.RemoveAll(exportDir)
+
+		data := randomBytes(t, 1024*1024)
+		var buf bytes.Buffer
+		exportName := "export.zip"
+		err = ioutil.WriteFile(filepath.Join(exportDir, exportName), data, 0600)
+		require.Nil(t, err)
+
+		n, resp := c.DownloadExport(exportName, &buf, 0)
+		require.Nil(t, resp.Error)
+		require.Equal(t, len(data), int(n))
+		require.Equal(t, data, buf.Bytes())
+	}, "full download")
+
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
+		err := os.Mkdir(exportDir, 0700)
+		require.Nil(t, err)
+		defer os.RemoveAll(exportDir)
+
+		data := randomBytes(t, 1024*1024)
+		var buf bytes.Buffer
+		exportName := "export.zip"
+		err = ioutil.WriteFile(filepath.Join(exportDir, exportName), data, 0600)
+		require.Nil(t, err)
+
+		offset := 1024 * 512
+		n, resp := c.DownloadExport(exportName, &buf, int64(offset))
+		require.Nil(t, resp.Error)
+		require.Equal(t, len(data)-offset, int(n))
+		require.Equal(t, data[offset:], buf.Bytes())
+	}, "download with offset")
+}
+
+func BenchmarkDownloadExport(b *testing.B) {
+	th := Setup(b)
+	defer th.TearDown()
+
+	dataDir, found := fileutils.FindDir("data")
+	require.True(b, found)
+	exportDir := filepath.Join(dataDir, *th.App.Config().ExportSettings.Directory)
+
+	err := os.Mkdir(exportDir, 0700)
+	require.Nil(b, err)
+	defer os.RemoveAll(exportDir)
+
+	exportName := "export.zip"
+	f, err := os.Create(filepath.Join(exportDir, exportName))
+	require.Nil(b, err)
+	f.Close()
+
+	err = os.Truncate(filepath.Join(exportDir, exportName), 1024*1024*1024)
+	require.Nil(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		outFilePath := filepath.Join(dataDir, fmt.Sprintf("export%d.zip", i))
+		outFile, _ := os.Create(outFilePath)
+		th.SystemAdminClient.DownloadExport(exportName, outFile, 0)
+		outFile.Close()
+		os.Remove(outFilePath)
+	}
+}

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -463,6 +463,7 @@ type AppIface interface {
 	DeleteCommand(commandId string) *model.AppError
 	DeleteEmoji(emoji *model.Emoji) *model.AppError
 	DeleteEphemeralPost(userId, postId string)
+	DeleteExport(name string) *model.AppError
 	DeleteFlaggedPosts(postId string)
 	DeleteGroup(groupID string) (*model.Group, *model.AppError)
 	DeleteGroupMember(groupID string, userID string) (*model.GroupMember, *model.AppError)
@@ -775,6 +776,7 @@ type AppIface interface {
 	LimitedClientConfig() map[string]string
 	ListAllCommands(teamId string, T goi18n.TranslateFunc) ([]*model.Command, *model.AppError)
 	ListDirectory(path string) ([]string, *model.AppError)
+	ListExports() ([]string, *model.AppError)
 	ListImports() ([]string, *model.AppError)
 	ListPluginKeys(pluginId string, page, perPage int) ([]string, *model.AppError)
 	ListTeamCommands(teamId string) ([]*model.Command, *model.AppError)

--- a/app/export.go
+++ b/app/export.go
@@ -722,3 +722,29 @@ func (a *App) exportFile(outPath, filePath string, zipWr *zip.Writer) *model.App
 
 	return nil
 }
+
+func (a *App) ListExports() ([]string, *model.AppError) {
+	exports, appErr := a.ListDirectory(*a.Config().ExportSettings.Directory)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	results := make([]string, len(exports))
+	for i := range exports {
+		results[i] = filepath.Base(exports[i])
+	}
+
+	return results, nil
+}
+
+func (a *App) DeleteExport(name string) *model.AppError {
+	filePath := filepath.Join(*a.Config().ExportSettings.Directory, name)
+
+	if ok, err := a.FileExists(filePath); err != nil {
+		return err
+	} else if !ok {
+		return nil
+	}
+
+	return a.RemoveFile(filePath)
+}

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -2734,6 +2734,28 @@ func (a *OpenTracingAppLayer) DeleteEphemeralPost(userId string, postId string) 
 	a.app.DeleteEphemeralPost(userId, postId)
 }
 
+func (a *OpenTracingAppLayer) DeleteExport(name string) *model.AppError {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.DeleteExport")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.DeleteExport(name)
+
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0
+}
+
 func (a *OpenTracingAppLayer) DeleteFlaggedPosts(postId string) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.DeleteFlaggedPosts")
@@ -10309,6 +10331,28 @@ func (a *OpenTracingAppLayer) ListDirectory(path string) ([]string, *model.AppEr
 
 	defer span.Finish()
 	resultVar0, resultVar1 := a.app.ListDirectory(path)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
+func (a *OpenTracingAppLayer) ListExports() ([]string, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.ListExports")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.ListExports()
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1317,6 +1317,10 @@
     "translation": "Unable to create the emoji. An error occurred when trying to open the attached image."
   },
   {
+    "id": "api.export.export_not_found.app_error",
+    "translation": "Unable to find export file."
+  },
+  {
     "id": "api.file.append_file.app_error",
     "translation": "Unable to append data to the file."
   },
@@ -4053,6 +4057,10 @@
   {
     "id": "app.export.export_write_line.json_marshall.error",
     "translation": "An error occurred marshalling the JSON data for export."
+  },
+  {
+    "id": "app.export.marshal.app_error",
+    "translation": "Unable to marshal response."
   },
   {
     "id": "app.export.zip_create.error",

--- a/web/params.go
+++ b/web/params.go
@@ -82,6 +82,7 @@ type Params struct {
 	FilterParentTeamPermitted bool
 	CategoryId                string
 	WarnMetricId              string
+	ExportName                string
 
 	// Cloud
 	InvoiceId string
@@ -343,6 +344,10 @@ func ParamsFromRequest(r *http.Request) *Params {
 
 	if val, ok := props["warn_metric_id"]; ok {
 		params.WarnMetricId = val
+	}
+
+	if val, ok := props["export_name"]; ok {
+		params.ExportName = val
 	}
 
 	return params


### PR DESCRIPTION
#### Summary

PR implements a new `/exports` API endpoint to list/delete/download export files.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-31249

#### Release Note

```release-note
NONE
```

#### Related PRs

https://github.com/mattermost/mattermost-api-reference/pull/597