### PR TITLE
[MM-33934] Prevent User.Timezone field from overflowing column capacity

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1693,6 +1693,16 @@ func TestPatchUser(t *testing.T) {
 	user := th.CreateUser()
 	th.Client.Login(user.Email, user.Password)
 
+	t.Run("Timezone limit error", func(t *testing.T) {
+		patch := &model.UserPatch{}
+		patch.Timezone = model.StringMap{}
+		patch.Timezone["manualTimezone"] = string(make([]byte, model.USER_TIMEZONE_MAX_RUNES))
+		ruser, resp := th.Client.PatchUser(user.Id, patch)
+		CheckBadRequestStatus(t, resp)
+		require.Equal(t, "model.user.is_valid.timezone_limit.app_error", resp.Error.Id)
+		require.Nil(t, ruser)
+	})
+
 	patch := &model.UserPatch{}
 	patch.Password = model.NewString("testpassword")
 	patch.Nickname = model.NewString("Joram Wilander")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8399,6 +8399,10 @@
     "translation": "Invalid locale."
   },
   {
+    "id": "model.user.is_valid.marshal.app_error",
+    "translation": "Failed to encode field to JSON"
+  },
+  {
     "id": "model.user.is_valid.nickname.app_error",
     "translation": "Invalid nickname."
   },

--- a/model/user.go
+++ b/model/user.go
@@ -56,6 +56,7 @@ const (
 	USER_NAME_MIN_LENGTH      = 1
 	USER_PASSWORD_MAX_LENGTH  = 72
 	USER_LOCALE_MAX_LENGTH    = 5
+	USER_TIMEZONE_MAX_RUNES   = 256
 )
 
 //msgp:tuple User
@@ -310,6 +311,14 @@ func (u *User) IsValid() *AppError {
 
 	if !IsValidLocale(u.Locale) {
 		return InvalidUserError("locale", u.Id)
+	}
+
+	if len(u.Timezone) > 0 {
+		if tzJSON, err := json.Marshal(u.Timezone); err != nil {
+			return NewAppError("User.IsValid", "model.user.is_valid.marshal.app_error", nil, err.Error(), http.StatusInternalServerError)
+		} else if utf8.RuneCount(tzJSON) > USER_TIMEZONE_MAX_RUNES {
+			return InvalidUserError("timezone_limit", u.Id)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary

I took a long time to understand how invalid JSON could end up in a user's timezone field especially since we validate the request body on a call to `/user/patch`. I was finally able to reproduce today by sending more data than what would fit in the MySQL `varchar(256)` column. 

The user update works just fine but data gets truncated making it invalid on any future call that fetches the user.
Honestly I thought the db driver would return an error due to possible data loss/inconsistency but apparently that's not the case.

PR adds a check to `User.IsValid()` to prevent this issue going forward.

#### Ticket

https://mattermost.atlassian.net/browse/MM-33934

#### Release Note

```release-note
NONE
```