### PR TITLE
Log intentionally unsent notifications as DEBUG

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -348,7 +348,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 				)
 			} else {
 				// register that a notification was not sent
-				a.NotificationsLog().Warn("Notification not sent",
+				a.NotificationsLog().Debug("Notification not sent",
 					mlog.String("ackId", ""),
 					mlog.String("type", model.PUSH_TYPE_MESSAGE),
 					mlog.String("userId", id),
@@ -380,7 +380,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 					)
 				} else {
 					// register that a notification was not sent
-					a.NotificationsLog().Warn("Notification not sent",
+					a.NotificationsLog().Debug("Notification not sent",
 						mlog.String("ackId", ""),
 						mlog.String("type", model.PUSH_TYPE_MESSAGE),
 						mlog.String("userId", id),


### PR DESCRIPTION
#### Summary

When a push notification is not sent because of a user's preferences, a log message is written noting this. Currently, the message is written at `WARN` level. Since this is expected behavior, however, this is an inappropriate log level for the message. This changes the log level for these messages to `DEBUG`.

#### Release Note

```release-note
NONE
```