### PR TITLE
MM-40143: Out of bounds error in *Channel.GetOtherUserIdForDM

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -290,6 +290,10 @@ func (o *Channel) GetOtherUserIdForDM(userId string) string {
 
 	userIds := strings.Split(o.Name, "__")
 
+	if len(userIds) != 2 {
+		return ""
+	}
+
 	var otherUserId string
 
 	if userIds[0] != userIds[1] {


### PR DESCRIPTION
We check if there are indeed 2 user ids after splitting the string
at "__".

https://mattermost.atlassian.net/browse/MM-40143

```release-note
NONE
```
