### PR TITLE
MM-38419: Split UPSERT statement into 2

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -618,14 +618,17 @@ func (s SqlChannelStore) upsertPublicChannelT(transaction *sqlxTxWrapper, channe
 			    PublicChannels(Id, DeleteAt, TeamId, DisplayName, Name, Header, Purpose)
 			VALUES
 			    (:id, :deleteat, :teamid, :displayname, :name, :header, :purpose)
-			ON DUPLICATE KEY UPDATE
-			    DeleteAt = :deleteat,
+		`, vals)
+		if err != nil && IsUniqueConstraintError(err, []string{"PRIMARY"}) {
+			_, err = transaction.NamedExec(`UPDATE PublicChannels
+				SET deleteAt = :deleteat,
 			    TeamId = :teamid,
 			    DisplayName = :displayname,
 			    Name = :name,
 			    Header = :header,
-			    Purpose = :purpose;
-		`, vals)
+			    Purpose = :purpose
+			    WHERE Id=:id`, vals)
+		}
 	} else {
 		_, err = transaction.NamedExec(`
 			INSERT INTO


### PR DESCRIPTION
The UPSERT statement was taking unexplained gap
locks, due to which the import was somehow failing.
I still don't know exactly how this is happening.

But splitting the UPSERT into 2 different statements
in the same transaction changes the locking semantics,
and avoids the deadlock.

Naturally, this proves that even our retrylayer
is sometimes ineffective against some problems.

```release-note
NONE
```
