### PR TITLE
MM-34878: Add metrics for websocket reconnects

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -317,7 +317,6 @@ func (wc *WebConn) writePump() {
 			// If the seq number is not in dead queue, but it was supposed to be,
 			// then generate a different connection ID,
 			// and set sequence to 0, and clear dead queue.
-			// TODO: Add metrics for this. (both true and false cases)
 			wc.clearDeadQueue()
 			wc.SetConnectionID(model.NewId())
 			wc.Sequence = 0

--- a/einterfaces/metrics.go
+++ b/einterfaces/metrics.go
@@ -43,6 +43,7 @@ type MetricsInterface interface {
 	DecrementWebSocketBroadcastBufferSize(hub string, amount float64)
 	IncrementWebSocketBroadcastUsersRegistered(hub string, amount float64)
 	DecrementWebSocketBroadcastUsersRegistered(hub string, amount float64)
+	IncrementWebsocketReconnectEvent(eventType string)
 
 	AddMemCacheHitCounter(cacheName string, amount float64)
 	AddMemCacheMissCounter(cacheName string, amount float64)

--- a/einterfaces/mocks/MetricsInterface.go
+++ b/einterfaces/mocks/MetricsInterface.go
@@ -230,6 +230,11 @@ func (_m *MetricsInterface) IncrementWebsocketEvent(eventType string) {
 	_m.Called(eventType)
 }
 
+// IncrementWebsocketReconnectEvent provides a mock function with given fields: eventType
+func (_m *MetricsInterface) IncrementWebsocketReconnectEvent(eventType string) {
+	_m.Called(eventType)
+}
+
 // ObserveApiEndpointDuration provides a mock function with given fields: endpoint, method, statusCode, elapsed
 func (_m *MetricsInterface) ObserveApiEndpointDuration(endpoint string, method string, statusCode string, elapsed float64) {
 	_m.Called(endpoint, method, statusCode, elapsed)


### PR DESCRIPTION
Added three new metrics to track successful websocket drain
and dead queue misses.

```release-note
NONE
```

https://mattermost.atlassian.net/browse/MM-34878
