### PR TITLE
MM-39804 - Remove license expiration checks for cloud

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -1755,6 +1755,11 @@ func (s *Server) doLicenseExpirationCheck() {
 		return
 	}
 
+	if *license.Features.Cloud { {
+		mlog.Debug("Skipping license expiration check for Cloud")
+		return
+	}
+
 	users, err := s.Store.User().GetSystemAdminProfiles()
 	if err != nil {
 		mlog.Error("Failed to get system admins for license expired message from Mattermost.")

--- a/app/server.go
+++ b/app/server.go
@@ -1755,7 +1755,7 @@ func (s *Server) doLicenseExpirationCheck() {
 		return
 	}
 
-	if *license.Features.Cloud { {
+	if *license.Features.Cloud {
 		mlog.Debug("Skipping license expiration check for Cloud")
 		return
 	}


### PR DESCRIPTION
#### Summary
Cloud workspaces are on a monthly subscription where the license expiration does not apply. They do not need to renew or update a license so they should not get prompted to renew. 

This PR checks if the license if for `cloud` and if so, it will skip the license expiration checks and avoid sending the renew now email to admins.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39804

#### Related Pull Requests

Webapp changes: https://github.com/mattermost/mattermost-webapp/pull/9318

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
