### PR TITLE
[MM-36537] Disable admin support email check job on server startup

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -1492,7 +1492,6 @@ func doReportUsageToAWSMeteringService(s *Server) {
 }
 
 func runCheckAdminSupportStatusJob(a *App, c *request.Context) {
-	doCheckAdminSupportStatus(a, c)
 	model.CreateRecurringTask("Check Admin Support Status Job", func() {
 		doCheckAdminSupportStatus(a, c)
 	}, time.Hour*model.WarnMetricJobInterval)


### PR DESCRIPTION
#### Summary

PR disables running the admin support email job on server startup. The scheduled check (once per week) remains unchanged.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36537

#### Release Note

```release-note
Disabled admin support email status check job on server startup.
```
