### PR TITLE
Add the abillity to run db operations asyncronsously

### DIFF
--- a/model/system.go
+++ b/model/system.go
@@ -37,6 +37,7 @@ const (
 	USER_LIMIT_OVERAGE_CYCLE_END_DATE             = "UserLimitOverageCycleEndDate"
 	OVER_USER_LIMIT_FORGIVEN_COUNT                = "OverUserLimitForgivenCount"
 	OVER_USER_LIMIT_LAST_EMAIL_SENT               = "OverUserLimitLastEmailSent"
+	ASYNC_MIGRATION_RUNNER_ID                     = "async_migration_runner_id"
 )
 
 const (

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -6578,16 +6578,16 @@ func (s *OpenTracingLayerSystemStore) GetByName(name string) (*model.System, err
 	return result, err
 }
 
-func (s *OpenTracingLayerSystemStore) InsertIfExists(system *model.System) (*model.System, error) {
+func (s *OpenTracingLayerSystemStore) InsertIfNotExists(system *model.System) (*model.System, error) {
 	origCtx := s.Root.Store.Context()
-	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SystemStore.InsertIfExists")
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SystemStore.InsertIfNotExists")
 	s.Root.Store.SetContext(newCtx)
 	defer func() {
 		s.Root.Store.SetContext(origCtx)
 	}()
 
 	defer span.Finish()
-	result, err := s.SystemStore.InsertIfExists(system)
+	result, err := s.SystemStore.InsertIfNotExists(system)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)
@@ -6684,6 +6684,24 @@ func (s *OpenTracingLayerSystemStore) Update(system *model.System) error {
 	}
 
 	return err
+}
+
+func (s *OpenTracingLayerSystemStore) UpsertWithCond(system *model.System, condArgs map[string]string) (*model.System, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "SystemStore.UpsertWithCond")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.SystemStore.UpsertWithCond(system, condArgs)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
 }
 
 func (s *OpenTracingLayerTeamStore) AnalyticsGetTeamCountForScheme(schemeId string) (int64, error) {

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -32,6 +32,12 @@ func newSqlPreferenceStore(sqlStore *SqlStore) store.PreferenceStore {
 	return s
 }
 
+func (s SqlPreferenceStore) generateAsyncMigrations() []AsyncMigration {
+	return []AsyncMigration{
+		s.deleteUnusedFeatures,
+	}
+}
+
 func (s SqlPreferenceStore) createIndexesIfNotExists() {
 	s.CreateIndexIfNotExists("idx_preferences_user_id", "Preferences", "UserId")
 	s.CreateIndexIfNotExists("idx_preferences_category", "Preferences", "Category")

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -968,7 +968,10 @@ func upgradeDatabaseToVersion532(sqlStore *SqlStore) {
 	sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
 	sqlStore.CreateColumnIfNotExistsNoDefault("Reactions", "UpdateAt", "bigint", "bigint")
 	sqlStore.CreateColumnIfNotExistsNoDefault("Reactions", "DeleteAt", "bigint", "bigint")
-
+	_, _ = sqlStore.System().InsertIfNotExists(&model.System{
+		Name:  model.ASYNC_MIGRATION_RUNNER_ID,
+		Value: "",
+	})
 	// saveSchemaVersion(sqlStore, Version5320)
 	// }
 }

--- a/store/store.go
+++ b/store/store.go
@@ -461,8 +461,9 @@ type SystemStore interface {
 	Get() (model.StringMap, error)
 	GetByName(name string) (*model.System, error)
 	PermanentDeleteByName(name string) (*model.System, error)
-	InsertIfExists(system *model.System) (*model.System, error)
+	InsertIfNotExists(system *model.System) (*model.System, error)
 	SaveOrUpdateWithWarnMetricHandling(system *model.System) error
+	UpsertWithCond(system *model.System, condArgs map[string]string) (*model.System, error)
 }
 
 type WebhookStore interface {

--- a/store/storetest/mocks/SystemStore.go
+++ b/store/storetest/mocks/SystemStore.go
@@ -60,8 +60,8 @@ func (_m *SystemStore) GetByName(name string) (*model.System, error) {
 	return r0, r1
 }
 
-// InsertIfExists provides a mock function with given fields: system
-func (_m *SystemStore) InsertIfExists(system *model.System) (*model.System, error) {
+// InsertIfNotExists provides a mock function with given fields: system
+func (_m *SystemStore) InsertIfNotExists(system *model.System) (*model.System, error) {
 	ret := _m.Called(system)
 
 	var r0 *model.System
@@ -160,4 +160,27 @@ func (_m *SystemStore) Update(system *model.System) error {
 	}
 
 	return r0
+}
+
+// UpsertWithCond provides a mock function with given fields: system, condArgs
+func (_m *SystemStore) UpsertWithCond(system *model.System, condArgs map[string]string) (*model.System, error) {
+	ret := _m.Called(system, condArgs)
+
+	var r0 *model.System
+	if rf, ok := ret.Get(0).(func(*model.System, map[string]string) *model.System); ok {
+		r0 = rf(system, condArgs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.System)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*model.System, map[string]string) error); ok {
+		r1 = rf(system, condArgs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }

--- a/store/storetest/system_store.go
+++ b/store/storetest/system_store.go
@@ -18,7 +18,7 @@ func TestSystemStore(t *testing.T, ss store.Store) {
 	t.Run("", func(t *testing.T) { testSystemStore(t, ss) })
 	t.Run("SaveOrUpdate", func(t *testing.T) { testSystemStoreSaveOrUpdate(t, ss) })
 	t.Run("PermanentDeleteByName", func(t *testing.T) { testSystemStorePermanentDeleteByName(t, ss) })
-	t.Run("InsertIfExists", func(t *testing.T) {
+	t.Run("InsertIfNotExists", func(t *testing.T) {
 		testInsertIfExists(t, ss)
 	})
 	t.Run("SaveOrUpdateWithWarnMetricHandling", func(t *testing.T) { testSystemStoreSaveOrUpdateWithWarnMetricHandling(t, ss) })
@@ -121,13 +121,13 @@ func testInsertIfExists(t *testing.T, ss store.Store) {
 	t.Run("Serial", func(t *testing.T) {
 		s1 := &model.System{Name: model.SYSTEM_CLUSTER_ENCRYPTION_KEY, Value: "somekey"}
 
-		s2, err := ss.System().InsertIfExists(s1)
+		s2, err := ss.System().InsertIfNotExists(s1)
 		require.Nil(t, err)
 		assert.Equal(t, s1.Value, s2.Value)
 
 		s1New := &model.System{Name: model.SYSTEM_CLUSTER_ENCRYPTION_KEY, Value: "anotherKey"}
 
-		s3, err := ss.System().InsertIfExists(s1New)
+		s3, err := ss.System().InsertIfNotExists(s1New)
 		require.Nil(t, err)
 		assert.Equal(t, s1.Value, s3.Value)
 	})
@@ -140,7 +140,7 @@ func testInsertIfExists(t *testing.T, ss store.Store) {
 			defer wg.Done()
 			s1 := &model.System{Name: model.SYSTEM_CLUSTER_ENCRYPTION_KEY, Value: "firstKey"}
 			var err error
-			s2, err = ss.System().InsertIfExists(s1)
+			s2, err = ss.System().InsertIfNotExists(s1)
 			require.Nil(t, err)
 		}()
 
@@ -148,7 +148,7 @@ func testInsertIfExists(t *testing.T, ss store.Store) {
 			defer wg.Done()
 			s1 := &model.System{Name: model.SYSTEM_CLUSTER_ENCRYPTION_KEY, Value: "secondKey"}
 			var err error
-			s3, err = ss.System().InsertIfExists(s1)
+			s3, err = ss.System().InsertIfNotExists(s1)
 			require.Nil(t, err)
 		}()
 		wg.Wait()

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -5946,10 +5946,10 @@ func (s *TimerLayerSystemStore) GetByName(name string) (*model.System, error) {
 	return result, err
 }
 
-func (s *TimerLayerSystemStore) InsertIfExists(system *model.System) (*model.System, error) {
+func (s *TimerLayerSystemStore) InsertIfNotExists(system *model.System) (*model.System, error) {
 	start := timemodule.Now()
 
-	result, err := s.SystemStore.InsertIfExists(system)
+	result, err := s.SystemStore.InsertIfNotExists(system)
 
 	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
 	if s.Root.Metrics != nil {
@@ -5957,7 +5957,7 @@ func (s *TimerLayerSystemStore) InsertIfExists(system *model.System) (*model.Sys
 		if err == nil {
 			success = "true"
 		}
-		s.Root.Metrics.ObserveStoreMethodDuration("SystemStore.InsertIfExists", success, elapsed)
+		s.Root.Metrics.ObserveStoreMethodDuration("SystemStore.InsertIfNotExists", success, elapsed)
 	}
 	return result, err
 }
@@ -6040,6 +6040,22 @@ func (s *TimerLayerSystemStore) Update(system *model.System) error {
 		s.Root.Metrics.ObserveStoreMethodDuration("SystemStore.Update", success, elapsed)
 	}
 	return err
+}
+
+func (s *TimerLayerSystemStore) UpsertWithCond(system *model.System, condArgs map[string]string) (*model.System, error) {
+	start := timemodule.Now()
+
+	result, err := s.SystemStore.UpsertWithCond(system, condArgs)
+
+	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("SystemStore.UpsertWithCond", success, elapsed)
+	}
+	return result, err
 }
 
 func (s *TimerLayerTeamStore) AnalyticsGetTeamCountForScheme(schemeId string) (int64, error) {


### PR DESCRIPTION
#### Summary
A vanilla implementation that will allow us to run database operations in an async way. Is not implementing migrations semantics(like up, down, run etc), but I think is good enough for async index creation on big tables, clean up tasks etc.

*NOTE* If direction wise this looks good, we will need to create a `create index concurrently` function that will allow concurrent index creation within the DB while being executed asynchronously from the server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30186

#### Release Note
```release-note
Allows async database operations to be executed without interfering with server boot up.
```
