### PR TITLE
[MM-34414] Add TrialEndAt to cloud model Subscription type

### DIFF
--- a/model/cloud.go
+++ b/model/cloud.go
@@ -95,6 +95,7 @@ type Subscription struct {
 	DNS         string   `json:"dns"`
 	IsPaidTier  string   `json:"is_paid_tier"`
 	LastInvoice *Invoice `json:"last_invoice"`
+	TrialEndAt  int64    `json:"trial_end_at"`
 }
 
 // GetWorkSpaceNameFromDNS returns the work space name. For example from test.mattermost.cloud.com, it returns test


### PR DESCRIPTION
#### Summary
CWS will be passing this value, and we want to be able to utilize it in mattermost-server (and pass to webapp)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34414
#### Release Note
```release-note
NONE
```
