### PR TITLE
MM-35332 honour config setting when extending session expiry

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -351,6 +351,10 @@ func (a *App) UpdateLastActivityAtIfNeeded(session model.Session) {
 // A new ExpiresAt is only written if enough time has elapsed since last update.
 // Returns true only if the session was extended.
 func (a *App) ExtendSessionExpiryIfNeeded(session *model.Session) bool {
+	if !*a.Srv().Config().ServiceSettings.ExtendSessionLengthWithActivity {
+		return false
+	}
+
 	if session == nil || session.IsExpired() {
 		return false
 	}


### PR DESCRIPTION
#### Summary
This PR fixes a bug in `(*App)ExtendSessionExpiryIfNeeded` which extended session expiration regardless of `ServiceSettings.ExtendSessionLengthWithActivity` config setting.

Also adds a unit test that tests for the setting being disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35332

#### Release Note
```release-note
Fixes bug where session expiration was extended with activity regardless of config setting (ServiceSettings.ExtendSessionLengthWithActivity).
```
