### PR TITLE
MM-34389: Reliable websockets: First commit

### DIFF
--- a/api4/websocket.go
+++ b/api4/websocket.go
@@ -45,6 +45,11 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 			// We just create a new ID.
 			connID = model.NewId()
 		} else {
+			if !model.IsValidId(connID) {
+				mlog.Error("Invalid connection ID", mlog.String("id", connID))
+				wc.WebSocket.Close()
+				return
+			}
 			// If present, we check if it's present in the connection manager.
 			// TODO: the connection manager internally should forward the request
 			// to the cluster if it does not have it.
@@ -62,7 +67,7 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			seq, err := strconv.Atoi(seqVal)
-			if err != nil {
+			if err != nil || seq < 0 {
 				mlog.Error("Invalid sequence number set in query param",
 					mlog.String("query", seqVal),
 					mlog.Err(err))

--- a/api4/websocket.go
+++ b/api4/websocket.go
@@ -5,10 +5,17 @@ package api4
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gorilla/websocket"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/shared/mlog"
+)
+
+const (
+	connectionIDParam   = "connection_id"
+	sequenceNumberParam = "sequence_number"
 )
 
 func (api *API) InitWebSocket() {
@@ -30,6 +37,46 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	wc := c.App.NewWebConn(ws, *c.App.Session(), c.App.T, "")
+
+	if *c.App.Config().ServiceSettings.EnableReliableWebSockets {
+		connID := r.URL.Query().Get(connectionIDParam)
+		if connID == "" {
+			// If not present, we assume client is not capable yet, or it's a fresh connection.
+			// We just create a new ID.
+			connID = model.NewId()
+		} else {
+			// If present, we check if it's present in the connection manager.
+			// TODO: the connection manager internally should forward the request
+			// to the cluster if it does not have it.
+			//
+			// If the connection is not present, then we assume either timeout,
+			// or server restart. In that case, we set a new one.
+			//
+			// Now we get the sequence number
+			seqVal := r.URL.Query().Get(sequenceNumberParam)
+			if seqVal == "" {
+				// Sequence_number must be sent with connection id.
+				// A client must be either non-compliant or fully compliant.
+				mlog.Error("Sequence number not present in websocket request")
+				wc.WebSocket.Close()
+				return
+			}
+			seq, err := strconv.Atoi(seqVal)
+			if err != nil {
+				mlog.Error("Invalid sequence number set in query param",
+					mlog.String("query", seqVal),
+					mlog.Err(err))
+				wc.WebSocket.Close()
+				return
+			}
+			wc.Sequence = int64(seq)
+			// Now if there have been past entries to be back-filled, we do it.
+			// First we find the right sequence number point.
+			// We start consuming from dead queue first, and then move to active queue
+		}
+		// In case of fresh connection id, sequence number is already zero.
+		wc.SetConnectionID(connID)
+	}
 
 	if c.App.Session().UserId != "" {
 		c.App.HubRegister(wc)

--- a/app/websocket_router.go
+++ b/app/websocket_router.go
@@ -55,10 +55,11 @@ func (wr *WebSocketRouter) ServeWebSocket(conn *WebConn, r *model.WebSocketReque
 			conn.WebSocket.Close()
 			return
 		}
-
 		conn.SetSession(session)
 		conn.SetSessionToken(session.Token)
 		conn.UserId = session.UserId
+
+		// TODO: Same logic to reconnect queue as api4/websocket.go
 
 		wr.app.HubRegister(conn)
 

--- a/model/config.go
+++ b/model/config.go
@@ -373,6 +373,7 @@ type ServiceSettings struct {
 	CollapsedThreads                                  *string `access:"experimental"`
 	ManagedResourcePaths                              *string `access:"environment,write_restrictable,cloud_restrictable"`
 	EnableLegacySidebar                               *bool   `access:"experimental"`
+	EnableReliableWebSockets                          *bool   `access:"experimental"`
 }
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {
@@ -817,6 +818,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.EnableLegacySidebar == nil {
 		s.EnableLegacySidebar = NewBool(false)
+	}
+
+	if s.EnableReliableWebSockets == nil {
+		s.EnableReliableWebSockets = NewBool(false)
 	}
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -373,7 +373,7 @@ type ServiceSettings struct {
 	CollapsedThreads                                  *string `access:"experimental"`
 	ManagedResourcePaths                              *string `access:"environment,write_restrictable,cloud_restrictable"`
 	EnableLegacySidebar                               *bool   `access:"experimental"`
-	EnableReliableWebSockets                          *bool   `access:"experimental"`
+	EnableReliableWebSockets                          *bool   `access:"experimental"` // telemetry: none
 }
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -440,6 +440,7 @@ func (ts *TelemetryService) trackConfig() {
 		"thread_auto_follow":                                      *cfg.ServiceSettings.ThreadAutoFollow,
 		"enable_link_previews":                                    *cfg.ServiceSettings.EnableLinkPreviews,
 		"enable_file_search":                                      *cfg.ServiceSettings.EnableFileSearch,
+		"enable_reliable_websockets":                              *cfg.ServiceSettings.EnableReliableWebSockets,
 		"restrict_link_previews":                                  isDefault(*cfg.ServiceSettings.RestrictLinkPreviews, ""),
 	})
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -440,7 +440,6 @@ func (ts *TelemetryService) trackConfig() {
 		"thread_auto_follow":                                      *cfg.ServiceSettings.ThreadAutoFollow,
 		"enable_link_previews":                                    *cfg.ServiceSettings.EnableLinkPreviews,
 		"enable_file_search":                                      *cfg.ServiceSettings.EnableFileSearch,
-		"enable_reliable_websockets":                              *cfg.ServiceSettings.EnableReliableWebSockets,
 		"restrict_link_previews":                                  isDefault(*cfg.ServiceSettings.RestrictLinkPreviews, ""),
 	})
 


### PR DESCRIPTION
This is the first commit which makes some basic changes
to get it ready for the actual implementation.

Changes include:
- A config field to conditionally enable it.
- Refactoring the WriteMessage along with setting the deadline
to a separate method.

The basic idea is that the client sends the connection_id
and sequence_number either during the handshake (via query params),
or during challenge_auth (via added parameters in the map).

If the conn_id is empty, then we create a new one and set it.
Otherwise, we get the queues from a connection manager (TBD)
and attach them to WebConn.

```release-note
NONE
```

https://mattermost.atlassian.net/browse/MM-34389
