### PR TITLE
[MM-41170] Disable bot accounts from getting notification emails

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -639,6 +639,11 @@ func (a *App) userAllowsEmail(user *model.User, channelMemberNotificationProps m
 		}
 	}
 
+	// if user is a bot account, then we do not send email
+	if user.IsBot {
+		userAllowsEmails = false
+	}
+
 	var status *model.Status
 	var err *model.AppError
 	if status, err = a.GetStatus(user.Id); err != nil {

--- a/app/notification.go
+++ b/app/notification.go
@@ -624,6 +624,11 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 func (a *App) userAllowsEmail(user *model.User, channelMemberNotificationProps model.StringMap, post *model.Post) bool {
 	userAllowsEmails := user.NotifyProps[model.EmailNotifyProp] != "false"
 
+	// if user is a bot account, then we do not send email
+	if user.IsBot {
+		return false
+	}
+
 	// if CRT is ON for user and the post is a reply disregard the channelEmail setting
 	if channelEmail, ok := channelMemberNotificationProps[model.EmailNotifyProp]; ok && !(a.IsCRTEnabledForUser(user.Id) && post.RootId != "") {
 		if channelEmail != model.ChannelNotifyDefault {
@@ -637,11 +642,6 @@ func (a *App) userAllowsEmail(user *model.User, channelMemberNotificationProps m
 			mlog.Debug("Channel muted for user", mlog.String("user_id", user.Id), mlog.String("channel_mute", channelMuted))
 			userAllowsEmails = false
 		}
-	}
-
-	// if user is a bot account, then we do not send email
-	if user.IsBot {
-		userAllowsEmails = false
 	}
 
 	var status *model.Status

--- a/app/notification.go
+++ b/app/notification.go
@@ -622,12 +622,12 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 }
 
 func (a *App) userAllowsEmail(user *model.User, channelMemberNotificationProps model.StringMap, post *model.Post) bool {
-	userAllowsEmails := user.NotifyProps[model.EmailNotifyProp] != "false"
-
 	// if user is a bot account, then we do not send email
 	if user.IsBot {
 		return false
 	}
+
+	userAllowsEmails := user.NotifyProps[model.EmailNotifyProp] != "false"
 
 	// if CRT is ON for user and the post is a reply disregard the channelEmail setting
 	if channelEmail, ok := channelMemberNotificationProps[model.EmailNotifyProp]; ok && !(a.IsCRTEnabledForUser(user.Id) && post.RootId != "") {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -2429,6 +2429,19 @@ func TestUserAllowsEmail(t *testing.T) {
 		assert.False(t, th.App.userAllowsEmail(user, channelMemberNotificationProps, &model.Post{Type: model.PostTypeAutoResponder}))
 	})
 
+	t.Run("should return false in the case user is a bot", func(t *testing.T) {
+		user := th.CreateUser()
+
+		th.App.ConvertUserToBot(user)
+
+		channelMemberNotifcationProps := model.StringMap{
+			model.EmailNotifyProp:      model.ChannelNotifyDefault,
+			model.MarkUnreadNotifyProp: model.ChannelMarkUnreadAll,
+		}
+
+		assert.False(t, th.App.userAllowsEmail(user, channelMemberNotifcationProps, &model.Post{Type: model.PostTypeAutoResponder}))
+	})
+
 }
 
 func TestInsertGroupMentions(t *testing.T) {

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -2432,14 +2432,14 @@ func TestUserAllowsEmail(t *testing.T) {
 	t.Run("should return false in the case user is a bot", func(t *testing.T) {
 		user := th.CreateUser()
 
-		user.IsBot = true
+		th.App.ConvertUserToBot(user)
 
-		channelMemberNotificationProps := model.StringMap{
+		channelMemberNotifcationProps := model.StringMap{
 			model.EmailNotifyProp:      model.ChannelNotifyDefault,
 			model.MarkUnreadNotifyProp: model.ChannelMarkUnreadAll,
 		}
 
-		assert.False(t, th.App.userAllowsEmail(user, channelMemberNotificationProps, &model.Post{Type: "some-post-type"}))
+		assert.False(t, th.App.userAllowsEmail(user, channelMemberNotifcationProps, &model.Post{Type: model.PostTypeAutoResponder}))
 	})
 
 }

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -2432,14 +2432,14 @@ func TestUserAllowsEmail(t *testing.T) {
 	t.Run("should return false in the case user is a bot", func(t *testing.T) {
 		user := th.CreateUser()
 
-		th.App.ConvertUserToBot(user)
+		user.IsBot = true
 
-		channelMemberNotifcationProps := model.StringMap{
+		channelMemberNotificationProps := model.StringMap{
 			model.EmailNotifyProp:      model.ChannelNotifyDefault,
 			model.MarkUnreadNotifyProp: model.ChannelMarkUnreadAll,
 		}
 
-		assert.False(t, th.App.userAllowsEmail(user, channelMemberNotifcationProps, &model.Post{Type: model.PostTypeAutoResponder}))
+		assert.False(t, th.App.userAllowsEmail(user, channelMemberNotificationProps, &model.Post{Type: "some-post-type"}))
 	})
 
 }


### PR DESCRIPTION
#### Summary

This pull request adds a check for userAllowEmail method if user is a bot, and setting userAllowsEmail to false accordingly. Also this PR adds a test for checking if user is a bot, and thus not getting email notifications.

#### Ticket Link

 Fixes https://github.com/mattermost/mattermost-server/issues/19406

#### Release Note
```release-note
NONE
```
