### PR TITLE
[MM-41350] All CRT server operations should only happen if ThreadAutoFollow is true 

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -2661,7 +2661,7 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(postID string, userID st
 		a.sanitizeProfiles(thread.Participants, false)
 		thread.Post.SanitizeProps()
 
-		if a.IsCRTEnabledForUser(userID) {
+		if a.isCRTEnabledForUser(userID) {
 			payload, jsonErr := json.Marshal(thread)
 			if jsonErr != nil {
 				mlog.Warn("Failed to encode thread to JSON")
@@ -2871,7 +2871,7 @@ func (a *App) MarkChannelsAsViewed(channelIDs []string, userID string, currentSe
 		a.clearPushNotification(currentSessionId, userID, channelID)
 	}
 
-	if *a.Config().ServiceSettings.ThreadAutoFollow && (!collapsedThreadsSupported || !a.IsCRTEnabledForUser(userID)) {
+	if *a.Config().ServiceSettings.ThreadAutoFollow && (!collapsedThreadsSupported || !a.isCRTEnabledForUser(userID)) {
 		if err := a.Srv().Store.Thread().MarkAllAsReadInChannels(userID, channelIDs); err != nil {
 			return nil, model.NewAppError("MarkChannelsAsViewed", "app.channel.update_last_viewed_at.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}

--- a/app/channel.go
+++ b/app/channel.go
@@ -2623,52 +2623,55 @@ func (a *App) markChannelAsUnreadFromPostCRTUnsupported(postID string, userID st
 		return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, nErr.Error(), http.StatusInternalServerError)
 	}
 
-	threadMembership, nErr := a.Srv().Store.Thread().GetMembershipForUser(user.Id, threadId)
-	var errNotFound *store.ErrNotFound
-	if nErr != nil && !errors.As(nErr, &errNotFound) {
-		return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, nErr.Error(), http.StatusInternalServerError)
-	}
-	// Follow thread if we're not already following it
-	if threadMembership == nil {
-		opts := store.ThreadMembershipOpts{
-			Following:             true,
-			IncrementMentions:     false,
-			UpdateFollowing:       true,
-			UpdateViewedTimestamp: false,
-			UpdateParticipants:    false,
+	if *a.Config().ServiceSettings.ThreadAutoFollow {
+		threadMembership, sErr := a.Srv().Store.Thread().GetMembershipForUser(user.Id, threadId)
+		var errNotFound *store.ErrNotFound
+		if sErr != nil && !errors.As(sErr, &errNotFound) {
+			return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, sErr.Error(), http.StatusInternalServerError)
 		}
-		threadMembership, nErr = a.Srv().Store.Thread().MaintainMembership(user.Id, threadId, opts)
-		if nErr != nil {
-			return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, nErr.Error(), http.StatusInternalServerError)
+		// Follow thread if we're not already following it
+		if threadMembership == nil {
+			opts := store.ThreadMembershipOpts{
+				Following:             true,
+				IncrementMentions:     false,
+				UpdateFollowing:       true,
+				UpdateViewedTimestamp: false,
+				UpdateParticipants:    false,
+			}
+			threadMembership, sErr = a.Srv().Store.Thread().MaintainMembership(user.Id, threadId, opts)
+			if sErr != nil {
+				return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, sErr.Error(), http.StatusInternalServerError)
+			}
 		}
-	}
-	// If threadmembership already exists but user had previously unfollowed the thread, then follow the thread again.
-	threadMembership.Following = true
-	threadMembership.LastViewed = post.UpdateAt - 1
-	threadMembership.UnreadMentions, err = a.countThreadMentions(user, rootPost, channel.TeamId, post.UpdateAt-1)
-	if err != nil {
-		return nil, err
-	}
-	threadMembership, nErr = a.Srv().Store.Thread().UpdateMembership(threadMembership)
-	if nErr != nil {
-		return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, nErr.Error(), http.StatusInternalServerError)
-	}
-	thread, nErr := a.Srv().Store.Thread().GetThreadForUser(channel.TeamId, threadMembership, true)
-	if nErr != nil {
-		return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, nErr.Error(), http.StatusInternalServerError)
-	}
-	a.sanitizeProfiles(thread.Participants, false)
-	thread.Post.SanitizeProps()
+		// If threadmembership already exists but user had previously unfollowed the thread, then follow the thread again.
+		threadMembership.Following = true
+		threadMembership.LastViewed = post.UpdateAt - 1
+		threadMembership.UnreadMentions, err = a.countThreadMentions(user, rootPost, channel.TeamId, post.UpdateAt-1)
+		if err != nil {
+			return nil, err
+		}
+		threadMembership, sErr = a.Srv().Store.Thread().UpdateMembership(threadMembership)
+		if sErr != nil {
+			return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, sErr.Error(), http.StatusInternalServerError)
+		}
+		thread, sErr := a.Srv().Store.Thread().GetThreadForUser(channel.TeamId, threadMembership, true)
+		if sErr != nil {
+			return nil, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, sErr.Error(), http.StatusInternalServerError)
+		}
+		a.sanitizeProfiles(thread.Participants, false)
+		thread.Post.SanitizeProps()
 
-	if a.isCRTEnabledForUser(userID) {
-		payload, jsonErr := json.Marshal(thread)
-		if jsonErr != nil {
-			mlog.Warn("Failed to encode thread to JSON")
+		if a.IsCRTEnabledForUser(userID) {
+			payload, jsonErr := json.Marshal(thread)
+			if jsonErr != nil {
+				mlog.Warn("Failed to encode thread to JSON")
+			}
+			message := model.NewWebSocketEvent(model.WebsocketEventThreadUpdated, channel.TeamId, "", userID, nil)
+			message.Add("thread", string(payload))
+			a.Publish(message)
 		}
-		message := model.NewWebSocketEvent(model.WebsocketEventThreadUpdated, channel.TeamId, "", userID, nil)
-		message.Add("thread", string(payload))
-		a.Publish(message)
 	}
+
 	channelUnread, nErr := a.Srv().Store.Channel().UpdateLastViewedAtPost(post, userID, unreadMentions, 0, false, false)
 	if nErr != nil {
 		return channelUnread, model.NewAppError("MarkChannelAsUnreadFromPost", "app.channel.update_last_viewed_at_post.app_error", nil, nErr.Error(), http.StatusInternalServerError)
@@ -2868,7 +2871,11 @@ func (a *App) MarkChannelsAsViewed(channelIDs []string, userID string, currentSe
 		a.clearPushNotification(currentSessionId, userID, channelID)
 	}
 
+<<<<<<< HEAD
 	if !collapsedThreadsSupported || !a.isCRTEnabledForUser(userID) {
+=======
+	if *a.Config().ServiceSettings.ThreadAutoFollow && (!collapsedThreadsSupported || !a.IsCRTEnabledForUser(userID)) {
+>>>>>>> 58879719f ([MM-41350] All CRT server operations should only happen if ThreadAutoFollow is true (#19411))
 		if err := a.Srv().Store.Thread().MarkAllAsReadInChannels(userID, channelIDs); err != nil {
 			return nil, model.NewAppError("MarkChannelsAsViewed", "app.channel.update_last_viewed_at.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}

--- a/app/channel.go
+++ b/app/channel.go
@@ -2871,11 +2871,7 @@ func (a *App) MarkChannelsAsViewed(channelIDs []string, userID string, currentSe
 		a.clearPushNotification(currentSessionId, userID, channelID)
 	}
 
-<<<<<<< HEAD
-	if !collapsedThreadsSupported || !a.isCRTEnabledForUser(userID) {
-=======
 	if *a.Config().ServiceSettings.ThreadAutoFollow && (!collapsedThreadsSupported || !a.IsCRTEnabledForUser(userID)) {
->>>>>>> 58879719f ([MM-41350] All CRT server operations should only happen if ThreadAutoFollow is true (#19411))
 		if err := a.Srv().Store.Thread().MarkAllAsReadInChannels(userID, channelIDs); err != nil {
 			return nil, model.NewAppError("MarkChannelsAsViewed", "app.channel.update_last_viewed_at.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}


### PR DESCRIPTION
Summary
CRT server book-keeping should only happen if ThreadAutoFollow is true.

Ticket Link
https://mattermost.atlassian.net/browse/MM-41350

(cherry picked from commit 58879719f2b43840084e3901e1029b3478dc31e5) onto release-6.1

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
On the server, CRT Threads will only be kept up to date if ThreadAutoFollow config is set to true

```
