### PR TITLE
update mattermost server build to use go 1.16.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
 
   check-app-layers:
     docker:
-      - image: mattermost/mattermost-build-server:20210709_golang-1.16.5
+      - image: mattermost/mattermost-build-server:20210720_golang-1.16.6
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -120,7 +120,7 @@ jobs:
 
   check-store-layers:
     docker:
-      - image: mattermost/mattermost-build-server:20210709_golang-1.16.5
+      - image: mattermost/mattermost-build-server:20210720_golang-1.16.6
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -133,7 +133,7 @@ jobs:
 
   check-mocks:
     docker:
-      - image: mattermost/mattermost-build-server:20210709_golang-1.16.5
+      - image: mattermost/mattermost-build-server:20210720_golang-1.16.6
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -146,7 +146,7 @@ jobs:
 
   check-migrations:
     docker:
-      - image: mattermost/mattermost-build-server:20210709_golang-1.16.5
+      - image: mattermost/mattermost-build-server:20210720_golang-1.16.6
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -172,7 +172,7 @@ jobs:
   # Dedicate job for mattermost-vet to make more clear when the job fails
   check-mattermost-vet:
     docker:
-      - image: mattermost/mattermost-build-server:20210709_golang-1.16.5
+      - image: mattermost/mattermost-build-server:20210720_golang-1.16.6
     working_directory: ~/mattermost
     steps:
       - attach_workspace:
@@ -223,7 +223,7 @@ jobs:
 
   build:
     docker:
-      - image: mattermost/mattermost-build-server:20210709_golang-1.16.5
+      - image: mattermost/mattermost-build-server:20210720_golang-1.16.6
     resource_class: xlarge
     working_directory: ~/mattermost
     steps:
@@ -287,7 +287,7 @@ jobs:
               --env MM_SQLSETTINGS_DRIVERNAME=<<parameters.dbdriver>> \
               -v ~/mattermost:/mattermost \
               -w /mattermost/mattermost-server \
-              mattermost/mattermost-build-server:20210709_golang-1.16.5 \
+              mattermost/mattermost-build-server:20210720_golang-1.16.6 \
               bash -c "ulimit -n 8096; make test-server<< parameters.racemode >> BUILD_NUMBER=$CIRCLE_BRANCH-$CIRCLE_PREVIOUS_BUILD_NUM TESTFLAGS= TESTFLAGSEE=" \
               bash -c scripts/diff-email-templates.sh
           no_output_timeout: 2h
@@ -352,7 +352,7 @@ jobs:
               --env MM_SQLSETTINGS_DRIVERNAME=postgres \
               -v ~/mattermost:/mattermost \
               -w /mattermost/mattermost-server \
-              mattermost/mattermost-build-server:20210709_golang-1.16.5 \
+              mattermost/mattermost-build-server:20210720_golang-1.16.6 \
               bash -c "ulimit -n 8096; make ARGS='version' run-cli && make MM_SQLSETTINGS_DATASOURCE='postgres://mmuser:mostest@postgres:5432/latest?sslmode=disable&connect_timeout=10' ARGS='version' run-cli"
 
             echo "Ignoring known mismatch: ChannelMembers.MentionCountRoot"
@@ -390,7 +390,7 @@ jobs:
               --env MM_SQLSETTINGS_DRIVERNAME=mysql \
               -v ~/mattermost:/mattermost \
               -w /mattermost/mattermost-server \
-              mattermost/mattermost-build-server:20210709_golang-1.16.5 \
+              mattermost/mattermost-build-server:20210720_golang-1.16.6 \
               bash -c "ulimit -n 8096; make ARGS='version' run-cli && make MM_SQLSETTINGS_DATASOURCE='mmuser:mostest@tcp(mysql:3306)/latest?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s' ARGS='version' run-cli"
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ include:
 
 variables:
   BUILD: "yes"
-  IMAGE_BUILD_SERVER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20201119_golang-1.15.5
+  IMAGE_BUILD_SERVER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20210720_golang-1.16.6
   IMAGE_BUILD_DOCKER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-docker:19.03.14-1
   IMAGE_DIND: $CI_REGISTRY/mattermost/ci/images/docker-dind:19.03.14-1
 

--- a/build/README.md
+++ b/build/README.md
@@ -18,4 +18,4 @@ In our Docker Hub Repository we have the following images:
 - `mattermost/mattermost-build-server:20200322_golang-1.14.1` which is based on Go 1.14.1 you can use for MM versions >= `5.24.x`
 - `mattermost/mattermost-build-server:20201023_golang-1.14.6` which is based on Go 1.14.6 you can use for MM versions >= `5.25.x`
 - `mattermost/mattermost-build-server:20201119_golang-1.15.5` which is based on Go 1.15.5 you can use for MM versions >= `5.26.x` to `5.37.x`
-- `mattermost/mattermost-build-server:20210709_golang-1.16.5` which is based on Go 1.16.5 you can use for MM versions >= `5.38.x`
+- `mattermost/mattermost-build-server:20210720_golang-1.16.6` which is based on Go 1.16.5 you can use for MM versions >= `5.38.x`

--- a/build/local-test-env.sh
+++ b/build/local-test-env.sh
@@ -32,7 +32,7 @@ up()
         -e GOPATH="/go" \
         -e MM_SQLSETTINGS_DATASOURCE="postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10" \
         -e MM_SQLSETTINGS_DRIVERNAME=postgres
-        mattermost/mattermost-build-server:20210709_golang-1.16.5 bash
+        mattermost/mattermost-build-server:20210720_golang-1.16.6 bash
 }
 
 down()


### PR DESCRIPTION

#### Summary
update mattermost server build to use go 1.16.6

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/DOPS-521

#### Release Note

```release-note
now Mattermost is built using go1.16.6
```
