### PR TITLE
Update webapp build image to Node 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   setup:
     working_directory: ~/mattermost/mattermost-server
     docker:
-      - image: mattermost/mattermost-build-webapp:20210518_node-14.16-1
+      - image: mattermost/mattermost-build-webapp:20210524_node-16
     resource_class: xlarge
     steps:
       - checkout


### PR DESCRIPTION
The server version of https://github.com/mattermost/mattermost-webapp/pull/8154.

I'll be talking a bit more about this later in the week, but Node 16 is when NPM 7 becomes default, and we need NPM 7 for the workspaces feature that makes the web app monorepo work.

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/8154

#### Release Note
```release-note
NONE
```