### PR TITLE
Remove unnecessary test TestValidateToken

### DIFF
--- a/shared/mfa/mfa_test.go
+++ b/shared/mfa/mfa_test.go
@@ -154,26 +154,12 @@ func TestDeactivate(t *testing.T) {
 }
 
 func TestValidateToken(t *testing.T) {
-	secret := newRandomBase32String(mfaSecretSize)
-	token := dgoogauth.ComputeCode(secret, time.Now().UTC().Unix()/30)
-
 	t.Run("fail on wrongly formatted token", func(t *testing.T) {
+		secret := newRandomBase32String(mfaSecretSize)
 		ok, err := New(nil).ValidateToken(secret, "invalid-token")
 		require.Error(t, err)
 		require.False(t, ok)
 		require.Contains(t, err.Error(), "unable to parse the token")
-	})
-
-	t.Run("fail on invalid token", func(t *testing.T) {
-		ok, err := New(nil).ValidateToken(secret, "000000")
-		require.NoError(t, err)
-		require.False(t, ok)
-	})
-
-	t.Run("valid token", func(t *testing.T) {
-		ok, err := New(nil).ValidateToken(secret, fmt.Sprintf("%06d", token))
-		require.NoError(t, err)
-		require.True(t, ok)
 	})
 }
 


### PR DESCRIPTION
The TestValidateToken was actually testing
the underlying library rather than testing our code.
So, in a way, it was ineffective.

The actual flaky test was that in a rare case,
the random string generated might actually lead
to 000000 being an actual code rather than invalid.

So using random strings is fundamentally incorrect.
Even the tests in the library use hardcoded strings
and not random strings.

To fix this properly would be to use hardcoded strings,
but then we would just be testing the library
and not our code. To keep things simple,
we just keep the test to verify the error message
and remove the others.

https://community-daily.mattermost.com/boards/workspace/zyoahc9uapdn3xdptac6jb69ic/285b80a3-257d-41f6-8cf4-ed80ca9d92e5/495cdb4d-c13a-4992-8eb9-80cfee2819a4/cidjhgy1ag3yktn5eszae1489yr

```release-note
NONE
```
