### PR TITLE
Introduce per platform make package targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist prepare-enteprise run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race start-docker-check migrations-bindata new-migration migration-prereqs
+.PHONY: build package run stop run-client run-server run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist prepare-enteprise run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-quick test-server-race start-docker-check migrations-bindata new-migration migration-prereqs
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -94,6 +94,9 @@ PLATFORM_FILES="./cmd/mattermost/main.go"
 # Output paths
 DIST_ROOT=dist
 DIST_PATH=$(DIST_ROOT)/mattermost
+DIST_PATH_LIN=$(DIST_ROOT)/linux/mattermost
+DIST_PATH_OSX=$(DIST_ROOT)/osx/mattermost
+DIST_PATH_WIN=$(DIST_ROOT)/windows/mattermost
 
 # Tests
 TESTS=.

--- a/build/release.mk
+++ b/build/release.mk
@@ -63,15 +63,10 @@ build-client:
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) build
 
-package:
+package-prep:
 	@ echo Packaging mattermost
 	@# Remove any old files
 	rm -Rf $(DIST_ROOT)
-
-	@# Create needed directories
-	mkdir -p $(DIST_PATH)/bin
-	mkdir -p $(DIST_PATH)/logs
-	mkdir -p $(DIST_PATH)/prepackaged_plugins
 
 	@# Resource directories
 	mkdir -p $(DIST_PATH)/config
