### PR TITLE
[MM-35931] Apply DB migrations regardless of version patch value

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -223,9 +223,23 @@ func saveSchemaVersion(sqlStore *SqlStore, version string) {
 }
 
 func shouldPerformUpgrade(sqlStore *SqlStore, currentSchemaVersion string, expectedSchemaVersion string) bool {
-	if sqlStore.GetCurrentSchemaVersion() == currentSchemaVersion {
-		mlog.Warn("Attempting to upgrade the database schema version", mlog.String("current_version", currentSchemaVersion), mlog.String("new_version", expectedSchemaVersion))
+	storedSchemaVersion := sqlStore.GetCurrentSchemaVersion()
 
+	storedVersion, err := semver.Parse(storedSchemaVersion)
+	if err != nil {
+		mlog.Error("Error parsing stored schema version", mlog.Err(err))
+		return false
+	}
+
+	currentVersion, err := semver.Parse(currentSchemaVersion)
+	if err != nil {
+		mlog.Error("Error parsing current schema version", mlog.Err(err))
+		return false
+	}
+
+	if storedVersion.Major == currentVersion.Major && storedVersion.Minor == currentVersion.Minor {
+		mlog.Warn("Attempting to upgrade the database schema version",
+			mlog.String("stored_version", storedSchemaVersion), mlog.String("current_version", currentSchemaVersion), mlog.String("new_version", expectedSchemaVersion))
 		return true
 	}
 

--- a/store/sqlstore/upgrade_test.go
+++ b/store/sqlstore/upgrade_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/mattermost/mattermost-server/v5/store"
 )
 
+func TestStoreUpgradeDotRelease(t *testing.T) {
+	StoreTest(t, func(t *testing.T, ss store.Store) {
+		sqlStore := ss.(*SqlStore)
+		saveSchemaVersion(sqlStore, "5.33.1")
+		err := upgradeDatabase(sqlStore, CurrentSchemaVersion)
+		require.NoError(t, err)
+		require.Equal(t, CurrentSchemaVersion, sqlStore.GetCurrentSchemaVersion())
+	})
+}
+
 func TestStoreUpgrade(t *testing.T) {
 	StoreTest(t, func(t *testing.T, ss store.Store) {
 		sqlStore := ss.(*SqlStore)


### PR DESCRIPTION
#### Summary

Saving dot releases versions in `model/version.go` had the outcome of storing that value in the `Systems` table for new installations.

Unfortunately though `store.shouldPerformUpgrade()` did a simple string equality comparison which would essentially fail for any dot release and prevent the migrations from happening, leaving everything frozen db schema wise.
I've changed the behaviour to actually parse the version and go ahead if both major and minor versions match, hence ignoring the patch version value.

Another approach I think could have been to add mock `upgradeDatabaseToVersion5XX()` methods for all the dot releases affected by this but it didn't look like a great solution.

#### Ticket

https://mattermost.atlassian.net/browse/MM-35931

#### Release Note

```release-note
Fixed an issue where subsequent migrations failed to run after running a dot release on new installations.
```
