### PR TITLE
Pin GolangCI to a specific version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,10 +202,11 @@ jobs:
             make gen-serialized
             if [[ -n $(git status --porcelain) ]]; then echo "Please update the serialized files using 'make gen-serialized'"; exit 1; fi
 
-  # Dedicate job for golangci-lint it does not need anything only the server code for that
+  # Dedicated job for golangci-lint it does not need anything only the server code for that
   # and to make more clear when the job fails
   check-golangci-lint:
     docker:
+      # Keep the version in sync with the command in Makefile
       - image: golangci/golangci-lint:v1.39.0
     steps:
       - checkout

--- a/Makefile
+++ b/Makefile
@@ -243,17 +243,14 @@ else
 endif
 
 golangci-lint: ## Run golangci-lint on codebase
-# https://stackoverflow.com/a/677212/1027058 (check if a command exists or not)
-	@if ! [ -x "$$(command -v golangci-lint)" ]; then \
-		echo "golangci-lint is not installed. Please see https://github.com/golangci/golangci-lint#install for installation instructions."; \
-		exit 1; \
-	fi; \
+	@# Keep the version in sync with the command in .circleci/config.yml
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.39.0
 
 	@echo Running golangci-lint
-	golangci-lint run ./...
+	$(GOBIN)/golangci-lint run ./...
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 ifneq ($(MM_NO_ENTERPRISE_LINT),true)
-	golangci-lint run ./enterprise/...
+	$(GOBIN)/golangci-lint run ./enterprise/...
 endif
 endif
 

--- a/api4/websocket_norace_test.go
+++ b/api4/websocket_norace_test.go
@@ -1,4 +1,3 @@
-//go:build !race
 // +build !race
 
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.

--- a/api4/websocket_norace_test.go
+++ b/api4/websocket_norace_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.


### PR DESCRIPTION
Go 1.16+ allows installing a tool directly from a specific version.
Therefore, we don't need to rely on the tool being pre-installed
and can directly install it using standard method.

This keeps the same version of the tool for a repo and limits the
binary placement to the GOBIN of the repo.

```release-note
NONE
```
