### PR TITLE
[MM-35841] Fix invalid use of variables in invite_body template

### DIFF
--- a/app/email.go
+++ b/app/email.go
@@ -628,6 +628,7 @@ func (es *EmailService) sendGuestInviteEmails(team *model.Team, channels []*mode
 			embeddedFiles := make(map[string]io.Reader)
 			if message != "" {
 				if senderProfileImage != nil {
+					data.Props["SenderPhoto"] = "user-avatar.png"
 					embeddedFiles = map[string]io.Reader{
 						"user-avatar.png": bytes.NewReader(senderProfileImage),
 					}

--- a/templates/invite_body.html
+++ b/templates/invite_body.html
@@ -433,7 +433,7 @@
                                         <tbody>
                                           <tr>
                                             <td style="width:276px;">
-                                              <img alt="" height="auto" src="cid:{{.SenderPhoto}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="276" />
+                                              <img alt="" height="auto" src="cid:{{.Props.SenderPhoto}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="276" />
                                             </td>
                                           </tr>
                                         </tbody>
@@ -450,14 +450,14 @@
                                   <tr>
                                     <td>
                                       <div class="postNameAndTime">
-                                        <div class="senderName">{{.SenderName}}</div>
-                                        {{if .Time}}
-                                        <div class="time">{{.Time}}</div>
+                                        <div class="senderName">{{.Props.SenderName}}</div>
+                                        {{if .Props.Time}}
+                                        <div class="time">{{.Props.Time}}</div>
                                         {{end}}
-                                        {{if .ChannelName}}
+                                        {{if .Props.ChannelName}}
                                         <div class="channelBg">
                                           <div class="channelLogo"><img src="{{$.Props.SiteURL}}/static/images/channel_icon.png" width=10px height=10px></img></div>
-                                          <div class="channelName">{{.ChannelName}}</div>
+                                          <div class="channelName">{{.Props.ChannelName}}</div>
                                         </div>
                                         {{end}}
                                       </div>
@@ -465,24 +465,9 @@
                                   </tr>
                                   <tr>
                                     <td align="center" class="senderMessage" style="font-size:0px;padding:0px;word-break:break-word;">
-                                      <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Message}}</div>
+                                      <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Message}}</div>
                                     </td>
                                   </tr>
-                                  {{if .MessageURL}}
-                                  <tr>
-                                    <td align="center" vertical-align="middle" class="messageButton" style="font-size:0px;padding:16px 0px 0px 0px;word-break:break-word;">
-                                      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                        <tr>
-                                          <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                            <a href="{{.MessageURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                              {{$.Props.MessageButton}}
-                                            </a>
-                                          </td>
-                                        </tr>
-                                      </table>
-                                    </td>
-                                  </tr>
-                                  {{end}}
                                 </tbody>
                               </table>
                             </div>


### PR DESCRIPTION
#### Summary
This PR fixes invalid uses of variables in the `invite_body` template. Something must have been copied over from `message_notification` without modifying the references. I've also made sure to add the `SenderPhoto` in the props as well, as that was missing.

This should be tested thoroughly before merge to ensure that the invite body templates are working properly.
NOTE: If using inbucket, I don't think you can see the sender photo if it exists. It might only work with a real SMTP server, so that might be worth testing.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35841

#### Release Note
```release-note
NONE
```
