### PR TITLE
[MM-40560] Add Server locale to link preview request

### DIFF
--- a/app/post_metadata.go
+++ b/app/post_metadata.go
@@ -549,6 +549,7 @@ func (a *App) getLinkMetadata(requestURL string, timestamp int64, isNewPost bool
 		} else {
 			request.Header.Add("Accept", "image/*")
 			request.Header.Add("Accept", "text/html;q=0.8")
+			request.Header.Add("Accept-Language", *a.Config().LocalizationSettings.DefaultServerLocale)
 
 			client := a.HTTPService().MakeClient(false)
 			client.Timeout = time.Duration(*a.Config().ExperimentalSettings.LinkMetadataTimeoutMilliseconds) * time.Millisecond


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).

|  before  |  after  |
|----|----|
| -- | -- |
-->
This PR adds the `Accept-Language` header to the Link Preview request, with its value set to the Default Server Language. If the external server allows this header, it should return content in the language specified.

There aren't any UI changes involved in this PR - but heres a screenshot of the end result for reference:

|  Link preview with server localization settings  | 
|----|
| ![mattermost-link-preview-localized](https://user-images.githubusercontent.com/26177230/145916056-ae597445-363c-4fc6-b5fb-90d6875cfc3e.png) | 



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-40560

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Add Accept-Language header to generate link previews in the Default Server language
```
