### PR TITLE
Support darwin arm64 builds.

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -212,6 +212,8 @@ type ManifestExecutables struct {
 	LinuxAmd64 string `json:"linux-amd64,omitempty" yaml:"linux-amd64,omitempty"`
 	// DarwinAmd64 is the path to your executable binary for the corresponding platform
 	DarwinAmd64 string `json:"darwin-amd64,omitempty" yaml:"darwin-amd64,omitempty"`
+	// DarwinArm64 is the path to your executable binary for the corresponding platform
+	DarwinArm64 string `json:"darwin-arm64,omitempty" yaml:"darwin-arm64,omitempty"`
 	// WindowsAmd64 is the path to your executable binary for the corresponding platform
 	// This file must have a ".exe" extension
 	WindowsAmd64 string `json:"windows-amd64,omitempty" yaml:"windows-amd64,omitempty"`


### PR DESCRIPTION
#### Summary

Adds support for building plugins to target darwin arm64 systems. This will allow plugins to do the following:

```diff
diff --git a/Makefile b/Makefile
index ca7f0bf..ef84135 100644
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ ifneq ($(HAS_SERVER),)
 	mkdir -p server/dist;
 	cd server && env GOOS=linux GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-linux-amd64;
 	cd server && env GOOS=darwin GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-darwin-amd64;
+	cd server && env GOOS=darwin GOARCH=arm64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-darwin-arm64;
 	cd server && env GOOS=windows GOARCH=amd64 $(GO) build $(GO_BUILD_FLAGS) -o dist/plugin-windows-amd64.exe;
 endif
 
diff --git a/plugin.json b/plugin.json
index d0993cf..617e462 100644
--- a/plugin.json
+++ b/plugin.json
@@ -11,6 +11,7 @@
     "executables": {
       "linux-amd64": "server/dist/plugin-linux-amd64",
       "darwin-amd64": "server/dist/plugin-darwin-amd64",
+      "darwin-arm64": "server/dist/plugin-darwin-arm64",
       "windows-amd64": "server/dist/plugin-windows-amd64.exe"
     }
   },
```

#### Ticket Link

n/a

#### Release Note

```release-note
Added the ability to build plugins targeting darwin arm64 systems (ie Apple M1).
```
