### PR TITLE
[MM-34240]-Cloud: Congratulations welcome email missing images

### DIFF
--- a/app/email.go
+++ b/app/email.go
@@ -295,7 +295,7 @@ func (es *EmailService) SendCloudWelcomeEmail(userEmail, locale, teamInviteID, w
 	T := i18n.GetUserTranslations(locale)
 	subject := T("api.templates.cloud_welcome_email.subject")
 
-	workSpacePath := fmt.Sprintf("https://%s.cloud.mattermost.com", workSpaceName)
+	workSpacePath := fmt.Sprintf("https://%s", dns)
 
 	data := es.newEmailTemplateData(locale)
 	data.Props["Title"] = T("api.templates.cloud_welcome_email.title", map[string]interface{}{"WorkSpace": workSpaceName})


### PR DESCRIPTION
#### Summary
This fixes issue where images are not showing in the cloud welcome email

#### Ticket Link
[MM-34240](https://mattermost.atlassian.net/browse/MM-34240?atlOrigin=eyJpIjoiNWZmNjQwNzNjMGZmNDcyMWI4YmM2NWJhZTY2MjdjOWMiLCJwIjoiaiJ9)

#### Release Note
```release-note
None
```