### PR TITLE
Add cloud attributes to feature flags and allow non-cloud servers to use split.io sync

### DIFF
--- a/app/feature_flags.go
+++ b/app/feature_flags.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"os"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v5/config"
@@ -56,10 +57,21 @@ func (s *Server) startFeatureFlagUpdateJob() error {
 		log = s.Log
 	}
 
+	attributes := map[string]interface{}{}
+
+	// if we are part of a cloud installation, add its installation and group id
+	if installationId := os.Getenv("MM_CLOUD_INSTALLATION_ID"); installationId != "" {
+		attributes["installation_id"] = installationId
+	}
+	if groupId := os.Getenv("MM_CLOUD_GROUP_ID"); groupId != "" {
+		attributes["group_id"] = groupId
+	}
+
 	synchronizer, err := config.NewFeatureFlagSynchronizer(config.FeatureFlagSyncParams{
-		ServerID: s.TelemetryId(),
-		SplitKey: *s.Config().ServiceSettings.SplitKey,
-		Log:      log,
+		ServerID:   s.TelemetryId(),
+		SplitKey:   *s.Config().ServiceSettings.SplitKey,
+		Log:        log,
+		Attributes: attributes,
 	})
 	if err != nil {
 		return err

--- a/app/feature_flags.go
+++ b/app/feature_flags.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"encoding/json"
 	"os"
 	"time"
 
@@ -40,7 +41,11 @@ func (s *Server) updateFeatureFlagValuesFromManagment() {
 	newCfg := s.configStore.GetNoEnv().Clone()
 	oldFlags := *newCfg.FeatureFlags
 	newFlags := s.featureFlagSynchronizer.UpdateFeatureFlagValues(oldFlags)
+	oldFlagsBytes, _ := json.Marshal(oldFlags)
+	newFlagsBytes, _ := json.Marshal(newFlags)
+	s.Log.Debug("Checking feature flags from management service", mlog.String("old_flags", string(oldFlagsBytes)), mlog.String("new_flags", string(newFlagsBytes)))
 	if oldFlags != newFlags {
+		s.Log.Debug("Feature flag change detected, updating config")
 		*newCfg.FeatureFlags = newFlags
 		s.SaveConfig(newCfg, true)
 	}

--- a/app/feature_flags.go
+++ b/app/feature_flags.go
@@ -17,16 +17,15 @@ import (
 func (s *Server) setupFeatureFlags() {
 	s.featureFlagSynchronizerMutex.Lock()
 	defer s.featureFlagSynchronizerMutex.Unlock()
-	license := s.License()
-	inCloud := license != nil && *license.Features.Cloud
 	splitKey := *s.Config().ServiceSettings.SplitKey
-	syncFeatureFlags := inCloud && splitKey != "" && s.IsLeader()
+	splitConfigured := splitKey != ""
+	syncFeatureFlags := splitConfigured && s.IsLeader()
 
-	s.configStore.PersistFeatures(inCloud)
+	s.configStore.PersistFeatures(splitConfigured)
 
 	if syncFeatureFlags {
 		if err := s.startFeatureFlagUpdateJob(); err != nil {
-			s.Log.Warn("Unable to setup synchronization with feature flag management. Will fallback to cloud cache.", mlog.Err(err))
+			s.Log.Warn("Unable to setup synchronization with feature flag management. Will fallback to cache.", mlog.Err(err))
 		}
 	} else {
 		s.stopFeatureFlagUpdateJob()

--- a/config/feature_flags.go
+++ b/config/feature_flags.go
@@ -22,6 +22,7 @@ type FeatureFlagSyncParams struct {
 	SplitKey            string
 	SyncIntervalSeconds int
 	Log                 *mlog.Logger
+	Attributes          map[string]interface{}
 }
 
 type FeatureFlagSynchronizer struct {
@@ -54,7 +55,7 @@ func NewFeatureFlagSynchronizer(params FeatureFlagSyncParams) (*FeatureFlagSynch
 	}, nil
 }
 
-// ensureReady blocks until the syncronizer is ready to update feature flag values
+// EnsureReady blocks until the syncronizer is ready to update feature flag values
 func (f *FeatureFlagSynchronizer) EnsureReady() error {
 	if err := f.client.BlockUntilReady(10); err != nil {
 		return errors.Wrap(err, "split.io client could not initialize")
@@ -64,7 +65,7 @@ func (f *FeatureFlagSynchronizer) EnsureReady() error {
 }
 
 func (f *FeatureFlagSynchronizer) UpdateFeatureFlagValues(base model.FeatureFlags) model.FeatureFlags {
-	featuresMap := f.client.Treatments(f.ServerID, featureNames, nil)
+	featuresMap := f.client.Treatments(f.ServerID, featureNames, f.Attributes)
 	ffm := featureFlagsFromMap(featuresMap, base)
 	return ffm
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Three things in this PR:

1. Add some cloud attributes to the feature flags so that we can use those to isolate treatments.
2. Allow non-cloud servers to use the split.io feature flag management. Primary motivator there is allowing our test servers to use split.io for feature flags even if they don't have a cloud license.
3. Add a bit more debug logs to feature flags.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
Add attributes to split.io feature flags
```
