### PR TITLE
MM-36697: adds page option to user threads

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -3004,6 +3004,7 @@ func getThreadsForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		Since:    0,
 		Before:   "",
 		After:    "",
+		Page:     uint64(c.Params.Page),
 		PageSize: uint64(c.Params.PerPage),
 		Unread:   false,
 		Extended: false,

--- a/model/thread.go
+++ b/model/thread.go
@@ -33,6 +33,9 @@ type GetUserThreadsOpts struct {
 	// PageSize specifies the size of the returned chunk of results. Default = 30
 	PageSize uint64
 
+	// Page specifies the page of the returned chunk of results. Default = 0
+	Page uint64
+
 	// Extended will enrich the response with participant details. Default = false
 	Extended bool
 

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -158,6 +158,11 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 		pageSize = opts.PageSize
 	}
 
+	page := uint64(0)
+	if opts.Page != 0 {
+		page = opts.Page
+	}
+
 	totalUnreadThreadsChan := make(chan store.StoreResult, 1)
 	totalCountChan := make(chan store.StoreResult, 1)
 	totalUnreadMentionsChan := make(chan store.StoreResult, 1)
@@ -265,7 +270,8 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 				LeftJoin("ThreadMemberships ON ThreadMemberships.PostId = Threads.PostId").
 				Where(newFetchConditions).
 				OrderBy("Threads.LastReplyAt " + order).
-				Limit(pageSize).ToSql()
+				Limit(pageSize).
+				Offset(pageSize * page).ToSql()
 
 			_, err := s.GetReplica().Select(&threads, query, args...)
 			threadsChan <- store.StoreResult{Data: threads, NErr: err}


### PR DESCRIPTION
#### Summary

Adds page option to GetThreadsForUser so we can paginate results.
This is done to add an "infinite" scrolling mechanism on global threads
list.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36697

#### Release Note

```release-note
NONE
```
