### PR TITLE
[MM-29951] searchengine/bleve/indexing: use oldest entity creation time instead

### DIFF
--- a/i18n/bg.json
+++ b/i18n/bg.json
@@ -2364,8 +2364,8 @@
     "translation": "Работника по индексиране на Bleve не успя да анализира крайния час."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Най-старата публикация не може да бъде извлечена от базата данни."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "Най-стария обект (потребител, канал или публикация) не може да бъде извлечен от базата данни."
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -5375,10 +5375,6 @@
     "translation": "Elasticsearch-Aggregator-Worker konnte die Endzeit nicht verarbeiten"
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Die älteste Nachricht konnte nicht aus der Datenbank abgerufen werden."
-  },
-  {
     "id": "bleveengine.indexer.do_job.engine_inactive",
     "translation": "Failed to run Bleve index job: engine is inactive."
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6235,8 +6235,8 @@
     "translation": "Failed to run Bleve index job: engine is inactive."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "The oldest post could not be retrieved from the database."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "The oldest entity (user, channel or post) could not be retrieved from the database."
   },
   {
     "id": "bleveengine.indexer.do_job.parse_end_time.error",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -5275,8 +5275,8 @@
     "translation": "El trabajo de Bleve falló al analizar la hora de finalización."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "El mensaje más antiguo no pudo ser recuperado de la base de datos."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "La entidad más vieja (usuario, canal o poste), no podría ser recuperado de la base de datos."
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -5319,10 +5319,6 @@
     "translation": "Le système d’agrégation Elasticsearch n'a pas pu interpréter l'heure de fin"
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Impossible de récupérer le message le plus ancien de la base de données."
-  },
-  {
     "id": "bleveengine.indexer.do_job.engine_inactive",
     "translation": "Failed to run Bleve index job: engine is inactive."
   },

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -5087,10 +5087,6 @@
     "translation": "Impossibile indicizzare gli utenti in batch."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Il post più vecchio non può essere recuperato dal database."
-  },
-  {
     "id": "bleveengine.indexer.do_job.parse_start_time.error",
     "translation": "Il lavoro di indicizzazione di Bleve non è riuscito a calcolare l'ora d'inizio."
   },

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -5314,8 +5314,8 @@
     "translation": "Bleveインデックス付与ワーカーが終了時刻を解析できませんでした。"
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "最も古い投稿をデータベースから取り出せませんでした。"
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "最も古いエンティティ(ユーザー、チャンネル、投稿)をデータベースから取得できませんでした。"
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -5314,10 +5314,6 @@
     "translation": "Bleve 색인 프로세스가 종료 시간을 구문 분석하지 못했습니다."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "데이터베이스에서 가장 오래된 게시물을 조회 할 수 없습니다"
-  },
-  {
     "id": "bleveengine.indexer.do_job.engine_inactive",
     "translation": "Failed to run Bleve index job: engine is inactive."
   },

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -5343,8 +5343,8 @@
     "translation": "Bleve indexing worker geeft een fout bij het verwerken de eindtijd."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "De oudste post kan niet worden opgehaald uit de database."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "De oudste entititeit (gebruiker,kanaal of bericht) kon niet worden opgehaald vanuit de databank."
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -5324,10 +5324,6 @@
     "translation": "Pracownik indeksujący Elasticsearch nie przeanalizował czasu zakończenia"
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Najstarszego postu nie można było pobrać z bazy danych."
-  },
-  {
     "id": "bleveengine.indexer.do_job.engine_inactive",
     "translation": "Failed to run Bleve index job: engine is inactive."
   },

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -5319,8 +5319,8 @@
     "translation": "Agregador do Bleve falhou em transformar a data de término."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "A publicação mais antiga não pode ser obtida do banco de dados."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "A entidade mais antiga (usuário, canal ou publicação) não pôde ser recuperada do banco de dados."
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/i18n/ro.json
+++ b/i18n/ro.json
@@ -5324,8 +5324,8 @@
     "translation": "Lucrătorul de indexare Bleve nu a reușit să analizeze ora de sfârșit."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Cea mai veche postare nu a putut fi preluată din baza de date."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "Cea mai veche entitate (utilizator, canal sau postare) nu a putut fi recuperată din baza de date."
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -5224,10 +5224,6 @@
     "translation": "Не удалось проиндексировать пакет пользователей."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Более старые сообщения не могут быть извлечены из базы данных."
