### PR TITLE
[MM-31731] Fix cleanup threads to properly handle not found errors

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -2106,7 +2106,8 @@ func (s *SqlPostStore) cleanupThreads(postId, rootId, userId string, permanent b
 	if rootId != "" {
 		thread, err := s.Thread().Get(rootId)
 		if err != nil {
-			if err != sql.ErrNoRows {
+			var nfErr *store.ErrNotFound
+			if !errors.As(err, &nfErr) {
 				return errors.Wrap(err, "failed to get a thread")
 			}
 		}


### PR DESCRIPTION
#### Summary
At this point, we were checking for `sql.ErrNoRows` instead of a `NotFoundErr`. Since the underlying function (`Thread().Get()`) is already transforming the ErrNoRows into a NotFoundErr, this check was failing.

This mainly caused that permanent deleting users or channels failed on previous versions (e.g. 5.29.1).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31731

#### Release Note
```release-note
NONE
```
