### PR TITLE
[MM-32604] Remove hard-coded override of MaxNotificationsPerChannel

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -72,8 +72,6 @@ import (
 	"github.com/mattermost/mattermost-server/v5/utils"
 )
 
-var MaxNotificationsPerChannelDefault int64 = 1000000
-
 // declaring this as var to allow overriding in tests
 var SentryDSN = "placeholder_sentry_dsn"
 
@@ -587,15 +585,9 @@ func NewServer(options ...Option) (*Server, error) {
 
 	s.checkPushNotificationServerUrl()
 
-	license := s.License()
-	if license == nil {
-		s.UpdateConfig(func(cfg *model.Config) {
-			cfg.TeamSettings.MaxNotificationsPerChannel = &MaxNotificationsPerChannelDefault
-		})
-	}
-
 	s.ReloadConfig()
 
+	license := s.License()
 	allowAdvancedLogging := license != nil && *license.Features.AdvancedLogging
 
 	if s.Audit == nil {


### PR DESCRIPTION
#### Summary

Another mystery to add to the collection. This was Introduced in e74c66d7f6a1f515d2380d0f163b2958f03c2bc7 . I couldn't exactly figure out why but maybe the config setting was mainly thought for enterprise customers (to limit push notifications?) and a higher default was deemed appropriate for team edition instead. Anyhow, removing this now as it should be left to the configuration.

#### Ticket

https://mattermost.atlassian.net/browse/MM-32604

#### Release Notes

```release-note
Removed hard-coded override of TeamSettings.MaxNotificationsPerChannel on unlicensed servers (e.g team edition).
```