### PR TITLE
[MM-38082] Add local-mode handler for config reload endpoint

### DIFF
--- a/api4/config.go
+++ b/api4/config.go
@@ -91,7 +91,10 @@ func configReload(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.App.ReloadConfig()
+	if err := c.App.ReloadConfig(); err != nil {
+		c.Err = model.NewAppError("configReload", "api.config.reload_config.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return
+	}
 
 	auditRec.Success()
 

--- a/api4/config_local.go
+++ b/api4/config_local.go
@@ -19,6 +19,7 @@ func (api *API) InitConfigLocal() {
 	api.BaseRoutes.APIRoot.Handle("/config", api.APILocal(localGetConfig)).Methods("GET")
 	api.BaseRoutes.APIRoot.Handle("/config", api.APILocal(localUpdateConfig)).Methods("PUT")
 	api.BaseRoutes.APIRoot.Handle("/config/patch", api.APILocal(localPatchConfig)).Methods("PUT")
+	api.BaseRoutes.APIRoot.Handle("/config/reload", api.APILocal(localConfigReload)).Methods("POST")
 	api.BaseRoutes.APIRoot.Handle("/config/migrate", api.APILocal(migrateConfig)).Methods("POST")
 }
 
@@ -138,4 +139,19 @@ func localPatchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(c.App.GetSanitizedConfig()); err != nil {
 		mlog.Warn("Error while writing response", mlog.Err(err))
 	}
+}
+
+func localConfigReload(c *Context, w http.ResponseWriter, r *http.Request) {
+	auditRec := c.MakeAuditRecord("localConfigReload", audit.Fail)
+	defer c.LogAuditRec(auditRec)
+
+	if err := c.App.ReloadConfig(); err != nil {
+		c.Err = model.NewAppError("localConfigReload", "api.config.reload_config.app_error", nil, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	auditRec.Success()
+
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	ReturnStatusOK(w)
 }

--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -126,10 +126,10 @@ func TestReloadConfig(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
-	t.Run("as system admin", func(t *testing.T) {
-		_, err := th.SystemAdminClient.ReloadConfig()
+	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
+		_, err := client.ReloadConfig()
 		require.NoError(t, err)
-	})
+	}, "as system admin and local mode")
 
 	t.Run("as restricted system admin", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ExperimentalSettings.RestrictSystemAdmin = true })

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1463,6 +1463,10 @@
     "translation": "Failed to merge given config."
   },
   {
+    "id": "api.config.reload_config.app_error",
+    "translation": "Failed to reload config."
+  },
+  {
     "id": "api.config.update_config.clear_siteurl.app_error",
     "translation": "Site URL cannot be cleared."
   },


### PR DESCRIPTION
#### Summary

PR adds missing local-mode handler for the config reload endpoint.

#### Ticket

https://mattermost.atlassian.net/browse/MM-38082

#### Release Note

```release-note
Fixed an issue where the `mmctl config reload` command was not working in local mode.
```
