### PR TITLE
MM-35030: Hoist GetDBVersion before creating store

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -20,7 +20,6 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -360,19 +359,6 @@ func NewServer(options ...Option) (*Server, error) {
 	if s.newStore == nil {
 		s.newStore = func() (store.Store, error) {
 			s.sqlStore = sqlstore.New(s.Config().SqlSettings, s.Metrics)
-			if s.sqlStore.DriverName() == model.DATABASE_DRIVER_POSTGRES {
-				ver, err2 := s.sqlStore.GetDbVersion(true)
-				if err2 != nil {
-					return nil, errors.Wrap(err2, "cannot get DB version")
-				}
-				intVer, err2 := strconv.Atoi(ver)
-				if err2 != nil {
-					return nil, errors.Wrap(err2, "cannot parse DB version")
-				}
-				if intVer < sqlstore.MinimumRequiredPostgresVersion {
-					return nil, fmt.Errorf("minimum required postgres version is %s; found %s", sqlstore.VersionString(sqlstore.MinimumRequiredPostgresVersion), sqlstore.VersionString(intVer))
-				}
-			}
 
 			lcl, err2 := localcachelayer.NewLocalCacheLayer(
 				retrylayer.New(s.sqlStore),

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -191,7 +191,7 @@ func New(settings model.SqlSettings, metrics einterfaces.MetricsInterface) *SqlS
 			os.Exit(ExitGenericFailure)
 		}
 		if intVer < MinimumRequiredPostgresVersion {
-			mlog.Critical(fmt.Sprintf("minimum required postgres version is %s; found %s", VersionString(MinimumRequiredPostgresVersion), VersionString(intVer)))
+			mlog.Critical("Minimum Postgres version requirements not met.", mlog.String("Found", VersionString(intVer)), mlog.String("Wanted", VersionString(MinimumRequiredPostgresVersion)))
 			os.Exit(ExitGenericFailure)
 		}
 	}


### PR DESCRIPTION
The creation of the store included running the migrations
which means that SQL statements would be executed before
we could make the check for DB version.

We make this a package-level function to allow checking
the DB version even before creating a store.

https://mattermost.atlassian.net/browse/MM-35030

```release-note
NONE
```