### PR TITLE
MM-35392 Load thread unreads for other teams on app load

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -420,8 +420,9 @@ func getTeamsUnreadForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// optional team id to be excluded from the result
 	teamId := r.URL.Query().Get("exclude_team")
+	includeCollapsedThreads := r.URL.Query().Get("include_collapsed_threads") == "true"
 
-	unreadTeamsList, err := c.App.GetTeamsUnreadForUser(teamId, c.Params.UserId)
+	unreadTeamsList, err := c.App.GetTeamsUnreadForUser(teamId, c.Params.UserId, includeCollapsedThreads)
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2651,22 +2651,22 @@ func TestGetMyTeamsUnread(t *testing.T) {
 	user := th.BasicUser
 	Client.Login(user.Email, user.Password)
 
-	teams, resp := Client.GetTeamsUnreadForUser(user.Id, "")
+	teams, resp := Client.GetTeamsUnreadForUser(user.Id, "", true)
 	CheckNoError(t, resp)
 	require.NotEqual(t, len(teams), 0, "should have results")
 
-	teams, resp = Client.GetTeamsUnreadForUser(user.Id, th.BasicTeam.Id)
+	teams, resp = Client.GetTeamsUnreadForUser(user.Id, th.BasicTeam.Id, true)
 	CheckNoError(t, resp)
 	require.Empty(t, teams, "should not have results")
 
-	_, resp = Client.GetTeamsUnreadForUser("fail", "")
+	_, resp = Client.GetTeamsUnreadForUser("fail", "", true)
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.GetTeamsUnreadForUser(model.NewId(), "")
+	_, resp = Client.GetTeamsUnreadForUser(model.NewId(), "", true)
 	CheckForbiddenStatus(t, resp)
 
 	Client.Logout()
-	_, resp = Client.GetTeamsUnreadForUser(user.Id, "")
+	_, resp = Client.GetTeamsUnreadForUser(user.Id, "", true)
 	CheckUnauthorizedStatus(t, resp)
 }
 

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -5551,7 +5551,7 @@ func TestGetThreadsForUser(t *testing.T) {
 
 		require.Nil(t, resp.Error)
 		require.Len(t, uss.Threads, 10)
-		require.Equal(t, uss.Threads[0].PostId, rootIdBefore)
+		require.Equal(t, rootIdBefore, uss.Threads[0].PostId)
 
 		uss2, resp2 := th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
 			Deleted:  false,
@@ -5561,7 +5561,7 @@ func TestGetThreadsForUser(t *testing.T) {
 		require.Nil(t, resp2.Error)
 		require.Len(t, uss2.Threads, 10)
 
-		require.Equal(t, uss2.Threads[0].PostId, rootIdAfter)
+		require.Equal(t, rootIdAfter, uss2.Threads[0].PostId)
 
 		uss3, resp3 := th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
 			Deleted:  false,

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -762,7 +762,7 @@ type AppIface interface {
 	GetTeamsForScheme(scheme *model.Scheme, offset int, limit int) ([]*model.Team, *model.AppError)
 	GetTeamsForSchemePage(scheme *model.Scheme, page int, perPage int) ([]*model.Team, *model.AppError)
 	GetTeamsForUser(userID string) ([]*model.Team, *model.AppError)
-	GetTeamsUnreadForUser(excludeTeamId string, userID string) ([]*model.TeamUnread, *model.AppError)
+	GetTeamsUnreadForUser(excludeTeamId string, userID string, includeCollapsedThreads bool) ([]*model.TeamUnread, *model.AppError)
 	GetTermsOfService(id string) (*model.TermsOfService, *model.AppError)
 	GetThreadForUser(teamID string, threadMembership *model.ThreadMembership, extended bool) (*model.ThreadResponse, *model.AppError)
 	GetThreadMembershipForUser(userId, threadId string) (*model.ThreadMembership, *model.AppError)

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -9250,7 +9250,7 @@ func (a *OpenTracingAppLayer) GetTeamsForUser(userID string) ([]*model.Team, *mo
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetTeamsUnreadForUser(excludeTeamId string, userID string) ([]*model.TeamUnread, *model.AppError) {
+func (a *OpenTracingAppLayer) GetTeamsUnreadForUser(excludeTeamId string, userID string, includeCollapsedThreads bool) ([]*model.TeamUnread, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetTeamsUnreadForUser")
 
@@ -9262,7 +9262,7 @@ func (a *OpenTracingAppLayer) GetTeamsUnreadForUser(excludeTeamId string, userID
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.GetTeamsUnreadForUser(excludeTeamId, userID)
+	resultVar0, resultVar1 := a.app.GetTeamsUnreadForUser(excludeTeamId, userID, includeCollapsedThreads)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -183,7 +183,7 @@ func (api *PluginAPI) GetTeamByName(name string) (*model.Team, *model.AppError) 
 }
 
 func (api *PluginAPI) GetTeamsUnreadForUser(userID string) ([]*model.TeamUnread, *model.AppError) {
-	return api.app.GetTeamsUnreadForUser("", userID)
+	return api.app.GetTeamsUnreadForUser("", userID, false)
 }
 
 func (api *PluginAPI) UpdateTeam(team *model.Team) (*model.Team, *model.AppError) {

--- a/app/team.go
+++ b/app/team.go
@@ -1667,7 +1667,7 @@ func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userID string, include
 
 	for _, member := range membersMap {
 		if includeCollapsedThreads {
-			data, err := a.Srv().Store.Thread().GetThreadsForUser(userID, member.TeamId, model.GetUserThreadsOpts{TotalsOnly: true})
+			data, err := a.Srv().Store.Thread().GetThreadsForUser(userID, member.TeamId, model.GetUserThreadsOpts{TotalsOnly: true, TeamOnly: true})
 			if err != nil {
 				return nil, model.NewAppError("GetTeamsUnreadForUser", "app.team.get_unread.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}

--- a/app/team.go
+++ b/app/team.go
@@ -1625,7 +1625,7 @@ func (a *App) FindTeamByName(name string) bool {
 	return true
 }
 
-func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userID string) ([]*model.TeamUnread, *model.AppError) {
+func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userID string, includeCollapsedThreads bool) ([]*model.TeamUnread, *model.AppError) {
 	data, err := a.Srv().Store.Team().GetChannelUnreadsForAllTeams(excludeTeamId, userID)
 	if err != nil {
 		return nil, model.NewAppError("GetTeamsUnreadForUser", "app.team.get_unread.app_error", nil, err.Error(), http.StatusInternalServerError)
@@ -1652,17 +1652,29 @@ func (a *App) GetTeamsUnreadForUser(excludeTeamId string, userID string) ([]*mod
 			membersMap[id] = unreads(data[i], mu)
 		} else {
 			membersMap[id] = unreads(data[i], &model.TeamUnread{
-				MsgCount:         0,
-				MentionCount:     0,
-				MentionCountRoot: 0,
-				MsgCountRoot:     0,
-				TeamId:           id,
+				MsgCount:           0,
+				MentionCount:       0,
+				MentionCountRoot:   0,
+				MsgCountRoot:       0,
+				ThreadCount:        0,
+				ThreadMentionCount: 0,
+				TeamId:             id,
 			})
 		}
 	}
 
-	for _, val := range membersMap {
-		members = append(members, val)
+	includeCollapsedThreads = includeCollapsedThreads && *a.Config().ServiceSettings.CollapsedThreads != model.COLLAPSED_THREADS_DISABLED
+
+	for _, member := range membersMap {
+		if includeCollapsedThreads {
+			data, err := a.Srv().Store.Thread().GetThreadsForUser(userID, member.TeamId, model.GetUserThreadsOpts{TotalsOnly: true})
+			if err != nil {
+				return nil, model.NewAppError("GetTeamsUnreadForUser", "app.team.get_unread.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
+			member.ThreadCount = data.TotalUnreadThreads
+			member.ThreadMentionCount = data.TotalUnreadMentions
+		}
+		members = append(members, member)
 	}
 
 	return members, nil

--- a/model/client4.go
+++ b/model/client4.go
@@ -1440,14 +1440,20 @@ func (c *Client4) AttachDeviceId(deviceId string) (bool, *Response) {
 
 // GetTeamsUnreadForUser will return an array with TeamUnread objects that contain the amount
 // of unread messages and mentions the current user has for the teams it belongs to.
-// An optional team ID can be set to exclude that team from the results. Must be authenticated.
-func (c *Client4) GetTeamsUnreadForUser(userId, teamIdToExclude string) ([]*TeamUnread, *Response) {
-	var optional string
+// An optional team ID can be set to exclude that team from the results.
+// An optional boolean can be set to include collapsed thread unreads. Must be authenticated.
+func (c *Client4) GetTeamsUnreadForUser(userId, teamIdToExclude string, includeCollapsedThreads bool) ([]*TeamUnread, *Response) {
+	query := url.Values{}
+
 	if teamIdToExclude != "" {
-		optional += fmt.Sprintf("?exclude_team=%s", url.QueryEscape(teamIdToExclude))
+		query.Set("exclude_team", teamIdToExclude)
 	}
 
-	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/unread"+optional, "")
+	if includeCollapsedThreads {
+		query.Set("include_collapsed_threads", "true")
+	}
+
+	r, err := c.DoApiGet(c.GetUserRoute(userId)+"/teams/unread?"+query.Encode(), "")
 	if err != nil {
 		return nil, BuildErrorResponse(r, err)
 	}

--- a/model/team_member.go
+++ b/model/team_member.go
@@ -31,11 +31,13 @@ type TeamMember struct {
 
 //msgp:ignore TeamUnread
 type TeamUnread struct {
-	TeamId           string `json:"team_id"`
-	MsgCount         int64  `json:"msg_count"`
-	MentionCount     int64  `json:"mention_count"`
-	MentionCountRoot int64  `json:"mention_count_root"`
-	MsgCountRoot     int64  `json:"msg_count_root"`
+	TeamId             string `json:"team_id"`
+	MsgCount           int64  `json:"msg_count"`
+	MentionCount       int64  `json:"mention_count"`
+	MentionCountRoot   int64  `json:"mention_count_root"`
+	MsgCountRoot       int64  `json:"msg_count_root"`
+	ThreadCount        int64  `json:"thread_count"`
+	ThreadMentionCount int64  `json:"thread_mention_count"`
 }
 
 //msgp:ignore TeamMemberForExport

--- a/model/thread.go
+++ b/model/thread.go
@@ -57,6 +57,9 @@ type GetUserThreadsOpts struct {
 
 	// TotalsOnly will not fetch any threads and just fetch the total counts
 	TotalsOnly bool
+
+	// TeamOnly will only fetch threads and unreads for the specified team and excludes DMs/GMs
+	TeamOnly bool
 }
 
 func (o *ThreadResponse) ToJson() string {

--- a/model/thread.go
+++ b/model/thread.go
@@ -54,6 +54,9 @@ type GetUserThreadsOpts struct {
 
 	// Unread will make sure that only threads with unread replies are returned
 	Unread bool
+
+	// TotalsOnly will not fetch any threads and just fetch the total counts
+	TotalsOnly bool
 }
 
 func (o *ThreadResponse) ToJson() string {

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -131,9 +131,19 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 	}
 
 	fetchConditions := sq.And{
-		sq.Or{sq.Eq{"Channels.TeamId": teamId}, sq.Eq{"Channels.TeamId": ""}},
 		sq.Eq{"ThreadMemberships.UserId": userId},
 		sq.Eq{"ThreadMemberships.Following": true},
+	}
+	if opts.TeamOnly {
+		fetchConditions = sq.And{
+			sq.Eq{"Channels.TeamId": teamId},
+			fetchConditions,
+		}
+	} else {
+		fetchConditions = sq.And{
+			sq.Or{sq.Eq{"Channels.TeamId": teamId}, sq.Eq{"Channels.TeamId": ""}},
+			fetchConditions,
+		}
 	}
 	if !opts.Deleted {
 		fetchConditions = sq.And{

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -223,6 +223,13 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 					sq.Expr(`LastReplyAt < (SELECT LastReplyAt FROM Threads WHERE PostId = ?)`, opts.Before),
 				}
 			}
+			if opts.After != "" {
+				order = "ASC"
+				newFetchConditions = sq.And{
+					newFetchConditions,
+					sq.Expr(`LastReplyAt > (SELECT LastReplyAt FROM Threads WHERE PostId = ?)`, opts.After),
+				}
+			}
 			if opts.Unread {
 				newFetchConditions = sq.And{newFetchConditions, sq.Expr("ThreadMemberships.LastViewed < Threads.LastReplyAt")}
 			}
@@ -343,7 +350,7 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 				UnreadReplies:  thread.UnreadReplies,
 				UnreadMentions: thread.UnreadMentions,
 				Participants:   participants,
-				Post:           &thread.Post,
+				Post:           thread.Post.ToNilIfInvalid(),
 			})
 		}
 	}


### PR DESCRIPTION
#### Summary
This is a subset of @calebroseland's PR #17813 with some minor updates. I'll be submitting further PRs to handle the other tickets related to team thread unreads.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35392

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Correctly display unread threads on app load for teams in the sidebar when collapsed threads is turned on.
```
