### PR TITLE
MM-38004 fix racy unit test

### DIFF
--- a/shared/mlog/mlog.go
+++ b/shared/mlog/mlog.go
@@ -103,18 +103,25 @@ var String = logr.String
 
 // Stringer constructs a field containing a key and a fmt.Stringer value.
 // The fmt.Stringer's `String` method is called lazily.
-var Stringer = logr.Stringer
+var Stringer = func(key string, s fmt.Stringer) logr.Field {
+	if s == nil {
+		return Field{Key: key, Type: logr.StringType, String: ""}
+	}
+	return Field{Key: key, Type: logr.StringType, String: s.String()}
+}
 
 // Err constructs a field containing a default key ("error") and error value.
 var Err = func(err error) logr.Field {
-	if err == nil {
-		return Field{Key: "error", Type: logr.StringType, String: "nil"}
-	}
-	return Field{Key: "error", Type: logr.StringType, String: err.Error()}
+	return NamedErr("error", err)
 }
 
 // NamedErr constructs a field containing a key and error value.
-var NamedErr = logr.NamedErr
+var NamedErr = func(key string, err error) logr.Field {
+	if err == nil {
+		return Field{Key: key, Type: logr.StringType, String: ""}
+	}
+	return Field{Key: key, Type: logr.StringType, String: err.Error()}
+}
 
 // Bool constructs a field containing a key and bool value.
 var Bool = logr.Bool

--- a/shared/mlog/mlog.go
+++ b/shared/mlog/mlog.go
@@ -106,7 +106,7 @@ var String = logr.String
 var Stringer = logr.Stringer
 
 // Err constructs a field containing a default key ("error") and error value.
-var Err = logr.Err
+var Err = func(err error) logr.Field { return Field{Key: "error", Type: logr.StringType, String: err.Error()} }
 
 // NamedErr constructs a field containing a key and error value.
 var NamedErr = logr.NamedErr

--- a/shared/mlog/mlog.go
+++ b/shared/mlog/mlog.go
@@ -106,7 +106,12 @@ var String = logr.String
 var Stringer = logr.Stringer
 
 // Err constructs a field containing a default key ("error") and error value.
-var Err = func(err error) logr.Field { return Field{Key: "error", Type: logr.StringType, String: err.Error()} }
+var Err = func(err error) logr.Field {
+	if err == nil {
+		return Field{Key: "error", Type: logr.StringType, String: "nil"}
+	}
+	return Field{Key: "error", Type: logr.StringType, String: err.Error()}
+}
 
 // NamedErr constructs a field containing a key and error value.
 var NamedErr = logr.NamedErr


### PR DESCRIPTION
#### Summary
This PR fixes a racy unit test.  Error logging was resolving all `error` interfaces to a string during formatting which happens asynchronously in a log writer thread.  In this case, due to a recent change for AppErrors, the AppError's fields are modified after the log call thus causing a race.  The fix is to resolve the error to a string in the calling thread and not storing the original `error`.

Other structs and interfaces are already resolved to strings by the caller - `error` was a special case because it has a specific `mlog.Err` generating the log field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38004

#### Release Note
```release-note
NONE
```
