### PR TITLE
MM-38712: Flush logs while exiting from store upgrade

### DIFF
--- a/shared/mlog/global.go
+++ b/shared/mlog/global.go
@@ -112,6 +112,7 @@ func Error(msg string, fields ...Field) {
 }
 
 // Convenience method equivalent to calling `Log` with the `Critical` level.
+// DEPRECATED: Either use Error or Fatal.
 func Critical(msg string, fields ...Field) {
 	logger := getGlobalLogger()
 	if logger == nil {
@@ -119,4 +120,13 @@ func Critical(msg string, fields ...Field) {
 		return
 	}
 	logger.Critical(msg, fields...)
+}
+
+func Fatal(msg string, fields ...Field) {
+	logger := getGlobalLogger()
+	if logger == nil {
+		defaultLog(LvlFatal, msg, fields...)
+		return
+	}
+	logger.Fatal(msg, fields...)
 }

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -65,36 +65,6 @@ const (
 	replicaLagPrefix = "replica-lag"
 )
 
-const (
-	ExitGenericFailure           = 1
-	ExitCreateTable              = 100
-	ExitDBOpen                   = 101
-	ExitPing                     = 102
-	ExitNoDriver                 = 103
-	ExitTableExists              = 104
-	ExitTableExistsMySQL         = 105
-	ExitColumnExists             = 106
-	ExitDoesColumnExistsPostgres = 107
-	ExitDoesColumnExistsMySQL    = 108
-	ExitDoesColumnExistsMissing  = 109
-	ExitCreateColumnPostgres     = 110
-	ExitCreateColumnMySQL        = 111
-	ExitCreateColumnMissing      = 112
-	ExitRemoveColumn             = 113
-	ExitRenameColumn             = 114
-	ExitMaxColumn                = 115
-	ExitAlterColumn              = 116
-	ExitCreateIndexPostgres      = 117
-	ExitCreateIndexMySQL         = 118
-	ExitCreateIndexFullMySQL     = 119
-	ExitCreateIndexMissing       = 120
-	ExitRemoveIndexPostgres      = 121
-	ExitRemoveIndexMySQL         = 122
-	ExitRemoveIndexMissing       = 123
-	ExitRemoveTable              = 134
-	ExitAlterPrimaryKey          = 139
-)
-
 type SqlStoreStores struct {
 	team                 store.TeamStore
 	channel              store.ChannelStore
@@ -178,20 +148,17 @@ func New(settings model.SqlSettings, metrics einterfaces.MetricsInterface) *SqlS
 
 	ver, err := store.GetDbVersion(true)
 	if err != nil {
-		mlog.Critical("Error while getting DB version.", mlog.Err(err))
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Error while getting DB version.", mlog.Err(err))
 	}
 
 	ok, err := store.ensureMinimumDBVersion(ver)
 	if !ok {
-		mlog.Critical("Error while checking DB version.", mlog.Err(err))
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Error while checking DB version.", mlog.Err(err))
 	}
 
 	err = store.migrate(migrationsDirectionUp)
 	if err != nil {
-		mlog.Critical("Failed to apply database migrations.", mlog.Err(err))
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Failed to apply database migrations.", mlog.Err(err))
 	}
 
 	store.stores.team = newSqlTeamStore(store)
@@ -237,16 +204,13 @@ func New(settings model.SqlSettings, metrics einterfaces.MetricsInterface) *SqlS
 		if IsDuplicate(err) {
 			mlog.Warn("Duplicate key error occurred; assuming table already created and proceeding.", mlog.Err(err))
 		} else {
-			mlog.Critical("Error creating database tables.", mlog.Err(err))
-			os.Exit(ExitCreateTable)
+			mlog.Fatal("Error creating database tables.", mlog.Err(err))
 		}
 	}
 
 	err = upgradeDatabase(store, model.CurrentVersion)
 	if err != nil {
-		mlog.Critical("Failed to upgrade database.", mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Failed to upgrade database.", mlog.Err(err))
 	}
 
 	store.stores.channel.(*SqlChannelStore).createIndexesIfNotExists()
@@ -289,9 +253,7 @@ func New(settings model.SqlSettings, metrics einterfaces.MetricsInterface) *SqlS
 func setupConnection(connType string, dataSource string, settings *model.SqlSettings) *dbsql.DB {
 	db, err := dbsql.Open(*settings.DriverName, dataSource)
 	if err != nil {
-		mlog.Critical("Failed to open SQL connection to err.", mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitDBOpen)
+		mlog.Fatal("Failed to open SQL connection to err.", mlog.Err(err))
 	}
 
 	for i := 0; i < DBPingAttempts; i++ {
@@ -303,9 +265,7 @@ func setupConnection(connType string, dataSource string, settings *model.SqlSett
 			break
 		} else {
 			if i == DBPingAttempts-1 {
-				mlog.Critical("Failed to ping DB, server will exit.", mlog.Err(err))
-				time.Sleep(time.Second)
-				os.Exit(ExitPing)
+				mlog.Fatal("Failed to ping DB, server will exit.", mlog.Err(err))
 			} else {
 				mlog.Error("Failed to ping DB", mlog.Err(err), mlog.Int("retrying in seconds", DBPingTimeoutSecs))
 				time.Sleep(DBPingTimeoutSecs * time.Second)
@@ -352,9 +312,7 @@ func getDBMap(settings *model.SqlSettings, db *dbsql.DB) *gorp.DbMap {
 			QueryTimeout:  connectionTimeout,
 		}
 	default:
-		mlog.Critical("Failed to create dialect specific driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitNoDriver)
+		mlog.Fatal("Failed to create dialect specific driver")
 		return nil
 	}
 	if settings.Trace != nil && *settings.Trace {
@@ -382,8 +340,7 @@ func (ss *SqlStore) initConnection() {
 		var err error
 		dataSource, err = resetReadTimeout(dataSource)
 		if err != nil {
-			mlog.Critical("Failed to reset read timeout from datasource.", mlog.Err(err))
-			os.Exit(ExitGenericFailure)
+			mlog.Fatal("Failed to reset read timeout from datasource.", mlog.Err(err))
 		}
 	}
 
@@ -609,9 +566,7 @@ func (ss *SqlStore) DoesTableExist(tableName string) bool {
 		)
 
 		if err != nil {
-			mlog.Critical("Failed to check if table exists", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitTableExists)
+			mlog.Fatal("Failed to check if table exists", mlog.Err(err))
 		}
 
 		return count > 0
@@ -631,17 +586,13 @@ func (ss *SqlStore) DoesTableExist(tableName string) bool {
 		)
 
 		if err != nil {
-			mlog.Critical("Failed to check if table exists", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitTableExistsMySQL)
+			mlog.Fatal("Failed to check if table exists", mlog.Err(err))
 		}
 
 		return count > 0
 
 	} else {
-		mlog.Critical("Failed to check if column exists because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitColumnExists)
+		mlog.Fatal("Failed to check if column exists because of missing driver")
 		return false
 	}
 }
@@ -663,9 +614,7 @@ func (ss *SqlStore) DoesColumnExist(tableName string, columnName string) bool {
 				return false
 			}
 
-			mlog.Critical("Failed to check if column exists", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitDoesColumnExistsPostgres)
+			mlog.Fatal("Failed to check if column exists", mlog.Err(err))
 		}
 
 		return count > 0
@@ -686,17 +635,13 @@ func (ss *SqlStore) DoesColumnExist(tableName string, columnName string) bool {
 		)
 
 		if err != nil {
-			mlog.Critical("Failed to check if column exists", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitDoesColumnExistsMySQL)
+			mlog.Fatal("Failed to check if column exists", mlog.Err(err))
 		}
 
 		return count > 0
 
 	} else {
-		mlog.Critical("Failed to check if column exists because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitDoesColumnExistsMissing)
+		mlog.Fatal("Failed to check if column exists because of missing driver")
 		return false
 	}
 }
@@ -759,9 +704,7 @@ func (ss *SqlStore) DoesTriggerExist(triggerName string) bool {
 		`, triggerName)
 
 		if err != nil {
-			mlog.Critical("Failed to check if trigger exists", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitGenericFailure)
+			mlog.Fatal("Failed to check if trigger exists", mlog.Err(err))
 		}
 
 		return count > 0
@@ -778,17 +721,13 @@ func (ss *SqlStore) DoesTriggerExist(triggerName string) bool {
 		`, triggerName)
 
 		if err != nil {
-			mlog.Critical("Failed to check if trigger exists", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitGenericFailure)
+			mlog.Fatal("Failed to check if trigger exists", mlog.Err(err))
 		}
 
 		return count > 0
 
 	} else {
-		mlog.Critical("Failed to check if column exists because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Failed to check if column exists because of missing driver")
 		return false
 	}
 }
@@ -802,9 +741,7 @@ func (ss *SqlStore) CreateColumnIfNotExists(tableName string, columnName string,
 	if ss.DriverName() == model.DatabaseDriverPostgres {
 		_, err := ss.GetMaster().ExecNoTimeout("ALTER TABLE " + tableName + " ADD " + columnName + " " + postgresColType + " DEFAULT '" + defaultValue + "'")
 		if err != nil {
-			mlog.Critical("Failed to create column", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitCreateColumnPostgres)
+			mlog.Fatal("Failed to create column", mlog.Err(err))
 		}
 
 		return true
@@ -812,17 +749,13 @@ func (ss *SqlStore) CreateColumnIfNotExists(tableName string, columnName string,
 	} else if ss.DriverName() == model.DatabaseDriverMysql {
 		_, err := ss.GetMaster().ExecNoTimeout("ALTER TABLE " + tableName + " ADD " + columnName + " " + mySqlColType + " DEFAULT '" + defaultValue + "'")
 		if err != nil {
-			mlog.Critical("Failed to create column", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitCreateColumnMySQL)
+			mlog.Fatal("Failed to create column", mlog.Err(err))
 		}
 
 		return true
 
 	} else {
-		mlog.Critical("Failed to create column because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitCreateColumnMissing)
+		mlog.Fatal("Failed to create column because of missing driver")
 		return false
 	}
 }
@@ -836,9 +769,7 @@ func (ss *SqlStore) CreateColumnIfNotExistsNoDefault(tableName string, columnNam
 	if ss.DriverName() == model.DatabaseDriverPostgres {
 		_, err := ss.GetMaster().ExecNoTimeout("ALTER TABLE " + tableName + " ADD " + columnName + " " + postgresColType)
 		if err != nil {
-			mlog.Critical("Failed to create column", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitCreateColumnPostgres)
+			mlog.Fatal("Failed to create column", mlog.Err(err))
 		}
 
 		return true
@@ -846,17 +777,13 @@ func (ss *SqlStore) CreateColumnIfNotExistsNoDefault(tableName string, columnNam
 	} else if ss.DriverName() == model.DatabaseDriverMysql {
 		_, err := ss.GetMaster().ExecNoTimeout("ALTER TABLE " + tableName + " ADD " + columnName + " " + mySqlColType)
 		if err != nil {
-			mlog.Critical("Failed to create column", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitCreateColumnMySQL)
+			mlog.Fatal("Failed to create column", mlog.Err(err))
 		}
 
 		return true
 
 	} else {
-		mlog.Critical("Failed to create column because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitCreateColumnMissing)
+		mlog.Fatal("Failed to create column because of missing driver")
 		return false
 	}
 }
@@ -869,9 +796,7 @@ func (ss *SqlStore) RemoveColumnIfExists(tableName string, columnName string) bo
 
 	_, err := ss.GetMaster().ExecNoTimeout("ALTER TABLE " + tableName + " DROP COLUMN " + columnName)
 	if err != nil {
-		mlog.Critical("Failed to drop column", mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitRemoveColumn)
+		mlog.Fatal("Failed to drop column", mlog.Err(err))
 	}
 
 	return true
@@ -884,9 +809,7 @@ func (ss *SqlStore) RemoveTableIfExists(tableName string) bool {
 
 	_, err := ss.GetMaster().ExecNoTimeout("DROP TABLE " + tableName)
 	if err != nil {
-		mlog.Critical("Failed to drop table", mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitRemoveTable)
+		mlog.Fatal("Failed to drop table", mlog.Err(err))
 	}
 
 	return true
@@ -905,9 +828,7 @@ func (ss *SqlStore) RenameColumnIfExists(tableName string, oldColumnName string,
 	}
 
 	if err != nil {
-		mlog.Critical("Failed to rename column", mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitRenameColumn)
+		mlog.Fatal("Failed to rename column", mlog.Err(err))
 	}
 
 	return true
@@ -927,9 +848,7 @@ func (ss *SqlStore) GetMaxLengthOfColumnIfExists(tableName string, columnName st
 	}
 
 	if err != nil {
-		mlog.Critical("Failed to get max length of column", mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitMaxColumn)
+		mlog.Fatal("Failed to get max length of column", mlog.Err(err))
 	}
 
 	return result
@@ -957,9 +876,7 @@ func (ss *SqlStore) AlterColumnTypeIfExists(tableName string, columnName string,
 		if mySqlColType == "JSON" && postgresColType == "jsonb" {
 			msg += " It is likely you have invalid JSON values in the column. Please fix the values manually and run the migration again."
 		}
-		mlog.Critical(msg, mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitAlterColumn)
+		mlog.Fatal(msg, mlog.Err(err))
 	}
 
 	return true
@@ -972,9 +889,7 @@ func (ss *SqlStore) RemoveDefaultIfColumnExists(tableName, columnName string) bo
 
 	_, err := ss.GetMaster().ExecNoTimeout("ALTER TABLE " + tableName + " ALTER COLUMN " + columnName + " DROP DEFAULT")
 	if err != nil {
-		mlog.Critical("Failed to drop column default", mlog.String("table", tableName), mlog.String("column", columnName), mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Failed to drop column default", mlog.String("table", tableName), mlog.String("column", columnName), mlog.Err(err))
 		return false
 	}
 
@@ -1004,9 +919,7 @@ func (ss *SqlStore) AlterDefaultIfColumnExists(tableName string, columnName stri
 		columnName = strings.ToLower(columnName)
 		defaultValue = *postgresColDefault
 	} else {
-		mlog.Critical("Failed to alter column default because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Failed to alter column default because of missing driver")
 		return false
 	}
 
@@ -1017,9 +930,7 @@ func (ss *SqlStore) AlterDefaultIfColumnExists(tableName string, columnName stri
 	query := "ALTER TABLE " + tableName + " ALTER COLUMN " + columnName + " SET DEFAULT " + defaultValue
 	_, err := ss.GetMaster().ExecNoTimeout(query)
 	if err != nil {
-		mlog.Critical("Failed to alter column default", mlog.String("table", tableName), mlog.String("column", columnName), mlog.String("default value", defaultValue), mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitGenericFailure)
+		mlog.Fatal("Failed to alter column default", mlog.String("table", tableName), mlog.String("column", columnName), mlog.String("default value", defaultValue), mlog.Err(err))
 		return false
 	}
 
@@ -1059,9 +970,7 @@ func (ss *SqlStore) AlterPrimaryKey(tableName string, columnNames []string) bool
 		currentPrimaryKey, err = ss.GetMaster().SelectStr(query)
 	}
 	if err != nil {
-		mlog.Critical("Failed to get current primary key", mlog.String("table", tableName), mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitAlterPrimaryKey)
+		mlog.Fatal("Failed to get current primary key", mlog.String("table", tableName), mlog.Err(err))
 	}
 
 	primaryKey := strings.Join(columnNames, ",")
@@ -1077,9 +986,7 @@ func (ss *SqlStore) AlterPrimaryKey(tableName string, columnNames []string) bool
 	}
 	_, err = ss.GetMaster().ExecNoTimeout(alterQuery)
 	if err != nil {
-		mlog.Critical("Failed to alter primary key", mlog.String("table", tableName), mlog.Err(err))
-		time.Sleep(time.Second)
-		os.Exit(ExitAlterPrimaryKey)
+		mlog.Fatal("Failed to alter primary key", mlog.String("table", tableName), mlog.Err(err))
 	}
 	return true
 }
@@ -1125,16 +1032,14 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 		query := ""
 		if indexType == IndexTypeFullText {
 			if len(columnNames) != 1 {
-				mlog.Critical("Unable to create multi column full text index")
-				os.Exit(ExitCreateIndexPostgres)
+				mlog.Fatal("Unable to create multi column full text index")
 			}
 			columnName := columnNames[0]
 			postgresColumnNames := convertMySQLFullTextColumnsToPostgres(columnName)
 			query = "CREATE INDEX " + indexName + " ON " + tableName + " USING gin(to_tsvector('english', " + postgresColumnNames + "))"
 		} else if indexType == IndexTypeFullTextFunc {
 			if len(columnNames) != 1 {
-				mlog.Critical("Unable to create multi column full text index")
-				os.Exit(ExitCreateIndexPostgres)
+				mlog.Fatal("Unable to create multi column full text index")
 			}
 			columnName := columnNames[0]
 			query = "CREATE INDEX " + indexName + " ON " + tableName + " USING gin(to_tsvector('english', " + columnName + "))"
@@ -1144,17 +1049,13 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 
 		_, err := ss.GetMaster().ExecNoTimeout(query)
 		if err != nil {
-			mlog.Critical("Failed to create index", mlog.Err(errExists), mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitCreateIndexPostgres)
+			mlog.Fatal("Failed to create index", mlog.Err(errExists), mlog.Err(err))
 		}
 	} else if ss.DriverName() == model.DatabaseDriverMysql {
 
 		count, err := ss.GetMaster().SelectInt("SELECT COUNT(0) AS index_exists FROM information_schema.statistics WHERE TABLE_SCHEMA = DATABASE() and table_name = ? AND index_name = ?", tableName, indexName)
 		if err != nil {
-			mlog.Critical("Failed to check index", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitCreateIndexMySQL)
+			mlog.Fatal("Failed to check index", mlog.Err(err))
 		}
 
 		if count > 0 {
@@ -1168,14 +1069,10 @@ func (ss *SqlStore) createIndexIfNotExists(indexName string, tableName string, c
 
 		_, err = ss.GetMaster().ExecNoTimeout("CREATE  " + uniqueStr + fullTextIndex + " INDEX " + indexName + " ON " + tableName + " (" + strings.Join(columnNames, ", ") + ")")
 		if err != nil {
-			mlog.Critical("Failed to create index", mlog.String("table", tableName), mlog.String("index_name", indexName), mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitCreateIndexFullMySQL)
+			mlog.Fatal("Failed to create index", mlog.String("table", tableName), mlog.String("index_name", indexName), mlog.Err(err))
 		}
 	} else {
-		mlog.Critical("Failed to create index because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitCreateIndexMissing)
+		mlog.Fatal("Failed to create index because of missing driver")
 	}
 
 	return true
@@ -1216,9 +1113,7 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool
 
 		_, err = ss.GetMaster().ExecNoTimeout("DROP INDEX " + indexName)
 		if err != nil {
-			mlog.Critical("Failed to remove index", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitRemoveIndexPostgres)
+			mlog.Fatal("Failed to remove index", mlog.Err(err))
 		}
 
 		return true
@@ -1226,9 +1121,7 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool
 
 		count, err := ss.GetMaster().SelectInt("SELECT COUNT(0) AS index_exists FROM information_schema.statistics WHERE TABLE_SCHEMA = DATABASE() and table_name = ? AND index_name = ?", tableName, indexName)
 		if err != nil {
-			mlog.Critical("Failed to check index", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitRemoveIndexMySQL)
+			mlog.Fatal("Failed to check index", mlog.Err(err))
 		}
 
 		if count <= 0 {
@@ -1237,14 +1130,10 @@ func (ss *SqlStore) RemoveIndexIfExists(indexName string, tableName string) bool
 
 		_, err = ss.GetMaster().ExecNoTimeout("DROP INDEX " + indexName + " ON " + tableName)
 		if err != nil {
-			mlog.Critical("Failed to remove index", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitRemoveIndexMySQL)
+			mlog.Fatal("Failed to remove index", mlog.Err(err))
 		}
 	} else {
-		mlog.Critical("Failed to create index because of missing driver")
-		time.Sleep(time.Second)
-		os.Exit(ExitRemoveIndexMissing)
+		mlog.Fatal("Failed to create index because of missing driver")
 	}
 
 	return true

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -6,9 +6,7 @@ package sqlstore
 import (
 	"database/sql"
 	"encoding/json"
-	"os"
 	"strings"
-	"time"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -220,9 +218,7 @@ func upgradeDatabase(sqlStore *SqlStore, currentModelVersionString string) error
 
 func saveSchemaVersion(sqlStore *SqlStore, version string) {
 	if err := sqlStore.System().SaveOrUpdate(&model.System{Name: "Version", Value: version}); err != nil {
-		mlog.Critical(err.Error())
-		time.Sleep(time.Second)
-		os.Exit(ExitVersionSave)
+		mlog.Fatal(err.Error())
 	}
 
 	mlog.Warn("The database schema version has been upgraded", mlog.String("version", version))
@@ -266,9 +262,7 @@ func upgradeDatabaseToVersion32(sqlStore *SqlStore) {
 }
 
 func themeMigrationFailed(err error) {
-	mlog.Critical("Failed to migrate User.ThemeProps to Preferences table", mlog.Err(err))
-	time.Sleep(time.Second)
-	os.Exit(ExitThemeMigration)
+	mlog.Fatal("Failed to migrate User.ThemeProps to Preferences table", mlog.Err(err))
 }
 
 func upgradeDatabaseToVersion33(sqlStore *SqlStore) {
@@ -536,7 +530,7 @@ func upgradeDatabaseToVersion49(sqlStore *SqlStore) {
 		defaultTimezone := timezones.DefaultUserTimezone()
 		defaultTimezoneValue, err := json.Marshal(defaultTimezone)
 		if err != nil {
-			mlog.Critical(err.Error())
+			mlog.Fatal(err.Error())
 		}
 		sqlStore.CreateColumnIfNotExists("Users", "Timezone", "varchar(256)", "varchar(256)", string(defaultTimezoneValue))
 		sqlStore.RemoveIndexIfExists("idx_channels_displayname", "Channels")
@@ -616,9 +610,7 @@ func upgradeDatabaseToVersion54(sqlStore *SqlStore) {
 		sqlStore.AlterColumnTypeIfExists("OutgoingWebhooks", "Description", "varchar(500)", "varchar(500)")
 		sqlStore.AlterColumnTypeIfExists("IncomingWebhooks", "Description", "varchar(500)", "varchar(500)")
 		if err := sqlStore.Channel().MigratePublicChannels(); err != nil {
-			mlog.Critical("Failed to migrate PublicChannels table", mlog.Err(err))
-			time.Sleep(time.Second)
-			os.Exit(ExitGenericFailure)
+			mlog.Fatal("Failed to migrate PublicChannels table", mlog.Err(err))
 		}
 		saveSchemaVersion(sqlStore, Version540)
 	}
@@ -866,8 +858,7 @@ func upgradeDatabaseToVersion527(sqlStore *SqlStore) {
 func upgradeDatabaseToVersion528(sqlStore *SqlStore) {
 	if shouldPerformUpgrade(sqlStore, Version5270, Version5280) {
 		if err := precheckMigrationToVersion528(sqlStore); err != nil {
-			mlog.Critical("Error upgrading DB schema to 5.28.0", mlog.Err(err))
-			os.Exit(ExitGenericFailure)
+			mlog.Fatal("Error upgrading DB schema to 5.28.0", mlog.Err(err))
 		}
 
 		sqlStore.CreateColumnIfNotExistsNoDefault("Commands", "PluginId", "VARCHAR(190)", "VARCHAR(190)")


### PR DESCRIPTION
Our store upgrade methods used mlog.Critical and then slept
for a second and triggered os.Exit.

First of all, with the new mlog refactor Critical wasn't a standard
log level so it was never to be logged.

And secondly, this completely missed the fact that there already
existed an API method Fatal which did exactly this.

We mark the Critical API as deprecated, and use Fatal for all
occurences.

The choice should be between either to use Error or Fatal.

While here, we also remove the non-standard exit codes which
just confused things further while debugging.

https://mattermost.atlassian.net/browse/MM-38712

```release-note
NONE
```
