### PR TITLE
[MM-35392, MM-35972] CRT: cross team unreads handling

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -420,8 +420,9 @@ func getTeamsUnreadForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// optional team id to be excluded from the result
 	teamId := r.URL.Query().Get("exclude_team")
+	collapsedThreads := r.URL.Query().Get("collapsedThreads") == "true"
 
-	unreadTeamsList, err := c.App.GetTeamsUnreadForUser(teamId, c.Params.UserId)
+	unreadTeamsList, err := c.App.GetTeamsUnreadForUser(teamId, c.Params.UserId, collapsedThreads)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2651,22 +2651,22 @@ func TestGetMyTeamsUnread(t *testing.T) {
 	user := th.BasicUser
 	Client.Login(user.Email, user.Password)
 
-	teams, resp := Client.GetTeamsUnreadForUser(user.Id, "")
+	teams, resp := Client.GetTeamsUnreadForUser(user.Id, "", true)
 	CheckNoError(t, resp)
 	require.NotEqual(t, len(teams), 0, "should have results")
 
-	teams, resp = Client.GetTeamsUnreadForUser(user.Id, th.BasicTeam.Id)
+	teams, resp = Client.GetTeamsUnreadForUser(user.Id, th.BasicTeam.Id, true)
 	CheckNoError(t, resp)
 	require.Empty(t, teams, "should not have results")
 
-	_, resp = Client.GetTeamsUnreadForUser("fail", "")
+	_, resp = Client.GetTeamsUnreadForUser("fail", "", true)
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.GetTeamsUnreadForUser(model.NewId(), "")
+	_, resp = Client.GetTeamsUnreadForUser(model.NewId(), "", true)
 	CheckForbiddenStatus(t, resp)
 
 	Client.Logout()
-	_, resp = Client.GetTeamsUnreadForUser(user.Id, "")
+	_, resp = Client.GetTeamsUnreadForUser(user.Id, "", true)
 	CheckUnauthorizedStatus(t, resp)
 }
 

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -753,7 +753,7 @@ type AppIface interface {
 	GetTeamsForScheme(scheme *model.Scheme, offset int, limit int) ([]*model.Team, *model.AppError)
 	GetTeamsForSchemePage(scheme *model.Scheme, page int, perPage int) ([]*model.Team, *model.AppError)
 	GetTeamsForUser(userID string) ([]*model.Team, *model.AppError)
-	GetTeamsUnreadForUser(excludeTeamId string, userID string) ([]*model.TeamUnread, *model.AppError)
+	GetTeamsUnreadForUser(excludeTeamId string, userID string, collapsedThreads bool) ([]*model.TeamUnread, *model.AppError)
 	GetTermsOfService(id string) (*model.TermsOfService, *model.AppError)
 	GetThreadForUser(userID, teamID, threadId string, extended bool) (*model.ThreadResponse, *model.AppError)
 	GetThreadMembershipsForUser(userID, teamID string) ([]*model.ThreadMembership, error)

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -9227,7 +9227,7 @@ func (a *OpenTracingAppLayer) GetTeamsForUser(userID string) ([]*model.Team, *mo
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetTeamsUnreadForUser(excludeTeamId string, userID string) ([]*model.TeamUnread, *model.AppError) {
+func (a *OpenTracingAppLayer) GetTeamsUnreadForUser(excludeTeamId string, userID string, collapsedThreads bool) ([]*model.TeamUnread, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetTeamsUnreadForUser")
 
@@ -9239,7 +9239,7 @@ func (a *OpenTracingAppLayer) GetTeamsUnreadForUser(excludeTeamId string, userID
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.GetTeamsUnreadForUser(excludeTeamId, userID)
+	resultVar0, resultVar1 := a.app.GetTeamsUnreadForUser(excludeTeamId, userID, collapsedThreads)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -183,7 +183,7 @@ func (api *PluginAPI) GetTeamByName(name string) (*model.Team, *model.AppError) 
 }
 
 func (api *PluginAPI) GetTeamsUnreadForUser(userID string) ([]*model.TeamUnread, *model.AppError) {
-	return api.app.GetTeamsUnreadForUser("", userID)
+	return api.app.GetTeamsUnreadForUser("", userID, false)
 }
 
 func (api *PluginAPI) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {

--- a/app/user.go
+++ b/app/user.go
@@ -2374,6 +2374,10 @@ func (a *App) UpdateThreadReadForUser(userID, teamID, threadID string, timestamp
 	if err != nil {
 		return nil, err
 	}
+	channel, nErr := a.Srv().Store.Channel().Get(post.ChannelId, true)
+	if nErr != nil {
+		return nil, model.NewAppError("UpdateThreadsReadForUser", "app.user.update_threads_read_for_user.app_error", nil, nErr.Error(), http.StatusInternalServerError)
+	}
 	membership.UnreadMentions, err = a.countThreadMentions(user, post, teamID, timestamp)
 	if err != nil {
 		return nil, err
@@ -2398,6 +2402,7 @@ func (a *App) UpdateThreadReadForUser(userID, teamID, threadID string, timestamp
 	message.Add("unread_mentions", membership.UnreadMentions)
 	message.Add("unread_replies", thread.UnreadReplies)
 	message.Add("channel_id", post.ChannelId)
+	message.Add("channel_type", channel.Type)
 	a.Publish(message)
 	return thread, nil
 }

--- a/model/client4.go
+++ b/model/client4.go
@@ -1441,13 +1441,18 @@ func (c *Client4) AttachDeviceId(deviceId string) (bool, *Response) {
 // GetTeamsUnreadForUser will return an array with TeamUnread objects that contain the amount
 // of unread messages and mentions the current user has for the teams it belongs to.
 // An optional team ID can be set to exclude that team from the results. Must be authenticated.
-func (c *Client4) GetTeamsUnreadForUser(userId, teamIdToExclude string) ([]*TeamUnread, *Response) {
-	var optional string
+func (c *Client4) GetTeamsUnreadForUser(userId, teamIdToExclude string, collapsedThreads bool) ([]*TeamUnread, *Response) {
+	query := url.Values{}
+
 	if teamIdToExclude != "" {
-		optional += fmt.Sprintf("?exclude_team=%s", url.QueryEscape(teamIdToExclude))
+		query.Set("exclude_team", teamIdToExclude)
 	}
 
-	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/unread"+optional, "")
+	if collapsedThreads {
+		query.Set("collapsedThreads", "true")
+	}
+
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/unread?"+query.Encode(), "")
 	if err != nil {
 		return nil, BuildErrorResponse(r, err)
 	}

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -31,11 +31,13 @@ type TeamMember struct {
 
 //msgp:ignore TeamUnread
 type TeamUnread struct {
-	TeamId           string `json:"team_id"`
-	MsgCount         int64  `json:"msg_count"`
-	MentionCount     int64  `json:"mention_count"`
-	MentionCountRoot int64  `json:"mention_count_root"`
-	MsgCountRoot     int64  `json:"msg_count_root"`
+	TeamId             string `json:"team_id"`
+	MsgCount           int64  `json:"msg_count"`
+	MentionCount       int64  `json:"mention_count"`
+	MentionCountRoot   int64  `json:"mention_count_root"`
+	MsgCountRoot       int64  `json:"msg_count_root"`
+	ThreadCount        int64  `json:"thread_count"`
+	ThreadMentionCount int64  `json:"thread_mention_count"`
 }
 
 //msgp:ignore TeamMemberForExport


### PR DESCRIPTION
#### Summary

- Supply `prevUnreadMentions`, `prevUnreadReplies`
- Add Thread unreads (per-team) to existing `GetTeamsUnreadForUser`, leveraging existing pipeline
- WEBSOCKET_EVENT_THREAD_READ_CHANGED, add `channel_type` so client can determine if count change should affect single team or all teams (GM/DM-threads)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35392
https://mattermost.atlassian.net/browse/MM-35972
https://mattermost.atlassian.net/browse/MM-35393

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/8290


#### Screenshots


#### Release Note

```release-note
NONE
```