### PR TITLE
Makefile: Refactor test-server-race

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,14 +9,18 @@ PACKAGES=$3
 TESTS=$4
 TESTFLAGS=$5
 GOBIN=$6
+TIMEOUT=$7
+COVERMODE=$8
 
 PACKAGES_COMMA=$(echo $PACKAGES | tr ' ' ',')
 
 echo "Packages to test: $PACKAGES"
+echo "GOFLAGS: $GOFLAGS"
+
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
 find . -type d -name data -not -path './vendor/*' -not -path './data' | xargs rm -rf
 
-$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=20m -covermode=count -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
+$GO test $GOFLAGS -run=$TESTS $TESTFLAGS -v -timeout=$TIMEOUT -covermode=$COVERMODE -coverpkg=$PACKAGES_COMMA -exec $DIR/test-xprog.sh $PACKAGES 2>&1 > >( tee output )
 EXIT_STATUS=$?
 
 cat output | $GOBIN/go-junit-report > report.xml


### PR DESCRIPTION
test-server-race wasn't using the same set of steps
that the test-server step did. Therefore one test was failing.

Refactored it such that scripts/test.sh can be used to run
normal and race tests as well

```release-note
NONE
```
