### PR TITLE
Skip and warn on emoji import when name conflicts with system emoji

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -1813,13 +1813,13 @@ func (a *App) importMultipleDirectPostLines(c *request.Context, lines []LineImpo
 }
 
 func (a *App) importEmoji(data *EmojiImportData, dryRun bool) *model.AppError {
-	systemEmoji, aerr := validateEmojiImportData(data)
+	aerr := validateEmojiImportData(data)
 	if aerr != nil {
+		if aerr.Id == "model.emoji.system_emoji_name.app_error" {
+			mlog.Warn("Skipping emoji import due to name conflict with system emoji", mlog.String("emoji_name", *data.Name))
+			return nil
+		}
 		return aerr
-	}
-	if systemEmoji {
-		mlog.Warn("Skipping emoji import due to name conflict with system emoji", mlog.String("emoji_name", *data.Name))
-		return nil
 	}
 
 	// If this is a Dry Run, do not continue any further.

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -1813,8 +1813,13 @@ func (a *App) importMultipleDirectPostLines(c *request.Context, lines []LineImpo
 }
 
 func (a *App) importEmoji(data *EmojiImportData, dryRun bool) *model.AppError {
-	if err := validateEmojiImportData(data); err != nil {
-		return err
+	systemEmoji, aerr := validateEmojiImportData(data)
+	if aerr != nil {
+		return aerr
+	}
+	if systemEmoji {
+		mlog.Warn("Skipping emoji import due to name conflict with system emoji", mlog.String("emoji_name", *data.Name))
+		return nil
 	}
 
 	// If this is a Dry Run, do not continue any further.

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -4075,6 +4075,10 @@ func TestImportImportEmoji(t *testing.T) {
 
 	err = th.App.importEmoji(&data, false)
 	assert.Nil(t, err, "Second run should have succeeded apply mode")
+
+	data = EmojiImportData{Name: ptrStr("smiley"), Image: ptrStr(testImage)}
+	err = th.App.importEmoji(&data, false)
+	assert.Nil(t, err, "System emoji should not fail")
 }
 
 func TestImportAttachment(t *testing.T) {

--- a/app/import_validators.go
+++ b/app/import_validators.go
@@ -562,28 +562,24 @@ func validateDirectPostImportData(data *DirectPostImportData, maxPostSize int) *
 
 // validateEmojiImportData validates emoji data and returns if the import name
 // conflicts with a system emoji.
-func validateEmojiImportData(data *EmojiImportData) (bool, *model.AppError) {
+func validateEmojiImportData(data *EmojiImportData) *model.AppError {
 	if data == nil {
-		return false, model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.empty.error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.empty.error", nil, "", http.StatusBadRequest)
 	}
 
 	if data.Name == nil || *data.Name == "" {
-		return false, model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.name_missing.error", nil, "", http.StatusBadRequest)
+		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.name_missing.error", nil, "", http.StatusBadRequest)
 	}
 
 	if data.Image == nil || *data.Image == "" {
-		return false, model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.image_missing.error", nil, "", http.StatusBadRequest)
-	}
-
-	if model.InSystemEmoji(*data.Name) {
-		return true, nil
+		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.image_missing.error", nil, "", http.StatusBadRequest)
 	}
 
 	if err := model.IsValidEmojiName(*data.Name); err != nil {
-		return false, err
+		return err
 	}
 
-	return false, nil
+	return nil
 }
 
 func isValidTrueOrFalseString(value string) bool {

--- a/app/import_validators.go
+++ b/app/import_validators.go
@@ -560,24 +560,30 @@ func validateDirectPostImportData(data *DirectPostImportData, maxPostSize int) *
 	return nil
 }
 
-func validateEmojiImportData(data *EmojiImportData) *model.AppError {
+// validateEmojiImportData validates emoji data and returns if the import name
+// conflicts with a system emoji.
+func validateEmojiImportData(data *EmojiImportData) (bool, *model.AppError) {
 	if data == nil {
-		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.empty.error", nil, "", http.StatusBadRequest)
+		return false, model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.empty.error", nil, "", http.StatusBadRequest)
 	}
 
 	if data.Name == nil || *data.Name == "" {
-		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.name_missing.error", nil, "", http.StatusBadRequest)
-	}
-
-	if err := model.IsValidEmojiName(*data.Name); err != nil {
-		return err
+		return false, model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.name_missing.error", nil, "", http.StatusBadRequest)
 	}
 
 	if data.Image == nil || *data.Image == "" {
-		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.image_missing.error", nil, "", http.StatusBadRequest)
+		return false, model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.image_missing.error", nil, "", http.StatusBadRequest)
 	}
 
-	return nil
+	if model.InSystemEmoji(*data.Name) {
+		return true, nil
+	}
+
+	if err := model.IsValidEmojiName(*data.Name); err != nil {
+		return false, err
+	}
+
+	return false, nil
 }
 
 func isValidTrueOrFalseString(value string) bool {

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -1343,34 +1343,41 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 }
 
 func TestImportValidateEmojiImportData(t *testing.T) {
-	data := EmojiImportData{
-		Name:  ptrStr("parrot2"),
-		Image: ptrStr("/path/to/image"),
+	var testCases = []struct {
+		testName          string
+		name              *string
+		image             *string
+		expectError       bool
+		expectSystemEmoji bool
+	}{
+		{"success", ptrStr("parrot2"), ptrStr("/path/to/image"), false, false},
+		{"system emoji", ptrStr("smiley"), ptrStr("/path/to/image"), false, true},
+		{"empty name", ptrStr(""), ptrStr("/path/to/image"), true, false},
+		{"empty image", ptrStr("parrot2"), ptrStr(""), true, false},
+		{"empty name and image", ptrStr(""), ptrStr(""), true, false},
+		{"nil name", nil, ptrStr("/path/to/image"), true, false},
+		{"nil image", ptrStr("parrot2"), nil, true, false},
+		{"nil name and image", nil, nil, true, false},
 	}
 
-	err := validateEmojiImportData(&data)
-	assert.Nil(t, err, "Validation should succeed")
+	for _, tc := range testCases {
+		t.Run(tc.testName, func(t *testing.T) {
+			data := EmojiImportData{
+				Name:  tc.name,
+				Image: tc.image,
+			}
 
-	*data.Name = "smiley"
-	err = validateEmojiImportData(&data)
-	assert.NotNil(t, err)
+			systemEmoji, err := validateEmojiImportData(&data)
+			if tc.expectError {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
 
-	*data.Name = ""
-	err = validateEmojiImportData(&data)
-	assert.NotNil(t, err)
-
-	*data.Name = ""
-	*data.Image = ""
-	err = validateEmojiImportData(&data)
-	assert.NotNil(t, err)
-
-	*data.Image = "/path/to/image"
-	data.Name = nil
-	err = validateEmojiImportData(&data)
-	assert.NotNil(t, err)
-
-	data.Name = ptrStr("parrot")
-	data.Image = nil
-	err = validateEmojiImportData(&data)
-	assert.NotNil(t, err)
+			assert.Equal(t, tc.expectSystemEmoji, systemEmoji)
+			if systemEmoji {
+				assert.True(t, model.InSystemEmoji(*data.Name))
+			}
+		})
+	}
 }

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -1351,7 +1351,7 @@ func TestImportValidateEmojiImportData(t *testing.T) {
 		expectSystemEmoji bool
 	}{
 		{"success", ptrStr("parrot2"), ptrStr("/path/to/image"), false, false},
-		{"system emoji", ptrStr("smiley"), ptrStr("/path/to/image"), false, true},
+		{"system emoji", ptrStr("smiley"), ptrStr("/path/to/image"), true, true},
 		{"empty name", ptrStr(""), ptrStr("/path/to/image"), true, false},
 		{"empty image", ptrStr("parrot2"), ptrStr(""), true, false},
 		{"empty name and image", ptrStr(""), ptrStr(""), true, false},
@@ -1367,16 +1367,12 @@ func TestImportValidateEmojiImportData(t *testing.T) {
 				Image: tc.image,
 			}
 
-			systemEmoji, err := validateEmojiImportData(&data)
+			err := validateEmojiImportData(&data)
 			if tc.expectError {
-				assert.NotNil(t, err)
+				require.NotNil(t, err)
+				assert.Equal(t, tc.expectSystemEmoji, err.Id == "model.emoji.system_emoji_name.app_error")
 			} else {
 				assert.Nil(t, err)
-			}
-
-			assert.Equal(t, tc.expectSystemEmoji, systemEmoji)
-			if systemEmoji {
-				assert.True(t, model.InSystemEmoji(*data.Name))
 			}
 		})
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8364,6 +8364,10 @@
     "translation": "Name must be 1 to 64 lowercase alphanumeric characters."
   },
   {
+    "id": "model.emoji.system_emoji_name.app_error",
+    "translation": "Name conflicts with existing system emoji name."
+  },
+  {
     "id": "model.emoji.update_at.app_error",
     "translation": "Update at must be a valid time."
   },

--- a/model/emoji.go
+++ b/model/emoji.go
@@ -25,7 +25,7 @@ type Emoji struct {
 	Name      string `json:"name"`
 }
 
-func InSystemEmoji(emojiName string) bool {
+func inSystemEmoji(emojiName string) bool {
 	_, ok := SystemEmojis[emojiName]
 	return ok
 }
@@ -78,8 +78,11 @@ func (emoji *Emoji) IsValid() *AppError {
 }
 
 func IsValidEmojiName(name string) *AppError {
-	if name == "" || len(name) > EmojiNameMaxLength || !IsValidAlphaNumHyphenUnderscorePlus(name) || InSystemEmoji(name) {
+	if name == "" || len(name) > EmojiNameMaxLength || !IsValidAlphaNumHyphenUnderscorePlus(name) {
 		return NewAppError("Emoji.IsValid", "model.emoji.name.app_error", nil, "", http.StatusBadRequest)
+	}
+	if inSystemEmoji(name) {
+		return NewAppError("Emoji.IsValid", "model.emoji.system_emoji_name.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/model/emoji.go
+++ b/model/emoji.go
@@ -25,7 +25,7 @@ type Emoji struct {
 	Name      string `json:"name"`
 }
 
-func inSystemEmoji(emojiName string) bool {
+func InSystemEmoji(emojiName string) bool {
 	_, ok := SystemEmojis[emojiName]
 	return ok
 }
@@ -78,7 +78,7 @@ func (emoji *Emoji) IsValid() *AppError {
 }
 
 func IsValidEmojiName(name string) *AppError {
-	if name == "" || len(name) > EmojiNameMaxLength || !IsValidAlphaNumHyphenUnderscorePlus(name) || inSystemEmoji(name) {
+	if name == "" || len(name) > EmojiNameMaxLength || !IsValidAlphaNumHyphenUnderscorePlus(name) || InSystemEmoji(name) {
 		return NewAppError("Emoji.IsValid", "model.emoji.name.app_error", nil, "", http.StatusBadRequest)
 	}
 


### PR DESCRIPTION
This changes import behavior related to emoji imports when the name
conflicts with the name of a system emoji. Previously, the import
would fail, but now a warning is logged and the conflicting emoji
is skipped.

Fixes https://mattermost.atlassian.net/browse/MM-41613

```release-note
Skip and warn on emoji import when name conflicts with system emoji
```
