### PR TITLE
[MM-38579] Removing some town square permissions stuff

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -713,32 +713,12 @@ func saveIsPinnedPost(c *Context, w http.ResponseWriter, isPinned bool) {
 		return
 	}
 
-	// Restrict pinning if the experimental read-only-town-square setting is on.
-	user, err := c.App.GetUser(c.AppContext.Session().UserId)
-	if err != nil {
-		c.Err = err
-		return
-	}
-
 	post, err := c.App.GetSinglePost(c.Params.PostId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 	auditRec.AddMeta("post", post)
-
-	channel, err := c.App.GetChannel(post.ChannelId)
-	if err != nil {
-		c.Err = err
-		return
-	}
-
-	if c.App.Srv().License() != nil &&
-		channel.Name == model.DefaultChannelName &&
-		!c.App.RolesGrantPermission(user.GetRoles(), model.PermissionManageSystem.Id) {
-		c.Err = model.NewAppError("saveIsPinnedPost", "api.post.save_is_pinned_post.town_square_read_only", nil, "", http.StatusForbidden)
-		return
-	}
 
 	patch := &model.PostPatch{}
 	patch.IsPinned = model.NewBool(isPinned)

--- a/app/channel.go
+++ b/app/channel.go
@@ -2311,12 +2311,6 @@ func (a *App) removeUserFromChannel(c *request.Context, userIDToRemove string, r
 	}
 	isGuest := user.IsGuest()
 
-	if channel.Name == model.DefaultChannelName {
-		if !isGuest {
-			return model.NewAppError("RemoveUserFromChannel", "api.channel.remove.default.app_error", map[string]interface{}{"Channel": model.DefaultChannelName}, "", http.StatusBadRequest)
-		}
-	}
-
 	if channel.IsGroupConstrained() && userIDToRemove != removerUserId && !user.IsBot {
 		nonMembers, err := a.FilterNonGroupChannelMembers([]string{userIDToRemove}, channel)
 		if err != nil {

--- a/app/channel.go
+++ b/app/channel.go
@@ -2311,6 +2311,12 @@ func (a *App) removeUserFromChannel(c *request.Context, userIDToRemove string, r
 	}
 	isGuest := user.IsGuest()
 
+	if channel.Name == model.DefaultChannelName {
+		if !isGuest {
+			return model.NewAppError("RemoveUserFromChannel", "api.channel.remove.default.app_error", map[string]interface{}{"Channel": model.DefaultChannelName}, "", http.StatusBadRequest)
+		}
+	}
+
 	if channel.IsGroupConstrained() && userIDToRemove != removerUserId && !user.IsBot {
 		nonMembers, err := a.FilterNonGroupChannelMembers([]string{userIDToRemove}, channel)
 		if err != nil {

--- a/app/post.go
+++ b/app/post.go
@@ -213,13 +213,6 @@ func (a *App) CreatePost(c *request.Context, post *model.Post, channel *model.Ch
 		post.AddProp("from_bot", "true")
 	}
 
-	if a.Srv().License() != nil &&
-		!post.IsSystemMessage() &&
-		channel.Name == model.DefaultChannelName &&
-		!a.RolesGrantPermission(user.GetRoles(), model.PermissionManageSystem.Id) {
-		return nil, model.NewAppError("createPost", "api.post.create_post.town_square_read_only", nil, "", http.StatusForbidden)
-	}
-
 	var ephemeralPost *model.Post
 	if post.Type == "" && !a.HasPermissionToChannel(user.Id, channel.Id, model.PermissionUseChannelMentions) {
 		mention := post.DisableMentionHighlights()

--- a/app/post.go
+++ b/app/post.go
@@ -57,30 +57,6 @@ func (a *App) CreatePostAsUser(c *request.Context, post *model.Post, currentSess
 			err.StatusCode = http.StatusBadRequest
 		}
 
-		if err.Id == "api.post.create_post.town_square_read_only" {
-			user, nErr := a.Srv().Store.User().Get(context.Background(), post.UserId)
-			if nErr != nil {
-				var nfErr *store.ErrNotFound
-				switch {
-				case errors.As(nErr, &nfErr):
-					return nil, model.NewAppError("CreatePostAsUser", MissingAccountError, nil, nfErr.Error(), http.StatusNotFound)
-				default:
-					return nil, model.NewAppError("CreatePostAsUser", "app.user.get.app_error", nil, nErr.Error(), http.StatusInternalServerError)
-				}
-			}
-
-			T := i18n.GetUserTranslations(user.Locale)
-			a.SendEphemeralPost(
-				post.UserId,
-				&model.Post{
-					ChannelId: channel.Id,
-					RootId:    post.RootId,
-					UserId:    post.UserId,
-					Message:   T("api.post.create_post.town_square_read_only"),
-					CreateAt:  model.GetMillis() + 1,
-				},
-			)
-		}
 		return nil, err
 	}
 

--- a/app/reaction.go
+++ b/app/reaction.go
@@ -29,18 +29,6 @@ func (a *App) SaveReactionForPost(c *request.Context, reaction *model.Reaction) 
 		return nil, model.NewAppError("deleteReactionForPost", "api.reaction.save.archived_channel.app_error", nil, "", http.StatusForbidden)
 	}
 
-	if a.Srv().License() != nil && channel.Name == model.DefaultChannelName {
-		var user *model.User
-		user, err = a.GetUser(reaction.UserId)
-		if err != nil {
-			return nil, err
-		}
-
-		if !a.RolesGrantPermission(user.GetRoles(), model.PermissionManageSystem.Id) {
-			return nil, model.NewAppError("saveReactionForPost", "api.reaction.town_square_read_only", nil, "", http.StatusForbidden)
-		}
-	}
-
 	reaction, nErr := a.Srv().Store.Reaction().Save(reaction)
 	if nErr != nil {
 		var appErr *model.AppError
@@ -121,17 +109,6 @@ func (a *App) DeleteReactionForPost(c *request.Context, reaction *model.Reaction
 
 	if channel.DeleteAt > 0 {
 		return model.NewAppError("DeleteReactionForPost", "api.reaction.delete.archived_channel.app_error", nil, "", http.StatusForbidden)
-	}
-
-	if a.Srv().License() != nil && channel.Name == model.DefaultChannelName {
-		user, err := a.GetUser(reaction.UserId)
-		if err != nil {
-			return err
-		}
-
-		if !a.RolesGrantPermission(user.GetRoles(), model.PermissionManageSystem.Id) {
-			return model.NewAppError("DeleteReactionForPost", "api.reaction.town_square_read_only", nil, "", http.StatusForbidden)
-		}
 	}
 
 	if _, err := a.Srv().Store.Reaction().Delete(reaction); err != nil {

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -777,11 +777,6 @@ func (a *App) HandleIncomingWebhook(c *request.Context, hookID string, req *mode
 	}
 	user = result.Data.(*model.User)
 
-	if a.Srv().License() != nil &&
-		channel.Name == model.DefaultChannelName && !a.RolesGrantPermission(user.GetRoles(), model.PermissionManageSystem.Id) {
-		return model.NewAppError("HandleIncomingWebhook", "api.post.create_post.town_square_read_only", nil, "", http.StatusForbidden)
-	}
-
 	if channel.Type != model.ChannelTypeOpen && !a.HasPermissionToChannel(hook.UserId, channel.Id, model.PermissionReadChannel) {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", nil, "", http.StatusForbidden)
 	}

--- a/app/webhook.go
+++ b/app/webhook.go
@@ -770,12 +770,10 @@ func (a *App) HandleIncomingWebhook(c *request.Context, hookID string, req *mode
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.channel_locked.app_error", nil, "", http.StatusForbidden)
 	}
 
-	var user *model.User
 	result = <-uchan
 	if result.NErr != nil {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.user.app_error", nil, result.NErr.Error(), http.StatusForbidden)
 	}
-	user = result.Data.(*model.User)
 
 	if channel.Type != model.ChannelTypeOpen && !a.HasPermissionToChannel(hook.UserId, channel.Id, model.PermissionReadChannel) {
 		return model.NewAppError("HandleIncomingWebhook", "web.incoming_webhook.permissions.app_error", nil, "", http.StatusForbidden)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2150,10 +2150,6 @@
     "translation": "Invalid RootId parameter."
   },
   {
-    "id": "api.post.create_post.town_square_read_only",
-    "translation": "This channel is read-only. Only members with permission can post here."
-  },
-  {
     "id": "api.post.create_webhook_post.creating.app_error",
     "translation": "Error creating post."
   },
@@ -2214,10 +2210,6 @@
   {
     "id": "api.post.patch_post.can_not_update_post_in_deleted.error",
     "translation": "Can not update a post in a deleted channel."
-  },
-  {
-    "id": "api.post.save_is_pinned_post.town_square_read_only",
-    "translation": "This channel is read-only. Only members with permission can pin or unpin posts here."
   },
   {
     "id": "api.post.search_files.invalid_body.app_error",
@@ -2358,10 +2350,6 @@
   {
     "id": "api.reaction.save_reaction.user_id.app_error",
     "translation": "You cannot save reaction for the other user."
-  },
-  {
-    "id": "api.reaction.town_square_read_only",
-    "translation": "Reacting to posts is not possible in read-only channels."
   },
   {
     "id": "api.remote_cluster.delete.app_error",


### PR DESCRIPTION
#### Summary
I removed all the mentions of the read only error and now you can post, react and pin just like any other channel. That can be disabled with the permissions in system console.

Town square still has some exceptions to the regular permissions though where you can't leave the channel, change it's type or archive it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38579

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
