### PR TITLE
[MM-38761] API allows changing the name of the Town Square channel

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -337,6 +337,13 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if oldChannel.Name == model.DefaultChannelName {
+		if *patch.Name != "" && *patch.Name != oldChannel.Name {
+			c.Err = model.NewAppError("patchChannel", "api.channel.update_channel.tried.app_error", map[string]interface{}{"Channel": model.DefaultChannelName}, "", http.StatusBadRequest)
+			return
+		}
+	}
+
 	rchannel, appErr := c.App.PatchChannel(c.AppContext, oldChannel, patch, c.AppContext.Session().UserId)
 	if appErr != nil {
 		c.Err = appErr

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -182,8 +182,14 @@ func TestUpdateChannel(t *testing.T) {
 	require.Equal(t, private.Header, newPrivateChannel.Header, "Update failed for Header in private channel")
 	require.Equal(t, private.Purpose, newPrivateChannel.Purpose, "Update failed for Purpose in private channel")
 
-	// Test that changing the type fails and returns error
+	//Test updating default channel's name and returns error
+	defaultChannel, _ := th.App.GetChannelByName(model.DefaultChannelName, team.Id, false)
+	defaultChannel.Name = "testing"
+	_, resp, err = client.UpdateChannel(defaultChannel)
+	require.Error(t, err)
+	CheckBadRequestStatus(t, resp)
 
+	// Test that changing the type fails and returns error
 	private.Type = model.ChannelTypeOpen
 	_, resp, err = client.UpdateChannel(private)
 	require.Error(t, err)
@@ -250,6 +256,7 @@ func TestPatchChannel(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 	client := th.Client
+	team := th.BasicTeam
 
 	patch := &model.ChannelPatch{
 		Name:        new(string),
@@ -276,6 +283,16 @@ func TestPatchChannel(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, oldName, channel.Name, "should not have updated")
+
+	//Test updating default channel's name and returns error
+	defaultChannel, _ := th.App.GetChannelByName(model.DefaultChannelName, team.Id, false)
+	defaultChannelPatch := &model.ChannelPatch{
+		Name: new(string),
+	}
+	*defaultChannelPatch.Name = "testing"
+	_, resp, err := client.PatchChannel(defaultChannel.Id, defaultChannelPatch)
+	require.Error(t, err)
+	CheckBadRequestStatus(t, resp)
 
 	// Test GroupConstrained flag
 	patch.GroupConstrained = model.NewBool(true)


### PR DESCRIPTION
#### Summary
Fixing patch endpoint so you can no longer rename town square

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38761

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
