### PR TITLE
Log error from a compliance job failure

### DIFF
--- a/app/compliance.go
+++ b/app/compliance.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
 )
 
@@ -45,7 +46,10 @@ func (a *App) SaveComplianceReport(job *model.Compliance) (*model.Compliance, *m
 
 	jCopy := job.DeepCopy()
 	a.Srv().Go(func() {
-		a.Compliance().RunComplianceJob(jCopy)
+		err := a.Compliance().RunComplianceJob(jCopy)
+		if err != nil {
+			mlog.Warn("Error running compliance job", mlog.Err(err))
+		}
 	})
 
 	return job, nil


### PR DESCRIPTION
Found this while investigating https://github.com/mattermost/enterprise/pull/1044.

```release-note
NONE
```
