### PR TITLE
[MM-29137] - adding a feature flag for inline post editing

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -70,6 +70,9 @@ type FeatureFlags struct {
 
 	// A/B test for whether radio buttons or toggle button is more effective in in-screen invite to team modal ("none", "toggle")
 	InviteToTeam string
+
+	// Enable inline post editing
+	InlinePostEditing bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -94,6 +97,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.GuidedChannelCreation = false
 	f.ResendInviteEmailInterval = ""
 	f.InviteToTeam = "none"
+	f.InlinePostEditing = false
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {


### PR DESCRIPTION
#### Summary
adds a feature flag (`MM_FEATUREFLAG_INLINEPOSTEDITING`) to enable inline post editing, defaulting to `false`

#### Ticket Link
[MM-29137](https://mattermost.atlassian.net/browse/MM-29137)

#### Release Note
```release-note
Added a new feature flag `INLINEPOSTEDITING` to enable inline post editing
```
