### PR TITLE
[MM-36909] Fix flaky TestCreateDefaultMemberships

### DIFF
--- a/app/syncables_test.go
+++ b/app/syncables_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestCreateDefaultMemberships(t *testing.T) {
-	t.Skip("MM-36909")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
@@ -297,14 +296,15 @@ func TestCreateDefaultMemberships(t *testing.T) {
 		t.Errorf("unable to add user to channel: %s", err.Error())
 	}
 
-	timeAfterLeaving := model.GetMillis()
+	timeAfterLeaving := model.GetMillis() + 1
 
 	// Purging channelmemberhistory doesn't re-add user to channel
-	_, _, nErr := th.App.Srv().Store.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
+	deletedCount, _, nErr := th.App.Srv().Store.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
 		0, timeBeforeLeaving, 1000, model.RetentionPolicyCursor{})
 	if nErr != nil {
 		t.Errorf("error permanently deleting channelmemberhistory: %s", nErr.Error())
 	}
+	require.Equal(t, int64(1), deletedCount)
 
 	pErr = th.App.CreateDefaultMemberships(th.Context, scienceChannelGroupSyncable.UpdateAt, false)
 	if pErr != nil {
@@ -317,11 +317,12 @@ func TestCreateDefaultMemberships(t *testing.T) {
 	}
 
 	// Purging channelmemberhistory doesn't re-add user to channel
-	_, _, nErr = th.App.Srv().Store.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
+	deletedCount, _, nErr = th.App.Srv().Store.ChannelMemberHistory().PermanentDeleteBatchForRetentionPolicies(
 		0, timeAfterLeaving, 1000, model.RetentionPolicyCursor{})
 	if nErr != nil {
 		t.Errorf("error permanently deleting channelmemberhistory: %s", nErr.Error())
 	}
+	require.Equal(t, int64(1), deletedCount)
 
 	pErr = th.App.CreateDefaultMemberships(th.Context, scienceChannelGroupSyncable.UpdateAt, false)
 	if pErr != nil {


### PR DESCRIPTION
#### Summary

We ensure `timeAfterLeaving` is actually after the member's `LeaveTime` otherwise the delete won't happen.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36909

#### Release Note

```release-note
NONE
```
