### PR TITLE
Bump focalboard prepackaged plugin version to v0.7.0 (#17822)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.5.0
-PLUGIN_PACKAGES += focalboard-v0.6.7-plugin
+PLUGIN_PACKAGES += focalboard-v0.7.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)


### PR DESCRIPTION
```release-note
Update the focalboard builtin plugin version to v0.7.0
```