### PR TITLE
MM-38508  CRT: DM notification missing the sender name

### DIFF
--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -174,7 +174,7 @@ func (a *App) getPushNotificationMessage(contentsConfig, postMessage string, exp
 	}
 
 	if contentsConfig == model.FullNotification {
-		if channelType == model.ChannelTypeDirect {
+		if channelType == model.ChannelTypeDirect && replyToThreadType != model.CommentsNotifyCRT {
 			return model.ClearMentionTags(postMessage)
 		}
 		return senderName + ": " + model.ClearMentionTags(postMessage)

--- a/app/notification_push_test.go
+++ b/app/notification_push_test.go
@@ -676,6 +676,12 @@ func TestGetPushNotificationMessage(t *testing.T) {
 			ChannelType:       model.ChannelTypeDirect,
 			ExpectedMessage:   "this is a message",
 		},
+		"full message, direct message channel, commented on CRT enabled thread": {
+			Message:           "this is a message",
+			replyToThreadType: model.CommentsNotifyCRT,
+			ChannelType:       model.ChannelTypeDirect,
+			ExpectedMessage:   "user: this is a message",
+		},
 		"generic message with channel, public channel, no mention": {
 			Message:                  "this is a message",
 			PushNotificationContents: model.GenericNotification,


### PR DESCRIPTION
#### Summary
Sender name is missing in the reply of a thread message.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38508

![Untitled](https://user-images.githubusercontent.com/3680799/138273258-3ccca37d-9969-4341-9692-ea7ac7c5a980.jpg)

![IMG_2326](https://user-images.githubusercontent.com/3680799/138273273-b620109a-aec7-4b4f-84bd-579f1c6fa4f8.jpg)


#### Release Note
```
NONE
```