### PR TITLE
MM-36429 Do not increment mention counts when marking root posts with no replies as unread

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -2503,7 +2503,7 @@ func (a *App) MarkChannelAsUnreadFromPost(postID string, userID string, collapse
 		if threadMembership == nil {
 			opts := store.ThreadMembershipOpts{
 				Following:             followThread,
-				IncrementMentions:     true,
+				IncrementMentions:     false,
 				UpdateFollowing:       true,
 				UpdateViewedTimestamp: true,
 				UpdateParticipants:    false,

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -2249,7 +2249,7 @@ func TestMarkUnreadWithThreads(t *testing.T) {
 	})
 
 	t.Run("Set unread mentions correctly", func(t *testing.T) {
-		t.Run("Root post with no replies or mentions", func(t *testing.T) {
+		t.Run("Never followed root post with no replies or mentions", func(t *testing.T) {
 			rootPost, appErr := th.App.CreatePost(th.Context, &model.Post{UserId: th.BasicUser2.Id, CreateAt: model.GetMillis(), ChannelId: th.BasicChannel.Id, Message: "hi"}, th.BasicChannel, false, false)
 			require.Nil(t, appErr)
 			_, appErr = th.App.MarkChannelAsUnreadFromPost(rootPost.Id, th.BasicUser.Id, true, true)
@@ -2261,7 +2261,7 @@ func TestMarkUnreadWithThreads(t *testing.T) {
 			assert.Zero(t, threadMembership.UnreadMentions)
 		})
 
-		t.Run("Previously unfollowed root post with replies and no mentions", func(t *testing.T) {
+		t.Run("Never followed root post with replies and no mentions", func(t *testing.T) {
 			rootPost, appErr := th.App.CreatePost(th.Context, &model.Post{UserId: th.BasicUser2.Id, CreateAt: model.GetMillis(), ChannelId: th.BasicChannel.Id, Message: "hi"}, th.BasicChannel, false, false)
 			require.Nil(t, appErr)
 			_, appErr = th.App.CreatePost(th.Context, &model.Post{RootId: rootPost.Id, UserId: th.BasicUser2.Id, CreateAt: model.GetMillis(), ChannelId: th.BasicChannel.Id, Message: "hi"}, th.BasicChannel, false, false)
@@ -2275,7 +2275,7 @@ func TestMarkUnreadWithThreads(t *testing.T) {
 			assert.Zero(t, threadMembership.UnreadMentions)
 		})
 
-		t.Run("Previously unfollowed root post with replies and mentions", func(t *testing.T) {
+		t.Run("Never followed root post with replies and mentions", func(t *testing.T) {
 			rootPost, appErr := th.App.CreatePost(th.Context, &model.Post{UserId: th.BasicUser2.Id, CreateAt: model.GetMillis(), ChannelId: th.BasicChannel.Id, Message: "hi"}, th.BasicChannel, false, false)
 			require.Nil(t, appErr)
 			_, appErr = th.App.CreatePost(th.Context, &model.Post{RootId: rootPost.Id, UserId: th.BasicUser2.Id, CreateAt: model.GetMillis(), ChannelId: th.BasicChannel.Id, Message: "hi @" + th.BasicUser.Username}, th.BasicChannel, false, false)

--- a/app/user.go
+++ b/app/user.go
@@ -2228,14 +2228,17 @@ func (a *App) UpdateThreadFollowForUser(userID, teamID, threadID string, state b
 		return model.NewAppError("UpdateThreadFollowForUser", "app.user.update_thread_follow_for_user.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	thread, err := a.Srv().Store.Thread().Get(threadID)
-
 	if err != nil {
 		return model.NewAppError("UpdateThreadFollowForUser", "app.user.update_thread_follow_for_user.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	replyCount := int64(0)
+	if thread != nil {
+		replyCount = thread.ReplyCount
 	}
 	message := model.NewWebSocketEvent(model.WEBSOCKET_EVENT_THREAD_FOLLOW_CHANGED, teamID, "", userID, nil)
 	message.Add("thread_id", threadID)
 	message.Add("state", state)
-	message.Add("reply_count", thread.ReplyCount)
+	message.Add("reply_count", replyCount)
 	a.Publish(message)
 	return nil
 }

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -626,7 +626,7 @@ func (s *SqlThreadStore) MaintainMembership(userId, postId string, opts store.Th
 		if getErr != nil {
 			return nil, getErr
 		}
-		if !thread.Participants.Contains(userId) {
+		if thread != nil && !thread.Participants.Contains(userId) {
 			thread.Participants = append(thread.Participants, userId)
 			if _, err = s.update(trx, thread); err != nil {
 				return nil, err

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -110,7 +110,7 @@ func (s *SqlThreadStore) get(ex gorp.SqlExecutor, id string) (*model.Thread, err
 	err := ex.SelectOne(&thread, query, args...)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, store.NewErrNotFound("Thread", id)
+			return nil, nil
 		}
 
 		return nil, errors.Wrapf(err, "failed to get thread with id=%s", id)

--- a/store/storetest/thread_store.go
+++ b/store/storetest/thread_store.go
@@ -469,8 +469,9 @@ func testThreadStorePermanentDeleteBatchForRetentionPolicies(t *testing.T, ss st
 	nowMillis := thread.LastReplyAt + *channelPolicy.PostDuration*24*60*60*1000 + 1
 	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
-	_, err = ss.Thread().Get(post.Id)
-	require.Error(t, err, "thread should have been deleted by channel policy")
+	thread, err = ss.Thread().Get(post.Id)
+	assert.NoError(t, err)
+	assert.Nil(t, thread, "thread should have been deleted by channel policy")
 
 	// create a new thread
 	threadStoreCreateReply(t, ss, channel.Id, post.Id, 2000)
@@ -498,8 +499,9 @@ func testThreadStorePermanentDeleteBatchForRetentionPolicies(t *testing.T, ss st
 	require.NoError(t, err)
 	_, _, err = ss.Thread().PermanentDeleteBatchForRetentionPolicies(nowMillis, 0, limit, model.RetentionPolicyCursor{})
 	require.NoError(t, err)
-	_, err = ss.Thread().Get(post.Id)
-	require.Error(t, err, "thread should have been deleted by team policy")
+	thread, err = ss.Thread().Get(post.Id)
+	assert.NoError(t, err)
+	assert.Nil(t, thread, "thread should have been deleted by team policy")
 }
 
 func testThreadStorePermanentDeleteBatchThreadMembershipsForRetentionPolicies(t *testing.T, ss store.Store) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
For root posts that had not been followed before (aka no thread membership) and had no replies (aka no thread) we were incrementing the mention count mistakenly. Added unit tests to cover these cases.

This also fixes a server error that occurs when following a root post that doesn't have a thread.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36429

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fix bug with collapsed reply threads where some posts without replies can show as having unread mentions
```
