### PR TITLE
MM-21333: Unexport fields in WebSocketEvent

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2501,8 +2501,8 @@ func TestUpdateChannelMemberSchemeRoles(t *testing.T) {
 	for waiting {
 		select {
 		case event := <-WebSocketClient.EventChannel:
-			if event.Event == model.WebsocketEventChannelMemberUpdated {
-				require.Equal(t, model.WebsocketEventChannelMemberUpdated, event.Event)
+			if event.EventType() == model.WebsocketEventChannelMemberUpdated {
+				require.Equal(t, model.WebsocketEventChannelMemberUpdated, event.EventType())
 				waiting = false
 			}
 		case <-timeout:

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -167,8 +167,8 @@ func TestCreatePost(t *testing.T) {
 		for eventsToGo > 0 {
 			select {
 			case event := <-WebSocketClient.EventChannel:
-				if event.Event == model.WebsocketEventEphemeralMessage {
-					require.Equal(t, model.WebsocketEventEphemeralMessage, event.Event)
+				if event.EventType() == model.WebsocketEventEphemeralMessage {
+					require.Equal(t, model.WebsocketEventEphemeralMessage, event.EventType())
 					eventsToGo = eventsToGo - 1
 				}
 			case <-timeout:

--- a/app/web_conn_test.go
+++ b/app/web_conn_test.go
@@ -256,7 +256,7 @@ func TestWebConnDrainDeadQueue(t *testing.T) {
 				_, buf, err = conn.ReadMessage()
 				ev := model.WebSocketEventFromJson(bytes.NewReader(buf))
 				require.LessOrEqual(t, int(i), limit)
-				assert.Equal(t, i, ev.Sequence)
+				assert.Equal(t, i, ev.GetSequence())
 				i++
 			}
 			if _, ok := err.(*websocket.CloseError); !ok {

--- a/model/websocket_message_test.go
+++ b/model/websocket_message_test.go
@@ -35,26 +35,23 @@ func TestWebSocketEventImmutable(t *testing.T) {
 	if new == m {
 		require.Fail(t, "pointers should not be the same")
 	}
-	require.NotEqual(t, m.Event, new.Event)
-	require.Equal(t, new.Event, "new_event")
-	require.Equal(t, new.Event, new.EventType())
+	require.NotEqual(t, m.EventType(), new.EventType())
+	require.Equal(t, new.EventType(), "new_event")
 
 	new = m.SetSequence(45)
 	if new == m {
 		require.Fail(t, "pointers should not be the same")
 	}
-	require.NotEqual(t, m.Sequence, new.Sequence)
-	require.Equal(t, new.Sequence, int64(45))
-	require.Equal(t, new.Sequence, new.GetSequence())
+	require.NotEqual(t, m.GetSequence(), new.GetSequence())
+	require.Equal(t, new.GetSequence(), int64(45))
 
 	broadcast := &WebsocketBroadcast{}
 	new = m.SetBroadcast(broadcast)
 	if new == m {
 		require.Fail(t, "pointers should not be the same")
 	}
-	require.NotEqual(t, m.Broadcast, new.Broadcast)
-	require.Equal(t, new.Broadcast, broadcast)
-	require.Equal(t, new.Broadcast, new.GetBroadcast())
+	require.NotEqual(t, m.GetBroadcast(), new.GetBroadcast())
+	require.Equal(t, new.GetBroadcast(), broadcast)
 
 	data := map[string]interface{}{
 		"key":  "val",
@@ -65,8 +62,8 @@ func TestWebSocketEventImmutable(t *testing.T) {
 		require.Fail(t, "pointers should not be the same")
 	}
 	require.NotEqual(t, m, new)
-	require.Equal(t, new.Data, data)
-	require.Equal(t, new.Data, new.GetData())
+	require.Equal(t, new.data, data)
+	require.Equal(t, new.data, new.GetData())
 
 	copy := m.Copy()
 	if copy == m {
@@ -81,10 +78,10 @@ func TestWebSocketEventFromJson(t *testing.T) {
 	data := `{"event": "test", "data": {"key": "val"}, "seq": 45, "broadcast": {"user_id": "userid"}}`
 	ev = WebSocketEventFromJson(strings.NewReader(data))
 	require.NotNil(t, ev, "should have parsed")
-	require.Equal(t, ev.Event, "test")
-	require.Equal(t, ev.Sequence, int64(45))
-	require.Equal(t, ev.Data, map[string]interface{}{"key": "val"})
-	require.Equal(t, ev.Broadcast, &WebsocketBroadcast{UserId: "userid"})
+	require.Equal(t, ev.EventType(), "test")
+	require.Equal(t, ev.GetSequence(), int64(45))
+	require.Equal(t, ev.data, map[string]interface{}{"key": "val"})
+	require.Equal(t, ev.GetBroadcast(), &WebsocketBroadcast{UserId: "userid"})
 }
 
 func TestWebSocketResponse(t *testing.T) {


### PR DESCRIPTION
```release-note
All fields in WebSocketEvent are now unexported. Use the getter methods
to access them.
```

https://mattermost.atlassian.net/browse/MM-21333
