### PR TITLE
build/package: remove dist/mattermost directory

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -231,3 +231,4 @@ endif
 	@#rm -f $(DIST_PATH)/bin/mattermost
 
 	rm -rf tmpprepackaged
+	rm -rf dist/mattermost


### PR DESCRIPTION
#### Summary
When we run the `make package` it generated the packages for linux/macos/windows and it keeps the directory `dist\mattermost` which is not needed after the package finish.

removing this also helps in the build/release pipeline when saving the data, will speed up a bit gitlab.

#### Ticket Link
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
