### PR TITLE
[MM-34164] Fix flaky TestS3FileBackend

### DIFF
--- a/shared/filestore/filesstore_test.go
+++ b/shared/filestore/filesstore_test.go
@@ -94,7 +94,13 @@ func (s *FileBackendTestSuite) SetupTest() {
 	s.backend = backend
 
 	// This is needed to create the bucket if it doesn't exist.
-	s.Nil(s.backend.TestConnection())
+	if err := s.backend.TestConnection(); err == ErrNoS3Bucket {
+		s3Backend, ok := s.backend.(*S3FileBackend)
+		s.True(ok)
+		s.NoError(s3Backend.MakeBucket())
+	} else {
+		s.NoError(err)
+	}
 }
 
 func (s *FileBackendTestSuite) TestConnection() {

--- a/shared/filestore/filesstore_test.go
+++ b/shared/filestore/filesstore_test.go
@@ -356,7 +356,7 @@ func (s *FileBackendTestSuite) TestAppendFile() {
 		read, err := s.backend.ReadFile(path)
 		s.Nil(err)
 		s.EqualValues(len(b)+len(b2), len(read))
-		s.EqualValues(append(b, b2...), read)
+		s.True(bytes.Equal(append(b, b2...), read))
 
 		b3 := make([]byte, 1024)
 		for i := range b3 {
@@ -370,7 +370,7 @@ func (s *FileBackendTestSuite) TestAppendFile() {
 		read, err = s.backend.ReadFile(path)
 		s.Nil(err)
 		s.EqualValues(len(b)+len(b2)+len(b3), len(read))
-		s.EqualValues(append(append(b, b2...), b3...), read)
+		s.True(bytes.Equal(append(append(b, b2...), b3...), read))
 	})
 }
 


### PR DESCRIPTION
#### Summary

PR fixes S3 filestore related tests which were failing if the bucket didn't exist.
Looks like the previous behaviour (create bucket if none found) was removed in https://github.com/mattermost/mattermost-server/pull/16977.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-34164

#### Release Note

```release-note
NONE
```

