### PR TITLE
MM-39928: Fix for: MaximumPluginFileSize is too small after adding arm64 target

### DIFF
--- a/api4/plugin.go
+++ b/api4/plugin.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	MaximumPluginFileSize = 50 * 1024 * 1024
+	MaximumPluginFileSize = 75 * 1024 * 1024
 )
 
 func (api *API) InitPlugin() {


### PR DESCRIPTION
#### Summary
- When adding the arm64 target, the Playbooks plugin bundle crosses the 50MB threshold (51MB). Increase the upload file limit for us and other plugins that will run into this in the future.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-39928
 
#### Release Note

-->
```release-note
NONE
```
