### PR TITLE
Adding deploy to AWS using Opta as a deployment option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Table of Contents
 
 _Note: Heroku preview does not include email or persistent storage_
 
+### Deploying Mattermost Team to AWS Using Opta
+Just use the Deploy to AWS button below!
+
+[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-button.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fmattermost%2Fmattermost-server%2Fblob%2Fmaster%2Fopta%2Fmattermost-aws.yaml&name=Mattermost)
+
+Click [here](https://github.com/run-x/opta/tree/main/examples/mattermost-team) for more instructions.
+
+_Note: The Opta AWS deployment DOES include email and persistent storage_
+
 ## Install Mattermost
 
 - [Quick Install Guide](https://docs.mattermost.com/getting-started/light-install.html) - Deploy in minutes via Mattermost Omnibus on Ubuntu.

--- a/opta/mattermost-aws.yaml
+++ b/opta/mattermost-aws.yaml
@@ -1,0 +1,50 @@
+name: mattermost-team
+org_name: <<org_name::org_name::Your Organization Name>>
+providers:
+  aws:
+    region: <<region::aws_region::Your AWS Region>>
+    account_id: <<account_id::aws_account_id::Your AWS Account ID>>
+modules:
+  - type: base
+  - type: k8s-cluster
+    node_instance_type: t3.medium
+    spot_instances: true
+  - type: k8s-base
+  - type: dns
+    domain: <<domain::string::The dns domain for your Mattermost deployment>>
+    delegated: false  # set this to true after setting dns records
+  - name: db
+    type: mysql
+  - type: helm-chart
+    repository: https://helm.mattermost.com
+    chart: mattermost-team-edition
+    namespace: mattermost
+    chart_version: 6.2.1
+    create_namespace: true
+    values:
+      extraPodAnnotations:
+        "linkerd.io/inject": enabled
+        "config.linkerd.io/skip-outbound-ports": "8126,5432,3306"
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 2000
+        runAsUser: 2000
+      mysql:
+        enabled: false
+      externalDB:
+        enabled: true
+        externalDriverType: "mysql"
+        externalConnectionString: "${{module.db.db_user}}:${{module.db.db_password}}@tcp(${{module.db.db_host}}:3306)/${{module.db.db_name}}?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s"
+      ingress:
+        enabled: true
+        hosts: [""]
+        annotations:
+          kubernetes.io/ingress.class: "nginx"
+      configJSON:
+        ServiceSettings:
+          SiteURL:  "${{module.dns.domain}}"
+        TeamSettings:
+          SiteName: "${{module.dns.domain}}"
+      serviceAccount:
+        create: true
+        name: "mattermost"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR adds a button that allows users to deploy Mattermost Community Edition to AWS using a tool called [Opta](https://github.com/run-x/opta). It works as follows:

1. The button links a user to a form, where the user fills out some configuration that Opta requires (similar to Heroku's deploy button). This configuration is used to generate an Opta configuration file, which is generated from this template.
2. The user downloads the generated configuration file and the Opta CLI, and then prepares their AWS credentials locally
3. The user deploys using the Opta CLI and the generated configuration file!

The Mattermost instance created by this tool will have persistent storage, as well as a robust database managed by RDS, and capable of being configured to send emails.

#### Testing
**Note that the HTML for the button in this PR does not work yet, as it points to a file at the path https://github.com/mattermost/mattermost-server/blob/master/opta/mattermost-aws.yaml. This path will become valid after this PR is merged. In order to help in testing, I've added a button below which is equivalent, but points to the forked repo that this request is coming from:

[![Deploy](https://raw.githubusercontent.com/run-x/opta/main/assets/deploy-to-aws-button.svg)](https://app.runx.dev/deploy-with-aws?url=https%3A%2F%2Fgithub.com%2Fjuandiegopalomino%2Fmattermost-server%2Fblob%2Fjd%2Fadding-opta-deploy%2Fopta%2Fmattermost-aws.yaml&name=Mattermost)

#### Screenshots
<img width="1792" alt="Screen Shot 2022-01-26 at 5 07 10 PM" src="https://user-images.githubusercontent.com/10430635/151272976-5cfab438-714f-4d3d-aa03-99b19db03d22.png">
<img width="1792" alt="Screen Shot 2022-01-26 at 5 07 19 PM" src="https://user-images.githubusercontent.com/10430635/151272972-eba75844-65ac-44f0-8d5d-f1c58bda68a8.png">
<img width="1792" alt="Screen Shot 2022-01-26 at 5 07 29 PM" src="https://user-images.githubusercontent.com/10430635/151272966-8d0d1bf1-a33a-418f-bac0-79c1eed64d8c.png">


#### Ticket Link
n/a
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
```release-note
NONE
```
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
