### PR TITLE
MM-38611 getSharedChannels: only return channels user is member of

### DIFF
--- a/api4/shared_channel.go
+++ b/api4/shared_channel.go
@@ -27,8 +27,19 @@ func getSharedChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// make sure user has access to the team.
+	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionViewTeam) {
+		c.SetPermissionError(model.PermissionViewTeam)
+		return
+	}
+
 	opts := model.SharedChannelFilterOpts{
 		TeamId: c.Params.TeamId,
+	}
+
+	// only return channels the user is a member of, unless they are a shared channels manager.
+	if !c.App.HasPermissionTo(c.AppContext.Session().UserId, model.PermissionManageSharedChannels) {
+		opts.MemberId = c.AppContext.Session().UserId
 	}
 
 	channels, appErr := c.App.GetSharedChannels(c.Params.Page, c.Params.PerPage, opts)

--- a/api4/shared_channel_test.go
+++ b/api4/shared_channel_test.go
@@ -64,9 +64,21 @@ func TestGetAllSharedChannels(t *testing.T) {
 	})
 
 	t.Run("get shared channels for invalid team", func(t *testing.T) {
-		channels, _, err := th.Client.GetAllSharedChannels(model.NewId(), 0, 100)
+		_, _, err := th.Client.GetAllSharedChannels(model.NewId(), 0, 100)
+		require.Error(t, err)
+	})
+
+	t.Run("get shared channels, user not member of team", func(t *testing.T) {
+		team := &model.Team{
+			DisplayName: "tteam",
+			Name:        GenerateTestTeamName(),
+			Type:        model.TeamOpen,
+		}
+		team, _, err := th.SystemAdminClient.CreateTeam(team)
 		require.NoError(t, err)
-		assert.Empty(t, channels)
+
+		_, _, err = th.Client.GetAllSharedChannels(team.Id, 0, 100)
+		require.Error(t, err)
 	})
 }
 

--- a/model/shared_channel.go
+++ b/model/shared_channel.go
@@ -238,6 +238,7 @@ func (scf *SharedChannelAttachment) IsValid() *AppError {
 type SharedChannelFilterOpts struct {
 	TeamId        string
 	CreatorId     string
+	MemberId      string
 	ExcludeHome   bool
 	ExcludeRemote bool
 }

--- a/store/sqlstore/shared_channel_store.go
+++ b/store/sqlstore/shared_channel_store.go
@@ -222,10 +222,7 @@ func (s SqlSharedChannelStore) getSharedChannelsQuery(opts model.SharedChannelFi
 	}
 
 	if opts.TeamId != "" {
-		query = query.Where(sq.Or{
-			sq.Eq{"sc.TeamId": opts.TeamId},
-			sq.Eq{"sc.TeamId": ""},
-		})
+		query = query.Where(sq.Eq{"sc.TeamId": opts.TeamId})
 	}
 
 	if opts.CreatorId != "" {

--- a/store/sqlstore/shared_channel_store.go
+++ b/store/sqlstore/shared_channel_store.go
@@ -216,8 +216,16 @@ func (s SqlSharedChannelStore) getSharedChannelsQuery(opts model.SharedChannelFi
 		Select(selectStr).
 		From("SharedChannels AS sc")
 
+	if opts.MemberId != "" {
+		query = query.Join("ChannelMembers AS cm ON cm.ChannelId = sc.ChannelId").
+			Where(sq.Eq{"cm.UserId": opts.MemberId})
+	}
+
 	if opts.TeamId != "" {
-		query = query.Where(sq.Eq{"sc.TeamId": opts.TeamId})
+		query = query.Where(sq.Or{
+			sq.Eq{"sc.TeamId": opts.TeamId},
+			sq.Eq{"sc.TeamId": ""},
+		})
 	}
 
 	if opts.CreatorId != "" {


### PR DESCRIPTION
#### Summary
getSharedChannels rest API should only return channels the user is a member of, unless the user has "manage_shared_channels" permission.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38611

#### Release Note
```release-note
NONE
```
