### PR TITLE
Automated cherry pick of #18885

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -62,6 +62,9 @@ type FeatureFlags struct {
 	// A/B test for the add members to channel button, possible values = ("top", "bottom")
 	AddMembersToChannel string
 
+	// Enable Create First Channel
+	GuidedChannelCreation bool
+
 	// Determine after which duration in hours to send a second invitation to someone that didn't join after the initial invite, possible values = ("48", "72")
 	ResendInviteEmailInterval string
 
@@ -88,6 +91,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.AutoTour = "none"
 	f.BoardsFeatureFlags = ""
 	f.AddMembersToChannel = "top"
+	f.GuidedChannelCreation = false
 	f.ResendInviteEmailInterval = ""
 	f.InviteToTeam = "none"
 }


### PR DESCRIPTION
Cherry pick of #18885 on cloud.

/cc  @pablovelezvidal

```release-note
NONE
```