### PR TITLE
ci: move sentry tasks to a dedicated job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,18 @@ jobs:
             make plugin-checker
             make vet BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}' MM_NO_ENTERPRISE_LINT=true MM_VET_OPENSPEC_PATH='${PWD}/../mattermost-api-reference/v4/html/static/mattermost-openapi-v4.yaml'
 
+  # Dedicate job for sentry it does not need anything only the server code for that
+  # and to make more clear when the job fails
+  sentry:
+    docker:
+      - image: getsentry/sentry-cli:1.64.1
+    steps:
+      - checkout
+      - run:
+          command: |
+            sentry-cli --log-level=debug releases new  --finalize -p mattermost-server `git rev-parse HEAD`
+            sentry-cli --log-level=debug releases set-commits --auto `git rev-parse HEAD`
+
   build-api-spec:
     docker:
       - image: circleci/node:lts
@@ -221,11 +233,6 @@ jobs:
             make config-reset
             make build-cmd BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'
             make package BUILD_NUMBER='${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}'
-            curl -sL https://sentry.io/get-cli/ | bash
-            echo Sentry will use version `git rev-parse HEAD`
-            sentry-cli --log-level=debug releases new  --finalize -p mattermost-server `git rev-parse HEAD`
-            sentry-cli --log-level=debug releases set-commits --auto `git rev-parse HEAD`
-
       - store_artifacts:
           path: ~/mattermost/mattermost-server/dist/mattermost-team-linux-amd64.tar.gz
       - store_artifacts:
@@ -500,8 +507,17 @@ workflows:
       - build-api-spec:
           requires:
             - setup
-      - build:
+      - sentry:
           context: matterbuild-sentry
+          requires:
+            - check-app-layers
+            - check-store-layers
+            - check-mocks
+            - check-migrations
+            - check-mattermost-vet
+            - check-golangci-lint
+            - build-api-spec
+      - build:
           requires:
             - check-app-layers
             - check-store-layers
@@ -589,8 +605,17 @@ workflows:
       - check-migrations:
           requires:
             - setup
-      - build:
+      - sentry:
           context: matterbuild-sentry
+          requires:
+            - check-app-layers
+            - check-store-layers
+            - check-mocks
+            - check-migrations
+            - check-mattermost-vet
+            - check-golangci-lint
+            - build-api-spec
+      - build:
           requires:
             - check-app-layers
             - check-store-layers


### PR DESCRIPTION
#### Summary
ci: move sentry tasks to a dedicated job

It is not clear if we need that for all PRs or only when building `master`/`cloud`/`release branches` 

We maybe do a follow up to remove that from the PR tests

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/DOPS-416

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
