### PR TITLE
[MM-37846] Fix payload for post deleted event

### DIFF
--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -1997,6 +1997,41 @@ func TestDeletePost(t *testing.T) {
 	CheckNoError(t, resp)
 }
 
+func TestDeletePostEvent(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	WebSocketClient, err := th.CreateWebSocketClient()
+	require.Nil(t, err)
+	WebSocketClient.Listen()
+	defer WebSocketClient.Close()
+
+	_, resp := th.SystemAdminClient.DeletePost(th.BasicPost.Id)
+	CheckNoError(t, resp)
+
+	var received bool
+
+	for {
+		var exit bool
+		select {
+		case event := <-WebSocketClient.EventChannel:
+			if event.EventType() == model.WebsocketEventPostDeleted {
+				var post model.Post
+				err := json.Unmarshal([]byte(event.GetData()["post"].(string)), &post)
+				require.NoError(t, err)
+				received = true
+			}
+		case <-time.After(500 * time.Millisecond):
+			exit = true
+		}
+		if exit {
+			break
+		}
+	}
+
+	require.True(t, received)
+}
+
 func TestDeletePostMessage(t *testing.T) {
 	th := Setup(t).InitBasic()
 	th.LinkUserToTeam(th.SystemAdminUser, th.BasicTeam)

--- a/app/post.go
+++ b/app/post.go
@@ -1148,13 +1148,18 @@ func (a *App) DeletePost(postID, deleteByID string) (*model.Post, *model.AppErro
 		}
 	}
 
+	postJSON, jsonErr := json.Marshal(post)
+	if jsonErr != nil {
+		mlog.Warn("Failed to encode post to JSON")
+	}
+
 	userMessage := model.NewWebSocketEvent(model.WebsocketEventPostDeleted, "", post.ChannelId, "", nil)
-	userMessage.Add("post", post)
+	userMessage.Add("post", string(postJSON))
 	userMessage.GetBroadcast().ContainsSanitizedData = true
 	a.Publish(userMessage)
 
 	adminMessage := model.NewWebSocketEvent(model.WebsocketEventPostDeleted, "", post.ChannelId, "", nil)
-	adminMessage.Add("post", post)
+	adminMessage.Add("post", string(postJSON))
 	adminMessage.Add("delete_by", deleteByID)
 	adminMessage.GetBroadcast().ContainsSensitiveData = true
 	a.Publish(adminMessage)


### PR DESCRIPTION
#### Summary

PR fixes an issue introduced in https://github.com/mattermost/mattermost-server/pull/17796. The client expects the post field of the deleted websocket event to be serialized. The additional parsing was hence broken causing a JS error.

#### Ticket

https://mattermost.atlassian.net/browse/MM-37846

#### Release Note

```release-note
NONE
```
