### PR TITLE
[MM-39542] Allow upsert for duplicate key in LinkMetadataStore

### DIFF
--- a/store/storetest/link_metadata_store.go
+++ b/store/storetest/link_metadata_store.go
@@ -107,7 +107,8 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 		assert.Equal(t, &model.PostImage{}, linkMetadata.Data)
 
-		metadata.Data = &model.PostImage{Height: 10, Width: 20}
+		newData := &model.PostImage{Height: 10, Width: 20}
+		metadata.Data = newData
 
 		linkMetadata, err = ss.LinkMetadata().Save(metadata)
 		require.NoError(t, err)
@@ -116,7 +117,7 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 		// Should return the original result, not the duplicate one
 		linkMetadata, err = ss.LinkMetadata().Get(metadata.URL, metadata.Timestamp)
 		require.NoError(t, err)
-		assert.NotEqual(t, &model.PostImage{}, linkMetadata.Data)
+		assert.Equal(t, newData, linkMetadata.Data)
 	})
 }
 

--- a/store/storetest/link_metadata_store.go
+++ b/store/storetest/link_metadata_store.go
@@ -95,7 +95,7 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 		assert.Equal(t, *metadata, *linkMetadata)
 	})
 
-	t.Run("should not save with duplicate URL and timestamp, but should not return an error", func(t *testing.T) {
+	t.Run("should save data with duplicate URL and timestamp", func(t *testing.T) {
 		metadata := &model.LinkMetadata{
 			URL:       "http://example.com",
 			Timestamp: getNextLinkMetadataTimestamp(),
@@ -116,7 +116,7 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 		// Should return the original result, not the duplicate one
 		linkMetadata, err = ss.LinkMetadata().Get(metadata.URL, metadata.Timestamp)
 		require.NoError(t, err)
-		assert.Equal(t, &model.PostImage{}, linkMetadata.Data)
+		assert.NotEqual(t, &model.PostImage{}, linkMetadata.Data)
 	})
 }
 

--- a/store/storetest/link_metadata_store.go
+++ b/store/storetest/link_metadata_store.go
@@ -112,7 +112,7 @@ func testLinkMetadataStoreSave(t *testing.T, ss store.Store) {
 
 		linkMetadata, err = ss.LinkMetadata().Save(metadata)
 		require.NoError(t, err)
-		assert.Equal(t, linkMetadata.Data, &model.PostImage{Height: 10, Width: 20})
+		assert.Equal(t, newData, linkMetadata.Data)
 
 		// Should return the original result, not the duplicate one
 		linkMetadata, err = ss.LinkMetadata().Get(metadata.URL, metadata.Timestamp)


### PR DESCRIPTION


#### Summary
Due to what I get from https://community.mattermost.com/core/pl/r453amcdmfrtpdjduinyi8arje I think it's ok to overwrite if we have same url and timestamp for the link. Otherwise we may need to do a db read before try inserting new value. 0/5 on either solution and I might be missing some context.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39542

#### Release Note

```release-note
NONE
```
