### PR TITLE
[MM-37494] Cherrypick #18031: Check for license SKU when preparing marketplace requests

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -720,7 +720,7 @@ func (s *Server) getBaseMarketplaceFilter() *model.MarketplacePluginFilter {
 	}
 
 	license := s.License()
-	if license != nil && *license.Features.EnterprisePlugins {
+	if license != nil && license.HasEnterpriseMarketplacePlugins() {
 		filter.EnterprisePlugins = true
 	}
 

--- a/model/license.go
+++ b/model/license.go
@@ -16,6 +16,11 @@ const (
 	InvalidLicenseError = "api.license.add_license.invalid.app_error"
 	LicenseGracePeriod  = 1000 * 60 * 60 * 24 * 10 //10 days
 	LicenseRenewalLink  = "https://mattermost.com/renew/"
+
+	LicenseShortSkuE10          = "E10"
+	LicenseShortSkuE20          = "E20"
+	LicenseShortSkuProfessional = "professional"
+	LicenseShortSkuEnterprise   = "enterprise"
 )
 
 const (
@@ -300,6 +305,13 @@ func (l *License) IsSanctionedTrial() bool {
 
 	return l.IsTrialLicense() &&
 		(duration >= sanctionedTrialDurationLowerBound.Milliseconds() || duration <= sanctionedTrialDurationUpperBound.Milliseconds())
+}
+
+func (l *License) HasEnterpriseMarketplacePlugins() bool {
+	return *l.Features.EnterprisePlugins ||
+		l.SkuShortName == LicenseShortSkuE20 ||
+		l.SkuShortName == LicenseShortSkuProfessional ||
+		l.SkuShortName == LicenseShortSkuEnterprise
 }
 
 // NewTestLicense returns a license that expires in the future and has the given features.


### PR DESCRIPTION
#### Summary

This PR solves an issue where Enterprise plugins were not showing for systems with a Professional license. We are now checking the license SKU while preparing the request to be sent to the marketplace.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-37494

#### Release Note

```release-note
E20, Professional, and Enterprise license SKUs are now supported for installing Enterprise plugins.
```
