### PR TITLE
[MM-35404] - Cloud Trial - Body of 'Trial ends today Email (Admin-only)' conflicts with subject line

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3092,11 +3092,11 @@
   },
   {
     "id": "api.templates.cloud_trial_ended_email.subtitle",
-    "translation": "{{.Name}}, your 14-day free trial of Mattermost Cloud Professional ends today {{.TodayDate}}. Please add your payment information to ensure your team can continue enjoying the benefits of Cloud Professional."
+    "translation": "{{.Name}}, your 14-day free trial of Mattermost Cloud Professional has ended today, {{.TodayDate}}. Please add your payment information to ensure your team can continue enjoying the benefits of Cloud Professional."
   },
   {
     "id": "api.templates.cloud_trial_ended_email.title",
-    "translation": "Your free 14-day trial of Mattermost ends today"
+    "translation": "Your free 14-day trial of Mattermost has ended today"
   },
   {
     "id": "api.templates.cloud_trial_ending_email.add_payment_method",


### PR DESCRIPTION
#### Summary
Fixes trial ended email tenses

<img width="1792" alt="Screenshot 2021-05-10 at 12 28 08" src="https://user-images.githubusercontent.com/28563179/117638207-4324fc80-b18b-11eb-8d09-a069488e04da.png">

<img width="1792" alt="Screenshot 2021-05-10 at 12 28 18" src="https://user-images.githubusercontent.com/28563179/117638290-58019000-b18b-11eb-939e-8849f17fc7a7.png">


#### Ticket Link
[MM-35404](https://mattermost.atlassian.net/browse/MM-35404?atlOrigin=eyJpIjoiNjc3NjAxMjEwYjQ3NDU2Yjk0MTAzOGE4ZmMzM2E5MGMiLCJwIjoiaiJ9)
#### Release Note
```release-note
NONE
```
