### PR TITLE
[GH-18190] Remove all instances of "zz" + model.NewId() in storetest/channel_sto…

### DIFF
--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -121,7 +121,7 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -135,7 +135,7 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	require.Error(t, nErr, "should be unique name")
 
 	o1.Id = ""
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeDirect
 	_, nErr = ss.Channel().Save(&o1, -1)
 	require.Error(t, nErr, "should not be able to save direct channel")
@@ -143,7 +143,7 @@ func testChannelStoreSave(t *testing.T, ss store.Store) {
 	o1 = model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 
 	_, nErr = ss.Channel().Save(&o1, -1)
@@ -172,7 +172,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlStore)
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeDirect
 
 	u1 := &model.User{}
@@ -227,7 +227,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlStore)
 
 	// Attempt to save a non-direct channel
 	o1.Id = ""
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().SaveDirectChannel(&o1, &m1, &m2)
 	require.Error(t, nErr, "Should not be able to save non-direct channel")
@@ -235,7 +235,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlStore)
 	// Save yourself Direct Message
 	o1.Id = ""
 	o1.DisplayName = "Myself"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeDirect
 	_, nErr = ss.Channel().SaveDirectChannel(&o1, &m1, &m1)
 	require.NoError(t, nErr, "couldn't save direct channel", nErr)
