### PR TITLE
[MM-40342] Fix panic in Mattermost Server for cloud installations

### DIFF
--- a/jobs/resend_invitation_email/worker.go
+++ b/jobs/resend_invitation_email/worker.go
@@ -109,7 +109,7 @@ func (rseworker *ResendInvitationEmailWorker) Execute(job *model.Job, elapsedTim
 		}
 	}
 
-	if (elapsedTimeSinceSchedule > firstDuration) && (systemValue == nil || (systemValue != nil && systemValue.Value == "0")) {
+	if (elapsedTimeSinceSchedule > firstDuration) && (systemValue == nil || systemValue.Value == "0") {
 		rseworker.ResendEmails(job, "48")
 		rseworker.setNumResendEmailSent(job, "1")
 	} else if elapsedTimeSinceSchedule > secondDuration {

--- a/jobs/resend_invitation_email/worker.go
+++ b/jobs/resend_invitation_email/worker.go
@@ -109,7 +109,7 @@ func (rseworker *ResendInvitationEmailWorker) Execute(job *model.Job, elapsedTim
 		}
 	}
 
-	if (elapsedTimeSinceSchedule > firstDuration) && (systemValue.Value == "0") {
+	if (elapsedTimeSinceSchedule > firstDuration) && (systemValue == nil || (systemValue != nil && systemValue.Value == "0")) {
 		rseworker.ResendEmails(job, "48")
 		rseworker.setNumResendEmailSent(job, "1")
 	} else if elapsedTimeSinceSchedule > secondDuration {
@@ -192,7 +192,7 @@ func (rseworker *ResendInvitationEmailWorker) GetDurations(job *model.Job) (int6
 	duration_48 := os.Getenv("MM_RESEND_INVITATION_EMAIL_JOB_DURATION_48")
 	DurationInMillis_48, parseError := strconv.ParseInt(duration_48, 10, 64)
 	if parseError != nil {
-		// default to 48 hours
+
 		DurationInMillis_48 = FourtyEightHoursInMillis
 	}
 

--- a/jobs/resend_invitation_email/worker.go
+++ b/jobs/resend_invitation_email/worker.go
@@ -188,7 +188,7 @@ func (rseworker *ResendInvitationEmailWorker) GetDurations(job *model.Job) (int6
 		// default to 24 hours
 		DurationInMillis_24 = TwentyFourHoursInMillis
 	}
-
+	// random comment
 	duration_48 := os.Getenv("MM_RESEND_INVITATION_EMAIL_JOB_DURATION_48")
 	DurationInMillis_48, parseError := strconv.ParseInt(duration_48, 10, 64)
 	if parseError != nil {

--- a/jobs/resend_invitation_email/worker.go
+++ b/jobs/resend_invitation_email/worker.go
@@ -188,11 +188,11 @@ func (rseworker *ResendInvitationEmailWorker) GetDurations(job *model.Job) (int6
 		// default to 24 hours
 		DurationInMillis_24 = TwentyFourHoursInMillis
 	}
-	// random comment
+
 	duration_48 := os.Getenv("MM_RESEND_INVITATION_EMAIL_JOB_DURATION_48")
 	DurationInMillis_48, parseError := strconv.ParseInt(duration_48, 10, 64)
 	if parseError != nil {
-
+		// default to 48 hours
 		DurationInMillis_48 = FourtyEightHoursInMillis
 	}
 


### PR DESCRIPTION
#### Summary
Some installations started to throw panic errors, stack trace pointed to this line. Old cloud installations/invitations may not have had this value populated in the System store, so we should treat nil as the default "0" case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40342

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
