### PR TITLE
Automated cherry pick of #17933

### DIFF
--- a/api4/license.go
+++ b/api4/license.go
@@ -178,6 +178,11 @@ func requestTrialLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if c.App.Srv().LicenseManager == nil {
+		c.Err = model.NewAppError("requestTrialLicense", "api.license.upgrade_needed.app_error", nil, "", http.StatusForbidden)
+		return
+	}
+
 	canStartTrialLicense, err := c.App.Srv().LicenseManager.CanStartTrial()
 	if err != nil {
 		c.Err = model.NewAppError("requestTrialLicense", "api.license.request-trial.can-start-trial.error", nil, err.Error(), http.StatusInternalServerError)
@@ -275,6 +280,11 @@ func requestRenewalLink(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getPrevTrialLicense(c *Context, w http.ResponseWriter, r *http.Request) {
+	if c.App.Srv().LicenseManager == nil {
+		c.Err = model.NewAppError("getPrevTrialLicense", "api.license.upgrade_needed.app_error", nil, "", http.StatusForbidden)
+		return
+	}
+
 	license, err := c.App.Srv().LicenseManager.GetPrevTrial()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api4/license_test.go
+++ b/api4/license_test.go
@@ -229,4 +229,12 @@ func TestRequestTrialLicense(t *testing.T) {
 		require.Equal(t, "api.license.add_license.unique_users.app_error", resp.Error.Id)
 		require.False(t, ok)
 	})
+
+	th.App.Srv().LicenseManager = nil
+	t.Run("trial license should fail if LicenseManager is nil", func(t *testing.T) {
+		ok, resp := th.SystemAdminClient.RequestTrialLicense(1)
+		CheckForbiddenStatus(t, resp)
+		require.False(t, ok)
+		require.Equal(t, "api.license.upgrade_needed.app_error", resp.Error.Id)
+	})
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2001,6 +2001,10 @@
     "translation": "Unable to request a trial license. Please configure a Site URL in the web server section of the Mattermost System Console."
   },
   {
+    "id": "api.license.upgrade_needed.app_error",
+    "translation": "Feature requires an upgrade to Enterprise Edition."
+  },
+  {
     "id": "api.marshal_error",
     "translation": "marshal error"
   },


### PR DESCRIPTION
Cherry pick of #17933 on cloud.

/cc  @streamer45

```release-note
Fixed a panic in the getPrevTrialLicense API request when loading system console on team edition.
```