### PR TITLE
PreferenceStore: Use native upsert for Postgres

### DIFF
--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -4,8 +4,6 @@
 package sqlstore
 
 import (
-	"fmt"
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/mattermost/gorp"
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -102,25 +100,6 @@ func (s SqlPreferenceStore) save(transaction *gorp.Transaction, preference *mode
 	if _, err = transaction.Exec(queryString, args...); err != nil {
 		return errors.Wrap(err, "failed to save Preference")
 	}
-	return nil
-}
-
-func (s SqlPreferenceStore) insert(transaction *gorp.Transaction, preference *model.Preference) error {
-	if err := transaction.Insert(preference); err != nil {
-		if IsUniqueConstraintError(err, []string{"UserId", "preferences_pkey"}) {
-			return store.NewErrInvalidInput("Preference", "<userId, category, name>", fmt.Sprintf("<%s, %s, %s>", preference.UserId, preference.Category, preference.Name))
-		}
-		return errors.Wrapf(err, "failed to save Preference with userId=%s, category=%s, name=%s", preference.UserId, preference.Category, preference.Name)
-	}
-
-	return nil
-}
-
-func (s SqlPreferenceStore) update(transaction *gorp.Transaction, preference *model.Preference) error {
-	if _, err := transaction.Update(preference); err != nil {
-		return errors.Wrapf(err, "failed to update Preference with userId=%s, category=%s, name=%s", preference.UserId, preference.Category, preference.Name)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Now that version 10 is minimum, we can start to use
advanced postgres features.

https://focalboard-community.octo.mattermost.com/workspace/zyoahc9uapdn3xdptac6jb69ic?id=285b80a3-257d-41f6-8cf4-ed80ca9d92e5&v=495cdb4d-c13a-4992-8eb9-80cfee2819a4&c=0445b560-91b9-469b-8f19-febf1881bcd6

```release-note
NONE
```
