### PR TITLE
Mm 39663

### DIFF
--- a/model/cloud.go
+++ b/model/cloud.go
@@ -156,7 +156,7 @@ type Invoice struct {
 type InvoiceLineItem struct {
 	PriceID      string                 `json:"price_id"`
 	Total        int64                  `json:"total"`
-	Quantity     int64                  `json:"quantity"`
+	Quantity     float64                `json:"quantity"`
 	PricePerUnit int64                  `json:"price_per_unit"`
 	Description  string                 `json:"description"`
 	Type         string                 `json:"type"`

--- a/model/cloud.go
+++ b/model/cloud.go
@@ -139,7 +139,6 @@ func (s *Subscription) GetWorkSpaceNameFromDNS() string {
 // Invoice model represents a cloud invoice
 type Invoice struct {
 	ID                 string             `json:"id"`
-	CurrentProductName string             `json:"current_product_name"`
 	Number             string             `json:"number"`
 	CreateAt           int64              `json:"create_at"`
 	Total              int64              `json:"total"`
@@ -150,6 +149,7 @@ type Invoice struct {
 	PeriodEnd          int64              `json:"period_end"`
 	SubscriptionID     string             `json:"subscription_id"`
 	Items              []*InvoiceLineItem `json:"line_items"`
+	CurrentProductName string             `json:"current_product_name"`
 }
 
 // InvoiceLineItem model represents a cloud invoice lineitem tied to an invoice.

--- a/model/cloud.go
+++ b/model/cloud.go
@@ -138,17 +138,18 @@ func (s *Subscription) GetWorkSpaceNameFromDNS() string {
 
 // Invoice model represents a cloud invoice
 type Invoice struct {
-	ID             string             `json:"id"`
-	Number         string             `json:"number"`
-	CreateAt       int64              `json:"create_at"`
-	Total          int64              `json:"total"`
-	Tax            int64              `json:"tax"`
-	Status         string             `json:"status"`
-	Description    string             `json:"description"`
-	PeriodStart    int64              `json:"period_start"`
-	PeriodEnd      int64              `json:"period_end"`
-	SubscriptionID string             `json:"subscription_id"`
-	Items          []*InvoiceLineItem `json:"line_items"`
+	ID                 string             `json:"id"`
+	CurrentProductName string             `json:"current_product_name"`
+	Number             string             `json:"number"`
+	CreateAt           int64              `json:"create_at"`
+	Total              int64              `json:"total"`
+	Tax                int64              `json:"tax"`
+	Status             string             `json:"status"`
+	Description        string             `json:"description"`
+	PeriodStart        int64              `json:"period_start"`
+	PeriodEnd          int64              `json:"period_end"`
+	SubscriptionID     string             `json:"subscription_id"`
+	Items              []*InvoiceLineItem `json:"line_items"`
 }
 
 // InvoiceLineItem model represents a cloud invoice lineitem tied to an invoice.


### PR DESCRIPTION
#### Summary
Add current product name to invoice so that we don't have to guess infer it in webapp system console billing history page. Make invoice item quantities a float to support metered billing.

Supported by: https://github.com/mattermost/customer-web-server/pull/661
Supports: https://github.com/mattermost/mattermost-webapp/pull/9652/files

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39663

#### Release Note

```release-note
Add current product name to invoice
Support metered billing invoices
```
