### PR TITLE
MM-36990: Use upsert for system key update

### DIFF
--- a/app/permissions_migrations.go
+++ b/app/permissions_migrations.go
@@ -183,7 +183,7 @@ func (s *Server) doPermissionsMigration(key string, migrationMap permissionsMap,
 		}
 	}
 
-	if err := s.Store.System().Save(&model.System{Name: key, Value: "true"}); err != nil {
+	if err := s.Store.System().SaveOrUpdate(&model.System{Name: key, Value: "true"}); err != nil {
 		return model.NewAppError("doPermissionsMigration", "app.system.save.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	return nil

--- a/store/sqlstore/system_store.go
+++ b/store/sqlstore/system_store.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	sq "github.com/Masterminds/squirrel"
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -45,14 +46,24 @@ func (s SqlSystemStore) Save(system *model.System) error {
 }
 
 func (s SqlSystemStore) SaveOrUpdate(system *model.System) error {
-	if err := s.GetMaster().SelectOne(&model.System{}, "SELECT * FROM Systems WHERE Name = :Name", map[string]interface{}{"Name": system.Name}); err == nil {
-		if _, err := s.GetMaster().Update(system); err != nil {
-			return errors.Wrapf(err, "failed to update system property with name=%s", system.Name)
-		}
+	query := s.getQueryBuilder().
+		Insert("Systems").
+		Columns("Name", "Value").
+		Values(system.Name, system.Value)
+
+	if s.DriverName() == model.DatabaseDriverMysql {
+		query = query.SuffixExpr(sq.Expr("ON DUPLICATE KEY UPDATE Value = ?", system.Value))
 	} else {
-		if err := s.GetMaster().Insert(system); err != nil {
-			return errors.Wrapf(err, "failed to save system property with name=%s", system.Name)
-		}
+		query = query.SuffixExpr(sq.Expr("ON CONFLICT (name) DO UPDATE SET Value = ?", system.Value))
+	}
+
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return errors.Wrap(err, "status_tosql")
+	}
+
+	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {
+		return errors.Wrap(err, "failed to upsert system property")
 	}
 	return nil
 }

--- a/store/sqlstore/system_store.go
+++ b/store/sqlstore/system_store.go
@@ -59,7 +59,7 @@ func (s SqlSystemStore) SaveOrUpdate(system *model.System) error {
 
 	queryString, args, err := query.ToSql()
 	if err != nil {
-		return errors.Wrap(err, "status_tosql")
+		return errors.Wrap(err, "system_tosql")
 	}
 
 	if _, err := s.GetMaster().Exec(queryString, args...); err != nil {

--- a/store/storetest/system_store.go
+++ b/store/storetest/system_store.go
@@ -51,10 +51,18 @@ func testSystemStoreSaveOrUpdate(t *testing.T, ss store.Store) {
 	err := ss.System().SaveOrUpdate(system)
 	require.NoError(t, err)
 
+	res, err := ss.System().GetByName(system.Name)
+	require.NoError(t, err)
+	assert.Equal(t, system.Value, res.Value)
+
 	system.Value = "value2"
 
 	err = ss.System().SaveOrUpdate(system)
 	require.NoError(t, err)
+
+	res, err = ss.System().GetByName(system.Name)
+	require.NoError(t, err)
+	assert.Equal(t, system.Value, res.Value)
 }
 
 func testSystemStoreSaveOrUpdateWithWarnMetricHandling(t *testing.T, ss store.Store) {


### PR DESCRIPTION
We make the app migration idempotent by using DB native upsert.

https://mattermost.atlassian.net/browse/MM-36990

```release-note
NONE
```
