### PR TITLE
Skip database-reliant tests during short mode unit testing

### DIFF
--- a/cmd/mattermost/commands/version_test.go
+++ b/cmd/mattermost/commands/version_test.go
@@ -8,6 +8,10 @@ import (
 )
 
 func TestVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping version test in short mode")
+	}
+
 	th := SetupWithStoreMock(t)
 	defer th.TearDown()
 

--- a/config/migrate_test.go
+++ b/config/migrate_test.go
@@ -18,6 +18,9 @@ import (
 type cleanUpFn func(store *Store)
 
 func TestMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping migration test in short mode")
+	}
 	files := []string{
 		"IdpCertificateFile",
 		"PublicCertificateFile",


### PR DESCRIPTION
#### Summary
This change disables unit tests that were found to rely on access to a database during ['short' (or 'quick')](https://github.com/mattermost/mattermost-server/blob/0eb50a6777e9d2069fec83b2757ac6d9de9b81ca/Makefile#L393-L400) unit testing.

Some additional context is available at https://github.com/mattermost/mattermost-server/pull/17718#issuecomment-855824322

cc @jespino; also please let me know if it's possible/better to instead upgrade these tests to use autodetection setup approach.  I was looking around for the code that does that, and it wasn't immediately clear to me - perhaps [this test helper code](https://github.com/mattermost/mattermost-server/blob/0eb50a6777e9d2069fec83b2757ac6d9de9b81ca/testlib/helper.go#L69-L71)?  Glad to do that instead if it is preferable to the naive approach here.

#### Release Note
```release-note
NONE
```