### PR TITLE
Improve error logged from App.addUserToChannel

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1435,7 +1435,8 @@ func (a *App) addUserToChannel(user *model.User, channel *model.Channel) (*model
 
 	newMember, nErr = a.Srv().Store.Channel().SaveMember(newMember)
 	if nErr != nil {
-		return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user.to.channel.failed.app_error", nil, fmt.Sprintf("failed to add member: user_id: %s, channel_id:%s", user.Id, channel.Id), http.StatusInternalServerError)
+		return nil, model.NewAppError("AddUserToChannel", "api.channel.add_user.to.channel.failed.app_error", nil,
+			fmt.Sprintf("failed to add member: %v, user_id: %s, channel_id: %s", nErr, user.Id, channel.Id), http.StatusInternalServerError)
 	}
 
 	if nErr := a.Srv().Store.ChannelMemberHistory().LogJoinEvent(user.Id, channel.Id, model.GetMillis()); nErr != nil {


### PR DESCRIPTION
#### Summary

Improving a log line from the returned error in `App.addUserToChannel()` to include the underlying store error for better debuggability.
Related discussion in https://github.com/mattermost/mattermost-server/pull/16583#discussion_r675379536

#### Release Note

```release-note
NONE
```
