### PR TITLE
Adds focalboard v0.6.7 as a prepackaged plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.5.0
+PLUGIN_PACKAGES += focalboard-v0.6.7-plugin
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)


### PR DESCRIPTION
#### Summary
Adds focalboard as a prepackaged plugin. The name of the plugin is different because of its source code existing within the `focalboard` repository.

#### Release Note

```release-note
Added focalboard v0.6.7 as a prepackaged plugin.
```