### PR TITLE
Add unique constraint on remote cluster site id, in order to prevent …

### DIFF
--- a/app/remote_cluster.go
+++ b/app/remote_cluster.go
@@ -6,6 +6,10 @@ package app
 import (
 	"net/http"
 
+	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-server/v5/store/sqlstore"
+
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/services/remotecluster"
 )
@@ -13,6 +17,10 @@ import (
 func (a *App) AddRemoteCluster(rc *model.RemoteCluster) (*model.RemoteCluster, *model.AppError) {
 	rc, err := a.Srv().Store.RemoteCluster().Save(rc)
 	if err != nil {
+		if sqlstore.IsUniqueConstraintError(errors.Cause(err), []string{sqlstore.RemoteClusterSiteURLUniqueIndex}) {
+			return nil, model.NewAppError("AddRemoteCluster", "api.remote_cluster.save_not_unique.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
 		return nil, model.NewAppError("AddRemoteCluster", "api.remote_cluster.save.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	return rc, nil
@@ -21,7 +29,11 @@ func (a *App) AddRemoteCluster(rc *model.RemoteCluster) (*model.RemoteCluster, *
 func (a *App) UpdateRemoteCluster(rc *model.RemoteCluster) (*model.RemoteCluster, *model.AppError) {
 	rc, err := a.Srv().Store.RemoteCluster().Update(rc)
 	if err != nil {
-		return nil, model.NewAppError("UpdateRemoteCluster", "api.remote_cluster.save.app_error", nil, err.Error(), http.StatusInternalServerError)
+		if sqlstore.IsUniqueConstraintError(errors.Cause(err), []string{sqlstore.RemoteClusterSiteURLUniqueIndex}) {
+			return nil, model.NewAppError("UpdateRemoteCluster", "api.remote_cluster.update_not_unique.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		return nil, model.NewAppError("UpdateRemoteCluster", "api.remote_cluster.update.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	return rc, nil
 }

--- a/app/remote_cluster_test.go
+++ b/app/remote_cluster_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+func TestAddRemoteCluster(t *testing.T) {
+	t.Run("adding remote cluster with duplicate site url", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		remoteCluster := &model.RemoteCluster{
+			RemoteTeamId: model.NewId(),
+			DisplayName:  "test",
+			SiteURL:      "http://localhost:8065",
+			Token:        "test",
+			RemoteToken:  "test",
+			Topics:       "",
+			CreatorId:    th.BasicUser.Id,
+		}
+
+		_, err := th.App.AddRemoteCluster(remoteCluster)
+		require.Nil(t, err, "Adding a remote cluster should not error")
+
+		remoteCluster.RemoteId = model.NewId()
+		_, err = th.App.AddRemoteCluster(remoteCluster)
+		assert.Error(t, err, "Adding a duplicate remote cluster should error")
+		assert.Contains(t, err.Error(), "Remote cluster has already been added.")
+	})
+}
+
+func TestUpdateRemoteCluster(t *testing.T) {
+	t.Run("update remote cluster with an already exitsing site url", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		remoteCluster := &model.RemoteCluster{
+			RemoteTeamId: model.NewId(),
+			DisplayName:  "test",
+			SiteURL:      "http://localhost:8065",
+			Token:        "test",
+			RemoteToken:  "test",
+			Topics:       "",
+			CreatorId:    th.BasicUser.Id,
+		}
+
+		otherRemoteCluster := &model.RemoteCluster{
+			RemoteTeamId: model.NewId(),
+			DisplayName:  "test",
+			SiteURL:      "http://localhost:8066",
+			Token:        "test",
+			RemoteToken:  "test",
+			Topics:       "",
+			CreatorId:    th.BasicUser.Id,
+		}
+
+		_, err := th.App.AddRemoteCluster(remoteCluster)
+		require.Nil(t, err, "Adding a remote cluster should not error")
+
+		savedRemoteClustered, err := th.App.AddRemoteCluster(otherRemoteCluster)
+		require.Nil(t, err, "Adding a remote cluster should not error")
+
+		savedRemoteClustered.SiteURL = remoteCluster.SiteURL
+		_, err = th.App.UpdateRemoteCluster(savedRemoteClustered)
+		assert.Error(t, err, "Updating remote cluster with duplicate site url should error")
+		assert.Contains(t, err.Error(), "Remote cluster with the same url already exists.")
+	})
+}

--- a/app/remote_cluster_test.go
+++ b/app/remote_cluster_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAddRemoteCluster(t *testing.T) {
-	t.Run("adding remote cluster with duplicate site url", func(t *testing.T) {
+	t.Run("adding remote cluster with duplicate site url and remote team id", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
@@ -32,13 +32,45 @@ func TestAddRemoteCluster(t *testing.T) {
 
 		remoteCluster.RemoteId = model.NewId()
 		_, err = th.App.AddRemoteCluster(remoteCluster)
-		assert.Error(t, err, "Adding a duplicate remote cluster should error")
+		require.Error(t, err, "Adding a duplicate remote cluster should error")
 		assert.Contains(t, err.Error(), "Remote cluster has already been added.")
+	})
+
+	t.Run("adding remote cluster with duplicate site url or remote team id is allowed", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		remoteCluster := &model.RemoteCluster{
+			RemoteTeamId: model.NewId(),
+			DisplayName:  "test",
+			SiteURL:      "http://localhost:8065",
+			Token:        "test",
+			RemoteToken:  "test",
+			Topics:       "",
+			CreatorId:    th.BasicUser.Id,
+		}
+
+		existingRemoteCluster, err := th.App.AddRemoteCluster(remoteCluster)
+		require.Nil(t, err, "Adding a remote cluster should not error")
+
+		// Same site url but different remote team id
+		remoteCluster.RemoteId = model.NewId()
+		remoteCluster.RemoteTeamId = model.NewId()
+		remoteCluster.SiteURL = existingRemoteCluster.SiteURL
+		_, err = th.App.AddRemoteCluster(remoteCluster)
+		assert.Nil(t, err, "Adding a remote cluster should not error")
+
+		// Same remote team id but different site url
+		remoteCluster.RemoteId = model.NewId()
+		remoteCluster.RemoteTeamId = existingRemoteCluster.RemoteTeamId
+		remoteCluster.SiteURL = existingRemoteCluster.SiteURL + "/new"
+		_, err = th.App.AddRemoteCluster(remoteCluster)
+		assert.Nil(t, err, "Adding a remote cluster should not error")
 	})
 }
 
 func TestUpdateRemoteCluster(t *testing.T) {
-	t.Run("update remote cluster with an already exitsing site url", func(t *testing.T) {
+	t.Run("update remote cluster with an already existing site url and team id", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
@@ -69,8 +101,52 @@ func TestUpdateRemoteCluster(t *testing.T) {
 		require.Nil(t, err, "Adding a remote cluster should not error")
 
 		savedRemoteClustered.SiteURL = remoteCluster.SiteURL
+		savedRemoteClustered.RemoteTeamId = remoteCluster.RemoteTeamId
 		_, err = th.App.UpdateRemoteCluster(savedRemoteClustered)
-		assert.Error(t, err, "Updating remote cluster with duplicate site url should error")
+		require.Error(t, err, "Updating remote cluster with duplicate site url should error")
 		assert.Contains(t, err.Error(), "Remote cluster with the same url already exists.")
+	})
+
+	t.Run("update remote cluster with an already existing site url or team id, is allowed", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		remoteCluster := &model.RemoteCluster{
+			RemoteTeamId: model.NewId(),
+			DisplayName:  "test",
+			SiteURL:      "http://localhost:8065",
+			Token:        "test",
+			RemoteToken:  "test",
+			Topics:       "",
+			CreatorId:    th.BasicUser.Id,
+		}
+
+		otherRemoteCluster := &model.RemoteCluster{
+			RemoteTeamId: model.NewId(),
+			DisplayName:  "test",
+			SiteURL:      "http://localhost:8066",
+			Token:        "test",
+			RemoteToken:  "test",
+			Topics:       "",
+			CreatorId:    th.BasicUser.Id,
+		}
+
+		existingRemoteCluster, err := th.App.AddRemoteCluster(remoteCluster)
+		require.Nil(t, err, "Adding a remote cluster should not error")
+
+		anotherExistingRemoteClustered, err := th.App.AddRemoteCluster(otherRemoteCluster)
+		require.Nil(t, err, "Adding a remote cluster should not error")
+
+		// Same site url but different remote team id
+		anotherExistingRemoteClustered.SiteURL = existingRemoteCluster.SiteURL
+		anotherExistingRemoteClustered.RemoteTeamId = model.NewId()
+		_, err = th.App.UpdateRemoteCluster(anotherExistingRemoteClustered)
+		assert.Nil(t, err, "Updating remote cluster should not error")
+
+		// Same remote team id but different site url
+		anotherExistingRemoteClustered.SiteURL = existingRemoteCluster.SiteURL + "/new"
+		anotherExistingRemoteClustered.RemoteTeamId = existingRemoteCluster.RemoteTeamId
+		_, err = th.App.UpdateRemoteCluster(anotherExistingRemoteClustered)
+		assert.Nil(t, err, "Updating remote cluster should not error")
 	})
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1971,8 +1971,16 @@
     "translation": "We encountered an error saving the remote cluster."
   },
   {
+    "id": "api.remote_cluster.save_not_unique.app_error",
+    "translation": "Remote cluster has already been added."
+  },
+  {
     "id": "api.remote_cluster.service_not_enabled.app_error",
     "translation": "The remote cluster service is not enabled."
+  },
+  {
+    "id": "api.remote_cluster.update_not_unique.app_error",
+    "translation": "Remote cluster with the same url already exists."
   },
   {
     "id": "api.restricted_system_admin",

--- a/store/sqlstore/remote_cluster_store.go
+++ b/store/sqlstore/remote_cluster_store.go
@@ -176,3 +176,7 @@ func (s sqlRemoteClusterStore) SetLastPingAt(remoteClusterId string) error {
 	}
 	return nil
 }
+
+func (s *sqlRemoteClusterStore) createIndexesIfNotExists() {
+	s.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", "siteurl")
+}

--- a/store/sqlstore/remote_cluster_store.go
+++ b/store/sqlstore/remote_cluster_store.go
@@ -178,5 +178,9 @@ func (s sqlRemoteClusterStore) SetLastPingAt(remoteClusterId string) error {
 }
 
 func (s *sqlRemoteClusterStore) createIndexesIfNotExists() {
-	s.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", "siteurl")
+	siteURLColumn := "siteurl"
+	if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
+		siteURLColumn = "siteurl(168)"
+	}
+	s.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", siteURLColumn)
 }

--- a/store/sqlstore/remote_cluster_store.go
+++ b/store/sqlstore/remote_cluster_store.go
@@ -178,9 +178,9 @@ func (s sqlRemoteClusterStore) SetLastPingAt(remoteClusterId string) error {
 }
 
 func (s *sqlRemoteClusterStore) createIndexesIfNotExists() {
-	siteURLColumn := "siteurl"
+	uniquenessColumns := []string{"SiteUrl", "RemoteTeamId"}
 	if s.DriverName() == model.DATABASE_DRIVER_MYSQL {
-		siteURLColumn = "siteurl(168)"
+		uniquenessColumns = []string{"RemoteTeamId", "SiteUrl(168)"}
 	}
-	s.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", siteURLColumn)
+	s.CreateUniqueCompositeIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", uniquenessColumns)
 }

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -238,6 +238,7 @@ func New(settings model.SqlSettings, metrics einterfaces.MetricsInterface) *SqlS
 	store.stores.sharedchannel.(*SqlSharedChannelStore).createIndexesIfNotExists()
 	store.stores.group.(*SqlGroupStore).createIndexesIfNotExists()
 	store.stores.scheme.(*SqlSchemeStore).createIndexesIfNotExists()
+	store.stores.remoteCluster.(*sqlRemoteClusterStore).createIndexesIfNotExists()
 	store.stores.preference.(*SqlPreferenceStore).deleteUnusedFeatures()
 
 	return store

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -968,11 +968,11 @@ func upgradeDatabaseToVersion532(sqlStore *SqlStore) {
 	sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
 	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
 	sqlStore.CreateColumnIfNotExists("ThreadMemberships", "UnreadMentions", "bigint", "bigint", "0")
-	siteURLColumn := "siteurl"
+	uniquenessColumns := []string{"SiteUrl", "RemoteTeamId"}
 	if sqlStore.DriverName() == model.DATABASE_DRIVER_MYSQL {
-		siteURLColumn = "siteurl(168)"
+		uniquenessColumns = []string{"RemoteTeamId", "SiteUrl(168)"}
 	}
-	sqlStore.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", siteURLColumn)
+	sqlStore.CreateUniqueCompositeIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", uniquenessColumns)
 	// saveSchemaVersion(sqlStore, Version5320)
 	// }
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -968,7 +968,11 @@ func upgradeDatabaseToVersion532(sqlStore *SqlStore) {
 	sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
 	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
 	sqlStore.CreateColumnIfNotExists("ThreadMemberships", "UnreadMentions", "bigint", "bigint", "0")
-	sqlStore.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", "siteurl")
+	siteURLColumn := "siteurl"
+	if sqlStore.DriverName() == model.DATABASE_DRIVER_MYSQL {
+		siteURLColumn = "siteurl(168)"
+	}
+	sqlStore.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", siteURLColumn)
 	// saveSchemaVersion(sqlStore, Version5320)
 	// }
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -960,12 +960,15 @@ func upgradeDatabaseToVersion531(sqlStore *SqlStore) {
 	}
 }
 
+const RemoteClusterSiteURLUniqueIndex = "remote_clusters_site_url_unique"
+
 func upgradeDatabaseToVersion532(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, Version5310, Version5320) {
 	// allow 10 files per post
 	sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
 	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
 	sqlStore.CreateColumnIfNotExists("ThreadMemberships", "UnreadMentions", "bigint", "bigint", "0")
+	sqlStore.CreateUniqueIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", "siteurl")
 	// saveSchemaVersion(sqlStore, Version5320)
 	// }
 }


### PR DESCRIPTION
#### Summary
Prevents remote clusters with the same site_url to be created.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32035

#### Release Note
```release-note
NONE
```
