### PR TITLE
MM-37575: Handle nil value in override_username

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -1069,8 +1069,8 @@ func (n *PostNotification) GetSenderName(userNameFormat string, overridesAllowed
 
 	if overridesAllowed && n.Channel.Type != model.ChannelTypeDirect {
 		if value := n.Post.GetProps()["override_username"]; value != nil && n.Post.GetProp("from_webhook") == "true" {
-			if _, ok := value.(string); ok {
-				return value.(string)
+			if s, ok := value.(string); ok {
+				return s
 			}
 		}
 	}

--- a/app/notification.go
+++ b/app/notification.go
@@ -1068,7 +1068,7 @@ func (n *PostNotification) GetSenderName(userNameFormat string, overridesAllowed
 	}
 
 	if overridesAllowed && n.Channel.Type != model.ChannelTypeDirect {
-		if value, ok := n.Post.GetProps()["override_username"]; ok && n.Post.GetProp("from_webhook") == "true" {
+		if value := n.Post.GetProps()["override_username"]; value != nil && n.Post.GetProp("from_webhook") == "true" {
 			return value.(string)
 		}
 	}

--- a/app/notification.go
+++ b/app/notification.go
@@ -1069,7 +1069,9 @@ func (n *PostNotification) GetSenderName(userNameFormat string, overridesAllowed
 
 	if overridesAllowed && n.Channel.Type != model.ChannelTypeDirect {
 		if value := n.Post.GetProps()["override_username"]; value != nil && n.Post.GetProp("from_webhook") == "true" {
-			return value.(string)
+			if _, ok := value.(string); ok {
+				return value.(string)
+			}
 		}
 	}
 

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1799,6 +1799,13 @@ func TestPostNotificationGetSenderName(t *testing.T) {
 		},
 	}
 
+	overriddenPost2 := &model.Post{
+		Props: model.StringInterface{
+			"override_username": nil,
+			"from_webhook":      "true",
+		},
+	}
+
 	for name, testCase := range map[string]struct {
 		channel        *model.Channel
 		post           *model.Post
@@ -1839,6 +1846,11 @@ func TestPostNotificationGetSenderName(t *testing.T) {
 		"overridden username, overrides disabled": {
 			post:           overriddenPost,
 			allowOverrides: false,
+			expected:       "@" + sender.Username,
+		},
+		"nil override_username": {
+			post:           overriddenPost2,
+			allowOverrides: true,
 			expected:       "@" + sender.Username,
 		},
 	} {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1806,6 +1806,13 @@ func TestPostNotificationGetSenderName(t *testing.T) {
 		},
 	}
 
+	overriddenPost3 := &model.Post{
+		Props: model.StringInterface{
+			"override_username": 10,
+			"from_webhook":      "true",
+		},
+	}
+
 	for name, testCase := range map[string]struct {
 		channel        *model.Channel
 		post           *model.Post
@@ -1850,6 +1857,11 @@ func TestPostNotificationGetSenderName(t *testing.T) {
 		},
 		"nil override_username": {
 			post:           overriddenPost2,
+			allowOverrides: true,
+			expected:       "@" + sender.Username,
+		},
+		"integer override_username": {
+			post:           overriddenPost3,
 			allowOverrides: true,
 			expected:       "@" + sender.Username,
 		},


### PR DESCRIPTION
Since props is a map[string]interface{}, an ", ok" check doesn't
really help because even if a key is not present, by default, a map
will always return the default value of the value, which would be a
nil interface.

So we can just check for the value of the map instead.

https://mattermost.atlassian.net/browse/MM-37575

```release-note
NONE
```
