### PR TITLE
[MM-41202] Fix make apply if an app method has a function argument

### DIFF
--- a/app/layer_generators/main.go
+++ b/app/layer_generators/main.go
@@ -85,7 +85,7 @@ func fixTypeName(t string) string {
 	if t == "...func(*UploadFileTask)" {
 		t = "...func(*app.UploadFileTask)"
 	}
-	if strings.Contains(t, ".") || strings.Contains(t, "{}") {
+	if strings.Contains(t, ".") || strings.Contains(t, "{}") || strings.Contains(t, "()") {
 		return t
 	}
 	typeOnly := textRegexp.FindString(t)


### PR DESCRIPTION
#### Summary
As part of working on https://github.com/mattermost/mattermost-server/pull/19387, I've added a ` Go(f func())` method to `App`, which forwards to `Server`. When running `make app-layers`, `app/app_iface.go` get's correctly updated to include ` Go(f func())`, but `./app/layer_generators` fails with:
```
go run ./app/layer_generators -in ./app/app_iface.go -out ./app/opentracing/opentracing_layer.go -template ./app/layer_generators/opentracing_layer.go.tmpl
2022/01/21 14:06:33 ./app/opentracing/opentracing_layer.go:11671:46: expected 'IDENT', found ')'
exit status 1
make: *** [Makefile:263: app-layers] Error 1
```

This PR fixes the issue by not trying to fix an package name if the argument passed in a functional one. The fix surely doesn't count in for all cases e.g. there is still a extra case for `UploadFileX` which has `...func(*UploadFileTask)` as one argument. But it seemed to be, that the code should be re-written using AST anyway, so this fix follows the existing, already hacky approach.

There are no tests, so I didn't add another one. CI works as the test, as the old "target" for the tool is `app_iface.go` anyway.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41202

#### Release Note
```release-note
NONE
```
