### PR TITLE
[MM-37147] - Return on err in the change subscription endpoint

### DIFF
--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -91,6 +91,7 @@ func changeSubscription(c *Context, w http.ResponseWriter, r *http.Request) {
 	var subscriptionChange *model.SubscriptionChange
 	if err = json.Unmarshal(bodyBytes, &subscriptionChange); err != nil {
 		c.Err = model.NewAppError("Api4.changeSubscription", "api.cloud.app_error", nil, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	currentSubscription, appErr := c.App.Cloud().GetSubscription(c.AppContext.Session().UserId)
@@ -102,11 +103,13 @@ func changeSubscription(c *Context, w http.ResponseWriter, r *http.Request) {
 	changedSub, err := c.App.Cloud().ChangeSubscription(c.AppContext.Session().UserId, currentSubscription.ID, subscriptionChange)
 	if err != nil {
 		c.Err = model.NewAppError("Api4.changeSubscription", "api.cloud.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	json, err := json.Marshal(changedSub)
 	if err != nil {
 		c.Err = model.NewAppError("Api4.changeSubscription", "api.cloud.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	w.Write(json)


### PR DESCRIPTION
#### Summary
This PR makes sure that in the cloud endpoint handler, `changeSubscription`, we return early when errors occur

#### Ticket Link
[MM-37147](https://mattermost.atlassian.net/browse/MM-37147?atlOrigin=eyJpIjoiMzE4ZDQxMzBkZDcxNGYyZWExNTI4ZWYyNTMxZjQ2MzYiLCJwIjoiaiJ9)

#### Release Note

```release-note
NONE

```
