### PR TITLE
Adding cascade to the permament delete of the bots

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -268,7 +268,7 @@ type AppIface interface {
 	// For internal requests, requests are routed directly to a plugin ServerHTTP hook
 	DoActionRequest(c *request.Context, rawURL string, body []byte) (*http.Response, *model.AppError)
 	// PermanentDeleteBot permanently deletes a bot and its corresponding user.
-	PermanentDeleteBot(botUserId string) *model.AppError
+	PermanentDeleteBot(c *request.Context, botUserId string) *model.AppError
 	// PopulateWebConnConfig checks if the connection id already exists in the hub,
 	// and if so, accordingly populates the other fields of the webconn.
 	PopulateWebConnConfig(s *model.Session, cfg *WebConnConfig, seqVal string) (*WebConnConfig, error)

--- a/app/bot.go
+++ b/app/bot.go
@@ -360,7 +360,7 @@ func (a *App) UpdateBotActive(c *request.Context, botUserId string, active bool)
 }
 
 // PermanentDeleteBot permanently deletes a bot and its corresponding user.
-func (a *App) PermanentDeleteBot(botUserId string) *model.AppError {
+func (a *App) PermanentDeleteBot(c *request.Context, botUserId string) *model.AppError {
 	if err := a.Srv().Store.Bot().PermanentDelete(botUserId); err != nil {
 		var invErr *store.ErrInvalidInput
 		switch {
@@ -371,7 +371,12 @@ func (a *App) PermanentDeleteBot(botUserId string) *model.AppError {
 		}
 	}
 
-	if err := a.Srv().Store.User().PermanentDelete(botUserId); err != nil {
+	user, err := a.GetUser(botUserId)
+	if err != nil {
+		return err
+	}
+
+	if err := a.PermanentDeleteUser(c, user); err != nil {
 		return model.NewAppError("PermanentDeleteBot", "app.user.permanent_delete.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -11933,7 +11933,7 @@ func (a *OpenTracingAppLayer) PermanentDeleteAllUsers(c *request.Context) *model
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) PermanentDeleteBot(botUserId string) *model.AppError {
+func (a *OpenTracingAppLayer) PermanentDeleteBot(c *request.Context, botUserId string) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.PermanentDeleteBot")
 
@@ -11945,7 +11945,7 @@ func (a *OpenTracingAppLayer) PermanentDeleteBot(botUserId string) *model.AppErr
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.PermanentDeleteBot(botUserId)
+	resultVar0 := a.app.PermanentDeleteBot(c, botUserId)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -924,7 +924,7 @@ func (api *PluginAPI) UpdateBotActive(userID string, active bool) (*model.Bot, *
 }
 
 func (api *PluginAPI) PermanentDeleteBot(userID string) *model.AppError {
-	return api.app.PermanentDeleteBot(userID)
+	return api.app.PermanentDeleteBot(api.ctx, userID)
 }
 
 func (api *PluginAPI) GetBotIconImage(userID string) ([]byte, *model.AppError) {

--- a/cmd/mattermost/commands/user.go
+++ b/cmd/mattermost/commands/user.go
@@ -773,7 +773,7 @@ func deleteUserCmdF(command *cobra.Command, args []string) error {
 		}
 
 		if user.IsBot {
-			if err := a.PermanentDeleteBot(user.Id); err != nil {
+			if err := a.PermanentDeleteBot(&request.Context{}, user.Id); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
#### Summary
The bot permanent deletion was deleting the `Bot` object from the database and
the `User` object from the database. That is wrong because the database gets
into an incosistent state where the user data exists all over the app, but the
user model itself is deleted.

For example, If you peramnently delete a bot that belongs to channels, that
channel/team memberships are going to be there but the user is not going to be
avaialble, that, for example, generate problems on LDAP group sync.

#### Ticket Link
[MM-36817](https://mattermost.atlassian.net/browse/MM-36817)

#### Release Note
```release-note
NONE
```