### PR TITLE
[MM-35316] Fix panic in app.CreateSidebarCategory

### DIFF
--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -248,10 +248,8 @@ func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategor
 	categoriesWithOrder, err := s.getSidebarCategoriesT(transaction, userId, teamId)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(categoriesWithOrder.Categories) < 1 {
-		return nil, errors.Wrap(err, "categories not found")
+	} else if len(categoriesWithOrder.Categories) == 0 {
+		return nil, store.NewErrNotFound("categories not found", fmt.Sprintf("userId=%s,teamId=%s", userId, teamId))
 	}
 
 	newOrder := categoriesWithOrder.Order
@@ -478,8 +476,11 @@ func (s SqlChannelStore) getSidebarCategoriesT(db dbSelecter, userId, teamId str
 	}
 
 	if _, err = db.Select(&categories, query, args...); err != nil {
+		return nil, errors.Wrapf(err, "failed to get categories for userId=%s,teamId=%s", userId, teamId)
+	} else if len(categories) == 0 {
 		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, teamId))
 	}
+
 	for _, category := range categories {
 		var prevCategory *model.SidebarCategoryWithChannels
 		for _, existing := range oc.Categories {

--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -476,8 +476,6 @@ func (s SqlChannelStore) getSidebarCategoriesT(db dbSelecter, userId, teamId str
 	}
 
 	if _, err = db.Select(&categories, query, args...); err != nil {
-		return nil, errors.Wrapf(err, "failed to get categories for userId=%s,teamId=%s", userId, teamId)
-	} else if len(categories) == 0 {
 		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, teamId))
 	}
 

--- a/store/storetest/channel_store_categories.go
+++ b/store/storetest/channel_store_categories.go
@@ -363,6 +363,22 @@ func testCreateInitialSidebarCategories(t *testing.T, ss store.Store) {
 }
 
 func testCreateSidebarCategory(t *testing.T, ss store.Store) {
+	t.Run("Creating category without initial categories should fail", func(t *testing.T) {
+		userId := model.NewId()
+		teamId := model.NewId()
+
+		// Create the category
+		created, err := ss.Channel().CreateSidebarCategory(userId, teamId, &model.SidebarCategoryWithChannels{
+			SidebarCategory: model.SidebarCategory{
+				DisplayName: model.NewId(),
+			},
+		})
+		require.Error(t, err)
+		var errNotFound *store.ErrNotFound
+		require.ErrorAs(t, err, &errNotFound)
+		require.Nil(t, created)
+	})
+
 	t.Run("should place the new category second if Favorites comes first", func(t *testing.T) {
 		userId := model.NewId()
 		teamId := model.NewId()


### PR DESCRIPTION
#### Summary

PR fixes a potential panic caused by wrapping a `nil` error in  `SqlChannelStore.CreateSidebarCategory()`.

#### Ticket

https://mattermost.atlassian.net/browse/MM-35316

#### Release Note

```release-note
NONE
```