### PR TITLE
MM-40752 - set encryption when copying files to minio honoring config defined value

### DIFF
--- a/shared/filestore/s3store.go
+++ b/shared/filestore/s3store.go
@@ -255,18 +255,25 @@ func (b *S3FileBackend) CopyFile(oldPath, newPath string) error {
 	oldPath = filepath.Join(b.pathPrefix, oldPath)
 	newPath = filepath.Join(b.pathPrefix, newPath)
 	srcOpts := s3.CopySrcOptions{
-		Bucket:     b.bucket,
-		Object:     oldPath,
-		Encryption: encrypt.NewSSE(),
+		Bucket: b.bucket,
+		Object: oldPath,
 	}
+	if b.encrypt {
+		srcOpts.Encryption = encrypt.NewSSE()
+	}
+
 	dstOpts := s3.CopyDestOptions{
-		Bucket:     b.bucket,
-		Object:     newPath,
-		Encryption: encrypt.NewSSE(),
+		Bucket: b.bucket,
+		Object: newPath,
 	}
+	if b.encrypt {
+		dstOpts.Encryption = encrypt.NewSSE()
+	}
+
 	if _, err := b.client.CopyObject(context.Background(), dstOpts, srcOpts); err != nil {
 		return errors.Wrapf(err, "unable to copy file from %s to %s", oldPath, newPath)
 	}
+
 	return nil
 }
 
@@ -274,14 +281,19 @@ func (b *S3FileBackend) MoveFile(oldPath, newPath string) error {
 	oldPath = filepath.Join(b.pathPrefix, oldPath)
 	newPath = filepath.Join(b.pathPrefix, newPath)
 	srcOpts := s3.CopySrcOptions{
-		Bucket:     b.bucket,
-		Object:     oldPath,
-		Encryption: encrypt.NewSSE(),
+		Bucket: b.bucket,
+		Object: oldPath,
 	}
+	if b.encrypt {
+		srcOpts.Encryption = encrypt.NewSSE()
+	}
+
 	dstOpts := s3.CopyDestOptions{
-		Bucket:     b.bucket,
-		Object:     newPath,
-		Encryption: encrypt.NewSSE(),
+		Bucket: b.bucket,
+		Object: newPath,
+	}
+	if b.encrypt {
+		dstOpts.Encryption = encrypt.NewSSE()
 	}
 
 	if _, err := b.client.CopyObject(context.Background(), dstOpts, srcOpts); err != nil {


### PR DESCRIPTION
#### Summary
When copying/moving files in the minio server, the code was defining the Encryption value as default to SSE-S3 which was failing as expected as exposed in minio ticket https://github.com/minio/minio/issues/6367#issuecomment-416182961. This PR adds a check to validate the value of AmazonS3SSE config and if it is set to true, then define the encryption.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40752

#### Release Note
```release-note
NONE
```
