### PR TITLE
Fix stopping mattermost server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update t
 # GOOS/GOARCH of the build host, used to determine whether we're cross-compiling or not
 BUILDER_GOOS_GOARCH="$(shell $(GO) env GOOS)_$(shell $(GO) env GOARCH)"
 
-PLATFORM_FILES="./cmd/mattermost/main.go"
+PLATFORM_FILES="./cmd/mattermost"
 
 # Output paths
 DIST_ROOT=dist
@@ -511,11 +511,11 @@ ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
 	wmic process where "Caption='go.exe' and CommandLine like '%go.exe run%'" call terminate
 	wmic process where "Caption='mattermost.exe' and CommandLine like '%go-build%'" call terminate
 else
-	@for PID in $$(ps -ef | grep "[g]o run" | awk '{ print $$2 }'); do \
+	@for PID in $$(ps -ef | grep "[g]o run" | grep "mattermost" | awk '{ print $$2 }'); do \
 		echo stopping go $$PID; \
 		kill $$PID; \
 	done
-	@for PID in $$(ps -ef | grep "[g]o-build" | awk '{ print $$2 }'); do \
+	@for PID in $$(ps -ef | grep "[g]o-build" | grep "mattermost" | awk '{ print $$2 }'); do \
 		echo stopping mattermost $$PID; \
 		kill $$PID; \
 	done


### PR DESCRIPTION
#### Summary

After the `disableconfigwatch` flag [went away](https://github.com/mattermost/mattermost-server/pull/17913/files) we were left with a rather generic grep match that would result into killing more than expected (any unrelated process running through `go run`). We fix this by adding an additional filtering.

#### Release Note

```release-note
NONE
```
