### PR TITLE
[MM-38177] Update CSP unsafe directives to be gated by developer-mode configuration flag, instead of build number

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -174,15 +174,12 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Instruct the browser not to display us in an iframe unless is the same origin for anti-clickjacking
 		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 
-		// Add unsafe-eval to the content security policy for faster source maps in development mode
 		devCSP := ""
 		if *c.App.Config().ServiceSettings.EnableDeveloper {
+			// Add unsafe-eval to the content security policy for faster source maps in development mode
 			devCSP += " 'unsafe-eval'"
-		}
-
-		// Add unsafe-inline to unlock extensions like React & Redux DevTools in Firefox
-		// see https://github.com/reduxjs/redux-devtools/issues/380
-		if *c.App.Config().ServiceSettings.EnableDeveloper {
+			// Add unsafe-inline to unlock extensions like React & Redux DevTools in Firefox
+			// see https://github.com/reduxjs/redux-devtools/issues/380
 			devCSP += " 'unsafe-inline'"
 		}
 

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -176,13 +176,13 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		// Add unsafe-eval to the content security policy for faster source maps in development mode
 		devCSP := ""
-		if model.BuildNumber == "dev" {
+		if *c.App.Config().ServiceSettings.EnableDeveloper {
 			devCSP += " 'unsafe-eval'"
 		}
 
 		// Add unsafe-inline to unlock extensions like React & Redux DevTools in Firefox
 		// see https://github.com/reduxjs/redux-devtools/issues/380
-		if model.BuildNumber == "dev" {
+		if *c.App.Config().ServiceSettings.EnableDeveloper {
 			devCSP += " 'unsafe-inline'"
 		}
 

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -361,19 +361,8 @@ func TestHandlerServeCSPHeader(t *testing.T) {
 	})
 
 	t.Run("static, development mode enabled", func(t *testing.T) {
-		th := SetupWithStoreMock(t)
+	        th := Setup(t).InitBasic()
 		defer th.TearDown()
-
-		mockStore := th.App.Srv().Store.(*mocks.Store)
-		mockPostStore := mocks.PostStore{}
-		mockPostStore.On("GetMaxPostSize").Return(65535, nil)
-		mockSystemStore := mocks.SystemStore{}
-		mockSystemStore.On("GetByName", "UpgradedFromTE").Return(&model.System{Name: "UpgradedFromTE", Value: "false"}, nil)
-		mockSystemStore.On("GetByName", "InstallationDate").Return(&model.System{Name: "InstallationDate", Value: "10"}, nil)
-		mockSystemStore.On("GetByName", "FirstServerRunTimestamp").Return(&model.System{Name: "FirstServerRunTimestamp", Value: "10"}, nil)
-
-		mockStore.On("Post").Return(&mockPostStore)
-		mockStore.On("System").Return(&mockSystemStore)
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			*cfg.ServiceSettings.EnableDeveloper = true

--- a/web/handlers_test.go
+++ b/web/handlers_test.go
@@ -360,8 +360,8 @@ func TestHandlerServeCSPHeader(t *testing.T) {
 		// assert.Contains(t, response.Header()["Content-Security-Policy"], "frame-ancestors 'self'; script-src 'self' cdn.rudderlabs.com 'sha256-tPOjw+tkVs9axL78ZwGtYl975dtyPHB6LYKAO2R3gR4='", "csp header incorrectly changed after subpath changed")
 	})
 
-	t.Run("static, development mode enabled", func(t *testing.T) {
-	        th := Setup(t).InitBasic()
+	t.Run("csp unsafe directives", func(t *testing.T) {
+		th := Setup(t).InitBasic()
 		defer th.TearDown()
 
 		th.App.UpdateConfig(func(cfg *model.Config) {


### PR DESCRIPTION
#### Summary
Instead of inspecting the application's `BuildNumber`, use the `ServiceSettings.EnableDeveloper` flag to determine whether the `unsafe-*` CSP directives should be added to the `Content-Security-Policy` header.

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-38177
Fixes #18288 

#### Release Note

```release-note
Development-mode Content Security Policy (CSP) directives (unsafe-eval, unsafe-inline) are now gated by the ServiceSettings.EnableDeveloper configuration flag instead of the application BuildNumber.
```
