### PR TITLE
MM-35847 inline style for email templates

### DIFF
--- a/templates/cloud_trial_end_warning.html
+++ b/templates/cloud_trial_end_warning.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -99,14 +101,18 @@
       font-weight: 600 !important;
       font-size: 28px !important;
       line-height: 36px !important;
-      letter-spacing: -0.02em !important;
-      color: #3D3C40 !important;
+      letter-spacing: -0.01em !important;
+      color: #3F4350 !important;
     }
 
     .subTitle div {
       font-size: 16px !important;
       line-height: 24px !important;
-      color: rgba(61, 60, 64, 0.64) !important;
+      color: rgba(63, 67, 80, 0.64) !important;
+    }
+
+    .subTitle a {
+      color: rgb(28, 88, 217) !important;
     }
 
     .button a {
@@ -118,10 +124,21 @@
       padding: 15px 24px !important;
     }
 
+    .messageButton a {
+      background-color: #FFFFFF !important;
+      border: 1px solid #FFFFFF !important;
+      box-sizing: border-box !important;
+      color: #1C58D9 !important;
+      padding: 12px 20px !important;
+      font-weight: 600 !important;
+      font-size: 14px !important;
+      line-height: 14px !important;
+    }
+
     .info div {
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 40px 0px !important;
     }
 
@@ -129,14 +146,14 @@
       font-weight: 600 !important;
       font-size: 16px !important;
       line-height: 24px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px 0px 4px 0px !important;
     }
 
     .footerInfo div {
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px 48px 0px 48px !important;
     }
 
@@ -158,7 +175,7 @@
     .emailFooter div {
       font-size: 12px !important;
       line-height: 16px !important;
-      color: rgba(61, 60, 64, 0.56) !important;
+      color: rgba(63, 67, 80, 0.56) !important;
       padding: 8px 24px 8px 24px !important;
     }
 
@@ -186,20 +203,67 @@
       width: 32px !important;
     }
 
-    .senderName div {
+    .postNameAndTime {
+      padding: 0px 0px 4px 0px !important;
+      display: flex;
+    }
+
+    .senderName {
+      font-family: Open Sans, sans-serif;
       text-align: left !important;
       font-weight: 600 !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
-      padding: 0px 0px 4px 0px !important;
+      color: #3F4350 !important;
+    }
+
+    .time {
+      font-family: Open Sans, sans-serif;
+      font-size: 12px;
+      line-height: 16px;
+      color: rgba(63, 67, 80, 0.56);
+      padding: 2px 6px;
+      align-items: center;
+      float: left;
+    }
+
+    .channelBg {
+      background: rgba(63, 67, 80, 0.08);
+      border-radius: 4px;
+      display: flex;
+      padding-left: 4px;
+    }
+
+    .channelLogo {
+      width: 10px;
+      height: 10px;
+      padding: 5px 4px 5px 6px;
+      float: left;
+    }
+
+    .channelName {
+      font-family: Open Sans, sans-serif;
+      font-weight: 600;
+      font-size: 10px;
+      line-height: 16px;
+      letter-spacing: 0.01em;
+      text-transform: uppercase;
+      color: rgba(63, 67, 80, 0.64);
+      padding: 2px 6px 2px 0px;
+    }
+
+    .gmChannelCount {
+      background-color: rgba(63, 67, 80, 0.2);
+      padding: 0 5px;
+      border-radius: 2px;
+      margin-right: 2px;
     }
 
     .senderMessage div {
       text-align: left !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px !important;
     }
 
@@ -256,13 +320,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:0;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:0;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -294,7 +358,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -317,13 +381,15 @@
                               <tr>
                                 <td align="left" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Arial;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Arial;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -336,7 +402,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -368,7 +434,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -386,9 +452,7 @@
                               <tr>
                                 <td align="left" style="font-size:0px;padding:0px 0px ;word-break:break-word;">
                                   <div style="font-family:Arial;font-size:14px;line-height:20px;text-align:left;color:#3D3C40;">{{.Props.QuestionInfo}}
-                                    <a href='mailto:{{.Props.SupportEmail}}'>
-                                      feedback-cloud@mattermost.com
-                                    </a>
+                                    <a href='mailto:{{.Props.SupportEmail}}'> feedback-cloud@mattermost.com </a>
                                   </div>
                                 </td>
                               </tr>
@@ -401,7 +465,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>

--- a/templates/cloud_trial_end_warning.html
+++ b/templates/cloud_trial_end_warning.html
@@ -60,6 +60,12 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700);
+  </style>
+  <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {
       .mj-column-per-100 {
@@ -85,241 +91,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:0;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:0;">
@@ -342,7 +117,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_gray.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_gray.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -370,7 +145,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" class="title" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Arial; text-align: left; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -384,7 +159,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Arial;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #FFFFFF; font-family: Arial; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -418,7 +193,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:320px;">
-                                          <img alt="" height="auto" src="{{.Props.SiteURL}}/static/images/add_payment_method.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320" />
+                                          <img alt height="auto" src="{{.Props.SiteURL}}/static/images/add_payment_method.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -446,13 +221,13 @@
                             <tbody>
                               <tr>
                                 <td align="left" class="footerTitle" style="font-size:0px;padding:24px 0px 0px 0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">{{.Props.QuestionTitle}}</div>
+                                  <div style="font-family: Arial; text-align: left; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.QuestionTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:0px 0px ;word-break:break-word;">
                                   <div style="font-family:Arial;font-size:14px;line-height:20px;text-align:left;color:#3D3C40;">{{.Props.QuestionInfo}}
-                                    <a href='mailto:{{.Props.SupportEmail}}'> feedback-cloud@mattermost.com </a>
+                                    <a href="mailto:{{.Props.SupportEmail}}" style="text-decoration: none; color: #1C58D9;"> feedback-cloud@mattermost.com </a>
                                   </div>
                                 </td>
                               </tr>
@@ -477,7 +252,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Organization}}
+                                  <div style="font-family: Arial; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                     {{.Props.FooterV2}}
                                   </div>
                                 </td>

--- a/templates/cloud_trial_ended_email.html
+++ b/templates/cloud_trial_ended_email.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -99,14 +101,18 @@
       font-weight: 600 !important;
       font-size: 28px !important;
       line-height: 36px !important;
-      letter-spacing: -0.02em !important;
-      color: #3D3C40 !important;
+      letter-spacing: -0.01em !important;
+      color: #3F4350 !important;
     }
 
     .subTitle div {
       font-size: 16px !important;
       line-height: 24px !important;
-      color: rgba(61, 60, 64, 0.64) !important;
+      color: rgba(63, 67, 80, 0.64) !important;
+    }
+
+    .subTitle a {
+      color: rgb(28, 88, 217) !important;
     }
 
     .button a {
@@ -118,10 +124,21 @@
       padding: 15px 24px !important;
     }
 
+    .messageButton a {
+      background-color: #FFFFFF !important;
+      border: 1px solid #FFFFFF !important;
+      box-sizing: border-box !important;
+      color: #1C58D9 !important;
+      padding: 12px 20px !important;
+      font-weight: 600 !important;
+      font-size: 14px !important;
+      line-height: 14px !important;
+    }
+
     .info div {
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 40px 0px !important;
     }
 
@@ -129,14 +146,14 @@
       font-weight: 600 !important;
       font-size: 16px !important;
       line-height: 24px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px 0px 4px 0px !important;
     }
 
     .footerInfo div {
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px 48px 0px 48px !important;
     }
 
@@ -158,7 +175,7 @@
     .emailFooter div {
       font-size: 12px !important;
       line-height: 16px !important;
-      color: rgba(61, 60, 64, 0.56) !important;
+      color: rgba(63, 67, 80, 0.56) !important;
       padding: 8px 24px 8px 24px !important;
     }
 
