### PR TITLE
sentry: remove ci steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,8 +197,6 @@ jobs:
             make package BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'
             curl -sL https://sentry.io/get-cli/ | bash
             echo Sentry will use version `git rev-parse HEAD`
-            sentry-cli --log-level=debug releases new  --finalize -p mattermost-server `git rev-parse HEAD`
-            sentry-cli --log-level=debug releases set-commits --auto `git rev-parse HEAD`
 
       - store_artifacts:
           path: ~/mattermost/mattermost-server/dist/mattermost-team-linux-amd64.tar.gz


### PR DESCRIPTION
#### Summary
remove ci steps for sentry, those lines do not exist on the release branch 5.34

context: https://community.mattermost.com/core/pl/6fymbthzdfbo9rudo6sx46jh9a

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note

```release-note
NONE
```
