### PR TITLE
MM-41143: Pass a custom logger to morph

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1013,7 +1013,7 @@ func (ss *SqlStore) migrate(direction migrationDirection) error {
 	}
 
 	opts := []morph.EngineOption{
-		morph.WithLogger(log.New(newMorphWriter(), "", log.Lshortfile)),
+		morph.WithLogger(log.New(&morphWriter{}, "", log.Lshortfile)),
 		morph.WithLock("mm-lock-key"),
 	}
 	engine, err := morph.New(context.Background(), driver, src, opts...)

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	dbsql "database/sql"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -27,7 +28,6 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
-	_ "github.com/lib/pq"
 	"github.com/mattermost/gorp"
 	"github.com/pkg/errors"
 
@@ -1012,7 +1012,11 @@ func (ss *SqlStore) migrate(direction migrationDirection) error {
 		return err
 	}
 
-	engine, err := morph.New(context.Background(), driver, src, morph.WithLock("mm-lock-key"))
+	opts := []morph.EngineOption{
+		morph.WithLogger(log.New(newMorphWriter(), "", log.Lshortfile),),
+		morph.WithLock("mm-lock-key"),
+	}
+	engine, err := morph.New(context.Background(), driver, src, opts...)
 	if err != nil {
 		return err
 	}

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1013,7 +1013,7 @@ func (ss *SqlStore) migrate(direction migrationDirection) error {
 	}
 
 	opts := []morph.EngineOption{
-		morph.WithLogger(log.New(newMorphWriter(), "", log.Lshortfile),),
+		morph.WithLogger(log.New(newMorphWriter(), "", log.Lshortfile)),
 		morph.WithLock("mm-lock-key"),
 	}
 	engine, err := morph.New(context.Background(), driver, src, opts...)

--- a/store/sqlstore/utils.go
+++ b/store/sqlstore/utils.go
@@ -147,3 +147,18 @@ func constructArrayArgs(ids []string) (string, []interface{}) {
 
 	return "(" + placeholder.String() + ")", values
 }
+
+// morphWriter is a target to pass to the logger instance of morph.
+// For now, everything is just logged at a debug level. If we need to log
+// errors/warnings from the library also, that needs to be seen later.
+type morphWriter struct {
+}
+
+func newMorphWriter() *morphWriter {
+	return &morphWriter{}
+}
+
+func (l *morphWriter) Write(in []byte) (int, error) {
+	mlog.Debug(string(in))
+	return len(in), nil
+}

--- a/store/sqlstore/utils.go
+++ b/store/sqlstore/utils.go
@@ -154,10 +154,6 @@ func constructArrayArgs(ids []string) (string, []interface{}) {
 type morphWriter struct {
 }
 
-func newMorphWriter() *morphWriter {
-	return &morphWriter{}
-}
-
 func (l *morphWriter) Write(in []byte) (int, error) {
 	mlog.Debug(string(in))
 	return len(in), nil


### PR DESCRIPTION
We create a custom io.Writer to pass to the logger
instance. For now, we keep everything to debug
as all errors are surfaced back to the server via
the API.

```release-note
NONE
```
