### PR TITLE
MM-31353: Fix incorrect time truncation logic

### DIFF
--- a/app/product_notices.go
+++ b/app/product_notices.go
@@ -83,12 +83,13 @@ func noticeMatchesConditions(config *model.Config, preferences store.PreferenceS
 
 	// check if notice date range matches current
 	if cnd.DisplayDate != nil {
-		now := time.Now().UTC().Truncate(time.Hour * 24)
+		y, m, d := time.Now().UTC().Date()
+		trunc := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 		c, err2 := date_constraints.NewConstraint(*cnd.DisplayDate)
 		if err2 != nil {
 			return false, errors.Wrapf(err2, "Cannot parse date range %s", *cnd.DisplayDate)
 		}
-		if !c.Check(&now) {
+		if !c.Check(&trunc) {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
As mentioned in the documentation:

> Truncate operates on the time as an absolute duration since the zero time;
    it does not operate on the presentation form of the time. Thus,
    Truncate(Hour) may return a time with a non-zero minute, depending on the
    time's Location.

As a result, truncating for anything more than an hour is buggy and should
not be done. The correct way is to construct the date object using the
day, month and year.

https://mattermost.atlassian.net/browse/MM-31353

```release-notes
Fixed a bug in product notices where a date constraint might
fail to match, and would lead to the notice not being fetched
```
