### PR TITLE
[MM-36318] Avoid redundant bot user update

### DIFF
--- a/app/bot.go
+++ b/app/bot.go
@@ -216,6 +216,10 @@ func (a *App) PatchBot(botUserId string, botPatch *model.BotPatch) (*model.Bot, 
 		return nil, err
 	}
 
+	if !bot.WouldPatch(botPatch) {
+		return bot, nil
+	}
+
 	bot.Patch(botPatch)
 
 	user, nErr := a.Srv().Store.User().Get(context.Background(), botUserId)

--- a/model/bot.go
+++ b/model/bot.go
@@ -129,6 +129,8 @@ func BotFromJson(data io.Reader) *Bot {
 }
 
 // Patch modifies an existing bot with optional fields from the given patch.
+// TODO 6.0: consider returning a boolean to indicate whether or not the patch
+// applied any changes.
 func (b *Bot) Patch(patch *BotPatch) {
 	if patch.Username != nil {
 		b.Username = *patch.Username
@@ -141,6 +143,23 @@ func (b *Bot) Patch(patch *BotPatch) {
 	if patch.Description != nil {
 		b.Description = *patch.Description
 	}
+}
+
+// WouldPatch returns whether or not the given patch would be applied or not.
+func (b *Bot) WouldPatch(patch *BotPatch) bool {
+	if patch == nil {
+		return false
+	}
+	if patch.Username != nil && *patch.Username != b.Username {
+		return true
+	}
+	if patch.DisplayName != nil && *patch.DisplayName != b.DisplayName {
+		return true
+	}
+	if patch.Description != nil && *patch.Description != b.Description {
+		return true
+	}
+	return false
 }
 
 // ToJson serializes the bot patch to json.

--- a/model/bot_test.go
+++ b/model/bot_test.go
@@ -491,6 +491,40 @@ func TestBotPatch(t *testing.T) {
 	}
 }
 
+func TestBotWouldPatch(t *testing.T) {
+	b := &Bot{
+		UserId: NewId(),
+	}
+
+	t.Run("nil patch", func(t *testing.T) {
+		ok := b.WouldPatch(nil)
+		require.False(t, ok)
+	})
+
+	t.Run("nil patch fields", func(t *testing.T) {
+		patch := &BotPatch{}
+		ok := b.WouldPatch(patch)
+		require.False(t, ok)
+	})
+
+	t.Run("patch", func(t *testing.T) {
+		patch := &BotPatch{
+			DisplayName: NewString("BotName"),
+		}
+		ok := b.WouldPatch(patch)
+		require.True(t, ok)
+	})
+
+	t.Run("no patch", func(t *testing.T) {
+		patch := &BotPatch{
+			DisplayName: NewString("BotName"),
+		}
+		b.Patch(patch)
+		ok := b.WouldPatch(patch)
+		require.False(t, ok)
+	})
+}
+
 func TestBotPatchToAndFromJson(t *testing.T) {
 	botPatch1 := &BotPatch{
 		Username:    sToP("username"),


### PR DESCRIPTION
#### Summary

A sudden spike in `getChannelMember` API calls was noticed during the (now hourly) community server updates (full context [here](https://community-daily.mattermost.com/private-core/pl/gen5i1kcu7n68xxs4n5zyufnrr)). Moreover, most of these calls were failing with 404s. After an initial investigation we were able to verify that such errors were all related  to bot users (plugin created) which are usually not part of any channel (hence the not founds).

Most of these plugins do a call to `Helpers.EnsureBot()` during activation. This caused the bot user to get updated and a websocket event to get sent. In response to such event each client would make the API call, which was tracked down to:

https://github.com/mattermost/mattermost-webapp/blob/0e8a3f375306d18eaf52aa191e07d8d5556fbea9/actions/websocket_actions.jsx#L1002

PR adds an additional check to verify if the bot update is needed, and if not return early. This avoids the ws event to get sent and should prevent the spike of calls coming in response.

#### Ticket

https://mattermost.atlassian.net/browse/MM-36318

#### Release Note

```release-note
Fixed an issue where a redundant user_update websocket event was generated for bot users.
```