-  },
-  {
     "id": "bleveengine.indexer.do_job.parse_start_time.error",
     "translation": "Работнику индексирования Bleve не удалось проанализировать время начала."
   },

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -1208,8 +1208,8 @@
     "translation": "Bleve:s indexeringsjobb kunde inte tolka sluttiden."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Det äldsta meddelandet kunde inte hämtas från databasen."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "Det äldsta objektet (användare, kanal eller meddelande) kunde inte hämtas från databasen."
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -5119,8 +5119,8 @@
     "translation": "Bleve dizine ekleme görevi yürütülemedi: İşleyici devre dışı."
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Veritabanından en eski ileti alınamadı."
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "Veritabanından en eski varlık (kullanıcı, kanal ya da ileti) alınamadı."
   },
   {
     "id": "bleveengine.indexer.do_job.parse_start_time.error",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -5324,10 +5324,6 @@
     "translation": "Працівник індексації Elasticsearch не зміг розібрати час закінчення"
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "Найстаріший запис не може бути завантажений з бази даних."
-  },
-  {
     "id": "bleveengine.indexer.do_job.engine_inactive",
     "translation": "Failed to run Bleve index job: engine is inactive."
   },

--- a/i18n/zh-CN.json
+++ b/i18n/zh-CN.json
@@ -5126,8 +5126,8 @@
     "translation": "批量索引用户失败。"
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "无法从数据库获取最旧的消息。"
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "无法从数据库中获取最早的实体（用户，频道或帖子）。"
   },
   {
     "id": "bleveengine.indexer.do_job.parse_end_time.error",

--- a/i18n/zh-TW.json
+++ b/i18n/zh-TW.json
@@ -5314,8 +5314,8 @@
     "translation": "Bleve 索引工作者解析中止時間時失敗。"
   },
   {
-    "id": "bleveengine.indexer.do_job.get_oldest_post.error",
-    "translation": "無法從資料庫取得最老的訊息。"
+    "id": "bleveengine.indexer.do_job.get_oldest_entity.error",
+    "translation": "無法從資料庫取得最老的實體 (使用者、頻道或訊息)。"
   },
   {
     "id": "bleveengine.indexer.do_job.engine_inactive",

--- a/services/searchengine/bleveengine/indexer/indexing_job.go
+++ b/services/searchengine/bleveengine/indexer/indexing_job.go
@@ -166,17 +166,18 @@ func (worker *BleveIndexerWorker) DoJob(job *model.Job) {
 		progress.StartAtTime = startInt
 		progress.LastEntityTime = progress.StartAtTime
 	} else {
-		// Set start time to oldest post in the database.
-		oldestPost, err := worker.jobServer.Store.Post().GetOldest()
+		// Set start time to oldest entity in the database.
+		// A user or a channel may be created before any post.
+		oldestEntityCreationTime, err := worker.jobServer.Store.Post().GetOldestEntityCreationTime()
 		if err != nil {
-			mlog.Error("Worker: Failed to fetch oldest post for job.", mlog.String("workername", worker.name), mlog.String("job_id", job.Id), mlog.String("start_time", startString), mlog.Err(err))
-			appError := model.NewAppError("BleveIndexerWorker", "bleveengine.indexer.do_job.get_oldest_post.error", nil, err.Error(), http.StatusInternalServerError)
+			mlog.Error("Worker: Failed to fetch oldest entity for job.", mlog.String("workername", worker.name), mlog.String("job_id", job.Id), mlog.String("start_time", startString), mlog.Err(err))
+			appError := model.NewAppError("BleveIndexerWorker", "bleveengine.indexer.do_job.get_oldest_entity.error", nil, err.Error(), http.StatusInternalServerError)
 			if err := worker.jobServer.SetJobError(job, appError); err != nil {
 				mlog.Error("Worker: Failed to set job error", mlog.String("workername", worker.name), mlog.String("job_id", job.Id), mlog.Err(err), mlog.NamedErr("set_error", appError))
 			}
 			return
 		}
-		progress.StartAtTime = oldestPost.CreateAt
+		progress.StartAtTime = oldestEntityCreationTime
 		progress.LastEntityTime = progress.StartAtTime
 	}
 


### PR DESCRIPTION

#### Summary

While indexing we were getting the oldest post creation time to fetch entities. But the system admin, or some channels are created before the first post. So, we should use `GetOldestEntityCreationTime` while indexing for the first time.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-29951

#### Release Note

```release-note
NONE
```