@@ -186,20 +203,67 @@
       width: 32px !important;
     }
 
-    .senderName div {
+    .postNameAndTime {
+      padding: 0px 0px 4px 0px !important;
+      display: flex;
+    }
+
+    .senderName {
+      font-family: Open Sans, sans-serif;
       text-align: left !important;
       font-weight: 600 !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
-      padding: 0px 0px 4px 0px !important;
+      color: #3F4350 !important;
+    }
+
+    .time {
+      font-family: Open Sans, sans-serif;
+      font-size: 12px;
+      line-height: 16px;
+      color: rgba(63, 67, 80, 0.56);
+      padding: 2px 6px;
+      align-items: center;
+      float: left;
+    }
+
+    .channelBg {
+      background: rgba(63, 67, 80, 0.08);
+      border-radius: 4px;
+      display: flex;
+      padding-left: 4px;
+    }
+
+    .channelLogo {
+      width: 10px;
+      height: 10px;
+      padding: 5px 4px 5px 6px;
+      float: left;
+    }
+
+    .channelName {
+      font-family: Open Sans, sans-serif;
+      font-weight: 600;
+      font-size: 10px;
+      line-height: 16px;
+      letter-spacing: 0.01em;
+      text-transform: uppercase;
+      color: rgba(63, 67, 80, 0.64);
+      padding: 2px 6px 2px 0px;
+    }
+
+    .gmChannelCount {
+      background-color: rgba(63, 67, 80, 0.2);
+      padding: 0 5px;
+      border-radius: 2px;
+      margin-right: 2px;
     }
 
     .senderMessage div {
       text-align: left !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px !important;
     }
 
@@ -256,13 +320,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:0;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:0;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -294,7 +358,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -317,13 +381,15 @@
                               <tr>
                                 <td align="left" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Arial;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Arial;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -336,7 +402,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -368,7 +434,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -401,7 +467,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>

--- a/templates/cloud_trial_ended_email.html
+++ b/templates/cloud_trial_ended_email.html
@@ -60,6 +60,12 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700);
+  </style>
+  <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {
       .mj-column-per-100 {
@@ -85,241 +91,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:0;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:0;">
@@ -342,7 +117,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_gray.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_gray.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -370,7 +145,7 @@
                             <tbody>
                               <tr>
                                 <td align="left" class="title" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Arial; text-align: left; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -384,7 +159,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Arial;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #FFFFFF; font-family: Arial; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -418,7 +193,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:320px;">
-                                          <img alt="" height="auto" src="{{.Props.SiteURL}}/static/images/add_subscription.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320" />
+                                          <img alt height="auto" src="{{.Props.SiteURL}}/static/images/add_subscription.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -446,13 +221,13 @@
                             <tbody>
                               <tr>
                                 <td align="left" class="footerTitle" style="font-size:0px;padding:24px 0px 0px 0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">{{.Props.QuestionTitle}}</div>
+                                  <div style="font-family: Arial; text-align: left; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.QuestionTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:0px 0px ;word-break:break-word;">
                                   <div style="font-family:Arial;font-size:14px;line-height:20px;text-align:left;color:#3D3C40;">{{.Props.QuestionInfo}}
-                                    <a href='mailto:{{.Props.SupportEmail}}'>
+                                    <a href="mailto:{{.Props.SupportEmail}}" style="text-decoration: none; color: #1C58D9;">
                                       {{.Props.SupportEmail}}
                                     </a>
                                   </div>
@@ -479,7 +254,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Organization}}
+                                  <div style="font-family: Arial; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                     {{.Props.FooterV2}}
                                   </div>
                                 </td>

--- a/templates/invite_body.html
+++ b/templates/invite_body.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -71,9 +73,9 @@
         max-width: 100%;
       }
 
-      .mj-column-per-50 {
-        width: 50% !important;
-        max-width: 50%;
+      .mj-column-per-33-333333333333336 {
+        width: 33.333333333333336% !important;
+        max-width: 33.333333333333336%;
       }
 
       .mj-column-per-90 {
@@ -88,9 +90,9 @@
       max-width: 100%;
     }
 
-    .moz-text-html .mj-column-per-50 {
-      width: 50% !important;
-      max-width: 50%;
+    .moz-text-html .mj-column-per-33-333333333333336 {
+      width: 33.333333333333336% !important;
+      max-width: 33.333333333333336%;
     }
 
     .moz-text-html .mj-column-per-90 {
@@ -255,6 +257,7 @@
       background: rgba(63, 67, 80, 0.08);
       border-radius: 4px;
       display: flex;
+      padding-left: 4px;
     }
 
     .channelLogo {
@@ -273,6 +276,13 @@
       text-transform: uppercase;
       color: rgba(63, 67, 80, 0.64);
       padding: 2px 6px 2px 0px;
+    }
+
+    .gmChannelCount {
+      background-color: rgba(63, 67, 80, 0.2);
+      padding: 0 5px;
+      border-radius: 2px;
+      margin-right: 2px;
     }
 
     .senderMessage div {
@@ -336,13 +346,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -374,7 +384,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -397,13 +407,15 @@
                               <tr>
                                 <td align="center" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -419,7 +431,7 @@
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{if .Props.Message}}
               <div class="postCard">
-                <!--[if mso | IE]><tr><td class="messageCard-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="messageCard-outlook" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                <!--[if mso | IE]><tr><td class="messageCard-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="messageCard-outlook" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                 <div class="messageCard" style="margin:0px auto;max-width:552px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
@@ -427,8 +439,8 @@
                         <td style="direction:ltr;font-size:0px;padding:0px;text-align:center;">
                           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="width:552px;" ><![endif]-->
                           <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
-                            <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:top;width:276px;" ><![endif]-->
-                            <div class="mj-column-per-50 mj-outlook-group-fix messageAvatarCol" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:50%;">
+                            <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:top;width:184px;" ><![endif]-->
+                            <div class="mj-column-per-33-333333333333336 mj-outlook-group-fix messageAvatarCol" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:33%;">
                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                                 <tbody>
                                   <tr>
@@ -436,8 +448,8 @@
                                       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
                                         <tbody>
                                           <tr>
-                                            <td style="width:276px;">
-                                              <img alt="" height="auto" src="cid:{{.Props.SenderPhoto}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="276" />
+                                            <td style="width:184px;">
+                                              <img alt="" height="auto" src="cid:{{.SenderPhoto}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="184" />
                                             </td>
                                           </tr>
                                         </tbody>
@@ -454,14 +466,21 @@
                                   <tr>
                                     <td>
                                       <div class="postNameAndTime">
-                                        <div class="senderName">{{.Props.SenderName}}</div>
-                                        {{if .Props.Time}}
-                                        <div class="time">{{.Props.Time}}</div>
+                                        <div class="senderName">{{.SenderName}}</div>
+                                        {{if .Time}}
+                                        <div class="time">{{.Time}}</div>
                                         {{end}}
-                                        {{if .Props.ChannelName}}
+                                        {{if .ChannelName}}
                                         <div class="channelBg">
+                                          {{if .ShowChannelIcon}}
                                           <div class="channelLogo"><img src="{{$.Props.SiteURL}}/static/images/channel_icon.png" width=10px height=10px></img></div>
-                                          <div class="channelName">{{.Props.ChannelName}}</div>
+                                          {{end}}
+                                          <div class="channelName">
+                                            {{if .OtherChannelMembersCount}}
+                                            <span class="gmChannelCount">{{.OtherChannelMembersCount}}</span>
+                                            {{end}}
+                                            {{.ChannelName}}
+                                          </div>
                                         </div>
                                         {{end}}
                                       </div>
@@ -469,20 +488,29 @@
                                   </tr>
                                   <tr>
                                     <td align="center" class="senderMessage" style="font-size:0px;padding:0px;word-break:break-word;">
-                                      <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Message}}</div>
+                                      <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Message}}</div>
                                     </td>
                                   </tr>
