### PR TITLE
[MM-41534] - Portal not picking up MMCLOUDURL cookie

### DIFF
--- a/app/login.go
+++ b/app/login.go
@@ -273,14 +273,13 @@ func (a *App) AttachCloudSessionCookie(c *request.Context, w http.ResponseWriter
 	}
 
 	cookie := &http.Cookie{
-		Name:     model.SessionCookieCloudUrl,
-		Value:    workspaceName,
-		Path:     subpath,
-		MaxAge:   maxAge,
-		Expires:  expiresAt,
-		HttpOnly: true,
-		Domain:   domain,
-		Secure:   secure,
+		Name:    model.SessionCookieCloudUrl,
+		Value:   workspaceName,
+		Path:    subpath,
+		MaxAge:  maxAge,
+		Expires: expiresAt,
+		Domain:  domain,
+		Secure:  secure,
 	}
 
 	http.SetCookie(w, cookie)


### PR DESCRIPTION
#### Summary
We need this cookie to be accessed by the portal using javascript hence we set it's `HttpOnly` attribute to false

#### Ticket Link
[MM-41534](https://mattermost.atlassian.net/browse/MM-41534)

#### Release Note

```release-note
NONE

```
