### PR TITLE
Automated cherry pick of #19423

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3820,6 +3820,10 @@
     "translation": "Received invalid response from OAuth service provider."
   },
   {
+    "id": "api.user.authorize_oauth_user.saml_response_too_long.app_error",
+    "translation": "SAML response is too long"
+  },
+  {
     "id": "api.user.authorize_oauth_user.service.app_error",
     "translation": "Token request to {{.Service}} failed."
   },

--- a/web/saml.go
+++ b/web/saml.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/utils"
 )
 
+const maxSAMLResponseSize = 2 * 1024 * 1024 // 2MB
+
 func (w *Web) InitSaml() {
 	w.MainRouter.Handle("/login/sso/saml", w.APIHandler(loginWithSaml)).Methods("GET")
 	w.MainRouter.Handle("/login/sso/saml", w.APIHandlerTrustRequester(completeSaml)).Methods("POST")
@@ -120,6 +122,13 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = err
 			c.Err.StatusCode = http.StatusFound
 		}
+	}
+
+	if len(encodedXML) > maxSAMLResponseSize {
+		err := model.NewAppError("completeSaml", "api.user.authorize_oauth_user.saml_response_too_long.app_error", nil, "SAML response is too long", http.StatusBadRequest)
+		mlog.Error(err.Error())
+		handleError(err)
+		return
 	}
 
 	user, err := samlInterface.DoLogin(c.AppContext, encodedXML, relayProps)


### PR DESCRIPTION
Cherry pick of #19423 on release-6.3.

/cc  @iomodo

```release-note
NONE
```