### PR TITLE
[MM-41188] Remove "Add Channel Button" feature flag

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -41,9 +41,6 @@ type FeatureFlags struct {
 	// Enable the Global Header
 	GlobalHeader bool
 
-	// Enable different team menu button treatments, possible values = ("none", "by_team_name", "inverted_sidebar_bg_color")
-	AddChannelButton string
-
 	// Determine whether when a user gets created, they'll have noisy notifications e.g. Send desktop notifications for all activity
 	NewAccountNoisy bool
 
@@ -89,7 +86,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PluginFocalboard = ""
 	f.PermalinkPreviews = true
 	f.GlobalHeader = true
-	f.AddChannelButton = "by_team_name"
 	f.NewAccountNoisy = false
 	f.CallsMobile = false
 	f.AutoTour = "none"


### PR DESCRIPTION
#### Summary
The result of the AB testing led us to pick the "by_team_name" variant. This PR applies this change and removes the other ones.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41188

#### Related Pull Requests
- Has webapp changes https://github.com/mattermost/mattermost-webapp/pull/9702

#### Release Note
```release-note
NONE
```
