### PR TITLE
golangci-lint: Fixes for updated version

### DIFF
--- a/api4/team_test.go
+++ b/api4/team_test.go
@@ -2915,7 +2915,7 @@ func TestImportTeam(t *testing.T) {
 		fileData, err := base64.StdEncoding.DecodeString(fileResp["results"])
 		require.NoError(t, err, "failed to decode base64 results data")
 
-		fileReturned := fmt.Sprintf("%s", fileData)
+		fileReturned := string(fileData)
 		require.Truef(t, strings.Contains(fileReturned, "darth.vader@stardeath.com"), "failed to report the user was imported, fileReturned: %s", fileReturned)
 
 		// Checking the imported users

--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -719,7 +719,7 @@ func TestGetOutgoingWebhook(t *testing.T) {
 	CheckForbiddenStatus(t, resp)
 
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
-		nonExistentHook := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id}
+		nonExistentHook := &model.OutgoingWebhook{Id: model.NewId()}
 		_, resp, err = client.GetOutgoingWebhook(nonExistentHook.Id)
 		require.Error(t, err)
 		CheckNotFoundStatus(t, resp)

--- a/api4/websocket_norace_test.go
+++ b/api4/websocket_norace_test.go
@@ -1,7 +1,8 @@
-// +build !race
-
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+//go:build !race
+// +build !race
 
 package api4
 

--- a/plugin/environment_test.go
+++ b/plugin/environment_test.go
@@ -28,7 +28,6 @@ func TestAvaliablePlugins(t *testing.T) {
 
 	t.Run("Should be able to load available plugins", func(t *testing.T) {
 		bundle1 := model.BundleInfo{
-			ManifestPath: "",
 			Manifest: &model.Manifest{
 				Id:      "someid",
 				Version: "1",

--- a/services/upgrader/upgrader.go
+++ b/services/upgrader/upgrader.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+//go:build !linux
 // +build !linux
 
 package upgrader

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -625,12 +625,6 @@ func testTeamStoreGetByInviteId(t *testing.T, ss store.Store) {
 	save1, err := ss.Team().Save(&o1)
 	require.NoError(t, err)
 
-	o2 := model.Team{}
-	o2.DisplayName = "DisplayName"
-	o2.Name = NewTestId()
-	o2.Email = MakeEmail()
-	o2.Type = model.TeamOpen
-
 	r1, err := ss.Team().GetByInviteId(save1.InviteId)
 	require.NoError(t, err)
 	require.Equal(t, *r1, o1, "invalid returned team")

--- a/utils/markdown.go
+++ b/utils/markdown.go
@@ -141,7 +141,7 @@ func (r *notificationRenderer) renderText(w util.BufWriter, source []byte, node 
 
 func (r *notificationRenderer) renderTextBlock(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
-		if _, ok := node.NextSibling().(ast.Node); ok && node.FirstChild() != nil {
+		if node.NextSibling() != nil && node.FirstChild() != nil {
 			_ = w.WriteByte(' ')
 		}
 	}


### PR DESCRIPTION
#### Summary
After upgrading golangci-lint, a number of linter errors presented themselves. The version in question was:

```
> golangci-lint --version
golangci-lint has version 1.44.0 built from 617470f on 2022-01-25T11:22:07Z
```

This pull request addresses same.

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
