### PR TITLE
ci: upgrade inbucket

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -65,8 +65,12 @@ services:
       MINIO_SECRET_KEY: miniosecretkey
       MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
   inbucket:
-    image: "mattermost/inbucket:release-1.2.0"
+    image: "inbucket/inbucket:stable"
     restart: always
+    environment:
+      INBUCKET_WEB_ADDR: "0.0.0.0:10080"
+      INBUCKET_POP3_ADDR: "0.0.0.0:10110"
+      INBUCKET_SMTP_ADDR: "0.0.0.0:10025"
     networks:
       - mm-test
   openldap:


### PR DESCRIPTION
#### Summary
Follow-up of https://github.com/mattermost/mattermost-server/pull/17559

this upgrades the docker image for inbucket, the service we use in the tests to validate the emails.

the newer release of inbucket changed the ports, This PR adjust the ports to match the ones we are already using

No need to cherry pick to other branches.

#### Ticket Link
N/A


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
