### PR TITLE
MM-32395 Display what roles a user already has after updating their roles

### DIFF
--- a/cmd/mattermost/commands/roles_test.go
+++ b/cmd/mattermost/commands/roles_test.go
@@ -14,16 +14,19 @@ func TestAssignRole(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	th.CheckCommand(t, "roles", "system_admin", th.BasicUser.Email)
+	output := th.CheckCommand(t, "roles", "system_admin", th.BasicUser.Email)
 
 	user, err := th.App.Srv().Store.User().GetByEmail(th.BasicUser.Email)
 	require.NoError(t, err)
 	assert.Equal(t, "system_user system_admin", user.Roles)
+	assert.Contains(t, output, user.Email, "should have the user email")
+	assert.Contains(t, output, "system_user, system_admin", "should have the user roles")
 
-	th.CheckCommand(t, "roles", "member", th.BasicUser.Email)
+	output = th.CheckCommand(t, "roles", "member", th.BasicUser.Email)
 
 	user, err = th.App.Srv().Store.User().GetByEmail(th.BasicUser.Email)
 	require.NoError(t, err)
 	assert.Equal(t, "system_user", user.Roles)
-
+	assert.Contains(t, output, user.Email, "should have the user email")
+	assert.Contains(t, output, "system_user", "should have the user roles")
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Display user roles after updating their roles in command line.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/16973
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```