### PR TITLE
Fix bulk export file when exporting reply threads

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -463,7 +463,7 @@ func (a *App) buildPostReplies(postID string, withAttachments bool) ([]ReplyImpo
 			if appErr != nil {
 				return nil, nil, appErr
 			}
-			replyImportObject.Attachments = &attachments
+			replyImportObject.Attachments = &postAttachments
 			if withAttachments && len(postAttachments) > 0 {
 				attachments = append(attachments, postAttachments...)
 			}


### PR DESCRIPTION
#### Summary

When bulk exporting, every posts with files in the reply thread have the information of all the files attached in the reply threads. This PR fix it.

#### Ticket Link
N/A (following [Contributions Without Ticket](https://developers.mattermost.com/contribute/getting-started/contributions-without-ticket/))

#### Release Note
```release-note
Fixed an issue where bulk export generated invalid post with files in reply threads
```
