### PR TITLE
Fix races in config refactor

### DIFF
--- a/config/store.go
+++ b/config/store.go
@@ -179,9 +179,7 @@ func (s *Store) Set(newCfg *model.Config) (*model.Config, error) {
 	}
 
 	newCfg = newCfg.Clone()
-	// no need to clone these as cached configs are getting replaced
-	// with brand new objects.
-	oldCfg := s.config
+	oldCfg := s.config.Clone()
 	oldCfgNoEnv := s.configNoEnv
 
 	// Setting defaults allows us to accept partial config objects.
@@ -255,7 +253,7 @@ func (s *Store) Load() error {
 
 	oldCfg := &model.Config{}
 	if s.config != nil {
-		oldCfg = s.config
+		oldCfg = s.config.Clone()
 	}
 
 	configBytes, err := s.backingStore.Load()


### PR DESCRIPTION
#### Summary

PR fixes some races introduced in the configure overhaul PR (https://github.com/mattermost/mattermost-server/pull/17578).
I was a bit too optimistic. The backup/restore of the FeatureFlags section in oldCfg was racy.

#### Release Note

```release-note
NONE
```
