### PR TITLE
[MM-36198] - Activating a user in System Console does not respect cloud user limits

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1377,6 +1377,18 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// if non cloud instances, isOverLimit is false and no error
+	isOverLimit, err := c.App.CheckCloudAccountAtOrOverLimit()
+	if err != nil {
+		c.Err = model.NewAppError("updateUserActive", "api.user.update_active.cloud_at_or_over_limit_check_error", nil, "userId="+c.Params.UserId, http.StatusInternalServerError)
+		return
+	}
+
+	if active && isOverLimit {
+		c.Err = model.NewAppError("updateUserActive", "api.user.update_active.cloud_at_or_over_limit_check_overcapacity", nil, "userId="+c.Params.UserId, http.StatusBadRequest)
+		return
+	}
+
 	if _, err = c.App.UpdateActive(c.AppContext, user, active); err != nil {
 		c.Err = err
 	}

--- a/api4/user.go
+++ b/api4/user.go
@@ -1378,13 +1378,13 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// if non cloud instances, isOverLimit is false and no error
-	isOverLimit, err := c.App.CheckCloudAccountAtOrOverLimit()
+	isAtLimit, err := c.App.CheckCloudAccountAtLimit()
 	if err != nil {
-		c.Err = model.NewAppError("updateUserActive", "api.user.update_active.cloud_at_or_over_limit_check_error", nil, "userId="+c.Params.UserId, http.StatusInternalServerError)
+		c.Err = model.NewAppError("updateUserActive", "api.user.update_active.cloud_at_limit_check_error", nil, "userId="+c.Params.UserId, http.StatusInternalServerError)
 		return
 	}
 
