### PR TITLE
MM-38093: updates notifications copy on CRT replies

### DIFF
--- a/app/email/email_batching.go
+++ b/app/email/email_batching.go
@@ -230,7 +230,7 @@ func (es *Service) sendBatchedEmailNotification(userID string, notifications []*
 	if *es.config().ServiceSettings.CollapsedThreads != model.CollapsedThreadsDisabled {
 		threadsEnabled = *es.config().ServiceSettings.CollapsedThreads == model.CollapsedThreadsDefaultOn
 		// check if a participant has overridden collapsed threads settings
-		if preference, err := es.store.Preference().Get(userID, model.PreferenceCategoryDisplaySettings, model.PreferenceNameCollapsedThreadsEnabled); err == nil {
+		if preference, errCrt := es.store.Preference().Get(userID, model.PreferenceCategoryDisplaySettings, model.PreferenceNameCollapsedThreadsEnabled); errCrt == nil {
 			threadsEnabled = preference.Value == "on"
 		}
 	}

--- a/app/notification.go
+++ b/app/notification.go
@@ -505,9 +505,9 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 				a.sendPushNotification(
 					notification,
 					profileMap[id],
-					profileMap[id].NotifyProps[model.PushThreadsNotifyProp] == model.UserNotifyMention,
 					false,
-					model.UserNotifyAll,
+					false,
+					model.CommentsNotifyCRT,
 				)
 			} else {
 				// register that a notification was not sent

--- a/app/notification_email.go
+++ b/app/notification_email.go
@@ -243,10 +243,7 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 	data.Props["NotificationFooterInfoLogin"] = translateFunc("app.notification.footer.infoLogin")
 	data.Props["NotificationFooterInfo"] = translateFunc("app.notification.footer.info")
 
-	if a.isCRTEnabledForUser(recipient.Id) && post.RootId != "" {
-		data.Props["Title"] = translateFunc("app.notification.body.thread.title", map[string]interface{}{"SenderName": senderName})
-		data.Props["SubTitle"] = translateFunc("app.notification.body.thread.subTitle", map[string]interface{}{"SenderName": senderName})
-	} else if channel.Type == model.ChannelTypeDirect {
+	if channel.Type == model.ChannelTypeDirect {
 		// Direct Messages
 		data.Props["Title"] = translateFunc("app.notification.body.dm.title", map[string]interface{}{"SenderName": senderName})
 		data.Props["SubTitle"] = translateFunc("app.notification.body.dm.subTitle", map[string]interface{}{"SenderName": senderName})
@@ -259,6 +256,26 @@ func (a *App) getNotificationEmailBody(recipient *model.User, post *model.Post, 
 		data.Props["Title"] = translateFunc("app.notification.body.mention.title", map[string]interface{}{"SenderName": senderName})
 		data.Props["SubTitle"] = translateFunc("app.notification.body.mention.subTitle", map[string]interface{}{"SenderName": senderName, "ChannelName": channelName})
 		pData.ChannelName = channelName
+	}
+
+	// Override title and subtile for replies with CRT enabled
+	if a.isCRTEnabledForUser(recipient.Id) && post.RootId != "" {
+		// Title is the same in all cases
+		data.Props["Title"] = translateFunc("app.notification.body.thread.title", map[string]interface{}{"SenderName": senderName})
+
+		if channel.Type == model.ChannelTypeDirect {
+			// Direct Reply
+			data.Props["SubTitle"] = translateFunc("app.notification.body.thread_dm.subTitle", map[string]interface{}{"SenderName": senderName})
+		} else if channel.Type == model.ChannelTypeGroup {
+			// Group Reply
+			data.Props["SubTitle"] = translateFunc("app.notification.body.thread_gm.subTitle", map[string]interface{}{"SenderName": senderName})
+		} else if emailNotificationContentsType == model.EmailNotificationContentsFull {
+			// Channel Reply with full content
+			data.Props["SubTitle"] = translateFunc("app.notification.body.thread_channel_full.subTitle", map[string]interface{}{"SenderName": senderName, "ChannelName": channelName})
+		} else {
+			// Channel Reply with generic content
+			data.Props["SubTitle"] = translateFunc("app.notification.body.thread_channel.subTitle", map[string]interface{}{"SenderName": senderName})
+		}
 	}
 
 	// only include posts in notification email if email notification contents type is set to full

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -181,7 +181,17 @@ func (a *App) getPushNotificationMessage(contentsConfig, postMessage string, exp
 	}
 
 	if channelType == model.ChannelTypeDirect {
+		if replyToThreadType == model.CommentsNotifyCRT {
+			if contentsConfig == model.GenericNoChannelNotification {
+				return senderName + userLocale("api.post.send_notification_and_forget.push_comment_on_crt_thread")
+			}
+			return senderName + userLocale("api.post.send_notification_and_forget.push_comment_on_crt_thread_dm")
+		}
 		return userLocale("api.post.send_notifications_and_forget.push_message")
+	}
+
+	if replyToThreadType == model.CommentsNotifyCRT {
+		return senderName + userLocale("api.post.send_notification_and_forget.push_comment_on_crt_thread")
 	}
 
 	if channelWideMention {
@@ -582,8 +592,16 @@ func (a *App) buildFullPushNotificationMessage(contentsConfig string, post *mode
 	cfg := a.Config()
 	if contentsConfig != model.GenericNoChannelNotification || channel.Type == model.ChannelTypeDirect {
 		msg.ChannelName = channelName
-		if a.isCRTEnabledForUser(user.Id) && post.RootId != "" {
-			msg.ChannelName = userLocale("api.push_notification.title.collapsed_threads")
+	}
+
+	if a.isCRTEnabledForUser(user.Id) && post.RootId != "" {
+		if contentsConfig != model.GenericNoChannelNotification {
+			props := map[string]interface{}{"channelName": channelName}
+			msg.ChannelName = userLocale("api.push_notification.title.collapsed_threads", props)
+
+			if channel.Type == model.ChannelTypeDirect {
+				msg.ChannelName = userLocale("api.push_notification.title.collapsed_threads_dm")
+			}
 		}
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2236,7 +2236,11 @@
   },
   {
     "id": "api.post.send_notification_and_forget.push_comment_on_crt_thread",
-    "translation": " commented on a thread you are following."
+    "translation": " replied to a thread you're following."
+  },
+  {
+    "id": "api.post.send_notification_and_forget.push_comment_on_crt_thread_dm",
+    "translation": " replied to a thread."
   },
   {
     "id": "api.post.send_notification_and_forget.push_comment_on_post",
@@ -2320,7 +2324,11 @@
   },
   {
     "id": "api.push_notification.title.collapsed_threads",
-    "translation": "Reply to Thread"
+    "translation": "Reply in {{.channelName}}"
+  },
+  {
+    "id": "api.push_notification.title.collapsed_threads_dm",
+    "translation": "Reply in Direct Message"
   },
   {
     "id": "api.push_notifications.message.parse.app_error",
@@ -5487,12 +5495,24 @@
     "translation": "{{.SenderName}} mentioned you in a message"
   },
   {
-    "id": "app.notification.body.thread.subTitle",
+    "id": "app.notification.body.thread.title",
+    "translation": "{{.SenderName}} replied to a thread"
+  },
+  {
+    "id": "app.notification.body.thread_channel.subTitle",
     "translation": "While you were away, {{.SenderName}} replied to a thread you're following."
   },
   {
-    "id": "app.notification.body.thread.title",
-    "translation": "{{.SenderName}} replied to a thread"
+    "id": "app.notification.body.thread_channel_full.subTitle",
+    "translation": "While you were away, {{.SenderName}} replied to a thread you're following in {{.ChannelName}}."
+  },
+  {
+    "id": "app.notification.body.thread_dm.subTitle",
+    "translation": "While you were away, {{.SenderName}} replied to a thread in your Direct Message."
+  },
+  {
+    "id": "app.notification.body.thread_gm.subTitle",
+    "translation": "While you were away, {{.SenderName}} replied to a thread in your group."
   },
   {
     "id": "app.notification.footer.info",

--- a/model/user.go
+++ b/model/user.go
@@ -38,6 +38,7 @@ const (
 	CommentsNotifyNever            = "never"
 	CommentsNotifyRoot             = "root"
 	CommentsNotifyAny              = "any"
+	CommentsNotifyCRT              = "crt"
 	FirstNameNotifyProp            = "first_name"
 	AutoResponderActiveNotifyProp  = "auto_responder_active"
 	AutoResponderMessageNotifyProp = "auto_responder_message"


### PR DESCRIPTION
#### Summary

Updates texts of push and email notifications when the user has CRT "on"
and the post is a reply to a thread.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-38093

#### Release Note

```release-note
NONE
```
