### PR TITLE
[MM-41408] Remove autotour feature flag

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -47,9 +47,6 @@ type FeatureFlags struct {
 	// Enable Calls plugin support in the mobile app
 	CallsMobile bool
 
-	// Start A/B tour tips automatically, possible values = ("none", "auto")
-	AutoTour string
-
 	// A dash separated list for feature flags to turn on for Boards
 	BoardsFeatureFlags string
 
@@ -88,7 +85,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.GlobalHeader = true
 	f.NewAccountNoisy = false
 	f.CallsMobile = false
-	f.AutoTour = "none"
 	f.BoardsFeatureFlags = ""
 	f.AddMembersToChannel = "top"
 	f.GuidedChannelCreation = false


### PR DESCRIPTION
#### Summary
The result of the A/B testing shows that we have a better conversion rate without the autotour. This PR drops the Autotour feature flag.

QA will be done on the webapp ticket

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41408

#### Related Pull Requests
- Has webapp changes https://github.com/mattermost/mattermost-webapp/pull/9752

#### Release Note
```release-note
NONE
```
