### PR TITLE
hotfix: user import issue where the user roles were overwritten for the import path

### DIFF
--- a/services/users/users.go
+++ b/services/users/users.go
@@ -32,33 +32,34 @@ func New(s store.UserStore, cfgFn func() *model.Config) *UserService {
 
 // CreateUser creates a user
 func (us *UserService) CreateUser(user *model.User, opts UserCreateOptions) (*model.User, error) {
-	user.Roles = model.SYSTEM_USER_ROLE_ID
-	if opts.Guest {
-		user.Roles = model.SYSTEM_GUEST_ROLE_ID
-	}
+	if !opts.FromImport {
+		user.Roles = model.SYSTEM_USER_ROLE_ID
+		if opts.Guest {
+			user.Roles = model.SYSTEM_GUEST_ROLE_ID
+		}
 
-	if !user.IsLDAPUser() && !user.IsSAMLUser() && !user.IsGuest() && !checkUserDomain(user, *us.config().TeamSettings.RestrictCreationToDomains) {
-		return nil, AcceptedDomainError
-	}
+		if !user.IsLDAPUser() && !user.IsSAMLUser() && !user.IsGuest() && !checkUserDomain(user, *us.config().TeamSettings.RestrictCreationToDomains) {
+			return nil, AcceptedDomainError
+		}
 
-	if !user.IsLDAPUser() && !user.IsSAMLUser() && user.IsGuest() && !checkUserDomain(user, *us.config().GuestAccountsSettings.RestrictCreationToDomains) {
-		return nil, AcceptedDomainError
-	}
+		if !user.IsLDAPUser() && !user.IsSAMLUser() && user.IsGuest() && !checkUserDomain(user, *us.config().GuestAccountsSettings.RestrictCreationToDomains) {
+			return nil, AcceptedDomainError
+		}
 
-	// Below is a special case where the first user in the entire
-	// system is granted the system_admin role
-	count, err := us.store.Count(model.UserCountOptions{IncludeDeleted: true})
-	if err != nil {
-		return nil, UserCountError
-	}
-	if count <= 0 && !opts.FromImport {
-		user.Roles = model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID
-	}
+		// Below is a special case where the first user in the entire
+		// system is granted the system_admin role
+		count, err := us.store.Count(model.UserCountOptions{IncludeDeleted: true})
+		if err != nil {
+			return nil, UserCountError
+		}
+		if count <= 0 {
+			user.Roles = model.SYSTEM_ADMIN_ROLE_ID + " " + model.SYSTEM_USER_ROLE_ID
+		}
 
-	if _, ok := i18n.GetSupportedLocales()[user.Locale]; !ok {
-		user.Locale = *us.config().LocalizationSettings.DefaultClientLocale
+		if _, ok := i18n.GetSupportedLocales()[user.Locale]; !ok {
+			user.Locale = *us.config().LocalizationSettings.DefaultClientLocale
+		}
 	}
-
 	ruser, err := us.createUser(user)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

#### Summary
While creating users, the user roles were getting overwritten for the import path. This was intended for the regular user creation path from the API. However, the user roles are already included in the import data and we should've avoid those steps. So, this PR adds a skip condition for those steps as it was [before](https://github.com/mattermost/mattermost-server/blob/d320b50abbdc8c05ebb6738a48ac823328d1a936/app/user.go#L296).

#### Release Note

```release-note
NONE
```
