### PR TITLE
MM-31612 Stream import archive contents to bulk importer

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7460,7 +7460,7 @@
   },
   {
     "id": "import_process.worker.do_job.file_exists",
-    "translation": "Unable to process import: file does not exists."
+    "translation": "Unable to process import: file does not exist."
   },
   {
     "id": "import_process.worker.do_job.missing_file",
@@ -7481,6 +7481,10 @@
   {
     "id": "import_process.worker.do_job.unzip",
     "translation": "Unable to process import: failed to unzip file."
+  },
+  {
+    "id": "import_process.worker.do_job.write_file",
+    "translation": "Unable to process import: failed to write file."
   },
   {
     "id": "interactive_message.decode_trigger_id.base64_decode_failed",

--- a/jobs/import_process/worker_linux.go
+++ b/jobs/import_process/worker_linux.go
@@ -61,7 +61,6 @@ func (w *ImportProcessWorker) unzipAndImport(job *model.Job, unpackDirectory str
 		}
 
 		go func(zipFile *zip.File, namedPipePath string, errors chan<- *model.AppError) {
-			mlog.Debug("Waiting for file to be read", mlog.String("pipe", namedPipePath))
 			namedPipe, err := os.OpenFile(namedPipePath, os.O_WRONLY, 0666)
 			if err != nil {
 				errors <- model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
@@ -78,6 +77,7 @@ func (w *ImportProcessWorker) unzipAndImport(job *model.Job, unpackDirectory str
 			defer fileAttachment.Close()
 			defer os.Remove(namedPipePath)
 
+			mlog.Debug("Waiting for file to be read", mlog.String("pipe", namedPipePath))
 			_, err = io.Copy(namedPipe, fileAttachment)
 			if err != nil {
 				errors <- model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.write_file", nil, err.Error(), http.StatusBadRequest)

--- a/jobs/import_process/worker_linux.go
+++ b/jobs/import_process/worker_linux.go
@@ -91,6 +91,7 @@ func (w *ImportProcessWorker) unzipToPipes(zipReader *zip.Reader, unpackDirector
 				return
 			}
 			defer namedPipe.Close()
+			defer os.Remove(namedPipePath)
 
 			fileAttachment, err := zipFile.Open()
 			if err != nil {
@@ -99,7 +100,6 @@ func (w *ImportProcessWorker) unzipToPipes(zipReader *zip.Reader, unpackDirector
 			}
 
 			defer fileAttachment.Close()
-			defer os.Remove(namedPipePath)
 
 			mlog.Debug("Waiting for file to be read", mlog.String("pipe", namedPipePath))
 			_, err = io.Copy(namedPipe, fileAttachment)

--- a/jobs/import_process/worker_linux.go
+++ b/jobs/import_process/worker_linux.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// +build linux
+
+package import_process
+
+import (
+	"archive/zip"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/mattermost/mattermost-server/v5/app"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/shared/filestore"
+	"github.com/mattermost/mattermost-server/v5/shared/mlog"
+)
+
+func (w *ImportProcessWorker) unzipAndImport(job *model.Job, unpackDirectory string, importFile filestore.ReadCloseSeeker, importFileSize int64, _ string) *model.AppError {
+	// extract the contents of the zipped file.
+	zipReader, err := zip.NewReader(importFile.(io.ReaderAt), importFileSize)
+	if err != nil {
+		appError := model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.file_exists", nil, err.Error(), http.StatusBadRequest)
+		return appError
+	}
+
+	var jsonFile io.ReadCloser
+	countFiles := len(zipReader.File)
+	errors := make(chan *model.AppError, countFiles)
+	for _, zipFile := range zipReader.File {
+		if jsonFile == nil && filepath.Ext(zipFile.Name) == ".jsonl" {
+			jsonFile, err = zipFile.Open()
+			if err != nil {
+				return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.unzip", nil, err.Error(), http.StatusBadRequest)
+			}
+			continue
+		}
+		zipFileName, err := filepath.Abs(zipFile.Name)
+		if err != nil {
+			return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.unzip", nil, err.Error(), http.StatusBadRequest)
+		}
+		if strings.Contains(zipFileName, "..") {
+			// this check is required to avoid a "zip slip" vulnerability
+			// https://cwe.mitre.org/data/definitions/22.html
+			return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.unzip", nil, "illegal .. found in zipfile file path", http.StatusBadRequest)
+		}
+		namedPipePath := filepath.Join(unpackDirectory, zipFileName)
+		err = os.MkdirAll(filepath.Dir(namedPipePath), 0700)
+		if err != nil {
+			return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.tmp_dir", nil, err.Error(), http.StatusBadRequest)
+		}
+		mlog.Debug("Opening pipe", mlog.String("pipe", namedPipePath))
+		err = syscall.Mkfifo(namedPipePath, 0666)
+		if err != nil {
+			return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
+		}
+
+		go func(zipFile *zip.File, namedPipePath string, errors chan<- *model.AppError) {
+			mlog.Debug("Waiting for file to be read", mlog.String("pipe", namedPipePath))
+			namedPipe, err := os.OpenFile(namedPipePath, os.O_WRONLY, 0666)
+			if err != nil {
+				appError := model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
+				errors <- appError
+				return
+			}
+			defer namedPipe.Close()
+
+			fileAttachment, err := zipFile.Open()
+			if err != nil {
+				appError := model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
+				errors <- appError
+				return
+			}
+
+			defer fileAttachment.Close()
+			defer os.Remove(namedPipePath)
+
+			_, err = io.Copy(namedPipe, fileAttachment)
+			if err != nil {
+				appError := model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.write_file", nil, err.Error(), http.StatusBadRequest)
+				errors <- appError
+				return
+			}
+
+			errors <- nil
+			mlog.Debug("Done with pipe", mlog.String("pipe", namedPipePath))
+		}(zipFile, namedPipePath, errors)
+	}
+
+	// do the actual import.
+	appErr, lineNumber := w.app.BulkImportWithPath(w.appContext, jsonFile, false, runtime.NumCPU(), filepath.Join(unpackDirectory, app.ExportDataDir))
+	if appErr != nil {
+		job.Data["line_number"] = strconv.Itoa(lineNumber)
+		return appErr
+	}
+
+	for completed := 0; completed < countFiles; completed++ {
+		appErr := <-errors
+		if appErr != nil {
+			return appErr
+		}
+	}
+	return nil
+}

--- a/jobs/import_process/worker_linux.go
+++ b/jobs/import_process/worker_linux.go
@@ -79,13 +79,13 @@ func (w *ImportProcessWorker) unzipToPipes(zipReader *zip.Reader, unpackDirector
 			return nil, model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.tmp_dir", nil, err.Error(), http.StatusBadRequest)
 		}
 		mlog.Debug("Opening pipe", mlog.String("pipe", namedPipePath))
-		err = syscall.Mkfifo(namedPipePath, 0666)
+		err = syscall.Mkfifo(namedPipePath, 0600)
 		if err != nil {
 			return nil, model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
 		}
 
 		go func(zipFile *zip.File, namedPipePath string, errors chan<- *model.AppError) {
-			namedPipe, err := os.OpenFile(namedPipePath, os.O_WRONLY, 0666)
+			namedPipe, err := os.OpenFile(namedPipePath, os.O_WRONLY, 0600)
 			if err != nil {
 				errors <- model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
 				return

--- a/jobs/import_process/worker_linux.go
+++ b/jobs/import_process/worker_linux.go
@@ -64,16 +64,14 @@ func (w *ImportProcessWorker) unzipAndImport(job *model.Job, unpackDirectory str
 			mlog.Debug("Waiting for file to be read", mlog.String("pipe", namedPipePath))
 			namedPipe, err := os.OpenFile(namedPipePath, os.O_WRONLY, 0666)
 			if err != nil {
-				appError := model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
-				errors <- appError
+				errors <- model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
 				return
 			}
 			defer namedPipe.Close()
 
 			fileAttachment, err := zipFile.Open()
 			if err != nil {
-				appError := model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
-				errors <- appError
+				errors <- model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusBadRequest)
 				return
 			}
 
@@ -82,8 +80,7 @@ func (w *ImportProcessWorker) unzipAndImport(job *model.Job, unpackDirectory str
 
 			_, err = io.Copy(namedPipe, fileAttachment)
 			if err != nil {
-				appError := model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.write_file", nil, err.Error(), http.StatusBadRequest)
-				errors <- appError
+				errors <- model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.write_file", nil, err.Error(), http.StatusBadRequest)
 				return
 			}
 

--- a/jobs/import_process/worker_nonlinux.go
+++ b/jobs/import_process/worker_nonlinux.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+// +build !linux
+
+package import_process
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"github.com/mattermost/mattermost-server/v5/app"
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/mattermost/mattermost-server/v5/shared/filestore"
+	"github.com/mattermost/mattermost-server/v5/utils"
+)
+
+func (w *ImportProcessWorker) unzipAndImport(job *model.Job, unpackDirectory string, importFile filestore.ReadCloseSeeker, importFileSize int64, importFilePath string) *model.AppError {
+	// TODO (MM-30187): improve this process by eliminating the need to unzip the import
+	// file locally and instead do the whole bulk import process in memory by
+	// streaming the import file.
+
+	// extract the contents of the zipped file.
+	paths, err := utils.UnzipToPath(importFile.(io.ReaderAt), importFileSize, unpackDirectory)
+	if err != nil {
+		return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.unzip", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	// find JSONL import file.
+	var jsonFilePath string
+	for _, path := range paths {
+		if filepath.Ext(path) == ".jsonl" {
+			jsonFilePath = path
+			break
+		}
+	}
+
+	if jsonFilePath == "" {
+		return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.missing_jsonl", nil, "", http.StatusBadRequest)
+	}
+
+	jsonFile, err := os.Open(jsonFilePath)
+	if err != nil {
+		return model.NewAppError("ImportProcessWorker", "import_process.worker.do_job.open_file", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	// do the actual import.
+	appErr, lineNumber := w.app.BulkImportWithPath(w.appContext, jsonFile, false, runtime.NumCPU(), filepath.Join(unpackDirectory, app.ExportDataDir))
+	if appErr != nil {
+		job.Data["line_number"] = strconv.Itoa(lineNumber)
+		return appErr
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR optimizes the import process by streaming archive contents to the bulk importer instead of unzipping the incoming archive to disk. I believe it should resolve MM-31612 but I have taken a different approach than I suspect was expected, so I'm going to explain the approach I've taken here and then together we can decide the fate of MM-31612 and whether this resolves it fully or whether we feel that there should be some follow-up work for a "cleaner" solution.

First of all, when I first conceived of this solution, I thought it was kind of a hack, but the more I've thought about it, the more I think it's a legitimate solution, so if you start reading this description and think "wow this is a weird approach" please bear with me while I explain the approach and reasoning behind it.

##### Background and More Obvious Approaches
Performing this optimization without leveraging the underlying OS would require taking the `*zip.Reader` and modifying a large portion of the Bulk Import and import_process worker code to be able to access files within the `*zip.Reader` directly instead of doing what it does today, for historical reasons, which is to use one `Reader` pointing to the JSONL file, and then after parsing that, when the importer finds an attached file, the application opens the file in the expected location specified in the JSONL file using `os.Open`, which expects a normal file.

Due to the use of `os.Open`, the way the Importer determines the location of the attached file, and the general need to instead pass a `Reader` for each file to the extraction routine, I determined that it would require a considerable amount of manna to modify the existing extraction routine to take `Reader`s instead of using `os.Open` after parsing the JSONL file. 

Another approach I considered, after discovering how the files are accessed by the Bulk Importer, was to modify the JSONL file format to potentially allow for encoding a S3 URL (seems messy, also very complicated) and to allow the Bulk Importer to access S3 directly, but this would've required deep changes to the Bulk Importer as well as redoing some of the work in the mattermost/cloud and mattermost/awat repos. 

##### Solution: Named Pipes
In order to avoid a massive change to the Bulk Importer, this implementation opens the incoming Zip archive in memory and creates a facsimile of the unzipped contents in the same location where the old code would simply extract the zip file. Instead of containing normal files, however, each file is a named pipe (or FIFO, e.g. https://man7.org/linux/man-pages/man3/mkfifo.3.html ) which is backed by a goroutine ready to stream, decompress, and write the correct file contents as soon as a reader becomes available. 

Let us recall that `Write` called on a FIFO blocks until a reader is ready, so the call to `io.Copy` inside of the goroutine will block until the call to `os.Open` by the bulk import routine is made, at which point the goroutine will write the bits from the Zip file (wherever it is, even in S3) into the pipe and the Bulk Importer will receive those bits from `os.Open` without being aware that these are not normal decompressed files, and that they are never written to the file system.

##### Benefits of this approach:
- It's robust and parallelizes well
- It's self-contained, and a fairly small change
- It leverages the tools the OS gives us to make our lives easier

##### Caveats to this approach:
1) The unpack location used by the bulk importer is set in part via convention and the structure and location of that archive when it is unzipped is assumed in several places. A solution to this issue that didn't use FIFOs may have been able to remove this convention and make it configurable or fully remove the need for an unpack location, but it would be a much more far-reaching change.

2) This approach _only works on Linux_. It's not even possible to compile the Server for Windows or Darwin targets whilst including the call to `syscall.Mkfifo`. However, Go makes it simple for us to keep the old behavior for non-Linux targets. This seems acceptable to me since Linux is our only supported production target. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Potentially fixes https://mattermost.atlassian.net/browse/MM-31612 and https://github.com/mattermost/mattermost-server/issues/16617

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Optimized the bulk import process on Linux to avoid writing files to disk
```
