### PR TITLE
MM-39420: Checks for presence of slice before index access.

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -601,16 +601,11 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 					a.sanitizeProfiles(userThread.Participants, false)
 					userThread.Post.SanitizeProps()
 
-					previewPost := post.GetPreviewPost()
-					if previewPost != nil {
-						previewedChannel, err := a.GetChannel(previewPost.Post.ChannelId)
-						if err != nil {
-							return nil, err
-						}
-						if previewedChannel != nil && !a.HasPermissionToReadChannel(uid, previewedChannel) && len(userThread.Post.Metadata.Embeds) > 0 {
-							userThread.Post.Metadata.Embeds[0].Data = nil
-						}
+					sanitizedPost, err := a.SanitizePostMetadataForUser(userThread.Post, uid)
+					if err != nil {
+						return nil, err
 					}
+					userThread.Post = sanitizedPost
 
 					payload, jsonErr := json.Marshal(userThread)
 					if jsonErr != nil {

--- a/app/notification.go
+++ b/app/notification.go
@@ -607,7 +607,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 						if err != nil {
 							return nil, err
 						}
-						if previewedChannel != nil && !a.HasPermissionToReadChannel(uid, previewedChannel) {
+						if previewedChannel != nil && !a.HasPermissionToReadChannel(uid, previewedChannel) && len(userThread.Post.Metadata.Embeds) > 0 {
 							userThread.Post.Metadata.Embeds[0].Data = nil
 						}
 					}

--- a/app/post.go
+++ b/app/post.go
@@ -737,7 +737,7 @@ func (a *App) publishWebsocketEventForPermalinkPost(post *model.Post, message *m
 
 	for _, cm := range channelMembers {
 		postForUser := post.Clone()
-		if !a.HasPermissionToReadChannel(cm.UserId, previewedChannel) {
+		if !a.HasPermissionToReadChannel(cm.UserId, previewedChannel) && len(postForUser.Metadata.Embeds) > 0 {
 			postForUser.Metadata.Embeds[0].Data = nil
 		}
 		messageCopy := message.Copy()

--- a/app/post.go
+++ b/app/post.go
@@ -721,24 +721,19 @@ func (a *App) publishWebsocketEventForPermalinkPost(post *model.Post, message *m
 		return false, err
 	}
 
-	previewedChannel, err := a.GetChannel(previewedPost.ChannelId)
-	if err != nil {
-		if err.StatusCode == http.StatusNotFound {
-			mlog.Warn("channel containing permalinked post not found", mlog.String("referenced_channel_id", previewedPost.ChannelId))
-			return false, nil
-		}
-		return false, err
-	}
-
 	channelMembers, err := a.GetChannelMembersPage(post.ChannelId, 0, 10000000)
 	if err != nil {
 		return false, err
 	}
 
 	for _, cm := range channelMembers {
-		postForUser := post.Clone()
-		if !a.HasPermissionToReadChannel(cm.UserId, previewedChannel) && len(postForUser.Metadata.Embeds) > 0 {
-			postForUser.Metadata.Embeds[0].Data = nil
+		postForUser, err := a.SanitizePostMetadataForUser(post, cm.UserId)
+		if err != nil {
+			if err.StatusCode == http.StatusNotFound {
+				mlog.Warn("channel containing permalinked post not found", mlog.String("referenced_channel_id", previewedPost.ChannelId))
+				return false, nil
+			}
+			return false, err
 		}
 		messageCopy := message.Copy()
 		broadcastCopy := messageCopy.GetBroadcast()

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -177,7 +177,7 @@ func (a *App) SanitizePostMetadataForUser(post *model.Post, userID string) (*mod
 		return nil, err
 	}
 
-	if previewedChannel != nil && !a.HasPermissionToReadChannel(userID, previewedChannel) && len(post.Metadata.Embeds) > 0 {
+	if previewedChannel != nil && !a.HasPermissionToReadChannel(userID, previewedChannel) {
 		post = post.Clone()
 		post.Metadata.Embeds[0].Data = nil
 	}

--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -177,7 +177,7 @@ func (a *App) SanitizePostMetadataForUser(post *model.Post, userID string) (*mod
 		return nil, err
 	}
 
-	if previewedChannel != nil && !a.HasPermissionToReadChannel(userID, previewedChannel) {
+	if previewedChannel != nil && !a.HasPermissionToReadChannel(userID, previewedChannel) && len(post.Metadata.Embeds) > 0 {
 		post = post.Clone()
 		post.Metadata.Embeds[0].Data = nil
 	}


### PR DESCRIPTION
#### Summary

Checks for presence of slice before index access.

TODO:

* [ ] Test `(*App).SendNotifications`
* [ ] Test `(*App).SanitizePostMetadataForUser`

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39420

#### Release Note

```release-note
Fixes bug caused by accessing an empty slice by index.
```
