### PR TITLE
Remove DND run debug log

### DIFF
--- a/app/status.go
+++ b/app/status.go
@@ -394,7 +394,6 @@ func (a *App) IsUserAway(lastActivityAt int64) bool {
 // UpdateDNDStatusOfUsers is a recurring task which is started when server starts
 // which unsets dnd status of users if needed and saves and broadcasts it
 func (a *App) UpdateDNDStatusOfUsers() {
-	mlog.Debug("UpdateDNDStatusOfUsers: scheduled run started")
 	statuses, err := a.UpdateExpiredDNDStatuses()
 	if err != nil {
 		mlog.Warn("Failed to fetch dnd statues from store", mlog.String("err", err.Error()))


### PR DESCRIPTION
This was being run every 5 minutes and unnecessarily clogs up
the logs. No other job makes a debug log before starting up.

```release-note
NONE
```
