### PR TITLE
MM-35181 Move SharedChannelsUsers.ChannelId column add to 5.36 migration

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	CurrentSchemaVersion   = Version5350
+	Version5360            = "5.36.0"
 	Version5350            = "5.35.0"
 	Version5340            = "5.34.0"
 	Version5330            = "5.33.0"
@@ -1053,12 +1054,20 @@ func upgradeDatabaseToVersion535(sqlStore *SqlStore) {
 			uniquenessColumns = []string{"RemoteTeamId", "SiteUrl(168)"}
 		}
 		sqlStore.CreateUniqueCompositeIndexIfNotExists(RemoteClusterSiteURLUniqueIndex, "RemoteClusters", uniquenessColumns)
-		sqlStore.CreateColumnIfNotExists("SharedChannelUsers", "ChannelId", "VARCHAR(26)", "VARCHAR(26)", "")
 
 		rootCountMigration(sqlStore)
 
 		saveSchemaVersion(sqlStore, Version5350)
 	}
+}
+
+func upgradeDatabaseToVersion536(sqlStore *SqlStore) {
+	//if shouldPerformUpgrade(sqlStore, Version5350, Version5360) {
+
+	sqlStore.CreateColumnIfNotExists("SharedChannelUsers", "ChannelId", "VARCHAR(26)", "VARCHAR(26)", "")
+
+	//saveSchemaVersion(sqlStore, Version5360)
+	//}
 }
 
 func rootCountMigration(sqlStore *SqlStore) {

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -207,6 +207,7 @@ func upgradeDatabase(sqlStore *SqlStore, currentModelVersionString string) error
 	upgradeDatabaseToVersion533(sqlStore)
 	upgradeDatabaseToVersion534(sqlStore)
 	upgradeDatabaseToVersion535(sqlStore)
+	upgradeDatabaseToVersion536(sqlStore)
 
 	return nil
 }


### PR DESCRIPTION
#### Summary
See discussion here https://community.mattermost.com/private-core/pl/n6aznzgxfjro9k9m5m6fajigjo

Background:  column was added for a PR that didn’t make it into 5.35, but the migration was added to 5.35.  The column migration was removed from 5.35 and this ticket is to put it into 5.36

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35181

#### Release Note
```release-note
NONE
```
