### PR TITLE
When inviting a remote send over the home channel type

### DIFF
--- a/app/shared_channel_service_iface.go
+++ b/app/shared_channel_service_iface.go
@@ -9,8 +9,8 @@ import "github.com/mattermost/mattermost-server/v5/model"
 type SharedChannelServiceIFace interface {
 	Shutdown() error
 	Start() error
-	NotifyChannelChanged(channelId string)
-	SendChannelInvite(channelId string, userId string, description string, rc *model.RemoteCluster) error
+	NotifyChannelChanged(channel string)
+	SendChannelInvite(channel *model.Channel, userId string, description string, rc *model.RemoteCluster) error
 	Active() bool
 }
 

--- a/app/shared_channel_service_iface.go
+++ b/app/shared_channel_service_iface.go
@@ -9,7 +9,7 @@ import "github.com/mattermost/mattermost-server/v5/model"
 type SharedChannelServiceIFace interface {
 	Shutdown() error
 	Start() error
-	NotifyChannelChanged(channel string)
+	NotifyChannelChanged(channelId string)
 	SendChannelInvite(channel *model.Channel, userId string, description string, rc *model.RemoteCluster) error
 	Active() bool
 }

--- a/app/slashcommands/command_share.go
+++ b/app/slashcommands/command_share.go
@@ -268,8 +268,12 @@ func (sp *ShareProvider) doInviteRemote(a *app.App, args *model.CommandArgs, mar
 		return responsef("Remote cluster id is invalid: %v", appErr)
 	}
 
+	channel, errApp := a.GetChannel(args.ChannelId)
+	if errApp != nil {
+		return responsef("Error inviting `%s` to this channel: %v", rc.DisplayName, err)
+	}
 	// send channel invite to remote cluster
-	if err := a.Srv().GetSharedChannelSyncService().SendChannelInvite(args.ChannelId, args.UserId, margs["description"], rc); err != nil {
+	if err := a.Srv().GetSharedChannelSyncService().SendChannelInvite(channel, args.UserId, margs["description"], rc); err != nil {
 		return responsef("Error inviting `%s` to this channel: %v", rc.DisplayName, err)
 	}
 


### PR DESCRIPTION
#### Summary
When creating a channel mirror on remote, respect the home channel's type

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32050

#### Release Note

```release-note
NONE
```
