### PR TITLE
[MM-37838] - Remove global header feature flag

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -38,9 +38,6 @@ type FeatureFlags struct {
 
 	PermalinkPreviews bool
 
-	// Enable the Global Header
-	GlobalHeader bool
-
 	// Enable the Invite Members button on the left panel, possible values = ("none", "sticky", "lhs_button", "user_icon")
 	InviteMembersButton string
 
@@ -60,7 +57,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PluginFocalboard = ""
 	f.TimedDND = false
 	f.PermalinkPreviews = true
-	f.GlobalHeader = false
 	f.InviteMembersButton = "none"
 	f.AddChannelButton = "none"
 }


### PR DESCRIPTION
#### Summary
removes the global header feature flag and default value.
**Since this is my first PR in here:** If there is something i am missing here please point it out and I will fix that.

#### Ticket Link
[MM-37838](https://mattermost.atlassian.net/browse/MM-37838)

#### Related PRs
https://github.com/mattermost/mattermost-webapp/pull/8740

#### Release Note
```release-note
NONE
```
