### PR TITLE
Fix go.mod to give priority to go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,11 +542,11 @@ update-dependencies: ## Uses go get -u to update all the dependencies while hold
 	# Update all dependencies (does not update across major versions)
 	$(GO) get -u ./...
 
-	# Tidy up
-	$(GO) mod tidy
-
 	# Copy everything to vendor directory
 	$(GO) mod vendor
+
+	# Tidy up
+	$(GO) mod tidy
 
 vet: ## Run mattermost go vet specific checks
 	@if ! [ -x "$$(command -v $(GOBIN)/mattermost-govet)" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.2 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.9.0
-	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/client_model v0.2.0
 	github.com/reflog/dateconstraints v0.2.1
 	github.com/rs/cors v1.7.0
 	github.com/rudderlabs/analytics-go v3.2.1+incompatible


### PR DESCRIPTION
There is a race between go mod tidy and go mod vendor
due to https://github.com/golang/go/issues/37376.

However, if we give priority to go mod vendor, then
gopls complains of inconsistent vendoring. We make go mod tidy happy
as it's a more commonly used command than go mod vendor,
and is a common problem faced by other devs too
