### PR TITLE
[MM-40167] Check for file deleted before download

### DIFF
--- a/api4/file.go
+++ b/api4/file.go
@@ -483,6 +483,10 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
+	if info.DeleteAt != 0 {
+		c.Err = model.NewAppError("getFile", "api.file.get_file.no_file.app_error", nil, "file_id="+info.Id, http.StatusNotFound)
+	}
+
 	auditRec.AddMeta("file", info)
 
 	if info.CreatorId != c.AppContext.Session().UserId && !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), info.PostId, model.PermissionReadChannel) {

--- a/api4/file.go
+++ b/api4/file.go
@@ -485,6 +485,7 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	if info.DeleteAt != 0 {
 		c.Err = model.NewAppError("getFile", "api.file.get_file.no_file.app_error", nil, "file_id="+info.Id, http.StatusNotFound)
+		return
 	}
 
 	auditRec.AddMeta("file", info)

--- a/api4/file.go
+++ b/api4/file.go
@@ -483,12 +483,13 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
+
+	auditRec.AddMeta("file", info)
+
 	if info.DeleteAt != 0 {
 		c.Err = model.NewAppError("getFile", "api.file.get_file.no_file.app_error", nil, "file_id="+info.Id, http.StatusNotFound)
 		return
 	}
-
-	auditRec.AddMeta("file", info)
 
 	if info.CreatorId != c.AppContext.Session().UserId && !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), info.PostId, model.PermissionReadChannel) {
 		c.SetPermissionError(model.PermissionReadChannel)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1718,6 +1718,10 @@
     "translation": "Unable to get the file size."
   },
   {
+    "id": "api.file.get_file.no_file.app_error",
+    "translation": "File not found"
+  },
+  {
     "id": "api.file.get_file.public_invalid.app_error",
     "translation": "The public link does not appear to be valid."
   },


### PR DESCRIPTION
#### Summary

Trying to access a soft-deleted file should end in a 404 not found

<img width="499" alt="Screen Shot 2021-11-18 at 14 34 26" src="https://user-images.githubusercontent.com/1515906/142425058-f30dd139-8edc-4aa3-8405-e8087fad62b2.png">

#### Ticket Link
[MM-40167](https://mattermost.atlassian.net/browse/MM-40167)

#### Release Note
```release-note
Prevented downloading a file when the post that was attached to was deleted
```
