### PR TITLE
register PreviewPost for RPC connections

### DIFF
--- a/plugin/client_rpc.go
+++ b/plugin/client_rpc.go
@@ -168,6 +168,7 @@ func init() {
 	gob.Register(&model.AutocompleteDynamicListArg{})
 	gob.Register(&model.AutocompleteStaticListArg{})
 	gob.Register(&model.AutocompleteTextArg{})
+	gob.Register(&model.PreviewPost{})
 }
 
 // These enforce compile time checks to make sure types implement the interface


### PR DESCRIPTION
#### Summary
- prevent RPC connections from crashing when PreviewPosts are sent to plugins
- split from https://github.com/mattermost/mattermost-server/pull/18445 to keep the commit logs clean

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-38774

#### Release Note
```release-note
NONE
```
