### PR TITLE
Change default log rotation size to 100MB 

### DIFF
--- a/config/logger.go
+++ b/config/logger.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	LogRotateSize           = 10000
+	LogRotateSize           = 100
 	LogCompress             = true
 	LogRotateMaxAge         = 0
 	LogRotateMaxBackups     = 0

--- a/config/logger.go
+++ b/config/logger.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	LogRotateSize           = 100
+	LogRotateSizeMB         = 100
 	LogCompress             = true
 	LogRotateMaxAge         = 0
 	LogRotateMaxBackups     = 0
@@ -211,6 +211,6 @@ func makePlainFormatOptions(enableColor bool) json.RawMessage {
 
 func makeFileOptions(filename string) json.RawMessage {
 	str := fmt.Sprintf(`{"filename": "%s", "max_size": %d, "max_age": %d, "max_backups": %d, "compress": %t}`,
-		filename, LogRotateSize, LogRotateMaxAge, LogRotateMaxBackups, LogCompress)
+		filename, LogRotateSizeMB, LogRotateMaxAge, LogRotateMaxBackups, LogCompress)
 	return json.RawMessage(str)
 }


### PR DESCRIPTION
#### Summary
The default log rotation size was mistakenly set to 10GB for V6.  The rotation size is supposed to be specified in megabytes but I think the default was mistakenly changed thinking it was KB.

This PR reverts the default to 100MB. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40191

#### Release Note
```release-note
Default log rotation file size was mistakenly set to 10GB for V6, and is now reverted back to 100MB.
```
