### PR TITLE
[MM-41206] Fix: Cloud workspaces unable to use OIDC Authentication

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -207,6 +207,9 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	subpath, _ := utils.GetSubpathFromConfig(c.App.Config())
 	siteURLHeader := app.GetProtocol(r) + "://" + r.Host + subpath
+	if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
+		siteURLHeader = *c.App.Config().ServiceSettings.SiteURL + subpath
+	}
 	c.SetSiteURLHeader(siteURLHeader)
 
 	w.Header().Set(model.HeaderRequestId, c.AppContext.RequestId())


### PR DESCRIPTION
#### Summary
A similar change to this one was introduced in https://github.com/mattermost/mattermost-server/pull/15747/files
That one was only introduced to the cloud branch. Last week, the cloud branch was deleted and recreated, and this change was lost in the process.

Without this change, the redirect URI is built based off of the `X-Forwarded-For` header, which in the cloud context is _always_ `http` - but the redirect URI the installation actually needs requires https, so there was a mismatch. Now, if in the context of a cloud installation, it will fall back on the siteURL instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41206

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
