### PR TITLE
MM-38497: Fix Sentry crash in PostAction.Equals

### DIFF
--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -115,6 +115,14 @@ func (p *PostAction) Equals(input *PostAction) bool {
 	}
 
 	// Compare PostActionIntegration
+
+	// If input is nil, then return true is original is also nil.
+	// Else return false.
+	if input.Integration == nil {
+		return p.Integration == nil
+	}
+
+	// Both are unequal and not nil.
 	if p.Integration.URL != input.Integration.URL {
 		return false
 	}

--- a/model/integration_action.go
+++ b/model/integration_action.go
@@ -116,7 +116,7 @@ func (p *PostAction) Equals(input *PostAction) bool {
 
 	// Compare PostActionIntegration
 
-	// If input is nil, then return true is original is also nil.
+	// If input is nil, then return true if original is also nil.
 	// Else return false.
 	if input.Integration == nil {
 		return p.Integration == nil

--- a/model/integration_action_test.go
+++ b/model/integration_action_test.go
@@ -145,8 +145,7 @@ func TestPostActionIntegrationEquals(t *testing.T) {
 
 	t.Run("nil check", func(t *testing.T) {
 		pa1 := &PostAction{
-			Integration: &PostActionIntegration{
-			},
+			Integration: &PostActionIntegration{},
 		}
 
 		pa2 := &PostAction{

--- a/model/integration_action_test.go
+++ b/model/integration_action_test.go
@@ -142,4 +142,17 @@ func TestPostActionIntegrationEquals(t *testing.T) {
 		}
 		require.False(t, pa1.Equals(pa2))
 	})
+
+	t.Run("nil check", func(t *testing.T) {
+		pa1 := &PostAction{
+			Integration: &PostActionIntegration{
+			},
+		}
+
+		pa2 := &PostAction{
+			Integration: nil,
+		}
+
+		require.False(t, pa1.Equals(pa2))
+	})
 }


### PR DESCRIPTION
We check for nil pointer before moving ahead.

https://mattermost.atlassian.net/browse/MM-38497

```release-note
NONE
```
