### PR TITLE
Allow developpers to use a docker-compose.override.yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ __debug_bin
 report.xml
 go.*.orig
 config.override.mk
+docker-compose.override.yaml

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,11 @@ ifeq ($(RUN_SERVER_IN_BACKGROUND),true)
 	RUN_IN_BACKGROUND := &
 endif
 
+DOCKER_COMPOSE_OVERRIDE=
+ifneq ("$(wildcard ./docker-compose.override.yaml)","")
+    DOCKER_COMPOSE_OVERRIDE=-f docker-compose.override.yaml
+endif
+
 start-docker-check:
 ifeq (,$(findstring minio,$(ENABLED_DOCKER_SERVICES)))
   TEMP_DOCKER_SERVICES:=$(TEMP_DOCKER_SERVICES) minio
@@ -185,9 +190,9 @@ else ifeq ($(MM_NO_DOCKER),true)
 else
 	@echo Starting docker containers
 
-	$(GO) run ./build/docker-compose-generator/main.go $(ENABLED_DOCKER_SERVICES) | docker-compose -f docker-compose.makefile.yml -f /dev/stdin run --rm start_dependencies
+	$(GO) run ./build/docker-compose-generator/main.go $(ENABLED_DOCKER_SERVICES) | docker-compose -f docker-compose.makefile.yml -f /dev/stdin $(DOCKER_COMPOSE_OVERRIDE) run --rm start_dependencies
 ifneq (,$(findstring openldap,$(ENABLED_DOCKER_SERVICES)))
-	cat tests/${LDAP_DATA}-data.ldif | docker-compose -f docker-compose.makefile.yml exec -T openldap bash -c 'ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest || true';
+	cat tests/${LDAP_DATA}-data.ldif | docker-compose -f docker-compose.makefile.yml $(DOCKER_COMPOSE_OVERRIDE) exec -T openldap bash -c 'ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest || true';
 endif
 ifneq (,$(findstring mysql-read-replica,$(ENABLED_DOCKER_SERVICES)))
 	./scripts/replica-mysql-config.sh
@@ -198,7 +203,7 @@ run-haserver:
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Starting mattermost in an HA topology '(3 node cluster)'
 
-	docker-compose -f docker-compose.yaml up --remove-orphans haproxy
+	docker-compose -f docker-compose.yaml $(DOCKER_COMPOSE_OVERRIDE) up --remove-orphans haproxy
 endif
 
 stop-haserver:


### PR DESCRIPTION
#### Summary
This PR allows developers to have a custom `docker-compose.override.yaml` file, to either customize/override or add new service on their local installation.

Two personal use-cases:
- There's a [known issue with the docker MySQL image on arch linux](https://github.com/docker-library/mysql/issues/579#issuecomment-519495808) that makes MySQL use all available memory, I can patch this easily by overriding `ulimit` on the MySQL service.
- while working on a few Rudder PR, I had to run a local installation of rudder that I added to the override file.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
