### PR TITLE
MM-41209: Fix flaky test CreateRecurringTaskFromNextIntervalTime

### DIFF
--- a/model/scheduled_task_test.go
+++ b/model/scheduled_task_test.go
@@ -76,8 +76,8 @@ func TestCancelTask(t *testing.T) {
 }
 
 func TestCreateRecurringTaskFromNextIntervalTime(t *testing.T) {
-	TaskName := "Test Recurring Task starting from next interval time"
-	TaskTime := time.Second * 2
+	taskName := "Test Recurring Task starting from next interval time"
+	taskTime := time.Second * 3
 
 	var executionTime time.Time
 	var mu sync.Mutex
@@ -87,22 +87,19 @@ func TestCreateRecurringTaskFromNextIntervalTime(t *testing.T) {
 		mu.Unlock()
 	}
 
-	task := CreateRecurringTaskFromNextIntervalTime(TaskName, testFunc, TaskTime)
+	task := CreateRecurringTaskFromNextIntervalTime(taskName, testFunc, taskTime)
 	defer task.Cancel()
 
-	time.Sleep(TaskTime)
+	time.Sleep(taskTime)
 	mu.Lock()
 	expectedSeconds := executionTime.Second()
 	mu.Unlock()
-	assert.EqualValues(t, 0, expectedSeconds%2)
+	// Ideally we would expect 0, but in busy CI environments it can lag
+	// by a second. If we see a lag of more than a second, we would need to disable
+	// the test entirely.
+	assert.LessOrEqual(t, expectedSeconds%3, 1)
 
-	time.Sleep(TaskTime)
-	mu.Lock()
-	expectedSeconds = executionTime.Second()
-	mu.Unlock()
-	assert.EqualValues(t, 0, expectedSeconds%2)
-
-	assert.Equal(t, TaskName, task.Name)
-	assert.Equal(t, TaskTime, task.Interval)
+	assert.Equal(t, taskName, task.Name)
+	assert.Equal(t, taskTime, task.Interval)
 	assert.True(t, task.Recurring)
 }


### PR DESCRIPTION
We were noting down the time of execution of a function and
expected that to match with the exact interval that we set.

However, sometimes in very busy CI environments, the goroutine
does not get a chance to be scheduled at the right time for
the interval to match exactly. Sometimes, we see a delay of
1 second.

To account for this, we increase the interval to 3 seconds,
and consider a 1 second buffer for this. If we see lags of
more than a second, then this test becomes useless and we
would need to remove it entirely.

https://mattermost.atlassian.net/browse/MM-41209

```release-note
NONE
```