@@ -281,7 +281,7 @@ func testChannelStoreUpdate(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -290,7 +290,7 @@ func testChannelStoreUpdate(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Name"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -371,7 +371,7 @@ func testChannelStoreGet(t *testing.T, ss store.Store, s SqlStore) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -402,7 +402,7 @@ func testChannelStoreGet(t *testing.T, ss store.Store, s SqlStore) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Direct Name"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeDirect
 
 	m1 := model.ChannelMember{}
@@ -442,7 +442,7 @@ func testChannelStoreGetChannelsByIds(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "aa" + model.NewId() + "b"
+	o1.Name = "aa" + model.NewId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -466,13 +466,13 @@ func testChannelStoreGetChannelsByIds(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Direct Name"
-	o2.Name = "bb" + model.NewId() + "b"
+	o2.Name = "bb" + model.NewId()
 	o2.Type = model.ChannelTypeDirect
 
 	o3 := model.Channel{}
 	o3.TeamId = model.NewId()
 	o3.DisplayName = "Deleted channel"
-	o3.Name = "cc" + model.NewId() + "b"
+	o3.Name = "cc" + model.NewId()
 	o3.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o3, -1)
 	require.NoError(t, nErr)
@@ -525,7 +525,7 @@ func testChannelStoreGetForPost(t *testing.T, ss store.Store) {
 	ch := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	o1, nErr := ss.Channel().Save(ch, -1)
@@ -547,7 +547,7 @@ func testChannelStoreRestore(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -569,7 +569,7 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -577,7 +577,7 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -585,7 +585,7 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	o3 := model.Channel{}
 	o3.TeamId = o1.TeamId
 	o3.DisplayName = "Channel3"
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = NewTestId()
 	o3.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o3, -1)
 	require.NoError(t, nErr)
@@ -593,7 +593,7 @@ func testChannelStoreDelete(t *testing.T, ss store.Store) {
 	o4 := model.Channel{}
 	o4.TeamId = o1.TeamId
 	o4.DisplayName = "Channel4"
-	o4.Name = "zz" + model.NewId() + "b"
+	o4.Name = NewTestId()
 	o4.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o4, -1)
 	require.NoError(t, nErr)
@@ -648,7 +648,7 @@ func testChannelStoreGetByName(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -680,7 +680,7 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -689,7 +689,7 @@ func testChannelStoreGetByNames(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      o1.TeamId,
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -735,7 +735,7 @@ func testChannelStoreGetDeletedByName(t *testing.T, ss store.Store) {
 	o1 := &model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Name"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(o1, -1)
 	require.NoError(t, nErr)
@@ -758,7 +758,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 
 	userId := model.NewId()
@@ -777,7 +777,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -789,7 +789,7 @@ func testChannelStoreGetDeleted(t *testing.T, ss store.Store) {
 	o3 := model.Channel{}
 	o3.TeamId = o1.TeamId
 	o3.DisplayName = "Channel3"
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = NewTestId()
 	o3.Type = model.ChannelTypeOpen
 
 	_, nErr = ss.Channel().Save(&o3, -1)
@@ -816,7 +816,7 @@ func testChannelMemberStore(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = model.NewId()
 	c1.DisplayName = "NameName"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = NewTestId()
 	c1.Type = model.ChannelTypeOpen
 	c1, nErr := ss.Channel().Save(c1, -1)
 	require.NoError(t, nErr)
@@ -928,7 +928,7 @@ func testChannelSaveMember(t *testing.T, ss store.Store) {
 	t.Run("insert member correctly (in channel without channel scheme and team without scheme)", func(t *testing.T) {
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -938,7 +938,7 @@ func testChannelSaveMember(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -1088,7 +1088,7 @@ func testChannelSaveMember(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 			SchemeId:    &ts.Id,
@@ -1099,7 +1099,7 @@ func testChannelSaveMember(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -1249,7 +1249,7 @@ func testChannelSaveMember(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -1259,7 +1259,7 @@ func testChannelSaveMember(t *testing.T, ss store.Store) {
 
 		channel, nErr := ss.Channel().Save(&model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 			SchemeId:    &cs.Id,
@@ -1427,7 +1427,7 @@ func testChannelSaveMultipleMembers(t *testing.T, ss store.Store) {
 	t.Run("insert members correctly (in channel without channel scheme and team without scheme)", func(t *testing.T) {
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -1437,7 +1437,7 @@ func testChannelSaveMultipleMembers(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -1601,7 +1601,7 @@ func testChannelSaveMultipleMembers(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 			SchemeId:    &ts.Id,
@@ -1612,7 +1612,7 @@ func testChannelSaveMultipleMembers(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -1776,7 +1776,7 @@ func testChannelSaveMultipleMembers(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -1786,7 +1786,7 @@ func testChannelSaveMultipleMembers(t *testing.T, ss store.Store) {
 
 		channel, nErr := ss.Channel().Save(&model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 			SchemeId:    &cs.Id,
@@ -1955,7 +1955,7 @@ func testChannelUpdateMember(t *testing.T, ss store.Store) {
 	t.Run("insert member correctly (in channel without channel scheme and team without scheme)", func(t *testing.T) {
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -1965,7 +1965,7 @@ func testChannelUpdateMember(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -2117,7 +2117,7 @@ func testChannelUpdateMember(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 			SchemeId:    &ts.Id,
@@ -2128,7 +2128,7 @@ func testChannelUpdateMember(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -2280,7 +2280,7 @@ func testChannelUpdateMember(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -2290,7 +2290,7 @@ func testChannelUpdateMember(t *testing.T, ss store.Store) {
 
 		channel, nErr := ss.Channel().Save(&model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 			SchemeId:    &cs.Id,
@@ -2460,7 +2460,7 @@ func testChannelUpdateMultipleMembers(t *testing.T, ss store.Store) {
 	t.Run("insert members correctly (in channel without channel scheme and team without scheme)", func(t *testing.T) {
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -2470,7 +2470,7 @@ func testChannelUpdateMultipleMembers(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -2629,7 +2629,7 @@ func testChannelUpdateMultipleMembers(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 			SchemeId:    &ts.Id,
@@ -2640,7 +2640,7 @@ func testChannelUpdateMultipleMembers(t *testing.T, ss store.Store) {
 
 		channel := &model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 		}
@@ -2799,7 +2799,7 @@ func testChannelUpdateMultipleMembers(t *testing.T, ss store.Store) {
 
 		team := &model.Team{
 			DisplayName: "Name",
-			Name:        "zz" + model.NewId(),
+			Name:        NewTestId(),
 			Email:       MakeEmail(),
 			Type:        model.TeamOpen,
 		}
@@ -2809,7 +2809,7 @@ func testChannelUpdateMultipleMembers(t *testing.T, ss store.Store) {
 
 		channel, nErr := ss.Channel().Save(&model.Channel{
 			DisplayName: "DisplayName",
-			Name:        "z-z-z" + model.NewId() + "b",
+			Name:        "z-z-z" + model.NewId(),
 			Type:        model.ChannelTypeOpen,
 			TeamId:      team.Id,
 			SchemeId:    &cs.Id,
@@ -3061,7 +3061,7 @@ func testChannelDeleteMemberStore(t *testing.T, ss store.Store) {
 	c1 := &model.Channel{}
 	c1.TeamId = model.NewId()
 	c1.DisplayName = "NameName"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = NewTestId()
 	c1.Type = model.ChannelTypeOpen
 	c1, nErr := ss.Channel().Save(c1, -1)
 	require.NoError(t, nErr)
@@ -3126,7 +3126,7 @@ func testChannelStoreGetChannels(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = team
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -3134,7 +3134,7 @@ func testChannelStoreGetChannels(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = team
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -3142,7 +3142,7 @@ func testChannelStoreGetChannels(t *testing.T, ss store.Store) {
 	o3 := model.Channel{}
 	o3.TeamId = team
 	o3.DisplayName = "Channel3"
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = NewTestId()
 	o3.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o3, -1)
 	require.NoError(t, nErr)
@@ -3264,7 +3264,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlStore) {
 
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
-	t1.Name = "zz" + model.NewId()
+	t1.Name = NewTestId()
 	t1.Email = MakeEmail()
 	t1.Type = model.TeamOpen
 	_, err := ss.Team().Save(&t1)
@@ -3272,7 +3272,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlStore) {
 
 	t2 := model.Team{}
 	t2.DisplayName = "Name2"
-	t2.Name = "zz" + model.NewId()
+	t2.Name = NewTestId()
 	t2.Email = MakeEmail()
 	t2.Type = model.TeamOpen
 	_, err = ss.Team().Save(&t2)
@@ -3281,7 +3281,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlStore) {
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1" + model.NewId()
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = NewTestId()
 	c1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&c1, -1)
 	require.NoError(t, nErr)
@@ -3301,7 +3301,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlStore) {
 	c2 := model.Channel{}
 	c2.TeamId = t1.Id
 	c2.DisplayName = "Channel2" + model.NewId()
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = NewTestId()
 	c2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&c2, -1)
 	require.NoError(t, nErr)
@@ -3313,7 +3313,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlStore) {
 	c3 := model.Channel{}
 	c3.TeamId = t2.Id
 	c3.DisplayName = "Channel3" + model.NewId()
-	c3.Name = "zz" + model.NewId() + "b"
+	c3.Name = NewTestId()
 	c3.Type = model.ChannelTypePrivate
 	_, nErr = ss.Channel().Save(&c3, -1)
 	require.NoError(t, nErr)
@@ -3328,7 +3328,7 @@ func testChannelStoreGetAllChannels(t *testing.T, ss store.Store, s SqlStore) {
 	c5 := model.Channel{}
 	c5.Name = model.GetGroupNameFromUserIds(userIds)
 	c5.DisplayName = "GroupChannel" + model.NewId()
-	c5.Name = "zz" + model.NewId() + "b"
+	c5.Name = NewTestId()
 	c5.Type = model.ChannelTypeGroup
 	_, nErr = ss.Channel().Save(&c5, -1)
 	require.NoError(t, nErr)
@@ -3416,7 +3416,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -3440,7 +3440,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      otherTeamId,
 		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -3458,7 +3458,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o3, -1)
@@ -3468,7 +3468,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelB",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o4, -1)
@@ -3478,7 +3478,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelC",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o5, -1)
@@ -3502,7 +3502,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o6 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelD",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o6, -1)
@@ -3513,7 +3513,7 @@ func testChannelStoreGetMoreChannels(t *testing.T, ss store.Store) {
 	o7 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelD",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o7, -1)
@@ -3560,7 +3560,7 @@ func testChannelStoreGetPrivateChannelsForTeam(t *testing.T, ss store.Store) {
 	p1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "PrivateChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr := ss.Channel().Save(&p1, -1)
@@ -3570,7 +3570,7 @@ func testChannelStoreGetPrivateChannelsForTeam(t *testing.T, ss store.Store) {
 	p2 := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "PrivateChannel1Team2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&p2, -1)
@@ -3580,7 +3580,7 @@ func testChannelStoreGetPrivateChannelsForTeam(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o1, -1)
@@ -3596,7 +3596,7 @@ func testChannelStoreGetPrivateChannelsForTeam(t *testing.T, ss store.Store) {
 	p3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "PrivateChannel2Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&p3, -1)
@@ -3606,7 +3606,7 @@ func testChannelStoreGetPrivateChannelsForTeam(t *testing.T, ss store.Store) {
 	p4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "PrivateChannel3Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&p4, -1)
@@ -3652,7 +3652,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -3662,7 +3662,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "OpenChannel1Team2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -3672,7 +3672,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "PrivateChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o3, -1)
@@ -3688,7 +3688,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel2Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o4, -1)
@@ -3698,7 +3698,7 @@ func testChannelStoreGetPublicChannelsForTeam(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel3Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o5, -1)
@@ -3744,7 +3744,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel1Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&oc1, -1)
@@ -3754,7 +3754,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc2 := model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "OpenChannel2TeamOther",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&oc2, -1)
@@ -3764,7 +3764,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	pc3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "PrivateChannel3Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&pc3, -1)
@@ -3786,7 +3786,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel4Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&oc4, -1)
@@ -3796,7 +3796,7 @@ func testChannelStoreGetPublicChannelsByIdsForTeam(t *testing.T, ss store.Store)
 	oc5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "OpenChannel4Team1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&oc5, -1)
@@ -3823,7 +3823,7 @@ func testChannelStoreGetChannelCounts(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -3831,7 +3831,7 @@ func testChannelStoreGetChannelCounts(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -3866,7 +3866,7 @@ func testChannelStoreGetChannelCounts(t *testing.T, ss store.Store) {
 func testChannelStoreGetMembersForUser(t *testing.T, ss store.Store) {
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
-	t1.Name = "zz" + model.NewId()
+	t1.Name = NewTestId()
 	t1.Email = MakeEmail()
 	t1.Type = model.TeamOpen
 	_, err := ss.Team().Save(&t1)
@@ -3875,7 +3875,7 @@ func testChannelStoreGetMembersForUser(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = t1.Id
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -3883,7 +3883,7 @@ func testChannelStoreGetMembersForUser(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -3963,7 +3963,7 @@ func testChannelStoreGetMembersForUser(t *testing.T, ss store.Store) {
 func testChannelStoreGetMembersForUserWithPagination(t *testing.T, ss store.Store) {
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
-	t1.Name = "zz" + model.NewId()
+	t1.Name = NewTestId()
 	t1.Email = MakeEmail()
 	t1.Type = model.TeamOpen
 	_, err := ss.Team().Save(&t1)
@@ -3972,7 +3972,7 @@ func testChannelStoreGetMembersForUserWithPagination(t *testing.T, ss store.Stor
 	o1 := model.Channel{}
 	o1.TeamId = t1.Id
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -3980,7 +3980,7 @@ func testChannelStoreGetMembersForUserWithPagination(t *testing.T, ss store.Stor
 	o2 := model.Channel{}
 	o2.TeamId = o1.TeamId
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -4156,7 +4156,7 @@ func testChannelStoreUpdateLastViewedAt(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	o1.TotalMsgCount = 25
 	o1.LastPostAt = 12345
@@ -4173,7 +4173,7 @@ func testChannelStoreUpdateLastViewedAt(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel1"
-	o2.Name = "zz" + model.NewId() + "c"
+	o2.Name = NewTestId() + "c"
 	o2.Type = model.ChannelTypeOpen
 	o2.TotalMsgCount = 26
 	o2.LastPostAt = 123456
@@ -4216,7 +4216,7 @@ func testChannelStoreIncrementMentionCount(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "Channel1"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	o1.TotalMsgCount = 25
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -4339,7 +4339,7 @@ func testChannelStoreGetMemberForPost(t *testing.T, ss store.Store) {
 	ch := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 
@@ -4374,7 +4374,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 	c1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&c1, -1)
@@ -4383,7 +4383,7 @@ func testGetMemberCount(t *testing.T, ss store.Store) {
 	c2 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&c2, -1)
@@ -4491,7 +4491,7 @@ func testGetMemberCountsByGroup(t *testing.T, ss store.Store) {
 	c1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&c1, -1)
@@ -4697,7 +4697,7 @@ func testGetGuestCount(t *testing.T, ss store.Store) {
 	c1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&c1, -1)
@@ -4706,7 +4706,7 @@ func testGetGuestCount(t *testing.T, ss store.Store) {
 	c2 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&c2, -1)
@@ -4820,7 +4820,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -4845,7 +4845,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      otherTeamId,
 		DisplayName: "Channel2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -4862,7 +4862,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o3, -1)
@@ -4871,7 +4871,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelB",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o4, -1)
@@ -4880,7 +4880,7 @@ func testChannelStoreSearchMore(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelC",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o5, -1)
@@ -5011,7 +5011,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -5020,7 +5020,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      otherTeamId,
 		DisplayName: "ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -5053,7 +5053,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "ChannelA (alternate)",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o3, -1)
@@ -5062,7 +5062,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel B",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o4, -1)
@@ -5071,7 +5071,7 @@ func testChannelStoreSearchInTeam(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "Channel C",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o5, -1)
@@ -5204,7 +5204,7 @@ func testChannelStoreSearchForUserInTeam(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "test-dev-1",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -5213,7 +5213,7 @@ func testChannelStoreSearchForUserInTeam(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "test-dev-2",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -5222,7 +5222,7 @@ func testChannelStoreSearchForUserInTeam(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "dev-3",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o3, -1)
@@ -5231,7 +5231,7 @@ func testChannelStoreSearchForUserInTeam(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      teamId,
 		DisplayName: "dev-4",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o4, -1)
@@ -5240,7 +5240,7 @@ func testChannelStoreSearchForUserInTeam(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:      otherTeamId,
 		DisplayName: "other-team-dev-5",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o5, -1)
@@ -5306,7 +5306,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
-	t1.Name = "zz" + model.NewId()
+	t1.Name = NewTestId()
 	t1.Email = MakeEmail()
 	t1.Type = model.TeamOpen
 	_, err := ss.Team().Save(&t1)
@@ -5314,7 +5314,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 
 	t2 := model.Team{}
 	t2.DisplayName = "Name2"
-	t2.Name = "zz" + model.NewId()
+	t2.Name = NewTestId()
 	t2.Email = MakeEmail()
 	t2.Type = model.TeamOpen
 	_, err = ss.Team().Save(&t2)
@@ -5323,7 +5323,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o1 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "A1 ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr := ss.Channel().Save(&o1, -1)
@@ -5332,7 +5332,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o2 := model.Channel{
 		TeamId:      t2.Id,
 		DisplayName: "A2 ChannelA",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o2, -1)
@@ -5365,7 +5365,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o3 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "A3 ChannelA (alternate)",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 	_, nErr = ss.Channel().Save(&o3, -1)
@@ -5374,7 +5374,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o4 := model.Channel{
 		TeamId:      t1.Id,
 		DisplayName: "A4 ChannelB",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypePrivate,
 	}
 	_, nErr = ss.Channel().Save(&o4, -1)
@@ -5383,7 +5383,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 	o5 := model.Channel{
 		TeamId:           t1.Id,
 		DisplayName:      "A5 ChannelC",
-		Name:             "zz" + model.NewId() + "b",
+		Name:             NewTestId(),
 		Type:             model.ChannelTypePrivate,
 		GroupConstrained: model.NewBool(true),
 	}
@@ -5562,7 +5562,7 @@ func testChannelStoreGetMembersByIds(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "ChannelA"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -5807,7 +5807,7 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	o1 := model.Channel{}
 	o1.TeamId = model.NewId()
 	o1.DisplayName = "ChannelA"
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o1, -1)
 	require.NoError(t, nErr)
@@ -5815,7 +5815,7 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	o2 := model.Channel{}
 	o2.TeamId = model.NewId()
 	o2.DisplayName = "Channel2"
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -5823,7 +5823,7 @@ func testChannelStoreAnalyticsDeletedTypeCount(t *testing.T, ss store.Store) {
 	p3 := model.Channel{}
 	p3.TeamId = model.NewId()
 	p3.DisplayName = "Channel3"
-	p3.Name = "zz" + model.NewId() + "b"
+	p3.Name = NewTestId()
 	p3.Type = model.ChannelTypePrivate
 	_, nErr = ss.Channel().Save(&p3, -1)
 	require.NoError(t, nErr)
@@ -5887,7 +5887,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	ch1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 
@@ -5909,7 +5909,7 @@ func testChannelStoreGetPinnedPosts(t *testing.T, ss store.Store) {
 	ch2 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 
@@ -5972,7 +5972,7 @@ func testChannelStoreGetPinnedPostCount(t *testing.T, ss store.Store) {
 	ch1 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 
@@ -6002,7 +6002,7 @@ func testChannelStoreGetPinnedPostCount(t *testing.T, ss store.Store) {
 	ch2 := &model.Channel{
 		TeamId:      model.NewId(),
 		DisplayName: "Name",
-		Name:        "zz" + model.NewId() + "b",
+		Name:        NewTestId(),
 		Type:        model.ChannelTypeOpen,
 	}
 
@@ -6449,7 +6449,7 @@ func testMaterializedPublicChannels(t *testing.T, ss store.Store, s SqlStore) {
 func testChannelStoreGetAllChannelsForExportAfter(t *testing.T, ss store.Store) {
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
-	t1.Name = "zz" + model.NewId()
+	t1.Name = NewTestId()
 	t1.Email = MakeEmail()
 	t1.Type = model.TeamOpen
 	_, err := ss.Team().Save(&t1)
@@ -6458,7 +6458,7 @@ func testChannelStoreGetAllChannelsForExportAfter(t *testing.T, ss store.Store) 
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = NewTestId()
 	c1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&c1, -1)
 	require.NoError(t, nErr)
@@ -6481,7 +6481,7 @@ func testChannelStoreGetAllChannelsForExportAfter(t *testing.T, ss store.Store) 
 func testChannelStoreGetChannelMembersForExport(t *testing.T, ss store.Store) {
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
-	t1.Name = "zz" + model.NewId()
+	t1.Name = NewTestId()
 	t1.Email = MakeEmail()
 	t1.Type = model.TeamOpen
 	_, err := ss.Team().Save(&t1)
@@ -6490,7 +6490,7 @@ func testChannelStoreGetChannelMembersForExport(t *testing.T, ss store.Store) {
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = NewTestId()
 	c1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&c1, -1)
 	require.NoError(t, nErr)
@@ -6498,7 +6498,7 @@ func testChannelStoreGetChannelMembersForExport(t *testing.T, ss store.Store) {
 	c2 := model.Channel{}
 	c2.TeamId = model.NewId()
 	c2.DisplayName = "Channel2"
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = NewTestId()
 	c2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(&c2, -1)
 	require.NoError(t, nErr)
@@ -6538,7 +6538,7 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, ss store.Store, s
 	// Set up all the objects needed in the store.
 	t1 := model.Team{}
 	t1.DisplayName = "Name"
-	t1.Name = "zz" + model.NewId()
+	t1.Name = NewTestId()
 	t1.Email = MakeEmail()
 	t1.Type = model.TeamOpen
 	_, err := ss.Team().Save(&t1)
@@ -6547,7 +6547,7 @@ func testChannelStoreRemoveAllDeactivatedMembers(t *testing.T, ss store.Store, s
 	c1 := model.Channel{}
 	c1.TeamId = t1.Id
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = NewTestId()
 	c1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&c1, -1)
 	require.NoError(t, nErr)
@@ -6623,7 +6623,7 @@ func testChannelStoreExportAllDirectChannels(t *testing.T, ss store.Store, s Sql
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Name" + model.NewId()
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeDirect
 
 	userIds := []string{model.NewId(), model.NewId(), model.NewId()}
@@ -6631,7 +6631,7 @@ func testChannelStoreExportAllDirectChannels(t *testing.T, ss store.Store, s Sql
 	o2 := model.Channel{}
 	o2.Name = model.GetGroupNameFromUserIds(userIds)
 	o2.DisplayName = "GroupChannel" + model.NewId()
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeGroup
 	_, nErr := ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -6680,13 +6680,13 @@ func testChannelStoreExportAllDirectChannelsExcludePrivateAndPublic(t *testing.T
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "The Direct Channel" + model.NewId()
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeDirect
 
 	o2 := model.Channel{}
 	o2.TeamId = teamId
 	o2.DisplayName = "Channel2" + model.NewId()
-	o2.Name = "zz" + model.NewId() + "b"
+	o2.Name = NewTestId()
 	o2.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(&o2, -1)
 	require.NoError(t, nErr)
@@ -6694,7 +6694,7 @@ func testChannelStoreExportAllDirectChannelsExcludePrivateAndPublic(t *testing.T
 	o3 := model.Channel{}
 	o3.TeamId = teamId
 	o3.DisplayName = "Channel3" + model.NewId()
-	o3.Name = "zz" + model.NewId() + "b"
+	o3.Name = NewTestId()
 	o3.Type = model.ChannelTypePrivate
 	_, nErr = ss.Channel().Save(&o3, -1)
 	require.NoError(t, nErr)
@@ -6742,7 +6742,7 @@ func testChannelStoreExportAllDirectChannelsDeletedChannel(t *testing.T, ss stor
 	o1 := model.Channel{}
 	o1.TeamId = teamId
 	o1.DisplayName = "Different Name" + model.NewId()
-	o1.Name = "zz" + model.NewId() + "b"
+	o1.Name = NewTestId()
 	o1.Type = model.ChannelTypeDirect
 
 	u1 := &model.User{}
@@ -6790,7 +6790,7 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 	// Set up all the objects needed
 	c1 := &model.Channel{}
 	c1.DisplayName = "Channel1"
-	c1.Name = "zz" + model.NewId() + "b"
+	c1.Name = NewTestId()
 	c1.Type = model.ChannelTypeOpen
 	_, nErr := ss.Channel().Save(c1, -1)
 	require.NoError(t, nErr)
@@ -6799,7 +6799,7 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 
 	c2 := &model.Channel{}
 	c2.DisplayName = "Channel2"
-	c2.Name = "zz" + model.NewId() + "b"
+	c2.Name = NewTestId()
 	c2.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(c2, -1)
 	require.NoError(t, nErr)
@@ -6809,21 +6809,21 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 
 	c3 := &model.Channel{}
 	c3.DisplayName = "Channel3"
-	c3.Name = "zz" + model.NewId() + "b"
+	c3.Name = NewTestId()
 	c3.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(c3, -1)
 	require.NoError(t, nErr)
 
 	c4 := &model.Channel{}
 	c4.DisplayName = "Channel4"
-	c4.Name = "zz" + model.NewId() + "b"
+	c4.Name = NewTestId()
 	c4.Type = model.ChannelTypePrivate
 	_, nErr = ss.Channel().Save(c4, -1)
 	require.NoError(t, nErr)
 
 	c5 := &model.Channel{}
 	c5.DisplayName = "Channel5"
-	c5.Name = "zz" + model.NewId() + "b"
+	c5.Name = NewTestId()
 	c5.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(c5, -1)
 	require.NoError(t, nErr)
@@ -6832,7 +6832,7 @@ func testChannelStoreGetChannelsBatchForIndexing(t *testing.T, ss store.Store) {
 
 	c6 := &model.Channel{}
 	c6.DisplayName = "Channel6"
-	c6.Name = "zz" + model.NewId() + "b"
+	c6.Name = NewTestId()
 	c6.Type = model.ChannelTypeOpen
 	_, nErr = ss.Channel().Save(c6, -1)
 	require.NoError(t, nErr)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Remove all instances of "zz" + model.NewId() in storetest/channel_store.go
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/18190
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
