### PR TITLE
MM-32033: Check if a remote is already added before inviting

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -197,6 +197,8 @@ type AppIface interface {
 	GetTeamSchemeChannelRoles(teamId string) (guestRoleName string, userRoleName string, adminRoleName string, err *model.AppError)
 	// GetTotalUsersStats is used for the DM list total
 	GetTotalUsersStats(viewRestrictions *model.ViewUsersRestrictions) (*model.UsersStats, *model.AppError)
+	// HasRemote returns whether a given channelID is present in the channel remotes or not.
+	HasRemote(channelID string) (bool, error)
 	// HubRegister registers a connection to a hub.
 	HubRegister(webConn *WebConn)
 	// HubStart starts all the hubs.
@@ -758,7 +760,6 @@ type AppIface interface {
 	HasPermissionToChannelByPost(askingUserId string, postId string, permission *model.Permission) bool
 	HasPermissionToTeam(askingUserId string, teamId string, permission *model.Permission) bool
 	HasPermissionToUser(askingUserId string, userId string) bool
-	HasRemote(channelID string) (bool, error)
 	HubStop()
 	ImageProxy() *imageproxy.ImageProxy
 	ImageProxyAdder() func(string) string

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -758,6 +758,7 @@ type AppIface interface {
 	HasPermissionToChannelByPost(askingUserId string, postId string, permission *model.Permission) bool
 	HasPermissionToTeam(askingUserId string, teamId string, permission *model.Permission) bool
 	HasPermissionToUser(askingUserId string, userId string) bool
+	HasRemote(channelID string) (bool, error)
 	HubStop()
 	ImageProxy() *imageproxy.ImageProxy
 	ImageProxyAdder() func(string) string

--- a/app/channel_share.go
+++ b/app/channel_share.go
@@ -89,6 +89,11 @@ func (a *App) GetSharedChannelRemotes(channelId string) ([]*model.SharedChannelR
 	return a.Srv().Store.SharedChannel().GetRemotes(channelId)
 }
 
+// HasRemote returns whether a given channelID is present in the channel remotes or not.
+func (a *App) HasRemote(channelID string) (bool, error) {
+	return a.Srv().Store.SharedChannel().HasRemote(channelID)
+}
+
 func (a *App) UpdateSharedChannelRemoteLastSyncAt(id string, syncTime int64) error {
 	return a.Srv().Store.SharedChannel().UpdateRemoteLastSyncAt(id, syncTime)
 }

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -9899,6 +9899,28 @@ func (a *OpenTracingAppLayer) HasPermissionToUser(askingUserId string, userId st
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) HasRemote(channelID string) (bool, error) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.HasRemote")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.HasRemote(channelID)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) HubRegister(webConn *app.WebConn) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.HubRegister")

--- a/app/slashcommands/command_share.go
+++ b/app/slashcommands/command_share.go
@@ -240,6 +240,14 @@ func (sp *ShareProvider) doInviteRemote(a *app.App, args *model.CommandArgs, mar
 		return responsef("Must specify a valid remote cluster id to invite.")
 	}
 
+	all, err := a.GetSharedChannelRemotes(args.ChannelId)
+	if err != nil {
+		return responsef("Error fetching remote clusters: %v", err)
+	}
+	if len(all) > 0 {
+		return responsef("The remote cluster has already been invited")
+	}
+
 	rc, err := a.GetRemoteCluster(remoteId)
 	if err != nil {
 		return responsef("Remote cluster id is invalid: %v", err)

--- a/app/slashcommands/command_share.go
+++ b/app/slashcommands/command_share.go
@@ -240,11 +240,11 @@ func (sp *ShareProvider) doInviteRemote(a *app.App, args *model.CommandArgs, mar
 		return responsef("Must specify a valid remote cluster id to invite.")
 	}
 
-	all, err := a.GetSharedChannelRemotes(args.ChannelId)
+	has, err := a.HasRemote(args.ChannelId)
 	if err != nil {
 		return responsef("Error fetching remote clusters: %v", err)
 	}
-	if len(all) > 0 {
+	if has {
 		return responsef("The remote cluster has already been invited")
 	}
 

--- a/app/slashcommands/command_share.go
+++ b/app/slashcommands/command_share.go
@@ -248,9 +248,9 @@ func (sp *ShareProvider) doInviteRemote(a *app.App, args *model.CommandArgs, mar
 		return responsef("The remote cluster has already been invited")
 	}
 
-	rc, err := a.GetRemoteCluster(remoteId)
-	if err != nil {
-		return responsef("Remote cluster id is invalid: %v", err)
+	rc, appErr := a.GetRemoteCluster(remoteId)
+	if appErr != nil {
+		return responsef("Remote cluster id is invalid: %v", appErr)
 	}
 
 	// send channel invite to remote cluster

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -6760,6 +6760,24 @@ func (s *OpenTracingLayerSharedChannelStore) GetRemotesStatus(channelId string) 
 	return result, err
 }
 
+func (s *OpenTracingLayerSharedChannelStore) HasRemote(channelID string) (bool, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SharedChannelStore.HasRemote")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.SharedChannelStore.HasRemote(channelID)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
+}
+
 func (s *OpenTracingLayerSharedChannelStore) Save(sc *model.SharedChannel) (*model.SharedChannel, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SharedChannelStore.Save")

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -7326,6 +7326,26 @@ func (s *RetryLayerSharedChannelStore) GetRemotesStatus(channelId string) ([]*mo
 
 }
 
+func (s *RetryLayerSharedChannelStore) HasRemote(channelID string) (bool, error) {
+
+	tries := 0
+	for {
+		result, err := s.SharedChannelStore.HasRemote(channelID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+	}
+
+}
+
 func (s *RetryLayerSharedChannelStore) Save(sc *model.SharedChannel) (*model.SharedChannel, error) {
 
 	tries := 0

--- a/store/store.go
+++ b/store/store.go
@@ -806,6 +806,7 @@ type SharedChannelStore interface {
 	SaveRemote(remote *model.SharedChannelRemote) (*model.SharedChannelRemote, error)
 	UpdateRemote(remote *model.SharedChannelRemote) (*model.SharedChannelRemote, error)
 	GetRemote(id string) (*model.SharedChannelRemote, error)
+	HasRemote(channelID string) (bool, error)
 	GetRemoteByIds(channelId string, remoteId string) (*model.SharedChannelRemote, error)
 	GetRemotes(channelId string) ([]*model.SharedChannelRemote, error)
 	UpdateRemoteLastSyncAt(id string, syncTime int64) error

--- a/store/storetest/mocks/SharedChannelStore.go
+++ b/store/storetest/mocks/SharedChannelStore.go
@@ -216,6 +216,27 @@ func (_m *SharedChannelStore) GetRemotesStatus(channelId string) ([]*model.Share
 	return r0, r1
 }
 
+// HasRemote provides a mock function with given fields: channelID
+func (_m *SharedChannelStore) HasRemote(channelID string) (bool, error) {
+	ret := _m.Called(channelID)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(channelID)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(channelID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Save provides a mock function with given fields: sc
 func (_m *SharedChannelStore) Save(sc *model.SharedChannel) (*model.SharedChannel, error) {
 	ret := _m.Called(sc)

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -6110,6 +6110,22 @@ func (s *TimerLayerSharedChannelStore) GetRemotesStatus(channelId string) ([]*mo
 	return result, err
 }
 
+func (s *TimerLayerSharedChannelStore) HasRemote(channelID string) (bool, error) {
+	start := timemodule.Now()
+
+	result, err := s.SharedChannelStore.HasRemote(channelID)
+
+	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("SharedChannelStore.HasRemote", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerSharedChannelStore) Save(sc *model.SharedChannel) (*model.SharedChannel, error) {
 	start := timemodule.Now()
 


### PR DESCRIPTION
We check the store if the remote already exists in the DB.
If it does, we return an error.

https://mattermost.atlassian.net/browse/MM-32033

```release-note
NONE
```
