### PR TITLE
[MM-35767] Ignore readTimeout param from MySQL datasource

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -353,8 +353,11 @@ func (ss *SqlStore) Context() context.Context {
 func (ss *SqlStore) initConnection() {
 	dataSource := *ss.settings.DataSource
 	if ss.DriverName() == model.DATABASE_DRIVER_MYSQL {
+		// TODO: We ignore the readTimeout datasource parameter for MySQL since QueryTimeout
+		// covers that already. Ideally we'd like to do this only for the upgrade
+		// step. To be reviewed in MM-35789.
 		var err error
-		dataSource, err = ss.resetReadTimeout(*ss.settings.DataSource)
+		dataSource, err = resetReadTimeout(dataSource)
 		if err != nil {
 			mlog.Critical("Failed to reset read timeout from datasource.", mlog.Err(err))
 			os.Exit(ExitGenericFailure)
@@ -1499,7 +1502,7 @@ func (ss *SqlStore) appendMultipleStatementsFlag(dataSource string) (string, err
 	return dataSource, nil
 }
 
-func (ss *SqlStore) resetReadTimeout(dataSource string) (string, error) {
+func resetReadTimeout(dataSource string) (string, error) {
 	config, err := mysql.ParseDSN(dataSource)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
#### Summary

PR fixes an issue where long-running migrations (on MySQL) could still time out. While we are not setting a timeout for migrations anymore at the app layer (since https://github.com/mattermost/mattermost-server/pull/17444) there was still a timeout happening at the network (tcp) layer governed by the `readTimeout` query parameter from the datasource.

PR fixes this by ignoring the provided parameter and resetting it to zero (no timeout). This should be also safe for queries running outside the "migration phase" since those will respect the timeout value defined at the application level through the `SqlSettings.QueryTimeout` setting.

cc @amyblais 

#### Ticket

https://github.com/mattermost/mattermost-server/pull/new/MM-35767

#### Release Note

```release-note
Fixed an issue where long migrations where failing with an "invalid connection" error on MySQL installations.
```