### PR TITLE
Trigger outgoing webhooks from incoming webhooks when enabled. Add co…

### DIFF
--- a/app/webhook.go
+++ b/app/webhook.go
@@ -297,8 +297,10 @@ func (a *App) CreateWebhookPost(userId string, channel *model.Channel, text, ove
 		return nil, err
 	}
 
+	triggerWebhooks := *a.Config().ServiceSettings.IncomingWebhooksTriggerOutgoingWebhooks
+
 	for _, split := range splits {
-		if _, err := a.CreatePostMissingChannel(split, false); err != nil {
+		if _, err := a.CreatePostMissingChannel(split, triggerWebhooks); err != nil {
 			return nil, model.NewAppError("CreateWebhookPost", "api.post.create_webhook_post.creating.app_error", nil, "err="+err.Message, http.StatusInternalServerError)
 		}
 	}

--- a/model/config.go
+++ b/model/config.go
@@ -286,6 +286,7 @@ type ServiceSettings struct {
 	EnableOAuthServiceProvider                        *bool    `access:"integrations"`
 	EnableIncomingWebhooks                            *bool    `access:"integrations"`
 	EnableOutgoingWebhooks                            *bool    `access:"integrations"`
+	IncomingWebhooksTriggerOutgoingWebhooks           *bool    `access:"integrations"`
 	EnableCommands                                    *bool    `access:"integrations"`
 	DEPRECATED_DO_NOT_USE_EnableOnlyAdminIntegrations *bool    `json:"EnableOnlyAdminIntegrations" mapstructure:"EnableOnlyAdminIntegrations"` // This field is deprecated and must not be used.
 	EnablePostUsernameOverride                        *bool    `access:"integrations"`
@@ -451,6 +452,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.EnableOutgoingWebhooks == nil {
 		s.EnableOutgoingWebhooks = NewBool(true)
+	}
+
+	if s.IncomingWebhooksTriggerOutgoingWebhooks == nil {
+		s.IncomingWebhooksTriggerOutgoingWebhooks = NewBool(true)
 	}
 
 	if s.ConnectionSecurity == nil {

--- a/model/outgoing_webhook.go
+++ b/model/outgoing_webhook.go
@@ -119,7 +119,6 @@ func OutgoingWebhookResponseFromJson(data io.Reader) (*OutgoingWebhookResponse, 
 }
 
 func (o *OutgoingWebhook) IsValid() *AppError {
-
 	if !IsValidId(o.Id) {
 		return NewAppError("OutgoingWebhook.IsValid", "model.outgoing_hook.is_valid.id.app_error", nil, "", http.StatusBadRequest)
 	}


### PR DESCRIPTION

#### Summary

Added a config attribute "IncomingWebhooksTriggerOutgoingWebhooks" with default value true. If it is enabled outgoing webhooks can be triggered by incoming webhooks.
Also added a test.

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-server/issues/16238
 JIRA-Ticket: https://mattermost.atlassian.net/browse/MM-31208

#### Release Note

It's now possible to for outgoing webhooks to be triggered by incoming webhooks with the setting IncomingWebhooksTriggerOutgoingWebhooks