-                                  {{if .Props.MessageURL}}
+                                </tbody>
+                              </table>
+                            </div>
+                            <!--[if mso | IE]></td><td style="vertical-align:top;width:552px;" ><![endif]-->
+                            <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                              <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                                <tbody>
+                                  {{if .MessageURL}}
                                   <tr>
                                     <td align="center" vertical-align="middle" class="messageButton" style="font-size:0px;padding:16px 0px 0px 0px;word-break:break-word;">
                                       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                        <tr>
-                                          <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                            <a href="{{.Props.MessageURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                              {{$.Props.MessageButton}}
-                                            </a>
-                                          </td>
-                                        </tr>
+                                        <tbody>
+                                          <tr>
+                                            <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                              <a href="{{.MessageURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                {{$.Props.MessageButton}}
+                                              </a>
+                                            </td>
+                                          </tr>
+                                        </tbody>
                                       </table>
                                     </td>
                                   </tr>
@@ -501,7 +529,7 @@
                 <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               </div>
               {{else}}
-                <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                 <div style="margin:0px auto;max-width:552px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
@@ -535,7 +563,7 @@
                 </div>
                 <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
                 {{end}}
-                <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                 <div style="margin:0px auto;max-width:552px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
@@ -570,7 +598,7 @@
                     </tbody>
                   </table>
                 </div>
-                <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                 <div style="margin:0px auto;max-width:552px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>

--- a/templates/invite_body.html
+++ b/templates/invite_body.html
@@ -111,241 +111,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
@@ -368,7 +137,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -396,12 +165,12 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="title" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="subTitle" style="font-size:0px;padding:16px 24px 16px 24px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.SubTitle}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 16px; line-height: 24px; color: rgba(63, 67, 80, 0.64);">{{.Props.SubTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -410,7 +179,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -430,9 +199,9 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{if .Props.Message}}
-              <div class="postCard">
+              <div class="postCard" style="padding: 0px 24px 40px 24px;">
                 <!--[if mso | IE]><tr><td class="messageCard-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="messageCard-outlook" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                <div class="messageCard" style="margin:0px auto;max-width:552px;">
+                <div class="messageCard" style="margin: 0px auto; max-width: 552px; background: #FFFFFF; border: 1px solid rgba(61, 60, 64, 0.08); box-sizing: border-box; box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12); border-radius: 4px; padding: 32px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
                       <tr>
@@ -440,7 +209,7 @@
                           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="width:552px;" ><![endif]-->
                           <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
                             <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:top;width:184px;" ><![endif]-->
-                            <div class="mj-column-per-33-333333333333336 mj-outlook-group-fix messageAvatarCol" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:33%;">
+                            <div class="mj-column-per-33-333333333333336 mj-outlook-group-fix messageAvatarCol" style="font-size: 0px; text-align: left; direction: ltr; display: inline-block; vertical-align: top; width: 32px;">
                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                                 <tbody>
                                   <tr>
@@ -449,7 +218,7 @@
                                         <tbody>
                                           <tr>
                                             <td style="width:184px;">
-                                              <img alt="" height="auto" src="cid:{{.SenderPhoto}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="184" />
+                                              <img alt height="32" src="cid:{{.SenderPhoto}}" style="border: 0; display: block; outline: none; text-decoration: none; font-size: 13px; width: 32px; height: 32px; padding: 0px; border-radius: 32px;" width="32">
                                             </td>
                                           </tr>
                                         </tbody>
@@ -460,24 +229,24 @@
                               </table>
                             </div>
                             <!--[if mso | IE]></td><td style="vertical-align:top;width:496px;" ><![endif]-->
-                            <div class="mj-column-per-90 mj-outlook-group-fix senderInfoCol" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:90%;">
+                            <div class="mj-column-per-90 mj-outlook-group-fix senderInfoCol" style="font-size: 0px; text-align: left; direction: ltr; display: inline-block; vertical-align: top; width: 394px; padding: 0px 0px 0px 12px;">
                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                                 <tbody>
                                   <tr>
                                     <td>
-                                      <div class="postNameAndTime">
-                                        <div class="senderName">{{.SenderName}}</div>
+                                      <div class="postNameAndTime" style="display: flex; padding: 0px 0px 4px 0px;">
+                                        <div class="senderName" style="font-family: Open Sans, sans-serif; text-align: left; font-weight: 600; font-size: 14px; line-height: 20px; color: #3F4350;">{{.SenderName}}</div>
                                         {{if .Time}}
-                                        <div class="time">{{.Time}}</div>
+                                        <div class="time" style="font-family: Open Sans, sans-serif; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 2px 6px; align-items: center; float: left;">{{.Time}}</div>
                                         {{end}}
                                         {{if .ChannelName}}
-                                        <div class="channelBg">
+                                        <div class="channelBg" style="background: rgba(63, 67, 80, 0.08); border-radius: 4px; display: flex; padding-left: 4px;">
                                           {{if .ShowChannelIcon}}
-                                          <div class="channelLogo"><img src="{{$.Props.SiteURL}}/static/images/channel_icon.png" width=10px height=10px></img></div>
+                                          <div class="channelLogo" style="width: 10px; height: 10px; padding: 5px 4px 5px 6px; float: left;"><img src="{{$.Props.SiteURL}}/static/images/channel_icon.png" width="10px" height="10px"></div>
                                           {{end}}
-                                          <div class="channelName">
+                                          <div class="channelName" style="font-family: Open Sans, sans-serif; font-weight: 600; font-size: 10px; line-height: 16px; letter-spacing: 0.01em; text-transform: uppercase; color: rgba(63, 67, 80, 0.64); padding: 2px 6px 2px 0px;">
                                             {{if .OtherChannelMembersCount}}
-                                            <span class="gmChannelCount">{{.OtherChannelMembersCount}}</span>
+                                            <span class="gmChannelCount" style="background-color: rgba(63, 67, 80, 0.2); padding: 0 5px; border-radius: 2px; margin-right: 2px;">{{.OtherChannelMembersCount}}</span>
                                             {{end}}
                                             {{.ChannelName}}
                                           </div>
@@ -488,7 +257,7 @@
                                   </tr>
                                   <tr>
                                     <td align="center" class="senderMessage" style="font-size:0px;padding:0px;word-break:break-word;">
-                                      <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Message}}</div>
+                                      <div style="font-family: Open Sans, sans-serif; text-align: left; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px;">{{.Message}}</div>
                                     </td>
                                   </tr>
                                 </tbody>
@@ -505,7 +274,7 @@
                                         <tbody>
                                           <tr>
                                             <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                              <a href="{{.MessageURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                              <a href="{{.MessageURL}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #FFFFFF; border: 1px solid #FFFFFF; box-sizing: border-box; color: #1C58D9; padding: 12px 20px; font-weight: 600; font-size: 14px; line-height: 14px;" target="_blank">
                                                 {{$.Props.MessageButton}}
                                               </a>
                                             </td>
@@ -545,7 +314,7 @@
                                       <tbody>
                                         <tr>
                                           <td style="width:246px;">
-                                            <img alt="" height="auto" src="{{.Props.SiteURL}}/static/images/invite_illustration.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="246" />
+                                            <img alt height="auto" src="{{.Props.SiteURL}}/static/images/invite_illustration.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="246">
                                           </td>
                                         </tr>
                                       </tbody>
@@ -575,17 +344,17 @@
                               <tbody>
                                 <tr>
                                   <td align="center" class="footerTitle" style="font-size:0px;padding:0px;word-break:break-word;">
-                                    <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.InviteFooterTitle}}</div>
+                                    <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.InviteFooterTitle}}</div>
                                   </td>
                                 </tr>
                                 <tr>
                                   <td align="center" class="footerInfo" style="font-size:0px;padding:0px;word-break:break-word;">
