### PR TITLE
Consider empty body before unmarshal on do post action

### DIFF
--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -250,7 +249,7 @@ func (a *App) DoPostActionWithCookie(c *request.Context, postID, actionId, userI
 	defer resp.Body.Close()
 
 	var response model.PostActionIntegrationResponse
-	respBytes, err := io.ReadAll(resp.Body)
+	respBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", model.NewAppError("DoPostActionWithCookie", "api.post.do_action.action_integration.app_error", nil, "err="+err.Error(), http.StatusBadRequest)
 	}

--- a/app/integration_action.go
+++ b/app/integration_action.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -249,8 +250,15 @@ func (a *App) DoPostActionWithCookie(c *request.Context, postID, actionId, userI
 	defer resp.Body.Close()
 
 	var response model.PostActionIntegrationResponse
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
 		return "", model.NewAppError("DoPostActionWithCookie", "api.post.do_action.action_integration.app_error", nil, "err="+err.Error(), http.StatusBadRequest)
+	}
+
+	if len(respBytes) > 0 {
+		if err = json.Unmarshal(respBytes, &response); err != nil {
+			return "", model.NewAppError("DoPostActionWithCookie", "api.post.do_action.action_integration.app_error", nil, "err="+err.Error(), http.StatusBadRequest)
+		}
 	}
 
 	if response.Update != nil {

--- a/app/integration_action_test.go
+++ b/app/integration_action_test.go
@@ -69,6 +69,59 @@ func TestPostActionInvalidURL(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), "missing protocol scheme"))
 }
 
+func TestPostActionEmptyResponse(t *testing.T) {
+	t.Run("Empty response on post action", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
+		channel := th.BasicChannel
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost,127.0.0.1"
+		})
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer ts.Close()
+
+		interactivePost := model.Post{
+			Message:       "Interactive post",
+			ChannelId:     channel.Id,
+			PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+			UserId:        th.BasicUser.Id,
+			Props: model.StringInterface{
+				"attachments": []*model.SlackAttachment{
+					{
+						Text: "hello",
+						Actions: []*model.PostAction{
+							{
+								Integration: &model.PostActionIntegration{
+									Context: model.StringInterface{
+										"s": "foo",
+										"n": 3,
+									},
+									URL: ts.URL,
+								},
+								Name:       "action",
+								Type:       "some_type",
+								DataSource: "some_source",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		post, err := th.App.CreatePostAsUser(th.Context, &interactivePost, "", true)
+		require.NoError(t, err)
+
+		attachments, ok := post.GetProp("attachments").([]*model.SlackAttachment)
+		require.True(t, ok)
+
+		_, err = th.App.DoPostAction(th.Context, post.Id, attachments[0].Actions[0].Id, th.BasicUser.Id, "")
+		require.NoError(t, err)
+	})
+}
+
 func TestPostAction(t *testing.T) {
 	testCases := []struct {
 		Description string

--- a/app/integration_action_test.go
+++ b/app/integration_action_test.go
@@ -112,13 +112,13 @@ func TestPostActionEmptyResponse(t *testing.T) {
 		}
 
 		post, err := th.App.CreatePostAsUser(th.Context, &interactivePost, "", true)
-		require.NoError(t, err)
+		require.Nil(t, err)
 
 		attachments, ok := post.GetProp("attachments").([]*model.SlackAttachment)
 		require.True(t, ok)
 
 		_, err = th.App.DoPostAction(th.Context, post.Id, attachments[0].Actions[0].Id, th.BasicUser.Id, "")
-		require.NoError(t, err)
+		require.Nil(t, err)
 	})
 }
 


### PR DESCRIPTION
#### Summary
Consider an empty body in the doPostAction function before doing the unmarshalling.

If we don't do this, an empty response (which is common) will make this function error out after creating the trigger ID and sending it to the integration.
A subsequent call to openDialog will not fail because the trigger ID exist in the server, but the trigger ID has not been passed over to the client (because the function error out). Therefore, openDialog says that everything is fine, but no dialog is shown in the client.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36757

#### Release Note
```release-note
Fix bug when opening a dialog from an interactive message when returning an empty response
```
