### PR TITLE
Remove server from WebsocketRouter

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -496,10 +496,9 @@ func NewServer(options ...Option) (*Server, error) {
 	}
 
 	s.WebSocketRouter = &WebSocketRouter{
-		server:   s,
 		handlers: make(map[string]webSocketHandler),
+		app:      fakeApp,
 	}
-	s.WebSocketRouter.app = fakeApp
 
 	mailConfig := s.MailServiceConfig()
 

--- a/app/websocket_router.go
+++ b/app/websocket_router.go
@@ -16,7 +16,6 @@ type webSocketHandler interface {
 }
 
 type WebSocketRouter struct {
-	server   *Server
 	app      *App
 	handlers map[string]webSocketHandler
 }


### PR DESCRIPTION
App contains server.
Server contains WebsocketRouter.

There is no need for WebsocketRouter to contain
server too. As is evident because the code never used it.

```release-note
NONE
```
