### PR TITLE
rel5.33

### DIFF
--- a/api4/websocket.go
+++ b/api4/websocket.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"net/http"
-	"runtime"
 	"time"
 
 	"github.com/gobwas/ws"
@@ -49,7 +48,7 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.App.HubRegister(wc)
 	}
 
-	if runtime.GOOS == "windows" {
+	if !wc.Epoll() {
 		wc.BlockingPump()
 	} else {
 		go wc.Pump()

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -36,6 +36,8 @@ const (
 	webConnMemberCacheTime = 1000 * 60 * 30 // 30 minutes
 )
 
+var errNonEpollConnClose = errors.New("connection closed")
+
 // WebConn represents a single websocket connection to a user.
 // It contains all the necessary state to manage sending/receiving data to/from
 // a websocket.
@@ -55,7 +57,7 @@ type WebConn struct {
 	send                      chan model.WebSocketMessage
 	sessionToken              atomic.Value
 	session                   atomic.Value
-	isWindows                 bool
+	hasEpoll                  bool
 	endWritePump              chan struct{}
 	pumpFinished              chan struct{}
 	closeOnce                 sync.Once
@@ -78,7 +80,7 @@ func (a *App) NewWebConn(ws net.Conn, session model.Session, t goi18n.TranslateF
 		UserId:             session.UserId,
 		T:                  t,
 		Locale:             locale,
-		isWindows:          runtime.GOOS == "windows",
+		hasEpoll:           *a.Config().ServiceSettings.ConnectionSecurity == "" && runtime.GOOS != "windows",
 		endWritePump:       make(chan struct{}),
 		pumpFinished:       make(chan struct{}),
 	}
@@ -87,8 +89,7 @@ func (a *App) NewWebConn(ws net.Conn, session model.Session, t goi18n.TranslateF
 	wc.SetSessionToken(session.Token)
 	wc.SetSessionExpiresAt(session.ExpiresAt)
 
-	// epoll/kqueue is not available on Windows.
-	if !wc.isWindows {
+	if wc.hasEpoll {
 		wc.startPoller()
 	}
 	return wc
@@ -101,7 +102,7 @@ func (a *App) NewWebConn(ws net.Conn, session model.Session, t goi18n.TranslateF
 func (wc *WebConn) Close() {
 	wc.closeOnce.Do(func() {
 		wc.WebSocket.Close()
-		if !wc.isWindows {
+		if wc.hasEpoll {
 			// This triggers the pump exit.
 			// If the pump has already exited, this just becomes a noop.
 			close(wc.endWritePump)
@@ -145,6 +146,11 @@ func (wc *WebConn) SetSession(v *model.Session) {
 	wc.session.Store(v)
 }
 
+// Epoll returns whether the websocket is eligible to use epoll or not.
+func (wc *WebConn) Epoll() bool {
+	return wc.hasEpoll
+}
+
 // Pump starts the WebConn instance. After this, the websocket
 // is ready to send messages.
 // This is only used by *nix platforms.
@@ -156,7 +162,7 @@ func (wc *WebConn) Pump() {
 	close(wc.pumpFinished)
 }
 
-// BlockingPump is the Windows alternative of Pump.
+// BlockingPump is the non-epoll alternative of Pump.
 // It creates two goroutines - one for reading, another
 // for writing.
 func (wc *WebConn) BlockingPump() {
@@ -242,9 +248,9 @@ func (wc *WebConn) ReadMsg() error {
 	switch hdr.OpCode {
 	case ws.OpClose:
 		// Return if closed.
-		// We need to return an error for Windows to let the reader exit.
-		if wc.isWindows {
-			return errors.New("connection closed")
+		// We need to return an error for non-epoll systems to let the reader exit.
+		if !wc.hasEpoll {
+			return errNonEpollConnClose
 		}
 		return nil
 	case ws.OpPong:
@@ -274,7 +280,9 @@ func (wc *WebConn) readPump() {
 
 	for {
 		if err := wc.ReadMsg(); err != nil {
-			wc.logSocketErr("websocket.read", err)
+			if err != errNonEpollConnClose {
+				wc.logSocketErr("websocket.read", err)
+			}
 			return
 		}
 	}

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -58,6 +58,7 @@ type WebConn struct {
 	isWindows                 bool
 	endWritePump              chan struct{}
 	pumpFinished              chan struct{}
+	closeOnce                 sync.Once
 }
 
 // NewWebConn returns a new WebConn instance.
@@ -94,15 +95,20 @@ func (a *App) NewWebConn(ws net.Conn, session model.Session, t goi18n.TranslateF
 }
 
 // Close closes the WebConn.
+// It is made idempotent in nature by using a sync.Once
+// to avoid a race condition that happens when an EventReadHup event
+// and a connection close event happens at the same time.
 func (wc *WebConn) Close() {
-	wc.WebSocket.Close()
-	if !wc.isWindows {
-		// This triggers the pump exit.
-		// If the pump has already exited, this just becomes a noop.
-		close(wc.endWritePump)
-	}
-	// We wait for the pump to fully exit.
-	<-wc.pumpFinished
+	wc.closeOnce.Do(func() {
+		wc.WebSocket.Close()
+		if !wc.isWindows {
+			// This triggers the pump exit.
+			// If the pump has already exited, this just becomes a noop.
+			close(wc.endWritePump)
+		}
+		// We wait for the pump to fully exit.
+		<-wc.pumpFinished
+	})
 }
 
 // GetSessionExpiresAt returns the time at which the session expires.

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -90,6 +90,20 @@ func TestHubStopWithMultipleConnections(t *testing.T) {
 	defer wc3.Close()
 }
 
+func TestWebConnDoubleClose(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	wc1 := registerDummyWebConn(t, th.App, s.Listener.Addr(), "userID")
+	wc1.Close()
+	require.NotPanics(t, func() {
+		wc1.Close()
+	})
+}
+
 // TestHubStopRaceCondition verifies that attempts to use the hub after it has shutdown does not
 // block the caller indefinitely.
 func TestHubStopRaceCondition(t *testing.T) {


### PR DESCRIPTION
- MM-33233: Fix double close of webconn pump (#17026)
- MM-34000: Use non-epoll mode for TLS connections (#17172)
