### PR TITLE
MM-33756 fix client crashes on sync (post sync order)

### DIFF
--- a/services/remotecluster/mocks_test.go
+++ b/services/remotecluster/mocks_test.go
@@ -56,6 +56,9 @@ type mockLogger struct {
 	t *testing.T
 }
 
+func (ml *mockLogger) IsLevelEnabled(level mlog.LogLevel) bool {
+	return true
+}
 func (ml *mockLogger) Debug(s string, flds ...mlog.Field) {
 	ml.t.Log("debug", s, fieldsToStrings(flds))
 }

--- a/services/remotecluster/send_test.go
+++ b/services/remotecluster/send_test.go
@@ -42,7 +42,17 @@ func TestBroadcastMsg(t *testing.T) {
 		merr := merror.New()
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			defer w.WriteHeader(200)
+			defer func() {
+				w.WriteHeader(200)
+				var resp Response
+				b, errMarshall := json.Marshal(&resp)
+				if errMarshall != nil {
+					merr.Append(errMarshall)
+					return
+				}
+				w.Write(b)
+			}()
+
 			atomic.AddInt32(&countWebReq, 1)
 
 			frame, appErr := model.RemoteClusterFrameFromJSON(r.Body)

--- a/services/sharedchannel/mock_AppIface_test.go
+++ b/services/sharedchannel/mock_AppIface_test.go
@@ -132,6 +132,31 @@ func (_m *MockAppIface) CreateUploadSession(us *model.UploadSession) (*model.Upl
 	return r0, r1
 }
 
+// DeletePost provides a mock function with given fields: postID, deleteByID
+func (_m *MockAppIface) DeletePost(postID string, deleteByID string) (*model.Post, *model.AppError) {
+	ret := _m.Called(postID, deleteByID)
+
+	var r0 *model.Post
+	if rf, ok := ret.Get(0).(func(string, string) *model.Post); ok {
+		r0 = rf(postID, deleteByID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Post)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func(string, string) *model.AppError); ok {
+		r1 = rf(postID, deleteByID)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // DeleteReactionForPost provides a mock function with given fields: reaction
 func (_m *MockAppIface) DeleteReactionForPost(reaction *model.Reaction) *model.AppError {
 	ret := _m.Called(reaction)

--- a/services/sharedchannel/msg.go
+++ b/services/sharedchannel/msg.go
@@ -78,6 +78,11 @@ func (scs *Service) postsToSyncMessages(posts []*model.Post, rc *model.RemoteClu
 			postSync = nil
 		}
 
+		// Don't send a deleted post if it is just the original copy from an edit.
+		if p.DeleteAt > 0 && p.OriginalId != "" {
+			postSync = nil
+		}
+
 		// don't sync a post back to the remote it came from.
 		if p.RemoteId != nil && *p.RemoteId == rc.RemoteId {
 			postSync = nil

--- a/services/sharedchannel/service.go
+++ b/services/sharedchannel/service.go
@@ -47,6 +47,7 @@ type AppIface interface {
 	PermanentDeleteChannel(channel *model.Channel) *model.AppError
 	CreatePost(post *model.Post, channel *model.Channel, triggerWebhooks bool, setOnline bool) (savedPost *model.Post, err *model.AppError)
 	UpdatePost(post *model.Post, safeUpdate bool) (*model.Post, *model.AppError)
+	DeletePost(postID, deleteByID string) (*model.Post, *model.AppError)
 	SaveReactionForPost(reaction *model.Reaction) (*model.Reaction, *model.AppError)
 	DeleteReactionForPost(reaction *model.Reaction) *model.AppError
 	PatchChannelModerationsForChannel(channel *model.Channel, channelModerationsPatch []*model.ChannelModerationPatch) ([]*model.ChannelModeration, *model.AppError)

--- a/services/sharedchannel/sync_recv.go
+++ b/services/sharedchannel/sync_recv.go
@@ -24,7 +24,7 @@ func (scs *Service) onReceiveSyncMessage(msg model.RemoteClusterMsg, rc *model.R
 	}
 
 	if scs.server.GetLogger().IsLevelEnabled(mlog.LvlSharedChannelServiceMessagesInbound) {
-		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceMessagesOutbound, "inbound message",
+		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceMessagesInbound, "inbound message",
 			mlog.String("remote", rc.DisplayName),
 			mlog.String("msg", string(msg.Payload)),
 		)

--- a/services/sharedchannel/sync_recv.go
+++ b/services/sharedchannel/sync_recv.go
@@ -247,6 +247,13 @@ func (scs *Service) upsertSyncPost(post *model.Post, channel *model.Channel, rc 
 			mlog.String("post_id", post.Id),
 			mlog.String("channel_id", post.ChannelId),
 		)
+	} else if post.DeleteAt > 0 {
+		// delete post
+		rpost, appErr = scs.app.DeletePost(post.Id, post.UserId)
+		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceDebug, "Deleted sync post",
+			mlog.String("post_id", post.Id),
+			mlog.String("channel_id", post.ChannelId),
+		)
 	} else if post.EditAt > rpost.EditAt || post.Message != rpost.Message {
 		// update post
 		rpost, appErr = scs.app.UpdatePost(post, false)

--- a/services/sharedchannel/sync_recv.go
+++ b/services/sharedchannel/sync_recv.go
@@ -23,6 +23,13 @@ func (scs *Service) onReceiveSyncMessage(msg model.RemoteClusterMsg, rc *model.R
 		return errors.New("empty sync message")
 	}
 
+	if scs.server.GetLogger().IsLevelEnabled(mlog.LvlSharedChannelServiceMessagesInbound) {
+		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceMessagesOutbound, "inbound message",
+			mlog.String("remote", rc.DisplayName),
+			mlog.String("msg", string(msg.Payload)),
+		)
+	}
+
 	var syncMessages []syncMsg
 
 	if err := json.Unmarshal(msg.Payload, &syncMessages); err != nil {

--- a/services/sharedchannel/sync_recv.go
+++ b/services/sharedchannel/sync_recv.go
@@ -247,7 +247,7 @@ func (scs *Service) upsertSyncPost(post *model.Post, channel *model.Channel, rc 
 			mlog.String("post_id", post.Id),
 			mlog.String("channel_id", post.ChannelId),
 		)
-	} else if rpost.DeleteAt == 0 {
+	} else if post.EditAt > rpost.EditAt || post.Message != rpost.Message {
 		// update post
 		rpost, appErr = scs.app.UpdatePost(post, false)
 		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceDebug, "Updated sync post",
@@ -255,8 +255,8 @@ func (scs *Service) upsertSyncPost(post *model.Post, channel *model.Channel, rc 
 			mlog.String("channel_id", post.ChannelId),
 		)
 	} else {
-		// this is an re-sync of a deleted post; no need to update it
-		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceDebug, "Update to deleted sync post ignored",
+		// nothing to update
+		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceDebug, "Update to sync post ignored",
 			mlog.String("post_id", post.Id),
 			mlog.String("channel_id", post.ChannelId),
 		)

--- a/services/sharedchannel/sync_send.go
+++ b/services/sharedchannel/sync_send.go
@@ -329,6 +329,13 @@ func (scs *Service) updateForRemote(task syncTask, rc *model.RemoteCluster) erro
 	}
 	msg := model.NewRemoteClusterMsg(TopicSync, b)
 
+	if scs.server.GetLogger().IsLevelEnabled(mlog.LvlSharedChannelServiceMessagesOutbound) {
+		scs.server.GetLogger().Log(mlog.LvlSharedChannelServiceMessagesOutbound, "outbound message",
+			mlog.String("remote", rc.DisplayName),
+			mlog.String("msg", string(b)),
+		)
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), remotecluster.SendTimeout)
 	defer cancel()
 

--- a/shared/mlog/default.go
+++ b/shared/mlog/default.go
@@ -33,6 +33,10 @@ func defaultLog(level, msg string, fields ...Field) {
 	}
 }
 
+func defaultIsLevelEnabled(level LogLevel) bool {
+	return true
+}
+
 func defaultDebugLog(msg string, fields ...Field) {
 	defaultLog("debug", msg, fields...)
 }

--- a/shared/mlog/global.go
+++ b/shared/mlog/global.go
@@ -23,6 +23,7 @@ func InitGlobalLogger(logger *Logger) {
 	glob := *logger
 	glob.zap = glob.zap.WithOptions(zap.AddCallerSkip(1))
 	globalLogger = &glob
+	IsLevelEnabled = globalLogger.IsLevelEnabled
 	Debug = globalLogger.Debug
 	Info = globalLogger.Info
 	Warn = globalLogger.Warn
@@ -59,6 +60,7 @@ func RedirectStdLog(logger *Logger) {
 	log.SetOutput(logWriterFunc(writer))
 }
 
+type IsLevelEnabledFunc func(LogLevel) bool
 type LogFunc func(string, ...Field)
 type LogFuncCustom func(LogLevel, string, ...Field)
 type LogFuncCustomMulti func([]LogLevel, string, ...Field)
@@ -79,6 +81,7 @@ func GloballyEnableDebugLogForTest() {
 	globalLogger.consoleLevel.SetLevel(zapcore.DebugLevel)
 }
 
+var IsLevelEnabled IsLevelEnabledFunc = defaultIsLevelEnabled
 var Debug LogFunc = defaultDebugLog
 var Info LogFunc = defaultInfoLog
 var Warn LogFunc = defaultWarnLog

--- a/shared/mlog/levels.go
+++ b/shared/mlog/levels.go
@@ -39,8 +39,8 @@ var (
 	LvlSharedChannelServiceDebug            = LogLevel{ID: 200, Name: "SharedChannelServiceDebug"}
 	LvlSharedChannelServiceError            = LogLevel{ID: 201, Name: "SharedChannelServiceError"}
 	LvlSharedChannelServiceWarn             = LogLevel{ID: 202, Name: "SharedChannelServiceWarn"}
-	LvlSharedChannelServiceMessagesInbound  = LogLevel{ID: 203, Name: "SharedChannelServiceMessages"}
-	LvlSharedChannelServiceMessagesOutbound = LogLevel{ID: 204, Name: "SharedChannelServiceMessages"}
+	LvlSharedChannelServiceMessagesInbound  = LogLevel{ID: 203, Name: "SharedChannelServiceMsgInbound"}
+	LvlSharedChannelServiceMessagesOutbound = LogLevel{ID: 204, Name: "SharedChannelServiceMsgOutbound"}
 
 	// add more here ...
 )

--- a/shared/mlog/levels.go
+++ b/shared/mlog/levels.go
@@ -36,9 +36,11 @@ var (
 	LvlRemoteClusterServiceWarn  = LogLevel{ID: 132, Name: "RemoteClusterServiceWarn"}
 
 	// used by Shared Channel Sync Service
-	LvlSharedChannelServiceDebug = LogLevel{ID: 200, Name: "SharedChannelServiceDebug"}
-	LvlSharedChannelServiceError = LogLevel{ID: 201, Name: "SharedChannelServiceError"}
-	LvlSharedChannelServiceWarn  = LogLevel{ID: 202, Name: "SharedChannelServiceWarn"}
+	LvlSharedChannelServiceDebug            = LogLevel{ID: 200, Name: "SharedChannelServiceDebug"}
+	LvlSharedChannelServiceError            = LogLevel{ID: 201, Name: "SharedChannelServiceError"}
+	LvlSharedChannelServiceWarn             = LogLevel{ID: 202, Name: "SharedChannelServiceWarn"}
+	LvlSharedChannelServiceMessagesInbound  = LogLevel{ID: 203, Name: "SharedChannelServiceMessages"}
+	LvlSharedChannelServiceMessagesOutbound = LogLevel{ID: 204, Name: "SharedChannelServiceMessages"}
 
 	// add more here ...
 )

--- a/shared/mlog/log.go
+++ b/shared/mlog/log.go
@@ -219,7 +219,7 @@ func (l *Logger) Sugar() *SugarLogger {
 }
 
 func (l *Logger) IsLevelEnabled(level LogLevel) bool {
-	return isLevelEnabled(l.getLogger(), logr.Debug)
+	return isLevelEnabled(l.getLogger(), logr.Level(level))
 }
 
 func (l *Logger) Debug(message string, fields ...Field) {

--- a/shared/mlog/log.go
+++ b/shared/mlog/log.go
@@ -58,6 +58,7 @@ var Bool = zap.Bool
 var Duration = zap.Duration
 
 type LoggerIFace interface {
+	IsLevelEnabled(LogLevel) bool
 	Debug(string, ...Field)
 	Info(string, ...Field)
 	Warn(string, ...Field)
@@ -215,6 +216,10 @@ func (l *Logger) Sugar() *SugarLogger {
 		wrappedLogger: l,
 		zapSugar:      l.zap.Sugar(),
 	}
+}
+
+func (l *Logger) IsLevelEnabled(level LogLevel) bool {
+	return isLevelEnabled(l.getLogger(), logr.Debug)
 }
 
 func (l *Logger) Debug(message string, fields ...Field) {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -942,7 +942,7 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 		Where(sq.GtOrEq{"UpdateAt": options.Since}).
 		Where(sq.Eq{"ChannelId": options.ChannelId}).
 		Limit(uint64(options.Limit)).
-		OrderBy("UpdateAt"+order, "Id")
+		OrderBy("CreateAt"+order, "Id")
 
 	if options.Until > 0 {
 		query = query.Where(sq.LtOrEq{"UpdateAt": options.Until})

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -949,7 +949,7 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 	}
 
 	if !options.IncludeDeleted {
-		query = query.Where(sq.NotEq{"Delete": 0})
+		query = query.Where(sq.Eq{"DeleteAt": 0})
 	}
 
 	if options.ExcludeRemoteId != "" {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -941,8 +941,9 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 		From("Posts").
 		Where(sq.GtOrEq{"UpdateAt": options.Since}).
 		Where(sq.Eq{"ChannelId": options.ChannelId}).
+		Where(sq.Eq{"DeleteAt": 0}).
 		Limit(uint64(options.Limit)).
-		OrderBy("CreateAt"+order, "DeleteAt", "Id")
+		OrderBy("CreateAt"+order, "Id")
 
 	if options.Until > 0 {
 		query = query.Where(sq.LtOrEq{"UpdateAt": options.Until})

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -941,9 +941,8 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 		From("Posts").
 		Where(sq.GtOrEq{"UpdateAt": options.Since}).
 		Where(sq.Eq{"ChannelId": options.ChannelId}).
-		Where(sq.Eq{"DeleteAt": 0}).
 		Limit(uint64(options.Limit)).
-		OrderBy("CreateAt"+order, "Id")
+		OrderBy("CreateAt"+order, "DeleteAt", "Id")
 
 	if options.Until > 0 {
 		query = query.Where(sq.LtOrEq{"UpdateAt": options.Until})

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -942,7 +942,7 @@ func (s *SqlPostStore) GetPostsSinceForSync(options model.GetPostsSinceForSyncOp
 		Where(sq.GtOrEq{"UpdateAt": options.Since}).
 		Where(sq.Eq{"ChannelId": options.ChannelId}).
 		Limit(uint64(options.Limit)).
-		OrderBy("CreateAt"+order, "Id")
+		OrderBy("CreateAt"+order, "DeleteAt", "Id")
 
 	if options.Until > 0 {
 		query = query.Where(sq.LtOrEq{"UpdateAt": options.Until})


### PR DESCRIPTION
#### Summary
This PR fixes a crash in the client after a sync when edited/deleted posts are included in a certain order.

- don't send the deleted post that is just a copy of an original edited post
- detect true deleted post and use delete api instead of update to get "message deleted" on client
- make sending message for sync a synchronous call so next sync cannot over-take
- add logging levels for logging message traffic


**To be merged with feature branch.**

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33756

#### Release Note
```release-note
NONE
```
