### PR TITLE
Pin the FROM in dockerfiles

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14@sha256:635f0aa53d99017b38d1a0aa5b2082f7812b03e3cdb299103fe77b5c8a07f1d2
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"

--- a/build/Dockerfile.buildenv
+++ b/build/Dockerfile.buildenv
@@ -1,3 +1,3 @@
-FROM golang:1.16.7
+FROM golang:1.16.7@sha256:0b5bf2d2c5682b0de7425b8a379330493bb8bbe984ebbcaf7ced1c0138640417
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq


### PR DESCRIPTION
This prevents supply chain attacks where the latest image is replaced with a malicious version.

Pinning done by using https://github.com/Jille/dockpin (pins to the latest hash when run)
