### PR TITLE
Add Focalboard to known plugin telemetry

### DIFF
--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -1338,6 +1338,7 @@ func (ts *TelemetryService) trackPluginConfig(cfg *model.Config, marketplaceURL 
 		"memes",
 		"skype4business",
 		"zoom",
+		"focalboard",
 	}
 
 	marketplacePlugins, err := ts.getAllMarketplaceplugins(marketplaceURL)


### PR DESCRIPTION
#### Summary
Add Focalboard to the list of known plugins to enable telemetry.

```release-note
NONE
```