### PR TITLE
[MM-36236] Fix nil map assignment crash

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1509,6 +1509,10 @@ func (ss *SqlStore) appendMultipleStatementsFlag(dataSource string) (string, err
 			return "", err
 		}
 
+		if config.Params == nil {
+			config.Params = map[string]string{}
+		}
+
 		config.Params["multiStatements"] = "true"
 		return config.FormatDSN(), nil
 	}

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -682,7 +682,6 @@ func TestAppendMultipleStatementsFlagMysql(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Scenario, func(t *testing.T) {
-			t.Parallel()
 			store := &SqlStore{settings: &model.SqlSettings{DriverName: &tc.Driver, DataSource: &tc.DSN}}
 			res, err := store.appendMultipleStatementsFlag(*store.settings.DataSource)
 			require.NoError(t, err)


### PR DESCRIPTION
#### Summary

PR fixes a crash due to a nil map assignment. This was silently introduced in https://github.com/mattermost/mattermost-server/pull/17428 . What's worse is that the test covering this would have failed and showed the issue right away but that also had a bug as it was running concurrently and only testing the last test-case/DSN as a result.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36236

#### Release Note

```release-note
Fixed an issue where a datasource with missing query parameters could cause the server to crash during startup on MySQL installations.
```
