### PR TITLE
Give local dev HA cluster a name

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -107,6 +107,7 @@ services:
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
+      - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
     networks:
       - mm-test
     depends_on:
@@ -142,6 +143,7 @@ services:
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
+      - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
     networks:
       - mm-test
     depends_on:
@@ -177,6 +179,7 @@ services:
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
+      - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
     networks:
       - mm-test
     depends_on:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- The servers in a HA cluster won't communicate with each other unless they have the same name. An empty name doesn't work, so we set a generic name. Even with an incorrect configuration the cluster appeared to work because the nginx proxy was distributing http API requests to each individual server, but cluster messaging wouldn't work, because of which websocket events weren't firing correctly.
 
 
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- Discovered while working on https://mattermost.atlassian.net/browse/MM-35396
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
