### PR TITLE
Fix 5.35 migration

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1108,11 +1108,16 @@ func upgradeDatabaseToVersion535(sqlStore *SqlStore) {
 			SET MsgCountRoot=TotalMsgCountRoot
 			`
 	}
-	if _, err := sqlStore.GetMaster().Exec(updateChannels); err != nil {
-		mlog.Error("Error updating Channels table", mlog.Err(err))
+
+	if !sqlStore.DoesColumnExist("Channels", "TotalMsgCountRoot") {
+		if _, err := sqlStore.GetMaster().Exec(updateChannels); err != nil {
+			mlog.Error("Error updating Channels table", mlog.Err(err))
+		}
 	}
-	if _, err := sqlStore.GetMaster().Exec(updateChannelMembers); err != nil {
-		mlog.Error("Error updating ChannelMembers table", mlog.Err(err))
+	if !sqlStore.DoesColumnExist("ChannelMembers", "MsgCountRoot") {
+		if _, err := sqlStore.GetMaster().Exec(updateChannelMembers); err != nil {
+			mlog.Error("Error updating ChannelMembers table", mlog.Err(err))
+		}
 	}
 
 	// 	saveSchemaVersion(sqlStore, Version5350)

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1032,6 +1032,9 @@ func upgradeDatabaseToVersion535(sqlStore *SqlStore) {
 	sqlStore.CreateUniqueCompositeIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", uniquenessColumns)
 	sqlStore.CreateColumnIfNotExists("SharedChannelUsers", "ChannelId", "VARCHAR(26)", "VARCHAR(26)", "")
 
+	totalMsgCountRootExists := sqlStore.DoesColumnExist("Channels", "TotalMsgCountRoot")
+	msgCountRootExists := sqlStore.DoesColumnExist("ChannelMembers", "MsgCountRoot")
+
 	// note: setting default 0 on pre-5.0 tables causes test-db-migration script to fail, so this column will be added to ignore list
 	sqlStore.CreateColumnIfNotExists("ChannelMembers", "MentionCountRoot", "bigint", "bigint", "0")
 	sqlStore.AlterColumnDefaultIfExists("ChannelMembers", "MentionCountRoot", model.NewString("0"), model.NewString("0"))
@@ -1109,12 +1112,12 @@ func upgradeDatabaseToVersion535(sqlStore *SqlStore) {
 			`
 	}
 
-	if !sqlStore.DoesColumnExist("Channels", "TotalMsgCountRoot") {
+	if !totalMsgCountRootExists {
 		if _, err := sqlStore.GetMaster().Exec(updateChannels); err != nil {
 			mlog.Error("Error updating Channels table", mlog.Err(err))
 		}
 	}
-	if !sqlStore.DoesColumnExist("ChannelMembers", "MsgCountRoot") {
+	if !msgCountRootExists {
 		if _, err := sqlStore.GetMaster().Exec(updateChannelMembers); err != nil {
 			mlog.Error("Error updating ChannelMembers table", mlog.Err(err))
 		}

--- a/store/sqlstore/upgrade_test.go
+++ b/store/sqlstore/upgrade_test.go
@@ -221,6 +221,10 @@ func TestMsgCountRootMigration(t *testing.T) {
 							}
 						}
 
+						_, err = sqlStore.GetMaster().Exec(`ALTER TABLE Channels DROP COLUMN TotalMsgCountRoot`)
+						require.NoError(t, err)
+						_, err = sqlStore.GetMaster().Exec(`ALTER TABLE ChannelMembers DROP COLUMN MsgCountRoot`)
+						require.NoError(t, err)
 						upgradeDatabaseToVersion535(sqlStore)
 
 						members, err := ss.Channel().GetMembersByIds(channel.Id, userIds)


### PR DESCRIPTION
#### Summary

PR fixes 5.35 migration code to only run performance heavy queries once. This is to fix some issues we are having on community-daily (more context [here](https://community-daily.mattermost.com/private-core/pl/h3s8mpkabjfcfczszqby88sozy)).

#### Release Note

```release-note
NONE
```

