### PR TITLE
[MM-32621] Remove app.waitForSidebarCategories

### DIFF
--- a/app/channel_category.go
+++ b/app/channel_category.go
@@ -6,34 +6,30 @@ package app
 import (
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/mattermost/mattermost-server/v5/mlog"
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/mattermost/mattermost-server/v5/store"
 )
 
-func (a *App) createInitialSidebarCategories(userID, teamID string) *model.AppError {
-	nErr := a.Srv().Store.Channel().CreateInitialSidebarCategories(userID, teamID)
-
+func (a *App) createInitialSidebarCategories(userID, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
+	categories, nErr := a.Srv().Store.Channel().CreateInitialSidebarCategories(userID, teamID)
 	if nErr != nil {
-		return model.NewAppError("createInitialSidebarCategories", "app.channel.create_initial_sidebar_categories.internal_error", nil, nErr.Error(), http.StatusInternalServerError)
+		return nil, model.NewAppError("createInitialSidebarCategories", "app.channel.create_initial_sidebar_categories.internal_error", nil, nErr.Error(), http.StatusInternalServerError)
 	}
 
-	return nil
+	return categories, nil
 }
 
 func (a *App) GetSidebarCategories(userID, teamID string) (*model.OrderedSidebarCategories, *model.AppError) {
+	var appErr *model.AppError
 	categories, err := a.Srv().Store.Channel().GetSidebarCategories(userID, teamID)
-
 	if err == nil && len(categories.Categories) == 0 {
 		// A user must always have categories, so migration must not have happened yet, and we should run it ourselves
-		appErr := a.createInitialSidebarCategories(userID, teamID)
+		categories, appErr = a.createInitialSidebarCategories(userID, teamID)
 		if appErr != nil {
 			return nil, appErr
 		}
-
-		categories, err = a.waitForSidebarCategories(userID, teamID)
 	}
 
 	if err != nil {
@@ -47,32 +43,6 @@ func (a *App) GetSidebarCategories(userID, teamID string) (*model.OrderedSidebar
 	}
 
 	return categories, nil
-}
-
-// waitForSidebarCategories is used to get a user's sidebar categories after they've been created since there may be
-// replication lag if any database replicas exist. It will wait until results are available to return them.
-func (a *App) waitForSidebarCategories(userID, teamID string) (*model.OrderedSidebarCategories, error) {
-	if len(a.Config().SqlSettings.DataSourceReplicas) == 0 {
-		// The categories should be available immediately on a single database
-		return a.Srv().Store.Channel().GetSidebarCategories(userID, teamID)
-	}
-
-	now := model.GetMillis()
-
-	for model.GetMillis()-now < 12000 {
-		time.Sleep(100 * time.Millisecond)
-
-		categories, err := a.Srv().Store.Channel().GetSidebarCategories(userID, teamID)
-
-		if err != nil || len(categories.Categories) > 0 {
-			// We've found something, so return
-			return categories, err
-		}
-	}
-
-	mlog.Error("waitForSidebarCategories giving up", mlog.String("user_id", userID), mlog.String("team_id", teamID))
-
-	return &model.OrderedSidebarCategories{}, nil
 }
 
 func (a *App) GetSidebarCategoryOrder(userID, teamID string) ([]string, *model.AppError) {

--- a/app/team.go
+++ b/app/team.go
@@ -783,7 +783,7 @@ func (a *App) JoinUserToTeam(team *model.Team, user *model.User, userRequestorId
 		return model.NewAppError("JoinUserToTeam", "app.user.update_update.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
-	if err := a.createInitialSidebarCategories(user.Id, team.Id); err != nil {
+	if _, err := a.createInitialSidebarCategories(user.Id, team.Id); err != nil {
 		mlog.Warn(
 			"Encountered an issue creating default sidebar categories.",
 			mlog.String("user_id", user.Id),

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -661,7 +661,7 @@ func (s *OpenTracingLayerChannelStore) CreateDirectChannel(userId *model.User, o
 	return result, err
 }
 
-func (s *OpenTracingLayerChannelStore) CreateInitialSidebarCategories(userId string, teamID string) error {
+func (s *OpenTracingLayerChannelStore) CreateInitialSidebarCategories(userId string, teamID string) (*model.OrderedSidebarCategories, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.CreateInitialSidebarCategories")
 	s.Root.Store.SetContext(newCtx)
@@ -670,13 +670,13 @@ func (s *OpenTracingLayerChannelStore) CreateInitialSidebarCategories(userId str
 	}()
 
 	defer span.Finish()
-	err := s.ChannelStore.CreateInitialSidebarCategories(userId, teamID)
+	result, err := s.ChannelStore.CreateInitialSidebarCategories(userId, teamID)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)
 	}
 
-	return err
+	return result, err
 }
 
 func (s *OpenTracingLayerChannelStore) CreateSidebarCategory(userId string, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -704,21 +704,21 @@ func (s *RetryLayerChannelStore) CreateDirectChannel(userId *model.User, otherUs
 
 }
 
-func (s *RetryLayerChannelStore) CreateInitialSidebarCategories(userId string, teamID string) error {
+func (s *RetryLayerChannelStore) CreateInitialSidebarCategories(userId string, teamID string) (*model.OrderedSidebarCategories, error) {
 
 	tries := 0
 	for {
-		err := s.ChannelStore.CreateInitialSidebarCategories(userId, teamID)
+		result, err := s.ChannelStore.CreateInitialSidebarCategories(userId, teamID)
 		if err == nil {
-			return nil
+			return result, nil
 		}
 		if !isRepeatableError(err) {
-			return err
+			return result, err
 		}
 		tries++
 		if tries >= 3 {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
-			return err
+			return result, err
 		}
 	}
 

--- a/store/store.go
+++ b/store/store.go
@@ -215,7 +215,7 @@ type ChannelStore interface {
 	ResetAllChannelSchemes() error
 	ClearAllCustomRoleAssignments() error
 	MigratePublicChannels() error
-	CreateInitialSidebarCategories(userId, teamID string) error
+	CreateInitialSidebarCategories(userId, teamID string) (*model.OrderedSidebarCategories, error)
 	GetSidebarCategories(userId, teamID string) (*model.OrderedSidebarCategories, error)
 	GetSidebarCategory(categoryID string) (*model.SidebarCategoryWithChannels, error)
 	GetSidebarCategoryOrder(userId, teamID string) ([]string, error)

--- a/store/storetest/channel_store_categories.go
+++ b/store/storetest/channel_store_categories.go
@@ -33,72 +33,80 @@ func testCreateInitialSidebarCategories(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		assert.NoError(t, nErr)
-
-		res, err := ss.Channel().GetSidebarCategories(userId, teamId)
-		assert.NoError(t, err)
 		assert.Len(t, res.Categories, 3)
 		assert.Equal(t, model.SidebarCategoryFavorites, res.Categories[0].Type)
 		assert.Equal(t, model.SidebarCategoryChannels, res.Categories[1].Type)
 		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Categories[2].Type)
+
+		res2, err := ss.Channel().GetSidebarCategories(userId, teamId)
+		assert.NoError(t, err)
+		assert.Equal(t, res, res2)
 	})
 
 	t.Run("should create initial favorites/channels/DMs categories for multiple users", func(t *testing.T) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		userId2 := model.NewId()
 
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId2, teamId)
+		res, nErr = ss.Channel().CreateInitialSidebarCategories(userId2, teamId)
 		assert.NoError(t, nErr)
-
-		res, err := ss.Channel().GetSidebarCategories(userId2, teamId)
-		assert.NoError(t, err)
 		assert.Len(t, res.Categories, 3)
 		assert.Equal(t, model.SidebarCategoryFavorites, res.Categories[0].Type)
 		assert.Equal(t, model.SidebarCategoryChannels, res.Categories[1].Type)
 		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Categories[2].Type)
+
+		res2, err := ss.Channel().GetSidebarCategories(userId2, teamId)
+		assert.NoError(t, err)
+		assert.Equal(t, res, res2)
 	})
 
 	t.Run("should create initial favorites/channels/DMs categories on different teams", func(t *testing.T) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		teamId2 := model.NewId()
 
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId2)
+		res, nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId2)
 		assert.NoError(t, nErr)
-
-		res, err := ss.Channel().GetSidebarCategories(userId, teamId2)
-		assert.NoError(t, err)
 		assert.Len(t, res.Categories, 3)
 		assert.Equal(t, model.SidebarCategoryFavorites, res.Categories[0].Type)
 		assert.Equal(t, model.SidebarCategoryChannels, res.Categories[1].Type)
 		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Categories[2].Type)
+
+		res2, err := ss.Channel().GetSidebarCategories(userId, teamId2)
+		assert.NoError(t, err)
+		assert.Equal(t, res, res2)
 	})
 
 	t.Run("shouldn't create additional categories when ones already exist", func(t *testing.T) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		initialCategories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
+		require.Equal(t, res, initialCategories)
 
 		// Calling CreateInitialSidebarCategories a second time shouldn't create any new categories
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		assert.NoError(t, nErr)
+		assert.NotEmpty(t, res)
 
-		res, err := ss.Channel().GetSidebarCategories(userId, teamId)
+		res, err = ss.Channel().GetSidebarCategories(userId, teamId)
 		assert.NoError(t, err)
 		assert.Equal(t, initialCategories.Categories, res.Categories)
 	})
@@ -115,7 +123,7 @@ func testCreateInitialSidebarCategories(t *testing.T, ss store.Store) {
 			go func() {
 				defer wg.Done()
 
-				_ = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+				_, _ = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 			}()
 		}
 
@@ -168,17 +176,18 @@ func testCreateInitialSidebarCategories(t *testing.T, ss store.Store) {
 		require.NoError(t, nErr)
 
 		// Create the categories
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
-		require.NoError(t, nErr)
-
-		// Get and check the categories for channels
-		categories, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
+		categories, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
 		require.Len(t, categories.Categories, 3)
 		assert.Equal(t, model.SidebarCategoryFavorites, categories.Categories[0].Type)
 		assert.Equal(t, []string{channel1.Id}, categories.Categories[0].Channels)
 		assert.Equal(t, model.SidebarCategoryChannels, categories.Categories[1].Type)
 		assert.Equal(t, []string{channel2.Id}, categories.Categories[1].Channels)
+
+		// Get and check the categories for channels
+		categories2, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
+		require.NoError(t, nErr)
+		require.Equal(t, categories, categories2)
 	})
 
 	t.Run("should populate the Favorites category in alphabetical order", func(t *testing.T) {
@@ -231,15 +240,16 @@ func testCreateInitialSidebarCategories(t *testing.T, ss store.Store) {
 		require.NoError(t, nErr)
 
 		// Create the categories
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
-		require.NoError(t, nErr)
-
-		// Get and check the categories for channels
-		categories, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
+		categories, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
 		require.Len(t, categories.Categories, 3)
 		assert.Equal(t, model.SidebarCategoryFavorites, categories.Categories[0].Type)
 		assert.Equal(t, []string{channel2.Id, channel1.Id}, categories.Categories[0].Channels)
+
+		// Get and check the categories for channels
+		categories2, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
+		require.NoError(t, nErr)
+		require.Equal(t, categories, categories2)
 	})
 
 	t.Run("should populate the Favorites category with DMs and GMs", func(t *testing.T) {
@@ -293,17 +303,18 @@ func testCreateInitialSidebarCategories(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 
 		// Create the categories
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		categories, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
-
-		// Get and check the categories for channels
-		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
-		require.NoError(t, err)
 		require.Len(t, categories.Categories, 3)
 		assert.Equal(t, model.SidebarCategoryFavorites, categories.Categories[0].Type)
 		assert.Equal(t, []string{dmChannel1.Id}, categories.Categories[0].Channels)
 		assert.Equal(t, model.SidebarCategoryDirectMessages, categories.Categories[2].Type)
 		assert.Equal(t, []string{dmChannel2.Id}, categories.Categories[2].Channels)
+
+		// Get and check the categories for channels
+		categories2, err := ss.Channel().GetSidebarCategories(userId, teamId)
+		require.NoError(t, err)
+		require.Equal(t, categories, categories2)
 	})
 
 	t.Run("should not populate the Favorites category with channels from other teams", func(t *testing.T) {
@@ -336,17 +347,18 @@ func testCreateInitialSidebarCategories(t *testing.T, ss store.Store) {
 		require.NoError(t, nErr)
 
 		// Create the categories
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
-		require.NoError(t, nErr)
-
-		// Get and check the categories for channels
-		categories, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
+		categories, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
 		require.Len(t, categories.Categories, 3)
 		assert.Equal(t, model.SidebarCategoryFavorites, categories.Categories[0].Type)
 		assert.Equal(t, []string{}, categories.Categories[0].Channels)
 		assert.Equal(t, model.SidebarCategoryChannels, categories.Categories[1].Type)
 		assert.Equal(t, []string{}, categories.Categories[1].Channels)
+
+		// Get and check the categories for channels
+		categories2, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
+		require.NoError(t, nErr)
+		require.Equal(t, categories, categories2)
 	})
 }
 
@@ -355,8 +367,9 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		// Create the category
 		created, err := ss.Channel().CreateSidebarCategory(userId, teamId, &model.SidebarCategoryWithChannels{
@@ -367,7 +380,7 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 
 		// Confirm that it comes second
-		res, err := ss.Channel().GetSidebarCategories(userId, teamId)
+		res, err = ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 		assert.Equal(t, model.SidebarCategoryFavorites, res.Categories[0].Type)
@@ -379,8 +392,9 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		// Re-arrange the categories so that Favorites comes last
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
@@ -404,7 +418,7 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 
 		// Confirm that it comes first
-		res, err := ss.Channel().GetSidebarCategories(userId, teamId)
+		res, err = ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 		assert.Equal(t, model.SidebarCategoryCustom, res.Categories[0].Type)
@@ -415,8 +429,9 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		// Create some channels
 		channel1, err := ss.Channel().Save(&model.Channel{
@@ -443,17 +458,18 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		assert.Equal(t, []string{channel2.Id, channel1.Id}, created.Channels)
 
 		// Get the channel again to ensure that the SidebarChannels were saved correctly
-		res, err := ss.Channel().GetSidebarCategory(created.Id)
+		res2, err := ss.Channel().GetSidebarCategory(created.Id)
 		require.NoError(t, err)
-		assert.Equal(t, []string{channel2.Id, channel1.Id}, res.Channels)
+		assert.Equal(t, []string{channel2.Id, channel1.Id}, res2.Channels)
 	})
 
 	t.Run("should remove any channels from their previous categories", func(t *testing.T) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -498,13 +514,13 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		assert.Equal(t, []string{channel2.Id, channel1.Id}, created.Channels)
 
 		// Confirm that the channels were removed from their original categories
-		res, err := ss.Channel().GetSidebarCategory(favoritesCategory.Id)
+		res2, err := ss.Channel().GetSidebarCategory(favoritesCategory.Id)
 		require.NoError(t, err)
-		assert.Equal(t, []string{}, res.Channels)
+		assert.Equal(t, []string{}, res2.Channels)
 
-		res, err = ss.Channel().GetSidebarCategory(channelsCategory.Id)
+		res2, err = ss.Channel().GetSidebarCategory(channelsCategory.Id)
 		require.NoError(t, err)
-		assert.Equal(t, []string{}, res.Channels)
+		assert.Equal(t, []string{}, res2.Channels)
 	})
 }
 
@@ -517,8 +533,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		channelId2 := model.NewId()
 		channelId3 := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		// Create a category and assign some channels to it
 		created, err := ss.Channel().CreateSidebarCategory(userId, teamId, &model.SidebarCategoryWithChannels{
@@ -533,12 +550,12 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		require.NotNil(t, created)
 
 		// Ensure that they're returned in order
-		res, err := ss.Channel().GetSidebarCategory(created.Id)
+		res2, err := ss.Channel().GetSidebarCategory(created.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, created.Id, res.Id)
-		assert.Equal(t, model.SidebarCategoryCustom, res.Type)
-		assert.Equal(t, created.DisplayName, res.DisplayName)
-		assert.Equal(t, []string{channelId1, channelId2, channelId3}, res.Channels)
+		assert.Equal(t, created.Id, res2.Id)
+		assert.Equal(t, model.SidebarCategoryCustom, res2.Type)
+		assert.Equal(t, created.DisplayName, res2.DisplayName)
+		assert.Equal(t, []string{channelId1, channelId2, channelId3}, res2.Channels)
 	})
 
 	t.Run("should return any orphaned channels with the Channels category", func(t *testing.T) {
@@ -546,8 +563,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the channels category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -596,11 +614,11 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		assert.Equal(t, int64(0), count)
 
 		// Ensure that the Channels are returned in alphabetical order
-		res, err := ss.Channel().GetSidebarCategory(channelsCategory.Id)
+		res2, err := ss.Channel().GetSidebarCategory(channelsCategory.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, channelsCategory.Id, res.Id)
+		assert.Equal(t, channelsCategory.Id, res2.Id)
 		assert.Equal(t, model.SidebarCategoryChannels, channelsCategory.Type)
-		assert.Equal(t, []string{channel2.Id, channel1.Id}, res.Channels)
+		assert.Equal(t, []string{channel2.Id, channel1.Id}, res2.Channels)
 	})
 
 	t.Run("shouldn't return orphaned channels on another team with the Channels category", func(t *testing.T) {
@@ -608,8 +626,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the channels category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -624,6 +643,7 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 			Type:   model.CHANNEL_OPEN,
 		}, 10)
 		require.NoError(t, nErr)
+		defer ss.Channel().PermanentDelete(channel1.Id)
 
 		_, nErr = ss.Channel().SaveMember(&model.ChannelMember{
 			UserId:      userId,
@@ -633,11 +653,11 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		require.NoError(t, nErr)
 
 		// Ensure that no channels are returned
-		res, err := ss.Channel().GetSidebarCategory(channelsCategory.Id)
+		res2, err := ss.Channel().GetSidebarCategory(channelsCategory.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, channelsCategory.Id, res.Id)
+		assert.Equal(t, channelsCategory.Id, res2.Id)
 		assert.Equal(t, model.SidebarCategoryChannels, channelsCategory.Type)
-		assert.Len(t, res.Channels, 0)
+		assert.Len(t, res2.Channels, 0)
 	})
 
 	t.Run("shouldn't return non-orphaned channels with the Channels category", func(t *testing.T) {
@@ -645,8 +665,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the channels category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -695,11 +716,11 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		require.NoError(t, err)
 
 		// Ensure that the correct channel is returned in the Channels category
-		res, err := ss.Channel().GetSidebarCategory(channelsCategory.Id)
+		res2, err := ss.Channel().GetSidebarCategory(channelsCategory.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, channelsCategory.Id, res.Id)
+		assert.Equal(t, channelsCategory.Id, res2.Id)
 		assert.Equal(t, model.SidebarCategoryChannels, channelsCategory.Type)
-		assert.Equal(t, []string{channel1.Id}, res.Channels)
+		assert.Equal(t, []string{channel1.Id}, res2.Channels)
 	})
 
 	t.Run("should return any orphaned DM channels with the Direct Messages category", func(t *testing.T) {
@@ -707,8 +728,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the DMs category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -735,11 +757,11 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		require.NoError(t, nErr)
 
 		// Ensure that the DM is returned
-		res, err := ss.Channel().GetSidebarCategory(dmsCategory.Id)
+		res2, err := ss.Channel().GetSidebarCategory(dmsCategory.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, dmsCategory.Id, res.Id)
-		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Type)
-		assert.Equal(t, []string{dmChannel.Id}, res.Channels)
+		assert.Equal(t, dmsCategory.Id, res2.Id)
+		assert.Equal(t, model.SidebarCategoryDirectMessages, res2.Type)
+		assert.Equal(t, []string{dmChannel.Id}, res2.Channels)
 	})
 
 	t.Run("should return any orphaned GM channels with the Direct Messages category", func(t *testing.T) {
@@ -747,8 +769,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the DMs category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -763,6 +786,7 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 			Type:   model.CHANNEL_GROUP,
 		}, 10)
 		require.NoError(t, nErr)
+		defer ss.Channel().PermanentDelete(gmChannel.Id)
 		_, nErr = ss.Channel().SaveMember(&model.ChannelMember{
 			UserId:      userId,
 			ChannelId:   gmChannel.Id,
@@ -771,11 +795,11 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		require.NoError(t, nErr)
 
 		// Ensure that the DM is returned
-		res, err := ss.Channel().GetSidebarCategory(dmsCategory.Id)
+		res2, err := ss.Channel().GetSidebarCategory(dmsCategory.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, dmsCategory.Id, res.Id)
-		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Type)
-		assert.Equal(t, []string{gmChannel.Id}, res.Channels)
+		assert.Equal(t, dmsCategory.Id, res2.Id)
+		assert.Equal(t, model.SidebarCategoryDirectMessages, res2.Type)
+		assert.Equal(t, []string{gmChannel.Id}, res2.Channels)
 	})
 
 	t.Run("should return orphaned DM channels in the DMs categorywhich are in a custom category on another team", func(t *testing.T) {
@@ -783,8 +807,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the DMs category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -813,8 +838,9 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		// Create another team and assign the DM to a custom category on that team
 		otherTeamId := model.NewId()
 
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, otherTeamId)
+		res, nErr = ss.Channel().CreateInitialSidebarCategories(userId, otherTeamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		_, err = ss.Channel().CreateSidebarCategory(userId, otherTeamId, &model.SidebarCategoryWithChannels{
 			SidebarCategory: model.SidebarCategory{
@@ -826,11 +852,11 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		require.NoError(t, err)
 
 		// Ensure that the DM is returned with the DMs category on the original team
-		res, err := ss.Channel().GetSidebarCategory(dmsCategory.Id)
+		res2, err := ss.Channel().GetSidebarCategory(dmsCategory.Id)
 		assert.NoError(t, err)
-		assert.Equal(t, dmsCategory.Id, res.Id)
-		assert.Equal(t, model.SidebarCategoryDirectMessages, res.Type)
-		assert.Equal(t, []string{dmChannel.Id}, res.Channels)
+		assert.Equal(t, dmsCategory.Id, res2.Id)
+		assert.Equal(t, model.SidebarCategoryDirectMessages, res2.Type)
+		assert.Equal(t, []string{dmChannel.Id}, res2.Channels)
 	})
 }
 
@@ -839,8 +865,9 @@ func testGetSidebarCategories(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		channelIds := []string{
 			model.NewId(),
@@ -857,7 +884,7 @@ func testGetSidebarCategories(t *testing.T, ss store.Store) {
 		gotCategory, err := ss.Channel().GetSidebarCategory(newCategory.Id)
 		require.NoError(t, err)
 
-		res, err := ss.Channel().GetSidebarCategories(userId, teamId)
+		res, err = ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 4)
 
@@ -876,8 +903,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		teamId := model.NewId()
 
 		// Create the initial categories
-		err := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, err := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, err)
+		require.NotEmpty(t, res)
 
 		initialCategories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -909,8 +937,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		teamId := model.NewId()
 
 		// Create the initial categories
-		err := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, err := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, err)
+		require.NotEmpty(t, res)
 
 		initialCategories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -935,8 +964,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		initialCategories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -1001,8 +1031,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the favorites category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -1033,10 +1064,10 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
 		// And then remove it
 		channelsCategory := categories.Categories[1]
@@ -1050,10 +1081,10 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.Error(t, nErr)
 		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 	})
 
 	t.Run("should add and remove favorites preferences for DMs", func(t *testing.T) {
@@ -1061,8 +1092,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the favorites category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -1098,10 +1130,10 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
+		res2, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
 		// And then remove it
 		dmsCategory := categories.Categories[2]
@@ -1115,10 +1147,10 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
 		assert.Error(t, nErr)
 		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 	})
 
 	t.Run("should add and remove favorites preferences, even if the channel is already favorited in preferences", func(t *testing.T) {
@@ -1127,8 +1159,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		teamId2 := model.NewId()
 
 		// Create the initial categories and find the favorites categories in each team
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -1136,8 +1169,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		favoritesCategory := categories.Categories[0]
 		require.Equal(t, model.SidebarCategoryFavorites, favoritesCategory.Type)
 
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId2)
+		res, nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId2)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories2, err := ss.Channel().GetSidebarCategories(userId, teamId2)
 		require.NoError(t, err)
