### PR TITLE
MM-31715: Flip ExperimentalGossip to be true by default

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -848,7 +848,7 @@ func (s *ClusterSettings) SetDefaults() {
 	}
 
 	if s.UseExperimentalGossip == nil {
-		s.UseExperimentalGossip = NewBool(false)
+		s.UseExperimentalGossip = NewBool(true)
 	}
 
 	if s.EnableExperimentalGossipEncryption == nil {

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -320,7 +320,7 @@
         "ClusterName": "",
         "OverrideHostname": "",
         "UseIpAddress": true,
-        "UseExperimentalGossip": false,
+        "UseExperimentalGossip": true,
         "ReadOnlyConfig": true,
         "GossipPort": 8074,
         "StreamingPort": 8075,


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-31715

```release-notes
The UseExperimentalGossip field under ClusterSettings is now true by default.
This means that new installations will use the gossip protocol for cluster communication.
There will be no changes to existing installations.

The Gossip protocol is now considered to be in General Availability and is the recommended clustering mode.
```
