### PR TITLE
MM-39341: Sentry crash: nil dereference in *User.ClearNonProfileFields

### DIFF
--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -460,7 +460,9 @@ func (s *SqlThreadStore) GetThreadForUser(teamId string, threadMembership *model
 				break
 			}
 		}
-		participants = append(participants, participant)
+		if participant != nil {
+			participants = append(participants, participant)
+		}
 	}
 
 	result := &model.ThreadResponse{

--- a/store/storetest/thread_store.go
+++ b/store/storetest/thread_store.go
@@ -451,6 +451,25 @@ func testThreadStorePopulation(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 		require.Equal(t, int64(0), th.UnreadReplies)
 	})
+
+	t.Run("Empty participantID should not appear in thread response", func(t *testing.T) {
+		newPosts := makeSomePosts()
+		opts := store.ThreadMembershipOpts{
+			Following:             true,
+			IncrementMentions:     false,
+			UpdateFollowing:       true,
+			UpdateViewedTimestamp: false,
+			UpdateParticipants:    true,
+		}
+		m, err := ss.Thread().MaintainMembership("", newPosts[0].Id, opts)
+		require.NoError(t, err)
+		m.UserId = newPosts[0].UserId
+		th, err := ss.Thread().GetThreadForUser("", m, true)
+		require.NoError(t, err)
+		for _, user := range th.Participants {
+			require.NotNil(t, user)
+		}
+	})
 }
 
 func testThreadSQLOperations(t *testing.T, ss store.Store, s SqlStore) {


### PR DESCRIPTION
In some cases, an invalid participant id like an empty string
might creep into the database. It's not exactly clear
how can this happen, but if it does, then it breaks the logic
of assuming that the users slice will contain all users
in the participants slice.

To prevent this, we check if a match was found before
adding it in the slice.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4/7sixm4t7c6rsr3d8ydxbtfgy9gr

```release-note
NONE
```