### PR TITLE
[MM-38321] Fix possible panics during license validation

### DIFF
--- a/app/license.go
+++ b/app/license.go
@@ -6,6 +6,7 @@ package app
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"time"
@@ -272,6 +273,12 @@ func (s *Server) RequestTrialLicense(trialRequest *model.TrialLicenseRequest) *m
 		return model.NewAppError("RequestTrialLicense", "api.license.request_trial_license.app_error", nil, err.Error(), http.StatusBadRequest)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return model.NewAppError("RequestTrialLicense", "api.license.request_trial_license.app_error", nil,
+			fmt.Sprintf("Unexpected HTTP status code %q returned by server", resp.Status), http.StatusInternalServerError)
+	}
+
 	licenseResponse := model.MapFromJSON(resp.Body)
 
 	if _, ok := licenseResponse["license"]; !ok {

--- a/utils/license.go
+++ b/utils/license.go
@@ -71,14 +71,14 @@ func (l *LicenseValidatorImpl) ValidateLicense(signed []byte) (bool, string) {
 		return false, ""
 	}
 
+	// remove null terminator
+	for len(decoded) > 0 && decoded[len(decoded)-1] == byte(0) {
+		decoded = decoded[:len(decoded)-1]
+	}
+
 	if len(decoded) <= 256 {
 		mlog.Error("Signed license not long enough")
 		return false, ""
-	}
-
-	// remove null terminator
-	for decoded[len(decoded)-1] == byte(0) {
-		decoded = decoded[:len(decoded)-1]
 	}
 
 	plaintext := decoded[:len(decoded)-256]


### PR DESCRIPTION
#### Summary

PR fixes two possible panics that could occur during license validation if the input data was particularly "bad".

1. We were enforcing a minimum length but then proceeded to remove some data (null terminators). Then we assumed the data was long enough. This is what triggered the reported panic.
2. I've also noticed the for loop that took care of removing null bytes didn't have an exit condition so it could panic in case the input data was full of them.

Although this should fix the potential crashes, I am still not sure what could have caused it given the reported panic happened on a license trial request so I am thinking whatever data was returned by `https://customers.mattermost.com/api/v1/trials` triggered this. /cc @marianunez 

#### Ticket

https://mattermost.atlassian.net/browse/MM-38321

#### Release Note

```release-note
Fixed a possible panic during license validation.
```
