### PR TITLE
[MM-34919] Use Mattermost-Plugin-ID header to pass ID in inter-plugin requests

### DIFF
--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -1404,6 +1404,10 @@ func TestInterpluginPluginHTTP(t *testing.T) {
 				return
 			}
 
+			if r.Header.Get("Mattermost-Plugin-ID") != "testplugininterclient" {
+				return
+			}
+
 			buf := bytes.Buffer{}
 			buf.ReadFrom(r.Body)
 			resp := "we got:" + buf.String()

--- a/app/plugin_requests.go
+++ b/app/plugin_requests.go
@@ -74,6 +74,8 @@ func (a *App) ServeInterPluginRequest(w http.ResponseWriter, r *http.Request, so
 		SourcePluginId: sourcePluginId,
 	}
 
+	r.Header.Set("Mattermost-Plugin-ID", sourcePluginId)
+
 	hooks.ServeHTTP(context, w, r)
 }
 
@@ -134,6 +136,9 @@ func (a *App) servePluginRequest(w http.ResponseWriter, r *http.Request, handler
 	} else {
 		token = r.URL.Query().Get("access_token")
 	}
+
+	// Mattermost-Plugin-ID can only be set by inter-plugin requests
+	r.Header.Del("Mattermost-Plugin-ID")
 
 	r.Header.Del("Mattermost-User-Id")
 	if token != "" {

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -12,5 +12,5 @@ type Context struct {
 	IpAddress      string
 	AcceptLanguage string
 	UserAgent      string
-	SourcePluginId string
+	SourcePluginId string // Deprecated: Use the "Mattermost-Plugin-ID" HTTP header instead
 }


### PR DESCRIPTION
#### Summary
Pass the source plugin ID via a `Mattermost-Plugin-ID` header. The exiting mechanism to pass the id -  the `SourcePluginId` in `plugin.Context´ is now deprecated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34919

#### Release Note
```release-note
NONE
```