@@ -96,9 +91,6 @@ package:
 	@# Package webapp
 	mkdir -p $(DIST_PATH)/client
 	cp -RL $(BUILD_WEBAPP_DIR)/dist/* $(DIST_PATH)/client
-
-	@#Download MMCTL
-	scripts/download_mmctl_release.sh "" $(DIST_PATH)/bin
 
 	@# Help files
 ifeq ($(BUILD_ENTERPRISE_READY),true)
@@ -126,103 +118,113 @@ endif
 	done
 
 
-	@# ----- PLATFORM SPECIFIC -----
+package-osx: package-prep
+	@# Create needed directories
+	mkdir -p $(DIST_PATH_OSX)/bin
+	mkdir -p $(DIST_PATH_OSX)/logs
+	mkdir -p $(DIST_PATH_OSX)/prepackaged_plugins
 
-	@# Make osx package
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
-	cp $(GOBIN)/mattermost $(DIST_PATH)/bin # from native bin dir, not cross-compiled
+	cp $(GOBIN)/mattermost $(DIST_PATH_OSX)/bin # from native bin dir, not cross-compiled
 else
-	cp $(GOBIN)/darwin_amd64/mattermost $(DIST_PATH)/bin # from cross-compiled bin dir
+	cp $(GOBIN)/darwin_amd64/mattermost $(DIST_PATH_OSX)/bin # from cross-compiled bin dir
 endif
 	#Download MMCTL for OSX
-	scripts/download_mmctl_release.sh "Darwin" $(DIST_PATH)/bin
+	scripts/download_mmctl_release.sh "Darwin" $(DIST_PATH_OSX)/bin
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="osx-amd64"; \
-		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH)/prepackaged_plugins; \
-		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH)/prepackaged_plugins; \
-		HAS_ARCH=`tar -tf $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
+		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH_OSX)/prepackaged_plugins; \
+		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_OSX)/prepackaged_plugins; \
+		HAS_ARCH=`tar -tf $(DIST_PATH_OSX)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
 		if [ "$$HAS_ARCH" != "dist/plugin-darwin-amd64" ]; then \
 			echo "Contains $$HAS_ARCH in $$plugin_package-$$ARCH.tar.gz but needs dist/plugin-darwin-amd64"; \
 			exit 1; \
 		fi; \
-		gpg --verify $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz; \
+		gpg --verify $(DIST_PATH_OSX)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_OSX)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz; \
 		if [ $$? -ne 0 ]; then \
 			echo "Failed to verify $$plugin_package-$$ARCH.tar.gz|$$plugin_package-$$ARCH.tar.gz.sig"; \
 			exit 1; \
 		fi; \
 	done
 	@# Package
-	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-osx-amd64.tar.gz mattermost
+	tar -C $(DIST_PATH_OSX)/.. -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-osx-amd64.tar.gz mattermost ../mattermost
 	@# Cleanup
-	rm -f $(DIST_PATH)/bin/mattermost
-	rm -f $(DIST_PATH)/bin/platform
-	rm -f $(DIST_PATH)/bin/mmctl
-	rm -f $(DIST_PATH)/prepackaged_plugins/*
+	rm -rf $(DIST_PATH_OSX)
 
-	@# Make windows package
+package-windows: package-prep
+	@# Create needed directories
+	mkdir -p $(DIST_PATH_WIN)/bin
+	mkdir -p $(DIST_PATH_WIN)/logs
+	mkdir -p $(DIST_PATH_WIN)/prepackaged_plugins
+
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
-	cp $(GOBIN)/mattermost.exe $(DIST_PATH)/bin # from native bin dir, not cross-compiled
+	cp $(GOBIN)/mattermost.exe $(DIST_PATH_WIN)/bin # from native bin dir, not cross-compiled
 else
-	cp $(GOBIN)/windows_amd64/mattermost.exe $(DIST_PATH)/bin # from cross-compiled bin dir
+	cp $(GOBIN)/windows_amd64/mattermost.exe $(DIST_PATH_WIN)/bin # from cross-compiled bin dir
 endif
 	#Download MMCTL for Windows
-	scripts/download_mmctl_release.sh "Windows" $(DIST_PATH)/bin
+	scripts/download_mmctl_release.sh "Windows" $(DIST_PATH_WIN)/bin
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="windows-amd64"; \
-		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH)/prepackaged_plugins; \
-		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH)/prepackaged_plugins; \
-		HAS_ARCH=`tar -tf $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
+		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH_WIN)/prepackaged_plugins; \
+		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_WIN)/prepackaged_plugins; \
+		HAS_ARCH=`tar -tf $(DIST_PATH_WIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
 		if [ "$$HAS_ARCH" != "dist/plugin-windows-amd64.exe" ]; then \
 			echo "Contains $$HAS_ARCH in $$plugin_package-$$ARCH.tar.gz but needs dist/plugin-windows-amd64.exe"; \
 			exit 1; \
 		fi; \
-		gpg --verify $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz; \
+		gpg --verify $(DIST_PATH_WIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_WIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz; \
 		if [ $$? -ne 0 ]; then \
 			echo "Failed to verify $$plugin_package-$$ARCH.tar.gz|$$plugin_package-$$ARCH.tar.gz.sig"; \
 			exit 1; \
 		fi; \
 	done
 	@# Package
-	cd $(DIST_ROOT) && zip -9 -r -q -l mattermost-$(BUILD_TYPE_NAME)-windows-amd64.zip mattermost && cd ..
+	cd $(DIST_PATH_WIN)/.. && zip -9 -r -q -l ../mattermost-$(BUILD_TYPE_NAME)-windows-amd64.zip mattermost ../mattermost && cd ../..
 	@# Cleanup
-	rm -f $(DIST_PATH)/bin/mattermost.exe
-	rm -f $(DIST_PATH)/bin/platform.exe
-	rm -f $(DIST_PATH)/bin/mmctl.exe
-	rm -f $(DIST_PATH)/prepackaged_plugins/*
+	rm -rf $(DIST_PATH_WIN)
 
-	@# Make linux package
+package-linux: package-prep
+	@# Create needed directories
+	mkdir -p $(DIST_PATH_LIN)/bin
+	mkdir -p $(DIST_PATH_LIN)/logs
+	mkdir -p $(DIST_PATH_LIN)/prepackaged_plugins
+
 	@# Copy binary
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
-	cp $(GOBIN)/mattermost $(DIST_PATH)/bin # from native bin dir, not cross-compiled
+	cp $(GOBIN)/mattermost $(DIST_PATH_LIN)/bin # from native bin dir, not cross-compiled
 else
-	cp $(GOBIN)/linux_amd64/mattermost $(DIST_PATH)/bin # from cross-compiled bin dir
+	cp $(GOBIN)/linux_amd64/mattermost $(DIST_PATH_LIN)/bin # from cross-compiled bin dir
 endif
 	#Download MMCTL for Linux
-	scripts/download_mmctl_release.sh "Linux" $(DIST_PATH)/bin
+	scripts/download_mmctl_release.sh "Linux" $(DIST_PATH_LIN)/bin
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="linux-amd64"; \
-		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH)/prepackaged_plugins; \
-		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH)/prepackaged_plugins; \
-		HAS_ARCH=`tar -tf $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
+		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH_LIN)/prepackaged_plugins; \
+		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_LIN)/prepackaged_plugins; \
+		HAS_ARCH=`tar -tf $(DIST_PATH_LIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
 		if [ "$$HAS_ARCH" != "dist/plugin-linux-amd64" ]; then \
 			echo "Contains $$HAS_ARCH in $$plugin_package-$$ARCH.tar.gz but needs dist/plugin-linux-amd64"; \
 			exit 1; \
 		fi; \
-		gpg --verify $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz; \
+		gpg --verify $(DIST_PATH_LIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_LIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz; \
 		if [ $$? -ne 0 ]; then \
 			echo "Failed to verify $$plugin_package-$$ARCH.tar.gz|$$plugin_package-$$ARCH.tar.gz.sig"; \
 			exit 1; \
 		fi; \
 	done
 	@# Package
-	tar -C dist -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-linux-amd64.tar.gz mattermost
-	@# Don't clean up native package so dev machines will have an unzipped package available
-	@#rm -f $(DIST_PATH)/bin/mattermost
+	tar -C $(DIST_PATH_LIN)/.. -czf $(DIST_PATH)-$(BUILD_TYPE_NAME)-linux-amd64.tar.gz mattermost ../mattermost
+	@# Preserve native package so dev machines will have an unzipped package available
+	mv $(DIST_PATH_LIN)/bin $(DIST_PATH)/bin
+	@# Cleanup
+	rm -rf $(DIST_PATH_LIN)
 
+package: package-osx package-windows package-linux
 	rm -rf tmpprepackaged
-	rm -rf dist/mattermost
+	rm -rf $(DIST_PATH)


### PR DESCRIPTION
#### Summary

Currently we have per platform `make build-foo` targets yet a single `make package` target.
Introduce separate `make package-foo` targets. Thus people can package only what they need.

As a nice bonus point, this allows macosx, windows and linux packaging to happen in parallel.

#### Ticket Link

N/A

#### Release Note
```release-note
Add per-platform `make package' targets - package-osx, package-linux and package-windows.
```
