### PR TITLE
Remove job server dependency searchengine

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -316,8 +316,8 @@ func NewServer(options ...Option) (*Server, error) {
 	}
 	model.AppErrorInit(i18n.T)
 
-	searchEngine := searchengine.NewBroker(s.Config(), s.Jobs)
-	bleveEngine := bleveengine.NewBleveEngine(s.Config(), s.Jobs)
+	searchEngine := searchengine.NewBroker(s.Config())
+	bleveEngine := bleveengine.NewBleveEngine(s.Config())
 	if err := bleveEngine.Start(); err != nil {
 		return nil, err
 	}

--- a/services/searchengine/bleveengine/bleve.go
+++ b/services/searchengine/bleveengine/bleve.go
@@ -17,7 +17,6 @@ import (
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
 	"github.com/blevesearch/bleve/v2/mapping"
 
-	"github.com/mattermost/mattermost-server/v6/jobs"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
@@ -38,7 +37,6 @@ type BleveEngine struct {
 	Mutex        sync.RWMutex
 	ready        int32
 	cfg          *model.Config
-	jobServer    *jobs.JobServer
 	indexSync    bool
 }
 
@@ -120,10 +118,9 @@ func getUserIndexMapping() *mapping.IndexMappingImpl {
 	return indexMapping
 }
 
-func NewBleveEngine(cfg *model.Config, jobServer *jobs.JobServer) *BleveEngine {
+func NewBleveEngine(cfg *model.Config) *BleveEngine {
 	return &BleveEngine{
-		cfg:       cfg,
-		jobServer: jobServer,
+		cfg: cfg,
 	}
 }
 

--- a/services/searchengine/bleveengine/bleve_test.go
+++ b/services/searchengine/bleveengine/bleve_test.go
@@ -60,10 +60,10 @@ func (s *BleveEngineTestSuite) setupStore() {
 	cfg.BleveSettings.IndexDir = model.NewString(s.IndexDir)
 	cfg.SqlSettings.DisableDatabaseSearch = model.NewBool(true)
 
-	s.SearchEngine = searchengine.NewBroker(cfg, nil)
+	s.SearchEngine = searchengine.NewBroker(cfg)
 	s.Store = searchlayer.NewSearchLayer(&testlib.TestStore{Store: s.SQLStore}, s.SearchEngine, cfg)
 
-	s.BleveEngine = NewBleveEngine(cfg, nil)
+	s.BleveEngine = NewBleveEngine(cfg)
 	s.BleveEngine.indexSync = true
 	s.SearchEngine.RegisterBleveEngine(s.BleveEngine)
 	if err := s.BleveEngine.Start(); err != nil {

--- a/services/searchengine/bleveengine/indexer/indexing_job_test.go
+++ b/services/searchengine/bleveengine/indexer/indexing_job_test.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mattermost/mattermost-server/v6/jobs"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/services/searchengine/bleveengine"
 	"github.com/mattermost/mattermost-server/v6/store/storetest"
+	"github.com/mattermost/mattermost-server/v6/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,12 +47,20 @@ func TestBleveIndexer(t *testing.T) {
 			},
 		}
 
+		jobServer := &jobs.JobServer{
+			Store: mockStore,
+			ConfigService: &testutils.StaticConfigService{
+				Cfg: cfg,
+			},
+		}
+
 		bleveEngine := bleveengine.NewBleveEngine(cfg)
 		aErr := bleveEngine.Start()
 		require.Nil(t, aErr)
 
 		worker := &BleveIndexerWorker{
-			engine: bleveEngine,
+			jobServer: jobServer,
+			engine:    bleveEngine,
 		}
 
 		worker.DoJob(job)

--- a/services/searchengine/bleveengine/indexer/indexing_job_test.go
+++ b/services/searchengine/bleveengine/indexer/indexing_job_test.go
@@ -9,11 +9,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mattermost/mattermost-server/v6/jobs"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/services/searchengine/bleveengine"
 	"github.com/mattermost/mattermost-server/v6/store/storetest"
-	"github.com/mattermost/mattermost-server/v6/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,20 +45,12 @@ func TestBleveIndexer(t *testing.T) {
 			},
 		}
 
