### PR TITLE
Send websocket notification when shared channel state changes

### DIFF
--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -333,6 +333,23 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string, option
 	if channel, appErr = th.App.CreateChannel(channel, true); appErr != nil {
 		panic(appErr)
 	}
+
+	if channel.IsShared() {
+		id := model.NewId()
+		_, err := th.App.SaveSharedChannel(&model.SharedChannel{
+			ChannelId:        channel.Id,
+			TeamId:           channel.TeamId,
+			Home:             false,
+			ReadOnly:         false,
+			ShareName:        "shared-" + id,
+			ShareDisplayName: "shared-" + id,
+			CreatorId:        th.BasicUser.Id,
+			RemoteClusterId:  model.NewId(),
+		})
+		if err != nil {
+			panic(err)
+		}
+	}
 	utils.EnableDebugLogForTest()
 	return channel
 }

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -1927,7 +1927,7 @@ func TestSharedChannelSyncForPostActions(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
-		remoteClusterService := newMockRemoteClusterService(nil)
+		remoteClusterService := NewMockRemoteClusterService(nil)
 		th.App.srv.sharedChannelSyncService = remoteClusterService
 		testCluster := &testlib.FakeClusterInterface{}
 		th.Server.Cluster = testCluster
@@ -1951,7 +1951,7 @@ func TestSharedChannelSyncForPostActions(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
-		remoteClusterService := newMockRemoteClusterService(nil)
+		remoteClusterService := NewMockRemoteClusterService(nil)
 		th.App.srv.sharedChannelSyncService = remoteClusterService
 		testCluster := &testlib.FakeClusterInterface{}
 		th.Server.Cluster = testCluster
@@ -1979,7 +1979,7 @@ func TestSharedChannelSyncForPostActions(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
-		remoteClusterService := newMockRemoteClusterService(nil)
+		remoteClusterService := NewMockRemoteClusterService(nil)
 		th.App.srv.sharedChannelSyncService = remoteClusterService
 		testCluster := &testlib.FakeClusterInterface{}
 		th.Server.Cluster = testCluster

--- a/app/reaction_test.go
+++ b/app/reaction_test.go
@@ -17,7 +17,7 @@ func TestSharedChannelSyncForReactionActions(t *testing.T) {
 	t.Run("adding a reaction in a shared channel performs a content sync when sync service is running on that node", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 
-		remoteClusterService := newMockRemoteClusterService(nil)
+		remoteClusterService := NewMockRemoteClusterService(nil)
 		th.App.srv.sharedChannelSyncService = remoteClusterService
 		testCluster := &testlib.FakeClusterInterface{}
 		th.Server.Cluster = testCluster
@@ -52,7 +52,7 @@ func TestSharedChannelSyncForReactionActions(t *testing.T) {
 	t.Run("removing a reaction in a shared channel performs a content sync when sync service is running on that node", func(t *testing.T) {
 		th := Setup(t).InitBasic()
 
-		remoteClusterService := newMockRemoteClusterService(nil)
+		remoteClusterService := NewMockRemoteClusterService(nil)
 		th.App.srv.sharedChannelSyncService = remoteClusterService
 		testCluster := &testlib.FakeClusterInterface{}
 		th.Server.Cluster = testCluster

--- a/app/server.go
+++ b/app/server.go
@@ -1721,6 +1721,7 @@ func (s *Server) SetRemoteClusterService(remoteClusterService *remotecluster.Ser
 }
 
 // SetSharedChannelSyncService sets the `SharedChannelSyncService` to be used by the server.
+// For testing only.
 func (s *Server) SetSharedChannelSyncService(sharedChannelSyncService SharedChannelServiceIFace) {
 	s.sharedChannelSyncService = sharedChannelSyncService
 }

--- a/app/server.go
+++ b/app/server.go
@@ -1715,6 +1715,7 @@ func (s *Server) GetMetrics() einterfaces.MetricsInterface {
 }
 
 // SetRemoteClusterService sets the `RemoteClusterService` to be used by the server.
+// For testing only. 
 func (s *Server) SetRemoteClusterService(remoteClusterService *remotecluster.Service) {
 	s.remoteClusterService = remoteClusterService
 }

--- a/app/server.go
+++ b/app/server.go
@@ -1713,3 +1713,13 @@ func (s *Server) GetSharedChannelSyncService() SharedChannelServiceIFace {
 func (s *Server) GetMetrics() einterfaces.MetricsInterface {
 	return s.Metrics
 }
+
+// SetRemoteClusterService sets the `RemoteClusterService` to be used by the server.
+func (s *Server) SetRemoteClusterService(remoteClusterService *remotecluster.Service) {
+	s.remoteClusterService = remoteClusterService
+}
+
+// SetSharedChannelSyncService sets the `SharedChannelSyncService` to be used by the server.
+func (s *Server) SetSharedChannelSyncService(sharedChannelSyncService SharedChannelServiceIFace) {
+	s.sharedChannelSyncService = sharedChannelSyncService
+}

--- a/app/server.go
+++ b/app/server.go
@@ -1715,7 +1715,7 @@ func (s *Server) GetMetrics() einterfaces.MetricsInterface {
 }
 
 // SetRemoteClusterService sets the `RemoteClusterService` to be used by the server.
-// For testing only. 
+// For testing only.
 func (s *Server) SetRemoteClusterService(remoteClusterService *remotecluster.Service) {
 	s.remoteClusterService = remoteClusterService
 }

--- a/app/shared_channel_notifier_test.go
+++ b/app/shared_channel_notifier_test.go
@@ -16,7 +16,7 @@ func TestServerSyncSharedChannelHandler(t *testing.T) {
 		th := SetupWithStoreMock(t)
 		defer th.TearDown()
 
-		mockService := newMockRemoteClusterService(nil)
+		mockService := NewMockRemoteClusterService(nil)
 		mockService.active = false
 		th.App.srv.sharedChannelSyncService = mockService
 
@@ -28,7 +28,7 @@ func TestServerSyncSharedChannelHandler(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
-		mockService := newMockRemoteClusterService(nil)
+		mockService := NewMockRemoteClusterService(nil)
 		mockService.active = true
 		th.App.srv.sharedChannelSyncService = mockService
 		channel := th.CreateChannel(th.BasicTeam, WithShared(true))
@@ -43,7 +43,7 @@ func TestServerSyncSharedChannelHandler(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
-		mockService := newMockRemoteClusterService(nil)
+		mockService := NewMockRemoteClusterService(nil)
 		mockService.active = true
 		th.App.srv.sharedChannelSyncService = mockService
 
@@ -57,7 +57,7 @@ func TestServerSyncSharedChannelHandler(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
-		mockService := newMockRemoteClusterService(nil)
+		mockService := NewMockRemoteClusterService(nil)
 		mockService.active = true
 		th.App.srv.sharedChannelSyncService = mockService
 

--- a/app/shared_channel_service_iface.go
+++ b/app/shared_channel_service_iface.go
@@ -14,7 +14,7 @@ type SharedChannelServiceIFace interface {
 	Active() bool
 }
 
-func newMockRemoteClusterService(service SharedChannelServiceIFace) *mockRemoteClusterService {
+func NewMockRemoteClusterService(service SharedChannelServiceIFace) *mockRemoteClusterService {
 	return &mockRemoteClusterService{service, true, []string{}}
 }
 

--- a/app/slashcommands/command_share.go
+++ b/app/slashcommands/command_share.go
@@ -227,9 +227,9 @@ func (sp *ShareProvider) doUnshareChannel(a *app.App, args *model.CommandArgs, m
 		return responsef("Shared channel was not deleted: `are_you_sure` must be `Y`.")
 	}
 
-	sc, errApp := a.GetSharedChannel(args.ChannelId)
-	if errApp != nil {
-		return responsef("Cannot unshare this channel: %v", errApp)
+	sc, appErr := a.GetSharedChannel(args.ChannelId)
+	if appErr != nil {
+		return responsef("Cannot unshare this channel: %v", appErr)
 	}
 
 	deleted, err := a.DeleteSharedChannel(args.ChannelId)

--- a/app/slashcommands/command_share.go
+++ b/app/slashcommands/command_share.go
@@ -211,6 +211,9 @@ func (sp *ShareProvider) doShareChannel(a *app.App, args *model.CommandArgs, mar
 	if _, err := a.SaveSharedChannel(sc); err != nil {
 		return responsef("Could not share this channel: %v", err)
 	}
+
+	notifyClientsForChannelUpdate(a, sc)
+
 	return responsef("##### This channel is now shared.")
 }
 
@@ -224,6 +227,11 @@ func (sp *ShareProvider) doUnshareChannel(a *app.App, args *model.CommandArgs, m
 		return responsef("Shared channel was not deleted: `are_you_sure` must be `Y`.")
 	}
 
+	sc, errApp := a.GetSharedChannel(args.ChannelId)
+	if errApp != nil {
+		return responsef("Cannot unshare this channel: %v", errApp)
+	}
+
 	deleted, err := a.DeleteSharedChannel(args.ChannelId)
 	if err != nil {
 		return responsef("Could not unshare this channel: %v", err)
@@ -231,6 +239,9 @@ func (sp *ShareProvider) doUnshareChannel(a *app.App, args *model.CommandArgs, m
 	if !deleted {
 		return responsef("Cannot unshare a channel that is not shared.")
 	}
+
+	notifyClientsForChannelUpdate(a, sc)
+
 	return responsef("##### This channel is no longer shared.")
 }
 
@@ -332,4 +343,10 @@ func (sp *ShareProvider) doSync(a *app.App, args *model.CommandArgs, margs map[s
 	// TODO: send cluster message to each remote requesting a sync for this channel.
 
 	return responsef("##### Sync initiated.")
+}
+
+func notifyClientsForChannelUpdate(a *app.App, sharedChannel *model.SharedChannel) {
+	messageWs := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_CHANNEL_CONVERTED, sharedChannel.TeamId, "", "", nil)
+	messageWs.Add("channel_id", sharedChannel.ChannelId)
+	a.Publish(messageWs)
 }

--- a/app/slashcommands/command_share_test.go
+++ b/app/slashcommands/command_share_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package slashcommands
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-server/v5/testlib"
+
+	"github.com/mattermost/mattermost-server/v5/app"
+	"github.com/mattermost/mattermost-server/v5/services/remotecluster"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+)
+
+func TestShareProviderDoCommand(t *testing.T) {
+	t.Run("share command sends a websocket channel converted event", func(t *testing.T) {
+		th := setup(t).initBasic()
+		defer th.tearDown()
+
+		th.addPermissionToRole(model.PERMISSION_MANAGE_SHARED_CHANNELS.Id, th.BasicUser.Roles)
+
+		mockSyncService := app.NewMockRemoteClusterService(nil)
+		th.Server.SetSharedChannelSyncService(mockSyncService)
+		mockRemoteCluster, err := remotecluster.NewRemoteClusterService(th.Server)
+		require.NoError(t, err)
+
+		th.Server.SetRemoteClusterService(mockRemoteCluster)
+		testCluster := &testlib.FakeClusterInterface{}
+		th.Server.Cluster = testCluster
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(th.BasicTeam, WithShared(false))
+		args := &model.CommandArgs{
+			T:         func(s string, args ...interface{}) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.BasicUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share share_channel",
+		}
+
+		response := commandProvider.DoCommand(th.App, args, "")
+		require.Equal(t, "##### This channel is now shared.", response.Text)
+
+		channelConvertedMessages := testCluster.SelectMessages(func(msg *model.ClusterMessage) bool {
+			event := model.WebSocketEventFromJson(strings.NewReader(msg.Data))
+			return event != nil && event.EventType() == model.WEBSOCKET_EVENT_CHANNEL_CONVERTED
+		})
+		assert.Len(t, channelConvertedMessages, 1)
+	})
+
+	t.Run("unshare command sends a websocket channel converted event", func(t *testing.T) {
+		th := setup(t).initBasic()
+		defer th.tearDown()
+
+		th.addPermissionToRole(model.PERMISSION_MANAGE_SHARED_CHANNELS.Id, th.BasicUser.Roles)
+
+		mockSyncService := app.NewMockRemoteClusterService(nil)
+		th.Server.SetSharedChannelSyncService(mockSyncService)
+		mockRemoteCluster, err := remotecluster.NewRemoteClusterService(th.Server)
+		require.NoError(t, err)
+
+		th.Server.SetRemoteClusterService(mockRemoteCluster)
+		testCluster := &testlib.FakeClusterInterface{}
+		th.Server.Cluster = testCluster
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(th.BasicTeam, WithShared(true))
+		args := &model.CommandArgs{
+			T:         func(s string, args ...interface{}) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.BasicUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share unshare_channel --are_you_sure Y",
+		}
+
+		response := commandProvider.DoCommand(th.App, args, "")
+		require.Equal(t, "##### This channel is no longer shared.", response.Text)
+
+		channelConvertedMessages := testCluster.SelectMessages(func(msg *model.ClusterMessage) bool {
+			event := model.WebSocketEventFromJson(strings.NewReader(msg.Data))
+			return event != nil && event.EventType() == model.WEBSOCKET_EVENT_CHANNEL_CONVERTED
+		})
+		require.Len(t, channelConvertedMessages, 1)
+	})
+}

--- a/app/slashcommands/helper_test.go
+++ b/app/slashcommands/helper_test.go
@@ -226,15 +226,23 @@ func (th *TestHelper) createUserOrGuest(guest bool) *model.User {
 	return user
 }
 
-func (th *TestHelper) CreateChannel(team *model.Team) *model.Channel {
-	return th.createChannel(team, model.CHANNEL_OPEN)
+type ChannelOption func(*model.Channel)
+
+func WithShared(v bool) ChannelOption {
+	return func(channel *model.Channel) {
+		channel.Shared = model.NewBool(v)
+	}
+}
+
+func (th *TestHelper) CreateChannel(team *model.Team, options ...ChannelOption) *model.Channel {
+	return th.createChannel(team, model.CHANNEL_OPEN, options...)
 }
 
 func (th *TestHelper) createPrivateChannel(team *model.Team) *model.Channel {
 	return th.createChannel(team, model.CHANNEL_PRIVATE)
 }
 
-func (th *TestHelper) createChannel(team *model.Team, channelType string) *model.Channel {
+func (th *TestHelper) createChannel(team *model.Team, channelType string, options ...ChannelOption) *model.Channel {
 	id := model.NewId()
 
 	channel := &model.Channel{
@@ -245,10 +253,31 @@ func (th *TestHelper) createChannel(team *model.Team, channelType string) *model
 		CreatorId:   th.BasicUser.Id,
 	}
 
+	for _, option := range options {
+		option(channel)
+	}
+
 	utils.DisableDebugLogForTest()
 	var err *model.AppError
 	if channel, err = th.App.CreateChannel(channel, true); err != nil {
 		panic(err)
+	}
+
+	if channel.IsShared() {
+		id := model.NewId()
+		_, err := th.App.SaveSharedChannel(&model.SharedChannel{
+			ChannelId:        channel.Id,
+			TeamId:           channel.TeamId,
+			Home:             false,
+			ReadOnly:         false,
+			ShareName:        "shared-" + id,
+			ShareDisplayName: "shared-" + id,
+			CreatorId:        th.BasicUser.Id,
+			RemoteClusterId:  model.NewId(),
+		})
+		if err != nil {
+			panic(err)
+		}
 	}
 	utils.EnableDebugLogForTest()
 	return channel

--- a/testlib/cluster.go
+++ b/testlib/cluster.go
@@ -74,6 +74,19 @@ func (c *FakeClusterInterface) GetMessages() []*model.ClusterMessage {
 	return c.messages
 }
 
+func (c *FakeClusterInterface) SelectMessages(filterCond func(message *model.ClusterMessage) bool) []*model.ClusterMessage {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+
+	filteredMessages := []*model.ClusterMessage{}
+	for _, msg := range c.messages {
+		if filterCond(msg) {
+			filteredMessages = append(filteredMessages, msg)
+		}
+	}
+	return filteredMessages
+}
+
 func (c *FakeClusterInterface) ClearMessages() {
 	c.mut.Lock()
 	defer c.mut.Unlock()


### PR DESCRIPTION
#### Summary
Send websocket notification when channels shared state changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32119

#### Release Note

```release-note
NONE
```

*Note* We probably need to create another ticket for sending the system message that notifies that the channel is now shared or unshared.
