### PR TITLE
MM-34787: Add colored output for non JSON console logs

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -1200,6 +1200,7 @@ type LogSettings struct {
 	EnableConsole          *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
 	ConsoleLevel           *string `access:"environment_logging,write_restrictable,cloud_restrictable"`
 	ConsoleJson            *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	EnableColor            *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"` // telemetry: none
 	EnableFile             *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
 	FileLevel              *string `access:"environment_logging,write_restrictable,cloud_restrictable"`
 	FileJson               *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
@@ -1217,6 +1218,10 @@ func (s *LogSettings) SetDefaults() {
 
 	if s.ConsoleLevel == nil {
 		s.ConsoleLevel = NewString("DEBUG")
+	}
+
+	if s.EnableColor == nil {
+		s.EnableColor = NewBool(false)
 	}
 
 	if s.EnableFile == nil {
@@ -1305,6 +1310,7 @@ type NotificationLogSettings struct {
 	EnableConsole         *bool   `access:"write_restrictable,cloud_restrictable"`
 	ConsoleLevel          *string `access:"write_restrictable,cloud_restrictable"`
 	ConsoleJson           *bool   `access:"write_restrictable,cloud_restrictable"`
+	EnableColor           *bool   `access:"write_restrictable,cloud_restrictable"` // telemetry: none
 	EnableFile            *bool   `access:"write_restrictable,cloud_restrictable"`
 	FileLevel             *string `access:"write_restrictable,cloud_restrictable"`
 	FileJson              *bool   `access:"write_restrictable,cloud_restrictable"`
@@ -1335,6 +1341,10 @@ func (s *NotificationLogSettings) SetDefaults() {
 
 	if s.ConsoleJson == nil {
 		s.ConsoleJson = NewBool(true)
+	}
+
+	if s.EnableColor == nil {
+		s.EnableColor = NewBool(false)
 	}
 
 	if s.FileJson == nil {

--- a/shared/mlog/testing.go
+++ b/shared/mlog/testing.go
@@ -37,7 +37,7 @@ func NewTestingLogger(tb testing.TB, writer io.Writer) *Logger {
 		mutex:        &sync.RWMutex{},
 	}
 
-	logWriterCore := zapcore.NewCore(makeEncoder(true), zapcore.Lock(logWriterSync), testingLogger.consoleLevel)
+	logWriterCore := zapcore.NewCore(makeEncoder(true, false), zapcore.Lock(logWriterSync), testingLogger.consoleLevel)
 
 	testingLogger.zap = zap.New(logWriterCore,
 		zap.AddCaller(),

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -29,6 +29,7 @@ func MloggerConfigFromLoggerConfig(s *model.LogSettings, getFileFunc fileLocatio
 		FileJson:      *s.FileJson,
 		FileLevel:     strings.ToLower(*s.FileLevel),
 		FileLocation:  getFileFunc(*s.FileLocation),
+		EnableColor:   *s.EnableColor,
 	}
 }
 
@@ -58,6 +59,7 @@ func GetLogSettingsFromNotificationsLogSettings(notificationLogSettings *model.N
 		FileLevel:             notificationLogSettings.FileLevel,
 		FileLocation:          notificationLogSettings.FileLocation,
 		AdvancedLoggingConfig: notificationLogSettings.AdvancedLoggingConfig,
+		EnableColor:           notificationLogSettings.EnableColor,
 	}
 }
 


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-34787

```release-note
A new field EnableColor is added to LogSettings and NotificationLogSettings.
Non-JSON console logs will now be colored if that field is set to true.
```
![colors](https://user-images.githubusercontent.com/1774000/114511653-d125ca00-9c55-11eb-85e2-ed3712183490.png)

