### PR TITLE
MM-38150 Adding playbooks permissions

### DIFF
--- a/api4/role.go
+++ b/api4/role.go
@@ -178,7 +178,18 @@ func patchRole(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if oldRole.Name == model.TeamAdminRoleId || oldRole.Name == model.ChannelAdminRoleId || oldRole.Name == model.SystemUserRoleId || oldRole.Name == model.TeamUserRoleId || oldRole.Name == model.ChannelUserRoleId || oldRole.Name == model.SystemGuestRoleId || oldRole.Name == model.TeamGuestRoleId || oldRole.Name == model.ChannelGuestRoleId {
+	if oldRole.Name == model.TeamAdminRoleId ||
+		oldRole.Name == model.ChannelAdminRoleId ||
+		oldRole.Name == model.SystemUserRoleId ||
+		oldRole.Name == model.TeamUserRoleId ||
+		oldRole.Name == model.ChannelUserRoleId ||
+		oldRole.Name == model.SystemGuestRoleId ||
+		oldRole.Name == model.TeamGuestRoleId ||
+		oldRole.Name == model.ChannelGuestRoleId ||
+		oldRole.Name == model.PlaybookAdminRoleId ||
+		oldRole.Name == model.PlaybookMemberRoleId ||
+		oldRole.Name == model.RunAdminRoleId ||
+		oldRole.Name == model.RunMemberRoleId {
 		if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionSysconsoleWriteUserManagementPermissions) {
 			c.SetPermissionError(model.PermissionSysconsoleWriteUserManagementPermissions)
 			return

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -89,6 +89,10 @@ func TestDoAdvancedPermissionsMigration(t *testing.T) {
 		"system_user_access_token",
 		"team_post_all",
 		"team_post_all_public",
+		"playbook_admin",
+		"playbook_member",
+		"run_admin",
+		"run_member",
 	}
 
 	roles1, err1 := th.App.GetRolesByNames(roleNames)

--- a/app/migrations.go
+++ b/app/migrations.go
@@ -16,6 +16,7 @@ const EmojisPermissionsMigrationKey = "EmojisPermissionsMigrationComplete"
 const GuestRolesCreationMigrationKey = "GuestRolesCreationMigrationComplete"
 const SystemConsoleRolesCreationMigrationKey = "SystemConsoleRolesCreationMigrationComplete"
 const ContentExtractionConfigDefaultTrueMigrationKey = "ContentExtractionConfigDefaultTrueMigrationComplete"
+const PlaybookRolesCreationMigrationKey = "PlaybookRolesCreationMigrationComplete"
 
 // This function migrates the default built in roles from code/config to the database.
 func (a *App) DoAdvancedPermissionsMigration() {
@@ -307,6 +308,132 @@ func (s *Server) doContentExtractionConfigDefaultTrueMigration() {
 	}
 }
 
+func (s *Server) doPlaybooksRolesCreationMigration() {
+	// If the migration is already marked as completed, don't do it again.
+	if _, err := s.Store.System().GetByName(PlaybookRolesCreationMigrationKey); err == nil {
+		return
+	}
+
+	roles := model.MakeDefaultRoles()
+
+	allSucceeded := true
+	if _, err := s.Store.Role().GetByName(context.Background(), model.PlaybookAdminRoleId); err != nil {
+		if _, err := s.Store.Role().Save(roles[model.PlaybookAdminRoleId]); err != nil {
+			mlog.Critical("Failed to create new playbook admin role to database.", mlog.Err(err))
+			allSucceeded = false
+		}
+	}
+	if _, err := s.Store.Role().GetByName(context.Background(), model.PlaybookMemberRoleId); err != nil {
+		if _, err := s.Store.Role().Save(roles[model.PlaybookMemberRoleId]); err != nil {
+			mlog.Critical("Failed to create new playbook member role to database.", mlog.Err(err))
+			allSucceeded = false
+		}
+	}
+	if _, err := s.Store.Role().GetByName(context.Background(), model.RunAdminRoleId); err != nil {
+		if _, err := s.Store.Role().Save(roles[model.RunAdminRoleId]); err != nil {
+			mlog.Critical("Failed to create new run admin role to database.", mlog.Err(err))
+			allSucceeded = false
+		}
+	}
+	if _, err := s.Store.Role().GetByName(context.Background(), model.RunMemberRoleId); err != nil {
+		if _, err := s.Store.Role().Save(roles[model.RunMemberRoleId]); err != nil {
+			mlog.Critical("Failed to create new run member role to database.", mlog.Err(err))
+			allSucceeded = false
+		}
+	}
+	schemes, err := s.Store.Scheme().GetAllPage("", 0, 1000000)
+	if err != nil {
+		mlog.Critical("Failed to get all schemes.", mlog.Err(err))
+		allSucceeded = false
+	}
+
+	for _, scheme := range schemes {
+		if scheme.Scope == model.SchemeScopeTeam {
+			if scheme.DefaultPlaybookAdminRole == "" {
+				playbookAdminRole := &model.Role{
+					Name:          model.NewId(),
+					DisplayName:   fmt.Sprintf("Playbook Admin Role for Scheme %s", scheme.Name),
+					Permissions:   roles[model.PlaybookAdminRoleId].Permissions,
+					SchemeManaged: true,
+				}
+
+				if savedRole, err := s.Store.Role().Save(playbookAdminRole); err != nil {
+					mlog.Critical("Failed to create new playbook admin role for existing custom scheme.", mlog.Err(err))
+					allSucceeded = false
+				} else {
+					scheme.DefaultPlaybookAdminRole = savedRole.Name
+				}
+			}
+			if scheme.DefaultPlaybookMemberRole == "" {
+				playbookMember := &model.Role{
+					Name:          model.NewId(),
+					DisplayName:   fmt.Sprintf("Playbook Member Role for Scheme %s", scheme.Name),
+					Permissions:   roles[model.PlaybookMemberRoleId].Permissions,
+					SchemeManaged: true,
+				}
+
+				if savedRole, err := s.Store.Role().Save(playbookMember); err != nil {
+					mlog.Critical("Failed to create new playbook member role for existing custom scheme.", mlog.Err(err))
+					allSucceeded = false
+				} else {
+					scheme.DefaultPlaybookMemberRole = savedRole.Name
+				}
+			}
+
+			if scheme.DefaultRunAdminRole == "" {
+				runAdminRole := &model.Role{
+					Name:          model.NewId(),
+					DisplayName:   fmt.Sprintf("Run Admin Role for Scheme %s", scheme.Name),
+					Permissions:   roles[model.RunAdminRoleId].Permissions,
+					SchemeManaged: true,
+				}
+
+				if savedRole, err := s.Store.Role().Save(runAdminRole); err != nil {
+					mlog.Critical("Failed to create new run admin role for existing custom scheme.", mlog.Err(err))
+					allSucceeded = false
+				} else {
+					scheme.DefaultRunAdminRole = savedRole.Name
+				}
+			}
+
+			if scheme.DefaultRunMemberRole == "" {
+				runMemberRole := &model.Role{
+					Name:          model.NewId(),
+					DisplayName:   fmt.Sprintf("Run Member Role for Scheme %s", scheme.Name),
+					Permissions:   roles[model.RunMemberRoleId].Permissions,
+					SchemeManaged: true,
+				}
+
+				if savedRole, err := s.Store.Role().Save(runMemberRole); err != nil {
+					mlog.Critical("Failed to create new run admin role for existing custom scheme.", mlog.Err(err))
+					allSucceeded = false
+				} else {
+					scheme.DefaultRunMemberRole = savedRole.Name
+				}
+			}
+			_, err := s.Store.Scheme().Save(scheme)
+			if err != nil {
+				mlog.Critical("Failed to update custom scheme.", mlog.Err(err))
+				allSucceeded = false
+			}
+		}
+	}
+
+	if !allSucceeded {
+		return
+	}
+
+	system := model.System{
+		Name:  PlaybookRolesCreationMigrationKey,
+		Value: "true",
+	}
+
+	if err := s.Store.System().Save(&system); err != nil {
+		mlog.Critical("Failed to mark playbook roles creation migration as completed.", mlog.Err(err))
+	}
+
+}
+
 func (a *App) DoAppMigrations() {
 	a.Srv().doAppMigrations()
 }
@@ -323,4 +450,5 @@ func (s *Server) doAppMigrations() {
 		mlog.Critical("(app.App).DoPermissionsMigrations failed", mlog.Err(err))
 	}
 	s.doContentExtractionConfigDefaultTrueMigration()
+	s.doPlaybooksRolesCreationMigration()
 }

--- a/app/migrations.go
+++ b/app/migrations.go
@@ -405,7 +405,7 @@ func (s *Server) doPlaybooksRolesCreationMigration() {
 				}
 
 				if savedRole, err := s.Store.Role().Save(runMemberRole); err != nil {
-					mlog.Critical("Failed to create new run admin role for existing custom scheme.", mlog.Err(err))
+					mlog.Critical("Failed to create new run member role for existing custom scheme.", mlog.Err(err))
 					allSucceeded = false
 				} else {
 					scheme.DefaultRunMemberRole = savedRole.Name

--- a/app/migrations.go
+++ b/app/migrations.go
@@ -341,7 +341,7 @@ func (s *Server) doPlaybooksRolesCreationMigration() {
 			allSucceeded = false
 		}
 	}
-	schemes, err := s.Store.Scheme().GetAllPage("", 0, 1000000)
+	schemes, err := s.Store.Scheme().GetAllPage(model.SchemeScopeTeam, 0, 1000000)
 	if err != nil {
 		mlog.Critical("Failed to get all schemes.", mlog.Err(err))
 		allSucceeded = false

--- a/app/permissions_migrations.go
+++ b/app/permissions_migrations.go
@@ -915,6 +915,20 @@ func (a *App) getAddTestEmailAncillaryPermission() (permissionsMap, error) {
 	return transformations, nil
 }
 
+func (a *App) getAddPlaybooksPermissions() (permissionsMap, error) {
+	transformations := []permissionTransformation{}
+
+	transformations = append(transformations, permissionTransformation{
+		On: isRole(model.SystemUserRoleId),
+		Add: []string{
+			model.PermissionPublicPlaybookCreate.Id,
+			model.PermissionPrivatePlaybookCreate.Id,
+		},
+	})
+
+	return transformations, nil
+}
+
 // DoPermissionsMigrations execute all the permissions migrations need by the current version.
 func (a *App) DoPermissionsMigrations() error {
 	return a.Srv().doPermissionsMigrations()
@@ -953,6 +967,7 @@ func (s *Server) doPermissionsMigrations() error {
 		{Key: model.MigrationKeyAddAboutSubsectionPermissions, Migration: a.getAddAboutSubsectionPermissions},
 		{Key: model.MigrationKeyAddReportingSubsectionPermissions, Migration: a.getAddReportingSubsectionPermissions},
 		{Key: model.MigrationKeyAddTestEmailAncillaryPermission, Migration: a.getAddTestEmailAncillaryPermission},
+		{Key: model.MigrationKeyAddPlaybooksPermissions, Migration: a.getAddPlaybooksPermissions},
 	}
 
 	roles, err := s.Store.Role().GetAll()

--- a/app/permissions_migrations.go
+++ b/app/permissions_migrations.go
@@ -929,6 +929,24 @@ func (a *App) getAddPlaybooksPermissions() (permissionsMap, error) {
 		},
 	})
 
+	transformations = append(transformations, permissionTransformation{
+		On: isRole(model.SystemAdminRoleId),
+		Add: []string{
+			model.PermissionPublicPlaybookManageProperties.Id,
+			model.PermissionPublicPlaybookManageMembers.Id,
+			model.PermissionPublicPlaybookView.Id,
+			model.PermissionPublicPlaybookMakePrivate.Id,
+			model.PermissionPrivatePlaybookManageProperties.Id,
+			model.PermissionPrivatePlaybookManageMembers.Id,
+			model.PermissionPrivatePlaybookView.Id,
+			model.PermissionPrivatePlaybookMakePublic.Id,
+			model.PermissionRunCreate.Id,
+			model.PermissionRunManageProperties.Id,
+			model.PermissionRunManageMembers.Id,
+			model.PermissionRunView.Id,
+		},
+	})
+
 	return transformations, nil
 }
 

--- a/app/permissions_migrations.go
+++ b/app/permissions_migrations.go
@@ -919,7 +919,10 @@ func (a *App) getAddPlaybooksPermissions() (permissionsMap, error) {
 	transformations := []permissionTransformation{}
 
 	transformations = append(transformations, permissionTransformation{
-		On: isRole(model.SystemUserRoleId),
+		On: permissionOr(
+			permissionExists(model.PermissionCreatePublicChannel.Id),
+			permissionExists(model.PermissionCreatePrivateChannel.Id),
+		),
 		Add: []string{
 			model.PermissionPublicPlaybookCreate.Id,
 			model.PermissionPrivatePlaybookCreate.Id,

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -914,6 +914,10 @@ func (api *PluginAPI) HasPermissionToChannel(userID, channelID string, permissio
 	return api.app.HasPermissionToChannel(userID, channelID, permission)
 }
 
+func (api *PluginAPI) RolesGrantPermission(roleNames []string, permissionId string) bool {
+	return api.app.RolesGrantPermission(roleNames, permissionId)
+}
+
 func (api *PluginAPI) LogDebug(msg string, keyValuePairs ...interface{}) {
 	api.logger.Debugw(msg, keyValuePairs...)
 }

--- a/app/scheme.go
+++ b/app/scheme.go
@@ -83,6 +83,10 @@ func (a *App) CreateScheme(scheme *model.Scheme) (*model.Scheme, *model.AppError
 	scheme.DefaultChannelAdminRole = ""
 	scheme.DefaultChannelUserRole = ""
 	scheme.DefaultChannelGuestRole = ""
+	scheme.DefaultPlaybookAdminRole = ""
+	scheme.DefaultPlaybookMemberRole = ""
+	scheme.DefaultRunAdminRole = ""
+	scheme.DefaultRunMemberRole = ""
 	scheme.CreateAt = 0
 	scheme.UpdateAt = 0
 	scheme.DeleteAt = 0

--- a/model/migration.go
+++ b/model/migration.go
@@ -36,4 +36,5 @@ const (
 	MigrationKeyAddAboutSubsectionPermissions          = "about_subsection_permissions"
 	MigrationKeyAddIntegrationsSubsectionPermissions   = "integrations_subsection_permissions"
 	MigrationKeyFixCRTChannelUnreads                   = "fix_crt_channel_unreads"
+	MigrationKeyAddPlaybooksPermissions                = "playbooks_permissions"
 )

--- a/model/permission.go
+++ b/model/permission.go
@@ -4,9 +4,11 @@
 package model
 
 const (
-	PermissionScopeSystem  = "system_scope"
-	PermissionScopeTeam    = "team_scope"
-	PermissionScopeChannel = "channel_scope"
+	PermissionScopeSystem   = "system_scope"
+	PermissionScopeTeam     = "team_scope"
+	PermissionScopeChannel  = "channel_scope"
+	PermissionScopePlaybook = "playbook_scope"
+	PermissionScopeRun      = "run_scope"
 )
 
 type Permission struct {
@@ -330,6 +332,23 @@ var PermissionSysconsoleWriteExperimentalFeatureFlags *Permission
 
 var PermissionSysconsoleReadExperimentalBleve *Permission
 var PermissionSysconsoleWriteExperimentalBleve *Permission
+
+var PermissionPublicPlaybookCreate *Permission
+var PermissionPublicPlaybookManageProperties *Permission
+var PermissionPublicPlaybookManageMembers *Permission
+var PermissionPublicPlaybookView *Permission
+var PermissionPublicPlaybookMakePrivate *Permission
+
+var PermissionPrivatePlaybookCreate *Permission
+var PermissionPrivatePlaybookManageProperties *Permission
+var PermissionPrivatePlaybookManageMembers *Permission
+var PermissionPrivatePlaybookView *Permission
+var PermissionPrivatePlaybookMakePublic *Permission
+
+var PermissionRunCreate *Permission
+var PermissionRunManageProperties *Permission
+var PermissionRunManageMembers *Permission
+var PermissionRunView *Permission
 
 // General permission that encompasses all system admin functions
 // in the future this could be broken up to allow access to some
@@ -1895,6 +1914,105 @@ func initializePermissions() {
 		PermissionScopeSystem,
 	}
 
+	// Playbooks
+	PermissionPublicPlaybookCreate = &Permission{
+		"playbook_public_create",
+		"",
+		"",
+		PermissionScopeTeam,
+	}
+
+	PermissionPublicPlaybookManageProperties = &Permission{
+		"playbook_public_manage_properties",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionPublicPlaybookManageMembers = &Permission{
+		"playbook_public_manage_members",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionPublicPlaybookView = &Permission{
+		"playbook_public_view",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionPublicPlaybookMakePrivate = &Permission{
+		"playbook_public_make_private",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionPrivatePlaybookCreate = &Permission{
+		"playbook_private_create",
+		"",
+		"",
+		PermissionScopeTeam,
+	}
+
+	PermissionPrivatePlaybookManageProperties = &Permission{
+		"playbook_private_manage_properties",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionPrivatePlaybookManageMembers = &Permission{
+		"playbook_private_manage_members",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionPrivatePlaybookView = &Permission{
+		"playbook_private_view",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionPrivatePlaybookMakePublic = &Permission{
+		"playbook_private_make_public",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionRunCreate = &Permission{
+		"run_create",
+		"",
+		"",
+		PermissionScopePlaybook,
+	}
+
+	PermissionRunManageProperties = &Permission{
+		"run_manage_properties",
+		"",
+		"",
+		PermissionScopeRun,
+	}
+
+	PermissionRunManageMembers = &Permission{
+		"run_manage_members",
+		"",
+		"",
+		PermissionScopeRun,
+	}
+
+	PermissionRunView = &Permission{
+		"run_view",
+		"",
+		"",
+		PermissionScopeRun,
+	}
+
 	SysconsoleReadPermissions = []*Permission{
 		PermissionSysconsoleReadAboutEditionAndLicense,
 		PermissionSysconsoleReadBilling,
@@ -2108,6 +2226,8 @@ func initializePermissions() {
 		PermissionViewTeam,
 		PermissionViewMembers,
 		PermissionInviteGuest,
+		PermissionPublicPlaybookCreate,
+		PermissionPrivatePlaybookCreate,
 	}
 
 	ChannelScopedPermissions := []*Permission{
@@ -2163,12 +2283,32 @@ func initializePermissions() {
 		PermissionSysconsoleWriteCompliance,
 	}
 
+	PlaybookScopedPermissions := []*Permission{
+		PermissionPublicPlaybookManageProperties,
+		PermissionPublicPlaybookManageMembers,
+		PermissionPublicPlaybookView,
+		PermissionPublicPlaybookMakePrivate,
+		PermissionPrivatePlaybookManageProperties,
+		PermissionPrivatePlaybookManageMembers,
+		PermissionPrivatePlaybookView,
+		PermissionPrivatePlaybookMakePublic,
+		PermissionRunCreate,
+	}
+
+	RunScopedPermissions := []*Permission{
+		PermissionRunManageProperties,
+		PermissionRunManageMembers,
+		PermissionRunView,
+	}
+
 	AllPermissions = []*Permission{}
 	AllPermissions = append(AllPermissions, SystemScopedPermissionsMinusSysconsole...)
 	AllPermissions = append(AllPermissions, TeamScopedPermissions...)
 	AllPermissions = append(AllPermissions, ChannelScopedPermissions...)
 	AllPermissions = append(AllPermissions, SysconsoleReadPermissions...)
 	AllPermissions = append(AllPermissions, SysconsoleWritePermissions...)
+	AllPermissions = append(AllPermissions, PlaybookScopedPermissions...)
+	AllPermissions = append(AllPermissions, RunScopedPermissions...)
 
 	ChannelModeratedPermissions = []string{
 		PermissionCreatePost.Id,

--- a/model/role.go
+++ b/model/role.go
@@ -41,6 +41,11 @@ func init() {
 		ChannelGuestRoleId,
 		ChannelUserRoleId,
 		ChannelAdminRoleId,
+
+		PlaybookAdminRoleId,
+		PlaybookMemberRoleId,
+		RunAdminRoleId,
+		RunMemberRoleId,
 	}, NewSystemRoleIDs...)
 
 	// When updating the values here, the values in mattermost-redux must also be updated.
@@ -361,6 +366,11 @@ const (
 	ChannelGuestRoleId = "channel_guest"
 	ChannelUserRoleId  = "channel_user"
 	ChannelAdminRoleId = "channel_admin"
+
+	PlaybookAdminRoleId  = "playbook_admin"
+	PlaybookMemberRoleId = "playbook_member"
+	RunAdminRoleId       = "run_admin"
+	RunMemberRoleId      = "run_member"
 
 	RoleNameMaxLength        = 64
 	RoleDisplayNameMaxLength = 128
@@ -753,6 +763,8 @@ func MakeDefaultRoles() map[string]*Role {
 			PermissionCreatePrivateChannel.Id,
 			PermissionInviteUser.Id,
 			PermissionAddUserToTeam.Id,
+			PermissionPublicPlaybookCreate.Id,
+			PermissionPrivatePlaybookCreate.Id,
 		},
 		SchemeManaged: true,
 		BuiltIn:       true,
@@ -802,6 +814,57 @@ func MakeDefaultRoles() map[string]*Role {
 			PermissionConvertPrivateChannelToPublic.Id,
 			PermissionDeletePost.Id,
 			PermissionDeleteOthersPosts.Id,
+		},
+		SchemeManaged: true,
+		BuiltIn:       true,
+	}
+
+	roles[PlaybookAdminRoleId] = &Role{
+		Name:        PlaybookAdminRoleId,
+		DisplayName: "authentication.roles.playbook_admin.name",
+		Description: "authentication.roles.playbook_admin.description",
+		Permissions: []string{
+			PermissionPublicPlaybookManageMembers.Id,
+			PermissionPublicPlaybookManageProperties.Id,
+			PermissionPrivatePlaybookManageMembers.Id,
+			PermissionPrivatePlaybookManageProperties.Id,
+			PermissionPublicPlaybookMakePrivate.Id,
+		},
+		SchemeManaged: true,
+		BuiltIn:       true,
+	}
+
+	roles[PlaybookMemberRoleId] = &Role{
+		Name:        PlaybookMemberRoleId,
+		DisplayName: "authentication.roles.playbook_member.name",
+		Description: "authentication.roles.playbook_member.description",
+		Permissions: []string{
+			PermissionPublicPlaybookView.Id,
+			PermissionPrivatePlaybookView.Id,
+			PermissionRunCreate.Id,
+		},
+		SchemeManaged: true,
+		BuiltIn:       true,
+	}
+
+	roles[RunAdminRoleId] = &Role{
+		Name:        RunAdminRoleId,
+		DisplayName: "authentication.roles.playbook_member.name",
+		Description: "authentication.roles.playbook_member.description",
+		Permissions: []string{
+			PermissionRunManageMembers.Id,
+			PermissionRunManageProperties.Id,
+		},
+		SchemeManaged: true,
+		BuiltIn:       true,
+	}
+
+	roles[RunMemberRoleId] = &Role{
+		Name:        RunMemberRoleId,
+		DisplayName: "authentication.roles.playbook_member.name",
+		Description: "authentication.roles.playbook_member.description",
+		Permissions: []string{
+			PermissionRunView.Id,
 		},
 		SchemeManaged: true,
 		BuiltIn:       true,

--- a/model/role.go
+++ b/model/role.go
@@ -763,8 +763,6 @@ func MakeDefaultRoles() map[string]*Role {
 			PermissionCreatePrivateChannel.Id,
 			PermissionInviteUser.Id,
 			PermissionAddUserToTeam.Id,
-			PermissionPublicPlaybookCreate.Id,
-			PermissionPrivatePlaybookCreate.Id,
 		},
 		SchemeManaged: true,
 		BuiltIn:       true,

--- a/model/role.go
+++ b/model/role.go
@@ -851,8 +851,8 @@ func MakeDefaultRoles() map[string]*Role {
 
 	roles[RunAdminRoleId] = &Role{
 		Name:        RunAdminRoleId,
-		DisplayName: "authentication.roles.playbook_member.name",
-		Description: "authentication.roles.playbook_member.description",
+		DisplayName: "authentication.roles.run_admin.name",
+		Description: "authentication.roles.run_admin.description",
 		Permissions: []string{
 			PermissionRunManageMembers.Id,
 			PermissionRunManageProperties.Id,
@@ -863,8 +863,8 @@ func MakeDefaultRoles() map[string]*Role {
 
 	roles[RunMemberRoleId] = &Role{
 		Name:        RunMemberRoleId,
-		DisplayName: "authentication.roles.playbook_member.name",
-		Description: "authentication.roles.playbook_member.description",
+		DisplayName: "authentication.roles.run_member.name",
+		Description: "authentication.roles.run_member.description",
 		Permissions: []string{
 			PermissionRunView.Id,
 		},

--- a/model/role.go
+++ b/model/role.go
@@ -840,7 +840,11 @@ func MakeDefaultRoles() map[string]*Role {
 		Description: "authentication.roles.playbook_member.description",
 		Permissions: []string{
 			PermissionPublicPlaybookView.Id,
+			PermissionPublicPlaybookManageMembers.Id,
+			PermissionPublicPlaybookManageProperties.Id,
 			PermissionPrivatePlaybookView.Id,
+			PermissionPrivatePlaybookManageMembers.Id,
+			PermissionPrivatePlaybookManageProperties.Id,
 			PermissionRunCreate.Id,
 		},
 		SchemeManaged: true,

--- a/model/scheme.go
+++ b/model/scheme.go
@@ -14,23 +14,29 @@ const (
 	SchemeDescriptionMaxLength = 1024
 	SchemeScopeTeam            = "team"
 	SchemeScopeChannel         = "channel"
+	SchemeScopePlaybook        = "playbook"
+	SchemeScopeRun             = "run"
 )
 
 type Scheme struct {
-	Id                      string `json:"id"`
-	Name                    string `json:"name"`
-	DisplayName             string `json:"display_name"`
-	Description             string `json:"description"`
-	CreateAt                int64  `json:"create_at"`
-	UpdateAt                int64  `json:"update_at"`
-	DeleteAt                int64  `json:"delete_at"`
-	Scope                   string `json:"scope"`
-	DefaultTeamAdminRole    string `json:"default_team_admin_role"`
-	DefaultTeamUserRole     string `json:"default_team_user_role"`
-	DefaultChannelAdminRole string `json:"default_channel_admin_role"`
-	DefaultChannelUserRole  string `json:"default_channel_user_role"`
-	DefaultTeamGuestRole    string `json:"default_team_guest_role"`
-	DefaultChannelGuestRole string `json:"default_channel_guest_role"`
+	Id                        string `json:"id"`
+	Name                      string `json:"name"`
+	DisplayName               string `json:"display_name"`
+	Description               string `json:"description"`
+	CreateAt                  int64  `json:"create_at"`
+	UpdateAt                  int64  `json:"update_at"`
+	DeleteAt                  int64  `json:"delete_at"`
+	Scope                     string `json:"scope"`
+	DefaultTeamAdminRole      string `json:"default_team_admin_role"`
+	DefaultTeamUserRole       string `json:"default_team_user_role"`
+	DefaultChannelAdminRole   string `json:"default_channel_admin_role"`
+	DefaultChannelUserRole    string `json:"default_channel_user_role"`
+	DefaultTeamGuestRole      string `json:"default_team_guest_role"`
+	DefaultChannelGuestRole   string `json:"default_channel_guest_role"`
+	DefaultPlaybookAdminRole  string `json:"default_playbook_admin_role"`
+	DefaultPlaybookMemberRole string `json:"default_playbook_member_role"`
+	DefaultRunAdminRole       string `json:"default_run_admin_role"`
+	DefaultRunMemberRole      string `json:"default_run_member_role"`
 }
 
 type SchemePatch struct {
@@ -45,31 +51,39 @@ type SchemeIDPatch struct {
 
 // SchemeConveyor is used for importing and exporting a Scheme and its associated Roles.
 type SchemeConveyor struct {
-	Name         string  `json:"name"`
-	DisplayName  string  `json:"display_name"`
-	Description  string  `json:"description"`
-	Scope        string  `json:"scope"`
-	TeamAdmin    string  `json:"default_team_admin_role"`
-	TeamUser     string  `json:"default_team_user_role"`
-	TeamGuest    string  `json:"default_team_guest_role"`
-	ChannelAdmin string  `json:"default_channel_admin_role"`
-	ChannelUser  string  `json:"default_channel_user_role"`
-	ChannelGuest string  `json:"default_channel_guest_role"`
-	Roles        []*Role `json:"roles"`
+	Name           string  `json:"name"`
+	DisplayName    string  `json:"display_name"`
+	Description    string  `json:"description"`
+	Scope          string  `json:"scope"`
+	TeamAdmin      string  `json:"default_team_admin_role"`
+	TeamUser       string  `json:"default_team_user_role"`
+	TeamGuest      string  `json:"default_team_guest_role"`
+	ChannelAdmin   string  `json:"default_channel_admin_role"`
+	ChannelUser    string  `json:"default_channel_user_role"`
+	ChannelGuest   string  `json:"default_channel_guest_role"`
+	PlaybookAdmin  string  `json:"default_playbook_admin_role"`
+	PlaybookMember string  `json:"default_playbook_member_role"`
+	RunAdmin       string  `json:"default_run_admin_role"`
+	RunMember      string  `json:"default_run_member_role"`
+	Roles          []*Role `json:"roles"`
 }
 
 func (sc *SchemeConveyor) Scheme() *Scheme {
 	return &Scheme{
-		DisplayName:             sc.DisplayName,
-		Name:                    sc.Name,
-		Description:             sc.Description,
-		Scope:                   sc.Scope,
-		DefaultTeamAdminRole:    sc.TeamAdmin,
-		DefaultTeamUserRole:     sc.TeamUser,
-		DefaultTeamGuestRole:    sc.TeamGuest,
-		DefaultChannelAdminRole: sc.ChannelAdmin,
-		DefaultChannelUserRole:  sc.ChannelUser,
-		DefaultChannelGuestRole: sc.ChannelGuest,
+		DisplayName:               sc.DisplayName,
+		Name:                      sc.Name,
+		Description:               sc.Description,
+		Scope:                     sc.Scope,
+		DefaultTeamAdminRole:      sc.TeamAdmin,
+		DefaultTeamUserRole:       sc.TeamUser,
+		DefaultTeamGuestRole:      sc.TeamGuest,
+		DefaultChannelAdminRole:   sc.ChannelAdmin,
+		DefaultChannelUserRole:    sc.ChannelUser,
+		DefaultChannelGuestRole:   sc.ChannelGuest,
+		DefaultPlaybookAdminRole:  sc.PlaybookAdmin,
+		DefaultPlaybookMemberRole: sc.PlaybookMember,
+		DefaultRunAdminRole:       sc.RunAdmin,
+		DefaultRunMemberRole:      sc.RunMember,
 	}
 }
 
@@ -101,7 +115,7 @@ func (scheme *Scheme) IsValidForCreate() bool {
 	}
 
 	switch scheme.Scope {
-	case SchemeScopeTeam, SchemeScopeChannel:
+	case SchemeScopeTeam, SchemeScopeChannel, SchemeScopePlaybook, SchemeScopeRun:
 	default:
 		return false
 	}
@@ -142,6 +156,26 @@ func (scheme *Scheme) IsValidForCreate() bool {
 		}
 
 		if scheme.DefaultTeamGuestRole != "" {
+			return false
+		}
+	}
+
+	if scheme.Scope == SchemeScopePlaybook {
+		if !IsValidRoleName(scheme.DefaultPlaybookAdminRole) {
+			return false
+		}
+
+		if !IsValidRoleName(scheme.DefaultPlaybookMemberRole) {
+			return false
+		}
+	}
+
+	if scheme.Scope == SchemeScopeRun {
+		if !IsValidRoleName(scheme.DefaultRunAdminRole) {
+			return false
+		}
+
+		if !IsValidRoleName(scheme.DefaultRunMemberRole) {
 			return false
 		}
 	}

--- a/model/scheme.go
+++ b/model/scheme.go
@@ -144,6 +144,22 @@ func (scheme *Scheme) IsValidForCreate() bool {
 		if !IsValidRoleName(scheme.DefaultTeamGuestRole) {
 			return false
 		}
+
+		if !IsValidRoleName(scheme.DefaultPlaybookAdminRole) {
+			return false
+		}
+
+		if !IsValidRoleName(scheme.DefaultPlaybookMemberRole) {
+			return false
+		}
+
+		if !IsValidRoleName(scheme.DefaultRunAdminRole) {
+			return false
+		}
+
+		if !IsValidRoleName(scheme.DefaultRunMemberRole) {
+			return false
+		}
 	}
 
 	if scheme.Scope == SchemeScopeChannel {
@@ -156,26 +172,6 @@ func (scheme *Scheme) IsValidForCreate() bool {
 		}
 
 		if scheme.DefaultTeamGuestRole != "" {
-			return false
-		}
-	}
-
-	if scheme.Scope == SchemeScopePlaybook {
-		if !IsValidRoleName(scheme.DefaultPlaybookAdminRole) {
-			return false
-		}
-
-		if !IsValidRoleName(scheme.DefaultPlaybookMemberRole) {
-			return false
-		}
-	}
-
-	if scheme.Scope == SchemeScopeRun {
-		if !IsValidRoleName(scheme.DefaultRunAdminRole) {
-			return false
-		}
-
-		if !IsValidRoleName(scheme.DefaultRunMemberRole) {
 			return false
 		}
 	}

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -962,7 +962,7 @@ type API interface {
 
 	// RolesGrantPermission check if the specified roles grant the specified permission
 	//
-	// Minimum server version: 6.1
+	// Minimum server version: 6.3
 	RolesGrantPermission(roleNames []string, permissionId string) bool
 
 	// LogDebug writes a log message to the Mattermost server log file.

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -960,6 +960,11 @@ type API interface {
 	// Minimum server version: 5.3
 	HasPermissionToChannel(userID, channelId string, permission *model.Permission) bool
 
+	// RolesGrantPermission check if the specified roles grant the specified permission
+	//
+	// Minimum server version: 6.1
+	RolesGrantPermission(roleNames []string, permissionId string) bool
+
 	// LogDebug writes a log message to the Mattermost server log file.
 	// Appropriate context such as the plugin name will already be added as fields so plugins
 	// do not need to add that info.

--- a/plugin/api_timer_layer_generated.go
+++ b/plugin/api_timer_layer_generated.go
@@ -1034,6 +1034,13 @@ func (api *apiTimerLayer) HasPermissionToChannel(userID, channelId string, permi
 	return _returnsA
 }
 
+func (api *apiTimerLayer) RolesGrantPermission(roleNames []string, permissionId string) bool {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.RolesGrantPermission(roleNames, permissionId)
+	api.recordTime(startTime, "RolesGrantPermission", true)
+	return _returnsA
+}
+
 func (api *apiTimerLayer) LogDebug(msg string, keyValuePairs ...interface{}) {
 	startTime := timePkg.Now()
 	api.apiImpl.LogDebug(msg, keyValuePairs...)

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -4832,6 +4832,35 @@ func (s *apiRPCServer) HasPermissionToChannel(args *Z_HasPermissionToChannelArgs
 	return nil
 }
 
+type Z_RolesGrantPermissionArgs struct {
+	A []string
+	B string
+}
+
+type Z_RolesGrantPermissionReturns struct {
+	A bool
+}
+
+func (g *apiRPCClient) RolesGrantPermission(roleNames []string, permissionId string) bool {
+	_args := &Z_RolesGrantPermissionArgs{roleNames, permissionId}
+	_returns := &Z_RolesGrantPermissionReturns{}
+	if err := g.client.Call("Plugin.RolesGrantPermission", _args, _returns); err != nil {
+		log.Printf("RPC call to RolesGrantPermission API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) RolesGrantPermission(args *Z_RolesGrantPermissionArgs, returns *Z_RolesGrantPermissionReturns) error {
+	if hook, ok := s.impl.(interface {
+		RolesGrantPermission(roleNames []string, permissionId string) bool
+	}); ok {
+		returns.A = hook.RolesGrantPermission(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API RolesGrantPermission called but not implemented."))
+	}
+	return nil
+}
+
 type Z_SendMailArgs struct {
 	A string
 	B string

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -3023,6 +3023,20 @@ func (_m *API) RevokeUserAccessToken(tokenID string) *model.AppError {
 	return r0
 }
 
+// RolesGrantPermission provides a mock function with given fields: roleNames, permissionId
+func (_m *API) RolesGrantPermission(roleNames []string, permissionId string) bool {
+	ret := _m.Called(roleNames, permissionId)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func([]string, string) bool); ok {
+		r0 = rf(roleNames, permissionId)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // SaveConfig provides a mock function with given fields: config
 func (_m *API) SaveConfig(config *model.Config) *model.AppError {
 	ret := _m.Called(config)

--- a/store/sqlstore/integrity_test.go
+++ b/store/sqlstore/integrity_test.go
@@ -269,6 +269,38 @@ func createDefaultRoles(ss store.Store) {
 			model.PermissionCreatePost.Id,
 		},
 	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.PlaybookAdminRoleId,
+		DisplayName: model.PlaybookAdminRoleId,
+		Permissions: []string{
+			model.PermissionPrivatePlaybookManageMembers.Id,
+		},
+	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.PlaybookMemberRoleId,
+		DisplayName: model.PlaybookMemberRoleId,
+		Permissions: []string{
+			model.PermissionPrivatePlaybookManageMembers.Id,
+		},
+	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.RunAdminRoleId,
+		DisplayName: model.RunAdminRoleId,
+		Permissions: []string{
+			model.PermissionRunManageMembers.Id,
+		},
+	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.RunMemberRoleId,
+		DisplayName: model.RunMemberRoleId,
+		Permissions: []string{
+			model.PermissionRunManageMembers.Id,
+		},
+	})
 }
 
 func createScheme(ss store.Store) *model.Scheme {

--- a/store/sqlstore/scheme_store.go
+++ b/store/sqlstore/scheme_store.go
@@ -34,10 +34,10 @@ func newSqlSchemeStore(sqlStore *SqlStore) store.SchemeStore {
 		table.ColMap("DefaultChannelAdminRole").SetMaxSize(64)
 		table.ColMap("DefaultChannelUserRole").SetMaxSize(64)
 		table.ColMap("DefaultChannelGuestRole").SetMaxSize(64)
-		table.ColMap("DefaultPlaybookAdminRole").SetMaxSize(64)
-		table.ColMap("DefaultPlaybookMemberRole").SetMaxSize(64)
-		table.ColMap("DefaultRunAdminRole").SetMaxSize(64)
-		table.ColMap("DefaultRunMemberRole").SetMaxSize(64)
+		table.ColMap("DefaultPlaybookAdminRole").SetMaxSize(64).SetDefaultConstraint(model.NewString(""))
+		table.ColMap("DefaultPlaybookMemberRole").SetMaxSize(64).SetDefaultConstraint(model.NewString(""))
+		table.ColMap("DefaultRunAdminRole").SetMaxSize(64).SetDefaultConstraint(model.NewString(""))
+		table.ColMap("DefaultRunMemberRole").SetMaxSize(64).SetDefaultConstraint(model.NewString(""))
 	}
 
 	return s
@@ -119,7 +119,7 @@ func (s *SqlSchemeStore) createScheme(scheme *model.Scheme, transaction *sqlxTxW
 		defaultRoles[role.Name] = role
 	}
 
-	if len(defaultRoles) != 10 {
+	if len(defaultRoles) != len(defaultRoleNames) {
 		return nil, errors.New("createScheme: unable to retrieve default scheme roles")
 	}
 

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1414,5 +1414,10 @@ func upgradeDatabaseToVersion620(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, Version610, Version620) {
 
 	// 	saveSchemaVersion(sqlStore, Version620)
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
+
 	// }
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1414,10 +1414,10 @@ func upgradeDatabaseToVersion620(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, Version610, Version620) {
 
 	// 	saveSchemaVersion(sqlStore, Version620)
-	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
-	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
-	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
-	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultPlaybookAdminRole", "VARCHAR(64)", "VARCHAR(64)")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultPlaybookMemberRole", "VARCHAR(64)", "VARCHAR(64)")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultRunAdminRole", "VARCHAR(64)", "VARCHAR(64)")
+	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultRunMemberRole", "VARCHAR(64)", "VARCHAR(64)")
 
 	// }
 }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1414,17 +1414,17 @@ func upgradeDatabaseToVersion610(sqlStore *SqlStore) {
 func upgradeDatabaseToVersion620(sqlStore *SqlStore) {
 	if shouldPerformUpgrade(sqlStore, Version610, Version620) {
 		saveSchemaVersion(sqlStore, Version620)
-
-		sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
-		sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
-		sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
-		sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
 	}
 }
 
 func upgradeDatabaseToVersion630(sqlStore *SqlStore) {
 	// TODO: uncomment when the time arrive to upgrade the DB for 6.3
 	// if shouldPerformUpgrade(sqlStore, Version620, Version630) {
+
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
 
 	// 	saveSchemaVersion(sqlStore, Version630)
 	// }

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1414,10 +1414,10 @@ func upgradeDatabaseToVersion620(sqlStore *SqlStore) {
 	// if shouldPerformUpgrade(sqlStore, Version610, Version620) {
 
 	// 	saveSchemaVersion(sqlStore, Version620)
-	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultPlaybookAdminRole", "VARCHAR(64)", "VARCHAR(64)")
-	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultPlaybookMemberRole", "VARCHAR(64)", "VARCHAR(64)")
-	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultRunAdminRole", "VARCHAR(64)", "VARCHAR(64)")
-	sqlStore.CreateColumnIfNotExistsNoDefault("Schemes", "DefaultRunMemberRole", "VARCHAR(64)", "VARCHAR(64)")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultPlaybookMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunAdminRole", "VARCHAR(64)", "VARCHAR(64)", "")
+	sqlStore.CreateColumnIfNotExists("Schemes", "DefaultRunMemberRole", "VARCHAR(64)", "VARCHAR(64)", "")
 
 	// }
 }

--- a/store/storetest/scheme_store.go
+++ b/store/storetest/scheme_store.go
@@ -79,6 +79,38 @@ func createDefaultRoles(ss store.Store) {
 			model.PermissionCreatePost.Id,
 		},
 	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.PlaybookAdminRoleId,
+		DisplayName: model.PlaybookAdminRoleId,
+		Permissions: []string{
+			model.PermissionPrivatePlaybookManageMembers.Id,
+		},
+	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.PlaybookMemberRoleId,
+		DisplayName: model.PlaybookMemberRoleId,
+		Permissions: []string{
+			model.PermissionPrivatePlaybookManageMembers.Id,
+		},
+	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.RunAdminRoleId,
+		DisplayName: model.RunAdminRoleId,
+		Permissions: []string{
+			model.PermissionRunManageMembers.Id,
+		},
+	})
+
+	ss.Role().Save(&model.Role{
+		Name:        model.RunMemberRoleId,
+		DisplayName: model.RunMemberRoleId,
+		Permissions: []string{
+			model.PermissionRunManageMembers.Id,
+		},
+	})
 }
 
 func testSchemeStoreSave(t *testing.T, ss store.Store) {

--- a/testlib/store.go
+++ b/testlib/store.go
@@ -35,6 +35,7 @@ func GetMockStoreForSetupFunctions() *mocks.Store {
 	systemStore.On("GetByName", "EmojisPermissionsMigrationComplete").Return(&model.System{Name: "EmojisPermissionsMigrationComplete", Value: "true"}, nil)
 	systemStore.On("GetByName", "GuestRolesCreationMigrationComplete").Return(&model.System{Name: "GuestRolesCreationMigrationComplete", Value: "true"}, nil)
 	systemStore.On("GetByName", "SystemConsoleRolesCreationMigrationComplete").Return(&model.System{Name: "SystemConsoleRolesCreationMigrationComplete", Value: "true"}, nil)
+	systemStore.On("GetByName", "PlaybookRolesCreationMigrationComplete").Return(&model.System{Name: "PlaybookRolesCreationMigrationComplete", Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyEmojiPermissionsSplit).Return(&model.System{Name: model.MigrationKeyEmojiPermissionsSplit, Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyWebhookPermissionsSplit).Return(&model.System{Name: model.MigrationKeyWebhookPermissionsSplit, Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyListJoinPublicPrivateTeams).Return(&model.System{Name: model.MigrationKeyListJoinPublicPrivateTeams, Value: "true"}, nil)
@@ -62,6 +63,7 @@ func GetMockStoreForSetupFunctions() *mocks.Store {
 	systemStore.On("GetByName", model.MigrationKeyAddIntegrationsSubsectionPermissions).Return(&model.System{Name: model.MigrationKeyAddIntegrationsSubsectionPermissions, Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyAddManageSharedChannelPermissions).Return(&model.System{Name: model.MigrationKeyAddManageSharedChannelPermissions, Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyAddManageSecureConnectionsPermissions).Return(&model.System{Name: model.MigrationKeyAddManageSecureConnectionsPermissions, Value: "true"}, nil)
+	systemStore.On("GetByName", model.MigrationKeyAddPlaybooksPermissions).Return(&model.System{Name: model.MigrationKeyAddPlaybooksPermissions, Value: "true"}, nil)
 	systemStore.On("InsertIfExists", mock.AnythingOfType("*model.System")).Return(&model.System{}, nil).Once()
 	systemStore.On("Save", mock.AnythingOfType("*model.System")).Return(nil)
 


### PR DESCRIPTION
#### Summary
Adding roles and permissions for playbooks. None of these are used on the server. They will be used in an upcoming PR for the playbooks product.

This also adds a function to the plugin API to handle checking if a set of roles grant a specific permission. `RolesGrantPermission`

Permissions added:
- PermissionPublicPlaybookCreate
- PermissionPublicPlaybookManageProperties
- PermissionPublicPlaybookManageMembers
- PermissionPublicPlaybookView
- PermissionPublicPlaybookMakePrivate
- PermissionPrivatePlaybookCreate
- PermissionPrivatePlaybookManageProperties
- PermissionPrivatePlaybookManageMembers
- PermissionPrivatePlaybookView
- PermissionPrivatePlaybookMakePublic
- PermissionRunCreate
- PermissionRunManageProperties
- PermissionRunManageMembers
- PermissionRunView

Roles added:
- PlaybookAdmin
- PlaybookMember
- RunAdmin
- RunMember


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38504

#### Release Note
```release-note
NONE
```
