### PR TITLE
Disable sentry tracing completely

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -343,6 +343,9 @@ func NewServer(options ...Option) (*Server, error) {
 					}
 					return event
 				},
+				TracesSampler: sentry.TracesSamplerFunc(func(ctx sentry.SamplingContext) sentry.Sampled {
+					return sentry.SampledFalse
+				}),
 			}); err2 != nil {
 				mlog.Warn("Sentry could not be initiated, probably bad DSN?", mlog.Err(err2))
 			}


### PR DESCRIPTION
We don't do instrumentation of Sentry transactions
anywhere in the code. Only opentracing code is present.

One has to explicitly add custom instrumentation for it
to work: https://docs.sentry.io/platforms/go/performance/instrumentation/custom-instrumentation/

It's likely someone is running custom code and sending
transaction data to Sentry. It's not super hard to pick
off the sentry DSN string from the binary.

The PR is more of a best effort to stop any future
transaction events to be sent.

```release-note
NONE
```
