### PR TITLE
Fix for test-data make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,8 +426,9 @@ cover: ## Runs the golang coverage tool. You must run the unit tests first.
 	$(GO) tool cover -html=ecover.out
 
 test-data: run-server ## Add test data to the local instance.
- 	# TODO: Replace sleep with something better.
-	sleep 10
+	@if ! ./scripts/wait-for-system-start.sh; then \
+		make stop; \
+	fi
 
 	@echo ServiceSettings.EnableLocalMode must be set to true.
 

--- a/Makefile
+++ b/Makefile
@@ -425,9 +425,9 @@ cover: ## Runs the golang coverage tool. You must run the unit tests first.
 	$(GO) tool cover -html=cover.out
 	$(GO) tool cover -html=ecover.out
 
-test-data: start-docker ## Add test data to the local instance.
-	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' $(PLATFORM_FILES) config set TeamSettings.MaxUsersPerTeam 100
-	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' $(PLATFORM_FILES) sampledata -w 4 -u 60
+test-data: start-docker prepackaged-binaries ## Add test data to the local instance.
+	bin/mmctl config set TeamSettings.MaxUsersPerTeam 100 --local
+	bin/mmctl sampledata -u 60 --local
 
 	@echo You may need to restart the Mattermost server before using the following
 	@echo ========================================================================

--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,12 @@ cover: ## Runs the golang coverage tool. You must run the unit tests first.
 	$(GO) tool cover -html=cover.out
 	$(GO) tool cover -html=ecover.out
 
-test-data: start-docker prepackaged-binaries ## Add test data to the local instance.
+test-data: run-server ## Add test data to the local instance.
+ 	# TODO: Replace sleep with something better.
+	sleep 10
+
+	@echo ServiceSettings.EnableLocalMode must be set to true.
+
 	bin/mmctl config set TeamSettings.MaxUsersPerTeam 100 --local
 	bin/mmctl sampledata -u 60 --local
 

--- a/scripts/wait-for-system-start.sh
+++ b/scripts/wait-for-system-start.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+total=0
+max_wait_seconds=60
+
+echo "waiting $max_wait_seconds seconds for the server to start"
+
+while [[ "$total" -le "$max_wait_seconds" ]]; do
+    if bin/mmctl system status --local 2> /dev/null; then
+        exit 0
+    else
+        ((total=total+1))
+        printf "."
+        sleep 1
+    fi
+done
+
+printf "\nserver didn't start in $max_wait_seconds seconds\n"
+
+exit 1


### PR DESCRIPTION
#### Summary

Fixes `make test-data` to work with mmctl now that the cli has removed the `config` and `sampledata` commands.

#### Ticket Link

n/a

#### Release Note

```release-note
NONE
```
