### PR TITLE
MM-35945: handle lots of files in ExtractTarGz

### DIFF
--- a/app/extract_plugin_tar.go
+++ b/app/extract_plugin_tar.go
@@ -68,16 +68,20 @@ func extractTarGz(gzipStream io.Reader, dst string) error {
 				return err
 			}
 
-			outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))
-			if err != nil {
-				return err
+			copyFile := func() error {
+				outFile, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(header.Mode))
+				if err != nil {
+					return err
+				}
+				defer outFile.Close()
+				if _, err := io.Copy(outFile, tarReader); err != nil {
+					return err
+				}
+
+				return nil
 			}
-			_, err = io.Copy(outFile, tarReader)
 
-			// Close file regardless of error.
-			outFile.Close()
-
-			if err != nil {
+			if err := copyFile(); err != nil {
 				return err
 			}
 		}

--- a/app/extract_plugin_tar.go
+++ b/app/extract_plugin_tar.go
@@ -72,8 +72,12 @@ func extractTarGz(gzipStream io.Reader, dst string) error {
 			if err != nil {
 				return err
 			}
-			defer outFile.Close()
-			if _, err := io.Copy(outFile, tarReader); err != nil {
+			_, err = io.Copy(outFile, tarReader)
+
+			// Close file regardless of error.
+			outFile.Close()
+
+			if err != nil {
 				return err
 			}
 		}

--- a/app/extract_plugin_tar_test.go
+++ b/app/extract_plugin_tar_test.go
@@ -72,6 +72,24 @@ func TestExtractTarGz(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("huge tar", func(t *testing.T) {
+		files := make([]*tar.Header, 0, 10000)
+		for i := 0; i < 10000; i++ {
+			files = append(files, &tar.Header{
+				Name:     fmt.Sprintf("%d.txt", i),
+				Typeflag: tar.TypeReg,
+			})
+		}
+
+		dst, err := ioutil.TempDir("", "TestExtractTarGz")
+		require.NoError(t, err)
+		defer os.RemoveAll(dst)
+
+		archive := makeArchive(t, files)
+		err = extractTarGz(&archive, dst)
+		require.NoError(t, err)
+	})
+
 	testCases := []struct {
 		Files         []*tar.Header
 		ExpectedError bool


### PR DESCRIPTION
#### Summary
`ExtractTarGz` can fail on archives with a largish number or files, complaining about too many open file handles. Clean up as we go to avoid this.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-35945

#### Release Note
```release-note
NONE
```
