### PR TITLE
[MM-39583] - Intermediary web login page: Workspace Cookies

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -251,6 +251,26 @@ func Setup(tb testing.TB) *TestHelper {
 	return th
 }
 
+func SetupAndApplyConfigBeforeLogin(tb testing.TB, updateConfig func(cfg *model.Config)) *TestHelper {
+	if testing.Short() {
+		tb.SkipNow()
+	}
+
+	if mainHelper == nil {
+		tb.SkipNow()
+	}
+
+	dbStore := mainHelper.GetStore()
+	dbStore.DropAllTables()
+	dbStore.MarkSystemRanUnitTests()
+	mainHelper.PreloadMigrations()
+	searchEngine := mainHelper.GetSearchEngine()
+	th := setupTestHelper(dbStore, searchEngine, false, true, nil, nil)
+	th.App.UpdateConfig(updateConfig)
+	th.InitLogin()
+	return th
+}
+
 func SetupConfig(tb testing.TB, updateConfig func(cfg *model.Config)) *TestHelper {
 	if testing.Short() {
 		tb.SkipNow()

--- a/api4/user.go
+++ b/api4/user.go
@@ -1854,7 +1854,7 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// For context see: https://mattermost.atlassian.net/browse/MM-39583
 	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
-		c.App.AttachCWSIntermediaryLoginCookie(c.AppContext, w, r)
+		c.App.AttachCloudSessionCookie(c.AppContext, w, r)
 	}
 
 	userTermsOfService, err := c.App.GetUserTermsOfService(user.Id)

--- a/api4/user.go
+++ b/api4/user.go
@@ -1853,7 +1853,7 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For context see: https://mattermost.atlassian.net/browse/MM-39583
-	if c.App.Srv().License() == nil || !*c.App.Srv().License().Features.Cloud {
+	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
 		c.App.AttachCWSIntermediaryLoginCookie(c.AppContext, w, r)
 	}
 

--- a/api4/user.go
+++ b/api4/user.go
@@ -1853,7 +1853,9 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For context see: https://mattermost.atlassian.net/browse/MM-39583
-	c.App.AttachCWSIntermediaryLoginCookie(c.AppContext, w, r)
+	if c.App.Srv().License() == nil || !*c.App.Srv().License().Features.Cloud {
+		c.App.AttachCWSIntermediaryLoginCookie(c.AppContext, w, r)
+	}
 
 	userTermsOfService, err := c.App.GetUserTermsOfService(user.Id)
 	if err != nil && err.StatusCode != http.StatusNotFound {

--- a/api4/user.go
+++ b/api4/user.go
@@ -1852,6 +1852,9 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.App.AttachSessionCookies(c.AppContext, w, r)
 	}
 
+	// For context see: https://mattermost.atlassian.net/browse/MM-39583
+	c.App.AttachCWSIntermediaryLoginCookie(c.AppContext, w, r)
+
 	userTermsOfService, err := c.App.GetUserTermsOfService(user.Id)
 	if err != nil && err.StatusCode != http.StatusNotFound {
 		c.Err = err

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -3653,14 +3653,12 @@ func TestLoginCookies(t *testing.T) {
 
 		_, resp, _ := th.Client.Login(th.BasicUser.Email, th.BasicUser.Password)
 
-		cloudSessionCookie := ""
-		for _, cookie := range resp.Header["Set-Cookie"] {
-			if match := regexp.MustCompile("^" + model.SessionCookieCloudUrl + "=([a-z0-9]+)").FindStringSubmatch(cookie); match != nil {
-				cloudSessionCookie = match[1]
-			}
-		}
+		val := strings.Split(resp.Header["Set-Cookie"][0], ";")
+		cloudSessionCookie := strings.Split(val[0], "=")[1]
+		domain := strings.Split(val[2], "=")[1]
 
 		assert.Equal(t, "testchips", cloudSessionCookie)
+		assert.Equal(t, "mattermost.com", domain)
 	})
 
 	t.Run("should NOT return cookie with MMCLOUDURL for NON cloud installations", func(t *testing.T) {

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -391,7 +391,7 @@ type AppIface interface {
 	AllowOAuthAppAccessToUser(userID string, authRequest *model.AuthorizeRequest) (string, *model.AppError)
 	AppendFile(fr io.Reader, path string) (int64, *model.AppError)
 	AsymmetricSigningKey() *ecdsa.PrivateKey
-	AttachCWSIntermediaryLoginCookie(c *request.Context, w http.ResponseWriter, r *http.Request)
+	AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter, r *http.Request)
 	AttachDeviceId(sessionID string, deviceID string, expiresAt int64) *model.AppError
 	AttachSessionCookies(c *request.Context, w http.ResponseWriter, r *http.Request)
 	AuthenticateUserForLogin(c *request.Context, id, loginId, password, mfaToken, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError)

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -391,6 +391,7 @@ type AppIface interface {
 	AllowOAuthAppAccessToUser(userID string, authRequest *model.AuthorizeRequest) (string, *model.AppError)
 	AppendFile(fr io.Reader, path string) (int64, *model.AppError)
 	AsymmetricSigningKey() *ecdsa.PrivateKey
+	AttachCWSIntermediaryLoginCookie(c *request.Context, w http.ResponseWriter, r *http.Request)
 	AttachDeviceId(sessionID string, deviceID string, expiresAt int64) *model.AppError
 	AttachSessionCookies(c *request.Context, w http.ResponseWriter, r *http.Request)
 	AuthenticateUserForLogin(c *request.Context, id, loginId, password, mfaToken, cwsToken string, ldapOnly bool) (user *model.User, err *model.AppError)

--- a/app/login.go
+++ b/app/login.go
@@ -254,8 +254,7 @@ func (a *App) AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter
 		val = "localhost"
 	} else {
 		val = strings.SplitN(domain, ".", 2)[0]
-		// we want to share this cookie between 'https://customers.mattermost.com' and 'https://example.cloud.mattermost.com'
-		domain = "mattermost.com"
+		domain = strings.SplitN(domain, ".", 3)[2]
 	}
 
 	cookie := &http.Cookie{

--- a/app/login.go
+++ b/app/login.go
@@ -254,6 +254,8 @@ func (a *App) AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter
 		val = "localhost"
 	} else {
 		val = strings.SplitN(domain, ".", 2)[0]
+		// we want to share this cookie between 'https://customers.mattermost.com' and 'https://example.cloud.mattermost.com'
+		domain = "mattermost.com"
 	}
 
 	cookie := &http.Cookie{

--- a/app/login.go
+++ b/app/login.go
@@ -238,7 +238,7 @@ func (a *App) DoLogin(c *request.Context, w http.ResponseWriter, r *http.Request
 	return nil
 }
 
-func (a *App) AttachCWSIntermediaryLoginCookie(c *request.Context, w http.ResponseWriter, r *http.Request) {
+func (a *App) AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter, r *http.Request) {
 	secure := false
 	if GetProtocol(r) == "https" {
 		secure = true
@@ -249,16 +249,15 @@ func (a *App) AttachCWSIntermediaryLoginCookie(c *request.Context, w http.Respon
 	subpath, _ := utils.GetSubpathFromConfig(a.Config())
 	expiresAt := time.Unix(model.GetMillis()/1000+int64(maxAge), 0)
 
-	// for a domain like 'allan.cloud.mattermost.com' this will give us 'cloud.mattermost.com'
 	var val string
 	if strings.Contains(domain, "localhost") {
 		val = "localhost"
 	} else {
-		val = strings.SplitN(domain, ".", 2)[1]
+		val = strings.SplitN(domain, ".", 2)[0]
 	}
 
 	cookie := &http.Cookie{
-		Name:     model.SessionCookieCWSIntermediary,
+		Name:     model.SessionCookieCloudUrl,
 		Value:    val,
 		Path:     subpath,
 		MaxAge:   maxAge,

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -686,9 +686,9 @@ func (a *OpenTracingAppLayer) AsymmetricSigningKey() *ecdsa.PrivateKey {
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) AttachCWSIntermediaryLoginCookie(c *request.Context, w http.ResponseWriter, r *http.Request) {
+func (a *OpenTracingAppLayer) AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter, r *http.Request) {
 	origCtx := a.ctx
-	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AttachCWSIntermediaryLoginCookie")
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AttachCloudSessionCookie")
 
 	a.ctx = newCtx
 	a.app.Srv().Store.SetContext(newCtx)
@@ -698,7 +698,7 @@ func (a *OpenTracingAppLayer) AttachCWSIntermediaryLoginCookie(c *request.Contex
 	}()
 
 	defer span.Finish()
-	a.app.AttachCWSIntermediaryLoginCookie(c, w, r)
+	a.app.AttachCloudSessionCookie(c, w, r)
 }
 
 func (a *OpenTracingAppLayer) AttachDeviceId(sessionID string, deviceID string, expiresAt int64) *model.AppError {

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -686,6 +686,21 @@ func (a *OpenTracingAppLayer) AsymmetricSigningKey() *ecdsa.PrivateKey {
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) AttachCWSIntermediaryLoginCookie(c *request.Context, w http.ResponseWriter, r *http.Request) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AttachCWSIntermediaryLoginCookie")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	a.app.AttachCWSIntermediaryLoginCookie(c, w, r)
+}
+
 func (a *OpenTracingAppLayer) AttachDeviceId(sessionID string, deviceID string, expiresAt int64) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.AttachDeviceId")

--- a/model/session.go
+++ b/model/session.go
@@ -15,7 +15,7 @@ const (
 	SessionCookieToken            = "MMAUTHTOKEN"
 	SessionCookieUser             = "MMUSERID"
 	SessionCookieCsrf             = "MMCSRF"
-	SessionCookieCWSIntermediary  = "MMCWSINTERMEDIARYLOGINCOOKIE"
+	SessionCookieCloudUrl         = "MMCLOUDURL"
 	SessionCacheSize              = 35000
 	SessionPropPlatform           = "platform"
 	SessionPropOs                 = "os"

--- a/model/session.go
+++ b/model/session.go
@@ -15,6 +15,7 @@ const (
 	SessionCookieToken            = "MMAUTHTOKEN"
 	SessionCookieUser             = "MMUSERID"
 	SessionCookieCsrf             = "MMCSRF"
+	SessionCookieCWSIntermediary  = "MMCWSINTERMEDIARYLOGINCOOKIE"
 	SessionCacheSize              = 35000
 	SessionPropPlatform           = "platform"
 	SessionPropOs                 = "os"


### PR DESCRIPTION
#### Summary
The CWS has this page https://customers.mattermost.com/cloud/connect-workspace . We want to be able to autofill the company domain field based on a cookie set by a user's workspace after they logged into it. Atm, the cookie will hold a value of the last workspace the user interacted with.

#### Ticket Link
[MM-39583](https://mattermost.atlassian.net/browse/MM-39583)

#### Related
https://github.com/mattermost/customer-web-server/pull/639

#### Release Note

```release-note
NONE

```
