### PR TITLE
MM-36743: adds last_root_post_at in channels table

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -47,6 +47,7 @@ type Channel struct {
 	Header            string                 `json:"header"`
 	Purpose           string                 `json:"purpose"`
 	LastPostAt        int64                  `json:"last_post_at"`
+	LastRootPostAt    int64                  `json:"last_root_post_at"`
 	TotalMsgCount     int64                  `json:"total_msg_count"`
 	ExtraUpdateAt     int64                  `json:"extra_update_at"`
 	CreatorId         string                 `json:"creator_id"`


### PR DESCRIPTION
#### Summary

Channel recency for CRT users should not count replies,
this commit solves that issue by adding a new column to the channels
table: LastRootPostAt.
With that new info CRT users can have recent channels to work as
expected.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-36743

#### Release Note

```release-note
NONE
```
