### PR TITLE
MM-40594: Fix nil retention policies

### DIFF
--- a/store/sqlstore/retention_policy_store.go
+++ b/store/sqlstore/retention_policy_store.go
@@ -419,13 +419,14 @@ func (s *SqlRetentionPolicyStore) Get(id string) (*model.RetentionPolicyWithTeam
 	return &policy, nil
 }
 
-func (s *SqlRetentionPolicyStore) GetAll(offset, limit int) (policies []*model.RetentionPolicyWithTeamAndChannelCounts, err error) {
+func (s *SqlRetentionPolicyStore) GetAll(offset, limit int) ([]*model.RetentionPolicyWithTeamAndChannelCounts, error) {
+	policies := []*model.RetentionPolicyWithTeamAndChannelCounts{}
 	queryString, args, err := s.buildGetPoliciesQuery("", offset, limit)
 	if err != nil {
-		return
+		return policies, err
 	}
 	err = s.GetReplicaX().Select(&policies, queryString, args...)
-	return
+	return policies, err
 }
 
 func (s *SqlRetentionPolicyStore) GetCount() (int64, error) {

--- a/store/storetest/retention_policy_store.go
+++ b/store/storetest/retention_policy_store.go
@@ -326,6 +326,13 @@ func testRetentionPolicyStorePatch(t *testing.T, ss store.Store, s SqlStore) {
 }
 
 func testRetentionPolicyStoreGet(t *testing.T, ss store.Store, s SqlStore) {
+	t.Run("get none", func(t *testing.T) {
+		retrievedPolicies, err := ss.RetentionPolicy().GetAll(0, 10)
+		require.NoError(t, err)
+		require.NotNil(t, retrievedPolicies)
+		require.Equal(t, 0, len(retrievedPolicies))
+	})
+
 	// create multiple policies
 	policiesWithCounts := make([]*model.RetentionPolicyWithTeamAndChannelCounts, 0)
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
Due to the store method having named returns, the variable
was getting set to nil instead of being an empty slice.
We missed this during code review.

https://mattermost.atlassian.net/browse/MM-40594

```release-note
NONE
```
