### PR TITLE
MM-38774 - partial fix for: Community running out of memory

### DIFF
--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -775,7 +775,7 @@ func TestGetFileHeaders(t *testing.T) {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
-	testHeaders := func(data []byte, filename string, expectedContentType string, getInline, loadFile bool) func(*testing.T) {
+	testHeaders := func(data []byte, filename string, expectedContentType string, getInline bool, loadFile bool) func(*testing.T) {
 		return func(t *testing.T) {
 			if loadFile {
 				var err error

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -775,8 +775,14 @@ func TestGetFileHeaders(t *testing.T) {
 		t.Skip("skipping because no file driver is enabled")
 	}
 
-	testHeaders := func(data []byte, filename string, expectedContentType string, getInline bool) func(*testing.T) {
+	testHeaders := func(data []byte, filename string, expectedContentType string, getInline, loadFile bool) func(*testing.T) {
 		return func(t *testing.T) {
+			if loadFile {
+				var err error
+				data, err = testutils.ReadTestFile(filename)
+				require.NoError(t, err)
+			}
+
 			fileResp, _, err := client.UploadFile(data, channel.Id, filename)
 			require.NoError(t, err)
 
@@ -803,20 +809,20 @@ func TestGetFileHeaders(t *testing.T) {
 
 	data := []byte("ABC")
 
-	t.Run("png", testHeaders(data, "test.png", "image/png", true))
-	t.Run("gif", testHeaders(data, "test.gif", "image/gif", true))
-	t.Run("mp4", testHeaders(data, "test.mp4", "video/mp4", true))
-	t.Run("mp3", testHeaders(data, "test.mp3", "audio/mpeg", true))
-	t.Run("pdf", testHeaders(data, "test.pdf", "application/pdf", false))
-	t.Run("txt", testHeaders(data, "test.txt", "text/plain", false))
-	t.Run("html", testHeaders(data, "test.html", "text/plain", false))
-	t.Run("js", testHeaders(data, "test.js", "text/plain", false))
-	t.Run("go", testHeaders(data, "test.go", "application/octet-stream", false))
-	t.Run("zip", testHeaders(data, "test.zip", "application/zip", false))
+	t.Run("png", testHeaders(data, "test.png", "image/png", true, true))
+	t.Run("gif", testHeaders(data, "testgif.gif", "image/gif", true, true))
+	t.Run("mp4", testHeaders(data, "test.mp4", "video/mp4", true, false))
+	t.Run("mp3", testHeaders(data, "test.mp3", "audio/mpeg", true, false))
+	t.Run("pdf", testHeaders(data, "test.pdf", "application/pdf", false, false))
+	t.Run("txt", testHeaders(data, "test.txt", "text/plain", false, false))
+	t.Run("html", testHeaders(data, "test.html", "text/plain", false, false))
+	t.Run("js", testHeaders(data, "test.js", "text/plain", false, false))
+	t.Run("go", testHeaders(data, "test.go", "application/octet-stream", false, false))
+	t.Run("zip", testHeaders(data, "test.zip", "application/zip", false, false))
 	// Not every platform can recognize these
 	//t.Run("exe", testHeaders(data, "test.exe", "application/x-ms", false))
-	t.Run("no extension", testHeaders(data, "test", "application/octet-stream", false))
-	t.Run("no extension 2", testHeaders([]byte("<html></html>"), "test", "application/octet-stream", false))
+	t.Run("no extension", testHeaders(data, "test", "application/octet-stream", false, false))
+	t.Run("no extension 2", testHeaders([]byte("<html></html>"), "test", "application/octet-stream", false, false))
 }
 
 func TestGetFileThumbnail(t *testing.T) {

--- a/app/file.go
+++ b/app/file.go
@@ -1118,15 +1118,15 @@ func (a *App) generatePreviewImage(img image.Image, previewPath string) {
 // will save fileinfo with the preview added
 func (a *App) generateMiniPreview(fi *model.FileInfo) {
 	if fi.IsImage() && fi.MiniPreview == nil {
-		file, err := a.FileReader(fi.Path)
-		if err != nil {
-			mlog.Debug("error reading image file", mlog.Err(err))
+		file, appErr := a.FileReader(fi.Path)
+		if appErr != nil {
+			mlog.Debug("error reading image file", mlog.Err(appErr))
 			return
 		}
 		defer file.Close()
-		img, release, imgErr := prepareImage(a.srv.imgDecoder, file)
-		if imgErr != nil {
-			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr),
+		img, release, err := prepareImage(a.srv.imgDecoder, file)
+		if err != nil {
+			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(err),
 				mlog.String("fileinfo_id", fi.Id), mlog.String("channel_id", fi.ChannelId),
 				mlog.String("creator_id", fi.CreatorId))
 
@@ -1134,8 +1134,8 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 			// from entering generateMiniPreview in the future
 			fi.UpdateAt = model.GetMillis()
 			fi.MimeType = "invalid-" + fi.MimeType
-			if _, err2 := a.Srv().Store.FileInfo().Upsert(fi); err2 != nil {
-				mlog.Debug("FileInfo save failed", mlog.Err(err2))
+			if _, err = a.Srv().Store.FileInfo().Upsert(fi); err != nil {
+				mlog.Debug("Invalidating FileInfo failed", mlog.Err(err))
 			}
 
 			return
@@ -1147,8 +1147,8 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 		} else {
 			fi.MiniPreview = &miniPreview
 		}
-		if _, appErr := a.Srv().Store.FileInfo().Upsert(fi); appErr != nil {
-			mlog.Debug("creating mini preview failed", mlog.Err(appErr))
+		if _, err = a.Srv().Store.FileInfo().Upsert(fi); err != nil {
+			mlog.Debug("creating mini preview failed", mlog.Err(err))
 		} else {
 			a.Srv().Store.FileInfo().InvalidateFileInfosForPostCache(fi.PostId, false)
 		}

--- a/app/file.go
+++ b/app/file.go
@@ -1129,6 +1129,15 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 			mlog.Debug("generateMiniPreview: prepareImage failed", mlog.Err(imgErr),
 				mlog.String("fileinfo_id", fi.Id), mlog.String("channel_id", fi.ChannelId),
 				mlog.String("creator_id", fi.CreatorId))
+
+			// Since this file is not a valid image (for whatever reason), prevent this fileInfo
+			// from entering generateMiniPreview in the future
+			fi.UpdateAt = model.GetMillis()
+			fi.MimeType = "invalid-" + fi.MimeType
+			if _, err2 := a.Srv().Store.FileInfo().Upsert(fi); err2 != nil {
+				mlog.Debug("FileInfo save failed", mlog.Err(err2))
+			}
+
 			return
 		}
 		defer release()

--- a/app/file.go
+++ b/app/file.go
@@ -1141,7 +1141,8 @@ func (a *App) generateMiniPreview(fi *model.FileInfo) {
 			return
 		}
 		defer release()
-		if miniPreview, err := imaging.GenerateMiniPreviewImage(img,
+		var miniPreview []byte
+		if miniPreview, err = imaging.GenerateMiniPreviewImage(img,
 			miniPreviewImageWidth, miniPreviewImageHeight, jpegEncQuality); err != nil {
 			mlog.Info("Unable to generate mini preview image", mlog.Err(err))
 		} else {


### PR DESCRIPTION
#### Summary
- a fix to try to narrow down whether  generateMiniPreview is causing the community OOM issue
- add prefix `invalid-` to MimeType to prevent image from entering the generateMiniPreview

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38774

#### Release Note
```release-note
NONE
```
