### PR TITLE
Support 'postgresql' schema designator

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -153,7 +153,7 @@ func parseDSN(dsn string) (string, string, error) {
 		// Strip off the mysql:// for the dsn with which to connect.
 		dsn = s[1]
 
-	case "postgres":
+	case "postgres", "postgresql":
 		// No changes required
 
 	default:

--- a/config/utils.go
+++ b/config/utils.go
@@ -174,7 +174,9 @@ func Merge(cfg *model.Config, patch *model.Config, mergeConfig *utils.MergeConfi
 }
 
 func IsDatabaseDSN(dsn string) bool {
-	return strings.HasPrefix(dsn, "mysql://") || strings.HasPrefix(dsn, "postgres://")
+	return strings.HasPrefix(dsn, "mysql://") ||
+		strings.HasPrefix(dsn, "postgres://") ||
+		strings.HasPrefix(dsn, "postgresql://")
 }
 
 // stripPassword remove the password from a given DSN

--- a/config/utils_test.go
+++ b/config/utils_test.go
@@ -159,8 +159,13 @@ func TestIsDatabaseDSN(t *testing.T) {
 			Expected: true,
 		},
 		{
-			Name:     "Postgresql DSN",
+			Name:     "Postgresql 'postgres' DSN",
 			DSN:      "postgres://localhost",
+			Expected: true,
+		},
+		{
+			Name:     "Postgresql 'postgresql' DSN",
+			DSN:      "postgresql://localhost",
 			Expected: true,
 		},
 		{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Stumbled upon this when troubleshooting issue reported to Mattermost Operator https://github.com/mattermost/mattermost-operator/issues/269.

When `postgresql` schema designator is used in the connection string passed with `MM_CONFIG` env the Mattermost server treats it as a file path, not a database connection string.

According to Postgres docs, both designators are valid https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING so I think it would make sense to support both.
> The URI scheme designator can be either postgresql:// or postgres://.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Support `postgresql` schema designator
```
