### PR TITLE
[MM-39630] - Migrate from gorp to sqlx in store/sqlstore/tokens_store.go

### DIFF
--- a/store/sqlstore/tokens_store.go
+++ b/store/sqlstore/tokens_store.go
@@ -39,24 +39,31 @@ func (s SqlTokenStore) Save(token *model.Token) error {
 	if err := token.IsValid(); err != nil {
 		return err
 	}
-
-	if err := s.GetMaster().Insert(token); err != nil {
+	query, args, err := s.getQueryBuilder().
+		Insert("Tokens").
+		Columns("Token", "CreateAt", "Type", "Extra").
+		Values(token.Token, token.CreateAt, token.Type, token.Extra).
+		ToSql()
+	if err != nil {
+		return errors.Wrap(err, "token_tosql")
+	}
+	if _, err := s.GetMasterX().Exec(query, args...); err != nil {
 		return errors.Wrap(err, "failed to save Token")
 	}
 	return nil
 }
 
 func (s SqlTokenStore) Delete(token string) error {
-	if _, err := s.GetMaster().Exec("DELETE FROM Tokens WHERE Token = :Token", map[string]interface{}{"Token": token}); err != nil {
+	if _, err := s.GetMasterX().Exec("DELETE FROM Tokens WHERE Token = ?", token); err != nil {
 		return errors.Wrapf(err, "failed to delete Token with value %s", token)
 	}
 	return nil
 }
 
 func (s SqlTokenStore) GetByToken(tokenString string) (*model.Token, error) {
-	token := &model.Token{}
+	var token model.Token
 
-	if err := s.GetReplica().SelectOne(token, "SELECT * FROM Tokens WHERE Token = :Token", map[string]interface{}{"Token": tokenString}); err != nil {
+	if err := s.GetReplicaX().Get(&token, "SELECT * FROM Tokens WHERE Token = ", tokenString); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Token", fmt.Sprintf("Token=%s", tokenString))
 		}
@@ -64,32 +71,36 @@ func (s SqlTokenStore) GetByToken(tokenString string) (*model.Token, error) {
 		return nil, errors.Wrapf(err, "failed to get Token with value %s", tokenString)
 	}
 
-	return token, nil
+	return &token, nil
 }
 
 func (s SqlTokenStore) Cleanup() {
 	mlog.Debug("Cleaning up token store.")
 	deltime := model.GetMillis() - model.MaxTokenExipryTime
-	if _, err := s.GetMaster().Exec("DELETE FROM Tokens WHERE CreateAt < :DelTime", map[string]interface{}{"DelTime": deltime}); err != nil {
+	if _, err := s.GetMasterX().Exec("DELETE FROM Tokens WHERE CreateAt < ?", deltime); err != nil {
 		mlog.Error("Unable to cleanup token store.")
 	}
 }
 
 func (s SqlTokenStore) GetAllTokensByType(tokenType string) ([]*model.Token, error) {
 	tokens := []*model.Token{}
-	query, args, err := s.getQueryBuilder().Select("*").From("Tokens").Where(sq.Eq{"Type": tokenType}).ToSql()
+	query, args, err := s.getQueryBuilder().
+		Select("*").
+		From("Tokens").
+		Where(sq.Eq{"Type": tokenType}).
+		ToSql()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not build sql query to get all tokens by type")
 	}
 
-	if _, err := s.GetReplica().Select(&tokens, query, args...); err != nil {
+	if err := s.GetReplicaX().Select(&tokens, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to get all tokens of Type=%s", tokenType)
 	}
 	return tokens, nil
 }
 
 func (s SqlTokenStore) RemoveAllTokensByType(tokenType string) error {
-	if _, err := s.GetMaster().Exec("DELETE FROM Tokens WHERE Type = :TokenType", map[string]interface{}{"TokenType": tokenType}); err != nil {
+	if _, err := s.GetMasterX().Exec("DELETE FROM Tokens WHERE Type = ?", tokenType); err != nil {
 		return errors.Wrapf(err, "failed to remove all Tokens with Type=%s", tokenType)
 	}
 	return nil

--- a/store/sqlstore/tokens_store.go
+++ b/store/sqlstore/tokens_store.go
@@ -63,7 +63,7 @@ func (s SqlTokenStore) Delete(token string) error {
 func (s SqlTokenStore) GetByToken(tokenString string) (*model.Token, error) {
 	var token model.Token
 
-	if err := s.GetReplicaX().Get(&token, "SELECT * FROM Tokens WHERE Token = ", tokenString); err != nil {
+	if err := s.GetReplicaX().Get(&token, "SELECT * FROM Tokens WHERE Token = ?", tokenString); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Token", fmt.Sprintf("Token=%s", tokenString))
 		}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Migrate from `gorp` to `sqlx` in `store/sqlstore/tokens_store.go`
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #18868 
JIRA - https://mattermost.atlassian.net/browse/MM-39630
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
