### PR TITLE
MM-37378: Unskip TestPanicLog

### DIFF
--- a/app/server_test.go
+++ b/app/server_test.go
@@ -516,7 +516,6 @@ func checkEndpoint(t *testing.T, client *http.Client, url string) error {
 }
 
 func TestPanicLog(t *testing.T) {
-	t.Skip("MM-37378")
 	// Creating a temp file to collect logs
 	tmpfile, err := ioutil.TempFile("", "mlog")
 	if err != nil {


### PR DESCRIPTION
Config watcher has been removed from codebase.
It is safe to bring this back now.

https://mattermost.atlassian.net/browse/MM-37378

```release-note
NONE
```
