### PR TITLE
Avoid possible false possitives when generating team names

### DIFF
--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -411,7 +411,7 @@ func testSchemeStoreDelete(t *testing.T, ss store.Store) {
 	assert.Nil(t, err)
 
 	t4 := &model.Team{
-		Name:        model.NewId(),
+		Name:        "xx" + model.NewId(),
 		DisplayName: model.NewId(),
 		Email:       MakeEmail(),
 		Type:        model.TEAM_OPEN,


### PR DESCRIPTION
#### Summary
There is a potential collision with our team reserved words on the scheme tests when generating team Names. We can have a name that starts with `mfa` which is a reserved word.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32236

#### Release Note
-->
```release-note
NONE
```
