### PR TITLE
Set BuildDate compile flag to dev during development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)
 # If we don't set the build number it defaults to dev
 ifeq ($(BUILD_NUMBER),)
+	BUILD_DATE := dev
 	BUILD_NUMBER := dev
 endif
 BUILD_ENTERPRISE_DIR ?= ../enterprise

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)
 # If we don't set the build number it defaults to dev
 ifeq ($(BUILD_NUMBER),)
-	BUILD_DATE := dev
+	BUILD_DATE := n/a
 	BUILD_NUMBER := dev
 endif
 BUILD_ENTERPRISE_DIR ?= ../enterprise


### PR DESCRIPTION
#### Summary
The `BuildDate` flag was set at compile time as the current datetime, what makes the go compiler cache useless for the model package.

This change should save some compilation time.

#### Release Note
```release-note
NONE
```