### PR TITLE
Have `a.PermanentlyDeleteBot` clean up by using `a.PermanentlyDeleteUser`

### DIFF
--- a/app/bot.go
+++ b/app/bot.go
@@ -300,8 +300,14 @@ func (a *App) PermanentDeleteBot(botUserId string) *model.AppError {
 		}
 	}
 
-	if err := a.Srv().Store.User().PermanentDelete(botUserId); err != nil {
-		return model.NewAppError("PermanentDeleteBot", "app.user.permanent_delete.app_error", nil, err.Error(), http.StatusInternalServerError)
+	user, appErr := a.GetUser(botUserId)
+	if appErr != nil {
+		return model.NewAppError("PermanentDeleteBot", "app.user.get.app_error", nil, appErr.Error(), http.StatusInternalServerError)
+	}
+
+	appErr = a.PermanentDeleteUser(user)
+	if appErr != nil {
+		return model.NewAppError("PermanentDeleteBot", "app.user.permanent_delete.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 	}
 
 	return nil

--- a/app/bot.go
+++ b/app/bot.go
@@ -290,16 +290,6 @@ func (a *App) UpdateBotActive(botUserId string, active bool) (*model.Bot, *model
 
 // PermanentDeleteBot permanently deletes a bot and its corresponding user.
 func (a *App) PermanentDeleteBot(botUserId string) *model.AppError {
-	if err := a.Srv().Store.Bot().PermanentDelete(botUserId); err != nil {
-		var invErr *store.ErrInvalidInput
-		switch {
-		case errors.As(err, &invErr):
-			return model.NewAppError("PermanentDeleteBot", "app.bot.permenent_delete.bad_id", map[string]interface{}{"user_id": invErr.Value}, invErr.Error(), http.StatusBadRequest)
-		default: // last fallback in case it doesn't map to an existing app error.
-			return model.NewAppError("PatchBot", "app.bot.permanent_delete.internal_error", nil, err.Error(), http.StatusInternalServerError)
-		}
-	}
-
 	user, appErr := a.GetUser(botUserId)
 	if appErr != nil {
 		return model.NewAppError("PermanentDeleteBot", "app.user.get.app_error", nil, appErr.Error(), http.StatusInternalServerError)

--- a/app/bot_test.go
+++ b/app/bot_test.go
@@ -519,6 +519,10 @@ func TestPermanentDeleteBot(t *testing.T) {
 	_, err = th.App.GetBot(bot.UserId, false)
 	require.NotNil(t, err)
 	require.Equal(t, "store.sql_bot.get.missing.app_error", err.Id)
+
+	_, err = th.App.GetUser(bot.UserId)
+	require.NotNil(t, err)
+	require.Equal(t, "app.user.missing_account.const", err.Id)
 }
 
 func TestDisableUserBots(t *testing.T) {


### PR DESCRIPTION
#### Summary

The `a.PermanentlyDeleteBot` function was calling `a.Srv().Store.User().PermanentDelete` directly, rather than using the user cleanup functionality in `a.PermanentlyDeleteUser`.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-34827

#### Release Note

Does this release note need to be included?

```release-note
Bot deletion has been improved by utilizing user deletion clean up code
```
