### PR TITLE
Adding is_pinned attribute to post and direct_post objects when doing bulk import

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -1396,6 +1396,7 @@ func (a *App) importMultiplePostLines(c *request.Context, lines []LineImportWork
 		post.Message = *line.Post.Message
 		post.UserId = user.Id
 		post.CreateAt = *line.Post.CreateAt
+		post.IsPinned = *line.Post.IsPinned
 		post.Hashtags, _ = model.ParseHashtags(post.Message)
 
 		if line.Post.Type != nil {
@@ -1704,6 +1705,7 @@ func (a *App) importMultipleDirectPostLines(c *request.Context, lines []LineImpo
 		post.Message = *line.DirectPost.Message
 		post.UserId = user.Id
 		post.CreateAt = *line.DirectPost.CreateAt
+		post.IsPinned = *line.DirectPost.IsPinned
 		post.Hashtags, _ = model.ParseHashtags(post.Message)
 
 		if line.DirectPost.Type != nil {

--- a/app/import_types.go
+++ b/app/import_types.go
@@ -149,6 +149,7 @@ type PostImportData struct {
 	Reactions   *[]ReactionImportData   `json:"reactions,omitempty"`
 	Replies     *[]ReplyImportData      `json:"replies,omitempty"`
 	Attachments *[]AttachmentImportData `json:"attachments,omitempty"`
+	IsPinned    *bool                   `json:"is_pinned,omitempty"`
 }
 
 type DirectChannelImportData struct {
@@ -172,6 +173,7 @@ type DirectPostImportData struct {
 	Reactions   *[]ReactionImportData   `json:"reactions"`
 	Replies     *[]ReplyImportData      `json:"replies"`
 	Attachments *[]AttachmentImportData `json:"attachments"`
+	IsPinned    *bool                   `json:"is_pinned,omitempty"`
 }
 
 type SchemeImportData struct {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
