### PR TITLE
[MM-36695] Fix flaky TestRequestTrialLicense test

### DIFF
--- a/app/license.go
+++ b/app/license.go
@@ -20,11 +20,12 @@ import (
 )
 
 const (
-	requestTrialURL           = "https://customers.mattermost.com/api/v1/trials"
 	LicenseEnv                = "MM_LICENSE"
 	LicenseRenewalURL         = "https://customers.mattermost.com/subscribe/renew"
 	JWTDefaultTokenExpiration = 7 * 24 * time.Hour // 7 days of expiration
 )
+
+var RequestTrialURL = "https://customers.mattermost.com/api/v1/trials"
 
 // JWTClaims custom JWT claims with the needed information for the
 // renewal process
@@ -253,7 +254,7 @@ func (s *Server) GetSanitizedClientLicense() map[string]string {
 
 // RequestTrialLicense request a trial license from the mattermost official license server
 func (s *Server) RequestTrialLicense(trialRequest *model.TrialLicenseRequest) *model.AppError {
-	resp, err := http.Post(requestTrialURL, "application/json", bytes.NewBuffer([]byte(trialRequest.ToJson())))
+	resp, err := http.Post(RequestTrialURL, "application/json", bytes.NewBuffer([]byte(trialRequest.ToJson())))
 	if err != nil {
 		return model.NewAppError("RequestTrialLicense", "api.license.request_trial_license.app_error", nil, err.Error(), http.StatusBadRequest)
 	}


### PR DESCRIPTION
#### Summary

PR fixes flaky `TestRequestTrialLicense/trial_license_user_count_less_than_current_users`. We are using a mock HTTP server to return the trial license instead of relying on an actual network call to `https://customers.mattermost.com/api/v1/trials` which caused the flakyness.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36695

#### Release Note
```release-note
NONE
```