-		jobServer := &jobs.JobServer{
-			Store: mockStore,
-			ConfigService: &testutils.StaticConfigService{
-				Cfg: cfg,
-			},
-		}
-
-		bleveEngine := bleveengine.NewBleveEngine(cfg, jobServer)
+		bleveEngine := bleveengine.NewBleveEngine(cfg)
 		aErr := bleveEngine.Start()
 		require.Nil(t, aErr)
 
 		worker := &BleveIndexerWorker{
-			jobServer: jobServer,
-			engine:    bleveEngine,
+			engine: bleveEngine,
 		}
 
 		worker.DoJob(job)

--- a/services/searchengine/searchengine.go
+++ b/services/searchengine/searchengine.go
@@ -4,14 +4,12 @@
 package searchengine
 
 import (
-	"github.com/mattermost/mattermost-server/v6/jobs"
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
-func NewBroker(cfg *model.Config, jobServer *jobs.JobServer) *Broker {
+func NewBroker(cfg *model.Config) *Broker {
 	return &Broker{
-		cfg:       cfg,
-		jobServer: jobServer,
+		cfg: cfg,
 	}
 }
 
@@ -25,7 +23,6 @@ func (seb *Broker) RegisterBleveEngine(be SearchEngineInterface) {
 
 type Broker struct {
 	cfg                 *model.Config
-	jobServer           *jobs.JobServer
 	ElasticsearchEngine SearchEngineInterface
 	BleveEngine         SearchEngineInterface
 }

--- a/services/telemetry/telemetry_test.go
+++ b/services/telemetry/telemetry_test.go
@@ -179,7 +179,7 @@ func TestEnsureTelemetryID(t *testing.T) {
 
 		testLogger, _ := mlog.NewLogger()
 
-		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg, nil), testLogger)
+		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger)
 		assert.Equal(t, "test", telemetryService.TelemetryID)
 
 		telemetryService.ensureTelemetryID()
@@ -212,7 +212,7 @@ func TestEnsureTelemetryID(t *testing.T) {
 
 		testLogger, _ := mlog.NewLogger()
 
-		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg, nil), testLogger)
+		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger)
 		assert.Equal(t, generatedID, telemetryService.TelemetryID)
 	})
 
@@ -232,7 +232,7 @@ func TestEnsureTelemetryID(t *testing.T) {
 
 		testLogger, _ := mlog.NewLogger()
 
-		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg, nil), testLogger)
+		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger)
 		assert.Equal(t, "", telemetryService.TelemetryID)
 	})
 }
@@ -357,7 +357,7 @@ func TestRudderTelemetry(t *testing.T) {
 	}
 	defer testLogger.Shutdown()
 
-	telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg, nil), testLogger)
+	telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger)
 	telemetryService.TelemetryID = telemetryID
 	telemetryService.rudderClient = nil
 	telemetryService.initRudder(server.URL, RudderKey)

--- a/store/searchlayer/layer_test.go
+++ b/store/searchlayer/layer_test.go
@@ -29,7 +29,7 @@ func TestUpdateConfigRace(t *testing.T) {
 	cfg := &model.Config{}
 	cfg.SetDefaults()
 	cfg.ClusterSettings.MaxIdleConns = model.NewInt(1)
-	searchEngine := searchengine.NewBroker(cfg, nil)
+	searchEngine := searchengine.NewBroker(cfg)
 	layer := searchlayer.NewSearchLayer(&testlib.TestStore{Store: store}, searchEngine, cfg)
 	var wg sync.WaitGroup
 

--- a/testlib/helper.go
+++ b/testlib/helper.go
@@ -102,7 +102,7 @@ func (h *MainHelper) setupStore(withReadReplica bool) {
 	config := &model.Config{}
 	config.SetDefaults()
 
-	h.SearchEngine = searchengine.NewBroker(config, nil)
+	h.SearchEngine = searchengine.NewBroker(config)
 	h.ClusterInterface = &FakeClusterInterface{}
 	h.SQLStore = sqlstore.New(*h.Settings, nil)
 	h.Store = searchlayer.NewSearchLayer(&TestStore{


### PR DESCRIPTION
The job server field was not being used. We remove it
as part of a cleanup of server initialization refactor.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4?c=8a171d5e-4398-4bc9-8fbf-8b9b14f37069

```release-note
NONE
```
