### PR TITLE
MM-32553 hard delete channel when channel invite fails

### DIFF
--- a/services/sharedchannel/channelinvite.go
+++ b/services/sharedchannel/channelinvite.go
@@ -158,7 +158,7 @@ func (scs *Service) onReceiveChannelInvite(msg model.RemoteClusterMsg, rc *model
 	}
 
 	if _, err := scs.server.GetStore().SharedChannel().Save(sharedChannel); err != nil {
-		scs.app.DeleteChannel(channel, channel.CreatorId)
+		scs.app.PermanentDeleteChannel(channel)
 		return fmt.Errorf("cannot create shared channel (channel_id=%s): %w", invite.ChannelId, err)
 	}
 
@@ -173,7 +173,7 @@ func (scs *Service) onReceiveChannelInvite(msg model.RemoteClusterMsg, rc *model
 	}
 
 	if _, err := scs.server.GetStore().SharedChannel().SaveRemote(sharedChannelRemote); err != nil {
-		scs.app.DeleteChannel(channel, channel.CreatorId)
+		scs.app.PermanentDeleteChannel(channel)
 		scs.server.GetStore().SharedChannel().Delete(sharedChannel.ChannelId)
 		return fmt.Errorf("cannot create shared channel remote (channel_id=%s): %w", invite.ChannelId, err)
 	}

--- a/services/sharedchannel/mock_AppIface_test.go
+++ b/services/sharedchannel/mock_AppIface_test.go
@@ -105,22 +105,6 @@ func (_m *MockAppIface) CreatePost(post *model.Post, channel *model.Channel, tri
 	return r0, r1
 }
 
-// DeleteChannel provides a mock function with given fields: channel, userId
-func (_m *MockAppIface) DeleteChannel(channel *model.Channel, userId string) *model.AppError {
-	ret := _m.Called(channel, userId)
-
-	var r0 *model.AppError
-	if rf, ok := ret.Get(0).(func(*model.Channel, string) *model.AppError); ok {
-		r0 = rf(channel, userId)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.AppError)
-		}
-	}
-
-	return r0
-}
-
 // DeleteReactionForPost provides a mock function with given fields: reaction
 func (_m *MockAppIface) DeleteReactionForPost(reaction *model.Reaction) *model.AppError {
 	ret := _m.Called(reaction)
@@ -160,6 +144,22 @@ func (_m *MockAppIface) PatchChannelModerationsForChannel(channel *model.Channel
 	}
 
 	return r0, r1
+}
+
+// PermanentDeleteChannel provides a mock function with given fields: channel
+func (_m *MockAppIface) PermanentDeleteChannel(channel *model.Channel) *model.AppError {
+	ret := _m.Called(channel)
+
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(*model.Channel) *model.AppError); ok {
+		r0 = rf(channel)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
+		}
+	}
+
+	return r0
 }
 
 // SaveReactionForPost provides a mock function with given fields: reaction

--- a/services/sharedchannel/service.go
+++ b/services/sharedchannel/service.go
@@ -45,7 +45,7 @@ type AppIface interface {
 	CreateChannelWithUser(channel *model.Channel, userId string) (*model.Channel, *model.AppError)
 	AddUserToChannel(user *model.User, channel *model.Channel) (*model.ChannelMember, *model.AppError)
 	AddUserToTeamByTeamId(teamId string, user *model.User) *model.AppError
-	DeleteChannel(channel *model.Channel, userId string) *model.AppError
+	PermanentDeleteChannel(channel *model.Channel) *model.AppError
 	CreatePost(post *model.Post, channel *model.Channel, triggerWebhooks bool, setOnline bool) (savedPost *model.Post, err *model.AppError)
 	UpdatePost(post *model.Post, safeUpdate bool) (*model.Post, *model.AppError)
 	SaveReactionForPost(reaction *model.Reaction) (*model.Reaction, *model.AppError)


### PR DESCRIPTION

#### Summary
When accepting a channel invite a new channel is created. If the subsequent creation of `SharedChannelRemote` fails then the new channel is deleted.

Previously the channel was soft deleted.   This PR changes that to permanent delete the channel otherwise a retry will fail due to id collision.

**To be merged with feature branch**

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32553

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
