### PR TITLE
set CSP unsafe-inline during development

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -177,7 +177,13 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Add unsafe-eval to the content security policy for faster source maps in development mode
 		devCSP := ""
 		if model.BuildNumber == "dev" {
-			devCSP = " 'unsafe-eval'"
+			devCSP += " 'unsafe-eval'"
+		}
+
+		// Add unsafe-inline to unlock extensions like React & Redux DevTools in Firefox
+		// see https://github.com/reduxjs/redux-devtools/issues/380#issuecomment-329085853
+		if model.BuildNumber == "dev" {
+			devCSP += " 'unsafe-inline'"
 		}
 
 		// Set content security policy. This is also specified in the root.html of the webapp in a meta tag.

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -181,7 +181,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Add unsafe-inline to unlock extensions like React & Redux DevTools in Firefox
-		// see https://github.com/reduxjs/redux-devtools/issues/380#issuecomment-329085853
+		// see https://github.com/reduxjs/redux-devtools/issues/380
 		if model.BuildNumber == "dev" {
 			devCSP += " 'unsafe-inline'"
 		}


### PR DESCRIPTION
#### Summary
Extensions in Firefox are hampered by a [long-standing bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1267027) that (incorrectly) applies CSP to content scripts injected by extensions. This precludes the ability to use the React and Redux DevTools in Firefox.

When in dev mode, add `unsafe-inline` to the CSP directives to unlock the use of these extdensions.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```