### PR TITLE
MM-40003 Fix patch route for Town Square

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -339,7 +339,7 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if oldChannel.Name == model.DefaultChannelName {
-		if *patch.Name != "" && *patch.Name != oldChannel.Name {
+		if patch.Name != nil && *patch.Name != oldChannel.Name {
 			c.Err = model.NewAppError("patchChannel", "api.channel.update_channel.tried.app_error", map[string]interface{}{"Channel": model.DefaultChannelName}, "", http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
https://github.com/mattermost/mattermost-server/pull/18531 introduced an accidental bug where you couldn't use the patch endpoint for the Town Square without specifying a channel name, so the endpoint couldn't be used to update the `Channel.Description` field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40003

#### Release Note
```release-note
NONE
```