@@ -1173,10 +1207,10 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
+		res2, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
 		// Assign it to favorites on the second team. The favorites preference is already set.
 		updated, _, err := ss.Channel().UpdateSidebarCategories(userId, teamId, []*model.SidebarCategoryWithChannels{
@@ -1188,10 +1222,10 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		assert.NoError(t, err)
 		assert.Equal(t, []string{dmChannel.Id}, updated[0].Channels)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
 		// Remove it from favorites on the first team. This clears the favorites preference for all teams.
 		_, _, err = ss.Channel().UpdateSidebarCategories(userId, teamId, []*model.SidebarCategoryWithChannels{
@@ -1202,9 +1236,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
 		require.Error(t, nErr)
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 
 		// Remove it from favorites on the second team. The favorites preference was already deleted.
 		_, _, err = ss.Channel().UpdateSidebarCategories(userId, teamId2, []*model.SidebarCategoryWithChannels{
@@ -1215,9 +1249,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, dmChannel.Id)
 		require.Error(t, nErr)
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 	})
 
 	t.Run("should not affect other users' favorites preferences", func(t *testing.T) {
@@ -1225,8 +1259,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		teamId := model.NewId()
 
 		// Create the initial categories and find the favorites category
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories, err := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, err)
@@ -1239,8 +1274,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		// Create the other users' categories
 		userId2 := model.NewId()
 
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId2, teamId)
+		res, nErr = ss.Channel().CreateInitialSidebarCategories(userId2, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		categories2, err := ss.Channel().GetSidebarCategories(userId2, teamId)
 		require.NoError(t, err)
@@ -1283,14 +1319,14 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr := ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
-		res, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 
 		// And user2 favorite it
 		_, _, err = ss.Channel().UpdateSidebarCategories(userId2, teamId, []*model.SidebarCategoryWithChannels{
@@ -1305,15 +1341,15 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
-		res, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
 		// And then user1 unfavorite it
 		_, _, err = ss.Channel().UpdateSidebarCategories(userId, teamId, []*model.SidebarCategoryWithChannels{
@@ -1328,14 +1364,14 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 
-		res, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.NoError(t, nErr)
-		assert.NotNil(t, res)
-		assert.Equal(t, "true", res.Value)
+		assert.NotNil(t, res2)
+		assert.Equal(t, "true", res2.Value)
 
 		// And finally user2 favorite it
 		_, _, err = ss.Channel().UpdateSidebarCategories(userId2, teamId, []*model.SidebarCategoryWithChannels{
@@ -1350,13 +1386,13 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		})
 		assert.NoError(t, err)
 
-		res, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 
-		res, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
+		res2, nErr = ss.Preference().Get(userId2, model.PREFERENCE_CATEGORY_FAVORITE_CHANNEL, channel.Id)
 		assert.True(t, errors.Is(nErr, sql.ErrNoRows))
-		assert.Nil(t, res)
+		assert.Nil(t, res2)
 	})
 
 	t.Run("channels removed from Channels or DMs categories should be re-added", func(t *testing.T) {
@@ -1394,8 +1430,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		)
 		require.NoError(t, nErr)
 
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		// And some categories
 		initialCategories, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
@@ -1448,8 +1485,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		)
 		require.NoError(t, nErr)
 
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		// The DM should start in the DMs category
 		initialCategories, err := ss.Channel().GetSidebarCategories(userId, teamId)
@@ -1535,8 +1573,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 
 		// And then create the initial categories so that it includes the channel
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		initialCategories, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
@@ -1598,8 +1637,9 @@ func testUpdateSidebarCategories(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 
 		// And then create the initial categories so that Channels includes the channel
-		nErr = ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		initialCategories, nErr := ss.Channel().GetSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
@@ -1655,8 +1695,9 @@ func setupInitialSidebarCategories(t *testing.T, ss store.Store) (string, string
 	userId := model.NewId()
 	teamId := model.NewId()
 
-	nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+	res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 	require.NoError(t, nErr)
+	require.NotEmpty(t, res)
 
 	res, err := ss.Channel().GetSidebarCategories(userId, teamId)
 	require.NoError(t, err)
@@ -1775,10 +1816,11 @@ func testClearSidebarOnTeamLeave(t *testing.T, ss store.Store, s SqlStore) {
 		// Create a second team and set up the sidebar categories for it
 		teamId2 := model.NewId()
 
-		err := ss.Channel().CreateInitialSidebarCategories(userId, teamId2)
+		res, err := ss.Channel().CreateInitialSidebarCategories(userId, teamId2)
 		require.NoError(t, err)
+		require.NotEmpty(t, res)
 
-		res, err := ss.Channel().GetSidebarCategories(userId, teamId2)
+		res, err = ss.Channel().GetSidebarCategories(userId, teamId2)
 		require.NoError(t, err)
 		require.Len(t, res.Categories, 3)
 
@@ -1959,8 +2001,9 @@ func testUpdateSidebarChannelsByPreferences(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		channel, nErr := ss.Channel().Save(&model.Channel{
 			Name:   "channel",
@@ -1983,8 +2026,9 @@ func testUpdateSidebarChannelsByPreferences(t *testing.T, ss store.Store) {
 		userId := model.NewId()
 		teamId := model.NewId()
 
-		nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, teamId)
 		assert.NoError(t, nErr)
+		require.NotEmpty(t, res)
 
 		require.NotPanics(t, func() {
 			_ = ss.Channel().UpdateSidebarChannelsByPreferences(&model.Preferences{

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -181,17 +181,26 @@ func (_m *ChannelStore) CreateDirectChannel(userId *model.User, otherUserId *mod
 }
 
 // CreateInitialSidebarCategories provides a mock function with given fields: userId, teamID
-func (_m *ChannelStore) CreateInitialSidebarCategories(userId string, teamID string) error {
+func (_m *ChannelStore) CreateInitialSidebarCategories(userId string, teamID string) (*model.OrderedSidebarCategories, error) {
 	ret := _m.Called(userId, teamID)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+	var r0 *model.OrderedSidebarCategories
+	if rf, ok := ret.Get(0).(func(string, string) *model.OrderedSidebarCategories); ok {
 		r0 = rf(userId, teamID)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.OrderedSidebarCategories)
+		}
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(userId, teamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // CreateSidebarCategory provides a mock function with given fields: userId, teamID, newCategory

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -631,10 +631,10 @@ func (s *TimerLayerChannelStore) CreateDirectChannel(userId *model.User, otherUs
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) CreateInitialSidebarCategories(userId string, teamID string) error {
+func (s *TimerLayerChannelStore) CreateInitialSidebarCategories(userId string, teamID string) (*model.OrderedSidebarCategories, error) {
 	start := timemodule.Now()
 
-	err := s.ChannelStore.CreateInitialSidebarCategories(userId, teamID)
+	result, err := s.ChannelStore.CreateInitialSidebarCategories(userId, teamID)
 
 	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
 	if s.Root.Metrics != nil {
@@ -644,7 +644,7 @@ func (s *TimerLayerChannelStore) CreateInitialSidebarCategories(userId string, t
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.CreateInitialSidebarCategories", success, elapsed)
 	}
-	return err
+	return result, err
 }
 
 func (s *TimerLayerChannelStore) CreateSidebarCategory(userId string, teamID string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {


### PR DESCRIPTION
#### Summary

PR removes the need for `app.waitForSidebarCategories()` by making `ChannelStore.createInitialSidebarCategories()` return what it created instead of querying categories (from replica) through `GetSidebarCategories()`.

Interestingly `GetSidebarCategories()` was already querying from master so I am not sure why `app.waitForSidebarCategories()` was ever needed. 

#### Ticket

https://mattermost.atlassian.net/browse/MM-32621

```release-note
NONE
```

