### PR TITLE
global header feature flag default value

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -60,7 +60,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PluginFocalboard = ""
 	f.TimedDND = false
 	f.PermalinkPreviews = true
-	f.GlobalHeader = false
+	f.GlobalHeader = true
 	f.AddChannelButton = "by_team_name"
 	f.PrewrittenMessages = "none"
 }


### PR DESCRIPTION
#### Summary
Sets the default value for the global header feature flag to `true` until we are ready to remove the feature flag completely. This should be possible once [#8740](https://github.com/mattermost/mattermost-webapp/pull/8740) is merged. It depends on another PR to be merged beforehand, that is already up and in review from @deanwhillier: [#8862](https://github.com/mattermost/mattermost-webapp/pull/8862)

#### Ticket Link
no ticket was created for this

#### Release Note
```release-note
NONE
```
