### PR TITLE
MM-39433: Fixes (*App).getEmbedsAndImages parameter.

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -132,7 +132,7 @@ func (a *App) PreparePostForClient(originalPost *model.Post, isNewPost, isEditPo
 
 func (a *App) PreparePostForClientWithEmbedsAndImages(originalPost *model.Post, isNewPost, isEditPost bool) *model.Post {
 	post := a.PreparePostForClient(originalPost, isNewPost, isEditPost)
-	post = a.getEmbedsAndImages(post, true)
+	post = a.getEmbedsAndImages(post, isNewPost)
 	return post
 }
 


### PR DESCRIPTION
#### Summary

Fixes a parameter used with an invocation of `(*App).getEmbedsAndImages` which led to the re-retrieval of OpenGraph data from external servers because [the database lookup](https://github.com/mattermost/mattermost-server/blob/master/app/post_metadata.go#L505-L510) was being skipped.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-39433

#### Release Note

```release-note
Fixed slow channel loading for instances with website link previews enabled.
```
