### PR TITLE
MM-40664: fixes CRT notifications

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -156,6 +156,9 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 				if threadPost.Id == parentPostList.Order[0] && threadPost.IsFromOAuthBot() {
 					continue
 				}
+				if a.IsCRTEnabledForUser(profile.Id) {
+					continue
+				}
 				if profile.NotifyProps[model.CommentsNotifyProp] == model.CommentsNotifyAny || (profile.NotifyProps[model.CommentsNotifyProp] == model.CommentsNotifyRoot && threadPost.Id == parentPostList.Order[0]) {
 					mentionType := ThreadMention
 					if threadPost.Id == parentPostList.Order[0] {


### PR DESCRIPTION
#### Summary
Reply notification settings that take effect when CRT is off where
considered when CRT is on as well. Resulting, in some cases, in not
respecting the CRT setting for notifications.
This commit fixes that by guarding against `IsCRTEnabledForUser` when
checking for reply notification settings.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-40664

#### Release Note

```release-note
NONE
```
