### PR TITLE
MM-21357: Use typed constants for PreferenceCategory 

### DIFF
--- a/api4/preference.go
+++ b/api4/preference.go
@@ -49,7 +49,7 @@ func getPreferencesByCategory(c *Context, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	preferences, err := c.App.GetPreferenceByCategoryForUser(c.Params.UserId, c.Params.Category)
+	preferences, err := c.App.GetPreferenceByCategoryForUser(c.Params.UserId, model.PreferenceCategory(c.Params.Category))
 	if err != nil {
 		c.Err = err
 		return
@@ -69,7 +69,7 @@ func getPreferenceByCategoryAndName(c *Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	preferences, err := c.App.GetPreferenceByCategoryAndNameForUser(c.Params.UserId, c.Params.Category, c.Params.PreferenceName)
+	preferences, err := c.App.GetPreferenceByCategoryAndNameForUser(c.Params.UserId, model.PreferenceCategory(c.Params.Category), c.Params.PreferenceName)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/preference_test.go
+++ b/api4/preference_test.go
@@ -25,7 +25,7 @@ func TestGetPreferences(t *testing.T) {
 
 	user1 := th.BasicUser
 
-	category := model.NewId()
+	category := model.PreferenceCategory(model.NewId())
 	preferences1 := model.Preferences{
 		{
 			UserId:   user1.Id,
@@ -39,7 +39,7 @@ func TestGetPreferences(t *testing.T) {
 		},
 		{
 			UserId:   user1.Id,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     model.NewId(),
 		},
 	}
@@ -79,7 +79,7 @@ func TestGetPreferencesByCategory(t *testing.T) {
 	th.LoginBasic()
 	user1 := th.BasicUser
 
-	category := model.NewId()
+	category := model.PreferenceCategory(model.NewId())
 	preferences1 := model.Preferences{
 		{
 			UserId:   user1.Id,
@@ -93,7 +93,7 @@ func TestGetPreferencesByCategory(t *testing.T) {
 		},
 		{
 			UserId:   user1.Id,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     model.NewId(),
 		},
 	}
@@ -189,7 +189,7 @@ func TestUpdatePreferences(t *testing.T) {
 	th.LoginBasic()
 	user1 := th.BasicUser
 
-	category := model.NewId()
+	category := model.PreferenceCategory(model.NewId())
 	preferences1 := model.Preferences{
 		{
 			UserId:   user1.Id,
@@ -203,7 +203,7 @@ func TestUpdatePreferences(t *testing.T) {
 		},
 		{
 			UserId:   user1.Id,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     model.NewId(),
 		},
 	}
@@ -256,12 +256,12 @@ func TestUpdatePreferencesWebsocket(t *testing.T) {
 	preferences := &model.Preferences{
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     model.NewId(),
 		},
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     model.NewId(),
 		},
 	}
@@ -576,12 +576,12 @@ func TestDeletePreferencesWebsocket(t *testing.T) {
 	preferences := &model.Preferences{
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     model.NewId(),
 		},
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     model.NewId(),
 		},
 	}

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -695,8 +695,8 @@ type AppIface interface {
 	GetPostsForChannelAroundLastUnread(channelID, userID string, limitBefore, limitAfter int, skipFetchThreads bool, collapsedThreads, collapsedThreadsExtended bool) (*model.PostList, *model.AppError)
 	GetPostsPage(options model.GetPostsOptions) (*model.PostList, *model.AppError)
 	GetPostsSince(options model.GetPostsSinceOptions) (*model.PostList, *model.AppError)
-	GetPreferenceByCategoryAndNameForUser(userID string, category string, preferenceName string) (*model.Preference, *model.AppError)
-	GetPreferenceByCategoryForUser(userID string, category string) (model.Preferences, *model.AppError)
+	GetPreferenceByCategoryAndNameForUser(userID string, category model.PreferenceCategory, preferenceName string) (*model.Preference, *model.AppError)
+	GetPreferenceByCategoryForUser(userID string, category model.PreferenceCategory) (model.Preferences, *model.AppError)
 	GetPreferencesForUser(userID string) (model.Preferences, *model.AppError)
 	GetPrevPostIdFromPostList(postList *model.PostList, collapsedThreads bool) string
 	GetPrivateChannelsForTeam(teamID string, offset int, limit int) (*model.ChannelList, *model.AppError)

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -36,7 +36,7 @@ func ptrBool(b bool) *bool {
 	return &b
 }
 
-func checkPreference(t *testing.T, a *App, userID string, category string, name string, value string) {
+func checkPreference(t *testing.T, a *App, userID string, category model.PreferenceCategory, name string, value string) {
 	preferences, err := a.Srv().Store.Preference().GetCategory(userID, category)
 	require.NoErrorf(t, err, "Failed to get preferences for user %v with category %v", userID, category)
 	found := false

--- a/app/import_types.go
+++ b/app/import_types.go
@@ -202,6 +202,6 @@ type AttachmentImportData struct {
 }
 
 type ComparablePreference struct {
-	Category string
+	Category model.PreferenceCategory
 	Name     string
 }

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -7640,7 +7640,7 @@ func (a *OpenTracingAppLayer) GetPostsSince(options model.GetPostsSinceOptions) 
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetPreferenceByCategoryAndNameForUser(userID string, category string, preferenceName string) (*model.Preference, *model.AppError) {
+func (a *OpenTracingAppLayer) GetPreferenceByCategoryAndNameForUser(userID string, category model.PreferenceCategory, preferenceName string) (*model.Preference, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetPreferenceByCategoryAndNameForUser")
 
@@ -7662,7 +7662,7 @@ func (a *OpenTracingAppLayer) GetPreferenceByCategoryAndNameForUser(userID strin
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetPreferenceByCategoryForUser(userID string, category string) (model.Preferences, *model.AppError) {
+func (a *OpenTracingAppLayer) GetPreferenceByCategoryForUser(userID string, category model.PreferenceCategory) (model.Preferences, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetPreferenceByCategoryForUser")
 

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -272,7 +272,7 @@ func TestPluginAPIUpdateUserPreferences(t *testing.T) {
 	require.Nil(t, err)
 
 	assert.Equal(t, 2, len(preferences))
-	expectedCategories := []string{model.PreferenceCategoryTutorialSteps, model.PreferenceCategoryTheme}
+	expectedCategories := []model.PreferenceCategory{model.PreferenceCategoryTutorialSteps, model.PreferenceCategoryTheme}
 	for _, pref := range preferences {
 		assert.Contains(t, expectedCategories, pref.Category)
 		assert.Equal(t, user1.Id, pref.UserId)

--- a/app/preference.go
+++ b/app/preference.go
@@ -18,7 +18,7 @@ func (a *App) GetPreferencesForUser(userID string) (model.Preferences, *model.Ap
 	return preferences, nil
 }
 
-func (a *App) GetPreferenceByCategoryForUser(userID string, category string) (model.Preferences, *model.AppError) {
+func (a *App) GetPreferenceByCategoryForUser(userID string, category model.PreferenceCategory) (model.Preferences, *model.AppError) {
 	preferences, err := a.Srv().Store.Preference().GetCategory(userID, category)
 	if err != nil {
 		return nil, model.NewAppError("GetPreferenceByCategoryForUser", "app.preference.get_category.app_error", nil, err.Error(), http.StatusBadRequest)
@@ -30,7 +30,7 @@ func (a *App) GetPreferenceByCategoryForUser(userID string, category string) (mo
 	return preferences, nil
 }
 
-func (a *App) GetPreferenceByCategoryAndNameForUser(userID string, category string, preferenceName string) (*model.Preference, *model.AppError) {
+func (a *App) GetPreferenceByCategoryAndNameForUser(userID string, category model.PreferenceCategory, preferenceName string) (*model.Preference, *model.AppError) {
 	res, err := a.Srv().Store.Preference().Get(userID, category, preferenceName)
 	if err != nil {
 		return nil, model.NewAppError("GetPreferenceByCategoryAndNameForUser", "app.preference.get.app_error", nil, err.Error(), http.StatusBadRequest)

--- a/app/product_notices.go
+++ b/app/product_notices.go
@@ -214,7 +214,7 @@ func validateUserConfigEntry(preferences store.PreferenceStore, userID string, k
 	if _, ok := expectedValue.(string); !ok {
 		return false, errors.New("Invalid format of user config. Value should be string")
 	}
-	pref, err := preferences.Get(userID, parts[0], parts[1])
+	pref, err := preferences.Get(userID, model.PreferenceCategory(parts[0]), parts[1])
 	if err != nil {
 		return false, nil
 	}

--- a/app/team.go
+++ b/app/team.go
@@ -1217,7 +1217,7 @@ func (a *App) RemoveTeamMemberFromTeam(c *request.Context, teamMember *model.Tea
 	}
 
 	// delete the preferences that set the last channel used in the team and other team specific preferences
-	if err := a.Srv().Store.Preference().DeleteCategory(user.Id, teamMember.TeamId); err != nil {
+	if err := a.Srv().Store.Preference().DeleteCategory(user.Id, model.PreferenceCategory(teamMember.TeamId)); err != nil {
 		return model.NewAppError("RemoveTeamMemberFromTeam", "app.preference.delete.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -3791,7 +3791,7 @@ func (c *Client4) DeletePreferences(userId string, preferences *Preferences) (bo
 }
 
 // GetPreferencesByCategory returns the user's preferences from the provided category string.
-func (c *Client4) GetPreferencesByCategory(userId string, category string) (Preferences, *Response) {
+func (c *Client4) GetPreferencesByCategory(userId string, category PreferenceCategory) (Preferences, *Response) {
 	url := fmt.Sprintf(c.GetPreferencesRoute(userId)+"/%s", category)
 	r, err := c.DoApiGet(url, "")
 	if err != nil {
@@ -3803,7 +3803,7 @@ func (c *Client4) GetPreferencesByCategory(userId string, category string) (Pref
 }
 
 // GetPreferenceByCategoryAndName returns the user's preferences from the provided category and preference name string.
-func (c *Client4) GetPreferenceByCategoryAndName(userId string, category string, preferenceName string) (*Preference, *Response) {
+func (c *Client4) GetPreferenceByCategoryAndName(userId string, category PreferenceCategory, preferenceName string) (*Preference, *Response) {
 	url := fmt.Sprintf(c.GetPreferencesRoute(userId)+"/%s/name/%v", category, preferenceName)
 	r, err := c.DoApiGet(url, "")
 	if err != nil {

--- a/model/preference.go
+++ b/model/preference.go
@@ -12,16 +12,19 @@ import (
 	"unicode/utf8"
 )
 
-const (
-	PreferenceCategoryDirectChannelShow = "direct_channel_show"
-	PreferenceCategoryGroupChannelShow  = "group_channel_show"
-	PreferenceCategoryTutorialSteps     = "tutorial_step"
-	PreferenceCategoryAdvancedSettings  = "advanced_settings"
-	PreferenceCategoryFlaggedPost       = "flagged_post"
-	PreferenceCategoryFavoriteChannel   = "favorite_channel"
-	PreferenceCategorySidebarSettings   = "sidebar_settings"
+type PreferenceCategory string
 
-	PreferenceCategoryDisplaySettings     = "display_settings"
+const (
+	PreferenceCategoryDirectChannelShow PreferenceCategory = "direct_channel_show"
+	PreferenceCategoryGroupChannelShow  PreferenceCategory = "group_channel_show"
+	PreferenceCategoryTutorialSteps     PreferenceCategory = "tutorial_step"
+	PreferenceCategoryAdvancedSettings  PreferenceCategory = "advanced_settings"
+	PreferenceCategoryFlaggedPost       PreferenceCategory = "flagged_post"
+	PreferenceCategoryFavoriteChannel   PreferenceCategory = "favorite_channel"
+	PreferenceCategorySidebarSettings   PreferenceCategory = "sidebar_settings"
+
+	PreferenceCategoryDisplaySettings PreferenceCategory = "display_settings"
+
 	PreferenceNameCollapsedThreadsEnabled = "collapsed_reply_threads"
 	PreferenceNameChannelDisplayMode      = "channel_display_mode"
 	PreferenceNameCollapseSetting         = "collapse_previews"
@@ -29,24 +32,27 @@ const (
 	PreferenceNameNameFormat              = "name_format"
 	PreferenceNameUseMilitaryTime         = "use_military_time"
 
-	PreferenceCategoryTheme = "theme"
+	PreferenceCategoryTheme PreferenceCategory = "theme"
 	// the name for theme props is the team id
 
 	PreferenceCategoryAuthorizedOAuthApp = "oauth_app"
 	// the name for oauth_app is the client_id and value is the current scope
 
-	PreferenceCategoryLast    = "last"
+	PreferenceCategoryLast PreferenceCategory = "last"
+
 	PreferenceNameLastChannel = "channel"
 	PreferenceNameLastTeam    = "team"
 
-	PreferenceCategoryCustomStatus          = "custom_status"
+	PreferenceCategoryCustomStatus PreferenceCategory = "custom_status"
+
 	PreferenceNameRecentCustomStatuses      = "recent_custom_statuses"
 	PreferenceNameCustomStatusTutorialState = "custom_status_tutorial_state"
 
 	PreferenceCustomStatusModalViewed = "custom_status_modal_viewed"
 
-	PreferenceCategoryNotifications = "notifications"
-	PreferenceNameEmailInterval     = "email_interval"
+	PreferenceCategoryNotifications PreferenceCategory = "notifications"
+
+	PreferenceNameEmailInterval = "email_interval"
 
 	PreferenceEmailIntervalNoBatchingSeconds = "30"  // the "immediate" setting is actually 30s
 	PreferenceEmailIntervalBatchingSeconds   = "900" // fifteen minutes is 900 seconds
@@ -58,10 +64,10 @@ const (
 )
 
 type Preference struct {
-	UserId   string `json:"user_id"`
-	Category string `json:"category"`
-	Name     string `json:"name"`
-	Value    string `json:"value"`
+	UserId   string             `json:"user_id"`
+	Category PreferenceCategory `json:"category"`
+	Name     string             `json:"name"`
+	Value    string             `json:"value"`
 }
 
 func (o *Preference) ToJson() string {
@@ -81,7 +87,7 @@ func (o *Preference) IsValid() *AppError {
 	}
 
 	if o.Category == "" || len(o.Category) > 32 {
-		return NewAppError("Preference.IsValid", "model.preference.is_valid.category.app_error", nil, "category="+o.Category, http.StatusBadRequest)
+		return NewAppError("Preference.IsValid", "model.preference.is_valid.category.app_error", nil, "category="+string(o.Category), http.StatusBadRequest)
 	}
 
 	if len(o.Name) > 32 {

--- a/model/preference_test.go
+++ b/model/preference_test.go
@@ -23,7 +23,7 @@ func TestPreferenceIsValid(t *testing.T) {
 	preference.UserId = NewId()
 	require.Nil(t, preference.IsValid())
 
-	preference.Category = strings.Repeat("01234567890", 20)
+	preference.Category = PreferenceCategory(strings.Repeat("01234567890", 20))
 	require.NotNil(t, preference.IsValid())
 
 	preference.Category = PreferenceCategoryDirectChannelShow

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -5767,7 +5767,7 @@ func (s *OpenTracingLayerPreferenceStore) CleanupFlagsBatch(limit int64) (int64,
 	return result, err
 }
 
-func (s *OpenTracingLayerPreferenceStore) Delete(userID string, category string, name string) error {
+func (s *OpenTracingLayerPreferenceStore) Delete(userID string, category model.PreferenceCategory, name string) error {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PreferenceStore.Delete")
 	s.Root.Store.SetContext(newCtx)
@@ -5785,7 +5785,7 @@ func (s *OpenTracingLayerPreferenceStore) Delete(userID string, category string,
 	return err
 }
 
-func (s *OpenTracingLayerPreferenceStore) DeleteCategory(userID string, category string) error {
+func (s *OpenTracingLayerPreferenceStore) DeleteCategory(userID string, category model.PreferenceCategory) error {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PreferenceStore.DeleteCategory")
 	s.Root.Store.SetContext(newCtx)
@@ -5803,7 +5803,7 @@ func (s *OpenTracingLayerPreferenceStore) DeleteCategory(userID string, category
 	return err
 }
 
-func (s *OpenTracingLayerPreferenceStore) DeleteCategoryAndName(category string, name string) error {
+func (s *OpenTracingLayerPreferenceStore) DeleteCategoryAndName(category model.PreferenceCategory, name string) error {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PreferenceStore.DeleteCategoryAndName")
 	s.Root.Store.SetContext(newCtx)
@@ -5839,7 +5839,7 @@ func (s *OpenTracingLayerPreferenceStore) DeleteOrphanedRows(limit int) (int64, 
 	return result, err
 }
 
-func (s *OpenTracingLayerPreferenceStore) Get(userID string, category string, name string) (*model.Preference, error) {
+func (s *OpenTracingLayerPreferenceStore) Get(userID string, category model.PreferenceCategory, name string) (*model.Preference, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PreferenceStore.Get")
 	s.Root.Store.SetContext(newCtx)
@@ -5875,7 +5875,7 @@ func (s *OpenTracingLayerPreferenceStore) GetAll(userID string) (model.Preferenc
 	return result, err
 }
 
-func (s *OpenTracingLayerPreferenceStore) GetCategory(userID string, category string) (model.Preferences, error) {
+func (s *OpenTracingLayerPreferenceStore) GetCategory(userID string, category model.PreferenceCategory) (model.Preferences, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "PreferenceStore.GetCategory")
 	s.Root.Store.SetContext(newCtx)

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -6230,7 +6230,7 @@ func (s *RetryLayerPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error
 
 }
 
-func (s *RetryLayerPreferenceStore) Delete(userID string, category string, name string) error {
+func (s *RetryLayerPreferenceStore) Delete(userID string, category model.PreferenceCategory, name string) error {
 
 	tries := 0
 	for {
@@ -6250,7 +6250,7 @@ func (s *RetryLayerPreferenceStore) Delete(userID string, category string, name 
 
 }
 
-func (s *RetryLayerPreferenceStore) DeleteCategory(userID string, category string) error {
+func (s *RetryLayerPreferenceStore) DeleteCategory(userID string, category model.PreferenceCategory) error {
 
 	tries := 0
 	for {
@@ -6270,7 +6270,7 @@ func (s *RetryLayerPreferenceStore) DeleteCategory(userID string, category strin
 
 }
 
-func (s *RetryLayerPreferenceStore) DeleteCategoryAndName(category string, name string) error {
+func (s *RetryLayerPreferenceStore) DeleteCategoryAndName(category model.PreferenceCategory, name string) error {
 
 	tries := 0
 	for {
@@ -6310,7 +6310,7 @@ func (s *RetryLayerPreferenceStore) DeleteOrphanedRows(limit int) (int64, error)
 
 }
 
-func (s *RetryLayerPreferenceStore) Get(userID string, category string, name string) (*model.Preference, error) {
+func (s *RetryLayerPreferenceStore) Get(userID string, category model.PreferenceCategory, name string) (*model.Preference, error) {
 
 	tries := 0
 	for {
@@ -6350,7 +6350,7 @@ func (s *RetryLayerPreferenceStore) GetAll(userID string) (model.Preferences, er
 
 }
 
-func (s *RetryLayerPreferenceStore) GetCategory(userID string, category string) (model.Preferences, error) {
+func (s *RetryLayerPreferenceStore) GetCategory(userID string, category model.PreferenceCategory) (model.Preferences, error) {
 
 	tries := 0
 	for {

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -144,7 +144,7 @@ func (s SqlPreferenceStore) update(transaction *gorp.Transaction, preference *mo
 	return nil
 }
 
-func (s SqlPreferenceStore) Get(userId string, category string, name string) (*model.Preference, error) {
+func (s SqlPreferenceStore) Get(userId string, category model.PreferenceCategory, name string) (*model.Preference, error) {
 	var preference *model.Preference
 	query, args, err := s.getQueryBuilder().
 		Select("*").
@@ -164,7 +164,7 @@ func (s SqlPreferenceStore) Get(userId string, category string, name string) (*m
 	return preference, nil
 }
 
-func (s SqlPreferenceStore) GetCategory(userId string, category string) (model.Preferences, error) {
+func (s SqlPreferenceStore) GetCategory(userId string, category model.PreferenceCategory) (model.Preferences, error) {
 	var preferences model.Preferences
 	query, args, err := s.getQueryBuilder().
 		Select("*").
@@ -211,7 +211,7 @@ func (s SqlPreferenceStore) PermanentDeleteByUser(userId string) error {
 	return nil
 }
 
-func (s SqlPreferenceStore) Delete(userId, category, name string) error {
+func (s SqlPreferenceStore) Delete(userId string, category model.PreferenceCategory, name string) error {
 
 	sql, args, err := s.getQueryBuilder().
 		Delete("Preferences").
@@ -230,7 +230,7 @@ func (s SqlPreferenceStore) Delete(userId, category, name string) error {
 	return nil
 }
 
-func (s SqlPreferenceStore) DeleteCategory(userId string, category string) error {
+func (s SqlPreferenceStore) DeleteCategory(userId string, category model.PreferenceCategory) error {
 
 	sql, args, err := s.getQueryBuilder().
 		Delete("Preferences").
@@ -248,7 +248,7 @@ func (s SqlPreferenceStore) DeleteCategory(userId string, category string) error
 	return nil
 }
 
-func (s SqlPreferenceStore) DeleteCategoryAndName(category string, name string) error {
+func (s SqlPreferenceStore) DeleteCategoryAndName(category model.PreferenceCategory, name string) error {
 	sql, args, err := s.getQueryBuilder().
 		Delete("Preferences").
 		Where(sq.Eq{"Name": name}).

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -299,7 +299,7 @@ func upgradeDatabaseToVersion33(sqlStore *SqlStore) {
 				`INSERT INTO
 					Preferences(UserId, Category, Name, Value)
 				SELECT
-					Id, '`+model.PreferenceCategoryTheme+`', '', ThemeProps
+					Id, '`+string(model.PreferenceCategoryTheme)+`', '', ThemeProps
 				FROM
 					Users
 				WHERE
@@ -321,7 +321,7 @@ func upgradeDatabaseToVersion33(sqlStore *SqlStore) {
 
 			// rename solarized_* code themes to solarized-* to match client changes in 3.0
 			var data model.Preferences
-			if _, err := sqlStore.GetMaster().Select(&data, "SELECT * FROM Preferences WHERE Category = '"+model.PreferenceCategoryTheme+"' AND Value LIKE '%solarized_%'"); err == nil {
+			if _, err := sqlStore.GetMaster().Select(&data, "SELECT * FROM Preferences WHERE Category = '"+string(model.PreferenceCategoryTheme)+"' AND Value LIKE '%solarized_%'"); err == nil {
 				for i := range data {
 					data[i].Value = strings.Replace(data[i].Value, "solarized_", "solarized-", -1)
 				}

--- a/store/store.go
+++ b/store/store.go
@@ -573,12 +573,12 @@ type CommandWebhookStore interface {
 
 type PreferenceStore interface {
 	Save(preferences *model.Preferences) error
-	GetCategory(userID string, category string) (model.Preferences, error)
-	Get(userID string, category string, name string) (*model.Preference, error)
+	GetCategory(userID string, category model.PreferenceCategory) (model.Preferences, error)
+	Get(userID string, category model.PreferenceCategory, name string) (*model.Preference, error)
 	GetAll(userID string) (model.Preferences, error)
-	Delete(userID, category, name string) error
-	DeleteCategory(userID string, category string) error
-	DeleteCategoryAndName(category string, name string) error
+	Delete(userID string, category model.PreferenceCategory, name string) error
+	DeleteCategory(userID string, category model.PreferenceCategory) error
+	DeleteCategoryAndName(category model.PreferenceCategory, name string) error
 	PermanentDeleteByUser(userID string) error
 	DeleteOrphanedRows(limit int) (deleted int64, err error)
 	CleanupFlagsBatch(limit int64) (int64, error)

--- a/store/storetest/mocks/PreferenceStore.go
+++ b/store/storetest/mocks/PreferenceStore.go
@@ -36,11 +36,11 @@ func (_m *PreferenceStore) CleanupFlagsBatch(limit int64) (int64, error) {
 }
 
 // Delete provides a mock function with given fields: userID, category, name
-func (_m *PreferenceStore) Delete(userID string, category string, name string) error {
+func (_m *PreferenceStore) Delete(userID string, category model.PreferenceCategory, name string) error {
 	ret := _m.Called(userID, category, name)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string) error); ok {
+	if rf, ok := ret.Get(0).(func(string, model.PreferenceCategory, string) error); ok {
 		r0 = rf(userID, category, name)
 	} else {
 		r0 = ret.Error(0)
@@ -50,11 +50,11 @@ func (_m *PreferenceStore) Delete(userID string, category string, name string) e
 }
 
 // DeleteCategory provides a mock function with given fields: userID, category
-func (_m *PreferenceStore) DeleteCategory(userID string, category string) error {
+func (_m *PreferenceStore) DeleteCategory(userID string, category model.PreferenceCategory) error {
 	ret := _m.Called(userID, category)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+	if rf, ok := ret.Get(0).(func(string, model.PreferenceCategory) error); ok {
 		r0 = rf(userID, category)
 	} else {
 		r0 = ret.Error(0)
@@ -64,11 +64,11 @@ func (_m *PreferenceStore) DeleteCategory(userID string, category string) error 
 }
 
 // DeleteCategoryAndName provides a mock function with given fields: category, name
-func (_m *PreferenceStore) DeleteCategoryAndName(category string, name string) error {
+func (_m *PreferenceStore) DeleteCategoryAndName(category model.PreferenceCategory, name string) error {
 	ret := _m.Called(category, name)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+	if rf, ok := ret.Get(0).(func(model.PreferenceCategory, string) error); ok {
 		r0 = rf(category, name)
 	} else {
 		r0 = ret.Error(0)
@@ -99,11 +99,11 @@ func (_m *PreferenceStore) DeleteOrphanedRows(limit int) (int64, error) {
 }
 
 // Get provides a mock function with given fields: userID, category, name
-func (_m *PreferenceStore) Get(userID string, category string, name string) (*model.Preference, error) {
+func (_m *PreferenceStore) Get(userID string, category model.PreferenceCategory, name string) (*model.Preference, error) {
 	ret := _m.Called(userID, category, name)
 
 	var r0 *model.Preference
-	if rf, ok := ret.Get(0).(func(string, string, string) *model.Preference); ok {
+	if rf, ok := ret.Get(0).(func(string, model.PreferenceCategory, string) *model.Preference); ok {
 		r0 = rf(userID, category, name)
 	} else {
 		if ret.Get(0) != nil {
@@ -112,7 +112,7 @@ func (_m *PreferenceStore) Get(userID string, category string, name string) (*mo
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string) error); ok {
+	if rf, ok := ret.Get(1).(func(string, model.PreferenceCategory, string) error); ok {
 		r1 = rf(userID, category, name)
 	} else {
 		r1 = ret.Error(1)
@@ -145,11 +145,11 @@ func (_m *PreferenceStore) GetAll(userID string) (model.Preferences, error) {
 }
 
 // GetCategory provides a mock function with given fields: userID, category
-func (_m *PreferenceStore) GetCategory(userID string, category string) (model.Preferences, error) {
+func (_m *PreferenceStore) GetCategory(userID string, category model.PreferenceCategory) (model.Preferences, error) {
 	ret := _m.Called(userID, category)
 
 	var r0 model.Preferences
-	if rf, ok := ret.Get(0).(func(string, string) model.Preferences); ok {
+	if rf, ok := ret.Get(0).(func(string, model.PreferenceCategory) model.Preferences); ok {
 		r0 = rf(userID, category)
 	} else {
 		if ret.Get(0) != nil {
@@ -158,7 +158,7 @@ func (_m *PreferenceStore) GetCategory(userID string, category string) (model.Pr
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+	if rf, ok := ret.Get(1).(func(string, model.PreferenceCategory) error); ok {
 		r1 = rf(userID, category)
 	} else {
 		r1 = ret.Error(1)

--- a/store/storetest/preference_store.go
+++ b/store/storetest/preference_store.go
@@ -79,7 +79,7 @@ func testPreferenceGet(t *testing.T, ss store.Store) {
 		},
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     name,
 		},
 		{
@@ -97,7 +97,7 @@ func testPreferenceGet(t *testing.T, ss store.Store) {
 	require.Equal(t, preferences[0].ToJson(), data.ToJson(), "got incorrect preference")
 
 	// make sure getting a missing preference fails
-	_, err = ss.Preference().Get(model.NewId(), model.NewId(), model.NewId())
+	_, err = ss.Preference().Get(model.NewId(), model.PreferenceCategory(model.NewId()), model.NewId())
 	require.Error(t, err, "no error on getting a missing preference")
 }
 
@@ -121,7 +121,7 @@ func testPreferenceGetCategory(t *testing.T, ss store.Store) {
 		// same user/name, different category
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     name,
 		},
 		// same name/category, different user
@@ -145,7 +145,7 @@ func testPreferenceGetCategory(t *testing.T, ss store.Store) {
 	)
 
 	// make sure getting a missing preference category doesn't fail
-	preferencesByCategory, err = ss.Preference().GetCategory(model.NewId(), model.NewId())
+	preferencesByCategory, err = ss.Preference().GetCategory(model.NewId(), model.PreferenceCategory(model.NewId()))
 	require.NoError(t, err)
 	require.Equal(t, 0, len(preferencesByCategory), "shouldn't have got any preferences")
 }
@@ -170,7 +170,7 @@ func testPreferenceGetAll(t *testing.T, ss store.Store) {
 		// same user/name, different category
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     name,
 		},
 		// same name/category, different user
@@ -214,7 +214,7 @@ func testPreferenceDeleteByUser(t *testing.T, ss store.Store) {
 		// same user/name, different category
 		{
 			UserId:   userId,
-			Category: model.NewId(),
+			Category: model.PreferenceCategory(model.NewId()),
 			Name:     name,
 		},
 		// same name/category, different user
@@ -255,7 +255,7 @@ func testPreferenceDelete(t *testing.T, ss store.Store) {
 }
 
 func testPreferenceDeleteCategory(t *testing.T, ss store.Store) {
-	category := model.NewId()
+	category := model.PreferenceCategory(model.NewId())
 	userId := model.NewId()
 
 	preference1 := model.Preference{
@@ -288,7 +288,7 @@ func testPreferenceDeleteCategory(t *testing.T, ss store.Store) {
 }
 
 func testPreferenceDeleteCategoryAndName(t *testing.T, ss store.Store) {
-	category := model.NewId()
+	category := model.PreferenceCategory(model.NewId())
 	name := model.NewId()
 	userId := model.NewId()
 	userId2 := model.NewId()

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -5225,7 +5225,7 @@ func (s *TimerLayerPreferenceStore) CleanupFlagsBatch(limit int64) (int64, error
 	return result, err
 }
 
-func (s *TimerLayerPreferenceStore) Delete(userID string, category string, name string) error {
+func (s *TimerLayerPreferenceStore) Delete(userID string, category model.PreferenceCategory, name string) error {
 	start := timemodule.Now()
 
 	err := s.PreferenceStore.Delete(userID, category, name)
@@ -5241,7 +5241,7 @@ func (s *TimerLayerPreferenceStore) Delete(userID string, category string, name 
 	return err
 }
 
-func (s *TimerLayerPreferenceStore) DeleteCategory(userID string, category string) error {
+func (s *TimerLayerPreferenceStore) DeleteCategory(userID string, category model.PreferenceCategory) error {
 	start := timemodule.Now()
 
 	err := s.PreferenceStore.DeleteCategory(userID, category)
@@ -5257,7 +5257,7 @@ func (s *TimerLayerPreferenceStore) DeleteCategory(userID string, category strin
 	return err
 }
 
-func (s *TimerLayerPreferenceStore) DeleteCategoryAndName(category string, name string) error {
+func (s *TimerLayerPreferenceStore) DeleteCategoryAndName(category model.PreferenceCategory, name string) error {
 	start := timemodule.Now()
 
 	err := s.PreferenceStore.DeleteCategoryAndName(category, name)
@@ -5289,7 +5289,7 @@ func (s *TimerLayerPreferenceStore) DeleteOrphanedRows(limit int) (int64, error)
 	return result, err
 }
 
-func (s *TimerLayerPreferenceStore) Get(userID string, category string, name string) (*model.Preference, error) {
+func (s *TimerLayerPreferenceStore) Get(userID string, category model.PreferenceCategory, name string) (*model.Preference, error) {
 	start := timemodule.Now()
 
 	result, err := s.PreferenceStore.Get(userID, category, name)
@@ -5321,7 +5321,7 @@ func (s *TimerLayerPreferenceStore) GetAll(userID string) (model.Preferences, er
 	return result, err
 }
 
-func (s *TimerLayerPreferenceStore) GetCategory(userID string, category string) (model.Preferences, error) {
+func (s *TimerLayerPreferenceStore) GetCategory(userID string, category model.PreferenceCategory) (model.Preferences, error) {
 	start := timemodule.Now()
 
 	result, err := s.PreferenceStore.GetCategory(userID, category)


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-21357

```release-note
- Use typed constant for model.PreferenceCatogory
- Changed Client4 methods GetPreferencesByCategory and GetPreferenceByCategoryAndName
```
