### PR TITLE
mmctl plugin add: introduce default-false 'replace' flag

### DIFF
--- a/cmd/mattermost/commands/plugin.go
+++ b/cmd/mattermost/commands/plugin.go
@@ -91,6 +91,7 @@ func init() {
 		PluginAddPublicKeyCmd,
 		PluginDeletePublicKeyCmd,
 	)
+	PluginAddCmd.Flags().Bool("replace", false, "Allow replacement of existing plugin with the same ID.")
 	PluginCmd.AddCommand(
 		PluginAddCmd,
 		PluginDeleteCmd,
@@ -110,6 +111,8 @@ func pluginAddCmdF(command *cobra.Command, args []string) error {
 	}
 	defer a.Srv().Shutdown()
 
+	replace, _ := command.Flags().GetBool("replace")
+
 	if len(args) < 1 {
 		return errors.New("Expected at least one argument. See help text for details.")
 	}
@@ -120,7 +123,7 @@ func pluginAddCmdF(command *cobra.Command, args []string) error {
 			return err
 		}
 
-		if _, err := a.InstallPlugin(fileReader, false); err != nil {
+		if _, err := a.InstallPlugin(fileReader, replace); err != nil {
 			CommandPrintErrorln("Unable to add plugin: " + args[i] + ". Error: " + err.Error())
 		} else {
 			CommandPrettyPrintln("Added plugin: " + plugin)

--- a/cmd/mattermost/commands/plugin_test.go
+++ b/cmd/mattermost/commands/plugin_test.go
@@ -33,6 +33,10 @@ func TestPlugin(t *testing.T) {
 
 	output := th.CheckCommand(t, "plugin", "add", filepath.Join(path, "testplugin.tar.gz"))
 	assert.Contains(t, output, "Added plugin:")
+	output = th.CheckCommand(t, "plugin", "add", filepath.Join(path, "testplugin.tar.gz"))
+	assert.Contains(t, output, "Unable to add plugin:")
+	output = th.CheckCommand(t, "plugin", "add", "--replace", filepath.Join(path, "testplugin.tar.gz"))
+	assert.Contains(t, output, "Added plugin:")
 	output = th.CheckCommand(t, "plugin", "enable", "testplugin")
 	assert.Contains(t, output, "Enabled plugin: testplugin")
 


### PR DESCRIPTION
…allows existing plugins to be replaced
#### Summary
Adds a `--replace` flag to the `mmctl plugin add` command, allowing replacement of an existing plugin with the same ID.

#### Ticket Link
Resolves #18080.

#### Release Note
```release-note
Introduce support for replacement of existing plugins to the 'mmctl plugin add' command
```