### PR TITLE
Remove reliable websockets configuration

### DIFF
--- a/api4/websocket.go
+++ b/api4/websocket.go
@@ -46,20 +46,18 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 		Active:    true,
 	}
 
-	if *c.App.Config().ServiceSettings.EnableReliableWebSockets {
-		cfg.ConnectionID = r.URL.Query().Get(connectionIDParam)
-		if cfg.ConnectionID == "" || c.AppContext.Session().UserId == "" {
-			// If not present, we assume client is not capable yet, or it's a fresh connection.
-			// We just create a new ID.
-			cfg.ConnectionID = model.NewId()
-			// In case of fresh connection id, sequence number is already zero.
-		} else {
-			cfg, err = c.App.PopulateWebConnConfig(c.AppContext.Session(), cfg, r.URL.Query().Get(sequenceNumberParam))
-			if err != nil {
-				mlog.Warn("Error while populating webconn config", mlog.String("id", r.URL.Query().Get(connectionIDParam)), mlog.Err(err))
-				ws.Close()
-				return
-			}
+	cfg.ConnectionID = r.URL.Query().Get(connectionIDParam)
+	if cfg.ConnectionID == "" || c.AppContext.Session().UserId == "" {
+		// If not present, we assume client is not capable yet, or it's a fresh connection.
+		// We just create a new ID.
+		cfg.ConnectionID = model.NewId()
+		// In case of fresh connection id, sequence number is already zero.
+	} else {
+		cfg, err = c.App.PopulateWebConnConfig(c.AppContext.Session(), cfg, r.URL.Query().Get(sequenceNumberParam))
+		if err != nil {
+			mlog.Warn("Error while populating webconn config", mlog.String("id", r.URL.Query().Get(connectionIDParam)), mlog.Err(err))
+			ws.Close()
+			return
 		}
 	}
 

--- a/api4/websocket_test.go
+++ b/api4/websocket_test.go
@@ -204,10 +204,6 @@ func TestWebSocketReconnectRace(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ServiceSettings.EnableReliableWebSockets = true
-	})
-
 	WebSocketClient, err := th.CreateWebSocketClient()
 	require.NoError(t, err)
 	defer WebSocketClient.Close()

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -181,7 +181,7 @@ func (a *App) NewWebConn(cfg *WebConnConfig) *WebConn {
 		cfg.activeQueue = make(chan model.WebSocketMessage, sendQueueSize)
 	}
 
-	if cfg.deadQueue == nil && *a.ch.srv.Config().ServiceSettings.EnableReliableWebSockets {
+	if cfg.deadQueue == nil {
 		cfg.deadQueue = make([]*model.WebSocketEvent, deadQueueSize)
 	}
 
@@ -375,7 +375,7 @@ func (wc *WebConn) writePump() {
 		wc.WebSocket.Close()
 	}()
 
-	if *wc.App.Srv().Config().ServiceSettings.EnableReliableWebSockets && wc.Sequence != 0 {
+	if wc.Sequence != 0 {
 		if ok, index := wc.isInDeadQueue(wc.Sequence); ok {
 			if err := wc.drainDeadQueue(index); err != nil {
 				wc.logSocketErr("websocket.drainDeadQueue", err)
@@ -472,8 +472,7 @@ func (wc *WebConn) writePump() {
 				mlog.Warn("websocket.full", logData...)
 			}
 
-			if *wc.App.Srv().Config().ServiceSettings.EnableReliableWebSockets &&
-				evtOk {
+			if evtOk {
 				wc.addToDeadQueue(evt)
 			}
 

--- a/app/web_conn_test.go
+++ b/app/web_conn_test.go
@@ -155,8 +155,6 @@ func TestWebConnAddDeadQueue(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableReliableWebSockets = true })
-
 	wc := th.App.NewWebConn(&WebConnConfig{
 		WebSocket: &websocket.Conn{},
 	})
@@ -185,10 +183,6 @@ func TestWebConnAddDeadQueue(t *testing.T) {
 func TestWebConnIsInDeadQueue(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
-
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ServiceSettings.EnableReliableWebSockets = true
-	})
 
 	wc := th.App.NewWebConn(&WebConnConfig{
 		WebSocket: &websocket.Conn{},
@@ -250,10 +244,6 @@ func TestWebConnIsInDeadQueue(t *testing.T) {
 func TestWebConnDrainDeadQueue(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
-
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ServiceSettings.EnableReliableWebSockets = true
-	})
 
 	var dialConn = func(t *testing.T, a *App, addr net.Addr) *WebConn {
 		d := websocket.Dialer{}

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -465,11 +465,7 @@ func (h *Hub) Start() {
 			case webConn := <-h.unregister:
 				// If already removed (via queue full), then removing again becomes a noop.
 				// But if not removed, mark inactive.
-				if *h.srv.Config().ServiceSettings.EnableReliableWebSockets {
-					webConn.active = false
-				} else {
-					connIndex.Remove(webConn)
-				}
+				webConn.active = false
 
 				atomic.StoreInt64(&h.connectionCount, int64(connIndex.AllActive()))
 

--- a/config/client.go
+++ b/config/client.go
@@ -94,7 +94,8 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 
 	props["CloudUserLimit"] = strconv.FormatInt(*c.ExperimentalSettings.CloudUserLimit, 10)
 
-	props["EnableReliableWebSockets"] = strconv.FormatBool(*c.ServiceSettings.EnableReliableWebSockets)
+	// TODO: remove this when the mobile client release reaches 1.52.
+	props["EnableReliableWebSockets"] = strconv.FormatBool(true)
 
 	// Set default values for all options that require a license.
 	props["ExperimentalEnableAuthenticationTransfer"] = "true"

--- a/model/config.go
+++ b/model/config.go
@@ -365,7 +365,6 @@ type ServiceSettings struct {
 	ThreadAutoFollow                                  *bool   `access:"experimental_features"`
 	CollapsedThreads                                  *string `access:"experimental_features"`
 	ManagedResourcePaths                              *string `access:"environment_web_server,write_restrictable,cloud_restrictable"`
-	EnableReliableWebSockets                          *bool   `access:"experimental_features"` // telemetry: none
 }
 
 func (s *ServiceSettings) SetDefaults(isUpdate bool) {
@@ -781,10 +780,6 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.ManagedResourcePaths == nil {
 		s.ManagedResourcePaths = NewString("")
-	}
-
-	if s.EnableReliableWebSockets == nil {
-		s.EnableReliableWebSockets = NewBool(true)
 	}
 }
 


### PR DESCRIPTION
The feature is stable enough to be removed
as a config knob.

For backwards compatiblity with older mobile
clients, we keep sending the config param
as true for client config requests.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4/7m95frqbk9o8zxin6xo9c7iusoh

```release-note
The config setting ServiceSettings.EnableReliableWebSockets has been removed, and for compatiblity with older clients, the server will always return true for the /v4/config/client endpoint.
```

Mobile PR: https://github.com/mattermost/mattermost-mobile/pull/5843
Webapp PR: https://github.com/mattermost/mattermost-webapp/pull/9430