### PR TITLE
[MM-34166] Fix Flaky Test TestGenerateSupportPacket

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -188,11 +188,6 @@ func TestEmailTest(t *testing.T) {
 }
 
 func TestGenerateSupportPacket(t *testing.T) {
-	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
-	defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
-
-	os.Setenv("MM_SQLSETTINGS_DRIVERNAME", "postgres")
-
 	th := Setup(t)
 	defer th.TearDown()
 

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -188,6 +188,11 @@ func TestEmailTest(t *testing.T) {
 }
 
 func TestGenerateSupportPacket(t *testing.T) {
+	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
+	defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
+
+	os.Setenv("MM_SQLSETTINGS_DRIVERNAME", "postgres")
+
 	th := Setup(t)
 	defer th.TearDown()
 

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -227,6 +227,11 @@ func TestDatabaseTypeAndMattermostVersion(t *testing.T) {
 }
 
 func TestGenerateSupportPacket(t *testing.T) {
+	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
+	defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
+
+	os.Setenv("MM_SQLSETTINGS_DRIVERNAME", "postgres")
+
 	th := Setup(t)
 	defer th.TearDown()
 
@@ -369,6 +374,11 @@ func TestCreatePluginsFile(t *testing.T) {
 }
 
 func TestGenerateSupportPacketYaml(t *testing.T) {
+	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
+	defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
+
+	os.Setenv("MM_SQLSETTINGS_DRIVERNAME", "postgres")
+
 	th := Setup(t)
 	defer th.TearDown()
 

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -227,11 +227,6 @@ func TestDatabaseTypeAndMattermostVersion(t *testing.T) {
 }
 
 func TestGenerateSupportPacket(t *testing.T) {
-	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
-	defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
-
-	os.Setenv("MM_SQLSETTINGS_DRIVERNAME", "postgres")
-
 	th := Setup(t)
 	defer th.TearDown()
 
@@ -374,11 +369,6 @@ func TestCreatePluginsFile(t *testing.T) {
 }
 
 func TestGenerateSupportPacketYaml(t *testing.T) {
-	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
-	defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
-
-	os.Setenv("MM_SQLSETTINGS_DRIVERNAME", "postgres")
-
 	th := Setup(t)
 	defer th.TearDown()
 

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -205,7 +205,12 @@ func TestStartServerTLSSuccess(t *testing.T) {
 
 func TestDatabaseTypeAndMattermostVersion(t *testing.T) {
 	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
-	defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
+
+	if sqlDrivernameEnvironment !== "" {
+		defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
+	} else {
+		defer os.Unsetenv("MM_SQLSETTINGS_DRIVERNAME")
+	}
 
 	os.Setenv("MM_SQLSETTINGS_DRIVERNAME", "postgres")
 

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -206,7 +206,7 @@ func TestStartServerTLSSuccess(t *testing.T) {
 func TestDatabaseTypeAndMattermostVersion(t *testing.T) {
 	sqlDrivernameEnvironment := os.Getenv("MM_SQLSETTINGS_DRIVERNAME")
 
-	if sqlDrivernameEnvironment !== "" {
+	if sqlDrivernameEnvironment != "" {
 		defer os.Setenv("MM_SQLSETTINGS_DRIVERNAME", sqlDrivernameEnvironment)
 	} else {
 		defer os.Unsetenv("MM_SQLSETTINGS_DRIVERNAME")


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

Fix Flaky Test because the environment variable is not set which causes problem

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->


https://mattermost.atlassian.net/browse/MM-34166

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
