### PR TITLE
MM-39351: fixes LastRootPostAt being null

### DIFF
--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	CurrentSchemaVersion   = Version610
+	CurrentSchemaVersion   = Version611
 	Version620             = "6.2.0"
 	Version611             = "6.1.1"
 	Version610             = "6.1.0"


### PR DESCRIPTION
#### Summary

After upgrading to v6.1 there is a chance for LastRootPostAt to be null,
this might be due to a faulty migration when upgrading to Version5350.
Version5350 had rootCountMigration where LastRootPostAt was used as a
temporary column which at the end was deleted.
Then on Version610 we are adding that column again, this time to keep.

If the migration to Version5350 had failed and it didn't drop the column
the Version610 migration would leave some channels with LastRootPostAt
being NULL.

This resulted in crashing the app.

This commit fixes that by running again a migration to again set
LastRootPostAt only when it's NULL this time and then set it to 0
for channels that might still have LastRootPostAt being NULL
(channels with no posts).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39351

#### Release Note

```release-note
Fixes scan error on column name "LastRootPostAt": converting NULL to int64
```
