### PR TITLE
[MM-36603] - Text is cut-off on the bottom of the 14-day trial 3 day to end of trial email notification

### DIFF
--- a/app/email/email_test.go
+++ b/app/email/email_test.go
@@ -4,6 +4,7 @@
 package email
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,6 +89,47 @@ func TestSendInviteEmails(t *testing.T) {
 			"http://testserver",
 			"hello world",
 		)
+		require.NoError(t, err)
+
+		verifyMailbox(t)
+	})
+}
+
+func TestSendCloudTrialEndWarningEmail(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	th.ConfigureInbucketMail()
+
+	emailTo := "testclouduser@example.com"
+	emailToUsername := strings.Split(emailTo, "@")[0]
+
+	t.Run("SendCloudTrialEndWarningEmail", func(t *testing.T) {
+		verifyMailbox := func(t *testing.T) {
+			t.Helper()
+
+			var resultsMailbox mail.JSONMessageHeaderInbucket
+			err2 := mail.RetryInbucket(5, func() error {
+				var err error
+				resultsMailbox, err = mail.GetMailBox(emailTo)
+				return err
+			})
+			if err2 != nil {
+				t.Skipf("No email was received, maybe due load on the server: %v", err2)
+			}
+
+			require.Len(t, resultsMailbox, 1)
+			require.Contains(t, resultsMailbox[0].To[0], emailTo, "Wrong To: recipient")
+			resultsEmail, err := mail.GetMessageFromMailbox(emailTo, resultsMailbox[0].ID)
+			require.NoError(t, err, "Could not get message from mailbox")
+			require.Contains(t, resultsEmail.Body.HTML, "http://testserver", "Wrong received message %s", resultsEmail.Body.Text)
+			require.Contains(t, resultsEmail.Body.HTML, emailToUsername, "Wrong received message %s", resultsEmail.Body.Text)
+			require.Contains(t, resultsEmail.Body.Text, "http://testserver", "Wrong received message %s", resultsEmail.Body.Text)
+			require.Contains(t, resultsEmail.Body.Text, emailToUsername, "Wrong received message %s", resultsEmail.Body.Text)
+			require.Contains(t, resultsEmail.Body.Text, "feedback-cloud@mattermost.com")
+		}
+		mail.DeleteMailBox(emailTo)
+
+		err := th.service.SendCloudTrialEndWarningEmail(emailTo, emailToUsername, "June 23, 2200", th.BasicUser.Locale, "http://testserver")
 		require.NoError(t, err)
 
 		verifyMailbox(t)

--- a/templates/cloud_trial_end_warning.html
+++ b/templates/cloud_trial_end_warning.html
@@ -387,7 +387,7 @@
                                 <td align="left" style="font-size:0px;padding:0px 0px ;word-break:break-word;">
                                   <div style="font-family:Arial;font-size:14px;line-height:20px;text-align:left;color:#3D3C40;">{{.Props.QuestionInfo}}
                                     <a href='mailto:{{.Props.SupportEmail}}'>
-                                      {{.Props.SupportEmail}}
+                                      feedback-cloud@mattermost.com
                                     </a>
                                   </div>
                                 </td>

--- a/templates/cloud_trial_end_warning.mjml
+++ b/templates/cloud_trial_end_warning.mjml
@@ -40,7 +40,7 @@
           <mj-text font-size="14px" line-height="20px" color="#3D3C40" padding="0px 0px " align="left" font-family="Arial">
             {{.Props.QuestionInfo}}
             <a href='mailto:{{.Props.SupportEmail}}'>
-              {{.Props.SupportEmail}}
+              feedback-cloud@mattermost.com
             </a>
           </mj-text>
         </mj-column>


### PR DESCRIPTION
#### Summary
This PR ensures that when cloud trial emails ending warning emails have the Support Email defaults to `feedback-cloud@mattermost.com`

#### Ticket Link
[MM-36603](https://mattermost.atlassian.net/browse/MM-36603)

```release-note
NONE

```
