### PR TITLE
[MM-39448] Remove command arguments from auditCommandArgs

### DIFF
--- a/model/auditconv.go
+++ b/model/auditconv.go
@@ -4,6 +4,8 @@
 package model
 
 import (
+	"strings"
+
 	"github.com/francoispqt/gojay"
 )
 
@@ -268,7 +270,10 @@ func newAuditCommandArgs(ca *CommandArgs) auditCommandArgs {
 		cmdargs.ChannelID = ca.ChannelId
 		cmdargs.TeamID = ca.TeamId
 		cmdargs.TriggerID = ca.TriggerId
-		cmdargs.Command = ca.Command
+		cmdFields := strings.Fields(ca.Command)
+		if len(cmdFields) > 0 {
+			cmdargs.Command = cmdFields[0]
+		}
 	}
 	return cmdargs
 }

--- a/model/auditconv_test.go
+++ b/model/auditconv_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type Sample struct {
@@ -50,6 +51,48 @@ func TestAuditModelTypeConv(t *testing.T) {
 			if !tt.wantConverted {
 				assert.Equal(t, tt.wantNewVal, gotNewVal)
 			}
+		})
+	}
+}
+
+func TestAuditModelTypeConvCommandArgs(t *testing.T) {
+	tcs := []struct {
+		name            string
+		input           CommandArgs
+		expectedCommand string
+	}{
+		{
+			name:            "empty input",
+			input:           CommandArgs{},
+			expectedCommand: "",
+		},
+		{
+			name: "no arguments",
+			input: CommandArgs{
+				Command: "/command",
+			},
+			expectedCommand: "/command",
+		},
+		{
+			name: "some arguments",
+			input: CommandArgs{
+				Command: "/command --test test --test2 test",
+			},
+			expectedCommand: "/command",
+		},
+		{
+			name: "with multiple spaces and tabs",
+			input: CommandArgs{
+				Command: "/command		--test test --test2 test",
+			},
+			expectedCommand: "/command",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			args := newAuditCommandArgs(&tc.input)
+			require.Equal(t, tc.expectedCommand, args.Command)
 		})
 	}
 }


### PR DESCRIPTION
#### Summary

Removing command arguments from `auditCommandArgs`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39448

#### Release Note

```release-note
NONE
```
