### PR TITLE
Prevent JS Execution on Pre-login OAUTH screen 

### DIFF
--- a/utils/api.go
+++ b/utils/api.go
@@ -101,6 +101,11 @@ func RenderMobileAuthComplete(w http.ResponseWriter, redirectURL string) {
 }
 
 func RenderMobileError(config *model.Config, w http.ResponseWriter, err *model.AppError, redirectURL string) {
+	var link = redirectURL
+	u, redirectErr := url.Parse(redirectURL)
+	if redirectErr != nil || u.Scheme == "javascript" {
+		link = *config.ServiceSettings.SiteURL
+	}
 	RenderMobileMessage(w, `
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" style="width: 64px; height: 64px; fill: #ccc">
 			<!-- Font Awesome Free 5.15.3 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) -->
@@ -108,7 +113,7 @@ func RenderMobileError(config *model.Config, w http.ResponseWriter, err *model.A
 		</svg>
 		<h2> `+i18n.T("error")+` </h2>
 		<p> `+err.Message+` </p>
-		<a href="`+redirectURL+`">
+		<a href="`+link+`">
 			`+i18n.T("api.back_to_app", map[string]interface{}{"SiteName": config.TeamSettings.SiteName})+`
 		</a>
 	`)

--- a/utils/api.go
+++ b/utils/api.go
@@ -102,8 +102,13 @@ func RenderMobileAuthComplete(w http.ResponseWriter, redirectURL string) {
 
 func RenderMobileError(config *model.Config, w http.ResponseWriter, err *model.AppError, redirectURL string) {
 	var link = redirectURL
+	var invalidSchemes = map[string]bool{
+		"data":       true,
+		"javascript": true,
+		"vbscript":   true,
+	}
 	u, redirectErr := url.Parse(redirectURL)
-	if redirectErr != nil || u.Scheme == "javascript" {
+	if redirectErr != nil || invalidSchemes[u.Scheme] {
 		link = *config.ServiceSettings.SiteURL
 	}
 	RenderMobileMessage(w, `

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -388,27 +388,25 @@ func TestMobileLoginWithOAuth(t *testing.T) {
 	provider := &MattermostTestProvider{}
 	einterfaces.RegisterOauthProvider(model.SERVICE_GITLAB, provider)
 
-	responseWriter := httptest.NewRecorder()
-
 	t.Run("Should include redirect URL in the output when valid URL Scheme is passed", func(t *testing.T) {
+		responseWriter := httptest.NewRecorder()
 		request, _ := http.NewRequest(http.MethodGet, th.App.GetSiteURL()+"/oauth/gitlab/mobile_login?redirect_to="+url.QueryEscape("randomScheme://"), nil)
-
 		mobileLoginWithOAuth(c, responseWriter, request)
 		assert.Contains(t, responseWriter.Body.String(), "randomScheme://")
 		assert.NotContains(t, responseWriter.Body.String(), siteURL)
 	})
 
 	t.Run("Should not include the redirect URL consisting of javascript protocol", func(t *testing.T) {
+		responseWriter := httptest.NewRecorder()
 		request, _ := http.NewRequest(http.MethodGet, th.App.GetSiteURL()+"/oauth/gitlab/mobile_login?redirect_to="+url.QueryEscape("javascript:alert('hello')"), nil)
-
 		mobileLoginWithOAuth(c, responseWriter, request)
 		assert.NotContains(t, responseWriter.Body.String(), "javascript:alert('hello')")
 		assert.Contains(t, responseWriter.Body.String(), siteURL)
 	})
 
 	t.Run("Should not include the redirect URL consisting of javascript protocol in mixed case", func(t *testing.T) {
+		responseWriter := httptest.NewRecorder()
 		request, _ := http.NewRequest(http.MethodGet, th.App.GetSiteURL()+"/oauth/gitlab/mobile_login?redirect_to="+url.QueryEscape("JaVasCript:alert('hello')"), nil)
-
 		mobileLoginWithOAuth(c, responseWriter, request)
 		assert.NotContains(t, responseWriter.Body.String(), "JaVasCript:alert('hello')")
 		assert.Contains(t, responseWriter.Body.String(), siteURL)


### PR DESCRIPTION
#### Summary
Prevents `javascript:` protocol in pre login OAUTH screens. 

We are using the user passed query param value in the HTML output so that in case of misconfiguration, it will still let the user to **go back** to their respective mobile app. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36250

#### Release Note
```release-note
NONE
```
