### PR TITLE
MM-30728: Don't allow access token creation for another user

### DIFF
--- a/api4/user_local.go
+++ b/api4/user_local.go
@@ -34,7 +34,6 @@ func (api *API) InitUserLocal() {
 
 	api.BaseRoutes.Users.Handle("/tokens/revoke", api.ApiLocal(revokeUserAccessToken)).Methods("POST")
 	api.BaseRoutes.User.Handle("/tokens", api.ApiLocal(getUserAccessTokensForUser)).Methods("GET")
-	api.BaseRoutes.User.Handle("/tokens", api.ApiLocal(createUserAccessToken)).Methods("POST")
 
 	api.BaseRoutes.Users.Handle("/migrate_auth/ldap", api.ApiLocal(migrateAuthToLDAP)).Methods("POST")
 	api.BaseRoutes.Users.Handle("/migrate_auth/saml", api.ApiLocal(migrateAuthToSaml)).Methods("POST")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3219,6 +3219,10 @@
     "translation": "The email you provided does not belong to an accepted domain. Please contact your administrator or sign up with a different email."
   },
   {
+    "id": "api.user.create_token.forbidden.app_error",
+    "translation": "You cannot create an access token for another user."
+  },
+  {
     "id": "api.user.create_user.disabled.app_error",
     "translation": "User creation is disabled."
   },


### PR DESCRIPTION

#### Summary
A system admin is able to create a token for a user. That token could then be used by the admin to impersonate another user.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30728

#### Release Note
```release-note
System Admins can no longer create access tokens for other users (breaking).
```
