### PR TITLE
MM-37130 Add feature flag for global header.

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -38,6 +38,9 @@ type FeatureFlags struct {
 
 	// Enable timed dnd support for user status
 	TimedDND bool
+
+	// Enable the Global Header
+	GlobalHeader bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -53,6 +56,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PluginFocalboard = ""
 	f.CustomDataRetentionEnabled = false
 	f.TimedDND = false
+	f.GlobalHeader = false
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {


### PR DESCRIPTION
#### Summary
Adds the feature flag for global header. The rest of the feature is in the webapp PR: https://github.com/mattermost/mattermost-webapp/pull/8407

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37130

#### Release Note
```release-note
NONE
```
