### PR TITLE
[MM-41330] Fix JSON type check in `hasMissingMigrationsVersion600`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,6 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            ulimit -n 8096
             mkdir -p mattermost-server/client/plugins
             cd mattermost-server/build
             docker run -it --net circleci_mm-test \
@@ -372,7 +371,6 @@ jobs:
           name: Postgres schema migration validation
           command: |
             cd mattermost-server/build
-            ulimit -n 8096
             mkdir -p mattermost-server/client/plugins
             echo "Creating databases"
             docker-compose --no-ansi exec -T postgres sh -c 'exec echo "CREATE DATABASE migrated; CREATE DATABASE latest;" | exec psql -U mmuser mattermost_test'
@@ -401,7 +399,6 @@ jobs:
           name: MySQL schema migration validation
           command: |
             cd mattermost-server/build
-            ulimit -n 8096
             mkdir -p mattermost-server/client/plugins
             echo "Creating databases"
             docker-compose --no-ansi exec -T mysql mysql -uroot -pmostest -e "CREATE DATABASE migrated; CREATE DATABASE latest; GRANT ALL PRIVILEGES ON migrated.* TO mmuser; GRANT ALL PRIVILEGES ON latest.* TO mmuser"

--- a/store/sqlstore/upgrade.go
+++ b/store/sqlstore/upgrade.go
@@ -1596,7 +1596,7 @@ func hasMissingMigrationsVersion600(sqlStore *SqlStore) bool {
 				return true
 			}
 		} else if sqlStore.DriverName() == model.DatabaseDriverMysql {
-			jsonType := "JSON"
+			jsonType := "json"
 			// JSON is aliased as LONGTEXT for MariaDB.
 			// https://mariadb.com/kb/en/json-data-type/
 			if ok, err := sqlStore.isMariaDB(); ok {
@@ -1605,7 +1605,7 @@ func hasMissingMigrationsVersion600(sqlStore *SqlStore) bool {
 				mlog.Warn("Error checking db type", mlog.Err(err))
 			}
 
-			if info.DataType != jsonType {
+			if strings.ToLower(info.DataType) != jsonType {
 				return true
 			}
 		}


### PR DESCRIPTION
#### Summary

MySQL returned type for JSON would be lowercase but we checked against an uppercase string, hence failing the check and re-triggering the migration every time.

/cc @neillcollie @isacikgoz 

@amyblais This goes directly into 6.3 release and will need to be included in a dot release. From what I can see bug also affects 6.0.x,6.1.x,6.2.x releases.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-41330

#### Release Note

```release-note
Fixed an issue that on MySQL installations would re-trigger 6.0 migration on server restart.
```
