### PR TITLE
[#17294] DEBUG log ENV variables

### DIFF
--- a/config/environment.go
+++ b/config/environment.go
@@ -57,24 +57,24 @@ func applyEnvKey(key, value string, rValueSubject reflect.Value) {
 		applyEnvKey(keyParts[1], value, rFieldValue)
 	case reflect.String:
 		rFieldValue.Set(reflect.ValueOf(value))
-        mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
+		mlog.Debugf("Mattermost is loading %s value from environment variable.", keyParts[0])
 	case reflect.Bool:
 		boolVal, err := strconv.ParseBool(value)
 		if err == nil {
 			rFieldValue.Set(reflect.ValueOf(boolVal))
-			mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
+			mlog.Debugf("Mattermost is loading %s value from environment variable.", keyParts[0])
 		}
 	case reflect.Int:
 		intVal, err := strconv.ParseInt(value, 10, 0)
 		if err == nil {
 			rFieldValue.Set(reflect.ValueOf(int(intVal)))
-			mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
+			mlog.Debugf("Mattermost is loading %s value from environment variable.", keyParts[0])
 		}
 	case reflect.Int64:
 		intVal, err := strconv.ParseInt(value, 10, 0)
 		if err == nil {
 			rFieldValue.Set(reflect.ValueOf(intVal))
-			mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
+			mlog.Debugf("Mattermost is loading %s value from environment variable.", keyParts[0])
 		}
 	case reflect.SliceOf(reflect.TypeOf("")).Kind():
 		rFieldValue.Set(reflect.ValueOf(strings.Split(value, " ")))

--- a/config/environment.go
+++ b/config/environment.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+        "github.com/mattermost/mattermost-server/v5/shared/mlog"
 )
 
 func GetEnvironment() map[string]string {
@@ -56,20 +57,24 @@ func applyEnvKey(key, value string, rValueSubject reflect.Value) {
 		applyEnvKey(keyParts[1], value, rFieldValue)
 	case reflect.String:
 		rFieldValue.Set(reflect.ValueOf(value))
+        mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
 	case reflect.Bool:
 		boolVal, err := strconv.ParseBool(value)
 		if err == nil {
 			rFieldValue.Set(reflect.ValueOf(boolVal))
+			mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
 		}
 	case reflect.Int:
 		intVal, err := strconv.ParseInt(value, 10, 0)
 		if err == nil {
 			rFieldValue.Set(reflect.ValueOf(int(intVal)))
+			mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
 		}
 	case reflect.Int64:
 		intVal, err := strconv.ParseInt(value, 10, 0)
 		if err == nil {
 			rFieldValue.Set(reflect.ValueOf(intVal))
+			mlog.Debug("Mattermost is loading " + keyParts[0] " value from environment variable.")
 		}
 	case reflect.SliceOf(reflect.TypeOf("")).Kind():
 		rFieldValue.Set(reflect.ValueOf(strings.Split(value, " ")))


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Allows a user to see that  Mattermost will use a variable value from Environment instead of ``config.json``. 


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/17294

#### Release Note

- added import mlog to ``config/environment.go``
- added logging with level ``DEBUG`` which logs that Mattermost will use given environment variable 

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
```
