### PR TITLE
[MM-33469] Fix nil dereference in inviteGuestsToChannels

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -1278,6 +1278,11 @@ func inviteGuestsToChannels(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	guestsInvite := model.GuestsInviteFromJson(r.Body)
+	if guestsInvite == nil {
+		c.Err = model.NewAppError("Api4.inviteGuestsToChannels", "api.team.invite_guests_to_channels.invalid_body.app_error", nil, "", http.StatusBadRequest)
+		return
+	}
+
 	for i, email := range guestsInvite.Emails {
 		guestsInvite.Emails[i] = strings.ToLower(email)
 	}

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2924,6 +2924,13 @@ func TestInviteGuestsToTeam(t *testing.T) {
 	CheckNoError(t, resp)
 	require.True(t, okMsg, "should return true")
 
+	t.Run("invalid data in request body", func(t *testing.T) {
+		res, err := th.SystemAdminClient.DoApiPost(th.SystemAdminClient.GetTeamRoute(th.BasicTeam.Id)+"/invite-guests/email", "bad data")
+		require.Error(t, err)
+		require.Equal(t, "api.team.invite_guests_to_channels.invalid_body.app_error", err.Id)
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
+	})
+
 	nameFormat := *th.App.Config().TeamSettings.TeammateNameDisplay
 	expectedSubject := i18n.T("api.templates.invite_guest_subject",
 		map[string]interface{}{"SenderName": th.SystemAdminUser.GetDisplayName(nameFormat),

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2507,6 +2507,10 @@
     "translation": "The channels of the invite must be part of the team of the invite."
   },
   {
+    "id": "api.team.invite_guests_to_channels.invalid_body.app_error",
+    "translation": "Invalid or missing request body."
+  },
+  {
     "id": "api.team.invite_members.disabled.app_error",
     "translation": "Email invitations are disabled."
   },


### PR DESCRIPTION
#### Summary

PR fixes a panic due to `nil` dereference. Again this is caused by not handling JSON decoding errors.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-33469

#### Release Note

```release-note
NONE
```

