### PR TITLE
[MM-28985] Remove pointers to slice (part 2)

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -990,28 +990,28 @@ func TestGetAllChannels(t *testing.T) {
 		CheckNoError(t, resp)
 
 		// At least, all the not-deleted channels created during the InitBasic
-		require.True(t, len(*channels) >= 3)
-		for _, c := range *channels {
+		require.True(t, len(channels) >= 3)
+		for _, c := range channels {
 			require.NotEqual(t, c.TeamId, "")
 		}
 
 		channels, resp = client.GetAllChannels(0, 10, "")
 		CheckNoError(t, resp)
-		require.True(t, len(*channels) >= 3)
+		require.True(t, len(channels) >= 3)
 
 		channels, resp = client.GetAllChannels(1, 1, "")
 		CheckNoError(t, resp)
-		require.Len(t, *channels, 1)
+		require.Len(t, channels, 1)
 
 		channels, resp = client.GetAllChannels(10000, 10000, "")
 		CheckNoError(t, resp)
-		require.Empty(t, *channels)
+		require.Empty(t, channels)
 
 		channels, resp = client.GetAllChannels(0, 10000, "")
 		require.Nil(t, resp.Error)
-		beforeCount := len(*channels)
+		beforeCount := len(channels)
 
-		firstChannel := (*channels)[0].Channel
+		firstChannel := channels[0].Channel
 
 		ok, resp := client.DeleteChannel(firstChannel.Id)
 		require.Nil(t, resp.Error)
@@ -1019,20 +1019,20 @@ func TestGetAllChannels(t *testing.T) {
 
 		channels, resp = client.GetAllChannels(0, 10000, "")
 		var ids []string
-		for _, item := range *channels {
+		for _, item := range channels {
 			ids = append(ids, item.Channel.Id)
 		}
 		require.Nil(t, resp.Error)
-		require.Len(t, *channels, beforeCount-1)
+		require.Len(t, channels, beforeCount-1)
 		require.NotContains(t, ids, firstChannel.Id)
 
 		channels, resp = client.GetAllChannelsIncludeDeleted(0, 10000, "")
 		ids = []string{}
-		for _, item := range *channels {
+		for _, item := range channels {
 			ids = append(ids, item.Channel.Id)
 		}
 		require.Nil(t, resp.Error)
-		require.True(t, len(*channels) > beforeCount)
+		require.True(t, len(channels) > beforeCount)
 		require.Contains(t, ids, firstChannel.Id)
 	})
 
@@ -1041,7 +1041,7 @@ func TestGetAllChannels(t *testing.T) {
 
 	sysManagerChannels, resp := th.SystemManagerClient.GetAllChannels(0, 10000, "")
 	CheckOKStatus(t, resp)
-	policyChannel := (*sysManagerChannels)[0]
+	policyChannel := sysManagerChannels[0]
 	policy, savePolicyErr := th.App.Srv().Store.RetentionPolicy().Save(&model.RetentionPolicyWithTeamAndChannelIDs{
 		RetentionPolicy: model.RetentionPolicy{
 			DisplayName:  "Policy 1",
@@ -1058,7 +1058,7 @@ func TestGetAllChannels(t *testing.T) {
 		channels, resp := th.SystemAdminClient.GetAllChannelsExcludePolicyConstrained(0, 10000, "")
 		CheckOKStatus(t, resp)
 		found := false
-		for _, channel := range *channels {
+		for _, channel := range channels {
 			if channel.Id == policyChannel.Id {
 				found = true
 				break
@@ -1071,7 +1071,7 @@ func TestGetAllChannels(t *testing.T) {
 		channels, resp := th.SystemManagerClient.GetAllChannels(0, 10000, "")
 		CheckOKStatus(t, resp)
 		found := false
-		for _, channel := range *channels {
+		for _, channel := range channels {
 			if channel.Id == policyChannel.Id {
 				found = true
 				require.Nil(t, channel.PolicyID)
@@ -1085,7 +1085,7 @@ func TestGetAllChannels(t *testing.T) {
 		channels, resp := th.SystemAdminClient.GetAllChannels(0, 10000, "")
 		CheckOKStatus(t, resp)
 		found := false
-		for _, channel := range *channels {
+		for _, channel := range channels {
 			if channel.Id == policyChannel.Id {
 				found = true
 				require.Equal(t, *channel.PolicyID, policy.ID)
@@ -1443,9 +1443,9 @@ func TestSearchAllChannels(t *testing.T) {
 		t.Run(testCase.Description, func(t *testing.T) {
 			channels, resp := th.SystemAdminClient.SearchAllChannels(testCase.Search)
 			CheckNoError(t, resp)
-			assert.Equal(t, len(testCase.ExpectedChannelIds), len(*channels))
+			assert.Equal(t, len(testCase.ExpectedChannelIds), len(channels))
 			actualChannelIds := []string{}
-			for _, channelWithTeamData := range *channels {
+			for _, channelWithTeamData := range channels {
 				actualChannelIds = append(actualChannelIds, channelWithTeamData.Channel.Id)
 			}
 			assert.ElementsMatch(t, testCase.ExpectedChannelIds, actualChannelIds)
@@ -1455,7 +1455,7 @@ func TestSearchAllChannels(t *testing.T) {
 	// Searching with no terms returns all default channels
 	allChannels, resp := th.SystemAdminClient.SearchAllChannels(&model.ChannelSearch{Term: ""})
 	CheckNoError(t, resp)
-	assert.True(t, len(*allChannels) >= 3)
+	assert.True(t, len(allChannels) >= 3)
 
 	_, resp = Client.SearchAllChannels(&model.ChannelSearch{Term: ""})
 	CheckForbiddenStatus(t, resp)
@@ -1463,7 +1463,7 @@ func TestSearchAllChannels(t *testing.T) {
 	// Choose a policy which the system manager can read
 	sysManagerChannels, resp := th.SystemManagerClient.GetAllChannels(0, 10000, "")
 	CheckOKStatus(t, resp)
-	policyChannel := (*sysManagerChannels)[0]
+	policyChannel := sysManagerChannels[0]
 	policy, savePolicyErr := th.App.Srv().Store.RetentionPolicy().Save(&model.RetentionPolicyWithTeamAndChannelIDs{
 		RetentionPolicy: model.RetentionPolicy{
 			DisplayName:  "Policy 1",
@@ -1477,7 +1477,7 @@ func TestSearchAllChannels(t *testing.T) {
 		channels, resp := th.SystemManagerClient.SearchAllChannels(&model.ChannelSearch{Term: policyChannel.Name})
 		CheckOKStatus(t, resp)
 		found := false
-		for _, channel := range *channels {
+		for _, channel := range channels {
 			if channel.Id == policyChannel.Id {
 				found = true
 				require.Nil(t, channel.PolicyID)
@@ -1490,7 +1490,7 @@ func TestSearchAllChannels(t *testing.T) {
 		channels, resp := th.SystemAdminClient.SearchAllChannels(&model.ChannelSearch{Term: policyChannel.Name})
 		CheckOKStatus(t, resp)
 		found := false
-		for _, channel := range *channels {
+		for _, channel := range channels {
 			if channel.Id == policyChannel.Id {
 				found = true
 				require.Equal(t, *channel.PolicyID, policy.ID)
@@ -2067,19 +2067,19 @@ func TestGetChannelMembers(t *testing.T) {
 	th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
 		members, resp := client.GetChannelMembers(th.BasicChannel.Id, 0, 60, "")
 		CheckNoError(t, resp)
-		require.Len(t, *members, 3, "should only be 3 users in channel")
+		require.Len(t, members, 3, "should only be 3 users in channel")
 
 		members, resp = client.GetChannelMembers(th.BasicChannel.Id, 0, 2, "")
 		CheckNoError(t, resp)
-		require.Len(t, *members, 2, "should only be 2 users")
+		require.Len(t, members, 2, "should only be 2 users")
 
 		members, resp = client.GetChannelMembers(th.BasicChannel.Id, 1, 1, "")
 		CheckNoError(t, resp)
-		require.Len(t, *members, 1, "should only be 1 user")
+		require.Len(t, members, 1, "should only be 1 user")
 
 		members, resp = client.GetChannelMembers(th.BasicChannel.Id, 1000, 100000, "")
 		CheckNoError(t, resp)
-		require.Empty(t, *members, "should be 0 users")
+		require.Empty(t, members, "should be 0 users")
 
 		_, resp = client.GetChannelMembers("junk", 0, 60, "")
 		CheckBadRequestStatus(t, resp)
@@ -2111,22 +2111,22 @@ func TestGetChannelMembersByIds(t *testing.T) {
 
 	cm, resp := Client.GetChannelMembersByIds(th.BasicChannel.Id, []string{th.BasicUser.Id})
 	CheckNoError(t, resp)
-	require.Equal(t, th.BasicUser.Id, (*cm)[0].UserId, "returned wrong user")
+	require.Equal(t, th.BasicUser.Id, cm[0].UserId, "returned wrong user")
 
 	_, resp = Client.GetChannelMembersByIds(th.BasicChannel.Id, []string{})
 	CheckBadRequestStatus(t, resp)
 
 	cm1, resp := Client.GetChannelMembersByIds(th.BasicChannel.Id, []string{"junk"})
 	CheckNoError(t, resp)
-	require.Empty(t, *cm1, "no users should be returned")
+	require.Empty(t, cm1, "no users should be returned")
 
 	cm1, resp = Client.GetChannelMembersByIds(th.BasicChannel.Id, []string{"junk", th.BasicUser.Id})
 	CheckNoError(t, resp)
-	require.Len(t, *cm1, 1, "1 member should be returned")
+	require.Len(t, cm1, 1, "1 member should be returned")
 
 	cm1, resp = Client.GetChannelMembersByIds(th.BasicChannel.Id, []string{th.BasicUser2.Id, th.BasicUser.Id})
 	CheckNoError(t, resp)
-	require.Len(t, *cm1, 2, "2 members should be returned")
+	require.Len(t, cm1, 2, "2 members should be returned")
 
 	_, resp = Client.GetChannelMembersByIds("junk", []string{th.BasicUser.Id})
 	CheckBadRequestStatus(t, resp)
@@ -2190,7 +2190,7 @@ func TestGetChannelMembersForUser(t *testing.T) {
 
 	members, resp := Client.GetChannelMembersForUser(th.BasicUser.Id, th.BasicTeam.Id, "")
 	CheckNoError(t, resp)
-	require.Len(t, *members, 6, "should have 6 members on team")
+	require.Len(t, members, 6, "should have 6 members on team")
 
 	_, resp = Client.GetChannelMembersForUser("", th.BasicTeam.Id, "")
 	CheckNotFoundStatus(t, resp)
@@ -3169,8 +3169,8 @@ func TestAutocompleteChannels(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			channels, resp := th.Client.AutocompleteChannelsForTeam(tc.teamId, tc.fragment)
 			require.Nil(t, resp.Error)
-			names := make([]string, len(*channels))
-			for i, c := range *channels {
+			names := make([]string, len(channels))
+			for i, c := range channels {
 				names[i] = c.Name
 			}
 			for _, name := range tc.expectedIncludes {
@@ -3284,8 +3284,8 @@ func TestAutocompleteChannelsForSearch(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			channels, resp := th.Client.AutocompleteChannelsForTeamForSearch(tc.teamID, tc.fragment)
 			require.Nil(t, resp.Error)
-			names := make([]string, len(*channels))
-			for i, c := range *channels {
+			names := make([]string, len(channels))
+			for i, c := range channels {
 				names[i] = c.Name
 			}
 			for _, name := range tc.expectedIncludes {
@@ -3416,8 +3416,8 @@ func TestAutocompleteChannelsForSearchGuestUsers(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			channels, resp := th.Client.AutocompleteChannelsForTeamForSearch(tc.teamID, tc.fragment)
 			require.Nil(t, resp.Error)
-			names := make([]string, len(*channels))
-			for i, c := range *channels {
+			names := make([]string, len(channels))
+			for i, c := range channels {
 				names[i] = c.Name
 			}
 			for _, name := range tc.expectedIncludes {

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1208,10 +1208,10 @@ func TestGetFlaggedPostsForUser(t *testing.T) {
 		Name:     post1.Id,
 		Value:    "true",
 	}
-	_, resp := Client.UpdatePreferences(user.Id, &model.Preferences{preference})
+	_, resp := Client.UpdatePreferences(user.Id, model.Preferences{preference})
 	CheckNoError(t, resp)
 	preference.Name = post2.Id
-	_, resp = Client.UpdatePreferences(user.Id, &model.Preferences{preference})
+	_, resp = Client.UpdatePreferences(user.Id, model.Preferences{preference})
 	CheckNoError(t, resp)
 
 	opl := model.NewPostList()
@@ -1272,7 +1272,7 @@ func TestGetFlaggedPostsForUser(t *testing.T) {
 	post4 := th.CreatePostWithClient(Client, channel3)
 
 	preference.Name = post4.Id
-	Client.UpdatePreferences(user.Id, &model.Preferences{preference})
+	Client.UpdatePreferences(user.Id, model.Preferences{preference})
 
 	opl.AddPost(post4)
 	opl.AddOrder(post4.Id)
@@ -1298,7 +1298,7 @@ func TestGetFlaggedPostsForUser(t *testing.T) {
 	post5 := th.CreatePostWithClient(th.SystemAdminClient, channel4)
 
 	preference.Name = post5.Id
-	_, resp = Client.UpdatePreferences(user.Id, &model.Preferences{preference})
+	_, resp = Client.UpdatePreferences(user.Id, model.Preferences{preference})
 	CheckForbiddenStatus(t, resp)
 
 	rpl, resp = Client.GetFlaggedPostsForUser(user.Id, 0, 10)
@@ -1307,7 +1307,7 @@ func TestGetFlaggedPostsForUser(t *testing.T) {
 	require.Equal(t, opl.Posts, rpl.Posts, "posts should have matched")
 
 	th.AddUserToChannel(user, channel4)
-	_, resp = Client.UpdatePreferences(user.Id, &model.Preferences{preference})
+	_, resp = Client.UpdatePreferences(user.Id, model.Preferences{preference})
 	CheckNoError(t, resp)
 
 	rpl, resp = Client.GetFlaggedPostsForUser(user.Id, 0, 10)

--- a/api4/preference_test.go
+++ b/api4/preference_test.go
@@ -44,7 +44,7 @@ func TestGetPreferences(t *testing.T) {
 		},
 	}
 
-	Client.UpdatePreferences(user1.Id, &preferences1)
+	Client.UpdatePreferences(user1.Id, preferences1)
 
 	prefs, resp := Client.GetPreferences(user1.Id)
 	CheckNoError(t, resp)
@@ -100,7 +100,7 @@ func TestGetPreferencesByCategory(t *testing.T) {
 		},
 	}
 
-	Client.UpdatePreferences(user1.Id, &preferences1)
+	Client.UpdatePreferences(user1.Id, preferences1)
 
 	prefs, resp := Client.GetPreferencesByCategory(user1.Id, category)
 	CheckNoError(t, resp)
@@ -153,7 +153,7 @@ func TestGetPreferenceByCategoryAndName(t *testing.T) {
 		},
 	}
 
-	Client.UpdatePreferences(user.Id, &preferences)
+	Client.UpdatePreferences(user.Id, preferences)
 
 	pref, resp := Client.GetPreferenceByCategoryAndName(user.Id, model.PreferenceCategoryDirectChannelShow, name)
 	CheckNoError(t, resp)
@@ -163,7 +163,7 @@ func TestGetPreferenceByCategoryAndName(t *testing.T) {
 	require.Equal(t, preferences[0].Name, pref.Name, "Name preference not saved")
 
 	preferences[0].Value = model.NewId()
-	Client.UpdatePreferences(user.Id, &preferences)
+	Client.UpdatePreferences(user.Id, preferences)
 
 	_, resp = Client.GetPreferenceByCategoryAndName(user.Id, "junk", preferences[0].Name)
 	CheckBadRequestStatus(t, resp)
@@ -210,7 +210,7 @@ func TestUpdatePreferences(t *testing.T) {
 		},
 	}
 
-	_, resp := Client.UpdatePreferences(user1.Id, &preferences1)
+	_, resp := Client.UpdatePreferences(user1.Id, preferences1)
 	CheckNoError(t, resp)
 
 	preferences := model.Preferences{
@@ -221,7 +221,7 @@ func TestUpdatePreferences(t *testing.T) {
 		},
 	}
 
-	_, resp = Client.UpdatePreferences(user1.Id, &preferences)
+	_, resp = Client.UpdatePreferences(user1.Id, preferences)
 	CheckForbiddenStatus(t, resp)
 
 	preferences = model.Preferences{
@@ -231,14 +231,14 @@ func TestUpdatePreferences(t *testing.T) {
 		},
 	}
 
-	_, resp = Client.UpdatePreferences(user1.Id, &preferences)
+	_, resp = Client.UpdatePreferences(user1.Id, preferences)
 	CheckBadRequestStatus(t, resp)
 
-	_, resp = Client.UpdatePreferences(th.BasicUser2.Id, &preferences)
+	_, resp = Client.UpdatePreferences(th.BasicUser2.Id, preferences)
 	CheckForbiddenStatus(t, resp)
 
 	Client.Logout()
-	_, resp = Client.UpdatePreferences(user1.Id, &preferences1)
+	_, resp = Client.UpdatePreferences(user1.Id, preferences1)
 	CheckUnauthorizedStatus(t, resp)
 }
 
@@ -255,7 +255,7 @@ func TestUpdatePreferencesWebsocket(t *testing.T) {
 	require.Equal(t, wsResp.Status, model.StatusOk, "expected OK from auth challenge")
 
 	userId := th.BasicUser.Id
-	preferences := &model.Preferences{
+	preferences := model.Preferences{
 		{
 			UserId:   userId,
 			Category: model.NewId(),
@@ -285,7 +285,7 @@ func TestUpdatePreferencesWebsocket(t *testing.T) {
 			received, err := model.PreferencesFromJson(strings.NewReader(event.GetData()["preferences"].(string)))
 			require.NoError(t, err)
 
-			for i, p := range *preferences {
+			for i, p := range preferences {
 				require.Equal(t, received[i].UserId, p.UserId, "received incorrect UserId")
 				require.Equal(t, received[i].Category, p.Category, "received incorrect Category")
 				require.Equal(t, received[i].Name, p.Name, "received incorrect Name")
@@ -323,7 +323,7 @@ func TestUpdateSidebarPreferences(t *testing.T) {
 		require.Contains(t, categories.Categories[1].Channels, channel.Id)
 
 		// Favorite the channel
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -342,7 +342,7 @@ func TestUpdateSidebarPreferences(t *testing.T) {
 		assert.NotContains(t, categories.Categories[1].Channels, channel.Id)
 
 		// And unfavorite the channel
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -376,7 +376,7 @@ func TestUpdateSidebarPreferences(t *testing.T) {
 		dmChannel := th.CreateDmChannel(user2)
 
 		// Favorite the channel
-		_, resp := th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp := th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -402,7 +402,7 @@ func TestUpdateSidebarPreferences(t *testing.T) {
 		assert.NotContains(t, categories.Categories[2].Channels, dmChannel.Id)
 
 		// And unfavorite the channel
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -467,7 +467,7 @@ func TestUpdateSidebarPreferences(t *testing.T) {
 		require.Contains(t, categories.Categories[1].Channels, channel.Id)
 
 		// Favorite the channel
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -486,7 +486,7 @@ func TestUpdateSidebarPreferences(t *testing.T) {
 		assert.Contains(t, categories.Categories[1].Channels, channel.Id)
 
 		// Favorite the channel for the second user
-		_, resp = client2.UpdatePreferences(user2.Id, &model.Preferences{
+		_, resp = client2.UpdatePreferences(user2.Id, model.Preferences{
 			{
 				UserId:   user2.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -505,7 +505,7 @@ func TestUpdateSidebarPreferences(t *testing.T) {
 		assert.NotContains(t, categories.Categories[1].Channels, channel.Id)
 
 		// And unfavorite the channel
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -546,27 +546,27 @@ func TestDeletePreferences(t *testing.T) {
 		preferences = append(preferences, preference)
 	}
 
-	Client.UpdatePreferences(th.BasicUser.Id, &preferences)
+	Client.UpdatePreferences(th.BasicUser.Id, preferences)
 
 	// delete 10 preferences
 	th.LoginBasic2()
 
-	_, resp := Client.DeletePreferences(th.BasicUser2.Id, &preferences)
+	_, resp := Client.DeletePreferences(th.BasicUser2.Id, preferences)
 	CheckForbiddenStatus(t, resp)
 
 	th.LoginBasic()
 
-	_, resp = Client.DeletePreferences(th.BasicUser.Id, &preferences)
+	_, resp = Client.DeletePreferences(th.BasicUser.Id, preferences)
 	CheckNoError(t, resp)
 
-	_, resp = Client.DeletePreferences(th.BasicUser2.Id, &preferences)
+	_, resp = Client.DeletePreferences(th.BasicUser2.Id, preferences)
 	CheckForbiddenStatus(t, resp)
 
 	prefs, _ = Client.GetPreferences(th.BasicUser.Id)
 	require.Len(t, prefs, originalCount, "should've deleted preferences")
 
 	Client.Logout()
-	_, resp = Client.DeletePreferences(th.BasicUser.Id, &preferences)
+	_, resp = Client.DeletePreferences(th.BasicUser.Id, preferences)
 	CheckUnauthorizedStatus(t, resp)
 }
 
@@ -575,7 +575,7 @@ func TestDeletePreferencesWebsocket(t *testing.T) {
 	defer th.TearDown()
 
 	userId := th.BasicUser.Id
-	preferences := &model.Preferences{
+	preferences := model.Preferences{
 		{
 			UserId:   userId,
 			Category: model.NewId(),
@@ -614,7 +614,7 @@ func TestDeletePreferencesWebsocket(t *testing.T) {
 			received, err := model.PreferencesFromJson(strings.NewReader(event.GetData()["preferences"].(string)))
 			require.NoError(t, err)
 
-			for i, preference := range *preferences {
+			for i, preference := range preferences {
 				require.Equal(t, preference.UserId, received[i].UserId)
 				require.Equal(t, preference.Category, received[i].Category)
 				require.Equal(t, preference.Name, received[i].Name)
@@ -652,7 +652,7 @@ func TestDeleteSidebarPreferences(t *testing.T) {
 		require.Contains(t, categories.Categories[1].Channels, channel.Id)
 
 		// Favorite the channel
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -671,7 +671,7 @@ func TestDeleteSidebarPreferences(t *testing.T) {
 		assert.NotContains(t, categories.Categories[1].Channels, channel.Id)
 
 		// And unfavorite the channel by deleting the preference
-		_, resp = th.Client.DeletePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.DeletePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -704,7 +704,7 @@ func TestDeleteSidebarPreferences(t *testing.T) {
 		dmChannel := th.CreateDmChannel(user2)
 
 		// Favorite the channel
-		_, resp := th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp := th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -730,7 +730,7 @@ func TestDeleteSidebarPreferences(t *testing.T) {
 		assert.NotContains(t, categories.Categories[2].Channels, dmChannel.Id)
 
 		// And unfavorite the channel by deleting the preference
-		_, resp = th.Client.DeletePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.DeletePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -794,7 +794,7 @@ func TestDeleteSidebarPreferences(t *testing.T) {
 		require.Contains(t, categories.Categories[1].Channels, channel.Id)
 
 		// Favorite the channel for both users
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -804,7 +804,7 @@ func TestDeleteSidebarPreferences(t *testing.T) {
 		})
 		require.Nil(t, resp.Error)
 
-		_, resp = client2.UpdatePreferences(user2.Id, &model.Preferences{
+		_, resp = client2.UpdatePreferences(user2.Id, model.Preferences{
 			{
 				UserId:   user2.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,
@@ -823,7 +823,7 @@ func TestDeleteSidebarPreferences(t *testing.T) {
 		assert.NotContains(t, categories.Categories[1].Channels, channel.Id)
 
 		// And unfavorite the channel for the first user by deleting the preference
-		_, resp = th.Client.UpdatePreferences(user.Id, &model.Preferences{
+		_, resp = th.Client.UpdatePreferences(user.Id, model.Preferences{
 			{
 				UserId:   user.Id,
 				Category: model.PreferenceCategoryFavoriteChannel,

--- a/app/status.go
+++ b/app/status.go
@@ -437,11 +437,11 @@ func (a *App) RemoveCustomStatus(userID string) *model.AppError {
 }
 
 func (a *App) addRecentCustomStatus(userID string, status *model.CustomStatus) *model.AppError {
-	var newRCS *model.RecentCustomStatuses
+	var newRCS model.RecentCustomStatuses
 
 	pref, err := a.GetPreferenceByCategoryAndNameForUser(userID, model.PreferenceCategoryCustomStatus, model.PreferenceNameRecentCustomStatuses)
 	if err != nil || pref.Value == "" {
-		newRCS = &model.RecentCustomStatuses{*status}
+		newRCS = model.RecentCustomStatuses{*status}
 	} else {
 		existingRCS := model.RecentCustomStatusesFromJson(strings.NewReader(pref.Value))
 		newRCS = existingRCS.Add(status)

--- a/model/client4.go
+++ b/model/client4.go
@@ -2530,22 +2530,22 @@ func (c *Client4) RemoveTeamIcon(teamId string) (bool, *Response) {
 // Channel Section
 
 // GetAllChannels get all the channels. Must be a system administrator.
-func (c *Client4) GetAllChannels(page int, perPage int, etag string) (*ChannelListWithTeamData, *Response) {
+func (c *Client4) GetAllChannels(page int, perPage int, etag string) (ChannelListWithTeamData, *Response) {
 	return c.getAllChannels(page, perPage, etag, ChannelSearchOpts{})
 }
 
 // GetAllChannelsIncludeDeleted get all the channels. Must be a system administrator.
-func (c *Client4) GetAllChannelsIncludeDeleted(page int, perPage int, etag string) (*ChannelListWithTeamData, *Response) {
+func (c *Client4) GetAllChannelsIncludeDeleted(page int, perPage int, etag string) (ChannelListWithTeamData, *Response) {
 	return c.getAllChannels(page, perPage, etag, ChannelSearchOpts{IncludeDeleted: true})
 }
 
 // GetAllChannelsExcludePolicyConstrained gets all channels which are not part of a data retention policy.
 // Must be a system administrator.
-func (c *Client4) GetAllChannelsExcludePolicyConstrained(page, perPage int, etag string) (*ChannelListWithTeamData, *Response) {
+func (c *Client4) GetAllChannelsExcludePolicyConstrained(page, perPage int, etag string) (ChannelListWithTeamData, *Response) {
 	return c.getAllChannels(page, perPage, etag, ChannelSearchOpts{ExcludePolicyConstrained: true})
 }
 
-func (c *Client4) getAllChannels(page int, perPage int, etag string, opts ChannelSearchOpts) (*ChannelListWithTeamData, *Response) {
+func (c *Client4) getAllChannels(page int, perPage int, etag string, opts ChannelSearchOpts) (ChannelListWithTeamData, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v&include_deleted=%v&exclude_policy_constrained=%v",
 		page, perPage, opts.IncludeDeleted, opts.ExcludePolicyConstrained)
 	r, appErr := c.DoApiGet(c.GetChannelsRoute()+query, etag)
@@ -2554,7 +2554,7 @@ func (c *Client4) getAllChannels(page int, perPage int, etag string, opts Channe
 	}
 	defer closeBody(r)
 
-	var ch *ChannelListWithTeamData
+	var ch ChannelListWithTeamData
 	err := json.NewDecoder(r.Body).Decode(&ch)
 	if err != nil {
 		return nil, BuildErrorResponse(r, NewAppError("getAllChannels", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -2894,14 +2894,14 @@ func (c *Client4) SearchArchivedChannels(teamId string, search *ChannelSearch) (
 }
 
 // SearchAllChannels search in all the channels. Must be a system administrator.
-func (c *Client4) SearchAllChannels(search *ChannelSearch) (*ChannelListWithTeamData, *Response) {
+func (c *Client4) SearchAllChannels(search *ChannelSearch) (ChannelListWithTeamData, *Response) {
 	r, appErr := c.DoApiPost(c.GetChannelsRoute()+"/search", search.ToJson())
 	if appErr != nil {
 		return nil, BuildErrorResponse(r, appErr)
 	}
 	defer closeBody(r)
 
-	var ch *ChannelListWithTeamData
+	var ch ChannelListWithTeamData
 	err := json.NewDecoder(r.Body).Decode(&ch)
 	if err != nil {
 		return nil, BuildErrorResponse(r, NewAppError("SearchAllChannels", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -3046,7 +3046,7 @@ func (c *Client4) GetChannelByNameForTeamNameIncludeDeleted(channelName, teamNam
 }
 
 // GetChannelMembers gets a page of channel members.
-func (c *Client4) GetChannelMembers(channelId string, page, perPage int, etag string) (*ChannelMembers, *Response) {
+func (c *Client4) GetChannelMembers(channelId string, page, perPage int, etag string) (ChannelMembers, *Response) {
 	query := fmt.Sprintf("?page=%v&per_page=%v", page, perPage)
 	r, appErr := c.DoApiGet(c.GetChannelMembersRoute(channelId)+query, etag)
 	if appErr != nil {
@@ -3054,7 +3054,7 @@ func (c *Client4) GetChannelMembers(channelId string, page, perPage int, etag st
 	}
 	defer closeBody(r)
 
-	var ch *ChannelMembers
+	var ch ChannelMembers
 	err := json.NewDecoder(r.Body).Decode(&ch)
 	if err != nil {
 		return nil, BuildErrorResponse(r, NewAppError("GetChannelMembers", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -3063,14 +3063,14 @@ func (c *Client4) GetChannelMembers(channelId string, page, perPage int, etag st
 }
 
 // GetChannelMembersByIds gets the channel members in a channel for a list of user ids.
-func (c *Client4) GetChannelMembersByIds(channelId string, userIds []string) (*ChannelMembers, *Response) {
+func (c *Client4) GetChannelMembersByIds(channelId string, userIds []string) (ChannelMembers, *Response) {
 	r, appErr := c.DoApiPost(c.GetChannelMembersRoute(channelId)+"/ids", ArrayToJson(userIds))
 	if appErr != nil {
 		return nil, BuildErrorResponse(r, appErr)
 	}
 	defer closeBody(r)
 
-	var ch *ChannelMembers
+	var ch ChannelMembers
 	err := json.NewDecoder(r.Body).Decode(&ch)
 	if err != nil {
 		return nil, BuildErrorResponse(r, NewAppError("GetChannelMembersByIds", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -3095,14 +3095,14 @@ func (c *Client4) GetChannelMember(channelId, userId, etag string) (*ChannelMemb
 }
 
 // GetChannelMembersForUser gets all the channel members for a user on a team.
-func (c *Client4) GetChannelMembersForUser(userId, teamId, etag string) (*ChannelMembers, *Response) {
+func (c *Client4) GetChannelMembersForUser(userId, teamId, etag string) (ChannelMembers, *Response) {
 	r, appErr := c.DoApiGet(fmt.Sprintf(c.GetUserRoute(userId)+"/teams/%v/channels/members", teamId), etag)
 	if appErr != nil {
 		return nil, BuildErrorResponse(r, appErr)
 	}
 	defer closeBody(r)
 
-	var ch *ChannelMembers
+	var ch ChannelMembers
 	err := json.NewDecoder(r.Body).Decode(&ch)
 	if err != nil {
 		return nil, BuildErrorResponse(r, NewAppError("GetChannelMembersForUser", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -3228,7 +3228,7 @@ func (c *Client4) RemoveUserFromChannel(channelId, userId string) (bool, *Respon
 }
 
 // AutocompleteChannelsForTeam will return an ordered list of channels autocomplete suggestions.
-func (c *Client4) AutocompleteChannelsForTeam(teamId, name string) (*ChannelList, *Response) {
+func (c *Client4) AutocompleteChannelsForTeam(teamId, name string) (ChannelList, *Response) {
 	query := fmt.Sprintf("?name=%v", name)
 	r, app := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+"/autocomplete"+query, "")
 	if app != nil {
@@ -3236,7 +3236,7 @@ func (c *Client4) AutocompleteChannelsForTeam(teamId, name string) (*ChannelList
 	}
 	defer closeBody(r)
 
-	var ch *ChannelList
+	var ch ChannelList
 	err := json.NewDecoder(r.Body).Decode(&ch)
 	if err != nil {
 		return nil, BuildErrorResponse(r, NewAppError("AutocompleteChannelsForTeam", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -3245,7 +3245,7 @@ func (c *Client4) AutocompleteChannelsForTeam(teamId, name string) (*ChannelList
 }
 
 // AutocompleteChannelsForTeamForSearch will return an ordered list of your channels autocomplete suggestions.
-func (c *Client4) AutocompleteChannelsForTeamForSearch(teamId, name string) (*ChannelList, *Response) {
+func (c *Client4) AutocompleteChannelsForTeamForSearch(teamId, name string) (ChannelList, *Response) {
 	query := fmt.Sprintf("?name=%v", name)
 	r, appErr := c.DoApiGet(c.GetChannelsForTeamRoute(teamId)+"/search_autocomplete"+query, "")
 	if appErr != nil {
@@ -3253,7 +3253,7 @@ func (c *Client4) AutocompleteChannelsForTeamForSearch(teamId, name string) (*Ch
 	}
 	defer closeBody(r)
 
-	var ch *ChannelList
+	var ch ChannelList
 	err := json.NewDecoder(r.Body).Decode(&ch)
 	if err != nil {
 		return nil, BuildErrorResponse(r, NewAppError("AutocompleteChannelsForTeamForSearch", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -4201,7 +4201,7 @@ func (c *Client4) GetPreferences(userId string) (Preferences, *Response) {
 }
 
 // UpdatePreferences saves the user's preferences.
-func (c *Client4) UpdatePreferences(userId string, preferences *Preferences) (bool, *Response) {
+func (c *Client4) UpdatePreferences(userId string, preferences Preferences) (bool, *Response) {
 	buf, err := json.Marshal(preferences)
 	if err != nil {
 		return false, BuildErrorResponse(nil, NewAppError("UpdatePreferences", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))
@@ -4215,7 +4215,7 @@ func (c *Client4) UpdatePreferences(userId string, preferences *Preferences) (bo
 }
 
 // DeletePreferences deletes the user's preferences.
-func (c *Client4) DeletePreferences(userId string, preferences *Preferences) (bool, *Response) {
+func (c *Client4) DeletePreferences(userId string, preferences Preferences) (bool, *Response) {
 	buf, err := json.Marshal(preferences)
 	if err != nil {
 		return false, BuildErrorResponse(nil, NewAppError("DeletePreferences", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError))

--- a/model/custom_status.go
+++ b/model/custom_status.go
@@ -79,7 +79,7 @@ func RuneToHexadecimalString(r rune) string {
 
 type RecentCustomStatuses []CustomStatus
 
-func (rcs *RecentCustomStatuses) Contains(cs *CustomStatus) bool {
+func (rcs RecentCustomStatuses) Contains(cs *CustomStatus) bool {
 	var csJSON = cs.ToJson()
 
 	// status is empty
@@ -87,7 +87,7 @@ func (rcs *RecentCustomStatuses) Contains(cs *CustomStatus) bool {
 		return false
 	}
 
-	for _, status := range *rcs {
+	for _, status := range rcs {
 		if status.ToJson() == csJSON {
 			return true
 		}
@@ -96,11 +96,11 @@ func (rcs *RecentCustomStatuses) Contains(cs *CustomStatus) bool {
 	return false
 }
 
-func (rcs *RecentCustomStatuses) Add(cs *CustomStatus) *RecentCustomStatuses {
-	newRCS := (*rcs)[:0]
+func (rcs RecentCustomStatuses) Add(cs *CustomStatus) RecentCustomStatuses {
+	newRCS := rcs[:0]
 
 	// if same `text` exists in existing recent custom statuses, modify existing status
-	for _, status := range *rcs {
+	for _, status := range rcs {
 		if status.Text != cs.Text {
 			newRCS = append(newRCS, status)
 		}
@@ -109,33 +109,32 @@ func (rcs *RecentCustomStatuses) Add(cs *CustomStatus) *RecentCustomStatuses {
 	if len(newRCS) > MaxRecentCustomStatuses {
 		newRCS = newRCS[:MaxRecentCustomStatuses]
 	}
-	return &newRCS
+	return newRCS
 }
 
-func (rcs *RecentCustomStatuses) Remove(cs *CustomStatus) *RecentCustomStatuses {
+func (rcs RecentCustomStatuses) Remove(cs *CustomStatus) RecentCustomStatuses {
 	var csJSON = cs.ToJson()
 	if csJSON == "" || (cs.Emoji == "" && cs.Text == "") {
 		return rcs
 	}
 
-	newRCS := (*rcs)[:0]
-	for _, status := range *rcs {
+	newRCS := rcs[:0]
+	for _, status := range rcs {
 		if status.ToJson() != csJSON {
 			newRCS = append(newRCS, status)
 		}
 	}
 
-	return &newRCS
+	return newRCS
 }
 
-func (rcs *RecentCustomStatuses) ToJson() string {
-	rcsCopy := *rcs
-	b, _ := json.Marshal(rcsCopy)
+func (rcs RecentCustomStatuses) ToJson() string {
+	b, _ := json.Marshal(rcs)
 	return string(b)
 }
 
-func RecentCustomStatusesFromJson(data io.Reader) *RecentCustomStatuses {
-	var rcs *RecentCustomStatuses
+func RecentCustomStatusesFromJson(data io.Reader) RecentCustomStatuses {
+	var rcs RecentCustomStatuses
 	_ = json.NewDecoder(data).Decode(&rcs)
 	return rcs
 }


### PR DESCRIPTION
#### Summary

PR removes remaining uses of pointer to slice from  `model`.

#### Ticket

https://mattermost.atlassian.net/browse/MM-28985

#### Release Note

```release-note
NONE
```

#### Related PRs

https://github.com/mattermost/enterprise/pull/1042