### PR TITLE
[MM-32253] Fix "Cannot mark unread a DM message in a thread"

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -830,7 +830,7 @@ func (a *App) getGroupsAllowedForReferenceInChannel(channel *model.Channel, team
 	groupsMap := make(map[string]*model.Group)
 	opts := model.GroupSearchOpts{FilterAllowReference: true}
 
-	if channel.IsGroupConstrained() || team.IsGroupConstrained() {
+	if channel.IsGroupConstrained() || (team != nil && team.IsGroupConstrained()) {
 		var groups []*model.GroupWithSchemeAdmin
 		if channel.IsGroupConstrained() {
 			groups, err = a.Srv().Store.Group().GetGroupsByChannel(channel.Id, opts)

--- a/app/post.go
+++ b/app/post.go
@@ -1343,10 +1343,6 @@ func (a *App) MaxPostSize() int {
 
 // countThreadMentions returns the number of times the user is mentioned in a specified thread after the timestamp.
 func (a *App) countThreadMentions(user *model.User, post *model.Post, teamId string, timestamp int64) (int64, *model.AppError) {
-	team, err := a.GetTeam(teamId)
-	if err != nil {
-		return 0, err
-	}
 	channel, err := a.GetChannel(post.ChannelId)
 	if err != nil {
 		return 0, err
@@ -1377,6 +1373,11 @@ func (a *App) countThreadMentions(user *model.User, post *model.Post, teamId str
 		}
 
 		return int64(count), nil
+	}
+
+	team, err := a.GetTeam(teamId)
+	if err != nil {
+		return 0, err
 	}
 
 	groups, nErr := a.getGroupsAllowedForReferenceInChannel(channel, team)

--- a/app/post.go
+++ b/app/post.go
@@ -1375,9 +1375,12 @@ func (a *App) countThreadMentions(user *model.User, post *model.Post, teamId str
 		return int64(count), nil
 	}
 
-	team, err := a.GetTeam(teamId)
-	if err != nil {
-		return 0, err
+	var team *model.Team
+	if teamId != "" {
+		team, err = a.GetTeam(teamId)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	groups, nErr := a.getGroupsAllowedForReferenceInChannel(channel, team)


### PR DESCRIPTION
#### Summary
When marking a channel post unread, if there is a rootID, we do some extra checks. Among those checks, is counting the thread mentions. We used to check the team at the beginning of this function, but since DMs don't have a team, it failed. We moved the team check after the DM check to avoid this error.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32253

#### Release Note
```release-note
NONE
```
