### PR TITLE
PostStore: Remove `db:"-"` tag and some other hacks

### DIFF
--- a/model/post.go
+++ b/model/post.go
@@ -86,7 +86,7 @@ type Post struct {
 	// MessageSource will contain the message as submitted by the user if Message has been modified
 	// by Mattermost for presentation (e.g if an image proxy is being used). It should be used to
 	// populate edit boxes if present.
-	MessageSource string `json:"message_source,omitempty" db:"-"`
+	MessageSource string `json:"message_source,omitempty"`
 
 	Type          string          `json:"type"`
 	propsMu       sync.RWMutex    `db:"-"`       // Unexported mutex used to guard Post.Props.
@@ -94,16 +94,16 @@ type Post struct {
 	Hashtags      string          `json:"hashtags"`
 	Filenames     StringArray     `json:"-"` // Deprecated, do not use this field any more
 	FileIds       StringArray     `json:"file_ids,omitempty"`
-	PendingPostId string          `json:"pending_post_id" db:"-"`
+	PendingPostId string          `json:"pending_post_id"`
 	HasReactions  bool            `json:"has_reactions,omitempty"`
 	RemoteId      *string         `json:"remote_id,omitempty"`
 
 	// Transient data populated before sending a post to the client
-	ReplyCount   int64         `json:"reply_count" db:"-"`
-	LastReplyAt  int64         `json:"last_reply_at" db:"-"`
-	Participants []*User       `json:"participants" db:"-"`
-	IsFollowing  *bool         `json:"is_following,omitempty" db:"-"` // for root posts in collapsed thread mode indicates if the current user is following this thread
-	Metadata     *PostMetadata `json:"metadata,omitempty" db:"-"`
+	ReplyCount   int64         `json:"reply_count"`
+	LastReplyAt  int64         `json:"last_reply_at"`
+	Participants []*User       `json:"participants"`
+	IsFollowing  *bool         `json:"is_following,omitempty"` // for root posts in collapsed thread mode indicates if the current user is following this thread
+	Metadata     *PostMetadata `json:"metadata,omitempty"`
 }
 
 type PostEphemeral struct {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -909,12 +909,12 @@ func (s SqlChannelStore) Get(id string, allowFromCache bool) (*model.Channel, er
 func (s SqlChannelStore) GetPinnedPosts(channelId string) (*model.PostList, error) {
 	pl := model.NewPostList()
 
-	posts := []*postInternal{}
+	posts := []*model.Post{}
 	if err := s.GetReplicaX().Select(&posts, "SELECT *, (SELECT count(Posts.Id) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount  FROM Posts p WHERE IsPinned = true AND ChannelId = ? AND DeleteAt = 0 ORDER BY CreateAt ASC", channelId); err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
 	for _, post := range posts {
-		pl.AddPost(post.ToModel())
+		pl.AddPost(post)
 		pl.AddOrder(post.Id)
 	}
 	return pl, nil

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -35,77 +35,7 @@ type postWithExtra struct {
 	ThreadReplyCount   int64
 	IsFollowing        *bool
 	ThreadParticipants model.StringArray
-	postInternal
-}
-
-// postInternal is an internal struct without the `db:"-"` tags
-// for sqlx to be able to scan them. This should go away once
-// we have morph for migrations.
-// It is named like this to avoid clashes with the variable name "post"
-type postInternal struct {
-	Id            string
-	CreateAt      int64
-	UpdateAt      int64
-	EditAt        int64
-	DeleteAt      int64
-	IsPinned      bool
-	UserId        string
-	ChannelId     string
-	RootId        string
-	OriginalId    string
-	Message       string
-	MessageSource string
-	Type          string
-	Props         model.StringInterface
-	Hashtags      string
-	Filenames     model.StringArray
-	FileIds       model.StringArray
-	PendingPostId string
-	HasReactions  bool
-	RemoteId      *string
-	ReplyCount    int64
-	LastReplyAt   int64
-	Participants  []*model.User
-	IsFollowing   *bool
-	Metadata      *model.PostMetadata
-}
-
-func (p *postInternal) ToModel() *model.Post {
-	return &model.Post{
-		Id:            p.Id,
-		CreateAt:      p.CreateAt,
-		UpdateAt:      p.UpdateAt,
-		EditAt:        p.EditAt,
-		DeleteAt:      p.DeleteAt,
-		IsPinned:      p.IsPinned,
-		UserId:        p.UserId,
-		ChannelId:     p.ChannelId,
-		RootId:        p.RootId,
-		OriginalId:    p.OriginalId,
-		Message:       p.Message,
-		MessageSource: p.MessageSource,
-		Type:          p.Type,
-		Props:         p.Props,
-		Hashtags:      p.Hashtags,
-		Filenames:     p.Filenames,
-		FileIds:       p.FileIds,
-		PendingPostId: p.PendingPostId,
-		HasReactions:  p.HasReactions,
-		RemoteId:      p.RemoteId,
-		ReplyCount:    p.ReplyCount,
-		LastReplyAt:   p.LastReplyAt,
-		Participants:  p.Participants,
-		IsFollowing:   p.IsFollowing,
-		Metadata:      p.Metadata,
-	}
-}
-
-func sliceToModel(posts []*postInternal) []*model.Post {
-	res := make([]*model.Post, 0, len(posts))
-	for _, p := range posts {
-		res = append(res, p.ToModel())
-	}
-	return res
+	model.Post
 }
 
 func (s *SqlPostStore) ClearCaches() {
@@ -554,7 +484,7 @@ func (s *SqlPostStore) GetFlaggedPostsForChannel(userId, channelId string, offse
 func (s *SqlPostStore) getFlaggedPosts(userId, channelId, teamId string, offset int, limit int) (*model.PostList, error) {
 	pl := model.NewPostList()
 
-	posts := []*postInternal{}
+	posts := []*model.Post{}
 	query := `
             SELECT
                 A.*, (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN A.RootId = '' THEN A.Id ELSE A.RootId END) AND Posts.DeleteAt = 0) as ReplyCount
@@ -613,7 +543,7 @@ func (s *SqlPostStore) getFlaggedPosts(userId, channelId, teamId string, offset 
 	}
 
 	for _, post := range posts {
-		pl.AddPost(post.ToModel())
+		pl.AddPost(post)
 		pl.AddOrder(post.Id)
 	}
 
@@ -697,7 +627,7 @@ func (s *SqlPostStore) Get(ctx context.Context, id string, skipFetchThreads, col
 		return nil, store.NewErrInvalidInput("Post", "id", id)
 	}
 
-	var post postInternal
+	var post model.Post
 	postFetchQuery := "SELECT p.*, (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount FROM Posts p WHERE p.Id = ? AND p.DeleteAt = 0"
 	err := s.DBXFromContext(ctx).Get(&post, postFetchQuery, id)
 	if err != nil {
@@ -707,7 +637,7 @@ func (s *SqlPostStore) Get(ctx context.Context, id string, skipFetchThreads, col
 
 		return nil, errors.Wrapf(err, "failed to get Post with id=%s", id)
 	}
-	pl.AddPost(post.ToModel())
+	pl.AddPost(&post)
 	pl.AddOrder(id)
 	if !skipFetchThreads {
 		rootId := post.RootId
@@ -720,14 +650,14 @@ func (s *SqlPostStore) Get(ctx context.Context, id string, skipFetchThreads, col
 			return nil, errors.Wrapf(err, "invalid rootId with value=%s", rootId)
 		}
 
-		posts := []*postInternal{}
+		posts := []*model.Post{}
 		err = s.GetReplicaX().Select(&posts, "SELECT *, (SELECT count(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount FROM Posts p WHERE (Id = ? OR RootId = ?) AND DeleteAt = 0", rootId, rootId)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to find Posts")
 		}
 
 		for _, p := range posts {
-			pl.AddPost(p.ToModel())
+			pl.AddPost(p)
 			pl.AddOrder(p.Id)
 		}
 	}
@@ -755,7 +685,7 @@ func (s *SqlPostStore) GetSingle(id string, inclDeleted bool) (*model.Post, erro
 		return nil, errors.Wrap(err, "getsingleincldeleted_tosql")
 	}
 
-	var post postInternal
+	var post model.Post
 	err = s.GetReplicaX().Get(&post, queryString, args...)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -764,7 +694,7 @@ func (s *SqlPostStore) GetSingle(id string, inclDeleted bool) (*model.Post, erro
 
 		return nil, errors.Wrapf(err, "failed to get Post with id=%s", id)
 	}
-	return post.ToModel(), nil
+	return &post, nil
 }
 
 type etagPosts struct {
@@ -1019,16 +949,16 @@ func (s *SqlPostStore) prepareThreadedResponse(posts []*postWithExtra, extended,
 	}
 
 	processPost := func(p *postWithExtra) error {
-		p.postInternal.ReplyCount = p.ThreadReplyCount
+		p.Post.ReplyCount = p.ThreadReplyCount
 		if p.IsFollowing != nil {
-			p.postInternal.IsFollowing = model.NewBool(*p.IsFollowing)
+			p.Post.IsFollowing = model.NewBool(*p.IsFollowing)
 		}
 		for _, userID := range p.ThreadParticipants {
 			participant, ok := usersMap[userID]
 			if !ok {
 				return errors.New("cannot find thread participant with id=" + userID)
 			}
-			p.postInternal.Participants = append(p.postInternal.Participants, participant)
+			p.Post.Participants = append(p.Post.Participants, participant)
 		}
 		return nil
 	}
@@ -1044,8 +974,8 @@ func (s *SqlPostStore) prepareThreadedResponse(posts []*postWithExtra, extended,
 		if err := processPost(posts[idx]); err != nil {
 			return nil, err
 		}
-		post := &posts[idx].postInternal
-		list.AddPost(post.ToModel())
+		post := &posts[idx].Post
+		list.AddPost(post)
 		list.AddOrder(posts[idx].Id)
 	}
 
@@ -1174,7 +1104,7 @@ func (s *SqlPostStore) GetPostsSince(options model.GetPostsSinceOptions, allowFr
 		return s.getPostsSinceCollapsedThreads(options)
 	}
 
-	posts := []*postInternal{}
+	posts := []*model.Post{}
 
 	order := "DESC"
 	if options.SortAscending {
@@ -1244,7 +1174,7 @@ func (s *SqlPostStore) GetPostsSince(options model.GetPostsSinceOptions, allowFr
 	list := model.NewPostList()
 
 	for _, p := range posts {
-		list.AddPost(p.ToModel())
+		list.AddPost(p)
 		if p.UpdateAt > options.Time {
 			list.AddOrder(p.Id)
 		}
@@ -1335,7 +1265,7 @@ func (s *SqlPostStore) getPostsAround(before bool, options model.GetPostsOptions
 
 	offset := options.Page * options.PerPage
 	posts := []*postWithExtra{}
-	parents := []*postInternal{}
+	parents := []*model.Post{}
 
 	var direction string
 	var sort string
@@ -1436,7 +1366,7 @@ func (s *SqlPostStore) getPostsAround(before bool, options model.GetPostsOptions
 	}
 
 	for _, p := range parents {
-		list.AddPost(p.ToModel())
+		list.AddPost(p)
 	}
 
 	return list, nil
@@ -1544,7 +1474,7 @@ func (s *SqlPostStore) GetPostAfterTime(channelId string, time int64, collapsedT
 }
 
 func (s *SqlPostStore) getRootPosts(channelId string, offset int, limit int, skipFetchThreads bool) ([]*model.Post, error) {
-	posts := []*postInternal{}
+	posts := []*model.Post{}
 	var fetchQuery string
 	if skipFetchThreads {
 		fetchQuery = "SELECT p.*, (SELECT COUNT(*) FROM Posts WHERE Posts.RootId = (CASE WHEN p.RootId = '' THEN p.Id ELSE p.RootId END) AND Posts.DeleteAt = 0) as ReplyCount FROM Posts p WHERE ChannelId = ? AND DeleteAt = 0 ORDER BY CreateAt DESC LIMIT ? OFFSET ?"
@@ -1555,7 +1485,7 @@ func (s *SqlPostStore) getRootPosts(channelId string, offset int, limit int, ski
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Posts")
 	}
-	return sliceToModel(posts), nil
+	return posts, nil
 }
 
 func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, skipFetchThreads bool) ([]*model.Post, error) {
@@ -1622,7 +1552,7 @@ func (s *SqlPostStore) getParentsPosts(channelId string, offset int, limit int, 
 }
 
 func (s *SqlPostStore) getParentsPostsPostgreSQL(channelId string, offset int, limit int, skipFetchThreads bool) ([]*model.Post, error) {
-	posts := []*postInternal{}
+	posts := []*model.Post{}
 	replyCountQuery := ""
 	onStatement := "q1.RootId = q2.Id"
 	if skipFetchThreads {
@@ -1656,7 +1586,7 @@ func (s *SqlPostStore) getParentsPostsPostgreSQL(channelId string, offset int, l
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Posts with channelId=%s", channelId)
 	}
-	return sliceToModel(posts), nil
+	return posts, nil
 }
 
 var specialSearchChar = []string{
@@ -2166,7 +2096,7 @@ func (s *SqlPostStore) GetPostsByIds(postIds []string) ([]*model.Post, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "getPostsByIds_tosql")
 	}
-	posts := []*postInternal{}
+	posts := []*model.Post{}
 
 	err = s.GetReplicaX().Select(&posts, query, args...)
 	if err != nil {
@@ -2175,7 +2105,7 @@ func (s *SqlPostStore) GetPostsByIds(postIds []string) ([]*model.Post, error) {
 	if len(posts) == 0 {
 		return nil, store.NewErrNotFound("Post", fmt.Sprintf("postIds=%v", postIds))
 	}
-	return sliceToModel(posts), nil
+	return posts, nil
 }
 
 func (s *SqlPostStore) GetPostsBatchForIndexing(startTime int64, endTime int64, limit int) ([]*model.PostForIndexing, error) {


### PR DESCRIPTION
Before gorp, to use sqlx we had to resort to using
internal structs without the `db:"-"` tag so that
it doesn't interfere with the gorp table generation.

Now that it's gone, we can use the original model structs.

```release-note
NONE
```
