### PR TITLE
Refactor SQL queries in store/sqlstore/preference_store.go to use the squirrel builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,10 +422,12 @@ workflows:
               ignore:
                 - master
                 - /^release-.*/
-      - check-deps:
-          context: sast-webhook
-          requires:
-            - setup
+      # Disabling check-deps since the new version is not on bintray and all builds will fail
+      # we've are on top of this, and it's going to be temporary.
+      #- check-deps:
+      #     context: sast-webhook
+      #    requires:
+      #      - setup
       # - check-i18n:
       #     requires:
       #       - setup
@@ -498,10 +500,12 @@ workflows:
                 - master
                 - /^release-.*/
                 - cloud
-      - check-deps:
-          context: sast-webhook
-          requires:
-            - setup
+      # Disabling check-deps since the new version is not on bintray and all builds will fail
+      # we've are on top of this, and it's going to be temporary.
+      #- check-deps:
+      #    context: sast-webhook
+      #    requires:
+      #      - setup
       # - check-i18n:
       #     requires:
       #       - setup

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -145,7 +145,6 @@ func (s SqlPreferenceStore) update(transaction *gorp.Transaction, preference *mo
 
 func (s SqlPreferenceStore) Get(userId string, category string, name string) (*model.Preference, error) {
 	var preference *model.Preference
-	fmt.Println("userid ", userId, " ", category, " ", name)
 	query, args, err := s.getQueryBuilder().
 		Select("*").
 		From("Preferences").

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -230,14 +230,17 @@ func (s SqlPreferenceStore) Delete(userId, category, name string) error {
 }
 
 func (s SqlPreferenceStore) DeleteCategory(userId string, category string) error {
-	_, err := s.GetMaster().Exec(
-		`DELETE FROM
-			Preferences
-		WHERE
-			UserId = :UserId
-			AND Category = :Category`, map[string]interface{}{"UserId": userId, "Category": category})
+
+	sql, args, err := s.getQueryBuilder().
+		Delete("Preferences").
+		Where(sq.Eq{"UserId": userId}).
+		Where(sq.Eq{"Category": category}).ToSql()
 
 	if err != nil {
+		return errors.Wrap(err, "could not build sql query to get delete preference by category")
+	}
+
+	if _, err = s.GetMaster().Exec(sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete Preference with userId=%s and category=%s", userId, category)
 	}
 

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -44,7 +44,7 @@ func (s SqlPreferenceStore) deleteUnusedFeatures() {
 		Delete("Preferences").
 		Where(sq.Eq{"Category": model.PREFERENCE_CATEGORY_ADVANCED_SETTINGS}).
 		Where(sq.Eq{"Value": "false"}).
-		Where(sq.Like{"Name": store.FeatureTogglePrefix}).ToSql()
+		Where(sq.Like{"Name": store.FeatureTogglePrefix + "%"}).ToSql()
 	if err != nil {
 		mlog.Warn(errors.Wrap(err, "could not build sql query to delete unused features!").Error())
 	}

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -266,31 +266,6 @@ func (s SqlPreferenceStore) DeleteCategoryAndName(category string, name string) 
 	return nil
 }
 
-/*
-
-	nameArr := make([]string, 0)
-	nestedSql, nestedArgs, err := s.getQueryBuilder().
-		Select("Preferences.Name").
-		From("Preferences").
-		LeftJoin("Posts ON Preferences.Name = Posts.Id").
-		Where(sq.Eq{"Preferences.Category": model.PREFERENCE_CATEGORY_FLAGGED_POST}).
-		Where(sq.Eq{"Posts.Id": nil}).
-		Limit(uint64(limit)).
-		ToSql()
-
-	if err != nil {
-		return int64(0), errors.Wrap(err, "could not build nested sql query to delete preference")
-	}
-	if _, err = s.GetReplica().Select(&nameArr, nestedSql, nestedArgs...); err != nil {
-		return int64(0), errors.Wrapf(err, "failed to fetch nested sqlquery to delete preference")
-	}
-
-	sql, args, err := s.getQueryBuilder().
-		Delete("Preferences").
-		Where(sq.Eq{"Category": model.PREFERENCE_CATEGORY_FLAGGED_POST}).
-		Where(sq.Eq{"Name": nameArr}).
-		ToSql()
-*/
 func (s SqlPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error) {
 
 	nameInQ, nameInArgs, err := sq.Select("*").

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -317,7 +317,6 @@ func (s SqlPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error) {
 
 	sqlResult, err := s.GetMaster().Exec(query, args...)
 	if err != nil {
-		fmt.Println(err.Error())
 		return int64(0), errors.Wrap(err, "failed to delete Preference")
 	}
 	rowsAffected, err := sqlResult.RowsAffected()
@@ -325,6 +324,5 @@ func (s SqlPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error) {
 		return int64(0), errors.Wrap(err, "unable to get rows affected")
 	}
 
-	fmt.Println("Rows affected, ", rowsAffected)
 	return rowsAffected, nil
 }

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -177,22 +177,22 @@ func (s SqlPreferenceStore) GetCategory(userId string, category string) (model.P
 	if _, err = s.GetReplica().Select(&preferences, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find Preference with userId=%s, category=%s", userId, category)
 	}
-
 	return preferences, nil
 
 }
 
 func (s SqlPreferenceStore) GetAll(userId string) (model.Preferences, error) {
 	var preferences model.Preferences
-
-	if _, err := s.GetReplica().Select(&preferences,
-		`SELECT
-				*
-			FROM
-				Preferences
-			WHERE
-				UserId = :UserId`, map[string]interface{}{"UserId": userId}); err != nil {
-		return nil, errors.Wrapf(err, "failed to find Preferences with userId=%s", userId)
+	query, args, err := s.getQueryBuilder().
+		Select("*").
+		From("Preferences").
+		Where(sq.Eq{"UserId": userId}).
+		ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not build sql query to get preference")
+	}
+	if _, err = s.GetReplica().Select(&preferences, query, args...); err != nil {
+		return nil, errors.Wrapf(err, "failed to find Preference with userId=%s", userId)
 	}
 	return preferences, nil
 }

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -267,7 +267,11 @@ func (s SqlPreferenceStore) DeleteCategoryAndName(category string, name string) 
 }
 
 func (s SqlPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error) {
-
+	if limit < 0 {
+		// uint64 does not throw an error, it overflows if it is negative.
+		// it is better to manually check here, or change the function type to uint64
+		return int64(0), errors.Errorf("Received a negative limit")
+	}
 	nameInQ, nameInArgs, err := sq.Select("*").
 		FromSelect(
 			sq.Select("Preferences.Name").

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -359,7 +359,7 @@ func testPreferenceCleanupFlagsBatch(t *testing.T, ss store.Store) {
 	nErr := ss.Preference().Save(&model.Preferences{preference1, preference2})
 	require.NoError(t, nErr)
 
-	_, nErr =  ss.Preference().CleanupFlagsBatch(-1)
+	_, nErr = ss.Preference().CleanupFlagsBatch(-1)
 	require.Error(t, nErr)
 
 	_, nErr = ss.Preference().CleanupFlagsBatch(10000)

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -359,6 +359,9 @@ func testPreferenceCleanupFlagsBatch(t *testing.T, ss store.Store) {
 	nErr := ss.Preference().Save(&model.Preferences{preference1, preference2})
 	require.NoError(t, nErr)
 
+	_, nErr =  ss.Preference().CleanupFlagsBatch(-1)
+	require.Error(t, nErr)
+
 	_, nErr = ss.Preference().CleanupFlagsBatch(10000)
 	assert.NoError(t, nErr)
 

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -177,7 +177,13 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Add unsafe-eval to the content security policy for faster source maps in development mode
 		devCSP := ""
 		if model.BuildNumber == "dev" {
-			devCSP = " 'unsafe-eval'"
+			devCSP += " 'unsafe-eval'"
+		}
+
+		// Add unsafe-inline to unlock extensions like React & Redux DevTools in Firefox
+		// see https://github.com/reduxjs/redux-devtools/issues/380
+		if model.BuildNumber == "dev" {
+			devCSP += " 'unsafe-inline'"
 		}
 
 		// Set content security policy. This is also specified in the root.html of the webapp in a meta tag.


### PR DESCRIPTION
#### Summary
This pull request refactors the preference store to use squirrel queries instead of raw SQL queries.

Apart from refactoring, as `Limit` takes a parameter of `uint` and the function parameter for  `CleanupFlagsBatch` takes a limit of `int`, an extra check has been added to make sure that the integer is positive before converting it to `uint`. An additional check in tests has been added to ensure that an error is thrown

#### Ticket Link
Closes #16798 

#### Release Note
```
none
```
