### PR TITLE
MM-36411- Skip flaky TestUpdateConfigDiffInAuditRecord

### DIFF
--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -441,7 +441,6 @@ func TestUpdateConfigRestrictSystemAdmin(t *testing.T) {
 }
 
 func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
-	t.Skip("MM-36411")
 	logFile, err := ioutil.TempFile("", "adv.log")
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())
@@ -471,6 +470,8 @@ func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
 		cfg.ServiceSettings.ReadTimeout = model.NewInt(timeoutVal)
 	})
 	require.Equal(t, timeoutVal+1, *cfg.ServiceSettings.ReadTimeout)
+
+	require.NoError(t, logFile.Sync())
 
 	// Forcing a flush before attempting to read log's content.
 	err = th.Server.Log.Flush(context.Background())

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -441,6 +441,7 @@ func TestUpdateConfigRestrictSystemAdmin(t *testing.T) {
 }
 
 func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
+	t.Skip("MM-36411")
 	logFile, err := ioutil.TempFile("", "adv.log")
 	require.NoError(t, err)
 	defer os.Remove(logFile.Name())

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -471,11 +471,11 @@ func TestUpdateConfigDiffInAuditRecord(t *testing.T) {
 	})
 	require.Equal(t, timeoutVal+1, *cfg.ServiceSettings.ReadTimeout)
 
-	require.NoError(t, logFile.Sync())
-
 	// Forcing a flush before attempting to read log's content.
 	err = th.Server.Log.Flush(context.Background())
 	require.NoError(t, err)
+
+	require.NoError(t, logFile.Sync())
 
 	data, err := ioutil.ReadAll(logFile)
 	require.NoError(t, err)


### PR DESCRIPTION
The fix in https://github.com/mattermost/mattermost-server/pull/17777
doesn't seem to have worked fully as this was seen again.

Skipping it for now until we revisit this.

https://mattermost.atlassian.net/browse/MM-36411

```release-note
NONE
```
