### PR TITLE
MM-41231: Bump morph dependency to avoid advisory locks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/getsentry/sentry-go v0.11.0
 	github.com/go-asn1-ber/asn1-ber v1.5.3 // indirect
-	github.com/go-morph/morph v0.2.2
+	github.com/go-morph/morph v0.2.3-0.20220126093237-74bffc135498
 	github.com/go-redis/redis/v8 v8.11.4 // indirect
 	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
-github.com/go-morph/morph v0.2.2 h1:f7/+VZ+1/eR+5SUoMKYo16QQISewuvS4hogX8x/uFnA=
-github.com/go-morph/morph v0.2.2/go.mod h1:XQh5WcM351wOV3z3zEWRM8RaJ65E2p4P7WWbmFAi8x4=
+github.com/go-morph/morph v0.2.3-0.20220126093237-74bffc135498 h1:DTTRQXU9VOPKjn8iN67Gt6htfiIGyUYoF+0ndDzDbAo=
+github.com/go-morph/morph v0.2.3-0.20220126093237-74bffc135498/go.mod h1:XQh5WcM351wOV3z3zEWRM8RaJ65E2p4P7WWbmFAi8x4=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=

--- a/vendor/github.com/go-morph/morph/drivers/lock.go
+++ b/vendor/github.com/go-morph/morph/drivers/lock.go
@@ -76,3 +76,10 @@ type Locker interface {
 type Lockable interface {
 	DriverName() string
 }
+
+// IsLockable returns whether the given instance satisfies
+// drivers.Lockable or not.
+func IsLockable(x interface{}) bool {
+	_, ok := x.(Lockable)
+	return ok
+}

--- a/vendor/github.com/go-morph/morph/drivers/mysql/mysql.go
+++ b/vendor/github.com/go-morph/morph/drivers/mysql/mysql.go
@@ -132,6 +132,11 @@ func (driver *mysql) Close() error {
 }
 
 func (driver *mysql) Lock() error {
+	if drivers.IsLockable(driver) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(driver.config.databaseName, driver.config.MigrationsTable)
 	if err != nil {
 		return err
@@ -167,6 +172,11 @@ func (driver *mysql) Lock() error {
 }
 
 func (driver *mysql) Unlock() error {
+	if drivers.IsLockable(driver) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(driver.config.databaseName, driver.config.MigrationsTable)
 	if err != nil {
 		return err

--- a/vendor/github.com/go-morph/morph/drivers/postgres/postgres.go
+++ b/vendor/github.com/go-morph/morph/drivers/postgres/postgres.go
@@ -220,6 +220,11 @@ func (pg *postgres) Close() error {
 }
 
 func (pg *postgres) Lock() error {
+	if drivers.IsLockable(pg) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(pg.config.databaseName, pg.config.schemaName)
 	if err != nil {
 		return err
@@ -244,6 +249,11 @@ func (pg *postgres) Lock() error {
 }
 
 func (pg *postgres) Unlock() error {
+	if drivers.IsLockable(pg) {
+		// Supports lockable, so already locked at the global level.
+		return nil
+	}
+
 	aid, err := drivers.GenerateAdvisoryLockID(pg.config.databaseName, pg.config.schemaName)
 	if err != nil {
 		return err

--- a/vendor/github.com/go-morph/morph/morph.go
+++ b/vendor/github.com/go-morph/morph/morph.go
@@ -76,6 +76,7 @@ func WithLock(key string) EngineOption {
 }
 
 // New creates a new instance of the migrations engine from an existing db instance and a migrations source.
+// If the driver implements the Lockable interface, it will also wait until it has acquired a lock.
 func New(ctx context.Context, driver drivers.Driver, source sources.Source, options ...EngineOption) (*Morph, error) {
 	engine := &Morph{
 		config: &Config{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -214,7 +214,7 @@ github.com/gigawattio/window
 # github.com/go-asn1-ber/asn1-ber v1.5.3
 ## explicit
 github.com/go-asn1-ber/asn1-ber
-# github.com/go-morph/morph v0.2.2
+# github.com/go-morph/morph v0.2.3-0.20220126093237-74bffc135498
 ## explicit
 github.com/go-morph/morph
 github.com/go-morph/morph/drivers


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-41231

```release-note
NONE
```
