### PR TITLE
Add missing wrapped errors

### DIFF
--- a/app/brand.go
+++ b/app/brand.go
@@ -62,7 +62,7 @@ func (a *App) SaveBrandImage(imageData *multipart.FileHeader) *model.AppError {
 	a.MoveFile(BrandFilePath+BrandFileName, BrandFilePath+t.Format("2006-01-02T15:04:05")+".png")
 
 	if _, err := a.WriteFile(buf, BrandFilePath+BrandFileName); err != nil {
-		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.save_image.app_error", nil, "", http.StatusInternalServerError)
+		return model.NewAppError("SaveBrandImage", "brand.save_brand_image.save_image.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	return nil

--- a/app/channel.go
+++ b/app/channel.go
@@ -2206,7 +2206,7 @@ func (a *App) removeUserFromChannel(userIDToRemove string, removerUserId string,
 	if channel.IsGroupConstrained() && userIDToRemove != removerUserId && !user.IsBot {
 		nonMembers, err := a.FilterNonGroupChannelMembers([]string{userIDToRemove}, channel)
 		if err != nil {
-			return model.NewAppError("removeUserFromChannel", "api.channel.remove_user_from_channel.app_error", nil, "", http.StatusInternalServerError)
+			return model.NewAppError("removeUserFromChannel", "api.channel.remove_user_from_channel.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 		if len(nonMembers) == 0 {
 			return model.NewAppError("removeUserFromChannel", "api.channel.remove_members.denied", map[string]interface{}{"UserIDs": nonMembers}, "", http.StatusBadRequest)

--- a/app/emoji.go
+++ b/app/emoji.go
@@ -103,7 +103,7 @@ func (a *App) UploadEmojiImage(id string, imageData *multipart.FileHeader) *mode
 
 	file, err := imageData.Open()
 	if err != nil {
-		return model.NewAppError("uploadEmojiImage", "api.emoji.upload.open.app_error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("uploadEmojiImage", "api.emoji.upload.open.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 	defer file.Close()
 
@@ -113,7 +113,7 @@ func (a *App) UploadEmojiImage(id string, imageData *multipart.FileHeader) *mode
 	// make sure the file is an image and is within the required dimensions
 	config, _, err := image.DecodeConfig(bytes.NewReader(buf.Bytes()))
 	if err != nil {
-		return model.NewAppError("uploadEmojiImage", "api.emoji.upload.image.app_error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("uploadEmojiImage", "api.emoji.upload.image.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
 	if config.Width > MaxEmojiOriginalWidth || config.Height > MaxEmojiOriginalHeight {
@@ -134,24 +134,24 @@ func (a *App) UploadEmojiImage(id string, imageData *multipart.FileHeader) *mode
 		if info.MimeType == "image/gif" {
 			gif_data, err := gif.DecodeAll(bytes.NewReader(data))
 			if err != nil {
-				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.gif_decode_error", nil, "", http.StatusBadRequest)
+				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.gif_decode_error", nil, err.Error(), http.StatusBadRequest)
 			}
 
 			resized_gif := resizeEmojiGif(gif_data)
 			if err := gif.EncodeAll(newbuf, resized_gif); err != nil {
-				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.gif_encode_error", nil, "", http.StatusBadRequest)
+				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.gif_encode_error", nil, err.Error(), http.StatusBadRequest)
 			}
 
 			buf = newbuf
 		} else {
 			img, _, err := image.Decode(bytes.NewReader(data))
 			if err != nil {
-				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.decode_error", nil, "", http.StatusBadRequest)
+				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.decode_error", nil, err.Error(), http.StatusBadRequest)
 			}
 
 			resized_image := resizeEmoji(img, config.Width, config.Height)
 			if err := png.Encode(newbuf, resized_image); err != nil {
-				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.encode_error", nil, "", http.StatusBadRequest)
+				return model.NewAppError("uploadEmojiImage", "api.emoji.upload.large_image.encode_error", nil, err.Error(), http.StatusBadRequest)
 			}
 			buf = newbuf
 		}

--- a/app/oauth.go
+++ b/app/oauth.go
@@ -528,15 +528,15 @@ func (a *App) RevokeAccessToken(token string) *model.AppError {
 	}()
 
 	if _, err := a.Srv().Store.OAuth().GetAccessData(token); err != nil {
-		return model.NewAppError("RevokeAccessToken", "api.oauth.revoke_access_token.get.app_error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("RevokeAccessToken", "api.oauth.revoke_access_token.get.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 
 	if err := a.Srv().Store.OAuth().RemoveAccessData(token); err != nil {
-		return model.NewAppError("RevokeAccessToken", "api.oauth.revoke_access_token.del_token.app_error", nil, "", http.StatusInternalServerError)
+		return model.NewAppError("RevokeAccessToken", "api.oauth.revoke_access_token.del_token.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	if err := <-schan; err != nil {
-		return model.NewAppError("RevokeAccessToken", "api.oauth.revoke_access_token.del_session.app_error", nil, "", http.StatusInternalServerError)
+		return model.NewAppError("RevokeAccessToken", "api.oauth.revoke_access_token.del_session.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	if session != nil {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -605,13 +605,13 @@ func (a *App) mergePrepackagedPlugins(remoteMarketplacePlugins map[string]*model
 		// If available in the markteplace, only overwrite if newer.
 		prepackagedVersion, err := semver.Parse(prepackaged.Manifest.Version)
 		if err != nil {
-			return model.NewAppError("mergePrepackagedPlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
+			return model.NewAppError("mergePrepackagedPlugins", "app.plugin.invalid_version.app_error", nil, err.Error(), http.StatusBadRequest)
 		}
 
 		marketplacePlugin := remoteMarketplacePlugins[prepackaged.Manifest.Id]
 		marketplaceVersion, err := semver.Parse(marketplacePlugin.Manifest.Version)
 		if err != nil {
-			return model.NewAppError("mergePrepackagedPlugins", "app.plugin.invalid_version.app_error", nil, "", http.StatusBadRequest)
+			return model.NewAppError("mergePrepackagedPlugins", "app.plugin.invalid_version.app_error", nil, err.Error(), http.StatusBadRequest)
 		}
 
 		if prepackagedVersion.GT(marketplaceVersion) {

--- a/app/team.go
+++ b/app/team.go
@@ -1970,7 +1970,7 @@ func (a *App) SetTeamIconFromFile(team *model.Team, file io.Reader) *model.AppEr
 	path := "teams/" + team.Id + "/teamIcon.png"
 
 	if _, err := a.WriteFile(buf, path); err != nil {
-		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.write_file.app_error", nil, "", http.StatusInternalServerError)
+		return model.NewAppError("SetTeamIcon", "api.team.set_team_icon.write_file.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	curTime := model.GetMillis()

--- a/app/user.go
+++ b/app/user.go
@@ -1003,7 +1003,6 @@ func (a *App) AdjustImage(file io.Reader) (*bytes.Buffer, *model.AppError) {
 }
 
 func (a *App) SetProfileImageFromFile(userID string, file io.Reader) *model.AppError {
-
 	buf, err := a.AdjustImage(file)
 	if err != nil {
 		return err
@@ -1011,7 +1010,7 @@ func (a *App) SetProfileImageFromFile(userID string, file io.Reader) *model.AppE
 	path := "users/" + userID + "/profile.png"
 
 	if _, err := a.WriteFile(buf, path); err != nil {
-		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.upload_profile.app_error", nil, "", http.StatusInternalServerError)
+		return model.NewAppError("SetProfileImage", "api.user.upload_profile_user.upload_profile.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	if err := a.Srv().Store.User().UpdateLastPictureUpdate(userID); err != nil {
@@ -1730,7 +1729,7 @@ func (a *App) PermanentDeleteUser(user *model.User) *model.AppError {
 	}
 
 	if _, err := a.Srv().Store.FileInfo().PermanentDeleteByUser(user.Id); err != nil {
-		return model.NewAppError("PermanentDeleteUser", "app.file_info.permanent_delete_by_user.app_error", nil, ""+err.Error(), http.StatusInternalServerError)
+		return model.NewAppError("PermanentDeleteUser", "app.file_info.permanent_delete_by_user.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	if err := a.Srv().Store.User().PermanentDelete(user.Id); err != nil {

--- a/cmd/mattermost/commands/webhook.go
+++ b/cmd/mattermost/commands/webhook.go
@@ -548,7 +548,7 @@ func moveOutgoingWebhookCmd(command *cobra.Command, args []string) (cmdError err
 
 	updatedWebHook, createErr := app.CreateOutgoingWebhook(webhook)
 	if createErr != nil {
-		return model.NewAppError("moveOutgoingWebhookCmd", "cli.outgoing_webhook.inconsistent_state.app_error", nil, "", http.StatusInternalServerError)
+		return model.NewAppError("moveOutgoingWebhookCmd", "cli.outgoing_webhook.inconsistent_state.app_error", nil, createErr.Error(), http.StatusInternalServerError)
 	}
 
 	auditRec.Success()


### PR DESCRIPTION
#### Summary
There are a couple of places where `model.NewAppError` doesn't wrap a returned `error`. This makes debugging harder.

I stumbled across this when debugging an issue in `app/user.go` and decided to fill all other occurrences that I found. The regex I've used is `err != nil \{\n\t+return model.NewAppError\("[a-zA-Z]+", "[a-zA-Z._]+", nil, ""`. Please note that this is surely not an _exhaustive_ fix, but rather a one time afford. 

#### Ticket Link
https://community-daily.mattermost.com/core/pl/3aya19tnmirabcuxjy7jznmejo

#### Release Note
```release-note
NONE
```
