### PR TITLE
Use Node 14 build image for web app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   setup:
     working_directory: ~/mattermost/mattermost-server
     docker:
-      - image: mattermost/mattermost-build-webapp:20200829_node-10.22
+      - image: mattermost/mattermost-build-webapp:20210518_node-14.16-1
     resource_class: xlarge
     steps:
       - checkout


### PR DESCRIPTION
Just updating the server to match the client here. I'm not sure if the server is able to successfully build the web app at this point, but if it tries, it'll use the right Docker image at least.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34363

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/8132

#### Release Note
```release-note
NONE
```
