### PR TITLE
[MM-32521] remove local socket file if it already exists

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -1182,10 +1182,8 @@ func (s *Server) startLocalModeServer() error {
 	}
 
 	socket := *s.configStore.Get().ServiceSettings.LocalModeSocketLocation
-	if _, err := os.Stat(socket); !os.IsNotExist(err) {
-		if err = os.Remove(socket); err != nil {
-			return errors.Wrapf(err, utils.T("api.server.start_server.starting.critical"), err)
-		}
+	if err := os.RemoveAll(socket); err != nil {
+		return errors.Wrapf(err, utils.T("api.server.start_server.starting.critical"), err)
 	}
 
 	unixListener, err := net.Listen("unix", socket)

--- a/app/server.go
+++ b/app/server.go
@@ -1182,6 +1182,12 @@ func (s *Server) startLocalModeServer() error {
 	}
 
 	socket := *s.configStore.Get().ServiceSettings.LocalModeSocketLocation
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		if err = os.Remove(socket); err != nil {
+			return errors.Wrapf(err, utils.T("api.server.start_server.starting.critical"), err)
+		}
+	}
+
 	unixListener, err := net.Listen("unix", socket)
 	if err != nil {
 		return errors.Wrapf(err, utils.T("api.server.start_server.starting.critical"), err)


### PR DESCRIPTION

#### Summary
Sometimes we fail to remove local socket file (e.g. when server crashes). In such cases if we detect that the file already exists, we simply remove it and continue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32521

#### Release Note

```release-note
NONE
```

