### PR TITLE
Automated cherry pick of #18132

### DIFF
--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -339,6 +339,9 @@ func TestDiff(t *testing.T) {
 						"com.mattermost.nps": {
 							Enable: !defaultConfigGen().PluginSettings.PluginStates["com.mattermost.nps"].Enable,
 						},
+						"focalboard": {
+							Enable: true,
+						},
 						"playbooks": {
 							Enable: true,
 						},
@@ -368,6 +371,9 @@ func TestDiff(t *testing.T) {
 						"com.mattermost.newplugin": {
 							Enable: true,
 						},
+						"focalboard": {
+							Enable: true,
+						},
 						"playbooks": {
 							Enable: true,
 						},
@@ -389,6 +395,9 @@ func TestDiff(t *testing.T) {
 					Path:    "PluginSettings.PluginStates",
 					BaseVal: defaultConfigGen().PluginSettings.PluginStates,
 					ActualVal: map[string]*model.PluginState{
+						"focalboard": {
+							Enable: true,
+						},
 						"playbooks": {
 							Enable: true,
 						},

--- a/model/config.go
+++ b/model/config.go
@@ -2708,6 +2708,11 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates["com.mattermost.plugin-channel-export"] = &PluginState{Enable: true}
 	}
 
+	if s.PluginStates["focalboard"] == nil {
+		// Enable the focalboard plugin by default
+		s.PluginStates["focalboard"] = &PluginState{Enable: true}
+	}
+
 	if s.EnableMarketplace == nil {
 		s.EnableMarketplace = NewBool(PluginSettingsDefaultEnableMarketplace)
 	}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -378,6 +378,30 @@ func TestConfigDefaultChannelExportPluginState(t *testing.T) {
 	})
 }
 
+func TestConfigDefaultFocalboardPluginState(t *testing.T) {
+	t.Run("should enable Focalboard plugin by default", func(t *testing.T) {
+		c1 := Config{}
+		c1.SetDefaults()
+
+		assert.True(t, c1.PluginSettings.PluginStates["focalboard"].Enable)
+	})
+
+	t.Run("should not re-enable focalboard plugin after it has been disabled", func(t *testing.T) {
+		c1 := Config{
+			PluginSettings: PluginSettings{
+				PluginStates: map[string]*PluginState{
+					"focalboard": {
+						Enable: false,
+					},
+				},
+			},
+		}
+
+		c1.SetDefaults()
+		assert.False(t, c1.PluginSettings.PluginStates["focalboard"].Enable)
+	})
+}
+
 func TestTeamSettingsIsValidSiteNameEmpty(t *testing.T) {
 	c1 := Config{}
 	c1.SetDefaults()


### PR DESCRIPTION
Cherry pick of #18132 on release-6.0.

/cc  @sbishel

```release-note
NONE
```