### PR TITLE
[MM-32389] Fix FeatureFlags section erroneously getting written to config

### DIFF
--- a/config/common_test.go
+++ b/config/common_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 )
 
-var emptyConfig, readOnlyConfig, minimalConfig, invalidConfig, fixesRequiredConfig, ldapConfig, testConfig, customConfigDefaults *model.Config
+var emptyConfig, readOnlyConfig, minimalConfig, minimalConfigNoFF, invalidConfig, fixesRequiredConfig, ldapConfig, testConfig, customConfigDefaults *model.Config
 
 func init() {
 	emptyConfig = &model.Config{}
@@ -39,7 +39,12 @@ func init() {
 			DefaultClientLocale: sToP("en"),
 		},
 	}
+
 	minimalConfig.SetDefaults()
+
+	minimalConfigNoFF = minimalConfig.Clone()
+	minimalConfigNoFF.FeatureFlags = nil
+
 	invalidConfig = &model.Config{
 		ServiceSettings: model.ServiceSettings{
 			SiteURL: sToP("invalid"),

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -924,11 +924,35 @@ func TestFileStoreWatcherEmitter(t *testing.T) {
 		fs.AddListener(callback)
 
 		// Rewrite the config to the file on disk
-		cfgData, err := config.MarshalConfig(emptyConfig)
+		cfgData, err := config.MarshalConfig(minimalConfig)
 		require.NoError(t, err)
 
 		ioutil.WriteFile(path, cfgData, 0644)
 		require.True(t, wasCalled(called, 5*time.Second), "callback should have been called when config written")
+	})
+
+	t.Run("no change", func(t *testing.T) {
+		path, tearDown := setupConfigFile(t, minimalConfig)
+		defer tearDown()
+		fsInner, err := config.NewFileStore(path, false)
+		require.NoError(t, err)
+		fs, err := config.NewStoreFromBacking(fsInner, nil, false)
+		require.NoError(t, err)
+		defer fs.Close()
+
+		// Let the initial call to invokeConfigListeners finish.
+		time.Sleep(1 * time.Second)
+
+		called := make(chan bool, 1)
+		callback := func(oldfg, newCfg *model.Config) {
+			called <- true
+		}
+		fs.AddListener(callback)
+
+		_, err = fs.Set(minimalConfig)
+		require.NoError(t, err)
+
+		require.False(t, wasCalled(called, 1*time.Second), "callback should not have been called since no change has happened")
 	})
 }
 

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -119,7 +119,7 @@ func TestFileStoreNew(t *testing.T) {
 	})
 
 	t.Run("absolute path, already minimally configured", func(t *testing.T) {
-		path, tearDown := setupConfigFile(t, minimalConfig)
+		path, tearDown := setupConfigFile(t, minimalConfigNoFF)
 		defer tearDown()
 
 		fs, err := config.NewFileStore(path, false)
@@ -129,11 +129,11 @@ func TestFileStoreNew(t *testing.T) {
 		defer configStore.Close()
 
 		assert.Equal(t, "http://minimal", *configStore.Get().ServiceSettings.SiteURL)
-		assertFileEqualsConfig(t, minimalConfig, path)
+		assertFileEqualsConfig(t, minimalConfigNoFF, path)
 	})
 
 	t.Run("absolute path, already minimally configured, with custom defaults", func(t *testing.T) {
-		path, tearDown := setupConfigFile(t, minimalConfig)
+		path, tearDown := setupConfigFile(t, minimalConfigNoFF)
 		defer tearDown()
 
 		fs, err := config.NewFileStore(path, false)
@@ -146,7 +146,7 @@ func TestFileStoreNew(t *testing.T) {
 		// defaults should have no effect
 		assert.Equal(t, "http://minimal", *configStore.Get().ServiceSettings.SiteURL)
 		assert.NotEqual(t, *customConfigDefaults.DisplaySettings.ExperimentalTimezone, *configStore.Get().DisplaySettings.ExperimentalTimezone)
-		assertFileEqualsConfig(t, minimalConfig, path)
+		assertFileEqualsConfig(t, minimalConfigNoFF, path)
 	})
 
 	t.Run("absolute path, file does not exist", func(t *testing.T) {

--- a/config/store.go
+++ b/config/store.go
@@ -214,6 +214,8 @@ func (s *Store) loadLockedWithOld(oldCfg *model.Config, unlockOnce *sync.Once) e
 		}
 	}
 
+	loadedFeatureFlags := loadedConfig.FeatureFlags
+
 	// If we have custom defaults set, the initial config is merged on
 	// top of them and we delete them not to be used again in the
 	// configuration reloads
@@ -257,7 +259,7 @@ func (s *Store) loadLockedWithOld(oldCfg *model.Config, unlockOnce *sync.Once) e
 		// MM cloud uses config in the DB as a cache of the feature flag
 		// settings in case the management system is down when a pod starts.
 		if !s.persistFeatureFlags {
-			s.configNoEnv.FeatureFlags = nil
+			s.configNoEnv.FeatureFlags = loadedFeatureFlags
 		}
 		toStoreBytes, err := json.Marshal(s.configNoEnv)
 		if err != nil {


### PR DESCRIPTION
#### Summary

PR fixes an issue where the `FeatureFlags` section of the config was getting written back to the store even when `persistFeatureFlags = false` by adding to `loadLockedWithOld()` the same check present in `Set()` to avoid persisting the change.

#### Ticket

https://mattermost.atlassian.net/browse/MM-32389

#### Release Note

```release-note
Fixed FeatureFlags section erroneously getting written to config.
```