### PR TITLE
MM-35754: Fail fast if templates directory is not found

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -389,19 +389,18 @@ func NewServer(options ...Option) (*Server, error) {
 
 	templatesDir, ok := templates.GetTemplateDirectory()
 	if !ok {
-		mlog.Error("Failed find server templates", mlog.String("directory", "templates"))
-	} else {
-		htmlTemplateWatcher, errorsChan, err2 := templates.NewWithWatcher(templatesDir)
-		if err2 != nil {
-			return nil, errors.Wrap(err2, "cannot initialize server templates")
-		}
-		s.Go(func() {
-			for err2 := range errorsChan {
-				mlog.Warn("Server templates error", mlog.Err(err2))
-			}
-		})
-		s.htmlTemplateWatcher = htmlTemplateWatcher
+		return nil, errors.New("Failed find server templates in \"templates\" directory or MM_SERVER_PATH")
 	}
+	htmlTemplateWatcher, errorsChan, err2 := templates.NewWithWatcher(templatesDir)
+	if err2 != nil {
+		return nil, errors.Wrap(err2, "cannot initialize server templates")
+	}
+	s.Go(func() {
+		for err2 := range errorsChan {
+			mlog.Warn("Server templates error", mlog.Err(err2))
+		}
+	})
+	s.htmlTemplateWatcher = htmlTemplateWatcher
 
 	s.Store, err = s.newStore()
 	if err != nil {


### PR DESCRIPTION
We used to log an error and move forward, which led to
panics later during server execution, because the templates
don't exist.

While technically speaking the server will run fine
because it's just one HTTP handler goroutine which panics,
but properly handling the error requires much more adjustments
in the code to check for nil templates.

It is better to fail earlier and force the application
to start in a clean slate.

https://mattermost.atlassian.net/browse/MM-37574

```release-note
NONE
```
