### PR TITLE
MM-34271 fix race in TestLoggingAfterInitialized unit test

### DIFF
--- a/shared/mlog/global_test.go
+++ b/shared/mlog/global_test.go
@@ -28,8 +28,6 @@ func TestLoggingBeforeInitialized(t *testing.T) {
 }
 
 func TestLoggingAfterInitialized(t *testing.T) {
-	t.Skip("Racy test:  MM-34271")
-
 	testCases := []struct {
 		Description         string
 		LoggerConfiguration *mlog.LoggerConfiguration


### PR DESCRIPTION
#### Summary
The global logger is inherently racy in that some global vars are set to function values during startup and it is hoped nothing accesses those before or while they are being set.  Also if they are reset, such as in the case of certain unit tests, the hope is that nothing accesses those after the reset.

8 months ago I added some code to the server that does some logging when exiting a goroutine, which in rare cases during unit testing can trigger race detection for the global vars mentioned above.  

This PR does not fix the racy global logger - that will come as part of a larger clean-up.  However this PR does ensure the exiting goroutine does not try to access the global vars thus removing this specific unit test's (`TestLoggingAfterInitialized`) race condition.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34271

#### Release Note
```release-note
NONE
```
