### PR TITLE
global header feature flag value

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -57,7 +57,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PluginFocalboard = ""
 	f.TimedDND = false
 	f.PermalinkPreviews = true
-	f.GlobalHeader = false
+	f.GlobalHeader = true
 	f.AddChannelButton = "by_team_name"
 }
 


### PR DESCRIPTION
#### Summary
Sets the default value for the global header feature flag to `true` until we are ready to remove the feature flag completely. This should be possible once [#8740](https://github.com/mattermost/mattermost-webapp/pull/8740) is merged. It depends on another PR to be merged beforehand, that is already up and in review from @deanwhillier: [#8862](https://github.com/mattermost/mattermost-webapp/pull/8862)

this is a replacement for #18397 for the 6.0 release.

#### Ticket Link
no ticket was created for this

#### Release Note
```release-note
NONE
```
