### PR TITLE
Automated cherry pick of #18400

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -775,7 +775,6 @@ func TestPushNotificationAck(t *testing.T) {
 
 		handler.ServeHTTP(resp, req)
 		assert.Equal(t, http.StatusForbidden, resp.Code)
-		fmt.Printf("DEBUG/resp.Body: %+v\n", resp.Body)
 		assert.NotNil(t, resp.Body)
 	})
 }

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -218,7 +218,7 @@ func (a *App) getEmbedForPost(post *model.Post, firstLink string, isNewPost bool
 		return nil, nil
 	}
 
-	og, image, permalink, err := a.getLinkMetadata(firstLink, post.CreateAt, isNewPost)
+	og, image, permalink, err := a.getLinkMetadata(firstLink, post.CreateAt, isNewPost, post.GetPreviewedPostProp())
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +289,7 @@ func (a *App) getImagesForPost(post *model.Post, imageURLs []string, isNewPost b
 	}
 
 	for _, imageURL := range imageURLs {
-		if _, image, _, err := a.getLinkMetadata(imageURL, post.CreateAt, isNewPost); err != nil {
+		if _, image, _, err := a.getLinkMetadata(imageURL, post.CreateAt, isNewPost, post.GetPreviewedPostProp()); err != nil {
 			mlog.Debug("Failed to get dimensions of an image in a post",
 				mlog.String("post_id", post.Id), mlog.String("image_url", imageURL), mlog.Err(err))
 		} else if image != nil {
@@ -453,7 +453,7 @@ func looksLikeAPermalink(url, siteURL string) bool {
 	return matched
 }
 
-func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool) (*opengraph.OpenGraph, *model.PostImage, *model.Permalink, error) {
+func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool, previewedPostPropVal string) (*opengraph.OpenGraph, *model.PostImage, *model.Permalink, error) {
 	requestURL = resolveMetadataURL(requestURL, a.GetSiteURL())
 
 	timestamp = model.FloorToNearestHour(timestamp)
@@ -464,14 +464,14 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 		permalink = nil
 	}
 
-	if ok {
+	if ok && previewedPostPropVal == "" {
 		return og, image, permalink, nil
 	}
 
 	// Check the database if this isn't a new post. If it is a new post and the data is cached, it should be in memory.
 	if !isNewPost {
 		og, image, ok = a.getLinkMetadataFromDatabase(requestURL, timestamp)
-		if ok {
+		if ok && previewedPostPropVal == "" {
 			cacheLinkMetadata(requestURL, timestamp, og, image, nil)
 			return og, image, nil, nil
 		}

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -583,6 +583,53 @@ func TestPreparePostForClient(t *testing.T) {
 		preview := firstEmbed.Data.(*model.PreviewPost)
 		require.Equal(t, referencedPost.Id, preview.PostID)
 	})
+
+	t.Run("permalink preview renders after toggling off the feature", func(t *testing.T) {
+		th := setup(t)
+		defer th.TearDown()
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.SiteURL = "http://mymattermost.com"
+		})
+
+		th.Context.Session().UserId = th.BasicUser.Id
+
+		referencedPost, err := th.App.CreatePost(th.Context, &model.Post{
+			UserId:    th.BasicUser.Id,
+			ChannelId: th.BasicChannel.Id,
+			Message:   "hello world",
+		}, th.BasicChannel, false, true)
+		require.Nil(t, err)
+
+		link := fmt.Sprintf("%s/%s/pl/%s", *th.App.Config().ServiceSettings.SiteURL, th.BasicTeam.Name, referencedPost.Id)
+
+		previewPost, err := th.App.CreatePost(th.Context, &model.Post{
+			UserId:    th.BasicUser.Id,
+			ChannelId: th.BasicChannel.Id,
+			Message:   link,
+		}, th.BasicChannel, false, true)
+		require.Nil(t, err)
+
+		clientPost := th.App.PreparePostForClient(previewPost, false, false)
+		firstEmbed := clientPost.Metadata.Embeds[0]
+		preview := firstEmbed.Data.(*model.PreviewPost)
+		require.Equal(t, referencedPost.Id, preview.PostID)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnablePermalinkPreviews = false
+		})
+
+		th.App.PreparePostForClient(previewPost, false, false)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnablePermalinkPreviews = true
+		})
+
+		clientPost2 := th.App.PreparePostForClient(previewPost, false, false)
+		firstEmbed2 := clientPost2.Metadata.Embeds[0]
+		preview2 := firstEmbed2.Data.(*model.PreviewPost)
+		require.Equal(t, referencedPost.Id, preview2.PostID)
+	})
 }
 
 func TestPreparePostForClientWithImageProxy(t *testing.T) {
@@ -1730,7 +1777,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 			require.False(t, ok, "data should not exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 			require.NotNil(t, og)
 			assert.Nil(t, img)
@@ -1745,7 +1792,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 			require.False(t, ok, "data should not exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp+60*1000, false)
+			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp+60*1000, false, "")
 
 			require.NotNil(t, og)
 			assert.Nil(t, img)
@@ -1762,7 +1809,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(differentURL, timestamp)
 			require.False(t, ok, "data should not exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(differentURL, timestamp, false)
+			og, img, _, err := th.App.getLinkMetadata(differentURL, timestamp, false, "")
 
 			assert.Nil(t, og)
 			assert.Nil(t, img)
@@ -1778,7 +1825,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, differentTimestamp)
 			require.False(t, ok, "data should not exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(requestURL, differentTimestamp, false)
+			og, img, _, err := th.App.getLinkMetadata(requestURL, differentTimestamp, false, "")
 
 			assert.Nil(t, og)
 			assert.Nil(t, img)
@@ -1805,7 +1852,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 			require.True(t, ok, "data should already exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 			require.NotNil(t, og)
 			assert.Nil(t, img)
@@ -1822,7 +1869,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 			require.True(t, ok, "data should already exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp+60*1000, false)
+			og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp+60*1000, false, "")
 
 			require.NotNil(t, og)
 			assert.Nil(t, img)
@@ -1841,7 +1888,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(differentURL, timestamp)
 			require.False(t, ok, "data should not exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(differentURL, timestamp, false)
+			og, img, _, err := th.App.getLinkMetadata(differentURL, timestamp, false, "")
 
 			assert.Nil(t, og)
 			assert.Nil(t, img)
@@ -1859,7 +1906,7 @@ func TestGetLinkMetadata(t *testing.T) {
 			_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, differentTimestamp)
 			require.False(t, ok, "data should not exist in database")
 
-			og, img, _, err := th.App.getLinkMetadata(requestURL, differentTimestamp, false)
+			og, img, _, err := th.App.getLinkMetadata(requestURL, differentTimestamp, false, "")
 
 			assert.Nil(t, og)
 			assert.Nil(t, img)
@@ -1880,7 +1927,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 		require.False(t, ok, "data should not exist in database")
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 		assert.NotNil(t, og)
 		assert.Nil(t, img)
@@ -1900,7 +1947,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 		require.False(t, ok, "data should not exist in database")
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 		assert.NotNil(t, og)
 		assert.Nil(t, img)
@@ -1928,7 +1975,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 		require.False(t, ok, "data should not exist in database")
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 		assert.Nil(t, og)
 		assert.NotNil(t, img)
@@ -1956,7 +2003,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 		require.False(t, ok, "data should not exist in database")
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 		assert.Nil(t, og)
 		assert.Nil(t, img)
@@ -1986,7 +2033,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 		require.False(t, ok, "data should not exist in database")
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 		assert.Nil(t, og)
 		assert.Nil(t, img)
@@ -2020,7 +2067,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 		require.False(t, ok, "data should not exist in database")
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 
 		assert.Nil(t, og)
 		assert.Nil(t, img)
@@ -2051,7 +2098,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		_, _, ok = th.App.getLinkMetadataFromDatabase(requestURL, timestamp)
 		require.False(t, ok, "data should not exist in database")
 
-		_, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		_, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 		require.NoError(t, err)
 
 		_, _, _, ok = getLinkMetadataFromCache(requestURL, timestamp)
@@ -2073,7 +2120,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		requestURL := server.URL + "/json?name=" + t.Name()
 		timestamp := int64(1547510400000)
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 		assert.Nil(t, og)
 		assert.Nil(t, img)
 		assert.NoError(t, err)
@@ -2088,7 +2135,7 @@ func TestGetLinkMetadata(t *testing.T) {
 
 		cacheLinkMetadata(requestURL, timestamp, &opengraph.OpenGraph{Title: "cached"}, nil, nil)
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, true)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, true, "")
 		assert.NotNil(t, og)
 		assert.Nil(t, img)
 		assert.NoError(t, err)
@@ -2103,7 +2150,7 @@ func TestGetLinkMetadata(t *testing.T) {
 
 		th.App.saveLinkMetadataToDatabase(requestURL, timestamp, &opengraph.OpenGraph{Title: "cached"}, nil)
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, true)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, true, "")
 		assert.Nil(t, og)
 		assert.Nil(t, img)
 		assert.NoError(t, err)
@@ -2126,7 +2173,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		requestURL := "/image?height=200&width=300&name=" + t.Name()
 		timestamp := int64(1547510400000)
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 		assert.Nil(t, og)
 		assert.NotNil(t, img)
 		assert.NoError(t, err)
@@ -2154,7 +2201,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		requestURL := server.URL + "/image?height=200&width=300&name=" + t.Name()
 		timestamp := int64(1547510400000)
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, false, "")
 		assert.Nil(t, og)
 		assert.Nil(t, img)
 		assert.Error(t, err)
@@ -2164,7 +2211,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		requestURL = th.App.GetSiteURL() + "/api/v4/image?url=" + url.QueryEscape(requestURL)
 
 		// Note that this request still fails while testing because the request made by the image proxy is blocked
-		og, img, _, err = th.App.getLinkMetadata(requestURL, timestamp, false)
+		og, img, _, err = th.App.getLinkMetadata(requestURL, timestamp, false, "")
 		assert.Nil(t, og)
 		assert.Nil(t, img)
 		assert.Error(t, err)
@@ -2178,7 +2225,7 @@ func TestGetLinkMetadata(t *testing.T) {
 		requestURL := server.URL + "/mixed?name=" + t.Name()
 		timestamp := int64(1547510400000)
 
-		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, true)
+		og, img, _, err := th.App.getLinkMetadata(requestURL, timestamp, true, "")
 		assert.Nil(t, og)
 		assert.NotNil(t, img)
 		assert.NoError(t, err)

--- a/model/post.go
+++ b/model/post.go
@@ -696,3 +696,10 @@ func (o *Post) GetPreviewPost() *PreviewPost {
 	}
 	return nil
 }
+
+func (o *Post) GetPreviewedPostProp() string {
+	if val, ok := o.GetProp(PostPropsPreviewedPost).(string); ok {
+		return val
+	}
+	return ""
+}


### PR DESCRIPTION
Cherry pick of #18400 on release-6.0.

/cc  @mkraft

```release-note
NONE
```