### PR TITLE
[MM-32348] services/bleve: only log update conf when there is an actual change

### DIFF
--- a/services/searchengine/bleveengine/bleve.go
+++ b/services/searchengine/bleveengine/bleve.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -303,7 +304,9 @@ func (b *BleveEngine) UpdateConfig(cfg *model.Config) {
 	b.Mutex.Lock()
 	defer b.Mutex.Unlock()
 
-	mlog.Info("UpdateConf Bleve")
+	if !reflect.DeepEqual(cfg.BleveSettings, b.cfg.BleveSettings) {
+		mlog.Info("UpdateConf Bleve")
+	}
 
 	if *cfg.BleveSettings.EnableIndexing != *b.cfg.BleveSettings.EnableIndexing || *cfg.BleveSettings.IndexDir != *b.cfg.BleveSettings.IndexDir {
 		if err := b.closeIndexes(); err != nil {

--- a/services/searchengine/bleveengine/bleve.go
+++ b/services/searchengine/bleveengine/bleve.go
@@ -304,9 +304,11 @@ func (b *BleveEngine) UpdateConfig(cfg *model.Config) {
 	b.Mutex.Lock()
 	defer b.Mutex.Unlock()
 
-	if !reflect.DeepEqual(cfg.BleveSettings, b.cfg.BleveSettings) {
-		mlog.Info("UpdateConf Bleve")
+	if reflect.DeepEqual(cfg.BleveSettings, b.cfg.BleveSettings) {
+		return
 	}
+
+	mlog.Info("UpdateConf Bleve")
 
 	if *cfg.BleveSettings.EnableIndexing != *b.cfg.BleveSettings.EnableIndexing || *cfg.BleveSettings.IndexDir != *b.cfg.BleveSettings.IndexDir {
 		if err := b.closeIndexes(); err != nil {


### PR DESCRIPTION

#### Summary
Only log update conf when there is an actual change in the `BleveSettings`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32348

#### Release Note
```release-note
NONE
```