### PR TITLE
[MM-41022] - Fix panic when AllowCookiesSubdomain setting is false

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -260,8 +260,6 @@ func (a *App) AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter
 			domain = strings.SplitN(domain, ".", 3)[2]
 		}
 
-		fmt.Println("DOM", val, domain)
-
 		cookie := &http.Cookie{
 			Name:     model.SessionCookieCloudUrl,
 			Value:    val,

--- a/app/login.go
+++ b/app/login.go
@@ -249,26 +249,32 @@ func (a *App) AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter
 	subpath, _ := utils.GetSubpathFromConfig(a.Config())
 	expiresAt := time.Unix(model.GetMillis()/1000+int64(maxAge), 0)
 
-	var val string
-	if strings.Contains(domain, "localhost") {
-		val = "localhost"
-	} else {
-		val = strings.SplitN(domain, ".", 2)[0]
-		domain = strings.SplitN(domain, ".", 3)[2]
-	}
+	// domain could potentially be empty when ServiceSettings.AllowCookiesForSubdomains is false
+	// or SiteURL for some reason is not set
+	if domain != "" {
+		var val string
+		if strings.Contains(domain, "localhost") {
+			val = "localhost"
+		} else {
+			val = strings.SplitN(domain, ".", 2)[0]
+			domain = strings.SplitN(domain, ".", 3)[2]
+		}
 
-	cookie := &http.Cookie{
-		Name:     model.SessionCookieCloudUrl,
-		Value:    val,
-		Path:     subpath,
-		MaxAge:   maxAge,
-		Expires:  expiresAt,
-		HttpOnly: true,
-		Domain:   domain,
-		Secure:   secure,
-	}
+		fmt.Println("DOM", val, domain)
 
-	http.SetCookie(w, cookie)
+		cookie := &http.Cookie{
+			Name:     model.SessionCookieCloudUrl,
+			Value:    val,
+			Path:     subpath,
+			MaxAge:   maxAge,
+			Expires:  expiresAt,
+			HttpOnly: true,
+			Domain:   domain,
+			Secure:   secure,
+		}
+
+		http.SetCookie(w, cookie)
+	}
 }
 
 func (a *App) AttachSessionCookies(c *request.Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
