### PR TITLE
ci: update inbucket to use mattermost/inbucket:release-1.2.0 (#17559)

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -43,7 +43,7 @@ services:
       MINIO_SECRET_KEY: miniosecretkey
       MINIO_SSE_MASTER_KEY: "my-minio-key:6368616e676520746869732070617373776f726420746f206120736563726574"
   inbucket:
-    image: "jhillyerd/inbucket:release-1.2.0"
+    image: "mattermost/inbucket:release-1.2.0"
     restart: always
     networks:
       - mm-test


### PR DESCRIPTION
#### Summary
cherry pick of https://github.com/mattermost/mattermost-server/pull/17559

#### Ticket Link

-->
```release-note
NONE
```
