### PR TITLE
MM-22678 Use more user-friendly errors for channel commands

### DIFF
--- a/app/slashcommands/command_channel_header.go
+++ b/app/slashcommands/command_channel_header.go
@@ -94,8 +94,15 @@ func (*HeaderProvider) DoCommand(a *app.App, args *model.CommandArgs, message st
 
 	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
+		text := args.T("api.command_channel_header.update_channel.app_error")
+		if err.Id == "model.channel.is_valid.header.app_error" {
+			text = args.T("api.command_channel_header.update_channel.max_length", map[string]interface{}{
+				"MaxLength": model.CHANNEL_HEADER_MAX_RUNES,
+			})
+		}
+
 		return &model.CommandResponse{
-			Text:         args.T("api.command_channel_header.update_channel.app_error"),
+			Text:         text,
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 		}
 	}

--- a/app/slashcommands/command_channel_purpose.go
+++ b/app/slashcommands/command_channel_purpose.go
@@ -79,8 +79,15 @@ func (*PurposeProvider) DoCommand(a *app.App, args *model.CommandArgs, message s
 
 	_, err = a.PatchChannel(channel, patch, args.UserId)
 	if err != nil {
+		text := args.T("api.command_channel_purpose.update_channel.app_error")
+		if err.Id == "model.channel.is_valid.purpose.app_error" {
+			text = args.T("api.command_channel_purpose.update_channel.max_length", map[string]interface{}{
+				"MaxLength": model.CHANNEL_PURPOSE_MAX_RUNES,
+			})
+		}
+
 		return &model.CommandResponse{
-			Text:         args.T("api.command_channel_purpose.update_channel.app_error"),
+			Text:         text,
 			ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 		}
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -633,7 +633,7 @@
   },
   {
     "id": "api.command_channel_header.update_channel.max_length",
-    "translation": "That channel header is too long. It can be at most {{.MaxLength}} characters long."
+    "translation": "The text entered exceeds the character limit. The channel header is limited to {{.MaxLength}} characters."
   },
   {
     "id": "api.command_channel_purpose.channel.app_error",
@@ -669,7 +669,7 @@
   },
   {
     "id": "api.command_channel_purpose.update_channel.max_length",
-    "translation": "That channel purpose is too long. It can be at most {{.MaxLength}} characters long."
+    "translation": "The text entered exceeds the character limit. The channel purpose is limited to {{.MaxLength}} characters."
   },
   {
     "id": "api.command_channel_remove.channel.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -629,7 +629,11 @@
   },
   {
     "id": "api.command_channel_header.update_channel.app_error",
-    "translation": "Error to update the current channel."
+    "translation": "Error updating the channel header."
+  },
+  {
+    "id": "api.command_channel_header.update_channel.max_length",
+    "translation": "That channel header is too long. It can be at most {{.MaxLength}} characters long."
   },
   {
     "id": "api.command_channel_purpose.channel.app_error",
@@ -661,7 +665,11 @@
   },
   {
     "id": "api.command_channel_purpose.update_channel.app_error",
-    "translation": "Error to update the current channel."
+    "translation": "Error updating the channel purpose."
+  },
+  {
+    "id": "api.command_channel_purpose.update_channel.max_length",
+    "translation": "That channel purpose is too long. It can be at most {{.MaxLength}} characters long."
   },
   {
     "id": "api.command_channel_remove.channel.app_error",


### PR DESCRIPTION
The old "Error to update the current channel." error was both gramatically incorrect and didn't actually tell the user what went wrong. This should hopefully improve both of those.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-22678

#### Release Note
```release-note
Improved error messages for /header and /purpose commands.
```
