### PR TITLE
Set Docker platform option for compatibility with Apple Silicon.

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -1,6 +1,7 @@
 version: '2.4'
 services:
   mysql:
+    platform: linux/x86_64
     image: "mysql:5.6"
     restart: always
     networks:


### PR DESCRIPTION
#### Summary

Set the Docker platform option explicitly to what the image supports for compatibility with Apple Silicon dev. machines.

#### Ticket Link

n/a

#### Release Note

```release-note
NONE
```
