### PR TITLE
restore reset command as db reset

### DIFF
--- a/cmd/mattermost/commands/db.go
+++ b/cmd/mattermost/commands/db.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/config"
 	"github.com/mattermost/mattermost-server/v6/store/sqlstore"
 )
@@ -36,9 +37,19 @@ This command should be run using a database configuration DSN.`,
 	RunE: initDbCmdF,
 }
 
+var ResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset the database to initial state",
+	Long:  "Completely erases the database causing the loss of all data. This will reset Mattermost to its initial state.",
+	RunE:  resetCmdF,
+}
+
 func init() {
+	ResetCmd.Flags().Bool("confirm", false, "Confirm you really want to delete everything and a DB backup has been performed.")
+
 	DbCmd.AddCommand(
 		InitDbCmd,
+		ResetCmd,
 	)
 
 	RootCmd.AddCommand(
@@ -67,6 +78,38 @@ func initDbCmdF(command *cobra.Command, _ []string) error {
 	defer sqlStore.Close()
 
 	fmt.Println("Database store correctly initialised")
+
+	return nil
+}
+
+func resetCmdF(command *cobra.Command, args []string) error {
+	a, err := InitDBCommandContextCobra(command)
+	if err != nil {
+		return err
+	}
+	defer a.Srv().Shutdown()
+
+	confirmFlag, _ := command.Flags().GetBool("confirm")
+	if !confirmFlag {
+		var confirm string
+		CommandPrettyPrintln("Have you performed a database backup? (YES/NO): ")
+		fmt.Scanln(&confirm)
+
+		if confirm != "YES" {
+			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
+		}
+		CommandPrettyPrintln("Are you sure you want to delete everything? All data will be permanently deleted? (YES/NO): ")
+		fmt.Scanln(&confirm)
+		if confirm != "YES" {
+			return errors.New("ABORTED: You did not answer YES exactly, in all capitals.")
+		}
+	}
+
+	a.Srv().Store.DropAllTables()
+	CommandPrettyPrintln("Database successfully reset")
+
+	auditRec := a.MakeAuditRecord("reset", audit.Success)
+	a.LogAuditRec(auditRec, nil)
 
 	return nil
 }


### PR DESCRIPTION

#### Summary
It was handy to use `reset` command in load testing. It's quite devious to reset the db in other ways. So, I'm proposing to resurrect the command :)

#### Release Note

```release-note
Bring back the mattermost reset command as mattermost db reset.
```
