### PR TITLE
ci: update inbucket to use mattermost/inbucket:release-1.2.0

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -65,7 +65,7 @@ services:
       MINIO_SECRET_KEY: miniosecretkey
       MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
   inbucket:
-    image: "jhillyerd/inbucket:release-1.2.0"
+    image: "mattermost/inbucket:release-1.2.0"
     restart: always
     networks:
       - mm-test


### PR DESCRIPTION
### Summary
the docker image `jhillyerd/inbucket:release-1.2.0` we were using was removed from docker hub and now is available on `inbucket/inbucket` however that is a new release and have some breaking changes.

I will update our codebase to use the new release but for now, as a workaround, lets use the same image hosted in the mattermost docker hub.

We need to cherry-pick to all supported release branches and cloud, I will cherry pick to all that applies


#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
ci: update inbucket to use mattermost/inbucket:release-1.2.0
```
