### PR TITLE
[MM-34888] Revert Posts.FileIds migration on MySQL

### DIFF
--- a/scripts/mattermost-mysql-5.0.sql
+++ b/scripts/mattermost-mysql-5.0.sql
@@ -626,7 +626,7 @@ CREATE TABLE `Posts` (
   `Props` text,
   `Hashtags` text,
   `Filenames` text,
-  `FileIds` varchar(300) DEFAULT NULL,
+  `FileIds` text,
   `HasReactions` tinyint(1) DEFAULT NULL,
   PRIMARY KEY (`Id`),
   KEY `idx_posts_update_at` (`UpdateAt`),

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1007,8 +1007,9 @@ func upgradeDatabaseToVersion531(sqlStore *SqlStore) {
 
 func upgradeDatabaseToVersion532(sqlStore *SqlStore) {
 	if hasMissingMigrationsVersion532(sqlStore) {
-		// allow 10 files per post
-		sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
+		if sqlStore.DriverName() == model.DATABASE_DRIVER_POSTGRES {
+			sqlStore.AlterColumnTypeIfExists("Posts", "FileIds", "text", "varchar(300)")
+		}
 		sqlStore.CreateColumnIfNotExistsNoDefault("Channels", "Shared", "tinyint(1)", "boolean")
 		sqlStore.CreateColumnIfNotExists("ThreadMemberships", "UnreadMentions", "bigint", "bigint", "0")
 		sqlStore.CreateColumnIfNotExistsNoDefault("Reactions", "UpdateAt", "bigint", "bigint")


### PR DESCRIPTION
#### Summary

We forgot to update the cloud branch to eliminate the reverted migration for MySQL so when a new release branch was cut it still included the migration.

As a follow-up I'll immediately create a similar PR for the cloud branch.

#### Ticket

https://mattermost.atlassian.net/browse/MM-34888

#### Release note

```release-note
NONE
```
