### PR TITLE
Automated cherry pick of #18840

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -728,7 +728,7 @@ func (wc *WebConn) shouldSendEvent(msg *model.WebSocketEvent) bool {
 		}
 
 		if wc.allChannelMembers == nil {
-			result, err := wc.App.Srv().Store.Channel().GetAllChannelMembersForUser(wc.UserId, true, false)
+			result, err := wc.App.Srv().Store.Channel().GetAllChannelMembersForUser(wc.UserId, false, false)
 			if err != nil {
 				mlog.Error("webhub.shouldSendEvent.", mlog.Err(err))
 				return false


### PR DESCRIPTION
Cherry pick of #18840 on release-6.1.

/cc  @lieut-data

```release-note
NONE
```