### PR TITLE
Set required go version to 1.15

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-server/v5
 
-go 1.14
+go 1.15
 
 require (
 	code.sajari.com/docconv v1.1.1-0.20200701232649-d9ea05fbd50a


### PR DESCRIPTION
#### Summary
`SetConnMaxIdleTime` was added in go 1.15 so we need to upgrade it in the module.

This method is being used [here](https://github.com/mattermost/mattermost-server/blob/2846ad9f934c72109976a118e7336e26c33aeb43/store/sqlstore/store.go#L271)

#### Ticket Link

NONE

#### Release Note

```release-note
NONE
```

