### PR TITLE
API includes sort_order, and WebSocket includes data

### DIFF
--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -71,6 +71,23 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 		assert.NotContains(t, received.Channels, channel.Id)
 		assert.Equal(t, []string{th.BasicChannel.Id}, received.Channels)
 	})
+
+	t.Run("should return expected sort order value", func(t *testing.T) {
+		user, client := setupUserForSubtest(t, th)
+
+		customCategory, _, err := client.CreateSidebarCategoryForTeamForUser(user.Id, th.BasicTeam.Id, &model.SidebarCategoryWithChannels{
+			SidebarCategory: model.SidebarCategory{
+				UserId:      user.Id,
+				TeamId:      th.BasicTeam.Id,
+				DisplayName: "custom123",
+			},
+		})
+		require.NoError(t, err)
+
+		// Initial new category sort order is 10 (first)
+		require.Equal(t, int64(10), customCategory.SortOrder)
+	})
+
 }
 
 func TestUpdateCategoryForTeamForUser(t *testing.T) {

--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -4,7 +4,9 @@
 package api4
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,6 +90,65 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 		require.Equal(t, int64(10), customCategory.SortOrder)
 	})
 
+	t.Run("should publish expected WS payload", func(t *testing.T) {
+		userWSClient, err := th.CreateWebSocketClient()
+		require.NoError(t, err)
+		defer userWSClient.Close()
+		userWSClient.Listen()
+
+		category := &model.SidebarCategoryWithChannels{
+			SidebarCategory: model.SidebarCategory{
+				UserId:      th.BasicUser.Id,
+				TeamId:      th.BasicTeam.Id,
+				DisplayName: "test",
+			},
+			Channels: []string{th.BasicChannel.Id, "notachannel", th.BasicChannel2.Id},
+		}
+
+		received, _, err := th.Client.CreateSidebarCategoryForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, category)
+		require.NoError(t, err)
+
+		testCategories := []*model.SidebarCategoryWithChannels{
+			{
+				SidebarCategory: model.SidebarCategory{
+					Id:      received.Id,
+					UserId:  th.BasicUser.Id,
+					TeamId:  th.BasicTeam.Id,
+					Sorting: model.SidebarCategorySortRecent,
+					Muted:   true,
+				},
+				Channels: []string{th.BasicChannel.Id},
+			},
+		}
+
+		testCategories, _, err = th.Client.UpdateSidebarCategoriesForTeamForUser(th.BasicUser.Id, th.BasicTeam.Id, testCategories)
+		require.NoError(t, err)
+
+		b, err := json.Marshal(testCategories)
+		require.Nil(t, err)
+		expected := string(b)
+
+		var caught bool
+		func() {
+			for {
+				select {
+				case ev := <-userWSClient.EventChannel:
+					if ev.EventType() == model.WebsocketEventSidebarCategoryUpdated {
+						caught = true
+						data := ev.GetData()
+
+						updatedCategoriesData, ok := data["updatedCategories"]
+						require.True(t, ok)
+						require.EqualValues(t, expected, updatedCategoriesData)
+					}
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+
+		require.Truef(t, caught, "User should have received %s event", model.WebsocketEventSidebarCategoryUpdated)
+	})
 }
 
 func TestUpdateCategoryForTeamForUser(t *testing.T) {

--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -125,7 +125,7 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 		require.NoError(t, err)
 
 		b, err := json.Marshal(testCategories)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		expected := string(b)
 
 		var caught bool

--- a/app/channel_category.go
+++ b/app/channel_category.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -119,6 +120,14 @@ func (a *App) UpdateSidebarCategories(userID, teamID string, categories []*model
 	}
 
 	message := model.NewWebSocketEvent(model.WebsocketEventSidebarCategoryUpdated, teamID, "", userID, nil)
+
+	updatedCategoriesJSON, jsonErr := json.Marshal(updatedCategories)
+	if jsonErr != nil {
+		mlog.Warn("Failed to encode original categories to JSON", mlog.Err(jsonErr))
+	}
+
+	message.Add("updatedCategories", string(updatedCategoriesJSON))
+
 	a.Publish(message)
 
 	a.muteChannelsForUpdatedCategories(userID, updatedCategories, originalCategories)

--- a/model/channel_sidebar.go
+++ b/model/channel_sidebar.go
@@ -37,12 +37,11 @@ const (
 )
 
 // SidebarCategory represents the corresponding DB table
-// SortOrder is never returned to the user and only used for queries
 type SidebarCategory struct {
 	Id          string                 `json:"id"`
 	UserId      string                 `json:"user_id"`
 	TeamId      string                 `json:"team_id"`
-	SortOrder   int64                  `json:"-"`
+	SortOrder   int64                  `json:"sort_order"`
 	Sorting     SidebarCategorySorting `json:"sorting"`
 	Type        SidebarCategoryType    `json:"type"`
 	DisplayName string                 `json:"display_name"`


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

These changes unblock some future feature work on the mobile v2 (gekidou).

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-40470

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Adds sort order to category api, and includes category data in websocket category update event
```
