### PR TITLE
MM-38657 - Sentry crash: Fix nil dereference when post not found

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"image"
 	"io"
@@ -491,32 +490,14 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 			return nil, nil, nil, appErr
 		}
 
-		if referencedPost == nil {
-			msg := "Referenced post is nil"
-			mlog.Debug(msg, mlog.String("post_id", referencedPostID))
-			return nil, nil, nil, errors.New(msg)
-		}
-
 		referencedChannel, appErr := a.GetChannel(referencedPost.ChannelId)
 		if appErr != nil {
 			return nil, nil, nil, appErr
 		}
 
-		if referencedChannel == nil {
-			msg := "Referenced channel is nil"
-			mlog.Debug(msg, mlog.String("channel_id", referencedPost.ChannelId))
-			return nil, nil, nil, errors.New(msg)
-		}
-
 		referencedTeam, appErr := a.GetTeam(referencedChannel.TeamId)
 		if appErr != nil {
 			return nil, nil, nil, appErr
-		}
-
-		if referencedTeam == nil {
-			msg := "Referenced team is nil"
-			mlog.Debug(msg, mlog.String("team_id", referencedChannel.TeamId))
-			return nil, nil, nil, errors.New(msg)
 		}
 
 		permalink = &model.Permalink{PreviewPost: model.NewPreviewPost(referencedPost, referencedTeam, referencedChannel)}

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -2229,6 +2229,23 @@ func TestGetLinkMetadata(t *testing.T) {
 		assert.NotNil(t, img)
 		assert.NoError(t, err)
 	})
+
+	t.Run("should throw error if post doesn't exist", func(t *testing.T) {
+		th := setup(t)
+		defer th.TearDown()
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnablePermalinkPreviews = true
+			*cfg.ServiceSettings.SiteURL = server.URL
+			cfg.FeatureFlags.PermalinkPreviews = true
+		})
+
+		requestURL := server.URL + "/pl/5rpoy4o3nbgwjm7gs4cm71h6ho"
+		timestamp := int64(1547510400000)
+
+		_, _, _, err := th.App.getLinkMetadata(requestURL, timestamp, true, "")
+		assert.Error(t, err)
+	})
 }
 
 func TestResolveMetadataURL(t *testing.T) {


### PR DESCRIPTION
We were ignoring post not found errors, but moving forward nevertheless. This led to nil dereference panics.

To fix this, we return for any error but exclude from logging the error if it was a not found error.

And we also add a unit test and revert some of the old code.

https://mattermost.atlassian.net/browse/MM-38657

```release-note
NONE
```