### PR TITLE
[MM-37578] - Add setting for onboarding

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -42,6 +42,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["CloseUnusedDirectMessages"] = strconv.FormatBool(*c.ServiceSettings.CloseUnusedDirectMessages)
 	props["EnablePreviewFeatures"] = strconv.FormatBool(*c.ServiceSettings.EnablePreviewFeatures)
 	props["EnableTutorial"] = strconv.FormatBool(*c.ServiceSettings.EnableTutorial)
+	props["EnableOnboardingFlow"] = strconv.FormatBool(*c.ServiceSettings.EnableOnboardingFlow)
 	props["ExperimentalEnableDefaultChannelLeaveJoinMessages"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages)
 	props["ExperimentalGroupUnreadChannels"] = *c.ServiceSettings.ExperimentalGroupUnreadChannels
 	props["EnableSVGs"] = strconv.FormatBool(*c.ServiceSettings.EnableSVGs)

--- a/model/config.go
+++ b/model/config.go
@@ -348,6 +348,7 @@ type ServiceSettings struct {
 	CloseUnusedDirectMessages                         *bool    `access:"experimental_features"`
 	EnablePreviewFeatures                             *bool    `access:"experimental_features"`
 	EnableTutorial                                    *bool    `access:"experimental_features"`
+	EnableOnboardingFlow                              *bool    `access:"experimental_features"`
 	ExperimentalEnableDefaultChannelLeaveJoinMessages *bool    `access:"experimental_features"`
 	ExperimentalGroupUnreadChannels                   *string  `access:"experimental_features"`
 	ExperimentalChannelOrganization                   *bool    `access:"experimental_features"`
@@ -576,6 +577,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.EnableTutorial == nil {
 		s.EnableTutorial = NewBool(true)
+	}
+
+	if s.EnableOnboardingFlow == nil {
+		s.EnableOnboardingFlow = NewBool(true)
 	}
 
 	// Must be manually enabled for existing installations.

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -418,6 +418,7 @@ func (ts *TelemetryService) trackConfig() {
 		"close_unused_direct_messages":                            *cfg.ServiceSettings.CloseUnusedDirectMessages,
 		"enable_preview_features":                                 *cfg.ServiceSettings.EnablePreviewFeatures,
 		"enable_tutorial":                                         *cfg.ServiceSettings.EnableTutorial,
+		"enable_onboarding_flow":                                  *&cfg.ServiceSettings.EnableOnboardingFlow,
 		"experimental_enable_default_channel_leave_join_messages": *cfg.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages,
 		"experimental_group_unread_channels":                      *cfg.ServiceSettings.ExperimentalGroupUnreadChannels,
 		"collapsed_threads":                                       *cfg.ServiceSettings.CollapsedThreads,

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -418,7 +418,7 @@ func (ts *TelemetryService) trackConfig() {
 		"close_unused_direct_messages":                            *cfg.ServiceSettings.CloseUnusedDirectMessages,
 		"enable_preview_features":                                 *cfg.ServiceSettings.EnablePreviewFeatures,
 		"enable_tutorial":                                         *cfg.ServiceSettings.EnableTutorial,
-		"enable_onboarding_flow":                                  *&cfg.ServiceSettings.EnableOnboardingFlow,
+		"enable_onboarding_flow":                                  *cfg.ServiceSettings.EnableOnboardingFlow,
 		"experimental_enable_default_channel_leave_join_messages": *cfg.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages,
 		"experimental_group_unread_channels":                      *cfg.ServiceSettings.ExperimentalGroupUnreadChannels,
 		"collapsed_threads":                                       *cfg.ServiceSettings.CollapsedThreads,

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -59,6 +59,7 @@
         "CloseUnusedDirectMessages": false,
         "EnablePreviewFeatures": true,
         "EnableTutorial": true,
+        "EnableOnboardingFlow": true,
         "ExperimentalEnableDefaultChannelLeaveJoinMessages": true,
         "ExperimentalGroupUnreadChannels": "disabled",
         "ImageProxyType": "",


### PR DESCRIPTION
#### Summary
This PR adds a setting `EnableOnboardingFlow` in the configuration to toggle onboarding flow

#### Ticket Link
[MM-37578](https://mattermost.atlassian.net/browse/MM-37578?atlOrigin=eyJpIjoiNzViZDIyN2MzZTkzNGNhODk0NzRiNmUxY2Y0YWM4ZjAiLCJwIjoiaiJ9)

#### Release Note
```release-note
Added a new config setting ServiceSettings.EnableOnboardingFlow

```
