### PR TITLE
MM-30892: Avoid unnecessary table scan in AnalyticsPostCount.

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1526,7 +1526,7 @@ func (s *SqlPostStore) AnalyticsPostCount(teamId string, mustHaveFile bool, must
 	}
 
 	if mustHaveHashtag {
-		query = query.Where("p.Hashtags != ''")
+		query = query.Where(sq.NotEq{"p.Hashtags": ""})
 	}
 
 	queryString, args, err := query.ToSql()

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1522,7 +1522,7 @@ func (s *SqlPostStore) AnalyticsPostCount(teamId string, mustHaveFile bool, must
 	}
 
 	if mustHaveFile {
-		query = query.Where("p.FileIds != '[]' OR p.Filenames != '[]'")
+		query = query.Where(sq.Or{sq.NotEq{"p.FileIds": "[]"}, sq.NotEq{"p.Filenames": "[]"}})
 	}
 
 	if mustHaveHashtag {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1511,28 +1511,30 @@ func (s *SqlPostStore) AnalyticsPostCountsByDay(options *model.AnalyticsPostCoun
 }
 
 func (s *SqlPostStore) AnalyticsPostCount(teamId string, mustHaveFile bool, mustHaveHashtag bool) (int64, error) {
-	query :=
-		`SELECT
-			COUNT(Posts.Id) AS Value
-		FROM
-			Posts,
-			Channels
-		WHERE
-			Posts.ChannelId = Channels.Id`
+	query := s.getQueryBuilder().
+		Select("COUNT(p.Id) AS Value").
+		From("Posts p")
 
 	if len(teamId) > 0 {
-		query += " AND Channels.TeamId = :TeamId"
+		query = query.
+			Join("Channels c ON (c.Id = p.ChannelId)").
+			Where(sq.Eq{"c.TeamId": teamId})
 	}
 
 	if mustHaveFile {
-		query += " AND (Posts.FileIds != '[]' OR Posts.Filenames != '[]')"
+		query = query.Where("p.FileIds != '[]' OR p.Filenames != '[]'")
 	}
 
 	if mustHaveHashtag {
-		query += " AND Posts.Hashtags != ''"
+		query = query.Where("p.Hashtags != ''")
 	}
 
-	v, err := s.GetReplica().SelectInt(query, map[string]interface{}{"TeamId": teamId})
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return 0, errors.Wrap(err, "post_tosql")
+	}
+
+	v, err := s.GetReplica().SelectInt(queryString, args...)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to count Posts")
 	}

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -1601,6 +1601,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	o1.UserId = model.NewId()
 	o1.CreateAt = utils.MillisFromTime(utils.Yesterday())
 	o1.Message = "zz" + model.NewId() + "b"
+	o1.Hashtags = "hashtag"
 	o1, nErr = ss.Post().Save(o1)
 	require.Nil(t, nErr)
 
@@ -1609,6 +1610,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	o1a.UserId = model.NewId()
 	o1a.CreateAt = o1.CreateAt
 	o1a.Message = "zz" + model.NewId() + "b"
+	o1a.FileIds = []string{"fileId1"}
 	_, nErr = ss.Post().Save(o1a)
 	require.Nil(t, nErr)
 
@@ -1617,6 +1619,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	o2.UserId = model.NewId()
 	o2.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24 * 2)
 	o2.Message = "zz" + model.NewId() + "b"
+	o2.Filenames = []string{"filename1"}
 	o2, nErr = ss.Post().Save(o2)
 	require.Nil(t, nErr)
 
@@ -1625,6 +1628,8 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	o2a.UserId = o2.UserId
 	o2a.CreateAt = o1.CreateAt - (1000 * 60 * 60 * 24 * 2)
 	o2a.Message = "zz" + model.NewId() + "b"
+	o2a.Hashtags = "hashtag"
+	o2a.FileIds = []string{"fileId2"}
 	_, nErr = ss.Post().Save(o2a)
 	require.Nil(t, nErr)
 
@@ -1689,6 +1694,26 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	r2, err := ss.Post().AnalyticsPostCount(t1.Id, false, false)
 	require.Nil(t, err)
 	assert.Equal(t, int64(6), r2)
+
+	// total across teams
+	r2, err = ss.Post().AnalyticsPostCount("", false, false)
+	require.Nil(t, err)
+	assert.GreaterOrEqual(t, r2, int64(6))
+
+	// total across teams with files
+	r2, err = ss.Post().AnalyticsPostCount("", true, false)
+	require.Nil(t, err)
+	assert.GreaterOrEqual(t, r2, int64(3))
+
+	// total across teams with hastags
+	r2, err = ss.Post().AnalyticsPostCount("", false, true)
+	require.Nil(t, err)
+	assert.GreaterOrEqual(t, r2, int64(2))
+
+	// total across teams with hastags and files
+	r2, err = ss.Post().AnalyticsPostCount("", true, true)
+	require.Nil(t, err)
+	assert.GreaterOrEqual(t, r2, int64(1))
 }
 
 func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlStore) {


### PR DESCRIPTION
#### Summary
[AnalyticsPostCount](https://github.com/mattermost/mattermost-server/blob/d9e8402dc27bd11137e9301cf14eaf01d2786efd/store/sqlstore/post_store.go#L1513-L1541) unconditionally joins on the `Channels` table even when not filtering to a team.

This is a proposal to stop doing this, reducing this to a simple index query when no team or hashtag/file requirement is specified. Note that this is technically a subtle semantic difference, since orphaned posts (from deleted or invalid channel ids) are currently excluded. I submit the benefits outweigh the technical differences here, but would love some consideration on this front lest my assumptions are invalid.

For clarity, these improvements only apply for certain invocation of `AnalyticsPostCount`, namely:
* On startup, during warn metrics: https://github.com/mattermost/mattermost-server/blob/09d2f698cc3c0a71fa3eac550ec4c38006b37a06/app/server.go#L1381
* Daily, during telemetry: https://github.com/mattermost/mattermost-server/blob/09d2f698cc3c0a71fa3eac550ec4c38006b37a06/services/telemetry/telemetry.go#L289
* During the bleve indexing process: https://github.com/mattermost/mattermost-server/blob/09d2f698cc3c0a71fa3eac550ec4c38006b37a06/services/searchengine/bleveengine/indexer/indexing_job.go#L189
* When updating product notices (configurable NoticesFetchFrequency): https://github.com/mattermost/mattermost-server/blob/09d2f698cc3c0a71fa3eac550ec4c38006b37a06/app/product_notices.go#L305
* During the elasticsearch indexing process: https://github.com/mattermost/enterprise/blob/576fb923f9328ef93d73e94833f34f9334a3abeb/elasticsearch/indexing_job.go#L216

For additional context, see discussion at https://community-daily.mattermost.com/core/pl/c7wgdiyydiyauczzn73qqsap8o.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-30892

#### Release Note
```release-note
AnalyticsPostCount now avoids unnecessary table scans during various background jobs.
```
