### PR TITLE
MM-33832 remove slash command for manual shared channel sync 

### DIFF
--- a/app/slashcommands/command_share.go
+++ b/app/slashcommands/command_share.go
@@ -51,14 +51,11 @@ func (sp *ShareProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Com
 
 	status := model.NewAutocompleteData("status", "", T("api.command_share.channel_status.help"))
 
-	sync := model.NewAutocompleteData("sync", "", T("api.command_share.sync.help"))
-
 	share.AddCommand(shareChannel)
 	share.AddCommand(unshareChannel)
 	share.AddCommand(inviteRemote)
 	share.AddCommand(unInviteRemote)
 	share.AddCommand(status)
-	share.AddCommand(sync)
 
 	return &model.Command{
 		Trigger:          CommandTriggerShare,
@@ -161,8 +158,6 @@ func (sp *ShareProvider) DoCommand(a *app.App, args *model.CommandArgs, message 
 		return sp.doUninviteRemote(a, args, margs)
 	case "status":
 		return sp.doStatus(a, args, margs)
-	case "sync":
-		return sp.doSync(a, args, margs)
 	}
 	return responsef(args.T("api.command_share.unknown_action", map[string]interface{}{"Action": action, "Actions": AvailableShareActions}))
 }
@@ -337,15 +332,6 @@ func (sp *ShareProvider) doStatus(a *app.App, args *model.CommandArgs, margs map
 			status.ReadOnly, status.IsInviteAccepted, online, lastSync)
 	}
 	return responsef(sb.String())
-}
-
-func (sp *ShareProvider) doSync(a *app.App, args *model.CommandArgs, margs map[string]string) *model.CommandResponse {
-	// start sending updates to remote clusters.
-	a.Srv().GetSharedChannelSyncService().NotifyChannelChanged(args.ChannelId)
-
-	// TODO: send cluster message to each remote requesting a sync for this channel.
-
-	return responsef("##### " + args.T("api.command_share.sync_initiated"))
 }
 
 func notifyClientsForChannelUpdate(a *app.App, sharedChannel *model.SharedChannel) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1455,14 +1455,6 @@
     "translation": "Cannot unshare this channel: {{.Error}}."
   },
   {
-    "id": "api.command_share.sync.help",
-    "translation": "Forces a sync with remote instances this shared channel"
-  },
-  {
-    "id": "api.command_share.sync_initiated",
-    "translation": "Sync initiated."
-  },
-  {
     "id": "api.command_share.uninvite_remote.help",
     "translation": "Uninvites a remote instance from this shared channel"
   },


### PR DESCRIPTION
#### Summary
This PR removes the slash command for manually initiating a shared channel sync.  It was a temporary solution to testing sync before the automatic triggers were implemented. Also the manual sync command does not work reliably in multi-node clusters since sync must be initiated on the leader node. 

**This will be merged with the feature branch.**

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33832-->

#### Release Note
```release-note
NONE
```
