### PR TITLE
MM-37934: supports channel override for CRT notifications

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1222,12 +1222,20 @@ func (a *App) UpdateChannelMemberNotifyProps(data map[string]string, channelID s
 		filteredProps[model.DesktopNotifyProp] = desktop
 	}
 
+	if desktop_threads, exists := data[model.DesktopThreadsNotifyProp]; exists {
+		filteredProps[model.DesktopThreadsNotifyProp] = desktop_threads
+	}
+
 	if email, exists := data[model.EmailNotifyProp]; exists {
 		filteredProps[model.EmailNotifyProp] = email
 	}
 
 	if push, exists := data[model.PushNotifyProp]; exists {
 		filteredProps[model.PushNotifyProp] = push
+	}
+
+	if push_threads, exists := data[model.PushThreadsNotifyProp]; exists {
+		filteredProps[model.PushThreadsNotifyProp] = push_threads
 	}
 
 	if ignoreChannelMentions, exists := data[model.IgnoreChannelMentionsNotifyProp]; exists {

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -156,6 +156,26 @@ func IsIgnoreChannelMentionsValid(ignoreChannelMentions string) bool {
 	return ignoreChannelMentions == IgnoreChannelMentionsOn || ignoreChannelMentions == IgnoreChannelMentionsOff || ignoreChannelMentions == IgnoreChannelMentionsDefault
 }
 
+func ShouldChannelMemberNotifyCRT(notifyProps StringMap, isMentioned bool) (bool, bool) {
+	notifyDesktop := false
+	notifyPush := false
+
+	desktop := notifyProps[DesktopNotifyProp]
+	push := notifyProps[PushNotifyProp]
+
+	desktopThreads := notifyProps[DesktopThreadsNotifyProp]
+	pushThreads := notifyProps[PushThreadsNotifyProp]
+
+	if desktop != ChannelNotifyNone && (isMentioned || desktopThreads == ChannelNotifyAll || desktop == ChannelNotifyAll) {
+	}
+
+	if push != ChannelNotifyNone && (isMentioned || pushThreads == ChannelNotifyAll || push == ChannelNotifyAll) {
+		notifyPush = true
+	}
+
+	return notifyDesktop, notifyPush
+}
+
 func GetDefaultChannelNotifyProps() StringMap {
 	return StringMap{
 		DesktopNotifyProp:               ChannelNotifyDefault,

--- a/model/user.go
+++ b/model/user.go
@@ -802,6 +802,33 @@ func (u *UserPatch) SetField(fieldName string, fieldValue string) {
 	}
 }
 
+func (u *User) ShouldNotifyCRT(isMentioned bool) (bool, bool, bool) {
+	notifyDesktop := false
+	notifyPush := false
+	notifyEmail := false
+
+	desktop := u.NotifyProps[DesktopNotifyProp]
+	push := u.NotifyProps[PushNotifyProp]
+	shouldEmail := u.NotifyProps[EmailNotifyProp] == "true"
+
+	desktopThreads := u.NotifyProps[DesktopThreadsNotifyProp]
+	emailThreads := u.NotifyProps[EmailThreadsNotifyProp]
+	pushThreads := u.NotifyProps[PushThreadsNotifyProp]
+
+	if desktop != UserNotifyNone && (isMentioned || desktopThreads == UserNotifyAll || desktop == UserNotifyAll) {
+	}
+
+	if shouldEmail && (isMentioned || emailThreads == UserNotifyAll) {
+		notifyEmail = true
+	}
+
+	if push != UserNotifyNone && (isMentioned || pushThreads == UserNotifyAll || push == UserNotifyAll) {
+		notifyPush = true
+	}
+
+	return notifyDesktop, notifyPush, notifyEmail
+}
+
 // HashPassword generates a hash using the bcrypt.GenerateFromPassword
 func HashPassword(password string) string {
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), 10)


### PR DESCRIPTION
#### Summary

Users with CRT 'ON' are enabled to override global CRT notification
settings per channel basis.
#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37934

#### Release Note

```release-note
NONE
```
