### PR TITLE
Automated cherry pick of #18826

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -601,16 +601,11 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 					a.sanitizeProfiles(userThread.Participants, false)
 					userThread.Post.SanitizeProps()
 
-					previewPost := post.GetPreviewPost()
-					if previewPost != nil {
-						previewedChannel, err := a.GetChannel(previewPost.Post.ChannelId)
-						if err != nil {
-							return nil, err
-						}
-						if previewedChannel != nil && !a.HasPermissionToReadChannel(uid, previewedChannel) {
-							userThread.Post.Metadata.Embeds[0].Data = nil
-						}
+					sanitizedPost, err := a.SanitizePostMetadataForUser(userThread.Post, uid)
+					if err != nil {
+						return nil, err
 					}
+					userThread.Post = sanitizedPost
 
 					payload, jsonErr := json.Marshal(userThread)
 					if jsonErr != nil {

--- a/app/post.go
+++ b/app/post.go
@@ -721,24 +721,19 @@ func (a *App) publishWebsocketEventForPermalinkPost(post *model.Post, message *m
 		return false, err
 	}
 
-	previewedChannel, err := a.GetChannel(previewedPost.ChannelId)
-	if err != nil {
-		if err.StatusCode == http.StatusNotFound {
-			mlog.Warn("channel containing permalinked post not found", mlog.String("referenced_channel_id", previewedPost.ChannelId))
-			return false, nil
-		}
-		return false, err
-	}
-
 	channelMembers, err := a.GetChannelMembersPage(post.ChannelId, 0, 10000000)
 	if err != nil {
 		return false, err
 	}
 
 	for _, cm := range channelMembers {
-		postForUser := post.Clone()
-		if !a.HasPermissionToReadChannel(cm.UserId, previewedChannel) {
-			postForUser.Metadata.Embeds[0].Data = nil
+		postForUser, err := a.SanitizePostMetadataForUser(post, cm.UserId)
+		if err != nil {
+			if err.StatusCode == http.StatusNotFound {
+				mlog.Warn("channel containing permalinked post not found", mlog.String("referenced_channel_id", previewedPost.ChannelId))
+				return false, nil
+			}
+			return false, err
 		}
 		messageCopy := message.Copy()
 		broadcastCopy := messageCopy.GetBroadcast()


### PR DESCRIPTION
Cherry pick of #18826 on release-6.1.

/cc  @mkraft

```release-note
NONE
```