### PR TITLE
Update webapp build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ jobs:
   setup:
     working_directory: ~/mattermost/mattermost-server
     docker:
-      - image: mattermost/mattermost-build-webapp:oct-2-2018
+      - image: mattermost/mattermost-build-webapp:20200829_node-10.22
+    resource_class: xlarge
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
When the server tries to include a version of the web app that hasn't been built and uploaded to S3 yet, it falls back to building the web app itself. The process for that hasn't been updated in quite a while, and that's causing problems particularly because the Docker image used for building is a really old one that uses Node 8.

This upgrades to match the latest one from the web app repo, and it also increases the size of the runner to fix an out of memory error that would happen without it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33299

#### Release Note
```release-note
NONE
```
