### PR TITLE
MM-35206 CRT: is_following on posts not reflecting state properly

### DIFF
--- a/model/post.go
+++ b/model/post.go
@@ -207,6 +207,7 @@ func (o *Post) ShallowCopy(dst *Post) error {
 	dst.Participants = o.Participants
 	dst.LastReplyAt = o.LastReplyAt
 	dst.Metadata = o.Metadata
+	dst.IsFollowing = o.IsFollowing
 	dst.RemoteId = o.RemoteId
 	return nil
 }

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -478,17 +478,16 @@ func (s *SqlPostStore) getPostWithCollapsedThreads(id, userID string, extended b
 	var posts []*model.Post
 	_, err = s.GetReplica().Select(&posts, "SELECT * FROM Posts WHERE Posts.RootId = :RootId AND DeleteAt = 0", map[string]interface{}{"RootId": id})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to find Posts")
+		return nil, errors.Wrapf(err, "failed to find Posts for thread %s", id)
 	}
 
 	list, err := s.prepareThreadedResponse([]*postWithExtra{&post}, extended, false)
 	if err != nil {
 		return nil, err
 	}
-	for i := range posts {
-		idx := i
-		list.AddPost(posts[idx])
-		list.AddOrder(posts[idx].Id)
+	for _, p := range posts {
+		list.AddPost(p)
+		list.AddOrder(p.Id)
 	}
 	return list, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
forgot to copy isFollowing param
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-35206
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
