### PR TITLE
[MM-40682] - SIGSEGV after upgrade from 6.1.0 to 6.2.0

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -176,7 +176,9 @@ func (ch *Channels) initPlugins(c *request.Context, pluginDir, webappPluginDir s
 	ch.pluginsLock.RUnlock()
 	if pluginsEnvironment != nil || !*ch.srv.Config().PluginSettings.Enable {
 		ch.syncPluginsActiveState()
-		pluginsEnvironment.TogglePluginHealthCheckJob(*ch.srv.Config().PluginSettings.EnableHealthCheck)
+		if pluginsEnvironment != nil {
+			pluginsEnvironment.TogglePluginHealthCheckJob(*ch.srv.Config().PluginSettings.EnableHealthCheck)
+		}
 		return
 	}
 

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -626,6 +627,38 @@ func TestPluginSync(t *testing.T) {
 			})
 		})
 	}
+}
+
+// See https://github.com/mattermost/mattermost-server/issues/19189
+func TestChannelsPluginsInit(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	runNoPanicTest := func(t *testing.T) {
+		ctx := request.EmptyContext()
+		path, _ := fileutils.FindDir("tests")
+
+		panicTestFunc := func() {
+			th.Server.Channels().initPlugins(ctx, path, path)
+		}
+		require.NotPanics(t, panicTestFunc)
+	}
+
+	t.Run("no panics when plugins enabled", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = true
+		})
+
+		runNoPanicTest(t)
+	})
+
+	t.Run("no panics when plugins disabled", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = false
+		})
+
+		runNoPanicTest(t)
+	})
 }
 
 func TestSyncPluginsActiveState(t *testing.T) {

--- a/app/plugin_test.go
+++ b/app/plugin_test.go
@@ -638,10 +638,9 @@ func TestChannelsPluginsInit(t *testing.T) {
 		ctx := request.EmptyContext()
 		path, _ := fileutils.FindDir("tests")
 
-		panicTestFunc := func() {
+		require.NotPanics(t, func() {
 			th.Server.Channels().initPlugins(ctx, path, path)
-		}
-		require.NotPanics(t, panicTestFunc)
+		})
 	}
 
 	t.Run("no panics when plugins enabled", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR fixes a panic in the initPlugins function that was occurring due to pluginsEnvironment being nil at initialising

#### Ticket Link
[MM-40682](https://mattermost.atlassian.net/browse/MM-40682)

#### Release Note

```release-note
NONE

```
