### PR TITLE
Automated cherry pick of #19423

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3815,6 +3815,10 @@
     "translation": "Received invalid response from OAuth service provider."
   },
   {
+    "id": "api.user.authorize_oauth_user.saml_response_too_long.app_error",
+    "translation": "SAML response is too long"
+  },
+  {
     "id": "api.user.authorize_oauth_user.service.app_error",
     "translation": "Token request to {{.Service}} failed."
   },


### PR DESCRIPTION
Cherry pick of #19423 on release-5.37.

/cc  @iomodo

```release-note
NONE
```