### PR TITLE
MM-36894: Racy test: TestExecuteCommandInDirectMessageChannel

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -371,7 +371,6 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 					replyToThreadType = model.COMMENTS_NOTIFY_ROOT
 				}
 
-				notification.Post = notification.Post.Clone()
 				a.sendPushNotification(
 					notification,
 					profileMap[id],
@@ -404,7 +403,6 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 				}
 
 				if ShouldSendPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], false, status, post) {
-					notification.Post = notification.Post.Clone()
 					a.sendPushNotification(
 						notification,
 						profileMap[id],

--- a/app/notification.go
+++ b/app/notification.go
@@ -371,6 +371,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 					replyToThreadType = model.COMMENTS_NOTIFY_ROOT
 				}
 
+				notification.Post = notification.Post.Clone()
 				a.sendPushNotification(
 					notification,
 					profileMap[id],
@@ -403,6 +404,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 				}
 
 				if ShouldSendPushNotification(profileMap[id], channelMemberNotifyPropsMap[id], false, status, post) {
+					notification.Post = notification.Post.Clone()
 					a.sendPushNotification(
 						notification,
 						profileMap[id],

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -56,12 +56,6 @@ type PushNotification struct {
 func (a *App) sendPushNotificationSync(post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
 	explicitMention bool, channelWideMention bool, replyToThreadType string) *model.AppError {
 	cfg := a.Config()
-	message, err := utils.StripMarkdown(post.Message)
-	if err != nil {
-		mlog.Warn("Failed parse to markdown", mlog.String("post_id", post.Id), mlog.Err(err))
-	} else {
-		post.Message = message
-	}
 	msg, appErr := a.BuildPushNotificationMessage(
 		*cfg.EmailSettings.PushNotificationContents,
 		post,
@@ -585,6 +579,12 @@ func (a *App) buildFullPushNotificationMessage(contentsConfig string, post *mode
 	}
 
 	postMessage := post.Message
+	stripped, err := utils.StripMarkdown(postMessage)
+	if err != nil {
+		mlog.Warn("Failed parse to markdown", mlog.String("post_id", post.Id), mlog.Err(err))
+	} else {
+		postMessage = stripped
+	}
 	for _, attachment := range post.Attachments() {
 		if attachment.Fallback != "" {
 			postMessage += "\n" + attachment.Fallback


### PR DESCRIPTION
We were using the pointer to the same post object
in multiple push notifications because we were sending
it in a loop of mentioned user list.

This wasn't an issue so far, but after we started to parse
markdown in the push notification flow, we started to edit
the post struct as well.

To fix this, we move the markdown parsing deep into the push notification
construction such that we don't need to write back to the same post pointer
again.

https://mattermost.atlassian.net/browse/MM-36894

```release-note
NONE
```
