### PR TITLE
Fix flaky test: TestSendAutoResponseIfNecessary

### DIFF
--- a/app/auto_responder.go
+++ b/app/auto_responder.go
@@ -13,7 +13,7 @@ import (
 
 // check if there is any auto_response type post in channel by the user in a calender day
 func (a *App) checkIfRespondedToday(createdAt int64, channelId, userId string) (bool, error) {
-	y, m, d := time.Unix(createdAt, 0).Date()
+	y, m, d := time.Unix(int64(model.GetTimeForMillis(createdAt).Second()), 0).Date()
 	since := model.GetMillisForTime(time.Date(y, m, d, 0, 0, 0, 0, time.UTC))
 	return a.Srv().Store.Post().HasAutoResponsePostByUserSince(
 		model.GetPostsSinceOptions{ChannelId: channelId, Time: since},


### PR DESCRIPTION
The time needed to be converted to seconds before extracting
the year, month, an day.

Not sure how it passed CI for so long.

```release-note
NONE
```

https://focalboard-community.octo.mattermost.com/workspace/zyoahc9uapdn3xdptac6jb69ic?id=285b80a3-257d-41f6-8cf4-ed80ca9d92e5&v=495cdb4d-c13a-4992-8eb9-80cfee2819a4&c=de13d489-9e10-4fcc-896c-0d738a21f28f
