### PR TITLE
Add IsFreeTrial to Subscription and SubscriptionStats types

### DIFF
--- a/model/cloud.go
+++ b/model/cloud.go
@@ -95,6 +95,7 @@ type Subscription struct {
 	DNS         string   `json:"dns"`
 	IsPaidTier  string   `json:"is_paid_tier"`
 	LastInvoice *Invoice `json:"last_invoice"`
+	IsFreeTrial string   `json:"is_free_trial"`
 }
 
 // GetWorkSpaceNameFromDNS returns the work space name. For example from test.mattermost.cloud.com, it returns test
@@ -147,4 +148,5 @@ type CloudWorkspaceOwner struct {
 type SubscriptionStats struct {
 	RemainingSeats int    `json:"remaining_seats"`
 	IsPaidTier     string `json:"is_paid_tier"`
+	IsFreeTrial    string `json:"is_free_trial"`
 }


### PR DESCRIPTION
#### Summary
It's not cut and dry to determine if a subscription is in a trial with or without a credit card. The logic for determining this will live inside the customer portal. We want to be able to consume this value, as well as pass it along to the front-end as part of subscription and subscription stats.

#### Ticket Link
n/a
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
None
```
