### PR TITLE
[MM-36559] wrong email title for 1 and 2 notifcations in batched_email_notification.title

### DIFF
--- a/app/email/email_batching.go
+++ b/app/email/email_batching.go
@@ -288,8 +288,9 @@ func (es *Service) sendBatchedEmailNotification(userID string, notifications []*
 
 	data := es.NewEmailTemplateData(user.Locale)
 	data.Props["SiteURL"] = siteURL
-	data.Props["Title"] = translateFunc("api.email_batching.send_batched_email_notification.title", len(notifications)-1, map[string]interface{}{
-		"SenderName": firstSender.GetDisplayName(displayNameFormat),
+	data.Props["Title"] = translateFunc("api.email_batching.send_batched_email_notification.title", len(notifications), map[string]interface{}{
+		"SenderName":    firstSender.GetDisplayName(displayNameFormat),
+		"CountMinusOne": strconv.Itoa(len(notifications) - 1),
 	})
 	data.Props["SubTitle"] = translateFunc("api.email_batching.send_batched_email_notification.subTitle")
 	data.Props["Button"] = translateFunc("api.email_batching.send_batched_email_notification.button")

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1617,7 +1617,7 @@
     "id": "api.email_batching.send_batched_email_notification.title",
     "translation": {
       "one": "{{ .SenderName }} sent you new message",
-      "other": "{{ .SenderName }} and {{.Count}} others sent you new messages"
+      "other": "{{ .SenderName }} and {{.CountMinusOne}} others sent you new messages"
     }
   },
   {

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -6791,7 +6791,7 @@
     "id": "api.email_batching.send_batched_email_notification.title",
     "translation": {
       "one": "{{ .SenderName }} sent you new message",
-      "other": "{{ .SenderName }} and {{.Count}} others sent you new messages"
+      "other": "{{ .SenderName }} and {{.CountMinusOne}} others sent you new messages"
     }
   },
   {


### PR DESCRIPTION
#### Summary
api.email_batching.send_batched_email_notification.title doesn't display a count for a second message when batched

the text is "Nickname sent you new message" followed by 2 messages potentially from different people (second person not mentioned in the title at all).

if a single message is batched the title looks wrong: "Nickname and 0 others sent you new messages"

and if a single person sends you 4 messages the title is also wrong "Nickname and 3 others sent you new messages" followed by 4 messages from a single person.

#### Ticket Link

No ticket, feel free to cherry pick, and you can use only the first commit if the set is too edgy :)

#### Release Note

* Bugfix: When batch emails is enabled, title will now correctly display the number of people sending you a message.
