### PR TITLE
[MM-40177] Sanitize Teams response when requested with total count

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -1055,13 +1055,13 @@ func getAllTeams(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	c.App.SanitizeTeams(*c.AppContext.Session(), teams)
-
 	var js []byte
 	var jsonErr error
 	if c.Params.IncludeTotalCount {
+		c.App.SanitizeTeams(*c.AppContext.Session(), teamsWithCount.Teams)
 		js, jsonErr = json.Marshal(teamsWithCount)
 	} else {
+		c.App.SanitizeTeams(*c.AppContext.Session(), teams)
 		js, jsonErr = json.Marshal(teams)
 	}
 	if jsonErr != nil {

--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -1123,6 +1123,19 @@ func TestGetAllTeams(t *testing.T) {
 		require.Error(t, err)
 		CheckUnauthorizedStatus(t, resp)
 	})
+
+	t.Run("Sanitize the teams in the response with total count", func(t *testing.T) {
+		otherUser := th.CreateUser()
+		client.Login(otherUser.Email, otherUser.Password)
+		teams, _, _, err := client.GetAllTeamsWithTotalCount("", 0, 10)
+		require.NoError(t, err)
+		for _, team := range teams {
+			if team.Email != "" {
+				require.Nil(t, team.Email)
+				break
+			}
+		}
+	})
 }
 
 func TestGetAllTeamsSanitization(t *testing.T) {


### PR DESCRIPTION
#### Summary
We are not sanitizing teams when requested for the total count.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40177

#### Release Note
```
NONE
```