### PR TITLE
[MM-41290] Add Endpoint to complete onboarding

### DIFF
--- a/api4/plugin_test.go
+++ b/api4/plugin_test.go
@@ -1472,8 +1472,7 @@ func TestInstallMarketplacePlugin(t *testing.T) {
 			*cfg.PluginSettings.MarketplaceURL = testServer.URL
 		})
 
-		// The content of the request is irrelevant. This test only cares about enterprise_plugins.
-		pRequest := &model.InstallMarketplacePluginRequest{}
+		pRequest := &model.InstallMarketplacePluginRequest{Id: "testplugin"}
 		manifest, resp, err := client.InstallMarketplacePlugin(pRequest)
 		require.Error(t, err)
 		CheckInternalErrorStatus(t, resp)
@@ -1511,8 +1510,7 @@ func TestInstallMarketplacePlugin(t *testing.T) {
 		*l.Features.EnterprisePlugins = false
 		th.App.Srv().SetLicense(l)
 
-		// The content of the request is irrelevant. This test only cares about enterprise_plugins.
-		pRequest := &model.InstallMarketplacePluginRequest{}
+		pRequest := &model.InstallMarketplacePluginRequest{Id: "testplugin"}
 		manifest, resp, err := client.InstallMarketplacePlugin(pRequest)
 		require.Error(t, err)
 		CheckInternalErrorStatus(t, resp)
@@ -1546,8 +1544,7 @@ func TestInstallMarketplacePlugin(t *testing.T) {
 
 		th.App.Srv().SetLicense(model.NewTestLicense("enterprise_plugins"))
 
-		// The content of the request is irrelevant. This test only cares about enterprise_plugins.
-		pRequest := &model.InstallMarketplacePluginRequest{}
+		pRequest := &model.InstallMarketplacePluginRequest{Id: "testplugin"}
 		manifest, resp, err := client.InstallMarketplacePlugin(pRequest)
 		require.Error(t, err)
 		CheckInternalErrorStatus(t, resp)

--- a/api4/system.go
+++ b/api4/system.go
@@ -860,7 +860,7 @@ func updateViewedProductNotices(c *Context, w http.ResponseWriter, r *http.Reque
 }
 
 func completeOnboarding(c *Context, w http.ResponseWriter, r *http.Request) {
-	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) && !c.App.IsFirstUserAccount() {
+	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
 		c.Err = model.NewAppError("completeOnboarding", "app.system.complete_onboarding_request.no_first_user", nil, "", http.StatusForbidden)
 		return
 	}

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -5,11 +5,14 @@ package api4
 
 import (
 	"bytes"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,6 +23,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/utils/fileutils"
 )
 
 func TestGetPing(t *testing.T) {
@@ -776,5 +780,105 @@ func TestPushNotificationAck(t *testing.T) {
 		handler.ServeHTTP(resp, req)
 		assert.Equal(t, http.StatusForbidden, resp.Code)
 		assert.NotNil(t, resp.Body)
+	})
+}
+
+func TestCompleteOnboarding(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	path, _ := fileutils.FindDir("tests")
+	signatureFilename := "testplugin2.tar.gz.sig"
+	signatureFileReader, err := os.Open(filepath.Join(path, signatureFilename))
+	require.NoError(t, err)
+	sigFile, err := ioutil.ReadAll(signatureFileReader)
+	require.NoError(t, err)
+	pluginSignature := base64.StdEncoding.EncodeToString(sigFile)
+
+	tarData, err := ioutil.ReadFile(filepath.Join(path, "testplugin2.tar.gz"))
+	require.NoError(t, err)
+	pluginServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		res.Write(tarData)
+	}))
+	defer pluginServer.Close()
+
+	samplePlugins := []*model.MarketplacePlugin{{
+		BaseMarketplacePlugin: &model.BaseMarketplacePlugin{
+			HomepageURL: "https://example.com/mattermost/mattermost-plugin-nps",
+			IconData:    "https://example.com/icon.svg",
+			DownloadURL: pluginServer.URL,
+			Manifest: &model.Manifest{
+				Id:               "testplugin2",
+				Name:             "testplugin2",
+				Description:      "a second plugin",
+				Version:          "1.2.3",
+				MinServerVersion: "",
+			},
+			Signature: pluginSignature,
+		},
+		InstalledVersion: "",
+	}}
+
+	marketplaceServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		var data []byte
+		data, err = json.Marshal(samplePlugins)
+		require.NoError(t, err)
+		res.Write(data)
+	}))
+	defer marketplaceServer.Close()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.PluginSettings.Enable = true
+		*cfg.PluginSettings.EnableMarketplace = false
+		*cfg.PluginSettings.EnableRemoteMarketplace = true
+		*cfg.PluginSettings.MarketplaceURL = marketplaceServer.URL
+		*cfg.PluginSettings.AllowInsecureDownloadURL = true
+	})
+
+	key, err := os.Open(filepath.Join(path, "development-private-key.asc"))
+	require.NoError(t, err)
+	appErr := th.App.AddPublicKey("pub_key", key)
+	require.Nil(t, appErr)
+
+	t.Cleanup(func() {
+		appErr = th.App.DeletePublicKey("pub_key")
+		require.Nil(t, appErr)
+	})
+
+	req := &model.CompleteOnboardingRequest{
+		InstallPlugins: []string{"testplugin2"},
+	}
+
+	t.Run("as a regular user", func(t *testing.T) {
+		resp, err := th.Client.CompleteOnboarding(req)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("as a system admin", func(t *testing.T) {
+		resp, err := th.SystemAdminClient.CompleteOnboarding(req)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		t.Cleanup(func() {
+			resp, err = th.SystemAdminClient.RemovePlugin("testplugin2")
+			require.NoError(t, err)
+			CheckOKStatus(t, resp)
+		})
+
+		installedPlugin, resp, err := th.SystemAdminClient.GetPlugins()
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		found := false
+		for _, p := range installedPlugin.Active {
+			if p.Id == "testplugin2" {
+				found = true
+			}
+		}
+
+		require.True(t, found, "testplugin2 should have been installed and enabled")
 	})
 }

--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -868,12 +868,12 @@ func TestCompleteOnboarding(t *testing.T) {
 			CheckOKStatus(t, resp)
 		})
 
