### PR TITLE
[MM-31369] Fix racy TestFileStoreWatcherEmitter/enabled

### DIFF
--- a/config/file_test.go
+++ b/config/file_test.go
@@ -927,7 +927,12 @@ func TestFileStoreWatcherEmitter(t *testing.T) {
 		cfgData, err := config.MarshalConfig(minimalConfig)
 		require.NoError(t, err)
 
-		ioutil.WriteFile(path, cfgData, 0644)
+		f, err := os.OpenFile(path, os.O_WRONLY, 0644)
+		require.NoError(t, err)
+		defer f.Close()
+		_, err = f.Write(cfgData)
+		require.NoError(t, err)
+
 		require.True(t, wasCalled(called, 5*time.Second), "callback should have been called when config written")
 	})
 


### PR DESCRIPTION
#### Summary

PR fixes a race condition occurring in `TestFileStoreWatcherEmitter/enabled`.

The race is triggered by the underlying file (inotify) watcher receiving two `WRITE` events at the same time.
This in turn means spawning two callback goroutines doing the same thing, racing to a finish and eventually writing/reading the `fs.watcher` concurrently.

The reason `ioutil.WriteFile` causes this odd behaviour seems to lie in the use of the `os.O_TRUNC` flag when opening the file.
I've tried using a simple `os.OpenFile` with `os.O_WRONLY` + a `file.Write` (essentially decomposing what `ioutil.WriteFile` does but without `os.O_TRUNC`) and I cannot reproduce the duplicate event any longer. I am guessing the `os.O_TRUNC` is causing an additional write at the OS level.

#### Ticket

https://mattermost.atlassian.net/browse/MM-31369

#### Release Note

```release-note
NONE
```