### PR TITLE
Manual cherry pick of #18253 on release-5.39

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7963,6 +7963,10 @@
     "translation": "CollapsedThreads setting must be either disabled,default_on or default_off"
   },
   {
+    "id": "model.config.is_valid.collapsed_threads.autofollow.app_error",
+    "translation": "ThreadAutoFollow must be true to enable CollapsedThreads"
+  },
+  {
     "id": "model.config.is_valid.data_retention.deletion_job_start_time.app_error",
     "translation": "Data retention job start time must be a 24-hour time stamp in the form HH:MM."
   },

--- a/model/config.go
+++ b/model/config.go
@@ -3683,6 +3683,10 @@ func (s *ServiceSettings) isValid() *AppError {
 		return NewAppError("Config.IsValid", "model.config.is_valid.group_unread_channels.app_error", nil, "", http.StatusBadRequest)
 	}
 
+	if *s.CollapsedThreads != COLLAPSED_THREADS_DISABLED && !*s.ThreadAutoFollow {
+		return NewAppError("Config.IsValid", "model.config.is_valid.collapsed_threads.autofollow.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	if *s.CollapsedThreads != COLLAPSED_THREADS_DISABLED &&
 		*s.CollapsedThreads != COLLAPSED_THREADS_DEFAULT_ON &&
 		*s.CollapsedThreads != COLLAPSED_THREADS_DEFAULT_OFF {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -1467,3 +1467,29 @@ func TestConfigExportSettingsIsValid(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, "model.config.is_valid.export.retention_days_too_low.app_error", err.Id)
 }
+
+func TestConfigServiceSettingsIsValid(t *testing.T) {
+	cfg := Config{}
+	cfg.SetDefaults()
+
+	err := cfg.ServiceSettings.isValid()
+	require.Nil(t, err)
+
+	*cfg.ServiceSettings.CollapsedThreads = COLLAPSED_THREADS_DISABLED
+	err = cfg.ServiceSettings.isValid()
+	require.Nil(t, err)
+
+	*cfg.ServiceSettings.ThreadAutoFollow = false
+	err = cfg.ServiceSettings.isValid()
+	require.Nil(t, err)
+
+	*cfg.ServiceSettings.CollapsedThreads = COLLAPSED_THREADS_DEFAULT_OFF
+	err = cfg.ServiceSettings.isValid()
+	require.NotNil(t, err)
+	require.Equal(t, "model.config.is_valid.collapsed_threads.autofollow.app_error", err.Id)
+
+	*cfg.ServiceSettings.CollapsedThreads = COLLAPSED_THREADS_DEFAULT_ON
+	err = cfg.ServiceSettings.isValid()
+	require.NotNil(t, err)
+	require.Equal(t, "model.config.is_valid.collapsed_threads.autofollow.app_error", err.Id)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
The ThreadAutoFollow setting must be set to true to enable CollapsedThreads. Previously, this was stated the Mattermost documentation but not enforced - https://docs.mattermost.com/configure/configuration-settings.html#automatically-follow-threads
```