-		installedPlugin, resp, err := th.SystemAdminClient.GetPlugins()
+		installedPlugins, resp, err := th.SystemAdminClient.GetPlugins()
 		require.NoError(t, err)
 		CheckOKStatus(t, resp)
 
 		found := false
-		for _, p := range installedPlugin.Active {
+		for _, p := range installedPlugins.Active {
 			if p.Id == "testplugin2" {
 				found = true
 			}

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -437,6 +437,7 @@ type AppIface interface {
 	CompareAndDeletePluginKey(pluginID string, key string, oldValue []byte) (bool, *model.AppError)
 	CompareAndSetPluginKey(pluginID string, key string, oldValue, newValue []byte) (bool, *model.AppError)
 	CompleteOAuth(c *request.Context, service string, body io.ReadCloser, teamID string, props map[string]string, tokenUser *model.User) (*model.User, *model.AppError)
+	CompleteOnboarding(request *model.CompleteOnboardingRequest) *model.AppError
 	CompleteSwitchWithOAuth(service string, userData io.Reader, email string, tokenUser *model.User) (*model.User, *model.AppError)
 	Compliance() einterfaces.ComplianceInterface
 	Config() *model.Config

--- a/app/onboarding.go
+++ b/app/onboarding.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
+func (a *App) CompleteOnboarding(request *model.CompleteOnboardingRequest) *model.AppError {
+	var wg sync.WaitGroup
+
+	if !*a.Config().PluginSettings.Enable {
+		return model.NewAppError("completeOnboarding", "app.plugin.disabled.app_error", nil, "", http.StatusNotImplemented)
+	}
+
+	for _, id := range request.InstallPlugins {
+		wg.Add(1)
+
+		go func(id string) {
+			defer wg.Done()
+			installRequest := &model.InstallMarketplacePluginRequest{
+				Id: id,
+			}
+			_, appErr := a.Channels().InstallMarketplacePlugin(installRequest)
+			if appErr != nil {
+				mlog.Error("Failed to install plugin for onboarding", mlog.String("id", id), mlog.Err(appErr))
+				return
+			}
+
+			appErr = a.Channels().enablePlugin(id)
+			if appErr != nil {
+				mlog.Error("Failed to enable plugin for onboarding", mlog.String("id", id), mlog.Err(appErr))
+				return
+			}
+		}(id)
+	}
+
+	wg.Wait()
+
+	return nil
+}

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -1656,6 +1656,28 @@ func (a *OpenTracingAppLayer) CompleteOAuth(c *request.Context, service string, 
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) CompleteOnboarding(request *model.CompleteOnboardingRequest) *model.AppError {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CompleteOnboarding")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.CompleteOnboarding(request)
+
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0
+}
+
 func (a *OpenTracingAppLayer) CompleteSwitchWithOAuth(service string, userData io.Reader, email string, tokenUser *model.User) (*model.User, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CompleteSwitchWithOAuth")

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -538,6 +538,8 @@ func (a *App) GetMarketplacePlugins(filter *model.MarketplacePluginFilter) ([]*m
 }
 
 // getPrepackagedPlugin returns a pre-packaged plugin.
+//
+// If version is empty, the first matching plugin is returned.
 func (ch *Channels) getPrepackagedPlugin(pluginID, version string) (*plugin.PrepackagedPlugin, *model.AppError) {
 	pluginsEnvironment := ch.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
@@ -546,7 +548,7 @@ func (ch *Channels) getPrepackagedPlugin(pluginID, version string) (*plugin.Prep
 
 	prepackagedPlugins := pluginsEnvironment.PrepackagedPlugins()
 	for _, p := range prepackagedPlugins {
-		if p.Manifest.Id == pluginID && p.Manifest.Version == version {
+		if p.Manifest.Id == pluginID && (version == "" || p.Manifest.Version == version) {
 			return p, nil
 		}
 	}
@@ -555,6 +557,8 @@ func (ch *Channels) getPrepackagedPlugin(pluginID, version string) (*plugin.Prep
 }
 
 // getRemoteMarketplacePlugin returns plugin from marketplace-server.
+//
+// If version is empty, the latest compatible version is used.
 func (ch *Channels) getRemoteMarketplacePlugin(pluginID, version string) (*model.BaseMarketplacePlugin, *model.AppError) {
 	marketplaceClient, err := marketplace.NewClient(
 		*ch.srv.Config().PluginSettings.MarketplaceURL,
@@ -566,9 +570,13 @@ func (ch *Channels) getRemoteMarketplacePlugin(pluginID, version string) (*model
 
 	filter := ch.getBaseMarketplaceFilter()
 	filter.PluginId = pluginID
-	filter.ReturnAllVersions = true
 
-	plugin, err := marketplaceClient.GetPlugin(filter, version)
+	var plugin *model.BaseMarketplacePlugin
+	if version != "" {
+		plugin, err = marketplaceClient.GetPlugin(filter, version)
+	} else {
+		plugin, err = marketplaceClient.GetLastestPlugin(filter)
+	}
 	if err != nil {
 		return nil, model.NewAppError("GetMarketplacePlugin", "app.plugin.marketplace_plugins.not_found.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -575,7 +575,7 @@ func (ch *Channels) getRemoteMarketplacePlugin(pluginID, version string) (*model
 	if version != "" {
 		plugin, err = marketplaceClient.GetPlugin(filter, version)
 	} else {
-		plugin, err = marketplaceClient.GetLastestPlugin(filter)
+		plugin, err = marketplaceClient.GetLatestPlugin(filter)
 	}
 	if err != nil {
 		return nil, model.NewAppError("GetMarketplacePlugin", "app.plugin.marketplace_plugins.not_found.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6061,7 +6061,7 @@
   },
   {
     "id": "app.system.complete_onboarding_request.no_first_user",
-    "translation": "Onboarding can only be completed by an System Administrator."
+    "translation": "Onboarding can only be completed by a System Administrator."
   },
   {
     "id": "app.system.get.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6061,7 +6061,7 @@
   },
   {
     "id": "app.system.complete_onboarding_request.no_first_user",
-    "translation": "Onboarding can only be completed on a fresh server or by an admin"
+    "translation": "Onboarding can only be completed by an System Administrator."
   },
   {
     "id": "app.system.get.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6056,6 +6056,14 @@
     "translation": "Encountered an error encoding JSON for the interactive dialog."
   },
   {
+    "id": "app.system.complete_onboarding_request.app_error",
+    "translation": "Failed to decode the complete onboarding request."
+  },
+  {
+    "id": "app.system.complete_onboarding_request.no_first_user",
+    "translation": "Onboarding can only be completed on a fresh server or by an admin"
+  },
+  {
     "id": "app.system.get.app_error",
     "translation": "We encountered an error finding the system properties."
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -7432,6 +7432,20 @@ func (c *Client4) MarkNoticesViewed(ids []string) (*Response, error) {
 	return BuildResponse(r), nil
 }
 
+func (c *Client4) CompleteOnboarding(request *CompleteOnboardingRequest) (*Response, error) {
+	buf, err := json.Marshal(request)
+	if err != nil {
+		return nil, NewAppError("CompleteOnboarding", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+	r, err := c.DoAPIPost(c.systemRoute()+"/onboarding/complete", string(buf))
+	if err != nil {
+		return BuildResponse(r), err
+	}
+	defer closeBody(r)
+
+	return BuildResponse(r), nil
+}
+
 // CreateUpload creates a new upload session.
 func (c *Client4) CreateUpload(us *UploadSession) (*UploadSession, *Response, error) {
 	buf, err := json.Marshal(us)

--- a/model/onboarding.go
+++ b/model/onboarding.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// CompleteOnboardingRequest describes parameters of the requested plugin.
+type CompleteOnboardingRequest struct {
+	InstallPlugins []string `json:"install_plugins"` // InstallPlugins is a list of plugins to be installed
+}
+
+// CompleteOnboardingRequest decodes a json-encoded request from the given io.Reader.
+func CompleteOnboardingRequestFromReader(reader io.Reader) (*CompleteOnboardingRequest, error) {
+	var r *CompleteOnboardingRequest
+	err := json.NewDecoder(reader).Decode(&r)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}

--- a/services/marketplace/client.go
+++ b/services/marketplace/client.go
@@ -66,6 +66,16 @@ func (c *Client) GetPlugins(request *model.MarketplacePluginFilter) ([]*model.Ba
 }
 
 func (c *Client) GetPlugin(filter *model.MarketplacePluginFilter, pluginVersion string) (*model.BaseMarketplacePlugin, error) {
+	filter.ReturnAllVersions = true
+
+	if filter.PluginId == "" {
+		return nil, errors.New("missing pluginID")
+	}
+
+	if pluginVersion == "" {
+		return nil, errors.New("missing pluginVersion")
+	}
+
 	plugins, err := c.GetPlugins(filter)
 	if err != nil {
 		return nil, err
@@ -76,6 +86,29 @@ func (c *Client) GetPlugin(filter *model.MarketplacePluginFilter, pluginVersion 
 		}
 	}
 	return nil, errors.New("plugin not found")
+}
+
+func (c *Client) GetLastestPlugin(filter *model.MarketplacePluginFilter) (*model.BaseMarketplacePlugin, error) {
+	filter.ReturnAllVersions = false
+
+	if filter.PluginId == "" {
+		return nil, errors.New("no pluginID provided")
+	}
+
+	plugins, err := c.GetPlugins(filter)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(plugins) == 0 {
+		return nil, errors.New("plugin not found")
+	}
+
+	if len(plugins) > 1 {
+		return nil, errors.Errorf("unexpectedly more then one plugin was returned from the marketplace")
+	}
+
+	return plugins[0], nil
 }
 
 // closeBody ensures the Body of an http.Response is properly closed.

--- a/services/marketplace/client.go
+++ b/services/marketplace/client.go
@@ -88,7 +88,7 @@ func (c *Client) GetPlugin(filter *model.MarketplacePluginFilter, pluginVersion 
 	return nil, errors.New("plugin not found")
 }
 
-func (c *Client) GetLastestPlugin(filter *model.MarketplacePluginFilter) (*model.BaseMarketplacePlugin, error) {
+func (c *Client) GetLatestPlugin(filter *model.MarketplacePluginFilter) (*model.BaseMarketplacePlugin, error) {
 	filter.ReturnAllVersions = false
 
 	if filter.PluginId == "" {


### PR DESCRIPTION
#### Summary
This PR adds a `/system/onboarding/complete` endpoint. This will be called by the webapp once the onboarding flow in completed and will process the user data. As part of this PR only a list of plugin can be provided, which is then installed and enabled. Additional fields will be added in the future.

The endpoint can be accessed by admins (this is mostly needed for testing, but also to re-run the wizard) and if no user can been created yet.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41290

#### Release Note
```release-note
Added new API endpoint POST /system/onboarding/complete to complete onboarding
```
