### PR TITLE
MM-31369: Fix racy test FileStoreWatcherEmitter encore

### DIFF
--- a/config/file_test.go
+++ b/config/file_test.go
@@ -882,8 +882,6 @@ func TestFileStoreWatcherEmitter(t *testing.T) {
 		t.Skip("skipping watcher test in short mode")
 	}
 
-	t.Parallel()
-
 	t.Run("disabled", func(t *testing.T) {
 		path, tearDown := setupConfigFile(t, emptyConfig)
 		defer tearDown()


### PR DESCRIPTION
There was a mistake in my earlier analysis. t.Parallel only
applies to the current test and not its subtests.

There is some other test running with t.Parallel that is causing duplicate
file watcher events to be fired. I have now verified that removing this
causes the race to go away in CI
