### PR TITLE
Automated cherry pick of #18437

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"image"
 	"io"
@@ -490,14 +491,32 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 			return nil, nil, nil, appErr
 		}
 
+		if referencedPost == nil {
+			msg := "Referenced post is nil"
+			mlog.Debug(msg, mlog.String("post_id", referencedPostID))
+			return nil, nil, nil, errors.New(msg)
+		}
+
 		referencedChannel, appErr := a.GetChannel(referencedPost.ChannelId)
 		if appErr != nil {
 			return nil, nil, nil, appErr
 		}
 
+		if referencedChannel == nil {
+			msg := "Referenced channel is nil"
+			mlog.Debug(msg, mlog.String("channel_id", referencedPost.ChannelId))
+			return nil, nil, nil, errors.New(msg)
+		}
+
 		referencedTeam, appErr := a.GetTeam(referencedChannel.TeamId)
 		if appErr != nil {
 			return nil, nil, nil, appErr
+		}
+
+		if referencedTeam == nil {
+			msg := "Referenced team is nil"
+			mlog.Debug(msg, mlog.String("team_id", referencedChannel.TeamId))
+			return nil, nil, nil, errors.New(msg)
 		}
 
 		permalink = &model.Permalink{PreviewPost: model.NewPreviewPost(referencedPost, referencedTeam, referencedChannel)}


### PR DESCRIPTION
Cherry pick of #18437 on cloud.

/cc  @mickmister

```release-note
NONE
```