### PR TITLE
MM-30314 Don't delete all SidebarChannels when removed from team

### DIFF
--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -953,50 +953,36 @@ func (s SqlChannelStore) UpdateSidebarChannelCategoryOnMove(channel *model.Chann
 
 func (s SqlChannelStore) ClearSidebarOnTeamLeave(userId, teamId string) error {
 	// if user leaves the team, clean his team related entries in sidebar channels and categories
-	transaction, err := s.GetMaster().Begin()
-	if err != nil {
-		return errors.Wrap(err, "begin_transaction")
-	}
-	defer finalizeTransaction(transaction)
-
-	s.GetMaster().TraceOn("HARRISON", &TraceOnAdapter{})
-	defer s.GetMaster().TraceOff()
-
-	selectQuery, selectParams, _ := s.getQueryBuilder().
-		Select("Id").
-		From("SidebarCategories").
-		Where(sq.Eq{
-			"TeamId": teamId,
-			"UserId": userId,
-		}).ToSql()
-
-	var categoryIds []string
-	if _, err := transaction.Select(&categoryIds, selectQuery, selectParams...); err != nil {
-		return errors.Wrap(err, "Failed to get sidebar category IDs for deletion")
+	params := map[string]interface{}{
+		"UserId": userId,
+		"TeamId": teamId,
 	}
 
-	if len(categoryIds) > 0 {
-		deleteCategoryQuery, deleteCategoryParams, _ := s.getQueryBuilder().
-			Delete("SidebarCategories").
-			Where(sq.Eq{"Id": categoryIds}).ToSql()
-
-		if _, err := transaction.Exec(deleteCategoryQuery, deleteCategoryParams...); err != nil {
-			return errors.Wrap(err, "Failed to delete sidebar categories")
-		}
-
-		deleteChannelsQuery, deleteChannelsParams, _ := s.getQueryBuilder().
-			Delete("SidebarChannels").
-			Where(sq.Eq{"CategoryId": categoryIds}).ToSql()
-
-		if _, err := transaction.Exec(deleteChannelsQuery, deleteChannelsParams...); err != nil {
-			return errors.Wrap(err, "Failed to delete sidebar channels")
-		}
+	var deleteQuery string
+	if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
+		deleteQuery = "DELETE SidebarChannels FROM SidebarChannels LEFT JOIN SidebarCategories ON SidebarCategories.Id = SidebarChannels.CategoryId WHERE SidebarCategories.TeamId=:TeamId AND SidebarCategories.UserId=:UserId"
+	} else {
+		deleteQuery = `
+			DELETE FROM
+				SidebarChannels
+			WHERE
+				CategoryId IN (
+					SELECT
+						CategoryId
+					FROM
+						SidebarChannels,
+						SidebarCategories
+					WHERE
+						SidebarChannels.CategoryId = SidebarCategories.Id
+						AND SidebarCategories.TeamId = :TeamId
+						AND SidebarChannels.UserId = :UserId)`
 	}
-
-	if err := transaction.Commit(); err != nil {
-		return errors.Wrap(err, "commit_transaction")
+	if _, err := s.GetMaster().Exec(deleteQuery, params); err != nil {
+		return errors.Wrap(err, "failed to delete from SidebarChannels")
 	}
-
+	if _, err := s.GetMaster().Exec("DELETE FROM SidebarCategories WHERE SidebarCategories.TeamId = :TeamId AND SidebarCategories.UserId = :UserId", params); err != nil {
+		return errors.Wrap(err, "failed to delete from SidebarCategories")
+	}
 	return nil
 }
 


### PR DESCRIPTION
This fixes a strange bug where sometimes a user's custom categories would lose all the channels in them.

It turns out that this happens because of the code that removes the sidebar data when a user leaves or is removed from a team while they have a DM channel in a custom category on that team. This also only affected Postgres, so we weren't going to find it on community even if we did join/leave teams more often.

The reason this happened is because of the DELETE FROM query used to delete the SIdebarChannels, although I'm honestly not sure why. If I ran that query myself, it would reproduce the issue, but if I changed it to a SELECT with the same JOIN and WHERE, it only returned rows on the team that the user would've been leaving. I'm not entirely sure it has to do with a DM channel in particular, but that was the simplest repro steps I could find.

Since I didn't understand exactly why that caused a problem, I rewrote those queries in the most naive way I could think of. This isn't a hot API route, so I think we can afford the extra DB hit to be extra clear about what we're doing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30314
Fixes #16517 

#### Release Note
```release-note
Fixed bug where channels would sometimes be removed from custom categories when a user leaves a team
```
