### PR TITLE
Automated cherry pick of #18281

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -62,7 +62,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PermalinkPreviews = true
 	f.GlobalHeader = false
 	f.InviteMembersButton = "none"
-	f.AddChannelButton = "none"
+	f.AddChannelButton = "by_team_name"
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {


### PR DESCRIPTION
Cherry pick of #18281 on release-6.0.

/cc  @neallred

```release-notes
NONE
```