### PR TITLE
[MM-35345]: fix unreads in threads and migration

### DIFF
--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -651,8 +651,8 @@ func (s *SqlThreadStore) CollectThreadsWithNewerReplies(userId string, channelId
 			sq.Eq{"Threads.ChannelId": channelIds},
 			sq.Eq{"ChannelMembers.UserId": userId},
 			sq.Or{
-				sq.Expr("Threads.LastReplyAt >= ChannelMembers.LastViewedAt"),
-				sq.GtOrEq{"Threads.LastReplyAt": timestamp},
+				sq.Expr("Threads.LastReplyAt > ChannelMembers.LastViewedAt"),
+				sq.Gt{"Threads.LastReplyAt": timestamp},
 			},
 		}).
 		ToSql()

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1251,7 +1251,7 @@ func fixCRTThreadCountsAndUnreads(sqlStore *SqlStore) {
 			UPDATE ThreadMemberships
 			INNER JOIN (` + threadMembershipsCTE + `) as q
 			ON ThreadMemberships.Postid = q.PostId AND ThreadMemberships.UserId = q.UserId
-			SET LastViewed = q.CM_LastViewedAt, UnreadMentions = 0, LastUpdated = :Now
+			SET LastViewed = q.CM_LastViewedAt + 1, UnreadMentions = 0, LastUpdated = :Now
 		`
 	}
 

--- a/store/sqlstore/upgrade_test.go
+++ b/store/sqlstore/upgrade_test.go
@@ -336,7 +336,7 @@ func TestFixCRTCountsAndUnreads(t *testing.T) {
 		// Check bad threadMemberships is fixed
 		fixedThreadMembership1, err := ss.Thread().GetMembershipForUser(uId1, rootPost1.Id)
 		require.NoError(t, err)
-		require.EqualValues(t, lastReplyAt, fixedThreadMembership1.LastViewed)
+		require.EqualValues(t, lastReplyAt+1, fixedThreadMembership1.LastViewed)
 		require.EqualValues(t, int64(0), fixedThreadMembership1.UnreadMentions)
 		require.NotEqual(t, goodThreadMembership1.LastUpdated, fixedThreadMembership1.LastUpdated)
 

--- a/store/sqlstore/upgrade_test.go
+++ b/store/sqlstore/upgrade_test.go
@@ -331,6 +331,7 @@ func TestFixCRTCountsAndUnreads(t *testing.T) {
 		require.NoError(t, err)
 
 		// Run migration to fix threads and memberships
+		ss.System().PermanentDeleteByName("CRTThreadCountsAndUnreadsMigrationComplete")
 		fixCRTThreadCountsAndUnreads(sqlStore)
 
 		// Check bad threadMemberships is fixed
@@ -387,6 +388,7 @@ func TestFixCRTChannelUnreads(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		ss.System().PermanentDeleteByName("CRTChannelMembershipCountsMigrationComplete")
 		fixCRTChannelMembershipCounts(sqlStore)
 
 		cm1AfterFix, err := ss.Channel().GetMember(context.Background(), c1.Id, uId1)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Fix unreads query for threads to check deleted option
- Normalize unreads query to look for threads after given time
- Fix migration to only run once, and increment timestamp by one so that threads are definitely marked as read.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- Fixes issues with https://mattermost.atlassian.net/browse/MM-35345
- And possibly some issues with thread unreads. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
