### PR TITLE
[MM-23279] Idiomatic naming (IP)

### DIFF
--- a/app/command_autocomplete.go
+++ b/app/command_autocomplete.go
@@ -259,7 +259,7 @@ func (a *App) getDynamicListArgument(c *request.Context, commandArgs *model.Comm
 	pluginContext := pluginContext(c)
 	params.Add("request_id", pluginContext.RequestId)
 	params.Add("session_id", pluginContext.SessionId)
-	params.Add("ip_address", pluginContext.IpAddress)
+	params.Add("ip_address", pluginContext.IPAddress)
 	params.Add("accept_language", pluginContext.AcceptLanguage)
 	params.Add("user_agent", pluginContext.UserAgent)
 

--- a/app/context.go
+++ b/app/context.go
@@ -20,7 +20,7 @@ func pluginContext(c *request.Context) *plugin.Context {
 	context := &plugin.Context{
 		RequestId:      c.RequestId(),
 		SessionId:      c.Session().Id,
-		IpAddress:      c.IpAddress(),
+		IPAddress:      c.IPAddress(),
 		AcceptLanguage: c.AcceptLanguage(),
 		UserAgent:      c.UserAgent(),
 	}

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -918,7 +918,7 @@ func TestHookContext(t *testing.T) {
 	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
 	mockAPI.On("LogDebug", ctx.Session().Id).Return(nil)
 	mockAPI.On("LogInfo", ctx.RequestId()).Return(nil)
-	mockAPI.On("LogError", ctx.IpAddress()).Return(nil)
+	mockAPI.On("LogError", ctx.IPAddress()).Return(nil)
 	mockAPI.On("LogWarn", ctx.AcceptLanguage()).Return(nil)
 	mockAPI.On("DeleteTeam", ctx.UserAgent()).Return(nil)
 
@@ -939,7 +939,7 @@ func TestHookContext(t *testing.T) {
 		func (p *MyPlugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
 			p.API.LogDebug(c.SessionId)
 			p.API.LogInfo(c.RequestId)
-			p.API.LogError(c.IpAddress)
+			p.API.LogError(c.IPAddress)
 			p.API.LogWarn(c.AcceptLanguage)
 			p.API.DeleteTeam(c.UserAgent)
 		}

--- a/app/plugin_requests.go
+++ b/app/plugin_requests.go
@@ -118,7 +118,7 @@ func (s *Server) servePluginRequest(w http.ResponseWriter, r *http.Request, hand
 	token := ""
 	context := &plugin.Context{
 		RequestId:      model.NewId(),
-		IpAddress:      utils.GetIPAddress(r, s.Config().ServiceSettings.TrustedProxyIPHeader),
+		IPAddress:      utils.GetIPAddress(r, s.Config().ServiceSettings.TrustedProxyIPHeader),
 		AcceptLanguage: r.Header.Get("Accept-Language"),
 		UserAgent:      r.UserAgent(),
 	}

--- a/app/ratelimit.go
+++ b/app/ratelimit.go
@@ -66,7 +66,7 @@ func (rl *RateLimiter) GenerateKey(r *http.Request) string {
 		key += utils.GetIPAddress(r, rl.trustedProxyIPHeader)
 	}
 
-	// Note that most of the time the user won't have to set this because the utils.GetIpAddress above tries the
+	// Note that most of the time the user won't have to set this because the utils.GetIPAddress above tries the
 	// most common headers anyway.
 	if rl.header != "" {
 		key += strings.ToLower(r.Header.Get(rl.header))

--- a/app/request/context.go
+++ b/app/request/context.go
@@ -51,7 +51,7 @@ func (c *Context) Session() *model.Session {
 func (c *Context) RequestId() string {
 	return c.requestId
 }
-func (c *Context) IpAddress() string {
+func (c *Context) IPAddress() string {
 	return c.ipAddress
 }
 func (c *Context) Path() string {
@@ -78,7 +78,7 @@ func (c *Context) SetT(t i18n.TranslateFunc) {
 func (c *Context) SetRequestId(s string) {
 	c.requestId = s
 }
-func (c *Context) SetIpAddress(s string) {
+func (c *Context) SetIPAddress(s string) {
 	c.ipAddress = s
 }
 func (c *Context) SetUserAgent(s string) {

--- a/config/environment_test.go
+++ b/config/environment_test.go
@@ -81,13 +81,13 @@ func TestRemoveEnvOverrides(t *testing.T) {
 		{
 			name: "bool setting",
 			inputConfig: modifiedDefault(func(in *model.Config) {
-				*in.ClusterSettings.UseIpAddress = false
+				*in.ClusterSettings.UseIPAddress = false
 			}),
 			env: map[string]string{
 				"MM_CLUSTERSETTINGS_USEIPADDRESS": "true",
 			},
 			expectedConfig: modifiedDefault(func(in *model.Config) {
-				*in.ClusterSettings.UseIpAddress = true
+				*in.ClusterSettings.UseIPAddress = true
 			}),
 		},
 		{

--- a/einterfaces/mocks/AppContextInterface.go
+++ b/einterfaces/mocks/AppContextInterface.go
@@ -28,8 +28,8 @@ func (_m *AppContextInterface) AcceptLanguage() string {
 	return r0
 }
 
-// IpAddress provides a mock function with given fields:
-func (_m *AppContextInterface) IpAddress() string {
+// IPAddress provides a mock function with given fields:
+func (_m *AppContextInterface) IPAddress() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/model/client4.go
+++ b/model/client4.go
@@ -24,7 +24,7 @@ const (
 	HeaderEtagServer         = "ETag"
 	HeaderEtagClient         = "If-None-Match"
 	HeaderForwarded          = "X-Forwarded-For"
-	HeaderRealIp             = "X-Real-IP"
+	HeaderRealIP             = "X-Real-IP"
 	HeaderForwardedProto     = "X-Forwarded-Proto"
 	HeaderToken              = "token"
 	HeaderCsrfToken          = "X-CSRF-Token"

--- a/model/cluster_discovery.go
+++ b/model/cluster_discovery.go
@@ -46,13 +46,13 @@ func (o *ClusterDiscovery) AutoFillHostname() {
 	}
 }
 
-func (o *ClusterDiscovery) AutoFillIpAddress(iface string, ipAddress string) {
+func (o *ClusterDiscovery) AutoFillIPAddress(iface string, ipAddress string) {
 	// attempt to set the hostname to the first non-local IP address
 	if o.Hostname == "" {
 		if ipAddress != "" {
 			o.Hostname = ipAddress
 		} else {
-			o.Hostname = GetServerIpAddress(iface)
+			o.Hostname = GetServerIPAddress(iface)
 		}
 	}
 }

--- a/model/cluster_discovery_test.go
+++ b/model/cluster_discovery_test.go
@@ -54,7 +54,7 @@ func TestClusterDiscovery(t *testing.T) {
 	o.Hostname = ""
 	o.AutoFillHostname()
 
-	o.AutoFillIpAddress("", "")
+	o.AutoFillIPAddress("", "")
 	o.Hostname = ""
-	o.AutoFillIpAddress("", "")
+	o.AutoFillIPAddress("", "")
 }

--- a/model/cluster_info.go
+++ b/model/cluster_info.go
@@ -12,7 +12,7 @@ type ClusterInfo struct {
 	Id         string `json:"id"`
 	Version    string `json:"version"`
 	ConfigHash string `json:"config_hash"`
-	IpAddress  string `json:"ipaddress"`
+	IPAddress  string `json:"ipaddress"`
 	Hostname   string `json:"hostname"`
 }
 

--- a/model/cluster_info_test.go
+++ b/model/cluster_info_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestClusterInfosJson(t *testing.T) {
-	cluster := ClusterInfo{IpAddress: NewId(), Hostname: NewId()}
+	cluster := ClusterInfo{IPAddress: NewId(), Hostname: NewId()}
 	clusterInfos := make([]*ClusterInfo, 1)
 	clusterInfos[0] = &cluster
 	json := ClusterInfosToJson(clusterInfos)
 	result := ClusterInfosFromJson(strings.NewReader(json))
 
-	assert.Equal(t, clusterInfos[0].IpAddress, result[0].IpAddress, "Ids do not match")
+	assert.Equal(t, clusterInfos[0].IPAddress, result[0].IPAddress, "Ids do not match")
 }

--- a/model/config.go
+++ b/model/config.go
@@ -537,7 +537,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	if isUpdate {
 		// When updating an existing configuration, ensure that defaults are set.
 		if s.TrustedProxyIPHeader == nil {
-			s.TrustedProxyIPHeader = []string{HeaderForwarded, HeaderRealIp}
+			s.TrustedProxyIPHeader = []string{HeaderForwarded, HeaderRealIP}
 		}
 	} else {
 		// When generating a blank configuration, leave the list empty.
@@ -844,7 +844,7 @@ type ClusterSettings struct {
 	NetworkInterface                            *string `access:"environment_high_availability,write_restrictable,cloud_restrictable"`
 	BindAddress                                 *string `access:"environment_high_availability,write_restrictable,cloud_restrictable"`
 	AdvertiseAddress                            *string `access:"environment_high_availability,write_restrictable,cloud_restrictable"`
-	UseIpAddress                                *bool   `access:"environment_high_availability,write_restrictable,cloud_restrictable"`
+	UseIPAddress                                *bool   `access:"environment_high_availability,write_restrictable,cloud_restrictable"`
 	DEPRECATED_DO_NOT_USE_UseExperimentalGossip *bool   `json:"UseExperimentalGossip" access:"environment_high_availability,write_restrictable,cloud_restrictable"` // Deprecated: do not use
 	EnableGossipCompression                     *bool   `access:"environment_high_availability,write_restrictable,cloud_restrictable"`
 	EnableExperimentalGossipEncryption          *bool   `access:"environment_high_availability,write_restrictable,cloud_restrictable"`
@@ -881,8 +881,8 @@ func (s *ClusterSettings) SetDefaults() {
 		s.AdvertiseAddress = NewString("")
 	}
 
-	if s.UseIpAddress == nil {
-		s.UseIpAddress = NewBool(true)
+	if s.UseIPAddress == nil {
+		s.UseIPAddress = NewBool(true)
 	}
 
 	if s.DEPRECATED_DO_NOT_USE_UseExperimentalGossip == nil {

--- a/model/utils.go
+++ b/model/utils.go
@@ -320,7 +320,7 @@ func ToJson(v interface{}) []byte {
 	return b
 }
 
-func GetServerIpAddress(iface string) string {
+func GetServerIPAddress(iface string) string {
 	var addrs []net.Addr
 	if iface == "" {
 		var err error

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -343,8 +343,8 @@ func TestIsValidAlphaNum(t *testing.T) {
 	}
 }
 
-func TestGetServerIpAddress(t *testing.T) {
-	require.NotEmpty(t, GetServerIpAddress(""), "Should find local ip address")
+func TestGetServerIPAddress(t *testing.T) {
+	require.NotEmpty(t, GetServerIPAddress(""), "Should find local ip address")
 }
 
 func TestIsValidAlphaNumHyphenUnderscore(t *testing.T) {

--- a/plugin/context.go
+++ b/plugin/context.go
@@ -9,7 +9,7 @@ package plugin
 type Context struct {
 	SessionId      string
 	RequestId      string
-	IpAddress      string
+	IPAddress      string
 	AcceptLanguage string
 	UserAgent      string
 }

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -710,7 +710,7 @@ func (ts *TelemetryService) trackConfig() {
 		"network_interface":                     isDefault(*cfg.ClusterSettings.NetworkInterface, ""),
 		"bind_address":                          isDefault(*cfg.ClusterSettings.BindAddress, ""),
 		"advertise_address":                     isDefault(*cfg.ClusterSettings.AdvertiseAddress, ""),
-		"use_ip_address":                        *cfg.ClusterSettings.UseIpAddress,
+		"use_ip_address":                        *cfg.ClusterSettings.UseIPAddress,
 		"enable_experimental_gossip_encryption": *cfg.ClusterSettings.EnableExperimentalGossipEncryption,
 		"enable_gossip_compression":             *cfg.ClusterSettings.EnableGossipCompression,
 		"read_only_config":                      *cfg.ClusterSettings.ReadOnlyConfig,

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -322,7 +322,7 @@
         "Enable": false,
         "ClusterName": "",
         "OverrideHostname": "",
-        "UseIpAddress": true,
+        "UseIPAddress": true,
         "UseExperimentalGossip": true,
         "ReadOnlyConfig": true,
         "GossipPort": 8074,

--- a/web/context.go
+++ b/web/context.go
@@ -59,7 +59,7 @@ func (c *Context) MakeAuditRecord(event string, initialStatus string) *audit.Rec
 		UserID:    c.AppContext.Session().UserId,
 		SessionID: c.AppContext.Session().Id,
 		Client:    c.AppContext.UserAgent(),
-		IPAddress: c.AppContext.IpAddress(),
+		IPAddress: c.AppContext.IPAddress(),
 		Meta:      audit.Meta{audit.KeyClusterID: c.App.GetClusterId()},
 	}
 	rec.AddMetaTypeConverter(model.AuditModelTypeConv)
@@ -68,7 +68,7 @@ func (c *Context) MakeAuditRecord(event string, initialStatus string) *audit.Rec
 }
 
 func (c *Context) LogAudit(extraInfo string) {
-	audit := &model.Audit{UserId: c.AppContext.Session().UserId, IpAddress: c.AppContext.IpAddress(), Action: c.AppContext.Path(), ExtraInfo: extraInfo, SessionId: c.AppContext.Session().Id}
+	audit := &model.Audit{UserId: c.AppContext.Session().UserId, IpAddress: c.AppContext.IPAddress(), Action: c.AppContext.Path(), ExtraInfo: extraInfo, SessionId: c.AppContext.Session().Id}
 	if err := c.App.Srv().Store.Audit().Save(audit); err != nil {
 		appErr := model.NewAppError("LogAudit", "app.audit.save.saving.app_error", nil, err.Error(), http.StatusInternalServerError)
 		c.LogErrorByCode(appErr)
@@ -80,7 +80,7 @@ func (c *Context) LogAuditWithUserId(userId, extraInfo string) {
 		extraInfo = strings.TrimSpace(extraInfo + " session_user=" + c.AppContext.Session().UserId)
 	}
 
-	audit := &model.Audit{UserId: userId, IpAddress: c.AppContext.IpAddress(), Action: c.AppContext.Path(), ExtraInfo: extraInfo, SessionId: c.AppContext.Session().Id}
+	audit := &model.Audit{UserId: userId, IpAddress: c.AppContext.IPAddress(), Action: c.AppContext.Path(), ExtraInfo: extraInfo, SessionId: c.AppContext.Session().Id}
 	if err := c.App.Srv().Store.Audit().Save(audit); err != nil {
 		appErr := model.NewAppError("LogAuditWithUserId", "app.audit.save.saving.app_error", nil, err.Error(), http.StatusInternalServerError)
 		c.LogErrorByCode(appErr)

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -113,7 +113,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t, _ := i18n.GetTranslationsAndLocaleFromRequest(r)
 	c.AppContext.SetT(t)
 	c.AppContext.SetRequestId(requestID)
-	c.AppContext.SetIpAddress(utils.GetIPAddress(r, c.App.Config().ServiceSettings.TrustedProxyIPHeader))
+	c.AppContext.SetIPAddress(utils.GetIPAddress(r, c.App.Config().ServiceSettings.TrustedProxyIPHeader))
 	c.AppContext.SetUserAgent(r.UserAgent())
 	c.AppContext.SetAcceptLanguage(r.Header.Get("Accept-Language"))
 	c.AppContext.SetPath(r.URL.Path)
@@ -126,7 +126,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		_ = opentracing.GlobalTracer().Inject(span.Context(), opentracing.HTTPHeaders, carrier)
 		ext.HTTPMethod.Set(span, r.Method)
 		ext.HTTPUrl.Set(span, c.AppContext.Path())
-		ext.PeerAddress.Set(span, c.AppContext.IpAddress())
+		ext.PeerAddress.Set(span, c.AppContext.IPAddress())
 		span.SetTag("request_id", c.AppContext.RequestId())
 		span.SetTag("user_agent", c.AppContext.UserAgent())
 
@@ -257,7 +257,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	c.Logger = c.App.Log().With(
 		mlog.String("path", c.AppContext.Path()),
 		mlog.String("request_id", c.AppContext.RequestId()),
-		mlog.String("ip_addr", c.AppContext.IpAddress()),
+		mlog.String("ip_addr", c.AppContext.IPAddress()),
 		mlog.String("user_id", c.AppContext.Session().UserId),
 		mlog.String("method", r.Method),
 	)


### PR DESCRIPTION
#### Summary
This is a the third PR that changes identifies to use more idiomatic naming.

I intentional didn't change the field names of structs that are used to create DB columns as `gorp` doesn't like it when you change field names.

In the future we might be able to enforce this via golangci-lint.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23279

#### Release Note
```release-note
Renamed plugin.Context.IpAddress to plugin.Context.IPAddress
Renamed fields in the model package to have more idiomatic names
```
