### PR TITLE
[MM-31776] explicitly call level functions for mlog

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -87,22 +87,30 @@ func (c *Context) LogAuditWithUserId(userId, extraInfo string) {
 
 func (c *Context) LogErrorByCode(err *model.AppError) {
 	code := err.StatusCode
-	var level mlog.LogLevel
 	switch {
 	case (code >= http.StatusBadRequest && code < http.StatusInternalServerError) ||
 		err.Id == "web.check_browser_compatibility.app_error":
-		level = mlog.LvlDebug
+		c.Logger.Debug(
+			err.SystemMessage(utils.TDefault),
+			mlog.String("err_where", err.Where),
+			mlog.Int("http_code", err.StatusCode),
+			mlog.String("err_details", err.DetailedError),
+		)
 	case code == http.StatusNotImplemented:
-		level = mlog.LvlInfo
+		c.Logger.Info(
+			err.SystemMessage(utils.TDefault),
+			mlog.String("err_where", err.Where),
+			mlog.Int("http_code", err.StatusCode),
+			mlog.String("err_details", err.DetailedError),
+		)
 	default:
-		level = mlog.LvlError
+		c.Logger.Error(
+			err.SystemMessage(utils.TDefault),
+			mlog.String("err_where", err.Where),
+			mlog.Int("http_code", err.StatusCode),
+			mlog.String("err_details", err.DetailedError),
+		)
 	}
-	c.Logger.Log(level,
-		err.SystemMessage(utils.TDefault),
-		mlog.String("err_where", err.Where),
-		mlog.Int("http_code", err.StatusCode),
-		mlog.String("err_details", err.DetailedError),
-	)
 }
 
 func (c *Context) IsSystemAdmin() bool {

--- a/web/context.go
+++ b/web/context.go
@@ -87,29 +87,20 @@ func (c *Context) LogAuditWithUserId(userId, extraInfo string) {
 
 func (c *Context) LogErrorByCode(err *model.AppError) {
 	code := err.StatusCode
+	msg := err.SystemMessage(utils.TDefault)
+	fields := []mlog.Field{
+		mlog.String("err_where", err.Where),
+		mlog.Int("http_code", err.StatusCode),
+		mlog.String("err_details", err.DetailedError),
+	}
 	switch {
 	case (code >= http.StatusBadRequest && code < http.StatusInternalServerError) ||
 		err.Id == "web.check_browser_compatibility.app_error":
-		c.Logger.Debug(
-			err.SystemMessage(utils.TDefault),
-			mlog.String("err_where", err.Where),
-			mlog.Int("http_code", err.StatusCode),
-			mlog.String("err_details", err.DetailedError),
-		)
+		c.Logger.Debug(msg, fields...)
 	case code == http.StatusNotImplemented:
-		c.Logger.Info(
-			err.SystemMessage(utils.TDefault),
-			mlog.String("err_where", err.Where),
-			mlog.Int("http_code", err.StatusCode),
-			mlog.String("err_details", err.DetailedError),
-		)
+		c.Logger.Info(msg, fields...)
 	default:
-		c.Logger.Error(
-			err.SystemMessage(utils.TDefault),
-			mlog.String("err_where", err.Where),
-			mlog.Int("http_code", err.StatusCode),
-			mlog.String("err_details", err.DetailedError),
-		)
+		c.Logger.Error(msg, fields...)
 	}
 }
 


### PR DESCRIPTION

#### Summary
It turns out `mlog.Debug(msg, fields...)` is different than `mlog.Log(mlog.DebugLevel, msg, fields...)`. 🤦 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-31776

#### Release Note
```release-note
NONE
```
