### PR TITLE
Reliable Websockets: default to true

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -823,7 +823,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.EnableReliableWebSockets == nil {
-		s.EnableReliableWebSockets = NewBool(false)
+		s.EnableReliableWebSockets = NewBool(true)
 	}
 }
 


### PR DESCRIPTION
```release-note
The config setting EnableReliableWebSockets now defaults to true.
```
