### PR TITLE
Prepackage boards to v0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.5.0
-PLUGIN_PACKAGES += focalboard-v0.11.0
+PLUGIN_PACKAGES += focalboard-v0.12.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)


### PR DESCRIPTION
#### Summary
Update prepackaged boards version to 0.12.0

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/1991
  
#### Release Note
```release-note
Update prepackaged boards version to 0.12.0
```