-                                    <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.InviteFooterInfo}}</div>
+                                    <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px 48px 0px 48px;">{{.Props.InviteFooterInfo}}</div>
                                   </td>
                                 </tr>
                                 <tr>
                                   <td align="center" class="footerInfo" style="font-size:0px;padding:4px 0px 0px 0px;word-break:break-word;">
-                                    <div style="font-family:Open Sans, sans-serif;font-size:13px;font-weight:600;line-height:1;text-align:center;color:#000000;"><a href="mattermost.com" color="#1C58D9">
+                                    <div style="font-family: Open Sans, sans-serif; font-weight: 600; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px 48px 0px 48px;"><a href="mattermost.com" color="#1C58D9" style="text-decoration: none; color: #1C58D9;">
                                         {{.Props.InviteFooterLearnMore}}</a></div>
                                   </td>
                                 </tr>
@@ -610,7 +379,7 @@
                               <tbody>
                                 <tr>
                                   <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                    <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Organization}}
+                                    <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                       {{.Props.FooterV2}}
                                     </div>
                                   </td>

--- a/templates/license_up_for_renewal.html
+++ b/templates/license_up_for_renewal.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -100,13 +102,17 @@
       font-size: 28px !important;
       line-height: 36px !important;
       letter-spacing: -0.01em !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
     }
 
     .subTitle div {
       font-size: 16px !important;
       line-height: 24px !important;
-      color: rgba(61, 60, 64, 0.64) !important;
+      color: rgba(63, 67, 80, 0.64) !important;
+    }
+
+    .subTitle a {
+      color: rgb(28, 88, 217) !important;
     }
 
     .button a {
@@ -132,7 +138,7 @@
     .info div {
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 40px 0px !important;
     }
 
@@ -140,14 +146,14 @@
       font-weight: 600 !important;
       font-size: 16px !important;
       line-height: 24px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px 0px 4px 0px !important;
     }
 
     .footerInfo div {
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px 48px 0px 48px !important;
     }
 
@@ -169,7 +175,7 @@
     .emailFooter div {
       font-size: 12px !important;
       line-height: 16px !important;
-      color: rgba(61, 60, 64, 0.56) !important;
+      color: rgba(63, 67, 80, 0.56) !important;
       padding: 8px 24px 8px 24px !important;
     }
 
@@ -208,23 +214,24 @@
       font-weight: 600 !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
     }
 
     .time {
       font-family: Open Sans, sans-serif;
       font-size: 12px;
       line-height: 16px;
-      color: rgba(61, 60, 64, 0.56);
+      color: rgba(63, 67, 80, 0.56);
       padding: 2px 6px;
       align-items: center;
       float: left;
     }
 
     .channelBg {
-      background: rgba(61, 60, 64, 0.08);
+      background: rgba(63, 67, 80, 0.08);
       border-radius: 4px;
       display: flex;
+      padding-left: 4px;
     }
 
     .channelLogo {
@@ -241,15 +248,22 @@
       line-height: 16px;
       letter-spacing: 0.01em;
       text-transform: uppercase;
-      color: rgba(61, 60, 64, 0.64);
+      color: rgba(63, 67, 80, 0.64);
       padding: 2px 6px 2px 0px;
+    }
+
+    .gmChannelCount {
+      background-color: rgba(63, 67, 80, 0.2);
+      padding: 0 5px;
+      border-radius: 2px;
+      margin-right: 2px;
     }
 
     .senderMessage div {
       text-align: left !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px !important;
     }
 
@@ -306,13 +320,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:0;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:0;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -344,7 +358,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -372,13 +386,15 @@
                               <tr>
                                 <td align="center" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#0058CC" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#0058CC;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#0058CC;color:#ffffff;font-family:Arial;font-size:16px;font-weight:normal;line-height:24px;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#0058CC" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#0058CC;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#0058CC;color:#ffffff;font-family:Arial;font-size:16px;font-weight:normal;line-height:24px;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -391,7 +407,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -423,7 +439,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -456,7 +472,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>

