### PR TITLE
MM-31391: Add max connection idle timeout to config

### DIFF
--- a/go.tools.mod
+++ b/go.tools.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20201216181404-3faa6075089a // indirect
+	github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20210122154757-d807da7d142a // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/reflog/struct2interface v0.6.1 // indirect
 	github.com/tinylib/msgp v1.1.2 // indirect

--- a/go.tools.sum
+++ b/go.tools.sum
@@ -77,6 +77,8 @@ github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20201013204121-e463fc
 github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20201216181404-3faa6075089a/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
 github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20210103185547-4c12aa739237 h1:w6GQs7SU6abD0QXKoqwd4bpEzNaW1xKwpeftBpIX1Do=
 github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20210103185547-4c12aa739237/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
+github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20210122154757-d807da7d142a h1:H8g7UkbNEpYE6UD7ej8UWp2W9q0eW+7BtvUl1v+bGMc=
+github.com/mattermost/mattermost-utilities/mmgotool v0.0.0-20210122154757-d807da7d142a/go.mod h1:3gKozJI8n2Y/vW37GfnFWAdehGXe5yZlt+HykK6Y3DM=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7467,6 +7467,10 @@
     "translation": "Site name must be less than or equal to {{.MaxLength}} characters."
   },
   {
+    "id": "model.config.is_valid.sql_conn_max_idle_time_milliseconds.app_error",
+    "translation": "Invalid connection maximum idle time for SQL settings. Must be a non-negative number."
+  },
+  {
     "id": "model.config.is_valid.sql_conn_max_lifetime_milliseconds.app_error",
     "translation": "Invalid connection maximum lifetime for SQL settings. Must be a non-negative number."
   },

--- a/model/config.go
+++ b/model/config.go
@@ -3247,7 +3247,7 @@ func (s *SqlSettings) isValid() *AppError {
 	}
 
 	if *s.ConnMaxIdleTimeMilliseconds < 0 {
-		return NewAppError("Config.IsValid", "model.config.is_valid.sql_conn_max_lifetime_milliseconds.app_error", nil, "", http.StatusBadRequest)
+		return NewAppError("Config.IsValid", "model.config.is_valid.sql_conn_max_idle_time_milliseconds.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	if *s.QueryTimeout <= 0 {

--- a/model/config.go
+++ b/model/config.go
@@ -1091,6 +1091,7 @@ type SqlSettings struct {
 	DataSourceSearchReplicas    []string `access:"environment,write_restrictable,cloud_restrictable"`
 	MaxIdleConns                *int     `access:"environment,write_restrictable,cloud_restrictable"`
 	ConnMaxLifetimeMilliseconds *int     `access:"environment,write_restrictable,cloud_restrictable"`
+	ConnMaxIdleTimeMilliseconds *int     `access:"environment,write_restrictable,cloud_restrictable"`
 	MaxOpenConns                *int     `access:"environment,write_restrictable,cloud_restrictable"`
 	Trace                       *bool    `access:"environment,write_restrictable,cloud_restrictable"`
 	AtRestEncryptKey            *string  `access:"environment,write_restrictable,cloud_restrictable"`
@@ -1135,6 +1136,10 @@ func (s *SqlSettings) SetDefaults(isUpdate bool) {
 
 	if s.ConnMaxLifetimeMilliseconds == nil {
 		s.ConnMaxLifetimeMilliseconds = NewInt(3600000)
+	}
+
+	if s.ConnMaxIdleTimeMilliseconds == nil {
+		s.ConnMaxIdleTimeMilliseconds = NewInt(300000)
 	}
 
 	if s.Trace == nil {
@@ -3238,6 +3243,10 @@ func (s *SqlSettings) isValid() *AppError {
 	}
 
 	if *s.ConnMaxLifetimeMilliseconds < 0 {
+		return NewAppError("Config.IsValid", "model.config.is_valid.sql_conn_max_lifetime_milliseconds.app_error", nil, "", http.StatusBadRequest)
+	}
+
+	if *s.ConnMaxIdleTimeMilliseconds < 0 {
 		return NewAppError("Config.IsValid", "model.config.is_valid.sql_conn_max_lifetime_milliseconds.app_error", nil, "", http.StatusBadRequest)
 	}
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -474,6 +474,7 @@ func (ts *TelemetryService) trackConfig() {
 		"trace":                          cfg.SqlSettings.Trace,
 		"max_idle_conns":                 *cfg.SqlSettings.MaxIdleConns,
 		"conn_max_lifetime_milliseconds": *cfg.SqlSettings.ConnMaxLifetimeMilliseconds,
+		"conn_max_idletime_milliseconds": *cfg.SqlSettings.ConnMaxIdleTimeMilliseconds,
 		"max_open_conns":                 *cfg.SqlSettings.MaxOpenConns,
 		"data_source_replicas":           len(cfg.SqlSettings.DataSourceReplicas),
 		"data_source_search_replicas":    len(cfg.SqlSettings.DataSourceSearchReplicas),

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -268,6 +268,7 @@ func setupConnection(con_type string, dataSource string, settings *model.SqlSett
 	db.SetMaxIdleConns(*settings.MaxIdleConns)
 	db.SetMaxOpenConns(*settings.MaxOpenConns)
 	db.SetConnMaxLifetime(time.Duration(*settings.ConnMaxLifetimeMilliseconds) * time.Millisecond)
+	db.SetConnMaxIdleTime(time.Duration(*settings.ConnMaxIdleTimeMilliseconds) * time.Millisecond)
 
 	var dbmap *gorp.DbMap
 

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -515,6 +515,7 @@ func makeSqliteSettings() *model.SqlSettings {
 	dataSource := ":memory:"
 	maxIdleConns := 1
 	connMaxLifetimeMilliseconds := 3600000
+	connMaxIdleTimeMilliseconds := 300000
 	maxOpenConns := 1
 	queryTimeout := 5
 
@@ -523,6 +524,7 @@ func makeSqliteSettings() *model.SqlSettings {
 		DataSource:                  &dataSource,
 		MaxIdleConns:                &maxIdleConns,
 		ConnMaxLifetimeMilliseconds: &connMaxLifetimeMilliseconds,
+		ConnMaxIdleTimeMilliseconds: &connMaxIdleTimeMilliseconds,
 		MaxOpenConns:                &maxOpenConns,
 		QueryTimeout:                &queryTimeout,
 	}

--- a/store/storetest/settings.go
+++ b/store/storetest/settings.go
@@ -133,6 +133,7 @@ func databaseSettings(driver, dataSource string) *model.SqlSettings {
 		DataSourceSearchReplicas:    []string{},
 		MaxIdleConns:                new(int),
 		ConnMaxLifetimeMilliseconds: new(int),
+		ConnMaxIdleTimeMilliseconds: new(int),
 		MaxOpenConns:                new(int),
 		Trace:                       model.NewBool(false),
 		AtRestEncryptKey:            model.NewString(model.NewRandomString(32)),
@@ -140,6 +141,7 @@ func databaseSettings(driver, dataSource string) *model.SqlSettings {
 	}
 	*settings.MaxIdleConns = 10
 	*settings.ConnMaxLifetimeMilliseconds = 3600000
+	*settings.ConnMaxIdleTimeMilliseconds = 300000
 	*settings.MaxOpenConns = 100
 	*settings.QueryTimeout = 60
 


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-31391

```release-note
A new config field called `ConnMaxIdleTimeMilliseconds` was added to `DatabaseSettings` which allows to control the maximum time a database connection can remain idle. The default value is set to 5 minutes.
```

Closes https://github.com/mattermost/mattermost-server/issues/16601