### PR TITLE
[MM-36529] - Add the config option for EnableReadReceipts

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -22,6 +22,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["LockTeammateNameDisplay"] = strconv.FormatBool(*c.TeamSettings.LockTeammateNameDisplay)
 	props["ExperimentalPrimaryTeam"] = *c.TeamSettings.ExperimentalPrimaryTeam
 	props["ExperimentalViewArchivedChannels"] = strconv.FormatBool(*c.TeamSettings.ExperimentalViewArchivedChannels)
+	props["EnableReadReceipts"] = strconv.FormatBool(*c.TeamSettings.EnableReadReceipts)
 
 	props["EnableBotAccountCreation"] = strconv.FormatBool(*c.ServiceSettings.EnableBotAccountCreation)
 	props["EnableOAuthServiceProvider"] = strconv.FormatBool(*c.ServiceSettings.EnableOAuthServiceProvider)

--- a/model/config.go
+++ b/model/config.go
@@ -1872,6 +1872,7 @@ type TeamSettings struct {
 	EnableUserDeactivation              *bool    `access:"experimental_features"`
 	RestrictCreationToDomains           *string  `access:"authentication_signup"` // telemetry: none
 	EnableCustomUserStatuses            *bool    `access:"site_users_and_teams"`
+	EnableReadReceipts                  *bool    `access:"site_users_and_teams"`
 	EnableCustomBrand                   *bool    `access:"site_customization"`
 	CustomBrandText                     *string  `access:"site_customization"`
 	CustomDescriptionText               *string  `access:"site_customization"`
@@ -1912,6 +1913,10 @@ func (s *TeamSettings) SetDefaults() {
 
 	if s.EnableCustomUserStatuses == nil {
 		s.EnableCustomUserStatuses = NewBool(true)
+	}
+
+	if s.EnableReadReceipts == nil {
+		s.EnableReadReceipts = NewBool(true)
 	}
 
 	if s.EnableCustomBrand == nil {

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -445,6 +445,7 @@ func (ts *TelemetryService) trackConfig() {
 		"enable_open_server":                      *cfg.TeamSettings.EnableOpenServer,
 		"enable_user_deactivation":                *cfg.TeamSettings.EnableUserDeactivation,
 		"enable_custom_user_statuses":             *cfg.TeamSettings.EnableCustomUserStatuses,
+		"enable_read_receipts":                    *cfg.TeamSettings.EnableReadReceipts,
 		"enable_custom_brand":                     *cfg.TeamSettings.EnableCustomBrand,
 		"restrict_direct_message":                 *cfg.TeamSettings.RestrictDirectMessage,
 		"max_notifications_per_channel":           *cfg.TeamSettings.MaxNotificationsPerChannel,


### PR DESCRIPTION
#### Summary
This PR adds the new config key for EnableReadReceipts as part of https://mattermost.atlassian.net/browse/MM-36529 so that the option can be turned off on admin level 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36529

#### Release Note

```release-note
Added a new config setting TeamSettings.EnableReadReceipts. Added telemetry. 
```

