### PR TITLE
[MM-25018] Bump Post.Props size limits

### DIFF
--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -511,8 +511,7 @@ func TestSplitWebhookPostAttachments(t *testing.T) {
 			post: makePost(maxPostSize*3/2, []int{5150, 2000, model.PostPropsMaxUserRunes - 1000}),
 			expected: []*model.Post{
 				makePost(maxPostSize, nil),
-				makePost(maxPostSize/2, []int{5150}),
-				makePost(0, []int{2000}),
+				makePost(maxPostSize/2, []int{5150, 2000}),
 				makePost(0, []int{model.PostPropsMaxUserRunes - 1000}),
 			},
 		},

--- a/model/post.go
+++ b/model/post.go
@@ -54,8 +54,8 @@ const (
 	PostMessageMaxRunesV1 = 4000
 	PostMessageMaxBytesV2 = 65535                     // Maximum size of a TEXT column in MySQL
 	PostMessageMaxRunesV2 = PostMessageMaxBytesV2 / 4 // Assume a worst-case representation
-	PostPropsMaxRunes     = 8000
-	PostPropsMaxUserRunes = PostPropsMaxRunes - 400 // Leave some room for system / pre-save modifications
+	PostPropsMaxRunes     = 800000
+	PostPropsMaxUserRunes = PostPropsMaxRunes - 40000 // Leave some room for system / pre-save modifications
 
 	PropsAddChannelMember = "add_channel_member"
 


### PR DESCRIPTION
#### Summary

Bumping the limit now that the column datatype supports it. I've simply multiplied existing values by 100 to give plenty of new space but still have some sort of protection against post bombs. Let me know if you had other numbers in mind.

#### Ticket

https://mattermost.atlassian.net/browse/MM-25018

#### Release Notes
```release-note
Increased Post.Props size limit to 800,000 characters.
```
