### PR TITLE
[M-36899] Remove deprecated SourcePluginId

### DIFF
--- a/app/plugin_requests.go
+++ b/app/plugin_requests.go
@@ -69,9 +69,8 @@ func (a *App) ServeInterPluginRequest(w http.ResponseWriter, r *http.Request, so
 	}
 
 	context := &plugin.Context{
-		RequestId:      model.NewId(),
-		UserAgent:      r.UserAgent(),
-		SourcePluginId: sourcePluginId,
+		RequestId: model.NewId(),
+		UserAgent: r.UserAgent(),
 	}
 
 	r.Header.Set("Mattermost-Plugin-ID", sourcePluginId)

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -12,5 +12,4 @@ type Context struct {
 	IpAddress      string
 	AcceptLanguage string
 	UserAgent      string
-	SourcePluginId string // Deprecated: Use the "Mattermost-Plugin-ID" HTTP header instead
 }


### PR DESCRIPTION
#### Summary
Plugin should rely on the `Mattermost-Plugin-ID` header as this makes the HTTP handling more uniform. `Context.SourcePluginId` was already deprecated and this PR removes it.

The only Mattermost affected by this is Workflow. I'm not sure if it's worth fixing it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36899

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Remove deprecated Context.SourcePluginId field.
```