-	if active && isOverLimit {
+	if active && isAtLimit {
 		c.Err = model.NewAppError("updateUserActive", "api.user.update_active.cloud_at_or_over_limit_check_overcapacity", nil, "userId="+c.Params.UserId, http.StatusBadRequest)
 		return
 	}

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2144,6 +2144,7 @@ func TestUpdateUserActive(t *testing.T) {
 		pass, resp = th.SystemAdminClient.UpdateUserActive(user.Id, true)
 		CheckBadRequestStatus(t, resp)
 		require.False(t, pass)
+		require.Equal(t, resp.Error.Message, "Unable to activate more users as the cloud account is over capacity.")
 	})
 	t.Run("basic tests", func(t *testing.T) {
 		th := Setup(t).InitBasic()

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -428,7 +428,7 @@ type AppIface interface {
 	ChannelMembersToRemove(teamID *string) ([]*model.ChannelMember, *model.AppError)
 	CheckAndSendUserLimitWarningEmails(c *request.Context) *model.AppError
 	CheckCanInviteToSharedChannel(channelId string) error
-	CheckCloudAccountAtOrOverLimit() (bool, *model.AppError)
+	CheckCloudAccountAtLimit() (bool, *model.AppError)
 	CheckForClientSideCert(r *http.Request) (string, string, string)
 	CheckMandatoryS3Fields(settings *model.FileSettings) *model.AppError
 	CheckPasswordAndAllCriteria(user *model.User, password string, mfaToken string) *model.AppError

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -428,6 +428,7 @@ type AppIface interface {
 	ChannelMembersToRemove(teamID *string) ([]*model.ChannelMember, *model.AppError)
 	CheckAndSendUserLimitWarningEmails(c *request.Context) *model.AppError
 	CheckCanInviteToSharedChannel(channelId string) error
+	CheckCloudAccountAtOrOverLimit() (bool, *model.AppError)
 	CheckForClientSideCert(r *http.Request) (string, string, string)
 	CheckMandatoryS3Fields(settings *model.FileSettings) *model.AppError
 	CheckPasswordAndAllCriteria(user *model.User, password string, mfaToken string) *model.AppError
@@ -733,6 +734,7 @@ type AppIface interface {
 	GetStatus(userID string) (*model.Status, *model.AppError)
 	GetStatusFromCache(userID string) *model.Status
 	GetStatusesByIds(userIDs []string) (map[string]interface{}, *model.AppError)
+	GetSubscriptionStats() (*model.SubscriptionStats, *model.AppError)
 	GetTeam(teamID string) (*model.Team, *model.AppError)
 	GetTeamByInviteId(inviteId string) (*model.Team, *model.AppError)
 	GetTeamByName(name string) (*model.Team, *model.AppError)

--- a/app/cloud.go
+++ b/app/cloud.go
@@ -79,6 +79,52 @@ func (a *App) SendAdminUpgradeRequestEmail(username string, subscription *model.
 	return nil
 }
 
+func (a *App) GetSubscriptionStats() (*model.SubscriptionStats, *model.AppError) {
+	if a.Srv().License() == nil || !*a.Srv().License().Features.Cloud {
+		return nil, model.NewAppError("app.GetSubscriptionStats", "api.cloud.license_error", nil, "", http.StatusInternalServerError)
+	}
+
+	subscription, appErr := a.Cloud().GetSubscription("")
+	if appErr != nil {
+		return nil, model.NewAppError("app.GetSubscriptionStats", "api.cloud.request_error", nil, appErr.Error(), http.StatusInternalServerError)
+	}
+
+	count, err := a.Srv().Store.User().Count(model.UserCountOptions{})
+	if err != nil {
+		return nil, model.NewAppError("app.GetSubscriptionStats", "app.user.get_total_users_count.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	cloudUserLimit := *a.Config().ExperimentalSettings.CloudUserLimit
+
+	s := cloudUserLimit - count
+
+	return &model.SubscriptionStats{
+		RemainingSeats: int(s),
+		IsPaidTier:     subscription.IsPaidTier,
+	}, nil
+}
+
+func (a *App) CheckCloudAccountAtOrOverLimit() (bool, *model.AppError) {
+	if a.Srv().License() == nil || (a.Srv().License() != nil && !*a.Srv().License().Features.Cloud) {
+		// Not cloud instance, so overlimit checks
+		return false, nil
+	}
+
+	stats, err := a.GetSubscriptionStats()
+	if err != nil {
+		return false, err
+	}
+
+	if (stats.IsPaidTier == "false") && (stats.RemainingSeats < 1) {
+		return true, nil
+	}
+
+	if (stats.IsPaidTier == "false") && (stats.RemainingSeats > 1) {
+		return false, nil
+	}
+
+	return false, nil
+}
+
 func (a *App) CheckAndSendUserLimitWarningEmails(c *request.Context) *model.AppError {
 	if a.Srv().License() == nil || (a.Srv().License() != nil && !*a.Srv().License().Features.Cloud) {
 		// Not cloud instance, do nothing

--- a/app/cloud.go
+++ b/app/cloud.go
@@ -103,9 +103,9 @@ func (a *App) GetSubscriptionStats() (*model.SubscriptionStats, *model.AppError)
 	}, nil
 }
 
-func (a *App) CheckCloudAccountAtOrOverLimit() (bool, *model.AppError) {
+func (a *App) CheckCloudAccountAtLimit() (bool, *model.AppError) {
 	if a.Srv().License() == nil || (a.Srv().License() != nil && !*a.Srv().License().Features.Cloud) {
-		// Not cloud instance, so overlimit checks
+		// Not cloud instance, so no at limit checks
 		return false, nil
 	}
 
@@ -114,12 +114,12 @@ func (a *App) CheckCloudAccountAtOrOverLimit() (bool, *model.AppError) {
 		return false, err
 	}
 
-	if (stats.IsPaidTier == "false") && (stats.RemainingSeats < 1) {
-		return true, nil
+	if stats.IsPaidTier == "true" {
+		return false, nil
 	}
 
-	if (stats.IsPaidTier == "false") && (stats.RemainingSeats > 1) {
-		return false, nil
+	if stats.RemainingSeats < 1 {
+		return true, nil
 	}
 
 	return false, nil

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -1134,6 +1134,28 @@ func (a *OpenTracingAppLayer) CheckCanInviteToSharedChannel(channelId string) er
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) CheckCloudAccountAtOrOverLimit() (bool, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CheckCloudAccountAtOrOverLimit")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.CheckCloudAccountAtOrOverLimit()
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) CheckForClientSideCert(r *http.Request) (string, string, string) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CheckForClientSideCert")
@@ -8722,6 +8744,28 @@ func (a *OpenTracingAppLayer) GetStatusesByIds(userIDs []string) (map[string]int
 
 	defer span.Finish()
 	resultVar0, resultVar1 := a.app.GetStatusesByIds(userIDs)
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
+func (a *OpenTracingAppLayer) GetSubscriptionStats() (*model.SubscriptionStats, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetSubscriptionStats")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetSubscriptionStats()
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -1134,9 +1134,9 @@ func (a *OpenTracingAppLayer) CheckCanInviteToSharedChannel(channelId string) er
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) CheckCloudAccountAtOrOverLimit() (bool, *model.AppError) {
+func (a *OpenTracingAppLayer) CheckCloudAccountAtLimit() (bool, *model.AppError) {
 	origCtx := a.ctx
-	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CheckCloudAccountAtOrOverLimit")
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CheckCloudAccountAtLimit")
 
 	a.ctx = newCtx
 	a.app.Srv().Store.SetContext(newCtx)
@@ -1146,7 +1146,7 @@ func (a *OpenTracingAppLayer) CheckCloudAccountAtOrOverLimit() (bool, *model.App
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.CheckCloudAccountAtOrOverLimit()
+	resultVar0, resultVar1 := a.app.CheckCloudAccountAtLimit()
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4135,7 +4135,7 @@
     "translation": "You cannot activate a guest account because Guest Access feature is not enabled."
   },
   {
-    "id": "api.user.update_active.cloud_at_or_over_limit_check_error",
+    "id": "api.user.update_active.cloud_at_limit_check_error",
     "translation": "Unable to make cloud check for at or over the limit."
   },
   {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4135,6 +4135,14 @@
     "translation": "You cannot activate a guest account because Guest Access feature is not enabled."
   },
   {
+    "id": "api.user.update_active.cloud_at_or_over_limit_check_error",
+    "translation": "Unable to make cloud check for at or over the limit."
+  },
+  {
+    "id": "api.user.update_active.cloud_at_or_over_limit_check_overcapacity",
+    "translation": "Unable to activate more users as the cloud account is over capacity."
+  },
+  {
     "id": "api.user.update_active.not_enable.app_error",
     "translation": "You cannot deactivate yourself because this feature is not enabled. Please contact your System Administrator."
   },


### PR DESCRIPTION
#### Summary
For cloud instances, when we're at the cloud limit, we should not allow activation of users from the system console

#### Ticket Link
[MM-36198](https://mattermost.atlassian.net/browse/MM-36198?atlOrigin=eyJpIjoiMDMzMDA3ZDM1MGQ2NGI3ZDgxOWNiZDk0NTk4ZWM3OGEiLCJwIjoiaiJ9)

#### Release Note
```release-note
NONE
```
