### PR TITLE
MM-35239: Fix racy test HubSessionRevokeRace

### DIFF
--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -117,8 +117,6 @@ func TestHubStopRaceCondition(t *testing.T) {
 }
 
 func TestHubSessionRevokeRace(t *testing.T) {
-	t.Skip("MM-35239")
-
 	th := SetupWithStoreMock(t)
 	defer th.TearDown()
 
@@ -169,8 +167,7 @@ func TestHubSessionRevokeRace(t *testing.T) {
 	defer s.Close()
 
 	wc1 := registerDummyWebConn(t, th.App, s.Listener.Addr(), "testid")
-	hub := th.App.Srv().hubs[0]
-	hub.Register(wc1)
+	hub := th.App.GetHubForUserId(wc1.UserId)
 
 	done := make(chan bool)
 


### PR DESCRIPTION
registerDummyWebConn already registers a webconn
to the hub. We were registering it again later.

This was incorrect. The test just passed nevertheless,
but there were 2 webconns getting added to the same userID.

https://mattermost.atlassian.net/browse/MM-35239

```release-note
NONE
```
