### PR TITLE
[MM-27593] s/AllExecutables/Executables/

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -196,21 +196,9 @@ type Manifest struct {
 }
 
 type ManifestServer struct {
-	// AllExecutables are the paths to your executable binaries, specifying multiple entry
+	// Executables are the paths to your executable binaries, specifying multiple entry
 	// points for different platforms when bundled together in a single plugin.
-	AllExecutables map[string]string `json:"executables,omitempty" yaml:"executables,omitempty"`
-
-	// Executables is a legacy field populated with a subset of supported platform executables.
-	// When unmarshalling, Executables is authoritative for the platform executable paths it
-	// contains, overriding any values in AllExecutables. When marshalling, AllExecutables
-	// is authoritative.
-	//
-	// Code duplication is avoided when (un)marshalling by leveraging type aliases in the
-	// various (Un)Marshal(JSON|YAML) methods, since aliases don't inherit the aliased type's
-	// methods.
-	//
-	// In v6.0, we should remove this field and rename AllExecutables back to Executables.
-	Executables *ManifestExecutables `json:"-" yaml:"-"`
+	Executables map[string]string `json:"executables,omitempty" yaml:"executables,omitempty"`
 
 	// Executable is the path to your executable binary. This should be relative to the root
 	// of your bundle and the location of the manifest file.
@@ -220,78 +208,6 @@ type ManifestServer struct {
 	// If your plugin is compiled for multiple platforms, consider bundling them together
 	// and using the Executables field instead.
 	Executable string `json:"executable" yaml:"executable"`
-}
-
-func (ms *ManifestServer) MarshalJSON() ([]byte, error) {
-	type auxManifestServer ManifestServer
-
-	// Populate AllExecutables from Executables, if it exists.
-	if ms.Executables != nil {
-		if ms.AllExecutables == nil {
-			ms.AllExecutables = make(map[string]string)
-		}
-
-		ms.AllExecutables["linux-amd64"] = ms.Executables.LinuxAmd64
-		ms.AllExecutables["darwin-amd64"] = ms.Executables.DarwinAmd64
-		ms.AllExecutables["windows-amd64"] = ms.Executables.WindowsAmd64
-	}
-
-	return json.Marshal((*auxManifestServer)(ms))
-}
-
-func (ms *ManifestServer) UnmarshalJSON(data []byte) error {
-	type auxManifestServer ManifestServer
-
-	aux := (*auxManifestServer)(ms)
-	if err := json.Unmarshal(data, aux); err != nil {
-		return err
-	}
-
-	if len(aux.AllExecutables) > 0 {
-		ms.Executables = &ManifestExecutables{
-			LinuxAmd64:   aux.AllExecutables["linux-amd64"],
-			DarwinAmd64:  aux.AllExecutables["darwin-amd64"],
-			WindowsAmd64: aux.AllExecutables["windows-amd64"],
-		}
-	}
-
-	return nil
-}
-
-func (ms *ManifestServer) MarshalYAML() ([]byte, error) {
-	type auxManifestServer ManifestServer
-
-	// Populate AllExecutables from Executables, if it exists.
-	if ms.Executables != nil {
-		if ms.AllExecutables == nil {
-			ms.AllExecutables = make(map[string]string)
-		}
-
-		ms.AllExecutables["linux-amd64"] = ms.Executables.LinuxAmd64
-		ms.AllExecutables["darwin-amd64"] = ms.Executables.DarwinAmd64
-		ms.AllExecutables["windows-amd64"] = ms.Executables.WindowsAmd64
-	}
-
-	return yaml.Marshal((*auxManifestServer)(ms))
-}
-
-func (ms *ManifestServer) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type auxManifestServer ManifestServer
-
-	aux := (*auxManifestServer)(ms)
-	if err := unmarshal(&aux); err != nil {
-		return err
-	}
-
-	if len(aux.AllExecutables) > 0 {
-		ms.Executables = &ManifestExecutables{
-			LinuxAmd64:   aux.AllExecutables["linux-amd64"],
-			DarwinAmd64:  aux.AllExecutables["darwin-amd64"],
-			WindowsAmd64: aux.AllExecutables["windows-amd64"],
-		}
-	}
-
-	return nil
 }
 
 // ManifestExecutables is a legacy structure capturing a subet of the known platform executables.
@@ -372,9 +288,9 @@ func (m *Manifest) GetExecutableForRuntime(goOs, goArch string) string {
 	}
 
 	var executable string
