### PR TITLE
Revert schema change

### DIFF
--- a/model/post.go
+++ b/model/post.go
@@ -45,7 +45,7 @@ const (
 	POST_EPHEMERAL              = "system_ephemeral"
 	POST_CHANGE_CHANNEL_PRIVACY = "system_change_chan_privacy"
 	POST_ADD_BOT_TEAMS_CHANNELS = "add_bot_teams_channels"
-	POST_FILEIDS_MAX_RUNES      = 300
+	POST_FILEIDS_MAX_RUNES      = 150
 	POST_FILENAMES_MAX_RUNES    = 4000
 	POST_HASHTAGS_MAX_RUNES     = 1000
 	POST_MESSAGE_MAX_RUNES_V1   = 4000

--- a/scripts/mattermost-mysql-5.0.sql
+++ b/scripts/mattermost-mysql-5.0.sql
@@ -626,7 +626,7 @@ CREATE TABLE `Posts` (
   `Props` text,
   `Hashtags` text,
   `Filenames` text,
-  `FileIds` varchar(300) DEFAULT NULL,
+  `FileIds` text,
   `HasReactions` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`Id`),
   KEY `idx_posts_update_at` (`UpdateAt`),

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1010,8 +1010,6 @@ func upgradeDatabaseToVersion531(sqlStore *SqlStore) {
 
 func upgradeDatabaseToVersion532(sqlStore *SqlStore) {
 	if hasMissingMigrationsVersion532(sqlStore) {
-		// allow 10 files per post
-		sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
 		sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
 		sqlStore.CreateColumnIfNotExists("ThreadMemberships", "UnreadMentions", "bigint", "bigint", "0")
 		sqlStore.CreateColumnIfNotExistsNoDefault("Reactions", "UpdateAt", "bigint", "bigint")


### PR DESCRIPTION
#### Summary

This migration was reverted in https://github.com/mattermost/mattermost-server/pull/16908 for performance reasons. We diverged from cloud since they had already applied the changes by the time we decided to revert. Still we should not go ahead with this migration on on-prem releases.

#### Release Note

```release-note
NONE
```

