### PR TITLE
[MM-33333] Fix GetSidebarCategories() failing on db replicas

### DIFF
--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -508,12 +508,7 @@ func (s SqlChannelStore) getSidebarCategoriesT(db dbSelecter, userId, teamId str
 }
 
 func (s SqlChannelStore) GetSidebarCategories(userId, teamId string) (*model.OrderedSidebarCategories, error) {
-	oc, err := s.getSidebarCategoriesT(s.GetReplica(), userId, teamId)
-	if err != nil {
-		return nil, err
-	}
-
-	return oc, nil
+	return s.getSidebarCategoriesT(s.GetReplica(), userId, teamId)
 }
 
 func (s SqlChannelStore) GetSidebarCategoryOrder(userId, teamId string) ([]string, error) {

--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -14,6 +14,10 @@ import (
 	"github.com/mattermost/mattermost-server/v5/store"
 )
 
+type dbSelecter interface {
+	Select(i interface{}, query string, args ...interface{}) ([]interface{}, error)
+}
+
 func (s SqlChannelStore) CreateInitialSidebarCategories(userId, teamId string) (*model.OrderedSidebarCategories, error) {
 	transaction, err := s.GetMaster().Begin()
 	if err != nil {
@@ -366,7 +370,7 @@ func (s SqlChannelStore) completePopulatingCategoryChannels(category *model.Side
 	return result, nil
 }
 
-func (s SqlChannelStore) completePopulatingCategoryChannelsT(transaction *gorp.Transaction, category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
+func (s SqlChannelStore) completePopulatingCategoryChannelsT(db dbSelecter, category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
 	if category.Type == model.SidebarCategoryCustom || category.Type == model.SidebarCategoryFavorites {
 		return category, nil
 	}
@@ -411,7 +415,7 @@ func (s SqlChannelStore) completePopulatingCategoryChannelsT(transaction *gorp.T
 		return nil, errors.Wrap(err, "channel_tosql")
 	}
 
-	if _, err = transaction.Select(&channels, sql, args...); err != nil {
+	if _, err = db.Select(&channels, sql, args...); err != nil {
 		return nil, store.NewErrNotFound("ChannelMembers", "<too many fields>")
 	}
 
@@ -451,7 +455,7 @@ func (s SqlChannelStore) GetSidebarCategory(categoryId string) (*model.SidebarCa
 	return s.completePopulatingCategoryChannels(result)
 }
 
-func (s SqlChannelStore) getSidebarCategoriesT(transaction *gorp.Transaction, userId, teamId string) (*model.OrderedSidebarCategories, error) {
+func (s SqlChannelStore) getSidebarCategoriesT(db dbSelecter, userId, teamId string) (*model.OrderedSidebarCategories, error) {
 	oc := model.OrderedSidebarCategories{
 		Categories: make(model.SidebarCategoriesWithChannels, 0),
 		Order:      make([]string, 0),
@@ -471,7 +475,7 @@ func (s SqlChannelStore) getSidebarCategoriesT(transaction *gorp.Transaction, us
 		return nil, errors.Wrap(err, "sidebar_categories_tosql")
 	}
 
-	if _, err = transaction.Select(&categories, query, args...); err != nil {
+	if _, err = db.Select(&categories, query, args...); err != nil {
 		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, teamId))
 	}
 	for _, category := range categories {
@@ -495,7 +499,7 @@ func (s SqlChannelStore) getSidebarCategoriesT(transaction *gorp.Transaction, us
 		}
 	}
 	for _, category := range oc.Categories {
-		if _, err := s.completePopulatingCategoryChannelsT(transaction, category); err != nil {
+		if _, err := s.completePopulatingCategoryChannelsT(db, category); err != nil {
 			return nil, err
 		}
 	}
@@ -504,20 +508,9 @@ func (s SqlChannelStore) getSidebarCategoriesT(transaction *gorp.Transaction, us
 }
 
 func (s SqlChannelStore) GetSidebarCategories(userId, teamId string) (*model.OrderedSidebarCategories, error) {
-	transaction, err := s.GetReplica().Begin()
-	if err != nil {
-		return nil, errors.Wrap(err, "begin_transaction")
-	}
-
-	defer finalizeTransaction(transaction)
-
-	oc, err := s.getSidebarCategoriesT(transaction, userId, teamId)
+	oc, err := s.getSidebarCategoriesT(s.GetReplica(), userId, teamId)
 	if err != nil {
 		return nil, err
-	}
-
-	if err = transaction.Commit(); err != nil {
-		return nil, errors.Wrap(err, "commit_transaction")
 	}
 
 	return oc, nil

--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -14,6 +14,8 @@ import (
 	"github.com/mattermost/mattermost-server/v5/store"
 )
 
+// dbSelecter is an interface used to enable some internal store methods to
+// accept both transactions (*gorp.Transaction) and common db handlers (*gorp.DbMap).
 type dbSelecter interface {
 	Select(i interface{}, query string, args ...interface{}) ([]interface{}, error)
 }


### PR DESCRIPTION
#### Summary

PR fixes `GetSidebarCategories()` from failing on db replicas. Now I understand why it was using master before :)
It was running everything in a transaction which isn't going to work on read-only replicas. To avoid code duplication I've added a small interface which makes `getSidebarCategoriesT` accept both transactions and regular db handlers.

#### Ticket

https://mattermost.atlassian.net/browse/MM-33333

#### Release Note

```release-note
NONE
```
