### PR TITLE
MM-38132: Improve Auto Responder logic (#18264)

### DIFF
--- a/app/auto_responder.go
+++ b/app/auto_responder.go
@@ -13,7 +13,7 @@ import (
 
 // check if there is any auto_response type post in channel by the user in a calender day
 func (a *App) checkIfRespondedToday(createdAt int64, channelId, userId string) (bool, error) {
-	y, m, d := time.Unix(int64(model.GetTimeForMillis(createdAt).Second()), 0).Date()
+	y, m, d := model.GetTimeForMillis(createdAt).Date()
 	since := model.GetMillisForTime(time.Date(y, m, d, 0, 0, 0, 0, time.UTC))
 	return a.Srv().Store.Post().HasAutoResponsePostByUserSince(
 		model.GetPostsSinceOptions{ChannelId: channelId, Time: since},

--- a/app/auto_responder_test.go
+++ b/app/auto_responder_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,7 +101,7 @@ func TestSendAutoResponseIfNecessary(t *testing.T) {
 
 		savedPost, _ := th.App.CreatePost(th.Context, &model.Post{
 			ChannelId: channel.Id,
-			Message:   "zz" + model.NewId() + "a",
+			Message:   NewTestId(),
 			UserId:    th.BasicUser.Id},
 			th.BasicChannel,
 			false, true)
@@ -130,7 +131,7 @@ func TestSendAutoResponseIfNecessary(t *testing.T) {
 
 		savedPost, _ := th.App.CreatePost(th.Context, &model.Post{
 			ChannelId: channel.Id,
-			Message:   "zz" + model.NewId() + "a",
+			Message:   NewTestId(),
 			UserId:    th.BasicUser.Id},
 			th.BasicChannel,
 			false, true)
@@ -147,7 +148,7 @@ func TestSendAutoResponseIfNecessary(t *testing.T) {
 
 		savedPost, _ := th.App.CreatePost(th.Context, &model.Post{
 			ChannelId: th.BasicChannel.Id,
-			Message:   "zz" + model.NewId() + "a",
+			Message:   NewTestId(),
 			UserId:    th.BasicUser.Id},
 			th.BasicChannel,
 			false, true)
@@ -187,7 +188,7 @@ func TestSendAutoResponseIfNecessary(t *testing.T) {
 
 		savedPost, _ := th.App.CreatePost(th.Context, &model.Post{
 			ChannelId: channel.Id,
-			Message:   "zz" + model.NewId() + "a",
+			Message:   NewTestId(),
 			UserId:    botUser.Id},
 			th.BasicChannel,
 			false, true)
@@ -215,24 +216,27 @@ func TestSendAutoResponseIfNecessary(t *testing.T) {
 
 		channel := th.CreateDmChannel(receiver)
 
+		// Clean up all posts from this user.
+		// There are some dummy messages like "user joined team" etc.
+		// which needs to be cleaned up.
+		require.NoError(t, th.GetSqlStore().Post().PermanentDeleteByUser(th.BasicUser.Id))
+
 		savedPost, err := th.App.CreatePost(th.Context, &model.Post{
 			ChannelId: channel.Id,
-			Message:   NewTestId(),
-			UserId:    th.BasicUser.Id},
+			Message:   patch.NotifyProps["auto_responder_message"],
+			UserId:    receiver.Id,
+			CreateAt:  model.GetMillisForTime(time.Now().Add(-48 * time.Hour)),
+			Type:      model.POST_AUTO_RESPONDER,
+		},
 			th.BasicChannel,
 			false, true)
-
-		assert.Nil(t, err)
+		require.Nil(t, err)
+		savedPost.CreateAt = model.GetMillisForTime(time.Now())
 
 		sent, err := th.App.SendAutoResponseIfNecessary(th.Context, channel, th.BasicUser, savedPost)
 
 		require.Nil(t, err)
 		assert.True(t, sent)
-
-		sent, err = th.App.SendAutoResponseIfNecessary(th.Context, channel, th.BasicUser, savedPost)
-
-		require.Nil(t, err)
-		assert.False(t, sent)
 	})
 }
 

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -3174,6 +3174,8 @@ func testHasAutoResponsePostByUserSince(t *testing.T, ss store.Store) {
 			Message:   "message",
 		})
 		require.NoError(t, err)
+		// We need to sleep because SendAutoResponseIfNecessary
+		// runs in a goroutine.
 		time.Sleep(time.Millisecond)
 
 		post2, err := ss.Post().Save(&model.Post{


### PR DESCRIPTION
We properly truncate the date part from the createAt time.

The SQL query is improved now to directly return the bool.

Fixed the test to properly test the feature.

https://mattermost.atlassian.net/browse/MM-38132

```release-note
NONE
```
