### PR TITLE
MM-34774 Root post with mention should be auto-followed but hidden from thread results

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -100,7 +100,6 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 		keywords := a.getMentionKeywordsInChannel(profileMap, allowChannelMentions, channelMemberNotifyPropsMap)
 
 		mentions = getExplicitMentions(post, keywords, groups)
-
 		// Add an implicit mention when a user is added to a channel
 		// even if the user has set 'username mentions' to false in account settings.
 		if post.Type == model.POST_ADD_TO_CHANNEL {
@@ -124,6 +123,8 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 
 		// get users that have comment thread mentions enabled
 		if post.RootId != "" && parentPostList != nil {
+			rootPost := parentPostList.Posts[parentPostList.Order[0]]
+			mentions.merge(getExplicitMentions(rootPost, keywords, groups))
 			for _, threadPost := range parentPostList.Posts {
 				profile := profileMap[threadPost.UserId]
 				if profile == nil {
@@ -752,6 +753,12 @@ func (m *ExplicitMentions) addGroupMention(word string, groups map[string]*model
 
 func (m *ExplicitMentions) addMentions(userIDs []string, mentionType MentionType) {
 	for _, userID := range userIDs {
+		m.addMention(userID, mentionType)
+	}
+}
+
+func (m *ExplicitMentions) merge(other *ExplicitMentions) {
+	for userID, mentionType := range other.Mentions {
 		m.addMention(userID, mentionType)
 	}
 }

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -1924,6 +1924,36 @@ func TestThreadMembership(t *testing.T) {
 	})
 }
 
+func TestAutofollowBasedOnRootPost(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	os.Setenv("MM_FEATUREFLAGS_COLLAPSEDTHREADS", "true")
+	defer os.Unsetenv("MM_FEATUREFLAGS_COLLAPSEDTHREADS")
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.ThreadAutoFollow = true
+		*cfg.ServiceSettings.CollapsedThreads = model.COLLAPSED_THREADS_DEFAULT_ON
+	})
+
+	channel := th.BasicChannel
+	user := th.BasicUser
+	user2 := th.BasicUser2
+	appErr := th.App.JoinChannel(channel, user.Id)
+	require.Nil(t, appErr)
+	appErr = th.App.JoinChannel(channel, user2.Id)
+	require.Nil(t, appErr)
+	p1, err := th.App.CreatePost(&model.Post{UserId: user.Id, ChannelId: channel.Id, Message: "Hi @" + user2.Username}, channel, false, false)
+	require.Nil(t, err)
+	m, e := th.App.GetThreadMembershipsForUser(user2.Id, th.BasicTeam.Id)
+	require.Nil(t, e)
+	require.Len(t, m, 0)
+	_, err2 := th.App.CreatePost(&model.Post{RootId: p1.Id, UserId: user.Id, ChannelId: channel.Id, Message: "Hola"}, channel, false, false)
+	require.Nil(t, err2)
+	m, e = th.App.GetThreadMembershipsForUser(user2.Id, th.BasicTeam.Id)
+	require.Nil(t, e)
+	require.Len(t, m, 1)
+}
+
 func TestCollapsedThreadFetch(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -1945,12 +1945,12 @@ func TestAutofollowBasedOnRootPost(t *testing.T) {
 	p1, err := th.App.CreatePost(&model.Post{UserId: user.Id, ChannelId: channel.Id, Message: "Hi @" + user2.Username}, channel, false, false)
 	require.Nil(t, err)
 	m, e := th.App.GetThreadMembershipsForUser(user2.Id, th.BasicTeam.Id)
-	require.Nil(t, e)
+	require.NoError(t, e)
 	require.Len(t, m, 0)
 	_, err2 := th.App.CreatePost(&model.Post{RootId: p1.Id, UserId: user.Id, ChannelId: channel.Id, Message: "Hola"}, channel, false, false)
 	require.Nil(t, err2)
 	m, e = th.App.GetThreadMembershipsForUser(user2.Id, th.BasicTeam.Id)
-	require.Nil(t, e)
+	require.NoError(t, e)
 	require.Len(t, m, 1)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
    implemented auto follow based on root post

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-34774

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
