### PR TITLE
Close search replicas on store close

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1017,6 +1017,10 @@ func (ss *SqlStore) Close() {
 	for _, replica := range ss.replicas {
 		replica.Db.Close()
 	}
+
+	for _, replica := range ss.searchReplicas {
+		replica.Db.Close()
+	}
 }
 
 func (ss *SqlStore) LockToMaster() {

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -166,9 +166,6 @@ func TestStoreLicenseRace(t *testing.T) {
 	store := New(*settings, nil)
 	defer func() {
 		store.Close()
-		for _, replica := range store.searchReplicas {
-			require.NoError(t, replica.Db.Close())
-		}
 		storetest.CleanupSqlSettings(settings)
 	}()
 
@@ -267,9 +264,6 @@ func TestGetReplica(t *testing.T) {
 			store := New(*settings, nil)
 			defer func() {
 				store.Close()
-				for _, replica := range store.searchReplicas {
-					require.NoError(t, replica.Db.Close())
-				}
 				storetest.CleanupSqlSettings(settings)
 			}()
 
@@ -341,9 +335,6 @@ func TestGetReplica(t *testing.T) {
 			store := New(*settings, nil)
 			defer func() {
 				store.Close()
-				for _, replica := range store.searchReplicas {
-					require.NoError(t, replica.Db.Close())
-				}
 				storetest.CleanupSqlSettings(settings)
 			}()
 
@@ -497,9 +488,6 @@ func TestGetAllConns(t *testing.T) {
 			store := New(*settings, nil)
 			defer func() {
 				store.Close()
-				for _, replica := range store.searchReplicas {
-					require.NoError(t, replica.Db.Close())
-				}
 				storetest.CleanupSqlSettings(settings)
 			}()
 


### PR DESCRIPTION
#### Summary
Close any opened searchReplicas on store close.

#### Ticket Link
N/A

#### Release Note
```release-note
* Close searchReplicas on store.Close()
```
