### PR TITLE
[MM-36411] Fix flaky TestUpdateConfigDiffInAuditRecord

### DIFF
--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -456,7 +456,12 @@ func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
 		},
 	}
 	th := SetupWithServerOptions(t, options)
-	defer th.TearDown()
+	shouldShutdown := true
+	defer func() {
+		if shouldShutdown {
+			th.TearDown()
+		}
+	}()
 
 	cfg, resp := th.SystemAdminClient.GetConfig()
 	CheckNoError(t, resp)
@@ -469,6 +474,10 @@ func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
 		cfg.ServiceSettings.ReadTimeout = model.NewInt(timeoutVal)
 	})
 	require.Equal(t, timeoutVal+1, *cfg.ServiceSettings.ReadTimeout)
+
+	// Shutting down the server to make sure all logged records get flushed.
+	th.TearDown()
+	shouldShutdown = false
 
 	data, err := ioutil.ReadAll(logFile)
 	require.NoError(t, err)


### PR DESCRIPTION
#### Summary

PR attempts to fix flaky `TestUpdateConfigDiffInAuditRecord`. I wasn't able to reproduce this locally but I have a feeling it may be caused by the logs not getting flushed in time. To force a flush we are now shutting down the server before attempting to read the log file.

#### Ticket

https://mattermost.atlassian.net/browse/MM-36411

#### Release Note

```release-note
NONE
```
