### PR TITLE
MM-35805: following a thread should also mark it as read

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -5704,6 +5704,7 @@ func TestFollowThreads(t *testing.T) {
 		})
 		CheckNoError(t, resp)
 		require.Len(t, uss.Threads, 1)
+		require.GreaterOrEqual(t, uss.Threads[0].LastViewedAt, uss.Threads[0].LastReplyAt)
 
 	})
 }

--- a/app/user.go
+++ b/app/user.go
@@ -2362,7 +2362,7 @@ func (a *App) UpdateThreadsReadForUser(userID, teamID string) *model.AppError {
 }
 
 func (a *App) UpdateThreadFollowForUser(userID, teamID, threadID string, state bool) *model.AppError {
-	_, err := a.Srv().Store.Thread().MaintainMembership(userID, threadID, state, false, true, false, false)
+	_, err := a.Srv().Store.Thread().MaintainMembership(userID, threadID, state, false, true, state, false)
 	if err != nil {
 		return model.NewAppError("UpdateThreadFollowForUser", "app.user.update_thread_follow_for_user.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}


### PR DESCRIPTION
#### Summary

Currently upon following a thread the thread is unread,
this commit changes that by explicitly marking it as read.
#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35805

#### Release Note

```release-note
NONE
```
