### PR TITLE
MM-34086: Fix flaky test StartServerTLSOverwriteCipher

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ workflows:
           name: test-mysql
           dbdriver: mysql
           dbsource: mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&multiStatements=true
-          racemode: "-race"
+          racemode: ""
           requires:
             - check-app-layers
             - check-store-layers
@@ -482,7 +482,7 @@ workflows:
           name: test-postgres
           dbdriver: postgres
           dbsource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
-          racemode: "-race"
+          racemode: ""
           requires:
             - check-app-layers
             - check-store-layers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ workflows:
           name: test-mysql
           dbdriver: mysql
           dbsource: mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&multiStatements=true
-          racemode: ""
+          racemode: "-race"
           requires:
             - check-app-layers
             - check-store-layers
@@ -482,7 +482,7 @@ workflows:
           name: test-postgres
           dbdriver: postgres
           dbsource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
-          racemode: ""
+          racemode: "-race"
           requires:
             - check-app-layers
             - check-store-layers


### PR DESCRIPTION
This suffered from the same race condition as
https://github.com/mattermost/mattermost-server/pull/17215.

We apply the same approach of using a memstore instead
of a file based config store.

It is likely that the test was also failing because of
the same race. Although I don't obviously see how, because
the race happens with mlog.Info. The test will fail only
if the config wasn't able to set properly. So although
not strictly related, it's somehow related.

If it fails again, we can look into it again. But this
atleast fixes the race.

While here, we also apply some cleanup of the code.

https://mattermost.atlassian.net/browse/MM-34086

```release-note
NONE
```
