### PR TITLE
Remove deprecated model.ComparePassword method

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -854,18 +854,6 @@ func HashPassword(password string) string {
 	return string(hash)
 }
 
-// ComparePassword compares the hash
-// This function is deprecated and will be removed in a future release.
-func ComparePassword(hash string, password string) bool {
-
-	if password == "" || hash == "" {
-		return false
-	}
-
-	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
-	return err == nil
-}
-
 var validUsernameChars = regexp.MustCompile(`^[a-z0-9\.\-_]+$`)
 var validUsernameCharsForRemote = regexp.MustCompile(`^[a-z0-9\.\-_:]+$`)
 

--- a/model/user_test.go
+++ b/model/user_test.go
@@ -13,13 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPasswordHash(t *testing.T) {
-	hash := HashPassword("Test")
-
-	assert.True(t, ComparePassword(hash, "Test"), "Passwords don't match")
-	assert.False(t, ComparePassword(hash, "Test2"), "Passwords should not have matched")
-}
-
 func TestUserDeepCopy(t *testing.T) {
 	id := NewId()
 	authData := "authdata"


### PR DESCRIPTION
#### Summary
Remove deprecated `model.ComparePassword` method

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37677

#### Release Note
```release-note
Remove deprecated model.ComparePassword method
```
