### PR TITLE
MM-34786: Fix racy test TestStartServerTLSSuccess

### DIFF
--- a/app/server_test.go
+++ b/app/server_test.go
@@ -32,15 +32,21 @@ import (
 	"github.com/mattermost/mattermost-server/v5/utils/fileutils"
 )
 
-func TestStartServerSuccess(t *testing.T) {
+func newServerWithConfig(f func(cfg *model.Config)) (*Server, error) {
 	configStore, _ := config.NewMemoryStore()
 	store, _ := config.NewStoreFromBacking(configStore, nil, false)
 	cfg := store.Get()
-	*cfg.ServiceSettings.ListenAddress = ":0"
+	f(cfg)
 
 	store.Set(cfg)
 
-	s, err := NewServer(ConfigStore(store))
+	return NewServer(ConfigStore(store))
+}
+
+func TestStartServerSuccess(t *testing.T) {
+	s, err := newServerWithConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.ListenAddress = ":0"
+	})
 	require.NoError(t, err)
 
 	serverErr := s.Start()
@@ -186,19 +192,14 @@ func TestStartServerNoS3Bucket(t *testing.T) {
 }
 
 func TestStartServerTLSSuccess(t *testing.T) {
-	configStore, _ := config.NewMemoryStore()
-	store, _ := config.NewStoreFromBacking(configStore, nil, false)
-	cfg := store.Get()
-	testDir, _ := fileutils.FindDir("tests")
+	s, err := newServerWithConfig(func(cfg *model.Config) {
+		testDir, _ := fileutils.FindDir("tests")
 
-	*cfg.ServiceSettings.ListenAddress = ":0"
-	*cfg.ServiceSettings.ConnectionSecurity = "TLS"
-	*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
-	*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
-
-	store.Set(cfg)
-
-	s, err := NewServer(ConfigStore(store))
+		*cfg.ServiceSettings.ListenAddress = ":0"
+		*cfg.ServiceSettings.ConnectionSecurity = "TLS"
+		*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
+		*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
+	})
 	require.NoError(t, err)
 
 	serverErr := s.Start()
@@ -447,23 +448,18 @@ func TestStartServerTLSVersion(t *testing.T) {
 }
 
 func TestStartServerTLSOverwriteCipher(t *testing.T) {
-	configStore, _ := config.NewMemoryStore()
-	store, _ := config.NewStoreFromBacking(configStore, nil, false)
-	cfg := store.Get()
-	testDir, _ := fileutils.FindDir("tests")
+	s, err := newServerWithConfig(func(cfg *model.Config) {
+		testDir, _ := fileutils.FindDir("tests")
 
-	*cfg.ServiceSettings.ListenAddress = ":0"
-	*cfg.ServiceSettings.ConnectionSecurity = "TLS"
-	cfg.ServiceSettings.TLSOverwriteCiphers = []string{
-		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-	}
-	*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
-	*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
-
-	store.Set(cfg)
-
-	s, err := NewServer(ConfigStore(store))
+		*cfg.ServiceSettings.ListenAddress = ":0"
+		*cfg.ServiceSettings.ConnectionSecurity = "TLS"
+		cfg.ServiceSettings.TLSOverwriteCiphers = []string{
+			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		}
+		*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
+		*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
+	})
 	require.NoError(t, err)
 
 	err = s.Start()
@@ -622,22 +618,16 @@ func TestSentry(t *testing.T) {
 		require.NoError(t, err)
 		SentryDSN = dsn.String()
 
-		configStore, _ := config.NewMemoryStore()
-		store, _ := config.NewStoreFromBacking(configStore, nil, false)
-		cfg := store.Get()
-		*cfg.ServiceSettings.ListenAddress = ":0"
-		*cfg.LogSettings.EnableSentry = false
-		*cfg.ServiceSettings.ConnectionSecurity = "TLS"
-		*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
-		*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
-		*cfg.LogSettings.EnableDiagnostics = true
-
-		store.Set(cfg)
-
-		s, err := NewServer(ConfigStore(store))
+		s, err := newServerWithConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ListenAddress = ":0"
+			*cfg.LogSettings.EnableSentry = false
+			*cfg.ServiceSettings.ConnectionSecurity = "TLS"
+			*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
+			*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
+			*cfg.LogSettings.EnableDiagnostics = true
+		})
 		require.NoError(t, err)
 
-		// Route for just panicing
 		s.Router.HandleFunc("/panic", func(writer http.ResponseWriter, request *http.Request) {
 			panic("log this panic")
 		})
@@ -672,19 +662,14 @@ func TestSentry(t *testing.T) {
 		require.NoError(t, err)
 		SentryDSN = dsn.String()
 
-		configStore, _ := config.NewMemoryStore()
-		store, _ := config.NewStoreFromBacking(configStore, nil, false)
-		cfg := store.Get()
-		*cfg.ServiceSettings.ListenAddress = ":0"
-		*cfg.ServiceSettings.ConnectionSecurity = "TLS"
-		*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
-		*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
-		*cfg.LogSettings.EnableSentry = true
-		*cfg.LogSettings.EnableDiagnostics = true
-
-		store.Set(cfg)
-
-		s, err := NewServer(ConfigStore(store))
+		s, err := newServerWithConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.ListenAddress = ":0"
+			*cfg.ServiceSettings.ConnectionSecurity = "TLS"
+			*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
+			*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
+			*cfg.LogSettings.EnableSentry = true
+			*cfg.LogSettings.EnableDiagnostics = true
+		})
 		require.NoError(t, err)
 
 		// Route for just panicing

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -32,9 +32,11 @@ import (
 	"github.com/mattermost/mattermost-server/v5/utils/fileutils"
 )
 
