### PR TITLE
[MM-39503] - Remove DownloadApps Feature Flag

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -44,9 +44,6 @@ type FeatureFlags struct {
 	// Enable different treatments for first time users, possible values = ("none", "tour_point", "around_input")
 	PrewrittenMessages string
 
-	// Enable different treatments for first time users, possible values = ("none", "tips_and_next_steps")
-	DownloadAppsCTA string
-
 	// Determine whether when a user gets created, they'll have noisy notifications e.g. Send desktop notifications for all activity
 	NewAccountNoisy bool
 	// Enable Boards Unfurl Preview
@@ -78,7 +75,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.GlobalHeader = true
 	f.AddChannelButton = "by_team_name"
 	f.PrewrittenMessages = "tour_point"
-	f.DownloadAppsCTA = "tips_and_next_steps"
 	f.NewAccountNoisy = false
 	f.BoardsUnfurl = true
 	f.CallsMobile = false


### PR DESCRIPTION
#### Summary
This PR removes DownloadAppsCTA from FeatureFlags model

#### Ticket Link
[MM-39503](https://mattermost.atlassian.net/browse/MM-39503)

#### Release Note

```release-note
Removed the DownloadAppsCTA feature flag

```
