### PR TITLE
Revert "Automated cherry pick of #19299"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.5.0
-PLUGIN_PACKAGES += focalboard-v0.12.0
+PLUGIN_PACKAGES += focalboard-v0.11.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target
 ifeq ($(BUILD_ENTERPRISE_READY),true)


### PR DESCRIPTION
Reverts mattermost/mattermost-server#19330

See https://community.mattermost.com/core/pl/xyubgtcdgjgc7p7bkfxusoka8o. I opened this PR to revert the Boards update to v0.12.0 from the Cloud branch so that Cloud customers won't see the latest bugs when we do a cloud release this Wednesday. We can cherry-pick the bump to 0.12.1 to the cloud branch once the Boards dot release is ready. Let me know if you see any issues with this.