### PR TITLE
Remove redundant additions to cache hit/miss counters

### DIFF
--- a/store/localcachelayer/user_layer.go
+++ b/store/localcachelayer/user_layer.go
@@ -136,11 +136,6 @@ func (s *LocalCacheUserStore) GetProfileByIds(ctx context.Context, userIds []str
 		}
 	}
 
-	if s.rootStore.metrics != nil {
-		s.rootStore.metrics.AddMemCacheHitCounter("Profile By Ids", float64(len(users)))
-		s.rootStore.metrics.AddMemCacheMissCounter("Profile By Ids", float64(len(remainingUserIds)))
-	}
-
 	if len(remainingUserIds) > 0 {
 		if fromMaster {
 			ctx = sqlstore.WithMaster(ctx)


### PR DESCRIPTION
#### Summary

PR fixes a small issue where cache hit/miss metrics counters for user cache were getting incremented/decremented more than needed. `rootStore.doStandardReadCache()` already takes care of that internally. Also, we were using a different cache name which made the resulting metrics more confusing.

#### Release Note

```release-note
NONE
```
