### PR TITLE
Jobs: Remove status as a filter condition

### DIFF
--- a/api4/job_test.go
+++ b/api4/job_test.go
@@ -251,7 +251,7 @@ func TestDownloadJob(t *testing.T) {
 	CheckBadRequestStatus(t, resp)
 
 	job.Data["is_downloadable"] = "true"
-	updateStatus, err := th.App.Srv().Store.Job().UpdateOptimistically(job, model.JobStatusSuccess)
+	updateStatus, err := th.App.Srv().Store.Job().UpdateOptimistically(job)
 	require.True(t, updateStatus)
 	require.NoError(t, err)
 

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -70,7 +70,7 @@ func (srv *JobServer) SetJobProgress(job *model.Job, progress int64) *model.AppE
 	job.Status = model.JobStatusInProgress
 	job.Progress = progress
 
-	if _, err := srv.Store.Job().UpdateOptimistically(job, model.JobStatusInProgress); err != nil {
+	if _, err := srv.Store.Job().UpdateOptimistically(job); err != nil {
 		return model.NewAppError("SetJobProgress", "app.job.update.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	return nil
@@ -118,7 +118,7 @@ func (srv *JobServer) SetJobError(job *model.Job, jobError *model.AppError) *mod
 	if jobError.DetailedError != "" {
 		job.Data["error"] += " — " + jobError.DetailedError
 	}
-	updated, err := srv.Store.Job().UpdateOptimistically(job, model.JobStatusInProgress)
+	updated, err := srv.Store.Job().UpdateOptimistically(job)
 	if err != nil {
 		return model.NewAppError("SetJobError", "app.job.update.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
@@ -127,7 +127,7 @@ func (srv *JobServer) SetJobError(job *model.Job, jobError *model.AppError) *mod
 	}
 
 	if !updated {
-		updated, err = srv.Store.Job().UpdateOptimistically(job, model.JobStatusCancelRequested)
+		updated, err = srv.Store.Job().UpdateOptimistically(job)
 		if err != nil {
 			return model.NewAppError("SetJobError", "app.job.update.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
@@ -154,7 +154,7 @@ func (srv *JobServer) SetJobCanceled(job *model.Job) *model.AppError {
 func (srv *JobServer) UpdateInProgressJobData(job *model.Job) *model.AppError {
 	job.Status = model.JobStatusInProgress
 	job.LastActivityAt = model.GetMillis()
-	if _, err := srv.Store.Job().UpdateOptimistically(job, model.JobStatusInProgress); err != nil {
+	if _, err := srv.Store.Job().UpdateOptimistically(job); err != nil {
 		return model.NewAppError("UpdateInProgressJobData", "app.job.update.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 	return nil

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -4357,7 +4357,7 @@ func (s *OpenTracingLayerJobStore) Save(job *model.Job) (*model.Job, error) {
 	return result, err
 }
 
-func (s *OpenTracingLayerJobStore) UpdateOptimistically(job *model.Job, currentStatus string) (bool, error) {
+func (s *OpenTracingLayerJobStore) UpdateOptimistically(job *model.Job) (bool, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "JobStore.UpdateOptimistically")
 	s.Root.Store.SetContext(newCtx)
@@ -4366,7 +4366,7 @@ func (s *OpenTracingLayerJobStore) UpdateOptimistically(job *model.Job, currentS
 	}()
 
 	defer span.Finish()
-	result, err := s.JobStore.UpdateOptimistically(job, currentStatus)
+	result, err := s.JobStore.UpdateOptimistically(job)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -4706,11 +4706,11 @@ func (s *RetryLayerJobStore) Save(job *model.Job) (*model.Job, error) {
 
 }
 
-func (s *RetryLayerJobStore) UpdateOptimistically(job *model.Job, currentStatus string) (bool, error) {
+func (s *RetryLayerJobStore) UpdateOptimistically(job *model.Job) (bool, error) {
 
 	tries := 0
 	for {
-		result, err := s.JobStore.UpdateOptimistically(job, currentStatus)
+		result, err := s.JobStore.UpdateOptimistically(job)
 		if err == nil {
 			return result, nil
 		}

--- a/store/sqlstore/job_store.go
+++ b/store/sqlstore/job_store.go
@@ -45,14 +45,14 @@ func (jss SqlJobStore) Save(job *model.Job) (*model.Job, error) {
 	return job, nil
 }
 
-func (jss SqlJobStore) UpdateOptimistically(job *model.Job, currentStatus string) (bool, error) {
+func (jss SqlJobStore) UpdateOptimistically(job *model.Job) (bool, error) {
 	query, args, err := jss.getQueryBuilder().
 		Update("Jobs").
 		Set("LastActivityAt", model.GetMillis()).
 		Set("Status", job.Status).
 		Set("Data", job.DataToJson()).
 		Set("Progress", job.Progress).
-		Where(sq.Eq{"Id": job.Id, "Status": currentStatus}).ToSql()
+		Where(sq.Eq{"Id": job.Id}).ToSql()
 	if err != nil {
 		return false, errors.Wrap(err, "job_tosql")
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -665,7 +665,7 @@ type ReactionStore interface {
 
 type JobStore interface {
 	Save(job *model.Job) (*model.Job, error)
-	UpdateOptimistically(job *model.Job, currentStatus string) (bool, error)
+	UpdateOptimistically(job *model.Job) (bool, error)
 	UpdateStatus(id string, status string) (*model.Job, error)
 	UpdateStatusOptimistically(id string, currentStatus string, newStatus string) (bool, error)
 	Get(id string) (*model.Job, error)

--- a/store/storetest/job_store.go
+++ b/store/storetest/job_store.go
@@ -461,12 +461,10 @@ func testJobUpdateOptimistically(t *testing.T, ss store.Store) {
 		"Foo": "Bar",
 	}
 
-	updated, err := ss.Job().UpdateOptimistically(job, model.JobStatusSuccess)
+	updated, err := ss.Job().UpdateOptimistically(job)
 	require.False(t, err != nil && updated)
 
-	time.Sleep(2 * time.Millisecond)
-
-	updated, err = ss.Job().UpdateOptimistically(job, model.JobStatusPending)
+	updated, err = ss.Job().UpdateOptimistically(job)
 	require.NoError(t, err)
 	require.True(t, updated)
 

--- a/store/storetest/mocks/JobStore.go
+++ b/store/storetest/mocks/JobStore.go
@@ -263,20 +263,20 @@ func (_m *JobStore) Save(job *model.Job) (*model.Job, error) {
 	return r0, r1
 }
 
-// UpdateOptimistically provides a mock function with given fields: job, currentStatus
-func (_m *JobStore) UpdateOptimistically(job *model.Job, currentStatus string) (bool, error) {
-	ret := _m.Called(job, currentStatus)
+// UpdateOptimistically provides a mock function with given fields: job
+func (_m *JobStore) UpdateOptimistically(job *model.Job) (bool, error) {
+	ret := _m.Called(job)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(*model.Job, string) bool); ok {
-		r0 = rf(job, currentStatus)
+	if rf, ok := ret.Get(0).(func(*model.Job) bool); ok {
+		r0 = rf(job)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*model.Job, string) error); ok {
-		r1 = rf(job, currentStatus)
+	if rf, ok := ret.Get(1).(func(*model.Job) error); ok {
+		r1 = rf(job)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -3963,10 +3963,10 @@ func (s *TimerLayerJobStore) Save(job *model.Job) (*model.Job, error) {
 	return result, err
 }
 
-func (s *TimerLayerJobStore) UpdateOptimistically(job *model.Job, currentStatus string) (bool, error) {
+func (s *TimerLayerJobStore) UpdateOptimistically(job *model.Job) (bool, error) {
 	start := timemodule.Now()
 
-	result, err := s.JobStore.UpdateOptimistically(job, currentStatus)
+	result, err := s.JobStore.UpdateOptimistically(job)
 
 	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
 	if s.Root.Metrics != nil {


### PR DESCRIPTION
The id is the primary key for the jobs table. There
is no need to filter by old status as well because
it's redundant.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4?c=65f70258-4e63-4999-8ab5-395db4cf7023

```release-note
NONE
```
