### PR TITLE
[MM-35424] Fix job schedulers server from missing leader change event

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -662,6 +662,16 @@ func NewServer(options ...Option) (*Server, error) {
 		}
 	}
 
+	if s.runEssentialJobs {
+		s.Go(func() {
+			s.runLicenseExpirationCheckJob()
+			runCheckAdminSupportStatusJob(fakeApp, c)
+			runCheckWarnMetricStatusJob(fakeApp, c)
+			runDNDStatusExpireJob(fakeApp)
+		})
+		s.runJobs()
+	}
+
 	s.doAppMigrations()
 
 	s.initPostMetadata()
@@ -674,15 +684,6 @@ func NewServer(options ...Option) (*Server, error) {
 			s.ShutDownPlugins()
 		}
 	})
-	if s.runEssentialJobs {
-		s.Go(func() {
-			s.runLicenseExpirationCheckJob()
-			runCheckAdminSupportStatusJob(fakeApp, c)
-			runCheckWarnMetricStatusJob(fakeApp, c)
-			runDNDStatusExpireJob(fakeApp)
-		})
-		s.runJobs()
-	}
 
 	return s, nil
 }

--- a/jobs/schedulers.go
+++ b/jobs/schedulers.go
@@ -232,7 +232,10 @@ func (schedulers *Schedulers) scheduleJob(cfg *model.Config, scheduler model.Sch
 
 func (schedulers *Schedulers) handleConfigChange(oldConfig, newConfig *model.Config) {
 	mlog.Debug("Schedulers received config change.")
-	schedulers.configChanged <- newConfig
+	select {
+	case schedulers.configChanged <- newConfig:
+	case <-schedulers.stop:
+	}
 }
 
 func (schedulers *Schedulers) handleClusterLeaderChange(isLeader bool) {

--- a/jobs/schedulers.go
+++ b/jobs/schedulers.go
@@ -230,7 +230,7 @@ func (schedulers *Schedulers) scheduleJob(cfg *model.Config, scheduler model.Sch
 	return scheduler.ScheduleJob(cfg, pendingJobs, lastSuccessfulJob)
 }
 
-func (schedulers *Schedulers) handleConfigChange(oldConfig, newConfig *model.Config) {
+func (schedulers *Schedulers) handleConfigChange(_, newConfig *model.Config) {
 	mlog.Debug("Schedulers received config change.")
 	select {
 	case schedulers.configChanged <- newConfig:

--- a/jobs/schedulers_test.go
+++ b/jobs/schedulers_test.go
@@ -137,4 +137,23 @@ func TestScheduler(t *testing.T) {
 			assert.Nil(t, element)
 		}
 	})
+
+	t.Run("ConfigChangedDeadlock", func(t *testing.T) {
+		jobServer.InitSchedulers()
+		jobServer.StartSchedulers()
+		time.Sleep(time.Second)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			jobServer.StopSchedulers()
+		}()
+		go func() {
+			defer wg.Done()
+			jobServer.schedulers.handleConfigChange(nil, nil)
+		}()
+
+		wg.Wait()
+	})
 }

--- a/jobs/schedulers_test.go
+++ b/jobs/schedulers_test.go
@@ -3,6 +3,7 @@
 package jobs
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -99,6 +100,29 @@ func TestScheduler(t *testing.T) {
 		for _, element := range jobServer.schedulers.nextRunTimes {
 			assert.Nil(t, element)
 		}
+	})
+
+	t.Run("ClusterLeaderChangedBeforeStart", func(t *testing.T) {
+		jobServer.InitSchedulers()
+		jobServer.HandleClusterLeaderChange(false)
+		jobServer.StartSchedulers()
+		time.Sleep(time.Second)
+		for _, element := range jobServer.schedulers.nextRunTimes {
+			assert.Nil(t, element)
+		}
+		jobServer.StopSchedulers()
+	})
+
+	t.Run("DoubleClusterLeaderChangedBeforeStart", func(t *testing.T) {
+		jobServer.InitSchedulers()
+		jobServer.HandleClusterLeaderChange(false)
+		jobServer.HandleClusterLeaderChange(true)
+		jobServer.StartSchedulers()
+		time.Sleep(time.Second)
+		for _, element := range jobServer.schedulers.nextRunTimes {
+			assert.NotNil(t, element)
+		}
+		jobServer.StopSchedulers()
 	})
 
 	t.Run("ConfigChanged", func(t *testing.T) {

--- a/jobs/server.go
+++ b/jobs/server.go
@@ -107,6 +107,6 @@ func (srv *JobServer) HandleClusterLeaderChange(isLeader bool) {
 	srv.mut.Lock()
 	defer srv.mut.Unlock()
 	if srv.schedulers != nil {
-		srv.schedulers.HandleClusterLeaderChange(isLeader)
+		srv.schedulers.handleClusterLeaderChange(isLeader)
 	}
 }


### PR DESCRIPTION
#### Summary

PR fixes an issue where the job scheduler server could potentially miss a "leader change" event. The proposed changes are:

- Moved the schedulers server start so that it happens before doing potentially long-running tasks (e.g. plugins initialization)
- Changed the `handleClusterLeaderChange` semantic to guarantee that the latest change is gets delivered.
- Fixed a possible deadlock case in the config change handler.

#### Ticket

https://mattermost.atlassian.net/browse/MM-35424

#### Release Note

```release-note
Fixed an issue where the job scheduler server could miss a "changed leader" cluster event.
```