-	if len(server.AllExecutables) > 0 {
+	if len(server.Executables) > 0 {
 		osArch := fmt.Sprintf("%s-%s", goOs, goArch)
-		executable = server.AllExecutables[osArch]
+		executable = server.Executables[osArch]
 	}
 
 	if executable == "" {

--- a/model/manifest_test.go
+++ b/model/manifest_test.go
@@ -280,12 +280,7 @@ func TestManifestUnmarshal(t *testing.T) {
 		MinServerVersion: "5.6.0",
 		Server: &ManifestServer{
 			Executable: "theexecutable",
-			Executables: &ManifestExecutables{
-				LinuxAmd64:   "theexecutable-linux-amd64",
-				DarwinAmd64:  "theexecutable-darwin-amd64",
-				WindowsAmd64: "theexecutable-windows-amd64",
-			},
-			AllExecutables: map[string]string{
+			Executables: map[string]string{
 				"linux-amd64":   "theexecutable-linux-amd64",
 				"darwin-amd64":  "theexecutable-darwin-amd64",
 				"windows-amd64": "theexecutable-windows-amd64",
@@ -446,12 +441,7 @@ func TestManifestJson(t *testing.T) {
 		Id: "theid",
 		Server: &ManifestServer{
 			Executable: "theexecutable",
-			Executables: &ManifestExecutables{
-				LinuxAmd64:   "linux-amd64/path/to/executable",
-				DarwinAmd64:  "darwin-amd64/path/to/executable",
-				WindowsAmd64: "windows-amd64/path/to/executable",
-			},
-			AllExecutables: map[string]string{
+			Executables: map[string]string{
 				"linux-amd64":   "linux-amd64/path/to/executable",
 				"darwin-amd64":  "darwin-amd64/path/to/executable",
 				"windows-amd64": "windows-amd64/path/to/executable",
@@ -620,25 +610,10 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"path/to/executable",
 		},
 		{
-			"multiple legacy executables ignored",
-			&Manifest{
-				Server: &ManifestServer{
-					Executables: &ManifestExecutables{
-						LinuxAmd64:   "linux-amd64/path/to/executable",
-						DarwinAmd64:  "darwin-amd64/path/to/executable",
-						WindowsAmd64: "windows-amd64/path/to/executable",
-					},
-				},
-			},
-			"linux",
-			"amd64",
-			"",
-		},
-		{
 			"multiple executables, no match",
 			&Manifest{
 				Server: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -654,7 +629,7 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"multiple executables, linux-amd64 match",
 			&Manifest{
 				Server: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -670,7 +645,7 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"multiple executables, linux-amd64 match, single executable ignored",
 			&Manifest{
 				Server: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -687,7 +662,7 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"multiple executables, darwin-amd64 match",
 			&Manifest{
 				Server: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -703,7 +678,7 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"multiple executables, windows-amd64 match",
 			&Manifest{
 				Server: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -719,7 +694,7 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"multiple executables, no match, single executable fallback",
 			&Manifest{
 				Server: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -736,7 +711,7 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"deprecated backend field, ignored since server present",
 			&Manifest{
 				Server: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -744,7 +719,7 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 					},
 				},
 				Backend: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
@@ -759,52 +734,10 @@ func TestManifestGetExecutableForRuntime(t *testing.T) {
 			"deprecated backend field used, since no server present",
 			&Manifest{
 				Backend: &ManifestServer{
-					AllExecutables: map[string]string{
+					Executables: map[string]string{
 						"linux-amd64":   "linux-amd64/path/to/executable",
 						"darwin-amd64":  "darwin-amd64/path/to/executable",
 						"windows-amd64": "windows-amd64/path/to/executable",
-					},
-				},
-			},
-			"linux",
-			"amd64",
-			"linux-amd64/path/to/executable",
-		},
-		{
-			"all executables, linux-arm64",
-			&Manifest{
-				Backend: &ManifestServer{
-					Executables: &ManifestExecutables{
-						LinuxAmd64:   "linux-amd64/path/to/executable",
-						DarwinAmd64:  "darwin-amd64/path/to/executable",
-						WindowsAmd64: "windows-amd64/path/to/executable",
-					},
-					AllExecutables: map[string]string{
-						"linux-amd64":   "linux-amd64/path/to/executable",
-						"darwin-amd64":  "darwin-amd64/path/to/executable",
-						"windows-amd64": "windows-amd64/path/to/executable",
-						"linux-arm64":   "linux-arm64/path/to/executable",
-					},
-				},
-			},
-			"linux",
-			"arm64",
-			"linux-arm64/path/to/executable",
-		},
-		{
-			"all executables, linux-amd64, legacy executables ignored",
-			&Manifest{
-				Backend: &ManifestServer{
-					Executables: &ManifestExecutables{
-						LinuxAmd64:   "linux-amd64/ignored/path/to/executable",
-						DarwinAmd64:  "darwin-amd64/ignored/path/to/executable",
-						WindowsAmd64: "windows-amd64/ignored/path/to/executable",
-					},
-					AllExecutables: map[string]string{
-						"linux-amd64":   "linux-amd64/path/to/executable",
-						"darwin-amd64":  "darwin-amd64/path/to/executable",
-						"windows-amd64": "windows-amd64/path/to/executable",
-						"linux-arm64":   "linux-arm64/path/to/executable",
 					},
 				},
 			},
@@ -856,10 +789,10 @@ func TestManifestHasServer(t *testing.T) {
 			"multiple executables",
 			&Manifest{
 				Server: &ManifestServer{
-					Executables: &ManifestExecutables{
-						LinuxAmd64:   "linux-amd64/path/to/executable",
-						DarwinAmd64:  "darwin-amd64/path/to/executable",
-						WindowsAmd64: "windows-amd64/path/to/executable",
+					Executables: map[string]string{
+						"linux-amd64":   "linux-amd64/path/to/executable",
+						"darwin-amd64":  "darwin-amd64/path/to/executable",
+						"windows-amd64": "windows-amd64/path/to/executable",
 					},
 				},
 			},
@@ -878,10 +811,10 @@ func TestManifestHasServer(t *testing.T) {
 			"multiple executables defined via deprecated backend",
 			&Manifest{
 				Backend: &ManifestServer{
-					Executables: &ManifestExecutables{
-						LinuxAmd64:   "linux-amd64/path/to/executable",
-						DarwinAmd64:  "darwin-amd64/path/to/executable",
-						WindowsAmd64: "windows-amd64/path/to/executable",
+					Executables: map[string]string{
+						"linux-amd64":   "linux-amd64/path/to/executable",
+						"darwin-amd64":  "darwin-amd64/path/to/executable",
+						"windows-amd64": "windows-amd64/path/to/executable",
 					},
 				},
 			},


### PR DESCRIPTION
#### Summary
This PR replaces the field `Executables` with a `map[string]string`, which can only any combination of platform and executable path. You can find more about this field in https://github.com/mattermost/mattermost-server/pull/14682.

Existing plugin are not affected by this change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27593

#### Release Note
```release-note
Convert Executables field in plugin manifest to map
```