--- a/templates/license_up_for_renewal.html
+++ b/templates/license_up_for_renewal.html
@@ -60,6 +60,12 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
+  <!--[if !mso]><!-->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700" rel="stylesheet" type="text/css">
+  <style type="text/css">
+    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,700);
+  </style>
+  <!--<![endif]-->
   <style type="text/css">
     @media only screen and (min-width:480px) {
       .mj-column-per-100 {
@@ -85,241 +91,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:0;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:0;">
@@ -342,7 +117,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_gray.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_gray.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -370,7 +145,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="title" style="font-size:0px;padding:10px 0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:28px;font-weight:bold;line-height:32px;text-align:center;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Arial; text-align: center; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -389,7 +164,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#0058CC" role="presentation" style="border:none;border-radius:4px;border-top:16px;cursor:auto;mso-padding-alt:10px 25px;background:#0058CC;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#0058CC;color:#ffffff;font-family:Arial;font-size:16px;font-weight:normal;line-height:24px;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #0058CC; font-family: Arial; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -423,7 +198,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:320px;">
-                                          <img alt="" height="auto" src="https://ucarecdn.com/8cd90d9d-8902-4845-a15b-f4664e5fcfb3/-/format/auto/-/quality/lighter/-/max_icc_size/10/-/resize/1288x/" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320" />
+                                          <img alt height="auto" src="https://ucarecdn.com/8cd90d9d-8902-4845-a15b-f4664e5fcfb3/-/format/auto/-/quality/lighter/-/max_icc_size/10/-/resize/1288x/" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -451,13 +226,13 @@
                             <tbody>
                               <tr>
                                 <td align="left" class="footerTitle" style="font-size:0px;padding:24px 0px 0px 0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:13px;line-height:1;text-align:left;color:#000000;">{{.Props.QuestionTitle}}</div>
+                                  <div style="font-family: Arial; text-align: left; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.QuestionTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="left" style="font-size:0px;padding:0px 0px ;word-break:break-word;">
                                   <div style="font-family:Arial;font-size:14px;line-height:20px;text-align:left;color:#3D3C40;">{{.Props.QuestionInfo}}
-                                    <a href='mailto:{{.Props.SupportEmail}}'>
+                                    <a href="mailto:{{.Props.SupportEmail}}" style="text-decoration: none; color: #1C58D9;">
                                       {{.Props.SupportEmail}}
                                     </a>
                                   </div>
@@ -484,7 +259,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Arial;font-size:12px;line-height:20px;text-align:center;color:#AAAAAA;">{{.Props.Organization}}
+                                  <div style="font-family: Arial; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                     {{.Props.FooterV2}}
                                   </div>
                                 </td>

--- a/templates/messages_notification.html
+++ b/templates/messages_notification.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -344,13 +346,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -382,7 +384,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -405,13 +407,15 @@
                               <tr>
                                 <td align="center" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -427,7 +431,7 @@
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{range .Props.Posts}}
               <div class="postCard">
-                <!--[if mso | IE]><tr><td class="messageCard-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="messageCard-outlook" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+                <!--[if mso | IE]><tr><td class="messageCard-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="messageCard-outlook" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
                 <div class="messageCard" style="margin:0px auto;max-width:552px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
@@ -498,13 +502,15 @@
                                   <tr>
                                     <td align="center" vertical-align="middle" class="messageButton" style="font-size:0px;padding:16px 0px 0px 0px;word-break:break-word;">
                                       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                        <tr>
-                                          <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                            <a href="{{.MessageURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                              {{$.Props.MessageButton}}
-                                            </a>
-                                          </td>
-                                        </tr>
+                                        <tbody>
+                                          <tr>
+                                            <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                              <a href="{{.MessageURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                {{$.Props.MessageButton}}
+                                              </a>
+                                            </td>
+                                          </tr>
+                                        </tbody>
                                       </table>
                                     </td>
                                   </tr>
@@ -522,7 +528,7 @@
                 </div>
                 <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               </div>{{end}}
-              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -551,7 +557,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>

--- a/templates/messages_notification.html
+++ b/templates/messages_notification.html
@@ -111,241 +111,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
@@ -368,7 +137,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -396,12 +165,12 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="title" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="subTitle" style="font-size:0px;padding:16px 24px 16px 24px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.SubTitle}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 16px; line-height: 24px; color: rgba(63, 67, 80, 0.64);">{{.Props.SubTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -410,7 +179,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -430,9 +199,9 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{range .Props.Posts}}
-              <div class="postCard">
+              <div class="postCard" style="padding: 0px 24px 40px 24px;">
                 <!--[if mso | IE]><tr><td class="messageCard-outlook" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="messageCard-outlook" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-                <div class="messageCard" style="margin:0px auto;max-width:552px;">
+                <div class="messageCard" style="margin: 0px auto; max-width: 552px; background: #FFFFFF; border: 1px solid rgba(61, 60, 64, 0.08); box-sizing: border-box; box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12); border-radius: 4px; padding: 32px;">
                   <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                     <tbody>
                       <tr>
@@ -440,7 +209,7 @@
                           <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="width:552px;" ><![endif]-->
                           <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0;line-height:0;text-align:left;display:inline-block;width:100%;direction:ltr;">
                             <!--[if mso | IE]><table border="0" cellpadding="0" cellspacing="0" role="presentation" ><tr><td style="vertical-align:top;width:184px;" ><![endif]-->
-                            <div class="mj-column-per-33-333333333333336 mj-outlook-group-fix messageAvatarCol" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:33%;">
+                            <div class="mj-column-per-33-333333333333336 mj-outlook-group-fix messageAvatarCol" style="font-size: 0px; text-align: left; direction: ltr; display: inline-block; vertical-align: top; width: 32px;">
                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                                 <tbody>
                                   <tr>
@@ -449,7 +218,7 @@
                                         <tbody>
                                           <tr>
                                             <td style="width:184px;">
-                                              <img alt="" height="auto" src="cid:{{.SenderPhoto}}" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="184" />
+                                              <img alt height="32" src="cid:{{.SenderPhoto}}" style="border: 0; display: block; outline: none; text-decoration: none; font-size: 13px; width: 32px; height: 32px; padding: 0px; border-radius: 32px;" width="32">
                                             </td>
                                           </tr>
                                         </tbody>
@@ -460,24 +229,24 @@
                               </table>
                             </div>
                             <!--[if mso | IE]></td><td style="vertical-align:top;width:496px;" ><![endif]-->
-                            <div class="mj-column-per-90 mj-outlook-group-fix senderInfoCol" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:90%;">
+                            <div class="mj-column-per-90 mj-outlook-group-fix senderInfoCol" style="font-size: 0px; text-align: left; direction: ltr; display: inline-block; vertical-align: top; width: 394px; padding: 0px 0px 0px 12px;">
                               <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
                                 <tbody>
                                   <tr>
                                     <td>
-                                      <div class="postNameAndTime">
-                                        <div class="senderName">{{.SenderName}}</div>
+                                      <div class="postNameAndTime" style="display: flex; padding: 0px 0px 4px 0px;">
+                                        <div class="senderName" style="font-family: Open Sans, sans-serif; text-align: left; font-weight: 600; font-size: 14px; line-height: 20px; color: #3F4350;">{{.SenderName}}</div>
                                         {{if .Time}}
-                                        <div class="time">{{.Time}}</div>
+                                        <div class="time" style="font-family: Open Sans, sans-serif; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 2px 6px; align-items: center; float: left;">{{.Time}}</div>
                                         {{end}}
                                         {{if .ChannelName}}
-                                        <div class="channelBg">
+                                        <div class="channelBg" style="background: rgba(63, 67, 80, 0.08); border-radius: 4px; display: flex; padding-left: 4px;">
                                           {{if .ShowChannelIcon}}
-                                          <div class="channelLogo"><img src="{{$.Props.SiteURL}}/static/images/channel_icon.png" width=10px height=10px></img></div>
+                                          <div class="channelLogo" style="width: 10px; height: 10px; padding: 5px 4px 5px 6px; float: left;"><img src="{{$.Props.SiteURL}}/static/images/channel_icon.png" width="10px" height="10px"></div>
                                           {{end}}
-                                          <div class="channelName">
+                                          <div class="channelName" style="font-family: Open Sans, sans-serif; font-weight: 600; font-size: 10px; line-height: 16px; letter-spacing: 0.01em; text-transform: uppercase; color: rgba(63, 67, 80, 0.64); padding: 2px 6px 2px 0px;">
                                             {{if .OtherChannelMembersCount}}
-                                            <span class="gmChannelCount">{{.OtherChannelMembersCount}}</span>
+                                            <span class="gmChannelCount" style="background-color: rgba(63, 67, 80, 0.2); padding: 0 5px; border-radius: 2px; margin-right: 2px;">{{.OtherChannelMembersCount}}</span>
                                             {{end}}
                                             {{.ChannelName}}
                                           </div>
@@ -488,7 +257,7 @@
                                   </tr>
                                   <tr>
                                     <td align="center" class="senderMessage" style="font-size:0px;padding:0px;word-break:break-word;">
-                                      <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Message}}</div>
+                                      <div style="font-family: Open Sans, sans-serif; text-align: left; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px;">{{.Message}}</div>
                                     </td>
                                   </tr>
                                 </tbody>
@@ -505,7 +274,7 @@
                                         <tbody>
                                           <tr>
                                             <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                              <a href="{{.MessageURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                              <a href="{{.MessageURL}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #FFFFFF; border: 1px solid #FFFFFF; box-sizing: border-box; color: #1C58D9; padding: 12px 20px; font-weight: 600; font-size: 14px; line-height: 14px;" target="_blank">
                                                 {{$.Props.MessageButton}}
                                               </a>
                                             </td>
@@ -540,12 +309,12 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="footerTitle" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.NotificationFooterTitle}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.NotificationFooterTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="footerInfo" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;"><a href="{{.Props.SiteURL}}">{{.Props.NotificationFooterInfoLogin}}</a>{{.Props.NotificationFooterInfo}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px 48px 0px 48px;"><a href="{{.Props.SiteURL}}" style="text-decoration: none; color: #1C58D9;">{{.Props.NotificationFooterInfoLogin}}</a>{{.Props.NotificationFooterInfo}}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -569,7 +338,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Organization}}
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                     {{.Props.FooterV2}}
                                   </div>
                                 </td>

--- a/templates/partials/style.mjml
+++ b/templates/partials/style.mjml
@@ -7,9 +7,9 @@
   <mj-class name="logo" width="132px" height="21.76px" padding="0px" />
 </mj-attributes>
 
-<mj-style>
+<mj-style inline="inline">
   @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-  
+
   .emailBody {
     background: #F3F3F3 !important;
   }
@@ -147,12 +147,12 @@
     align-items: center;
     float: left;
   }
-    
+
   .channelBg {
     background: rgba(63, 67, 80, 0.08);
     border-radius: 4px;
     display: flex;
-    padding-left: 4px; 
+    padding-left: 4px;
   }
 
   .channelLogo {
@@ -179,7 +179,7 @@
     border-radius: 2px;
     margin-right: 2px;
   }
