### PR TITLE
MM-35538 - display purchase modal when coming from email

### DIFF
--- a/app/email.go
+++ b/app/email.go
@@ -298,7 +298,7 @@ func (es *EmailService) SendCloudTrialEndWarningEmail(userEmail, name, trialEndD
 	data.Props["Title"] = T("api.templates.cloud_trial_ending_email.title")
 	data.Props["SubTitle"] = T("api.templates.cloud_trial_ending_email.subtitle", map[string]interface{}{"Name": name, "TrialEnd": trialEndDate})
 	data.Props["SiteURL"] = siteURL
-	data.Props["ButtonURL"] = fmt.Sprintf("%s/admin_console/billing/subscription?from=trial_ending_email", siteURL)
+	data.Props["ButtonURL"] = fmt.Sprintf("%s/admin_console/billing/subscription?action=show_purchase_modal", siteURL)
 	data.Props["Button"] = T("api.templates.cloud_trial_ending_email.add_payment_method")
 	data.Props["QuestionTitle"] = T("api.templates.questions_footer.title")
 	data.Props["QuestionInfo"] = T("api.templates.questions_footer.info")

--- a/app/email.go
+++ b/app/email.go
@@ -298,7 +298,7 @@ func (es *EmailService) SendCloudTrialEndWarningEmail(userEmail, name, trialEndD
 	data.Props["Title"] = T("api.templates.cloud_trial_ending_email.title")
 	data.Props["SubTitle"] = T("api.templates.cloud_trial_ending_email.subtitle", map[string]interface{}{"Name": name, "TrialEnd": trialEndDate})
 	data.Props["SiteURL"] = siteURL
-	data.Props["ButtonURL"] = fmt.Sprintf("%s/admin_console/billing/subscription", siteURL)
+	data.Props["ButtonURL"] = fmt.Sprintf("%s/admin_console/billing/subscription?from=trial_ending_email", siteURL)
 	data.Props["Button"] = T("api.templates.cloud_trial_ending_email.add_payment_method")
 	data.Props["QuestionTitle"] = T("api.templates.questions_footer.title")
 	data.Props["QuestionInfo"] = T("api.templates.questions_footer.info")


### PR DESCRIPTION
#### Summary
This PR adds a query param to the Cloud Email sent when the subscription is ending in 3 days.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35538

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/8234

#### Release Note

```release-note
NONE
```
