### PR TITLE
MM-31721: Fix Cache-Control directives

### DIFF
--- a/api4/bot.go
+++ b/api4/bot.go
@@ -293,7 +293,7 @@ func getBotIconImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, public", 24*60*60)) // 24 hrs
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, private", 24*60*60)) // 24 hrs
 	w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 	w.Header().Set("Content-Type", "image/svg+xml")
 	w.Write(img)

--- a/api4/compliance.go
+++ b/api4/compliance.go
@@ -130,7 +130,7 @@ func downloadComplianceReport(c *Context, w http.ResponseWriter, r *http.Request
 
 	c.LogAudit("downloaded " + job.Desc)
 
-	w.Header().Set("Cache-Control", "max-age=2592000, public")
+	w.Header().Set("Cache-Control", "max-age=2592000, private")
 	w.Header().Set("Content-Length", strconv.Itoa(len(reportBytes)))
 	w.Header().Del("Content-Type") // Content-Type will be set automatically by the http writer
 

--- a/api4/emoji.go
+++ b/api4/emoji.go
@@ -240,7 +240,7 @@ func getEmojiImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "image/"+imageType)
-	w.Header().Set("Cache-Control", "max-age=2592000, public")
+	w.Header().Set("Cache-Control", "max-age=2592000, private")
 	w.Write(image)
 }
 

--- a/api4/file.go
+++ b/api4/file.go
@@ -635,7 +635,7 @@ func getFileInfo(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Cache-Control", "max-age=2592000, public")
+	w.Header().Set("Cache-Control", "max-age=2592000, private")
 	w.Write([]byte(info.ToJson()))
 }
 

--- a/api4/post.go
+++ b/api4/post.go
@@ -746,7 +746,7 @@ func getFileInfosForPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Cache-Control", "max-age=2592000, public")
+	w.Header().Set("Cache-Control", "max-age=2592000, private")
 	w.Header().Set(model.HEADER_ETAG_SERVER, model.GetEtagForFileInfos(infos))
 	w.Write([]byte(model.FileInfosToJson(infos)))
 }

--- a/api4/team.go
+++ b/api4/team.go
@@ -1412,7 +1412,7 @@ func getTeamIcon(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "image/png")
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, public", 24*60*60)) // 24 hrs
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, private", 24*60*60)) // 24 hrs
 	w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 	w.Write(img)
 }

--- a/api4/user.go
+++ b/api4/user.go
@@ -368,7 +368,7 @@ func getDefaultProfileImage(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, public", 24*60*60)) // 24 hrs
+	w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, private", 24*60*60)) // 24 hrs
 	w.Header().Set("Content-Type", "image/png")
 	w.Write(img)
 }
@@ -408,9 +408,9 @@ func getProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if readFailed {
-		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, public", 5*60)) // 5 mins
+		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, private", 5*60)) // 5 mins
 	} else {
-		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, public", 24*60*60)) // 24 hrs
+		w.Header().Set("Cache-Control", fmt.Sprintf("max-age=%v, private", 24*60*60)) // 24 hrs
 		w.Header().Set(model.HEADER_ETAG_SERVER, etag)
 	}
 

--- a/web/oauth.go
+++ b/web/oauth.go
@@ -175,7 +175,7 @@ func authorizeOAuthPage(c *Context, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	w.Header().Set("Content-Security-Policy", "frame-ancestors 'self'")
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "no-cache, max-age=31556926, public")
+	w.Header().Set("Cache-Control", "no-cache, max-age=31556926")
 
 	staticDir, _ := fileutils.FindDir(model.CLIENT_DIR)
 	http.ServeFile(w, r, filepath.Join(staticDir, "root.html"))


### PR DESCRIPTION
We were incorrectly setting the cache control to public
when it should be rather private.

https://mattermost.atlassian.net/browse/MM-31721

```release-notes
Fix Cache-Control headers to instruct that responses may only be cached
on browsers.
```
