### PR TITLE
Convert URLs to fully-qualified for HTTP redirects

### DIFF
--- a/web/oauth.go
+++ b/web/oauth.go
@@ -289,6 +289,7 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 			hasRedirectURL = redirectURL != ""
 		}
 	}
+	redirectURL = fullyQualifiedRedirectURL(c.GetSiteURLHeader(), redirectURL)
 
 	renderError := func(err *model.AppError) {
 		if isMobile && hasRedirectURL {
@@ -341,11 +342,6 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		} else { // For web
 			c.App.AttachSessionCookies(c.AppContext, w, r)
-
-			// If no redirect url is passed, get the default one
-			if !hasRedirectURL {
-				redirectURL = c.GetSiteURLHeader()
-			}
 		}
 	}
 
@@ -437,4 +433,16 @@ func signupWithOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, authURL, http.StatusFound)
+}
+
+func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string) string {
+	parsed, _ := url.Parse(targetURL)
+	if parsed == nil || parsed.Scheme != "" || parsed.Host != "" {
+		return targetURL
+	}
+
+	if targetURL != "" && targetURL[0] != '/' {
+		targetURL = "/" + targetURL
+	}
+	return siteURLPrefix + targetURL
 }

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -805,3 +805,15 @@ func (th *TestHelper) AddPermissionToRole(permission string, roleName string) {
 		panic(err2)
 	}
 }
+
+func TestFullyQualifiedRedirectURL(t *testing.T) {
+	const siteURL = "https://xxx.yyy/mm"
+	for target, expected := range map[string]string{
+		"":           "https://xxx.yyy/mm",
+		"/some-path": "https://xxx.yyy/mm/some-path",
+	} {
+		t.Run(target, func(t *testing.T) {
+			require.Equal(t, expected, fullyQualifiedRedirectURL(siteURL, target))
+		})
+	}
+}

--- a/web/saml.go
+++ b/web/saml.go
@@ -110,6 +110,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		redirectURL = val
 		hasRedirectURL = val != ""
 	}
+	redirectURL = fullyQualifiedRedirectURL(c.GetSiteURLHeader(), redirectURL)
 
 	handleError := func(err *model.AppError) {
 		if isMobile && hasRedirectURL {
@@ -184,7 +185,6 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 			})
 			utils.RenderMobileAuthComplete(w, redirectURL)
 		} else {
-			redirectURL = c.GetSiteURLHeader() + redirectURL
 			http.Redirect(w, r, redirectURL, http.StatusFound)
 		}
 		return


### PR DESCRIPTION
#### Summary
Convert relative URLs to absolute on OAuth login redirects, so that they work on subpaths

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40151

#### Release Note

```release-note
Fixed MM-40151, OAuth2 login redirects work now with subpath
```
