### PR TITLE
Updates on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,33 @@ jobs:
             export PATH=$PATH:$GOBIN
             make migrations-bindata
             if [[ -n $(git status --porcelain) ]]; then echo "Please update the migration bindata using `make migrations-bindata`"; exit 1; fi
+
+  check-golangci-lint:
+    docker:
+      - image: golangci/golangci-lint:v1.33.2
+    steps:
+      - checkout
+      - run:
+          command: make golangci-lint
+
+  check-mattermost-vet:
+    docker:
+      - image: mattermost/mattermost-build-server:20201119_golang-1.15.5
+    resource_class: medium
+    working_directory: ~/mattermost
+    steps:
+      - attach_workspace:
+          at: ~/mattermost/
+      - run:
+          command: |
+            echo "Installing mattermost-govet"
+            export GOBIN=${PWD}/mattermost-server/bin
+            GO111MODULE=off go get -u github.com/mattermost/mattermost-govet
+            export PATH=$PATH:$GOBIN
+            cd mattermost-server
+            make config-reset
+            make check-style-ci BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}' MM_NO_ENTERPRISE_LINT=true MM_VET_OPENSPEC_PATH='${PWD}/../mattermost-api-reference/v4/html/static/mattermost-openapi-v4.yaml'
+
   build-api-spec:
     docker:
       - image: circleci/node:lts
@@ -184,15 +211,8 @@ jobs:
           at: ~/mattermost/
       - run:
           command: |
-            echo "Installing golangci-lint"
-            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/local/bin v1.33.2
-            echo "Installing mattermost-govet"
-            export GOBIN=${PWD}/mattermost-server/bin
-            GO111MODULE=off go get -u github.com/mattermost/mattermost-govet
-            export PATH=$PATH:$GOBIN
             cd mattermost-server
             make config-reset
-            make check-style BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}' MM_NO_ENTERPRISE_LINT=true MM_VET_OPENSPEC_PATH='${PWD}/../mattermost-api-reference/v4/html/static/mattermost-openapi-v4.yaml'
             make build-cmd BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'
             make package BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'
             curl -sL https://sentry.io/get-cli/ | bash
@@ -451,6 +471,12 @@ workflows:
       # - check-i18n:
       #     requires:
       #       - setup
+      - check-golangci-lint:
+          filters:
+            branches:
+              ignore:
+                - master
+                - /^release-.*/
       - check-app-layers:
           requires:
             - setup
@@ -463,6 +489,9 @@ workflows:
       - check-migrations:
           requires:
             - setup
+      - check-mattermost-vet:
+          requires:
+            - setup
       - build-api-spec:
           requires:
             - setup
@@ -473,6 +502,8 @@ workflows:
             - check-store-layers
             - check-mocks
             - check-migrations
+            - check-mattermost-vet
+            - check-golangci-lint
             - build-api-spec
       - upload-s3-sha:
           context: mattermost-ci-pr-builds-s3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ executors:
       image: "ubuntu-1604:201903-01"
     environment:
       COMPOSE_PROJECT_NAME: "circleci"
+
 jobs:
   setup:
     working_directory: ~/mattermost/mattermost-server
@@ -129,9 +130,10 @@ jobs:
             cd mattermost-server
             make store-layers
             if [[ -n $(git status --porcelain) ]]; then echo "Please update the store layers using make store-layers"; exit 1; fi
+
   check-mocks:
     docker:
-      - image: mattermost/mattermost-build-server:20200731_golang-1.14.6
+      - image: mattermost/mattermost-build-server:20201119_golang-1.15.5
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -141,6 +143,7 @@ jobs:
             cd mattermost-server
             make einterfaces-mocks store-mocks
             if [[ -n $(git status --porcelain) ]]; then echo "Please update the mocks using `make einterfaces-mocks store-mocks`"; exit 1; fi
+
   check-migrations:
     docker:
       - image: mattermost/mattermost-build-server:20201119_golang-1.15.5
@@ -156,6 +159,8 @@ jobs:
             make migrations-bindata
             if [[ -n $(git status --porcelain) ]]; then echo "Please update the migration bindata using `make migrations-bindata`"; exit 1; fi
 
+  # Dedicate job for golangci-lint it does not need anything only the server code for that
+  # and to make more clear when the job fails
   check-golangci-lint:
     docker:
       - image: golangci/golangci-lint:v1.33.2
@@ -164,10 +169,10 @@ jobs:
       - run:
           command: make golangci-lint
 
+  # Dedicate job for mattermost-vet to make more clear when the job fails
   check-mattermost-vet:
     docker:
       - image: mattermost/mattermost-build-server:20201119_golang-1.15.5
-    resource_class: medium
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -180,7 +185,8 @@ jobs:
             export PATH=$PATH:$GOBIN
             cd mattermost-server
             make config-reset
-            make check-style-ci BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}' MM_NO_ENTERPRISE_LINT=true MM_VET_OPENSPEC_PATH='${PWD}/../mattermost-api-reference/v4/html/static/mattermost-openapi-v4.yaml'
+            make plugin-checker
+            make vet BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}' MM_NO_ENTERPRISE_LINT=true MM_VET_OPENSPEC_PATH='${PWD}/../mattermost-api-reference/v4/html/static/mattermost-openapi-v4.yaml'
 
   build-api-spec:
     docker:
@@ -438,7 +444,6 @@ jobs:
     working_directory: ~/
     docker:
       - image: circleci/buildpack-deps:stretch
-    resource_class: xlarge
     steps:
       - attach_workspace:
           at: .
@@ -562,6 +567,13 @@ workflows:
       # - check-i18n:
       #     requires:
       #       - setup
+      - check-golangci-lint:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+                - cloud
       - check-app-layers:
           requires:
             - setup

--- a/Makefile
+++ b/Makefile
@@ -325,9 +325,8 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 	./scripts/prereq-check-enterprise.sh
 endif
 
-check-style: golangci-lint plugin-checker vet ## Runs golangci against all packages
+check-style: golangci-lint plugin-checker vet ## Runs style/lint checks
 
-check-style-ci: plugin-checker vet ## Runs plugin-checker and vet
 
 do-cover-file: ## Creates the test coverage report file.
 	@echo "mode: count" > cover.out

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,8 @@ endif
 
 check-style: golangci-lint plugin-checker vet ## Runs golangci against all packages
 
+check-style-ci: plugin-checker vet ## Runs plugin-checker and vet
+
 do-cover-file: ## Creates the test coverage report file.
 	@echo "mode: count" > cover.out
 


### PR DESCRIPTION
#### Summary
 - Moving out the lint/vet part from the build step to make more clear when it fails. 
 - some updates for some job in the resource_class, because we pay extra for bigger machines and in some steps we don't need that

#### Ticket Link
N/A

#### Release Note

```release-note
NONE
```
