### PR TITLE
Change displayname of System user to Info

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9068,7 +9068,7 @@
   },
   {
     "id": "system.message.name",
-    "translation": "System"
+    "translation": "Info"
   },
   {
     "id": "web.command_webhook.command.app_error",


### PR DESCRIPTION
#### Summary
Change system user display name to "Info". Why:
First impression of a new user to Mattermost: System?! It looks like as if the Terminator is chatting with us! 

#### Release Note
```release-note
Change display name of system user to "Info"
```