### PR TITLE
Adjust values waiting for webapp.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
 
           FILE_DIST=dist.tar.gz
           curl --version
-          curl --retry 75 --retry-delay 5 --retry-max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz
+          # Use `--retry-all-errors` instead of `until` after curl version >= 7.71.0
+          until curl --retry 75 --retry-delay 5 --retry-max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; done;
           if [ -f $FILE_DIST ]; then
             mkdir dist && tar -xvf $FILE_DIST -C dist --strip-components=1
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,7 @@ jobs:
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz
-              if [[ "$?" == 0 ]]; then
+              if curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz; then
                 break
               fi
               sleep 5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           echo "$WEBAPP_GIT_COMMIT"
 
           FILE_DIST=dist.tar.gz
-          until curl --max-time 5 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; sleep 110; done;
+          until curl --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; sleep 5; done;
           if [ ! -f $FILE_DIST ]; then
             npm ci && make build
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              if curl --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz; then
+              if curl --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz; then
                 break
               else
                 sleep 5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,11 @@ jobs:
           echo "$WEBAPP_GIT_COMMIT"
 
           FILE_DIST=dist.tar.gz
-          until curl --retry 75 --retry-delay 5 --retry-max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; done;
-          if [ ! -f $FILE_DIST ]; then
-            npm ci && make build
-          else
+          curl --retry 75 --retry-delay 5 --retry-max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz
+          if [ -f $FILE_DIST ]; then
             mkdir dist && tar -xvf $FILE_DIST -C dist --strip-components=1
+          else
+            npm ci && make build
           fi
           cd -
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,8 @@ jobs:
 
           FILE_DIST=dist.tar.gz
           curl --version
-          # Use `--retry-all-errors` instead of `until` after curl version >= 7.71.0
-          until curl --retry 75 --retry-delay 5 --retry-max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; done;
+          # Use `--retry-all-errors` instead of `until` after curl version >= 7.71.0; `retry` will not work, since it only retries on transient errors, 403 is not one of them.
+          until curl --max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz; do echo waiting for webapp build; sleep 5; done;
           if [ -f $FILE_DIST ]; then
             mkdir dist && tar -xvf $FILE_DIST -C dist --strip-components=1
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,10 @@ jobs:
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz && break
+              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz
+              if [[ "$?" == 0 ]]; then
+                break
+              fi
               sleep 5
           done
           ls -al

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
               curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz
               sleep 5
           done
+          ls -al
           if [ -f $FILE_DIST ]; then
             mkdir dist && tar -xvf $FILE_DIST -C dist --strip-components=1
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,10 @@ jobs:
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
               if curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz; then
                 break
+              else
+                sleep 5
+                continue
               fi
-              sleep 5
           done
           ls -al
           if tar -tzf $FILE_DIST >/dev/null; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
     docker:
       - image: mattermost/mattermost-build-webapp:20210524_node-16
     resource_class: xlarge
+    # Use `--retry-all-errors` instead of `until` after curl version >= 7.71.0; `retry` will not work, since it only retries on transient errors, 403 is not one of them.
     steps:
       - checkout
       - run: |
@@ -31,7 +32,6 @@ jobs:
 
           FILE_DIST=dist.tar.gz
           curl --version
-          # Use `--retry-all-errors` instead of `until` after curl version >= 7.71.0; `retry` will not work, since it only retries on transient errors, 403 is not one of them.
 
           runtime="1 minute"
           endtime=$(date -ud "$runtime" +%s)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           echo "$WEBAPP_GIT_COMMIT"
 
           FILE_DIST=dist.tar.gz
-          until curl --max-time 75 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; sleep 5; done;
+          until curl --retry 75 --retry-delay 5 --retry-max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; done;
           if [ ! -f $FILE_DIST ]; then
             npm ci && make build
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,11 @@ jobs:
           FILE_DIST=dist.tar.gz
           curl --version
 
-          runtime="1 minute"
+          runtime="2 minute"
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz
+              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz
               sleep 5
           done
           ls -al

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,14 @@ jobs:
           FILE_DIST=dist.tar.gz
           curl --version
           # Use `--retry-all-errors` instead of `until` after curl version >= 7.71.0; `retry` will not work, since it only retries on transient errors, 403 is not one of them.
-          until curl --max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz; do echo waiting for webapp build; sleep 5; done;
+
+          runtime="1 minute"
+          endtime=$(date -ud "$runtime" +%s)
+          while [[ $(date -u +%s) <= $endtime ]]; do
+              echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
+              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz
+              sleep 5
+          done
           if [ -f $FILE_DIST ]; then
             mkdir dist && tar -xvf $FILE_DIST -C dist --strip-components=1
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,8 @@ jobs:
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
               if curl --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz; then
                 break
-              else
-                sleep 5
-                continue
               fi
+              sleep 5
           done
           ls -al
           if tar -tzf $FILE_DIST >/dev/null; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) <= $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz
+              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz
               sleep 5
           done
           if [ -f $FILE_DIST ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
           runtime="1 minute"
           endtime=$(date -ud "$runtime" +%s)
-          while [[ $(date -u +%s) <= $endtime ]]; do
+          while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
               curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz
               sleep 5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz && break
+              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz && break
               sleep 5
           done
           ls -al

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,10 @@ jobs:
           runtime="2 minute"
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
-              echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
               if curl --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz; then
                 break
               fi
+              echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
               sleep 5
           done
           ls -al

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              if curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz; then
+              if curl --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/hello/mattermost-webapp.tar.gz; then
                 break
               else
                 sleep 5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
               sleep 5
           done
           ls -al
-          if [ -f $FILE_DIST ]; then
+          if tar -tzf $FILE_DIST >/dev/null; then
             mkdir dist && tar -xvf $FILE_DIST -C dist --strip-components=1
           else
             npm ci && make build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           endtime=$(date -ud "$runtime" +%s)
           while [[ $(date -u +%s) -le $endtime ]]; do
               echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz
+              curl --max-time 30 -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz && break
               sleep 5
           done
           ls -al

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           echo "$WEBAPP_GIT_COMMIT"
 
           FILE_DIST=dist.tar.gz
-          until curl --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; sleep 5; done;
+          until curl --max-time 75 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz; do echo waiting for webapp build; sleep 5; done;
           if [ ! -f $FILE_DIST ]; then
             npm ci && make build
           else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
           echo "$WEBAPP_GIT_COMMIT"
 
           FILE_DIST=dist.tar.gz
+          curl --version
           curl --retry 75 --retry-delay 5 --retry-max-time 375 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/${WEBAPP_GIT_COMMIT}/mattermost-webapp.tar.gz
           if [ -f $FILE_DIST ]; then
             mkdir dist && tar -xvf $FILE_DIST -C dist --strip-components=1


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->Forgot to commit the suggestion :facepalm: . 
It worked: https://app.circleci.com/pipelines/github/mattermost/mattermost-server/27571/workflows/276bb842-43fe-4bef-b768-f3d62634004b/jobs/193598

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
