### PR TITLE
MM-38635 - Debug statements for prepareImage errors on community-daily

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -1126,7 +1126,9 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 		defer file.Close()
 		img, release, imgErr := prepareImage(a.srv.imgDecoder, file)
 		if imgErr != nil {
-			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr), mlog.String("fileinfo_id", fi.Id))
+			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr),
+				mlog.String("fileinfo_id", fi.Id), mlog.String("channel_id", fi.ChannelId),
+				mlog.String("creator_id", fi.CreatorId))
 			return
 		}
 		defer release()

--- a/app/file.go
+++ b/app/file.go
@@ -1126,7 +1126,33 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 		defer file.Close()
 		img, release, imgErr := prepareImage(a.srv.imgDecoder, file)
 		if imgErr != nil {
-			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr))
+			channelName := "n/a"
+			if fi.ChannelId != "" {
+				channel, err2 := a.GetChannel(fi.ChannelId)
+				if err2 != nil {
+					debugErr := fmt.Errorf("tried to get channel from ChannelId: %s ; received error: %w ; original imgErr: %w",
+						fi.ChannelId, err2, imgErr)
+					mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
+					return
+				}
+				channelName = channel.Name
+			}
+
+			username := "n/a"
+			if fi.CreatorId != "" {
+				user, err2 := a.GetUser(fi.CreatorId)
+				if err2 != nil {
+					debugErr := fmt.Errorf("tried to get user from CreatorId: %s ; received error: %w ; original imgErr: %w",
+						fi.CreatorId, err2, imgErr)
+					mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
+					return
+				}
+				username = user.Username
+			}
+
+			debugErr := fmt.Errorf("FileInfo id: %s ; CreatorId: %s ; username: %s ; PostId: %s ; ChannelId: %s ; ChannelName: %s ; CreateAt: %d ; Name: %s ; Extension: %s ; Size: %d ; MimeType: %s ; Path: %s ; error: %w",
+				fi.Id, fi.CreatorId, username, fi.PostId, fi.ChannelId, channelName, fi.CreateAt, fi.Name, fi.Extension, fi.Size, fi.MimeType, fi.Path, imgErr)
+			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
 			return
 		}
 		defer release()

--- a/app/file.go
+++ b/app/file.go
@@ -1126,33 +1126,7 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 		defer file.Close()
 		img, release, imgErr := prepareImage(a.srv.imgDecoder, file)
 		if imgErr != nil {
-			channelName := "n/a"
-			if fi.ChannelId != "" {
-				channel, err2 := a.GetChannel(fi.ChannelId)
-				if err2 != nil {
-					debugErr := fmt.Errorf("tried to get channel from ChannelId: %s ; received error: %s ; original imgErr: %w",
-						fi.ChannelId, err2.Error(), imgErr)
-					mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
-					return
-				}
-				channelName = channel.Name
-			}
-
-			username := "n/a"
-			if fi.CreatorId != "" {
-				user, err2 := a.GetUser(fi.CreatorId)
-				if err2 != nil {
-					debugErr := fmt.Errorf("tried to get user from CreatorId: %s ; received error: %s ; original imgErr: %w",
-						fi.CreatorId, err2.Error(), imgErr)
-					mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
-					return
-				}
-				username = user.Username
-			}
-
-			debugErr := fmt.Errorf("FileInfo id: %s ; CreatorId: %s ; username: %s ; PostId: %s ; ChannelId: %s ; ChannelName: %s ; CreateAt: %d ; Name: %s ; Extension: %s ; Size: %d ; MimeType: %s ; Path: %s ; error: %w",
-				fi.Id, fi.CreatorId, username, fi.PostId, fi.ChannelId, channelName, fi.CreateAt, fi.Name, fi.Extension, fi.Size, fi.MimeType, fi.Path, imgErr)
-			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
+			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr), mlog.String("FileInfo Id", fi.Id))
 			return
 		}
 		defer release()

--- a/app/file.go
+++ b/app/file.go
@@ -1130,8 +1130,8 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 			if fi.ChannelId != "" {
 				channel, err2 := a.GetChannel(fi.ChannelId)
 				if err2 != nil {
-					debugErr := fmt.Errorf("tried to get channel from ChannelId: %s ; received error: %w ; original imgErr: %w",
-						fi.ChannelId, err2, imgErr)
+					debugErr := fmt.Errorf("tried to get channel from ChannelId: %s ; received error: %s ; original imgErr: %w",
+						fi.ChannelId, err2.Error(), imgErr)
 					mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
 					return
 				}
@@ -1142,8 +1142,8 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 			if fi.CreatorId != "" {
 				user, err2 := a.GetUser(fi.CreatorId)
 				if err2 != nil {
-					debugErr := fmt.Errorf("tried to get user from CreatorId: %s ; received error: %w ; original imgErr: %w",
-						fi.CreatorId, err2, imgErr)
+					debugErr := fmt.Errorf("tried to get user from CreatorId: %s ; received error: %s ; original imgErr: %w",
+						fi.CreatorId, err2.Error(), imgErr)
 					mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(debugErr))
 					return
 				}

--- a/app/file.go
+++ b/app/file.go
@@ -1126,7 +1126,7 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 		defer file.Close()
 		img, release, imgErr := prepareImage(a.srv.imgDecoder, file)
 		if imgErr != nil {
-			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr), mlog.String("FileInfo Id", fi.Id))
+			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr), mlog.String("fileinfo_id", fi.Id))
 			return
 		}
 		defer release()


### PR DESCRIPTION
#### Summary
- Review of current situation: We've been getting these errors:

```
{"timestamp":"2021-09-17 18:06:02.129 Z","level":"debug","msg":"generateMiniPreview: prepareImage failed","error":"prepareImage: failed to decode image: imaging: failed to decode image: image: unknown format"}
```

Looking at the logs, it seems that we get a few of those every day normally. But since the last update to daily (about 13 hours ago) we've been getting spikes of up to 685 errors over a 10 minute period.

![image](https://user-images.githubusercontent.com/1490756/133840721-b4ad3624-d424-469a-9cca-f71982f2c209.png)

The error is reported in `prepareImage`: https://github.com/mattermost/mattermost-server/blob/96593580aeea0bc3a4780e5284ab199f5e19bc83/app/file.go#L1127-L1131

If you continue down the call stack, the image library's `sniff` reports the bytes are not an image format (line 89 in `format.go`). 

So, in `generateMiniPreview` we're first checking if the `FileInfo` `fi.IsImage()`, and then try to prepare it. But `fi.IsImage()` is just checking the `MimeType`, not the bytes. 

It looks like someone (or something) is uploading files that aren't images, and the file is given an (incorrect) `image` `MimeType`.

The problem is, we're generating MiniPreviews in so many places, I can't even guess what's causing these spikes. 

This PR adds info to the error statement in the `generateMiniPreview`, to track down what files are causing these spikes.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38635

#### Release Note
```release-note
NONE
```
