### PR TITLE
MM-37445 - Create config setting to always have the team sidebar visible

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -49,6 +49,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["EnableLatex"] = strconv.FormatBool(*c.ServiceSettings.EnableLatex)
 	props["ExtendSessionLengthWithActivity"] = strconv.FormatBool(*c.ServiceSettings.ExtendSessionLengthWithActivity)
 	props["ManagedResourcePaths"] = *c.ServiceSettings.ManagedResourcePaths
+	props["AlwaysShowTeamSidebar"] = strconv.FormatBool(*c.ServiceSettings.AlwaysShowTeamSidebar)
 
 	// This setting is only temporary, so keep using the old setting name for the mobile and web apps
 	props["ExperimentalEnablePostMetadata"] = "true"

--- a/model/config.go
+++ b/model/config.go
@@ -242,6 +242,8 @@ const (
 	OpenidSettingsDefaultScope    = "profile openid email"
 
 	LocalModeSocketPath = "/var/tmp/mattermost_local.socket"
+
+	AlwaysShowTeamSidebar = ""
 )
 
 func GetDefaultAppCustomURLSchemes() []string {
@@ -376,6 +378,7 @@ type ServiceSettings struct {
 	ManagedResourcePaths                              *string `access:"environment_web_server,write_restrictable,cloud_restrictable"`
 	EnableLegacySidebar                               *bool   `access:"experimental_features"`
 	EnableReliableWebSockets                          *bool   `access:"experimental_features"` // telemetry: none
+	AlwaysShowTeamSidebar                             *bool   `access:"experimental_features"`
 }
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {
@@ -824,6 +827,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.EnableReliableWebSockets == nil {
 		s.EnableReliableWebSockets = NewBool(true)
+	}
+
+	if s.AlwaysShowTeamSidebar == nil {
+		s.AlwaysShowTeamSidebar = NewBool(true)
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR add a new configuration option `AlwaysShowTeamSidebar` with default value `true` that allow to constantly show team sidebar even the user only have one team. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

https://mattermost.atlassian.net/browse/MM-37445

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-37445
https://github.com/mattermost/mattermost-server/issues/18010
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added a new config setting AlwaysShowTeamSidebar
```