-  
+
   .senderMessage div {
     text-align: left !important;
     font-size: 14px !important;
@@ -230,7 +230,7 @@
     .postCard {
       padding: 0px 0px 40px 0px !important;
     }
-    
+
     .senderInfoCol {
       width: 80% !important;
       padding: 0px 0px 0px 12px !important;

--- a/templates/reset_body.html
+++ b/templates/reset_body.html
@@ -91,241 +91,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
@@ -348,7 +117,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -376,12 +145,12 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="title" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="subTitle" style="font-size:0px;padding:16px 24px 16px 24px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.SubTitle}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 16px; line-height: 24px; color: rgba(63, 67, 80, 0.64);">{{.Props.SubTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -390,7 +159,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -424,7 +193,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:312px;">
-                                          <img alt="" height="auto" src="{{.Props.SiteURL}}/static/images/forgot_password_illustration.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="312" />
+                                          <img alt height="auto" src="{{.Props.SiteURL}}/static/images/forgot_password_illustration.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="312">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -433,7 +202,7 @@
                               </tr>
                               <tr>
                                 <td align="center" class="info" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Info}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 40px 0px;">{{.Props.Info}}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -459,13 +228,13 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="footerTitle" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.QuestionTitle}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.QuestionTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="footerInfo" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.QuestionInfo}}
-                                    <a href="mailto:{{.Props.SupportEmail}}">
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px 48px 0px 48px;">{{.Props.QuestionInfo}}
+                                    <a href="mailto:{{.Props.SupportEmail}}" style="text-decoration: none; color: #1C58D9;">
                                       {{.Props.SupportEmail}}</a>
                                   </div>
                                 </td>
@@ -493,7 +262,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Organization}}
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                     {{.Props.FooterV2}}
                                   </div>
                                 </td>

--- a/templates/reset_body.html
+++ b/templates/reset_body.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -116,7 +118,7 @@
     }
 
     .subTitle a {
-    color: rgb(28, 88, 217) !important;
+      color: rgb(28, 88, 217) !important;
     }
 
     .button a {
@@ -218,23 +220,24 @@
       font-weight: 600 !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
     }
 
     .time {
       font-family: Open Sans, sans-serif;
       font-size: 12px;
       line-height: 16px;
-      color: rgba(61, 60, 64, 0.56);
+      color: rgba(63, 67, 80, 0.56);
       padding: 2px 6px;
       align-items: center;
       float: left;
     }
 
     .channelBg {
-      background: rgba(61, 60, 64, 0.08);
+      background: rgba(63, 67, 80, 0.08);
       border-radius: 4px;
       display: flex;
+      padding-left: 4px;
     }
 
     .channelLogo {
@@ -251,15 +254,22 @@
       line-height: 16px;
       letter-spacing: 0.01em;
       text-transform: uppercase;
-      color: rgba(61, 60, 64, 0.64);
+      color: rgba(63, 67, 80, 0.64);
       padding: 2px 6px 2px 0px;
+    }
+
+    .gmChannelCount {
+      background-color: rgba(63, 67, 80, 0.2);
+      padding: 0 5px;
+      border-radius: 2px;
+      margin-right: 2px;
     }
 
     .senderMessage div {
       text-align: left !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px !important;
     }
 
@@ -316,13 +326,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -354,7 +364,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -377,13 +387,15 @@
                               <tr>
                                 <td align="center" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -396,7 +408,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -435,7 +447,7 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{if .Props.SupportEmail}}
-              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -469,7 +481,7 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{end}}
-              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>

--- a/templates/verify_body.html
+++ b/templates/verify_body.html
@@ -91,241 +91,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
@@ -348,7 +117,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -376,18 +145,18 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="title" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="subTitle" style="font-size:0px;padding:16px 24px 0px 24px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.SubTitle1}}<a href="{{.Props.SiteURL}}">{{.Props.ServerURL}}</a></div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 16px; line-height: 24px; color: rgba(63, 67, 80, 0.64);">{{.Props.SubTitle1}}<a href="{{.Props.SiteURL}}" style="text-decoration: none; color: rgb(28, 88, 217);">{{.Props.ServerURL}}</a></div>
                                 </td>
                               </tr>
                               {{if .Props.ButtonURL}}
                               <tr>
                                 <td align="center" class="subTitle" style="font-size:0px;padding:0px 24px 16px 24px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.SubTitle2}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 16px; line-height: 24px; color: rgba(63, 67, 80, 0.64);">{{.Props.SubTitle2}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -396,7 +165,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -431,7 +200,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:320px;">
-                                          <img alt="" height="auto" src="{{.Props.SiteURL}}/static/images/welcome_illustration_new.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320" />
+                                          <img alt height="auto" src="{{.Props.SiteURL}}/static/images/welcome_illustration_new.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -459,7 +228,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="info" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Info}}<br>{{.Props.Info1}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 40px 0px;">{{.Props.Info}}<br>{{.Props.Info1}}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -485,13 +254,13 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="footerTitle" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.QuestionTitle}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.QuestionTitle}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="footerInfo" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.QuestionInfo}}
-                                    <a href="mailto:{{.Props.SupportEmail}}">
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px 48px 0px 48px;">{{.Props.QuestionInfo}}
+                                    <a href="mailto:{{.Props.SupportEmail}}" style="text-decoration: none; color: #1C58D9;">
                                       {{.Props.SupportEmail}}</a>
                                   </div>
                                 </td>
@@ -519,7 +288,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Organization}}
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                     {{.Props.FooterV2}}
                                   </div>
                                 </td>

--- a/templates/verify_body.html
+++ b/templates/verify_body.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -106,7 +108,7 @@
       font-size: 28px !important;
       line-height: 36px !important;
       letter-spacing: -0.01em !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
     }
 
     .subTitle div {
@@ -116,7 +118,7 @@
     }
 
     .subTitle a {
-      color: rgba(28, 88, 217, 1) !important;
+      color: rgb(28, 88, 217) !important;
     }
 
     .button a {
@@ -179,7 +181,7 @@
     .emailFooter div {
       font-size: 12px !important;
       line-height: 16px !important;
-      color: rgba(61, 60, 64, 0.56) !important;
+      color: rgba(63, 67, 80, 0.56) !important;
       padding: 8px 24px 8px 24px !important;
     }
 
@@ -218,23 +220,24 @@
       font-weight: 600 !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
     }
 
     .time {
       font-family: Open Sans, sans-serif;
       font-size: 12px;
       line-height: 16px;
-      color: rgba(61, 60, 64, 0.56);
+      color: rgba(63, 67, 80, 0.56);
       padding: 2px 6px;
       align-items: center;
       float: left;
     }
 
     .channelBg {
-      background: rgba(61, 60, 64, 0.08);
+      background: rgba(63, 67, 80, 0.08);
       border-radius: 4px;
       display: flex;
+      padding-left: 4px;
     }
 
     .channelLogo {
@@ -251,15 +254,22 @@
       line-height: 16px;
       letter-spacing: 0.01em;
       text-transform: uppercase;
-      color: rgba(61, 60, 64, 0.64);
+      color: rgba(63, 67, 80, 0.64);
       padding: 2px 6px 2px 0px;
+    }
+
+    .gmChannelCount {
+      background-color: rgba(63, 67, 80, 0.2);
+      padding: 0 5px;
+      border-radius: 2px;
+      margin-right: 2px;
     }
 
     .senderMessage div {
       text-align: left !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px !important;
     }
 
@@ -316,13 +326,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -354,7 +364,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -383,13 +393,15 @@
                               <tr>
                                 <td align="center" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -403,7 +415,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -435,7 +447,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -461,7 +473,7 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{if .Props.SupportEmail}}
-              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -495,7 +507,7 @@
               </div>
               <!--[if mso | IE]></td></tr></table></td></tr><![endif]-->
               {{end}}
-              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>

--- a/templates/welcome_body.html
+++ b/templates/welcome_body.html
@@ -91,241 +91,10 @@
       }
     }
   </style>
