### PR TITLE
Use original opengraph dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -144,8 +144,6 @@ require (
 	willnorris.com/go/imageproxy v0.10.0
 )
 
-replace github.com/dyatlov/go-opengraph => github.com/agnivade/go-opengraph v0.0.0-20201221052033-34e69ee2a627
-
 // Hack to prevent the willf/bitset module from being upgraded to 1.2.0.
 // They changed the module path from github.com/willf/bitset to
 // github.com/bits-and-blooms/bitset and a couple of dependent repos are yet

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMx
 github.com/advancedlogic/GoOse v0.0.0-20191112112754-e742535969c1/go.mod h1:f3HCSN1fBWjcpGtXyM119MJgeQl838v6so/PQOqvE1w=
 github.com/advancedlogic/GoOse v0.0.0-20200830213114-1225d531e0ad h1:gyzOmx++wVkSj5kLzYtvNN2ooeJGTFTtV37t5Do4sdM=
 github.com/advancedlogic/GoOse v0.0.0-20200830213114-1225d531e0ad/go.mod h1:f3HCSN1fBWjcpGtXyM119MJgeQl838v6so/PQOqvE1w=
-github.com/agnivade/go-opengraph v0.0.0-20201221052033-34e69ee2a627 h1:Z5Cd4rshcYMKhKuGaVeSaJ4sAiLHzB5YXF10+TvJDU4=
-github.com/agnivade/go-opengraph v0.0.0-20201221052033-34e69ee2a627/go.mod h1:4M/YtupetXsgPzt5YlR87whvFSHtYj1eBFUgcXiwrOY=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -251,6 +249,8 @@ github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdf
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dvyukov/go-fuzz v0.0.0-20210429054444-fca39067bc72/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
+github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09 h1:AQLr//nh20BzN3hIWj2+/Gt3FwSs8Nwo/nz4hMIcLPg=
+github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09/go.mod h1:nYia/MIs9OyvXXYboPmNOj0gVWo97Wx0sde+ZuKkoM4=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/vendor/github.com/dyatlov/go-opengraph/opengraph/opengraph.go
+++ b/vendor/github.com/dyatlov/go-opengraph/opengraph/opengraph.go
@@ -17,7 +17,7 @@ type Image struct {
 	Type      string `json:"type"`
 	Width     uint64 `json:"width"`
 	Height    uint64 `json:"height"`
-	draft     bool   `json:"-"`
+	draft     bool    `json:"-"`
 }
 
 // Video defines Open Graph Video type
@@ -27,7 +27,7 @@ type Video struct {
 	Type      string `json:"type"`
 	Width     uint64 `json:"width"`
 	Height    uint64 `json:"height"`
-	draft     bool   `json:"-"`
+	draft     bool    `json:"-"`
 }
 
 // Audio defines Open Graph Audio Type
@@ -35,7 +35,7 @@ type Audio struct {
 	URL       string `json:"url"`
 	SecureURL string `json:"secure_url"`
 	Type      string `json:"type"`
-	draft     bool   `json:"-"`
+	draft     bool    `json:"-"`
 }
 
 // Article contain Open Graph Article structure
@@ -182,7 +182,7 @@ func (og *OpenGraph) ProcessMeta(metaAttrs map[string]string) {
 	case "og:locale:alternate":
 		og.LocalesAlternate = append(og.LocalesAlternate, metaAttrs["content"])
 	case "og:audio":
-		if len(og.Audios) > 0 && og.Audios[len(og.Audios)-1].draft {
+		if len(og.Audios)>0 && og.Audios[len(og.Audios)-1].draft {
 			og.Audios[len(og.Audios)-1].URL = metaAttrs["content"]
 			og.Audios[len(og.Audios)-1].draft = false
 		} else {
@@ -195,7 +195,7 @@ func (og *OpenGraph) ProcessMeta(metaAttrs map[string]string) {
 		og.ensureHasAudio()
 		og.Audios[len(og.Audios)-1].Type = metaAttrs["content"]
 	case "og:image":
-		if len(og.Images) > 0 && og.Images[len(og.Images)-1].draft {
+		if len(og.Images)>0 && og.Images[len(og.Images)-1].draft {
 			og.Images[len(og.Images)-1].URL = metaAttrs["content"]
 			og.Images[len(og.Images)-1].draft = false
 		} else {
@@ -223,7 +223,7 @@ func (og *OpenGraph) ProcessMeta(metaAttrs map[string]string) {
 			og.Images[len(og.Images)-1].Height = h
 		}
 	case "og:video":
-		if len(og.Videos) > 0 && og.Videos[len(og.Videos)-1].draft {
+		if len(og.Videos)>0 && og.Videos[len(og.Videos)-1].draft {
 			og.Videos[len(og.Videos)-1].URL = metaAttrs["content"]
 			og.Videos[len(og.Videos)-1].draft = false
 		} else {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/dsnet/compress/internal/errors
 github.com/dsnet/compress/internal/prefix
 # github.com/dustin/go-humanize v1.0.0
 github.com/dustin/go-humanize
-# github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09 => github.com/agnivade/go-opengraph v0.0.0-20201221052033-34e69ee2a627
+# github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
 ## explicit
 github.com/dyatlov/go-opengraph/opengraph
 # github.com/fatih/color v1.12.0
@@ -955,4 +955,3 @@ willnorris.com/go/gifresize
 ## explicit
 willnorris.com/go/imageproxy
 willnorris.com/go/imageproxy/third_party/http
-# github.com/dyatlov/go-opengraph => github.com/agnivade/go-opengraph v0.0.0-20201221052033-34e69ee2a627


### PR DESCRIPTION
The PR is now merged with the original repo, so we can remove
the temporary replace.

https://focalboard-community.octo.mattermost.com/workspace/zyoahc9uapdn3xdptac6jb69ic?id=285b80a3-257d-41f6-8cf4-ed80ca9d92e5&v=495cdb4d-c13a-4992-8eb9-80cfee2819a4&c=59af323d-35a7-4312-87a1-e374239a03d9

```release-note
NONE
```
