### PR TITLE
MM-33789: Revert fallback to master for GetAllProfilesInChannel

### DIFF
--- a/store/localcachelayer/layer.go
+++ b/store/localcachelayer/layer.go
@@ -292,7 +292,6 @@ func NewLocalCacheLayer(baseStore store.Store, metrics einterfaces.MetricsInterf
 		UserStore:                      baseStore.User(),
 		rootStore:                      &localCacheStore,
 		userProfileByIdsInvalidations:  make(map[string]bool),
-		profilesInChannelInvalidations: make(map[string]bool),
 	}
 
 	// Teams

--- a/store/localcachelayer/layer.go
+++ b/store/localcachelayer/layer.go
@@ -289,9 +289,9 @@ func NewLocalCacheLayer(baseStore store.Store, metrics einterfaces.MetricsInterf
 		return
 	}
 	localCacheStore.user = &LocalCacheUserStore{
-		UserStore:                      baseStore.User(),
-		rootStore:                      &localCacheStore,
-		userProfileByIdsInvalidations:  make(map[string]bool),
+		UserStore:                     baseStore.User(),
+		rootStore:                     &localCacheStore,
+		userProfileByIdsInvalidations: make(map[string]bool),
 	}
 
 	// Teams

--- a/store/localcachelayer/user_layer.go
+++ b/store/localcachelayer/user_layer.go
@@ -15,9 +15,9 @@ import (
 
 type LocalCacheUserStore struct {
 	store.UserStore
-	rootStore                      *LocalCacheStore
-	userProfileByIdsMut            sync.Mutex
-	userProfileByIdsInvalidations  map[string]bool
+	rootStore                     *LocalCacheStore
+	userProfileByIdsMut           sync.Mutex
+	userProfileByIdsInvalidations map[string]bool
 }
 
 func (s *LocalCacheUserStore) handleClusterInvalidateScheme(msg *model.ClusterMessage) {

--- a/store/localcachelayer/user_layer.go
+++ b/store/localcachelayer/user_layer.go
@@ -18,8 +18,6 @@ type LocalCacheUserStore struct {
 	rootStore                      *LocalCacheStore
 	userProfileByIdsMut            sync.Mutex
 	userProfileByIdsInvalidations  map[string]bool
-	profilesInChannelMut           sync.Mutex
-	profilesInChannelInvalidations map[string]bool
 }
 
 func (s *LocalCacheUserStore) handleClusterInvalidateScheme(msg *model.ClusterMessage) {
@@ -37,9 +35,6 @@ func (s *LocalCacheUserStore) handleClusterInvalidateProfilesInChannel(msg *mode
 	if msg.Data == ClearCacheMessageData {
 		s.rootStore.profilesInChannelCache.Purge()
 	} else {
-		s.profilesInChannelMut.Lock()
-		s.profilesInChannelInvalidations[msg.Data] = true
-		s.profilesInChannelMut.Unlock()
 		s.rootStore.profilesInChannelCache.Remove(msg.Data)
 	}
 }
@@ -72,9 +67,6 @@ func (s *LocalCacheUserStore) InvalidateProfilesInChannelCacheByUser(userId stri
 			var userMap map[string]*model.User
 			if err = s.rootStore.profilesInChannelCache.Get(key, &userMap); err == nil {
 				if _, userInCache := userMap[userId]; userInCache {
-					s.profilesInChannelMut.Lock()
-					s.profilesInChannelInvalidations[key] = true
-					s.profilesInChannelMut.Unlock()
 					s.rootStore.doInvalidateCacheCluster(s.rootStore.profilesInChannelCache, key)
 					if s.rootStore.metrics != nil {
 						s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Profiles in Channel - Remove by User")
@@ -86,9 +78,6 @@ func (s *LocalCacheUserStore) InvalidateProfilesInChannelCacheByUser(userId stri
 }
 
 func (s *LocalCacheUserStore) InvalidateProfilesInChannelCache(channelID string) {
-	s.profilesInChannelMut.Lock()
-	s.profilesInChannelInvalidations[channelID] = true
-	s.profilesInChannelMut.Unlock()
 	s.rootStore.doInvalidateCacheCluster(s.rootStore.profilesInChannelCache, channelID)
 	if s.rootStore.metrics != nil {
 		s.rootStore.metrics.IncrementMemCacheInvalidationCounter("Profiles in Channel - Remove by Channel")
@@ -102,15 +91,6 @@ func (s *LocalCacheUserStore) GetAllProfilesInChannel(ctx context.Context, chann
 			return cachedMap, nil
 		}
 	}
-
-	// If it was invalidated, then we need to query master.
-	s.profilesInChannelMut.Lock()
-	if s.profilesInChannelInvalidations[channelId] {
-		ctx = sqlstore.WithMaster(ctx)
-		// And then remove the key from the map.
-		delete(s.profilesInChannelInvalidations, channelId)
-	}
-	s.profilesInChannelMut.Unlock()
 
 	userMap, err := s.UserStore.GetAllProfilesInChannel(ctx, channelId, allowFromCache)
 	if err != nil {


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/mattermost/mattermost-server/pull/16911.

It was causing problems with too many invalidations and overloading the writer instance for big installations.
Reverting this does not affect correctness at all because it was done out of abundance of caution and the
idea at that point was it was to be done for all caches.

https://mattermost.atlassian.net/browse/MM-33789

```release-note
NONE
```
