### PR TITLE
Temporary disabling .pages indexing to avoid crashes on malicious files

### DIFF
--- a/services/docextractor/documents.go
+++ b/services/docextractor/documents.go
@@ -15,14 +15,15 @@ import (
 type documentExtractor struct{}
 
 var doconvConverterByExtensions = map[string]func(io.Reader) (string, map[string]string, error){
-	"doc":   docconv.ConvertDoc,
-	"docx":  docconv.ConvertDocx,
-	"pptx":  docconv.ConvertPptx,
-	"odt":   docconv.ConvertODT,
-	"html":  func(r io.Reader) (string, map[string]string, error) { return docconv.ConvertHTML(r, true) },
-	"pages": docconv.ConvertPages,
-	"rtf":   docconv.ConvertRTF,
-	"pdf":   docconv.ConvertPDF,
+	"doc":  docconv.ConvertDoc,
+	"docx": docconv.ConvertDocx,
+	"pptx": docconv.ConvertPptx,
+	"odt":  docconv.ConvertODT,
+	"html": func(r io.Reader) (string, map[string]string, error) { return docconv.ConvertHTML(r, true) },
+	// Temporarily disabled to avoid crashes on malicious .pages files
+	// "pages": docconv.ConvertPages,
+	"rtf": docconv.ConvertRTF,
+	"pdf": docconv.ConvertPDF,
 }
 
 func (de *documentExtractor) Match(filename string) bool {


### PR DESCRIPTION
#### Summary
Temporary disabling .pages indexing to avoid crashes on malicious files

#### Ticket Link
[MM-41334](https://mattermost.atlassian.net/browse/MM-41334)

#### Release Note
```release-note
Temporarily disabled .pages file format for content extraction to avoid crashes on malicious formated .pages files
```