### PR TITLE
Add .gitlab-ci.collabora.yml continuous integration configuration

### DIFF
--- a/.gitlab-ci.collabora.yml
+++ b/.gitlab-ci.collabora.yml
@@ -1,0 +1,61 @@
+lint:
+  allow_failure: true
+  image: golangci/golangci-lint
+  script:
+    - GO111MODULE=off GOBIN=$PWD/bin go get -u github.com/mattermost/mattermost-govet
+    - make config-reset
+    - make check-style
+
+test-quick:
+  image: docker
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+    TEST_DATABASE_MYSQL_DSN: "mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&multiStatements=true"
+    TEST_DATABASE_POSTGRESQL_DSN: "postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+    TEST_DATABASE_MYSQL_ROOT_PASSWD: "mostest"
+  services:
+    - docker:dind
+  before_script:
+    - apk add --no-cache bash docker-compose go make
+    - make start-docker
+  script:
+    - docker run
+      --env MM_NO_DOCKER=true
+      --env-file "build/dotenv/test.env"
+      --mount "type=bind,source=$PWD,target=$PWD"
+      --network "$CI_PROJECT_NAME"_mm-test
+      docker
+        /bin/sh -c "
+          cd $PWD;
+          apk add --no-cache bash docker-compose go mailcap make;
+          make test-server-quick;
+        "
+
+test-full:
+  rules:
+  - if: '$CI_COMMIT_REF_NAME == "master"'
+  image: docker
+  variables:
+    DOCKER_HOST: tcp://docker:2375
+    DOCKER_TLS_CERTDIR: ""
+    TEST_DATABASE_MYSQL_DSN: "mmuser:mostest@tcp(mysql:3306)/mattermost_test?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s&multiStatements=true"
+    TEST_DATABASE_POSTGRESQL_DSN: "postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+    TEST_DATABASE_MYSQL_ROOT_PASSWD: "mostest"
+  services:
+    - docker:dind
+  before_script:
+    - apk add --no-cache bash docker-compose go make
+    - make start-docker
+  script:
+    - docker run
+      --env MM_NO_DOCKER=true
+      --env-file "build/dotenv/test.env"
+      --mount "type=bind,source=$PWD,target=$PWD"
+      --network "$CI_PROJECT_NAME"_mm-test
+      docker
+        /bin/sh -c "
+          cd $PWD;
+          apk add --no-cache bash docker-compose go mailcap make;
+          make test-server;
+        "


### PR DESCRIPTION
#### Summary
This changeset provides a GitLab-CI compatible YAML config to run linting and unit testing for `mattermost-server`.

The initially-presented filename `.gitlab-ci.collabora.yml` is what I've been using verbatim during development at @collabora - open to moving this to a `contrib` directory and/or otherwise reducing any namespace pollution or confusion.

As mentioned in #17843, the [`CI_CONFIG_PATH`](https://docs.gitlab.com/13.12/ee/ci/variables/predefined_variables.html) can be used to configure GitLab CI to read from this configuration file on a per-repository basis.

#### Ticket Link
Relates to #17843.

#### Release Note
This doesn't affect the functionality of the Mattermost product and application.

```release-note
NONE
```