### PR TITLE
Change about and help links back to default redirects

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -131,8 +131,8 @@ const (
 
 	SUPPORT_SETTINGS_DEFAULT_TERMS_OF_SERVICE_LINK = "https://mattermost.com/terms-of-service/"
 	SUPPORT_SETTINGS_DEFAULT_PRIVACY_POLICY_LINK   = "https://mattermost.com/privacy-policy/"
-	SUPPORT_SETTINGS_DEFAULT_ABOUT_LINK            = "https://docs.mattermost.com/overview/product.html"
-	SUPPORT_SETTINGS_DEFAULT_HELP_LINK             = "https://academy.mattermost.com/"
+	SUPPORT_SETTINGS_DEFAULT_ABOUT_LINK            = "https://about.mattermost.com/default-about/"
+	SUPPORT_SETTINGS_DEFAULT_HELP_LINK             = "https://about.mattermost.com/default-help/"
 	SUPPORT_SETTINGS_DEFAULT_REPORT_A_PROBLEM_LINK = "https://about.mattermost.com/default-report-a-problem/"
 	SUPPORT_SETTINGS_DEFAULT_SUPPORT_EMAIL         = ""
 	SUPPORT_SETTINGS_DEFAULT_RE_ACCEPTANCE_PERIOD  = 365


### PR DESCRIPTION
Originally changed in https://github.com/mattermost/mattermost-server/pull/17651

We want to keep the about link and help link set to a default page that redirects to appropriate page. The reason is that we may, for instance, want to link to a different help link in the future. If we do so, we only have to change the redirect without changes to the codebase.

Did not revert the change to terms of service and privacy policy links, given we want to point these to mattermost.com