### PR TITLE
MM-36947: Fix TestHeaderProviderDoCommand

### DIFF
--- a/app/slashcommands/helper_test.go
+++ b/app/slashcommands/helper_test.go
@@ -55,6 +55,7 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 	}
 	*config.PluginSettings.Directory = filepath.Join(tempWorkspace, "plugins")
 	*config.PluginSettings.ClientDirectory = filepath.Join(tempWorkspace, "webapp")
+	*config.PluginSettings.AutomaticPrepackagedPlugins = false
 	*config.LogSettings.EnableSentry = false // disable error reporting during tests
 	memoryStore.Set(config)
 
@@ -133,7 +134,6 @@ func setup(tb testing.TB) *TestHelper {
 	if testing.Short() {
 		tb.SkipNow()
 	}
-	tb.Skip("MM-36947")
 	dbStore := mainHelper.GetStore()
 	dbStore.DropAllTables()
 	dbStore.MarkSystemRanUnitTests()


### PR DESCRIPTION
Setting AutomaticPrepackagedPlugins to true was making the test
to download the plugin from the marketplace and initialize it.

While this wasn't wrong in itself but that's not what the test does
and just part of the app initialization and it unnecessarily slowed
down the test by downloading the plugin zip file.

And initializing a plugin from inside a test has some issues
to work properly. While those could be solved, a cleaner way
is to just not download the plugin at all.

https://mattermost.atlassian.net/browse/MM-36947

```release-note
NONE
```

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->
```
