### PR TITLE
MM-35127 CRT: Marking thread as unread doesn't set the timestamp correctly

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -1387,18 +1387,14 @@ func (a *App) countThreadMentions(user *model.User, post *model.Post, teamID str
 	if nErr != nil {
 		return 0, model.NewAppError("countMentionsFromPost", "app.channel.count_posts_since.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 	}
-
-	mentions := getExplicitMentions(post, keywords, groups)
-	if post.UpdateAt >= timestamp {
-		if _, ok := mentions.Mentions[user.Id]; ok {
-			count += 1
-		}
-	}
+	posts = append(posts, post)
 
 	for _, p := range posts {
-		mentions = getExplicitMentions(p, keywords, groups)
-		if _, ok := mentions.Mentions[user.Id]; ok {
-			count += 1
+		if p.CreateAt >= timestamp {
+			mentions := getExplicitMentions(p, keywords, groups)
+			if _, ok := mentions.Mentions[user.Id]; ok {
+				count += 1
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
correctly handle mention counting on timestamp change
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-35127
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```release-note
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```release-note
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```release-note
NONE
```
-->
```release-note
NONE
```