-func newServerWithConfig(f func(cfg *model.Config)) (*Server, error) {
-	configStore, _ := config.NewMemoryStore()
-	store, _ := config.NewStoreFromBacking(configStore, nil, false)
+func newServerWithConfig(t *testing.T, f func(cfg *model.Config)) (*Server, error) {
+	configStore, err := config.NewMemoryStore()
+	require.NoError(t, err)
+	store, err := config.NewStoreFromBacking(configStore, nil, false)
+	require.NoError(t, err)
 	cfg := store.Get()
 	f(cfg)
 
@@ -44,7 +46,7 @@ func newServerWithConfig(f func(cfg *model.Config)) (*Server, error) {
 }
 
 func TestStartServerSuccess(t *testing.T) {
-	s, err := newServerWithConfig(func(cfg *model.Config) {
+	s, err := newServerWithConfig(t, func(cfg *model.Config) {
 		*cfg.ServiceSettings.ListenAddress = ":0"
 	})
 	require.NoError(t, err)
@@ -192,7 +194,7 @@ func TestStartServerNoS3Bucket(t *testing.T) {
 }
 
 func TestStartServerTLSSuccess(t *testing.T) {
-	s, err := newServerWithConfig(func(cfg *model.Config) {
+	s, err := newServerWithConfig(t, func(cfg *model.Config) {
 		testDir, _ := fileutils.FindDir("tests")
 
 		*cfg.ServiceSettings.ListenAddress = ":0"
@@ -448,7 +450,7 @@ func TestStartServerTLSVersion(t *testing.T) {
 }
 
 func TestStartServerTLSOverwriteCipher(t *testing.T) {
-	s, err := newServerWithConfig(func(cfg *model.Config) {
+	s, err := newServerWithConfig(t, func(cfg *model.Config) {
 		testDir, _ := fileutils.FindDir("tests")
 
 		*cfg.ServiceSettings.ListenAddress = ":0"
@@ -618,7 +620,7 @@ func TestSentry(t *testing.T) {
 		require.NoError(t, err)
 		SentryDSN = dsn.String()
 
-		s, err := newServerWithConfig(func(cfg *model.Config) {
+		s, err := newServerWithConfig(t, func(cfg *model.Config) {
 			*cfg.ServiceSettings.ListenAddress = ":0"
 			*cfg.LogSettings.EnableSentry = false
 			*cfg.ServiceSettings.ConnectionSecurity = "TLS"
@@ -662,7 +664,7 @@ func TestSentry(t *testing.T) {
 		require.NoError(t, err)
 		SentryDSN = dsn.String()
 
-		s, err := newServerWithConfig(func(cfg *model.Config) {
+		s, err := newServerWithConfig(t, func(cfg *model.Config) {
 			*cfg.ServiceSettings.ListenAddress = ":0"
 			*cfg.ServiceSettings.ConnectionSecurity = "TLS"
 			*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")


### PR DESCRIPTION
There were a bunch of more tests which concurrently
updated config along with starting the server.

We apply the same fix as before in https://github.com/mattermost/mattermost-server/pull/17215

https://mattermost.atlassian.net/browse/MM-34786

```release-note
NONE
```
