### PR TITLE
[MM-36445] Changing elastic search docker version

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -84,7 +84,9 @@ services:
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:7.14.0"
+    build:
+      context: ./
+      dockerfile: ./elastic/Dockerfile
     networks:
       - mm-test
     environment:

--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -84,9 +84,7 @@ services:
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
   elasticsearch:
-    build:
-      context: ./
-      dockerfile: ./elastic/Dockerfile
+    image: "mattermost/mattermost-elasticsearch-docker:7.0.0"
     networks:
       - mm-test
     environment:

--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -98,10 +98,6 @@ services:
       http.cors.allow-credentials: "true"
       transport.host: "127.0.0.1"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
-    command: >
-      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q analysis-icu 
-      || ./bin/elasticsearch-plugin install analysis-icu; 
-      /usr/local/bin/docker-entrypoint.sh"
   dejavu:
     image: "appbaseio/dejavu:3.4.2"
     networks:

--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -84,7 +84,7 @@ services:
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
   elasticsearch:
-    image: "mattermost/mattermost-elasticsearch-docker:6.5.1"
+    image: "docker.elastic.co/elasticsearch/elasticsearch:7.14.0"
     networks:
       - mm-test
     environment:

--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -96,6 +96,10 @@ services:
       http.cors.allow-credentials: "true"
       transport.host: "127.0.0.1"
       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
+    command: >
+      /bin/sh -c "./bin/elasticsearch-plugin list | grep -q analysis-icu 
+      || ./bin/elasticsearch-plugin install analysis-icu; 
+      /usr/local/bin/docker-entrypoint.sh"
   dejavu:
     image: "appbaseio/dejavu:3.4.2"
     networks:

--- a/build/elastic/Dockerfile
+++ b/build/elastic/Dockerfile
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu

--- a/build/elastic/Dockerfile
+++ b/build/elastic/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.0.0
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu

--- a/build/elastic/Dockerfile
+++ b/build/elastic/Dockerfile
@@ -1,3 +1,4 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.14.0
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+

--- a/build/elastic/Dockerfile
+++ b/build/elastic/Dockerfile
@@ -1,3 +1,0 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.0.0
-
-RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu

--- a/build/elastic/Dockerfile
+++ b/build/elastic/Dockerfile
@@ -1,4 +1,3 @@
 FROM docker.elastic.co/elasticsearch/elasticsearch:7.14.0
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
-

--- a/build/gitlab-dc.common.yml
+++ b/build/gitlab-dc.common.yml
@@ -23,7 +23,7 @@ services:
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
   elasticsearch:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-elasticsearch-docker:6.5.1-1
+    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-elasticsearch-docker:7.0.0
     environment:
       http.host: "0.0.0.0"
       http.port: 9200


### PR DESCRIPTION
#### Summary
Using es7 for pipeline because we no longer support es 5 & 6

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36445

#### Related PRs
https://github.com/mattermost/enterprise/pull/1020


#### Release Note
```release-note
Using es7 in circle ci
```
