### PR TITLE
Fix typos in tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -19,9 +19,9 @@ It is possible to manually test specific sections of any test, instead of using 
 
 ## Test plugins
 
-There are two test plugins: `testplugin.tar.gz` and `testplugin2.tar.gz`. These are use in some integration tests in the `api4` package. Any changes to the plugin bundles require updating the coresponding signatures.
+There are two test plugins: `testplugin.tar.gz` and `testplugin2.tar.gz`. These are use in some integration tests in the `api4` package. Any changes to the plugin bundles require updating the corresponding signatures.
 
-First, import the public and privat development key:
+First, import the public and private development key:
 ```
 $ gpg --import ./development-public-key.gpg
 $ gpg --import ./development-private-key.asc
@@ -29,7 +29,7 @@ $ gpg --import ./development-private-key.asc
 
 This has to be done only once.
 
-Then update the sigantures:
+Then update the signatures:
 ```
 $ gpg -u F3FACE45E0DE642C8BD6A8E64C7C6562C192CC1F --verbose --personal-digest-preferences SHA256 --detach-sign testplugin.tar.gz
 $ gpg -u F3FACE45E0DE642C8BD6A8E64C7C6562C192CC1F --verbose --personal-digest-preferences SHA256 --detach-sign --armor testplugin.tar.gz


### PR DESCRIPTION
coresponding -> corresponding
privat -> private
sigantures -> signatures

#### Summary

Fixes 3 spelling errors in `tests/README.md`

#### Release Note

Not needed for simple typofixes.

```release-note
NONE
```
