### PR TITLE
MM31503 - screen to restrict access because workspace capacity

### DIFF
--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -35,7 +35,7 @@ func (api *API) InitCloud() {
 	api.BaseRoutes.Cloud.Handle("/subscription", api.ApiSessionRequired(getSubscription)).Methods("GET")
 	api.BaseRoutes.Cloud.Handle("/subscription/invoices", api.ApiSessionRequired(getInvoicesForSubscription)).Methods("GET")
 	api.BaseRoutes.Cloud.Handle("/subscription/invoices/{invoice_id:in_[A-Za-z0-9]+}/pdf", api.ApiSessionRequired(getSubscriptionInvoicePDF)).Methods("GET")
-	api.BaseRoutes.Cloud.Handle("/subscription/stats", api.ApiSessionRequired(getSubscriptionStats)).Methods("GET")
+	api.BaseRoutes.Cloud.Handle("/subscription/stats", api.ApiHandler(getSubscriptionStats)).Methods("GET")
 
 	// POST /api/v4/cloud/webhook
 	api.BaseRoutes.Cloud.Handle("/webhook", api.CloudApiKeyRequired(handleCWSWebhook)).Methods("POST")


### PR DESCRIPTION
#### Summary
This PR removes the session required from the /subscription/stats so it can be used to retrieve subscription information when users try to join a workspace via the invitation link and then decide if the user can join or not based on the stats information

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-31503

#### Release Note
```release-note
Removed session requered restriction from, GET api/v4/subscription/stats
```

