### PR TITLE
MM-36257 Change Post.IsFollowing to a pointer and set to nil for responses to updates to Posts

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -649,6 +649,11 @@ func (a *App) UpdatePost(c *request.Context, post *model.Post, safeUpdate bool) 
 
 	rpost = a.PreparePostForClient(rpost, false, true)
 
+	// Ensure IsFollowing is nil since this updated post will be broadcast to all users
+	// and we don't want to have to populate it for every single user and broadcast to each
+	// individually.
+	rpost.IsFollowing = nil
+
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_POST_EDITED, "", rpost.ChannelId, "", nil)
 	message.Add("post", rpost.ToJson())
 	a.Publish(message)

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -2080,7 +2080,7 @@ func TestCollapsedThreadFetch(t *testing.T) {
 		require.EqualValues(t, []string{user1.Id}, []string{l.Posts[postRoot.Id].Participants[0].Id})
 		require.Empty(t, l.Posts[postRoot.Id].Participants[0].Email)
 		require.NotZero(t, l.Posts[postRoot.Id].LastReplyAt)
-		require.True(t, l.Posts[postRoot.Id].IsFollowing)
+		require.True(t, *l.Posts[postRoot.Id].IsFollowing)
 
 		// try extended fetch
 		l, err = th.App.GetPostsForChannelAroundLastUnread(channel.Id, user1.Id, 10, 10, true, true, true)

--- a/model/post.go
+++ b/model/post.go
@@ -102,7 +102,7 @@ type Post struct {
 	ReplyCount   int64         `json:"reply_count" db:"-"`
 	LastReplyAt  int64         `json:"last_reply_at" db:"-"`
 	Participants []*User       `json:"participants" db:"-"`
-	IsFollowing  bool          `json:"is_following" db:"-"` // for root posts in collapsed thread mode indicates if the current user is following this thread
+	IsFollowing  *bool         `json:"is_following,omitempty" db:"-"` // for root posts in collapsed thread mode indicates if the current user is following this thread
 	Metadata     *PostMetadata `json:"metadata,omitempty" db:"-"`
 }
 
@@ -207,7 +207,9 @@ func (o *Post) ShallowCopy(dst *Post) error {
 	dst.Participants = o.Participants
 	dst.LastReplyAt = o.LastReplyAt
 	dst.Metadata = o.Metadata
-	dst.IsFollowing = o.IsFollowing
+	if o.IsFollowing != nil {
+		dst.IsFollowing = NewBool(*o.IsFollowing)
+	}
 	dst.RemoteId = o.RemoteId
 	return nil
 }

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -34,7 +34,7 @@ type SqlPostStore struct {
 
 type postWithExtra struct {
 	ThreadReplyCount   int64
-	IsFollowing        bool
+	IsFollowing        *bool
 	ThreadParticipants model.StringArray
 	model.Post
 }
@@ -739,7 +739,9 @@ func (s *SqlPostStore) prepareThreadedResponse(posts []*postWithExtra, extended,
 	}
 	processPost := func(p *postWithExtra) error {
 		p.Post.ReplyCount = p.ThreadReplyCount
-		p.Post.IsFollowing = p.IsFollowing
+		if p.IsFollowing != nil {
+			p.Post.IsFollowing = model.NewBool(*p.IsFollowing)
+		}
 		for _, th := range p.ThreadParticipants {
 			var participant *model.User
 			for _, u := range users {

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -451,7 +451,7 @@ func testPostStoreGetForThread(t *testing.T, ss store.Store) {
 	r1, err := ss.Post().Get(context.Background(), o1.Id, false, true, false, o1.UserId)
 	require.NoError(t, err)
 	require.Equal(t, r1.Posts[o1.Id].CreateAt, o1.CreateAt, "invalid returned post")
-	require.True(t, r1.Posts[o1.Id].IsFollowing)
+	require.True(t, *r1.Posts[o1.Id].IsFollowing)
 }
 
 func testPostStoreGetSingle(t *testing.T, ss store.Store) {


### PR DESCRIPTION
#### Summary
Change Post.IsFollowing to a pointer and set to nil for responses to updates to a Post. The reason we need to do this is that post edits are broadcast to all users in the corresponding channel and the `IsFollowing` field needs to be unique to each user. It would not be performant to look up the following state for every single user in the channel and broadcast individually to each user.

Instead, we explicitly don't set and omit `IsFollowing` in the responses and leave it to the client to figure out what the following state is since it should have all the information needed for that already.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36257

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