-  <style type="text/css">
-    @import url(https://fonts.googleapis.com/css?family=Open+Sans:300,400,500,600,700);
-
-    .emailBody {
-      background: #F3F3F3 !important;
-    }
-
-    .emailBody a {
-      text-decoration: none !important;
-      color: #1C58D9 !important;
-    }
-
-    .title div {
-      font-weight: 600 !important;
-      font-size: 28px !important;
-      line-height: 36px !important;
-      letter-spacing: -0.01em !important;
-      color: #3F4350 !important;
-    }
-
-    .subTitle div {
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: rgba(63, 67, 80, 0.64) !important;
-    }
-
-    .subTitle a {
-      color: rgb(28, 88, 217) !important;
-    }
-
-    .button a {
-      background-color: #1C58D9 !important;
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 18px !important;
-      color: #FFFFFF !important;
-      padding: 15px 24px !important;
-    }
-
-    .messageButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #FFFFFF !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 12px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .info div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 40px 0px !important;
-    }
-
-    .footerTitle div {
-      font-weight: 600 !important;
-      font-size: 16px !important;
-      line-height: 24px !important;
-      color: #3F4350 !important;
-      padding: 0px 0px 4px 0px !important;
-    }
-
-    .footerInfo div {
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px 48px 0px 48px !important;
-    }
-
-    .footerInfo a {
-      color: #1C58D9 !important;
-    }
-
-    .appDownloadButton a {
-      background-color: #FFFFFF !important;
-      border: 1px solid #1C58D9 !important;
-      box-sizing: border-box !important;
-      color: #1C58D9 !important;
-      padding: 13px 20px !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 14px !important;
-    }
-
-    .emailFooter div {
-      font-size: 12px !important;
-      line-height: 16px !important;
-      color: rgba(63, 67, 80, 0.56) !important;
-      padding: 8px 24px 8px 24px !important;
-    }
-
-    .postCard {
-      padding: 0px 24px 40px 24px !important;
-    }
-
-    .messageCard {
-      background: #FFFFFF !important;
-      border: 1px solid rgba(61, 60, 64, 0.08) !important;
-      box-sizing: border-box !important;
-      box-shadow: 0px 8px 24px rgba(0, 0, 0, 0.12) !important;
-      border-radius: 4px !important;
-      padding: 32px !important;
-    }
-
-    .messageAvatar img {
-      width: 32px !important;
-      height: 32px !important;
-      padding: 0px !important;
-      border-radius: 32px !important;
-    }
-
-    .messageAvatarCol {
-      width: 32px !important;
-    }
-
-    .postNameAndTime {
-      padding: 0px 0px 4px 0px !important;
-      display: flex;
-    }
-
-    .senderName {
-      font-family: Open Sans, sans-serif;
-      text-align: left !important;
-      font-weight: 600 !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-    }
-
-    .time {
-      font-family: Open Sans, sans-serif;
-      font-size: 12px;
-      line-height: 16px;
-      color: rgba(63, 67, 80, 0.56);
-      padding: 2px 6px;
-      align-items: center;
-      float: left;
-    }
-
-    .channelBg {
-      background: rgba(63, 67, 80, 0.08);
-      border-radius: 4px;
-      display: flex;
-      padding-left: 4px;
-    }
-
-    .channelLogo {
-      width: 10px;
-      height: 10px;
-      padding: 5px 4px 5px 6px;
-      float: left;
-    }
-
-    .channelName {
-      font-family: Open Sans, sans-serif;
-      font-weight: 600;
-      font-size: 10px;
-      line-height: 16px;
-      letter-spacing: 0.01em;
-      text-transform: uppercase;
-      color: rgba(63, 67, 80, 0.64);
-      padding: 2px 6px 2px 0px;
-    }
-
-    .gmChannelCount {
-      background-color: rgba(63, 67, 80, 0.2);
-      padding: 0 5px;
-      border-radius: 2px;
-      margin-right: 2px;
-    }
-
-    .senderMessage div {
-      text-align: left !important;
-      font-size: 14px !important;
-      line-height: 20px !important;
-      color: #3F4350 !important;
-      padding: 0px !important;
-    }
-
-    .senderInfoCol {
-      width: 394px !important;
-      padding: 0px 0px 0px 12px !important;
-    }
-
-    @media all and (min-width: 541px) {
-      .emailBody {
-        padding: 32px !important;
-      }
-    }
-
-    @media all and (max-width: 540px) and (min-width: 401px) {
-      .emailBody {
-        padding: 16px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-
-    @media all and (max-width: 400px) {
-      .emailBody {
-        padding: 0px !important;
-      }
-
-      .footerInfo div {
-        padding: 0px !important;
-      }
-
-      .messageCard {
-        padding: 16px !important;
-      }
-
-      .postCard {
-        padding: 0px 0px 40px 0px !important;
-      }
-
-      .senderInfoCol {
-        width: 80% !important;
-        padding: 0px 0px 0px 12px !important;
-      }
-    }
-  </style>
 </head>
 
 <body style="word-spacing:normal;">
-  <div class="emailBody" style="">
+  <div class="emailBody" style="background: #F3F3F3;">
     <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
@@ -348,7 +117,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:132px;">
-                                          <img alt="" height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132" />
+                                          <img alt height="21" src="{{.Props.SiteURL}}/static/images/logo_email_dark.png" style="border:0;display:block;outline:none;text-decoration:none;height:21.76px;width:100%;font-size:13px;" width="132">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -376,18 +145,18 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="title" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Title}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 28px; line-height: 36px; letter-spacing: -0.01em; color: #3F4350;">{{.Props.Title}}</div>
                                 </td>
                               </tr>
                               <tr>
                                 <td align="center" class="subTitle" style="font-size:0px;padding:16px 24px 0px 24px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.SubTitle1}}<a href="{{.Props.SiteURL}}">{{.Props.ServerURL}}</a></div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 16px; line-height: 24px; color: rgba(63, 67, 80, 0.64);">{{.Props.SubTitle1}}<a href="{{.Props.SiteURL}}" style="text-decoration: none; color: rgb(28, 88, 217);">{{.Props.ServerURL}}</a></div>
                                 </td>
                               </tr>
                               {{if .Props.ButtonURL}}
                               <tr>
                                 <td align="center" class="subTitle" style="font-size:0px;padding:0px 24px 16px 24px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.SubTitle2}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 16px; line-height: 24px; color: rgba(63, 67, 80, 0.64);">{{.Props.SubTitle2}}</div>
                                 </td>
                               </tr>
                               <tr>
@@ -396,7 +165,7 @@
                                     <tbody>
                                       <tr>
                                         <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                          <a href="{{.Props.ButtonURL}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #1C58D9; font-weight: 600; font-size: 16px; line-height: 18px; color: #FFFFFF; padding: 15px 24px;" target="_blank">
                                             {{.Props.Button}}
                                           </a>
                                         </td>
@@ -431,7 +200,7 @@
                                     <tbody>
                                       <tr>
                                         <td style="width:320px;">
-                                          <img alt="" height="auto" src="{{.Props.SiteURL}}/static/images/welcome_illustration_new.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320" />
+                                          <img alt height="auto" src="{{.Props.SiteURL}}/static/images/welcome_illustration_new.png" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="320">
                                         </td>
                                       </tr>
                                     </tbody>
@@ -459,7 +228,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="info" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Info}}<br>{{.Props.Info1}}</div>
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 40px 0px;">{{.Props.Info}}<br>{{.Props.Info1}}</div>
                                 </td>
                               </tr>
                             </tbody>
@@ -483,7 +252,7 @@
                             <tbody>
                               <tr>
                                 <td style="vertical-align:top;padding:0px 24px 0px 24px;">
-                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="" width="100%">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
                                     <tbody>
                                       {{if .Props.AppDownloadLink}}
                                       <tr>
