### PR TITLE
[MM-35061] - Welcome Email: Missing spacing between icon and paragraphs

### DIFF
--- a/templates/cloud_welcome_email.html
+++ b/templates/cloud_welcome_email.html
@@ -74,7 +74,7 @@
                                                 {{.Props.InviteInfo}}
                                             </span>
                                             <p
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40; margin-left: 26px">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40; margin-left: 26px;">
                                                 {{.Props.InviteSubInfo}}
                                                 <a style="text-decoration: none; color: #6DA4EB;" target="_blank"
                                                     rel="noopener noreferrer"
@@ -114,7 +114,7 @@
                                                 {{.Props.DownloadMMInfo}}
                                             </span>
                                             <p
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40;  margin-left: 26px">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40;  margin-left: 26px;">
                                                 {{.Props.SignInSubInfo}} <a
                                                     style="text-decoration: none; color: #6DA4EB;" target="_blank"
                                                     rel="noopener noreferrer"

--- a/templates/cloud_welcome_email.html
+++ b/templates/cloud_welcome_email.html
@@ -67,14 +67,14 @@
                                         <div style="position: relative;">
                                             <span>
                                                 <img src="{{.Props.WorkSpacePath}}/static/images/c_avatar.png"
-                                                    style="height: 15px; width: 15px;" alt="c_avatar">
+                                                    style="height: 15px; width: 15px; transform: translateY(2px);" alt="c_avatar">
                                             </span>
                                             <span
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 600; font-size: 16px; line-height: 24px; color: #3D3C40;">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 600; font-size: 16px; line-height: 24px; color: #3D3C40; margin-left: 8px;">
                                                 {{.Props.InviteInfo}}
                                             </span>
                                             <p
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40; margin-left: 18px">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40; margin-left: 26px">
                                                 {{.Props.InviteSubInfo}}
                                                 <a style="text-decoration: none; color: #6DA4EB;" target="_blank"
                                                     rel="noopener noreferrer"
@@ -86,15 +86,15 @@
                                             <span>
                                                 <span>
                                                     <img src="{{.Props.WorkSpacePath}}/static/images/c_socket.png"
-                                                        style="height: 15px; width: 15px;" alt="c_avatar">
+                                                        style="height: 15px; width: 15px; transform: translateY(2px);" alt="c_avatar">
                                                 </span>
                                             </span>
                                             <span
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 600; font-size: 16px; line-height: 24px; color: #3D3C40;">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 600; font-size: 16px; line-height: 24px; color: #3D3C40; margin-left: 8px;">
                                                 {{.Props.AddAppsInfo}}
                                             </span>
                                             <p
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40; margin-left: 18px;">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40; margin-left: 26px;">
                                                 {{.Props.AddAppsSubInfo}}
                                                 <a style="text-decoration: none; color: #6DA4EB;" target="_blank"
                                                     rel="noopener noreferrer"
@@ -106,15 +106,15 @@
                                             <span>
                                                 <span>
                                                     <img src="{{.Props.WorkSpacePath}}/static/images/c_download.png"
-                                                        style="height: 17px; width: 15px;" alt="c_avatar">
+                                                        style="height: 17px; width: 15px; transform: translateY(5px);" alt="c_avatar">
                                                 </span>
                                             </span>
                                             <span
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 600; font-size: 16px; line-height: 24px; color: #3D3C40;">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 600; font-size: 16px; line-height: 24px; color: #3D3C40; margin-left: 8px;">
                                                 {{.Props.DownloadMMInfo}}
                                             </span>
                                             <p
-                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40;  margin-left: 18px">
+                                                style="font-family: Open Sans, Arial; font-style: normal; font-weight: 400; font-size: 14px; line-height: 20px; color: #3D3C40;  margin-left: 26px">
                                                 {{.Props.SignInSubInfo}} <a
                                                     style="text-decoration: none; color: #6DA4EB;" target="_blank"
                                                     rel="noopener noreferrer"


### PR DESCRIPTION
#### Summary
Fix styling in the welcome email like space between icons and paragraphs

<img width="1792" alt="Screenshot 2021-05-03 at 18 54 59" src="https://user-images.githubusercontent.com/28563179/116900545-86d6ae00-ac41-11eb-82d6-6f5c3198c672.png">


#### Ticket Link
[MM-35061](https://mattermost.atlassian.net/browse/MM-35061?atlOrigin=eyJpIjoiYWIzZjZhMTQ0Zjg1NGRhY2E4NmMyNjVjNTdiN2IyZWIiLCJwIjoiaiJ9)

#### Release Note
```release-note
NONE

```
