### PR TITLE
[MM-35997] Make duplicate team error message more user friendly

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6225,7 +6225,7 @@
   },
   {
     "id": "app.team.save.existing.app_error",
-    "translation": "Must call update for existing team."
+    "translation": "Unable to create new team, the name is already in use."
   },
   {
     "id": "app.team.save_member.save.app_error",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR changes the error message when trying to create a team with a URL that already exists to something more user friendly.  Because I'm changing one of the localization strings, I had also run the `make i18n-extract` command, but as I'm lacking an enterprise code, the command removed all the `ent.` prefixed localization strings - So I'm creating this PR with just the text change (which I've manually verified works).


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-35997
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Changed Error message produced when trying to create a team with a URL that's in use to something more user friendly.
```
