### PR TITLE
MM-40222 - show gov references in license page when gov license

### DIFF
--- a/model/license.go
+++ b/model/license.go
@@ -52,6 +52,7 @@ type License struct {
 	SkuName      string    `json:"sku_name"`
 	SkuShortName string    `json:"sku_short_name"`
 	IsTrial      bool      `json:"is_trial"`
+	IsGovSku     bool      `json:"is_gov_sku"`
 }
 
 type Customer struct {

--- a/utils/license.go
+++ b/utils/license.go
@@ -200,6 +200,7 @@ func GetClientLicense(l *model.License) map[string]string {
 		props["SharedChannels"] = strconv.FormatBool(*l.Features.SharedChannels)
 		props["RemoteClusterService"] = strconv.FormatBool(*l.Features.RemoteClusterService)
 		props["IsTrial"] = strconv.FormatBool(l.IsTrial)
+		props["IsGovSku"] = strconv.FormatBool(l.IsGovSku)
 	}
 
 	return props


### PR DESCRIPTION
#### Summary
This PR adds the isGovSku value to the license model so we can use the isGov value to show the Gov references in the webapp license page.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40222

#### Related Pull Requests
- Has webapp changes (https://github.com/mattermost/mattermost-webapp/pull/9448)

#### Release Note
```release-note
NONE
```