@@ -492,7 +261,7 @@
                                             <tbody>
                                               <tr>
                                                 <td style="width:150px;">
-                                                  <img alt="" height="25" src="{{.Props.SiteURL}}/static/images/appIcons.png" style="border:0;display:block;outline:none;text-decoration:none;height:25.5px;width:100%;font-size:13px;" width="150" />
+                                                  <img alt height="25" src="{{.Props.SiteURL}}/static/images/appIcons.png" style="border:0;display:block;outline:none;text-decoration:none;height:25.5px;width:100%;font-size:13px;" width="150">
                                                 </td>
                                               </tr>
                                             </tbody>
@@ -501,12 +270,12 @@
                                       </tr>
                                       <tr>
                                         <td align="center" class="footerTitle" style="font-size:0px;padding:0px;word-break:break-word;">
-                                          <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.AppDownloadTitle}}</div>
+                                          <div style="font-family: Open Sans, sans-serif; text-align: center; font-weight: 600; font-size: 16px; line-height: 24px; color: #3F4350; padding: 0px 0px 4px 0px;">{{.Props.AppDownloadTitle}}</div>
                                         </td>
                                       </tr>
                                       <tr>
                                         <td align="center" class="footerInfo" style="font-size:0px;padding:0px;word-break:break-word;">
-                                          <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.AppDownloadInfo}}</div>
+                                          <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 14px; line-height: 20px; color: #3F4350; padding: 0px 48px 0px 48px;">{{.Props.AppDownloadInfo}}</div>
                                         </td>
                                       </tr>
                                       <tr>
@@ -515,7 +284,7 @@
                                             <tbody>
                                               <tr>
                                                 <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                                  <a href="{{.Props.AppDownloadLink}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                  <a href="{{.Props.AppDownloadLink}}" style="display: inline-block; background: #FFFFFF; font-family: Open Sans, sans-serif; margin: 0; text-transform: none; mso-padding-alt: 0px; border-radius: 4px; text-decoration: none; background-color: #FFFFFF; border: 1px solid #1C58D9; box-sizing: border-box; color: #1C58D9; padding: 13px 20px; font-weight: 600; font-size: 14px; line-height: 14px;" target="_blank">
                                                     {{.Props.AppDownloadButton}}
                                                   </a>
                                                 </td>
@@ -550,7 +319,7 @@
                             <tbody>
                               <tr>
                                 <td align="center" class="emailFooter" style="font-size:0px;padding:0px;word-break:break-word;">
-                                  <div style="font-family:Open Sans, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{.Props.Organization}}
+                                  <div style="font-family: Open Sans, sans-serif; text-align: center; font-size: 12px; line-height: 16px; color: rgba(63, 67, 80, 0.56); padding: 8px 24px 8px 24px;">{{.Props.Organization}}
                                     {{.Props.FooterV2}}
                                   </div>
                                 </td>

--- a/templates/welcome_body.html
+++ b/templates/welcome_body.html
@@ -46,12 +46,14 @@
     }
   </style>
   <!--[if mso]>
+        <noscript>
         <xml>
         <o:OfficeDocumentSettings>
           <o:AllowPNG/>
           <o:PixelsPerInch>96</o:PixelsPerInch>
         </o:OfficeDocumentSettings>
         </xml>
+        </noscript>
         <![endif]-->
   <!--[if lte mso 11]>
         <style type="text/css">
@@ -106,7 +108,7 @@
       font-size: 28px !important;
       line-height: 36px !important;
       letter-spacing: -0.01em !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
     }
 
     .subTitle div {
@@ -116,7 +118,7 @@
     }
 
     .subTitle a {
-      color: rgba(28, 88, 217, 1) !important;
+      color: rgb(28, 88, 217) !important;
     }
 
     .button a {
@@ -179,7 +181,7 @@
     .emailFooter div {
       font-size: 12px !important;
       line-height: 16px !important;
-      color: rgba(61, 60, 64, 0.56) !important;
+      color: rgba(63, 67, 80, 0.56) !important;
       padding: 8px 24px 8px 24px !important;
     }
 
@@ -218,23 +220,24 @@
       font-weight: 600 !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
     }
 
     .time {
       font-family: Open Sans, sans-serif;
       font-size: 12px;
       line-height: 16px;
-      color: rgba(61, 60, 64, 0.56);
+      color: rgba(63, 67, 80, 0.56);
       padding: 2px 6px;
       align-items: center;
       float: left;
     }
 
     .channelBg {
-      background: rgba(61, 60, 64, 0.08);
+      background: rgba(63, 67, 80, 0.08);
       border-radius: 4px;
       display: flex;
+      padding-left: 4px;
     }
 
     .channelLogo {
@@ -251,15 +254,22 @@
       line-height: 16px;
       letter-spacing: 0.01em;
       text-transform: uppercase;
-      color: rgba(61, 60, 64, 0.64);
+      color: rgba(63, 67, 80, 0.64);
       padding: 2px 6px 2px 0px;
+    }
+
+    .gmChannelCount {
+      background-color: rgba(63, 67, 80, 0.2);
+      padding: 0 5px;
+      border-radius: 2px;
+      margin-right: 2px;
     }
 
     .senderMessage div {
       text-align: left !important;
       font-size: 14px !important;
       line-height: 20px !important;
-      color: #3D3C40 !important;
+      color: #3F4350 !important;
       padding: 0px !important;
     }
 
@@ -316,13 +326,13 @@
 
 <body style="word-spacing:normal;">
   <div class="emailBody" style="">
-    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:8px;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:8px;">
         <tbody>
           <tr>
             <td style="direction:ltr;font-size:0px;padding:24px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -354,7 +364,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -383,13 +393,15 @@
                               <tr>
                                 <td align="center" vertical-align="middle" class="button" style="font-size:0px;padding:0px;word-break:break-word;">
                                   <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                    <tr>
-                                      <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                        <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                          {{.Props.Button}}
-                                        </a>
-                                      </td>
-                                    </tr>
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                          <a href="{{.Props.ButtonURL}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                            {{.Props.Button}}
+                                          </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
                                   </table>
                                 </td>
                               </tr>
@@ -403,7 +415,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -435,7 +447,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -459,7 +471,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>
@@ -500,13 +512,15 @@
                                       <tr>
                                         <td align="center" vertical-align="middle" class="appDownloadButton" style="font-size:0px;padding:12px 0px 0px 0px;word-break:break-word;">
                                           <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;line-height:100%;">
-                                            <tr>
-                                              <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
-                                                <a href="{{.Props.AppDownloadLink}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
-                                                  {{.Props.AppDownloadButton}}
-                                                </a>
-                                              </td>
-                                            </tr>
+                                            <tbody>
+                                              <tr>
+                                                <td align="center" bgcolor="#FFFFFF" role="presentation" style="border:none;border-radius:4px;cursor:auto;mso-padding-alt:10px 25px;background:#FFFFFF;" valign="middle">
+                                                  <a href="{{.Props.AppDownloadLink}}" style="display:inline-block;background:#FFFFFF;color:#ffffff;font-family:Open Sans, sans-serif;font-size:13px;font-weight:normal;line-height:120%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:4px;" target="_blank">
+                                                    {{.Props.AppDownloadButton}}
+                                                  </a>
+                                                </td>
+                                              </tr>
+                                            </tbody>
                                           </table>
                                         </td>
                                       </tr>
@@ -524,7 +538,7 @@
                   </tbody>
                 </table>
               </div>
-              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <!--[if mso | IE]></td></tr></table></td></tr><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:552px;" width="552" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
               <div style="margin:0px auto;max-width:552px;">
                 <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
                   <tbody>


### PR DESCRIPTION
#### Summary

Some email clients don't support the style element,
this commit changes `mjml-style` to generate inline styles instead of a
internal style-sheet.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35847

#### Release Note

```release-note
NONE
```
