### PR TITLE
Server support for collapse consecutive preference

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -55,6 +55,9 @@ var exportablePreferences = map[ComparablePreference]string{{
 }: "MessageDisplay", {
 	Category: model.PreferenceCategoryDisplaySettings,
 	Name:     "channel_display_mode",
+}: "CollapseConsecutive", {
+	Category: model.PreferenceCategoryDisplaySettings,
+	Name:     "collapse_consecutive_messages",
 }: "ChannelDisplayMode", {
 	Category: model.PreferenceCategoryTutorialSteps,
 	Name:     "",

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -635,6 +635,15 @@ func (a *App) importUser(data *UserImportData, dryRun bool) *model.AppError {
 		})
 	}
 
+	if data.CollapseConsecutive != nil {
+		preferences = append(preferences, model.Preference{
+			UserId:   savedUser.Id,
+			Category: model.PreferenceCategoryDisplaySettings,
+			Name:     model.PreferenceNameCollapseConsecutive,
+			Value:    *data.CollapseConsecutive,
+		})
+	}
+
 	if data.ChannelDisplayMode != nil {
 		preferences = append(preferences, model.Preference{
 			UserId:   savedUser.Id,

--- a/app/import_types.go
+++ b/app/import_types.go
@@ -64,13 +64,14 @@ type UserImportData struct {
 
 	Teams *[]UserTeamImportData `json:"teams,omitempty"`
 
-	Theme              *string `json:"theme,omitempty"`
-	UseMilitaryTime    *string `json:"military_time,omitempty"`
-	CollapsePreviews   *string `json:"link_previews,omitempty"`
-	MessageDisplay     *string `json:"message_display,omitempty"`
-	ChannelDisplayMode *string `json:"channel_display_mode,omitempty"`
-	TutorialStep       *string `json:"tutorial_step,omitempty"`
-	EmailInterval      *string `json:"email_interval,omitempty"`
+	Theme               *string `json:"theme,omitempty"`
+	UseMilitaryTime     *string `json:"military_time,omitempty"`
+	CollapsePreviews    *string `json:"link_previews,omitempty"`
+	MessageDisplay      *string `json:"message_display,omitempty"`
+	CollapseConsecutive *string `json:"collapse_consecutive_messages,omitempty"`
+	ChannelDisplayMode  *string `json:"channel_display_mode,omitempty"`
+	TutorialStep        *string `json:"tutorial_step,omitempty"`
+	EmailInterval       *string `json:"email_interval,omitempty"`
 
 	NotifyProps *UserNotifyPropsImportData `json:"notify_props,omitempty"`
 }

--- a/model/preference.go
+++ b/model/preference.go
@@ -25,6 +25,7 @@ const (
 	PreferenceNameChannelDisplayMode      = "channel_display_mode"
 	PreferenceNameCollapseSetting         = "collapse_previews"
 	PreferenceNameMessageDisplay          = "message_display"
+	PreferenceNameCollapseConsecutive     = "collapse_consecutive_messages"
 	PreferenceNameNameFormat              = "name_format"
 	PreferenceNameUseMilitaryTime         = "use_military_time"
 	PreferenceRecommendedNextSteps        = "recommended_next_steps"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This adds support for a new preference (`collapse_consecutive_messages`) which the client will use in a separate pull request to change how it displays several consecutive messages from the same user. This is push-compatible in all cases *except* when a new client sends the setting to an old server. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
I don't have a ticket link, just a feature request: https://mattermost.uservoice.com/forums/306457-general/suggestions/44543601-add-a-ui-option-to-always-show-the-username-of-a-p

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added a new preferences which can be updated from the API, `collapse_consecutive_messages`. 
```
