### PR TITLE
MM-34125: Remove WebSocketDelay feature flag

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -71,14 +71,14 @@ func (a *App) NewWebConn(ws *websocket.Conn, session model.Session, t i18n.Trans
 		})
 	}
 
-	if a.srv.Config().FeatureFlags.WebSocketDelay {
-		// Disable TCP_NO_DELAY for higher throughput
-		tcpConn, ok := ws.UnderlyingConn().(*net.TCPConn)
-		if ok {
-			err := tcpConn.SetNoDelay(false)
-			if err != nil {
-				mlog.Warn("Error in setting NoDelay socket opts", mlog.Err(err))
-			}
+	// Disable TCP_NO_DELAY for higher throughput
+	// Unfortunately, it doesn't work for tls.Conn,
+	// and currently, the API doesn't expose the underlying TCP conn.
+	tcpConn, ok := ws.UnderlyingConn().(*net.TCPConn)
+	if ok {
+		err := tcpConn.SetNoDelay(false)
+		if err != nil {
+			mlog.Warn("Error in setting NoDelay socket opts", mlog.Err(err))
 		}
 	}
 

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -34,8 +34,6 @@ type FeatureFlags struct {
 
 	// Toggle on and off support for Files search
 	FilesSearch bool
-	// Feature flag to control setting the TCP_NO_DELAY setting for websockets.
-	WebSocketDelay bool
 
 	// Control support for custom data retention policies
 	CustomDataRetentionEnabled bool
@@ -52,7 +50,6 @@ func (f *FeatureFlags) SetDefaults() {
 
 	f.PluginIncidentManagement = "1.7.0"
 	f.PluginApps = ""
-	f.WebSocketDelay = false
 	f.CustomDataRetentionEnabled = false
 }
 


### PR DESCRIPTION
It has been soaked for enough time in community-daily
and also in community. Enabling it for all.

```release-note
TCP_NO_DELAY is disabled for websocket connections
to allow for higher throughput
```

https://mattermost.atlassian.net/browse/MM-34125
