### PR TITLE
MM-41236: Sentry crash: Fix nil reference to token

### DIFF
--- a/app/license.go
+++ b/app/license.go
@@ -358,8 +358,11 @@ func (s *Server) renewalTokenValid(tokenString, signingKey string) (bool, error)
 	token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(signingKey), nil
 	})
-	if err != nil && !token.Valid {
+	if err != nil {
 		return false, errors.Wrapf(err, "Error validating JWT token")
+	}
+	if !token.Valid {
+		return false, errors.New("invalid JWT token")
 	}
 	expirationTime := time.Unix(claims.ExpiresAt, 0)
 	if expirationTime.Before(time.Now().UTC()) {

--- a/app/license_test.go
+++ b/app/license_test.go
@@ -4,9 +4,11 @@
 package app
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -79,6 +81,12 @@ func TestGetSanitizedClientLicense(t *testing.T) {
 func TestGenerateRenewalToken(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
+
+	t.Run("test invalid token", func(t *testing.T) {
+		_, err := th.App.Srv().renewalTokenValid("badtoken", "")
+		var vErr *jwt.ValidationError
+		require.True(t, errors.As(err, &vErr))
+	})
 
 	t.Run("renewal token generated correctly", func(t *testing.T) {
 		setLicense(th, nil)


### PR DESCRIPTION
The AND condition would mean that it would try to dereference
token.Valid if there was an error. And there's no guarantee
to always have a non-nil token in case of an error. We need
to track those conditions separately.

https://mattermost.atlassian.net/browse/MM-41236

```release-note
NONE
```
