### PR TITLE
[MM-39374] Remove DesktopLatestVersion and DesktopMinVersion

### DIFF
--- a/api4/system.go
+++ b/api4/system.go
@@ -129,8 +129,6 @@ func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {
 	s[model.STATUS] = model.StatusOk
 	s["AndroidLatestVersion"] = reqs.AndroidLatestVersion
 	s["AndroidMinVersion"] = reqs.AndroidMinVersion
-	s["DesktopLatestVersion"] = reqs.DesktopLatestVersion
-	s["DesktopMinVersion"] = reqs.DesktopMinVersion
 	s["IosLatestVersion"] = reqs.IosLatestVersion
 	s["IosMinVersion"] = reqs.IosMinVersion
 

--- a/config/client.go
+++ b/config/client.go
@@ -229,8 +229,6 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 
 	props["AndroidLatestVersion"] = c.ClientRequirements.AndroidLatestVersion
 	props["AndroidMinVersion"] = c.ClientRequirements.AndroidMinVersion
-	props["DesktopLatestVersion"] = c.ClientRequirements.DesktopLatestVersion
-	props["DesktopMinVersion"] = c.ClientRequirements.DesktopMinVersion
 	props["IosLatestVersion"] = c.ClientRequirements.IosLatestVersion
 	props["IosMinVersion"] = c.ClientRequirements.IosMinVersion
 

--- a/model/config.go
+++ b/model/config.go
@@ -1978,8 +1978,6 @@ func (s *TeamSettings) SetDefaults() {
 type ClientRequirements struct {
 	AndroidLatestVersion string `access:"write_restrictable,cloud_restrictable"`
 	AndroidMinVersion    string `access:"write_restrictable,cloud_restrictable"`
-	DesktopLatestVersion string `access:"write_restrictable,cloud_restrictable"`
-	DesktopMinVersion    string `access:"write_restrictable,cloud_restrictable"`
 	IosLatestVersion     string `access:"write_restrictable,cloud_restrictable"`
 	IosMinVersion        string `access:"write_restrictable,cloud_restrictable"`
 }

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -462,8 +462,6 @@ func (ts *TelemetryService) trackConfig() {
 	ts.sendTelemetry(TrackConfigClientReq, map[string]interface{}{
 		"android_latest_version": cfg.ClientRequirements.AndroidLatestVersion,
 		"android_min_version":    cfg.ClientRequirements.AndroidMinVersion,
-		"desktop_latest_version": cfg.ClientRequirements.DesktopLatestVersion,
-		"desktop_min_version":    cfg.ClientRequirements.DesktopMinVersion,
 		"ios_latest_version":     cfg.ClientRequirements.IosLatestVersion,
 		"ios_min_version":        cfg.ClientRequirements.IosMinVersion,
 	})

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -83,8 +83,6 @@
     "ClientRequirements": {
         "AndroidLatestVersion": "",
         "AndroidMinVersion": "",
-        "DesktopLatestVersion": "",
-        "DesktopMinVersion": "",
         "IosLatestVersion": "",
         "IosMinVersion": ""
     },


### PR DESCRIPTION
#### Summary
`DesktopMinVersion` and `DesktopLatestVersion` are config items that don't do anything. Since they were never finished, we've elected to remove them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39374

#### Release Note
```release-note
Removed DesktopLatestVersion and DesktopMinVersion config items
```
