### PR TITLE
[GH-19267] Spelling tests

### DIFF
--- a/api4/apitestlib.go
+++ b/api4/apitestlib.go
@@ -648,7 +648,7 @@ func (th *TestHelper) SetupSamlConfig() {
 		*cfg.SamlSettings.Enable = true
 		*cfg.SamlSettings.Verify = false
 		*cfg.SamlSettings.Encrypt = false
-		*cfg.SamlSettings.IdpURL = "https://does.notmatter.com"
+		*cfg.SamlSettings.IdpURL = "https://does.notmatter.example"
 		*cfg.SamlSettings.IdpDescriptorURL = "https://localhost/adfs/services/trust"
 		*cfg.SamlSettings.AssertionConsumerServiceURL = "https://localhost/login/sso/saml"
 		*cfg.SamlSettings.ServiceProviderIdentifier = "https://localhost/login/sso/saml"

--- a/api4/bot_test.go
+++ b/api4/bot_test.go
@@ -691,7 +691,7 @@ func TestGetBots(t *testing.T) {
 	th.LoginBasic2()
 	orphanedBot, resp, err := th.Client.CreateBot(&model.Bot{
 		Username:    GenerateTestUsername(),
-		Description: "an oprphaned bot",
+		Description: "an orphaned bot",
 	})
 	require.NoError(t, err)
 	CheckCreatedStatus(t, resp)

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2503,7 +2503,7 @@ func TestGetChannelStats(t *testing.T) {
 	stats, _, err := client.GetChannelStats(channel.Id, "")
 	require.NoError(t, err)
 
-	require.Equal(t, channel.Id, stats.ChannelId, "couldnt't get extra info")
+	require.Equal(t, channel.Id, stats.ChannelId, "couldn't get extra info")
 	require.Equal(t, int64(1), stats.MemberCount, "got incorrect member count")
 	require.Equal(t, int64(0), stats.PinnedPostCount, "got incorrect pinned post count")
 

--- a/api4/emoji_test.go
+++ b/api4/emoji_test.go
@@ -531,7 +531,7 @@ func TestGetEmojiImage(t *testing.T) {
 	require.Greater(t, len(emojiImage), 0, "no image returned")
 
 	_, imageType, err = image.DecodeConfig(bytes.NewReader(emojiImage))
-	require.NoError(t, err, "unable to indentify received image")
+	require.NoError(t, err, "unable to identify received image")
 	require.Equal(t, imageType, "gif", "expected gif")
 
 	emoji3 := &model.Emoji{
@@ -546,7 +546,7 @@ func TestGetEmojiImage(t *testing.T) {
 	require.Greater(t, len(emojiImage), 0, "no image returned")
 
 	_, imageType, err = image.DecodeConfig(bytes.NewReader(emojiImage))
-	require.NoError(t, err, "unable to indentify received image")
+	require.NoError(t, err, "unable to identify received image")
 	require.Equal(t, imageType, "jpeg", "expected jpeg")
 
 	emoji4 := &model.Emoji{
@@ -561,7 +561,7 @@ func TestGetEmojiImage(t *testing.T) {
 	require.Greater(t, len(emojiImage), 0, "no image returned")
 
 	_, imageType, err = image.DecodeConfig(bytes.NewReader(emojiImage))
-	require.NoError(t, err, "unable to idenitify received image")
+	require.NoError(t, err, "unable to identify received image")
 	require.Equal(t, imageType, "png", "expected png")
 
 	_, err = client.DeleteEmoji(emoji4.Id)

--- a/api4/integration_action_test.go
+++ b/api4/integration_action_test.go
@@ -55,7 +55,7 @@ func TestPostActionCookies(t *testing.T) {
 
 	for name, test := range map[string]struct {
 		Action             model.PostAction
-		ExpectedSucess     bool
+		ExpectedSuccess    bool
 		ExpectedStatusCode int
 	}{
 		"32 character ID": {
@@ -70,7 +70,7 @@ func TestPostActionCookies(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSucess:     true,
+			ExpectedSuccess:    true,
 			ExpectedStatusCode: http.StatusOK,
 		},
 		"6 character ID": {
@@ -85,7 +85,7 @@ func TestPostActionCookies(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSucess:     true,
+			ExpectedSuccess:    true,
 			ExpectedStatusCode: http.StatusOK,
 		},
 		"Empty ID": {
@@ -100,7 +100,7 @@ func TestPostActionCookies(t *testing.T) {
 					},
 				},
 			},
-			ExpectedSucess:     false,
+			ExpectedSuccess:    false,
 			ExpectedStatusCode: http.StatusNotFound,
 		},
 	} {
@@ -130,7 +130,7 @@ func TestPostActionCookies(t *testing.T) {
 
 			resp, err := client.DoPostActionWithCookie(post.Id, test.Action.Id, "", test.Action.Cookie)
 			require.NotNil(t, resp)
-			if test.ExpectedSucess {
+			if test.ExpectedSuccess {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -3466,7 +3466,7 @@ func TestSetDefaultProfileImage(t *testing.T) {
 
 	ruser, appErr := th.App.GetUser(user.Id)
 	require.Nil(t, appErr)
-	assert.Equal(t, int64(0), ruser.LastPictureUpdate, "Picture should have resetted to default")
+	assert.Equal(t, int64(0), ruser.LastPictureUpdate, "Picture should have reset to default")
 
 	info := &model.FileInfo{Path: "users/" + user.Id + "/profile.png"}
 	err = th.cleanupTestFile(info)
@@ -5269,7 +5269,7 @@ func TestPromoteGuestToUser(t *testing.T) {
 		require.NoError(t, err)
 
 		defer require.Nil(t, th.App.DemoteUserToGuest(user))
-	}, "promete a guest to user")
+	}, "promote a guest to user")
 
 	t.Run("websocket update user event", func(t *testing.T) {
 		webSocketClient, err := th.CreateWebSocketClient()

--- a/api4/user_viewmembers_test.go
+++ b/api4/user_viewmembers_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
-func TestAPIResctrictedViewMembers(t *testing.T) {
+func TestAPIRestrictedViewMembers(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 

--- a/api4/webhook_test.go
+++ b/api4/webhook_test.go
@@ -331,7 +331,7 @@ func TestGetIncomingWebhook(t *testing.T) {
 		CheckBadRequestStatus(t, resp)
 	}, "WhenInvalidHookID")
 
-	t.Run("WhenUserDoesNotHavePemissions", func(t *testing.T) {
+	t.Run("WhenUserDoesNotHavePermissions", func(t *testing.T) {
 		th.LoginBasic()
 		_, resp, err := th.Client.GetIncomingWebhook(rhook.Id, "")
 		require.Error(t, err)
@@ -378,7 +378,7 @@ func TestDeleteIncomingWebhook(t *testing.T) {
 		CheckNotFoundStatus(t, resp)
 	}, "WhenHookExists")
 
-	t.Run("WhenUserDoesNotHavePemissions", func(t *testing.T) {
+	t.Run("WhenUserDoesNotHavePermissions", func(t *testing.T) {
 		hook := &model.IncomingWebhook{ChannelId: th.BasicChannel.Id}
 		rhook, _, err := th.SystemAdminClient.CreateIncomingWebhook(hook)
 		require.NoError(t, err)
@@ -1264,7 +1264,7 @@ func TestDeleteOutgoingHook(t *testing.T) {
 		CheckNotFoundStatus(t, resp)
 	}, "WhenHookExists")
 
-	t.Run("WhenUserDoesNotHavePemissions", func(t *testing.T) {
+	t.Run("WhenUserDoesNotHavePermissions", func(t *testing.T) {
 		hook := &model.OutgoingWebhook{ChannelId: th.BasicChannel.Id, TeamId: th.BasicChannel.TeamId,
 			CallbackURLs: []string{"http://nowhere.com"}, TriggerWords: []string{"dogs"}}
 		rhook, _, err := th.SystemAdminClient.CreateOutgoingWebhook(hook)

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -88,15 +88,15 @@ func TestRemoveAllDeactivatedMembersFromChannel(t *testing.T) {
 	_, _, err = th.App.AddUserToTeam(th.Context, team.Id, th.BasicUser.Id, "")
 	require.Nil(t, err)
 
-	deacivatedUser := th.CreateUser()
-	_, _, err = th.App.AddUserToTeam(th.Context, team.Id, deacivatedUser.Id, "")
+	deactivatedUser := th.CreateUser()
+	_, _, err = th.App.AddUserToTeam(th.Context, team.Id, deactivatedUser.Id, "")
 	require.Nil(t, err)
-	_, err = th.App.AddUserToChannel(deacivatedUser, channel, false)
+	_, err = th.App.AddUserToChannel(deactivatedUser, channel, false)
 	require.Nil(t, err)
 	channelMembers, err := th.App.GetChannelMembersPage(channel.Id, 0, 10000000)
 	require.Nil(t, err)
 	require.Len(t, channelMembers, 2)
-	_, err = th.App.UpdateActive(th.Context, deacivatedUser, false)
+	_, err = th.App.UpdateActive(th.Context, deactivatedUser, false)
 	require.Nil(t, err)
 
 	err = th.App.RemoveAllDeactivatedMembersFromChannel(channel)
@@ -148,23 +148,23 @@ func TestMoveChannel(t *testing.T) {
 
 		// Test moving a channel with a deactivated user who isn't in the destination team.
 		// It should fail, unless removeDeactivatedMembers is true.
-		deacivatedUser := th.CreateUser()
+		deactivatedUser := th.CreateUser()
 		channel2 := th.CreateChannel(sourceTeam)
 		defer th.App.PermanentDeleteChannel(channel2)
 
-		_, _, err = th.App.AddUserToTeam(th.Context, sourceTeam.Id, deacivatedUser.Id, "")
+		_, _, err = th.App.AddUserToTeam(th.Context, sourceTeam.Id, deactivatedUser.Id, "")
 		require.Nil(t, err)
 		_, err = th.App.AddUserToChannel(th.BasicUser, channel2, false)
 		require.Nil(t, err)
 
-		_, err = th.App.AddUserToChannel(deacivatedUser, channel2, false)
+		_, err = th.App.AddUserToChannel(deactivatedUser, channel2, false)
 		require.Nil(t, err)
 
-		_, err = th.App.UpdateActive(th.Context, deacivatedUser, false)
+		_, err = th.App.UpdateActive(th.Context, deactivatedUser, false)
 		require.Nil(t, err)
 
 		err = th.App.MoveChannel(th.Context, targetTeam, channel2, th.BasicUser)
-		require.NotNil(t, err, "Should have failed due to mismatched deacivated member.")
+		require.NotNil(t, err, "Should have failed due to mismatched deactivated member.")
 
 		// Test moving a channel with no members.
 		channel3 := &model.Channel{
@@ -1821,9 +1821,9 @@ func TestPatchChannelModerationsForChannel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			higherScopedPermissionsOverriden := tc.HigherScopedMemberPermissions != nil || tc.HigherScopedGuestPermissions != nil
+			higherScopedPermissionsOverridden := tc.HigherScopedMemberPermissions != nil || tc.HigherScopedGuestPermissions != nil
 			// If the test case restricts higher scoped permissions.
-			if higherScopedPermissionsOverriden {
+			if higherScopedPermissionsOverridden {
 				higherScopedGuestRoleName, higherScopedMemberRoleName, _, _ := th.App.GetTeamSchemeChannelRoles(channel.TeamId)
 				if tc.HigherScopedMemberPermissions != nil {
 					higherScopedMemberRole, err := th.App.GetRoleByName(context.Background(), higherScopedMemberRoleName)

--- a/app/file_test.go
+++ b/app/file_test.go
@@ -331,11 +331,11 @@ func TestGenerateThumbnailImage(t *testing.T) {
 		defer th.TearDown()
 		img := createDummyImage()
 		dataPath, _ := fileutils.FindDir("data")
-		thumbailName := "thumb.jpg"
-		thumbnailPath := filepath.Join(dataPath, thumbailName)
+		thumbnailName := "thumb.jpg"
+		thumbnailPath := filepath.Join(dataPath, thumbnailName)
 
 		// when
-		th.App.generateThumbnailImage(img, thumbailName)
+		th.App.generateThumbnailImage(img, thumbnailName)
 		defer os.Remove(thumbnailPath)
 
 		// then

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -615,7 +615,7 @@ func TestImportImportChannel(t *testing.T) {
 		Team:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        &chanOpen,
-		Header:      ptrStr("Channe Header"),
+		Header:      ptrStr("Channel Header"),
 		Purpose:     ptrStr("Channel Purpose"),
 		Scheme:      &scheme1.Name,
 	}
@@ -680,7 +680,7 @@ func TestImportImportChannel(t *testing.T) {
 
 	// Alter all the fields of that channel.
 	cTypePr := model.ChannelTypePrivate
-	data.DisplayName = ptrStr("Chaned Disp Name")
+	data.DisplayName = ptrStr("Changed Disp Name")
 	data.Type = &cTypePr
 	data.Header = ptrStr("New Header")
 	data.Purpose = ptrStr("New Purpose")
@@ -1400,7 +1400,7 @@ func TestImportImportUser(t *testing.T) {
 		Name:        ptrStr(model.NewId()),
 		DisplayName: ptrStr("Display Name"),
 		Type:        &chanTypeOpen,
-		Header:      ptrStr("Channe Header"),
+		Header:      ptrStr("Channel Header"),
 		Purpose:     ptrStr("Channel Purpose"),
 	}
 	appErr = th.App.importChannel(th.Context, channelData, false)

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1458,7 +1458,7 @@ func TestGetMentionKeywords(t *testing.T) {
 
 	profiles = map[string]*model.User{userNoMentionKeys.Id: userNoMentionKeys}
 	mentions = th.App.getMentionKeywordsInChannel(profiles, true, channelMemberNotifyPropsMapEmptyOff)
-	assert.Equal(t, 1, len(mentions), "should've returned one metion keyword")
+	assert.Equal(t, 1, len(mentions), "should've returned one mention keyword")
 	ids, ok = mentions["@user"]
 	assert.True(t, ok)
 	assert.Equal(t, userNoMentionKeys.Id, ids[0], "should've returned mention key of @user")
@@ -2320,7 +2320,7 @@ func TestProcessText(t *testing.T) {
 				ChannelMentioned: true,
 			},
 		},
-		"Mention other pontential users or system calls": {
+		"Mention other potential users or system calls": {
 			Text:     "hello @potentialuser and @otherpotentialuser",
 			Keywords: map[string][]string{},
 			Groups:   map[string]*model.Group{"engineering": {Name: model.NewString("engineering")}, "developers": {Name: model.NewString("developers")}},

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -1850,7 +1850,7 @@ func TestPluginAPISearchPostsInTeamByUser(t *testing.T) {
 	api := th.SetupPluginAPI()
 
 	basicPostText := &th.BasicPost.Message
-	unknwonTerm := "Unknown Message"
+	unknownTerm := "Unknown Message"
 
 	testCases := []struct {
 		description      string
@@ -1870,7 +1870,7 @@ func TestPluginAPISearchPostsInTeamByUser(t *testing.T) {
 			"doesn't match any posts",
 			th.BasicTeam.Id,
 			th.BasicUser.Id,
-			model.SearchParameter{Terms: &unknwonTerm},
+			model.SearchParameter{Terms: &unknownTerm},
 			0,
 		},
 		{

--- a/app/post_metadata_test.go
+++ b/app/post_metadata_test.go
@@ -309,7 +309,7 @@ func TestPreparePostForClient(t *testing.T) {
 
 		emoji := "basketball"
 		url := "http://host.com/image.png"
-		overridenURL := "/static/emoji/1f3c0.png"
+		overriddenURL := "/static/emoji/1f3c0.png"
 
 		t.Run("does not override icon URL", func(t *testing.T) {
 			clientPost := prepare(false, url, emoji)
@@ -327,7 +327,7 @@ func TestPreparePostForClient(t *testing.T) {
 
 			s, ok := clientPost.GetProps()[model.PostPropsOverrideIconURL]
 			assert.True(t, ok)
-			assert.EqualValues(t, overridenURL, s)
+			assert.EqualValues(t, overriddenURL, s)
 			s, ok = clientPost.GetProps()[model.PostPropsOverrideIconEmoji]
 			assert.True(t, ok)
 			assert.EqualValues(t, emoji, s)
@@ -339,7 +339,7 @@ func TestPreparePostForClient(t *testing.T) {
 
 			s, ok := clientPost.GetProps()[model.PostPropsOverrideIconURL]
 			assert.True(t, ok)
-			assert.EqualValues(t, overridenURL, s)
+			assert.EqualValues(t, overriddenURL, s)
 			s, ok = clientPost.GetProps()[model.PostPropsOverrideIconEmoji]
 			assert.True(t, ok)
 			assert.EqualValues(t, colonEmoji, s)
@@ -1421,7 +1421,7 @@ func TestGetFirstLinkAndImages(t *testing.T) {
 		"markdown links (not returned)": {
 			Input: `this is a [our page](http://example.com) and [another page][]
 
-[another page]: http://www.exaple.com/another_page`,
+[another page]: http://www.example.com/another_page`,
 			ExpectedFirstLink: "",
 			ExpectedImages:    []string{},
 		},

--- a/app/product_notices_test.go
+++ b/app/product_notices_test.go
@@ -544,7 +544,7 @@ func TestNoticeValidation(t *testing.T) {
 			wantOk:  true,
 		},
 		{
-			name: "notice with depreacting an external dependency",
+			name: "notice with deprecating an external dependency",
 			args: args{
 				dbmsName: "mysql",
 				dbmsVer:  "5.6",
@@ -561,7 +561,7 @@ func TestNoticeValidation(t *testing.T) {
 			wantOk:  true,
 		},
 		{
-			name: "notice with depreacting an external dependency, on a future version",
+			name: "notice with deprecating an external dependency, on a future version",
 			args: args{
 				dbmsName:      "mysql",
 				dbmsVer:       "5.6",

--- a/app/remote_cluster_test.go
+++ b/app/remote_cluster_test.go
@@ -41,7 +41,7 @@ func TestAddRemoteCluster(t *testing.T) {
 		remoteCluster := &model.RemoteCluster{
 			RemoteTeamId: model.NewId(),
 			Name:         "test2",
-			SiteURL:      "http://www2.exmaple.com:8065",
+			SiteURL:      "http://www2.example.com:8065",
 			Token:        model.NewId(),
 			RemoteToken:  model.NewId(),
 			Topics:       "",
@@ -75,7 +75,7 @@ func TestUpdateRemoteCluster(t *testing.T) {
 		remoteCluster := &model.RemoteCluster{
 			RemoteTeamId: model.NewId(),
 			Name:         "test3",
-			SiteURL:      "http://www3.exmaple.com:8065",
+			SiteURL:      "http://www3.example.com:8065",
 			Token:        model.NewId(),
 			RemoteToken:  model.NewId(),
 			Topics:       "",

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -547,7 +547,7 @@ func TestPanicLog(t *testing.T) {
 	s, err := NewServer(SetLogger(logger))
 	require.NoError(t, err)
 
-	// Route for just panicing
+	// Route for just panicking
 	s.Router.HandleFunc("/panic", func(writer http.ResponseWriter, request *http.Request) {
 		s.Log.Info("inside panic handler")
 		panic("log this panic")
@@ -684,7 +684,7 @@ func TestSentry(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Route for just panicing
+		// Route for just panicking
 		s.Router.HandleFunc("/panic", func(writer http.ResponseWriter, request *http.Request) {
 			panic("log this panic")
 		})

--- a/app/team_test.go
+++ b/app/team_test.go
@@ -765,7 +765,7 @@ func TestJoinUserToTeam(t *testing.T) {
 		require.NotNil(t, appErr, "Should fail")
 	})
 
-	t.Run("re-join alfter leaving with limit problem", func(t *testing.T) {
+	t.Run("re-join after leaving with limit problem", func(t *testing.T) {
 		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
 		ruser1, _ := th.App.CreateUser(th.Context, &user1)
 

--- a/app/teams/teams_test.go
+++ b/app/teams/teams_test.go
@@ -107,7 +107,7 @@ func TestJoinUserToTeam(t *testing.T) {
 		require.Error(t, err, "Should fail")
 	})
 
-	t.Run("re-join alfter leaving with limit problem", func(t *testing.T) {
+	t.Run("re-join after leaving with limit problem", func(t *testing.T) {
 		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: "passwd1", AuthService: ""}
 		ruser1 := th.CreateUser(&user1)
 

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -827,10 +827,10 @@ func TestCreateUserWithToken(t *testing.T) {
 	})
 
 	t.Run("create guest having email domain restrictions", func(t *testing.T) {
-		enableGuestDomainRestricions := *th.App.Config().GuestAccountsSettings.RestrictCreationToDomains
+		enableGuestDomainRestrictions := *th.App.Config().GuestAccountsSettings.RestrictCreationToDomains
 		defer func() {
 			th.App.UpdateConfig(func(cfg *model.Config) {
-				cfg.GuestAccountsSettings.RestrictCreationToDomains = &enableGuestDomainRestricions
+				cfg.GuestAccountsSettings.RestrictCreationToDomains = &enableGuestDomainRestrictions
 			})
 		}()
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.RestrictCreationToDomains = "restricted.com" })
@@ -876,10 +876,10 @@ func TestCreateUserWithToken(t *testing.T) {
 		th.BasicTeam.AllowedDomains = "restricted-team.com"
 		_, err := th.App.UpdateTeam(th.BasicTeam)
 		require.Nil(t, err, "Should update the team")
-		enableGuestDomainRestricions := *th.App.Config().TeamSettings.RestrictCreationToDomains
+		enableGuestDomainRestrictions := *th.App.Config().TeamSettings.RestrictCreationToDomains
 		defer func() {
 			th.App.UpdateConfig(func(cfg *model.Config) {
-				cfg.TeamSettings.RestrictCreationToDomains = &enableGuestDomainRestricions
+				cfg.TeamSettings.RestrictCreationToDomains = &enableGuestDomainRestrictions
 			})
 		}()
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.RestrictCreationToDomains = "restricted.com" })

--- a/app/user_viewmembers_test.go
+++ b/app/user_viewmembers_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/store"
 )
 
-func TestResctrictedViewMembers(t *testing.T) {
+func TestRestrictedViewMembers(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 

--- a/app/webhook_test.go
+++ b/app/webhook_test.go
@@ -587,7 +587,7 @@ func TestTriggerOutGoingWebhookWithUsernameAndIconURL(t *testing.T) {
 		}
 	}
 
-	waitUntilWebhookResposeIsCreatedAsPost := func(channel *model.Channel, th *TestHelper, createdPost chan *model.Post) {
+	waitUntilWebhookResponseIsCreatedAsPost := func(channel *model.Channel, th *TestHelper, createdPost chan *model.Post) {
 		go func() {
 			for i := 0; i < 5; i++ {
 				time.Sleep(time.Second)
@@ -646,8 +646,8 @@ func TestTriggerOutGoingWebhookWithUsernameAndIconURL(t *testing.T) {
 				EnablePostUsernameOverride: true,
 				EnablePostIconOverride:     true,
 				ExpectedUsername:           "webhookuser",
-				ExpectedIconURL:            "http://webhok/icon",
-				WebhookResponse:            &model.OutgoingWebhookResponse{Text: &webHookResponse, Username: "webhookuser", IconURL: "http://webhok/icon"},
+				ExpectedIconURL:            "http://webhook/icon",
+				WebhookResponse:            &model.OutgoingWebhookResponse{Text: &webHookResponse, Username: "webhookuser", IconURL: "http://webhook/icon"},
 			},
 		}
 		return testCasesOutgoing
@@ -687,7 +687,7 @@ func TestTriggerOutGoingWebhookWithUsernameAndIconURL(t *testing.T) {
 
 			th.App.TriggerWebhook(th.Context, payload, hook, th.BasicPost, channel)
 
-			waitUntilWebhookResposeIsCreatedAsPost(channel, th, createdPost)
+			waitUntilWebhookResponseIsCreatedAsPost(channel, th, createdPost)
 
 			select {
 			case webhookPost := <-createdPost:

--- a/config/common_test.go
+++ b/config/common_test.go
@@ -147,7 +147,7 @@ func TestConfigEnvironmentOverrides(t *testing.T) {
 	base, err := NewStoreFromBacking(memstore, nil, false)
 	require.NoError(t, err)
 	originalConfig := &model.Config{}
-	originalConfig.ServiceSettings.SiteURL = model.NewString("http://notoverriden.ca")
+	originalConfig.ServiceSettings.SiteURL = model.NewString("http://notoverridden.ca")
 
 	os.Setenv("MM_SERVICESETTINGS_SITEURL", "http://overridden.ca")
 	defer os.Unsetenv("MM_SERVICESETTINGS_SITEURL")

--- a/config/database_test.go
+++ b/config/database_test.go
@@ -245,7 +245,7 @@ func TestDatabaseStoreGet(t *testing.T) {
 	assert.True(t, cfg == cfg2, "Get() returned different configuration instances")
 }
 
-func TestDatabaseStoreGetEnivironmentOverrides(t *testing.T) {
+func TestDatabaseStoreGetEnvironmentOverrides(t *testing.T) {
 	t.Run("get override for a string variable", func(t *testing.T) {
 		_, tearDown := setupConfigDatabase(t, testConfig, nil)
 		defer tearDown()
@@ -861,7 +861,7 @@ func TestDatabaseStoreLoad(t *testing.T) {
 		assert.Equal(t, "http://trailingslash", *ds.Get().ServiceSettings.SiteURL)
 	})
 
-	t.Run("listeners notifed on change", func(t *testing.T) {
+	t.Run("listeners notified on change", func(t *testing.T) {
 		_, tearDown := setupConfigDatabase(t, emptyConfig, nil)
 		defer tearDown()
 

--- a/config/environment_test.go
+++ b/config/environment_test.go
@@ -93,7 +93,7 @@ func TestRemoveEnvOverrides(t *testing.T) {
 		{
 			name: "[]string setting",
 			inputConfig: modifiedDefault(func(in *model.Config) {
-				in.SqlSettings.DataSourceReplicas = []string{"somthing"}
+				in.SqlSettings.DataSourceReplicas = []string{"something"}
 			}),
 			env: map[string]string{
 				"MM_SQLSETTINGS_DATASOURCEREPLICAS": "otherthing alsothis",

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -271,7 +271,7 @@ func TestFileStoreGet(t *testing.T) {
 	assert.False(t, newCfg == cfg, "returned config should have been different from original")
 }
 
-func TestFileStoreGetEnivironmentOverrides(t *testing.T) {
+func TestFileStoreGetEnvironmentOverrides(t *testing.T) {
 	t.Run("get override for a string variable", func(t *testing.T) {
 		path, tearDown := setupConfigFile(t, testConfig)
 		defer tearDown()
@@ -855,7 +855,7 @@ func TestFileStoreLoad(t *testing.T) {
 		assert.Equal(t, "en", *fs.Get().LocalizationSettings.DefaultClientLocale)
 	})
 
-	t.Run("listeners notifed", func(t *testing.T) {
+	t.Run("listeners notified", func(t *testing.T) {
 		path, tearDown := setupConfigFile(t, emptyConfig)
 		defer tearDown()
 

--- a/model/link_metadata_test.go
+++ b/model/link_metadata_test.go
@@ -253,7 +253,7 @@ func TestTruncateText(t *testing.T) {
 	t.Run("Truncates string to 300 + 5", func(t *testing.T) {
 		assert.Equal(t, utf8.RuneCountInString(truncateText(BigText)), 305, "should be 300 chars + 5")
 	})
-	t.Run("Truncated text ends in elipsis", func(t *testing.T) {
+	t.Run("Truncated text ends in ellipsis", func(t *testing.T) {
 		assert.True(t, strings.HasSuffix(truncateText(BigText), "[...]"))
 	})
 }

--- a/model/search_params_test.go
+++ b/model/search_params_test.go
@@ -94,17 +94,17 @@ func TestSplitWords(t *testing.T) {
 			Output: []string{"\"quoted multiple words\""},
 		},
 		{
-			Name:   "string has a mix of qouted words and non quoted words, output should contain 5 entries, quoted words should not be split",
+			Name:   "string has a mix of quoted words and non quoted words, output should contain 5 entries, quoted words should not be split",
 			Input:  "some stuff \"quoted multiple words\" more stuff",
 			Output: []string{"some", "stuff", "\"quoted multiple words\"", "more", "stuff"},
 		},
 		{
-			Name:   "string has a mix of qouted words with a - prefix and non quoted words, output should contain 5 entries, quoted words should not be split, - should be kept",
+			Name:   "string has a mix of quoted words with a - prefix and non quoted words, output should contain 5 entries, quoted words should not be split, - should be kept",
 			Input:  "some stuff -\"quoted multiple words\" more stuff",
 			Output: []string{"some", "stuff", "-\"quoted multiple words\"", "more", "stuff"},
 		},
 		{
-			Name:   "string has a mix of multiple qouted words with a - prefix and non quoted words including a # character, output should contain 5 entries, quoted words should not be split, # and - should be kept",
+			Name:   "string has a mix of multiple quoted words with a - prefix and non quoted words including a # character, output should contain 5 entries, quoted words should not be split, # and - should be kept",
 			Input:  "some \"stuff\" \"quoted multiple words\" #some \"more stuff\"",
 			Output: []string{"some", "\"stuff\"", "\"quoted multiple words\"", "#some", "\"more stuff\""},
 		},
@@ -393,7 +393,7 @@ func TestParseSearchFlags2(t *testing.T) {
 			},
 		},
 		{
-			Name:  "string with a non-floag followed by :",
+			Name:  "string with a non-flag followed by :",
 			Input: "fruit: cherry",
 			Words: []searchWord{
 				{
@@ -1418,7 +1418,7 @@ func TestParseSearchParams(t *testing.T) {
 			},
 		},
 		{
-			Name:  "input is a wilrdcar with a *, should result in one term with a *",
+			Name:  "input is a wildcard with a *, should result in one term with a *",
 			Input: "wildcar*",
 			Output: []*SearchParams{
 				{

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -107,7 +107,7 @@ func TestMapJson(t *testing.T) {
 	require.Equal(t, rm["id"], "test_id", "map should be valid")
 
 	rm2 := MapFromJSON(strings.NewReader(""))
-	require.LessOrEqual(t, len(rm2), 0, "make should be ivalid")
+	require.LessOrEqual(t, len(rm2), 0, "make should be invalid")
 }
 
 func TestIsValidEmail(t *testing.T) {
@@ -213,7 +213,7 @@ var hashtags = map[string]string{
 	"#?test":          "",
 	"#-test":          "",
 	"#yo_yo":          "#yo_yo",
-	"(#brakets)":      "#brakets",
+	"(#brackets)":     "#brackets",
 	")#stekarb(":      "#stekarb",
 	"<#less_than<":    "#less_than",
 	">#greater_than>": "#greater_than",
@@ -885,7 +885,7 @@ func TestIsValidHTTPURL(t *testing.T) {
 		},
 		{
 			"url with invalid scheme",
-			"htp://mattermost.com",
+			"http-bad://mattermost.com",
 			false,
 		},
 		{
@@ -905,7 +905,7 @@ func TestIsValidHTTPURL(t *testing.T) {
 		},
 		{
 			"correct url with http scheme",
-			"http://mattemost.com",
+			"http://mattermost.com",
 			true,
 		},
 		{

--- a/plugin/environment_test.go
+++ b/plugin/environment_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
-func TestAvaliablePlugins(t *testing.T) {
+func TestAvailablePlugins(t *testing.T) {
 	dir, err1 := ioutil.TempDir("", "mm-plugin-test")
 	require.NoError(t, err1)
 	t.Cleanup(func() {

--- a/scripts/get_latest_release.sh
+++ b/scripts/get_latest_release.sh
@@ -49,8 +49,8 @@ fi
 
 if [[ -z "$REL_TO_USE" ]]
 then
-  echo "An error has occured trying to get the latest mmctl release. Aborting. Perhaps api.github.com is down, or you are being rate-limited.";
-  echo "Set the GITHUB_USERNAME and GITHUB_TOKEN environment variables to the appropriate values to work around Github rate-limiting.";
+  echo "An error has occurred trying to get the latest mmctl release. Aborting. Perhaps api.github.com is down, or you are being rate-limited.";
+  echo "Set the GITHUB_USERNAME and GITHUB_TOKEN environment variables to the appropriate values to work around GitHub rate-limiting.";
   exit 1;
 else
   echo "$REL_TO_USE"

--- a/services/cache/lru_striped_test.go
+++ b/services/cache/lru_striped_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
-func makeLRUPredictibleTestData(num int) [][2]string {
+func makeLRUPredictableTestData(num int) [][2]string {
 	kv := make([][2]string, num)
 	for i := 0; i < len(kv); i++ {
 		kv[i] = [2]string{
@@ -39,7 +39,7 @@ func TestNewLRUStriped(t *testing.T) {
 }
 
 func TestLRUStripedKeyDistribution(t *testing.T) {
-	dataset := makeLRUPredictibleTestData(100)
+	dataset := makeLRUPredictableTestData(100)
 
 	scache, err := NewLRUStriped(LRUOptions{StripedBuckets: 4, Size: len(dataset)})
 	require.NoError(t, err)

--- a/services/docextractor/docextractor_test.go
+++ b/services/docextractor/docextractor_test.go
@@ -180,7 +180,7 @@ func (te *failingExtractor) Extract(filename string, r io.ReadSeeker) (string, e
 }
 
 func TestExtractWithExtraExtractors(t *testing.T) {
-	t.Run("overrite existing extractor", func(t *testing.T) {
+	t.Run("override existing extractor", func(t *testing.T) {
 		data, err := testutils.ReadTestFile("sample-doc.pdf")
 		require.NoError(t, err)
 

--- a/shared/mail/mail_test.go
+++ b/shared/mail/mail_test.go
@@ -183,7 +183,7 @@ func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {
 			require.NoError(t, err, "Could not get message from mailbox")
 			require.Contains(t, emailBody, resultsEmail.Body.Text, "Wrong received message %s", resultsEmail.Body.Text)
 			// Usign the message size because the inbucket API doesn't return embedded attachments through the API
-			require.Greater(t, resultsEmail.Size, 1500, "the file size should be more because the embedded attachemtns")
+			require.Greater(t, resultsEmail.Size, 1500, "the file size should be more because the embedded attachments")
 		}
 	}
 }
@@ -226,7 +226,7 @@ func TestSendMailUsingConfigAdvanced(t *testing.T) {
 	}
 
 	err = sendMailUsingConfigAdvanced(mail, cfg)
-	require.NoError(t, err, "Should connect to the STMP Server: %v", err)
+	require.NoError(t, err, "Should connect to the SMTP Server: %v", err)
 
 	//Check if the email was send to the right email address
 	var resultsMailbox JSONMessageHeaderInbucket

--- a/store/searchtest/file_info_layer.go
+++ b/store/searchtest/file_info_layer.go
@@ -90,7 +90,7 @@ var searchFileInfoStoreTests = []searchTest{
 		Tags: []string{EngineAll},
 	},
 	{
-		Name: "Should be able to exclude messages that contain a serch term",
+		Name: "Should be able to exclude messages that contain a search term",
 		Fn:   testFileInfoFilterFilesWithATerm,
 		Tags: []string{EngineMySql, EnginePostgres},
 	},

--- a/store/searchtest/post_layer.go
+++ b/store/searchtest/post_layer.go
@@ -90,7 +90,7 @@ var searchPostStoreTests = []searchTest{
 		Tags: []string{EngineAll},
 	},
 	{
-		Name: "Should be able to exclude messages that contain a serch term",
+		Name: "Should be able to exclude messages that contain a search term",
 		Fn:   testFilterMessagesWithATerm,
 		Tags: []string{EngineMySql, EnginePostgres},
 	},
@@ -152,7 +152,7 @@ var searchPostStoreTests = []searchTest{
 	},
 	{
 		Name: "Should support searching for multiple hashtags",
-		Fn:   testSearcWithMultipleHashtags,
+		Fn:   testSearchWithMultipleHashtags,
 		Tags: []string{EngineElasticSearch},
 	},
 	{
@@ -187,7 +187,7 @@ var searchPostStoreTests = []searchTest{
 	},
 	{
 		Name: "Should not return system messages",
-		Fn:   testSearchShouldExcludeSytemMessages,
+		Fn:   testSearchShouldExcludeSystemMessages,
 		Tags: []string{EngineAll},
 	},
 	{
@@ -1225,7 +1225,7 @@ func testSearchHashtagWithMarkdown(t *testing.T, th *SearchTestHelper) {
 	th.checkPostInSearchResults(t, p5.Id, results.Posts)
 }
 
-func testSearcWithMultipleHashtags(t *testing.T, th *SearchTestHelper) {
+func testSearchWithMultipleHashtags(t *testing.T, th *SearchTestHelper) {
 	p1, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "searching hashtag #hashtag", "#hashtwo #hashone", model.PostTypeDefault, 0, false)
 	require.NoError(t, err)
 	p2, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "searching term with `#hashtag`", "#hashtwo #hashthree", model.PostTypeDefault, 0, false)
@@ -1399,7 +1399,7 @@ func testSearchHashtagWithUnderscores(t *testing.T, th *SearchTestHelper) {
 	th.checkPostInSearchResults(t, p1.Id, results.Posts)
 }
 
-func testSearchShouldExcludeSytemMessages(t *testing.T, th *SearchTestHelper) {
+func testSearchShouldExcludeSystemMessages(t *testing.T, th *SearchTestHelper) {
 	_, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "test system message one", "", model.PostTypeJoinChannel, 0, false)
 	require.NoError(t, err)
 	_, err = th.createPost(th.User.Id, th.ChannelBasic.Id, "test system message two", "", model.PostTypeLeaveChannel, 0, false)

--- a/store/searchtest/user_layer.go
+++ b/store/searchtest/user_layer.go
@@ -114,7 +114,7 @@ var searchUserStoreTests = []searchTest{
 	},
 	{
 		Name: "Should support one or two character usernames and first/last names in search",
-		Fn:   testSearchOneTwoCharUsersnameAndFirstLastNames,
+		Fn:   testSearchOneTwoCharUsernamesAndFirstLastNames,
 		Tags: []string{EngineAll},
 	},
 	{
@@ -687,7 +687,7 @@ func testSearchUsersShouldBeCaseInsensitive(t *testing.T, th *SearchTestHelper) 
 	th.assertUsersMatchInAnyOrder(t, []*model.User{th.User2}, users.OutOfChannel)
 }
 
-func testSearchOneTwoCharUsersnameAndFirstLastNames(t *testing.T, th *SearchTestHelper) {
+func testSearchOneTwoCharUsernamesAndFirstLastNames(t *testing.T, th *SearchTestHelper) {
 	userAlternate, err := th.createUser("ho", "alternatenickname", "zi", "k")
 	require.NoError(t, err)
 

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -243,7 +243,7 @@ func testChannelStoreSaveDirectChannel(t *testing.T, ss store.Store, s SqlStore)
 	require.Len(t, members, 2, "should have saved 2 members")
 
 	_, nErr = ss.Channel().SaveDirectChannel(&o1, &m1, &m2)
-	require.Error(t, nErr, "shoudn't be a able to update from save")
+	require.Error(t, nErr, "shouldn't be a able to update from save")
 
 	// Attempt to save a direct channel that already exists
 	o1a := model.Channel{
@@ -535,7 +535,7 @@ func testChannelStoreGetChannelsByIds(t *testing.T, ss store.Store) {
 	t.Run("Get 2 existing channels", func(t *testing.T) {
 		r1, err := ss.Channel().GetChannelsByIds([]string{o1.Id, o2.Id}, false)
 		require.NoError(t, err, err)
-		require.Len(t, r1, 2, "invalid returned channels, exepected 2 and got "+strconv.Itoa(len(r1)))
+		require.Len(t, r1, 2, "invalid returned channels, expected 2 and got "+strconv.Itoa(len(r1)))
 		require.Equal(t, channelToJSON(t, &o1), channelToJSON(t, r1[0]))
 		require.Equal(t, channelToJSON(t, &o2), channelToJSON(t, r1[1]))
 	})
@@ -551,7 +551,7 @@ func testChannelStoreGetChannelsByIds(t *testing.T, ss store.Store) {
 	t.Run("Get 2 existing and 1 deleted channel", func(t *testing.T) {
 		r1, err := ss.Channel().GetChannelsByIds([]string{o1.Id, o2.Id, o3.Id}, true)
 		require.NoError(t, err, err)
-		require.Len(t, r1, 3, "invalid returned channels, exepected 3 and got "+strconv.Itoa(len(r1)))
+		require.Len(t, r1, 3, "invalid returned channels, expected 3 and got "+strconv.Itoa(len(r1)))
 		require.Equal(t, channelToJSON(t, &o1), channelToJSON(t, r1[0]))
 		require.Equal(t, channelToJSON(t, &o2), channelToJSON(t, r1[1]))
 		require.Equal(t, channelToJSON(t, &o3), channelToJSON(t, r1[2]))
@@ -4881,7 +4881,7 @@ func testGetMember(t *testing.T, ss store.Store) {
 	require.Equal(t, userId, member.UserId, "should've have gotten member for user")
 
 	member, err = ss.Channel().GetMember(context.Background(), c2.Id, userId)
-	require.NoError(t, err, "should'nt have errored when getting member", err)
+	require.NoError(t, err, "shouldn't have errored when getting member", err)
 	require.Equal(t, c2.Id, member.ChannelId, "should've gotten member of channel 2")
 	require.Equal(t, userId, member.UserId, "should've gotten member for user")
 

--- a/store/storetest/channel_store_categories.go
+++ b/store/storetest/channel_store_categories.go
@@ -819,7 +819,7 @@ func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {
 		assert.Equal(t, []string{gmChannel.Id}, res2.Channels)
 	})
 
-	t.Run("should return orphaned DM channels in the DMs categorywhich are in a custom category on another team", func(t *testing.T) {
+	t.Run("should return orphaned DM channels in the DMs category which are in a custom category on another team", func(t *testing.T) {
 		userId := model.NewId()
 		teamId := model.NewId()
 

--- a/store/storetest/shared_channel_store.go
+++ b/store/storetest/shared_channel_store.go
@@ -278,7 +278,7 @@ func testGetSharedChannels(t *testing.T, ss store.Store) {
 		}
 	})
 
-	t.Run("Get shared channels invalid pagnation", func(t *testing.T) {
+	t.Run("Get shared channels invalid pagination", func(t *testing.T) {
 		opts := model.SharedChannelFilterOpts{
 			TeamId: team1,
 		}

--- a/store/storetest/team_store.go
+++ b/store/storetest/team_store.go
@@ -316,7 +316,7 @@ func testTeamStoreSearchAll(t *testing.T, ss store.Store) {
 		},
 		{
 			"Search for open team without results",
-			&model.TeamSearch{Term: "notexists"},
+			&model.TeamSearch{Term: "nonexistent"},
 			0,
 			[]string{},
 		},
@@ -483,7 +483,7 @@ func testTeamStoreSearchOpen(t *testing.T, ss store.Store) {
 		},
 		{
 			"Search for open team without results",
-			"notexists",
+			"nonexistent",
 			0,
 			"",
 		},
@@ -589,7 +589,7 @@ func testTeamStoreSearchPrivate(t *testing.T, ss store.Store) {
 		},
 		{
 			"Search for private team without results",
-			"notexists",
+			"nonexistent",
 			0,
 			"",
 		},

--- a/utils/merge_test.go
+++ b/utils/merge_test.go
@@ -448,7 +448,7 @@ func TestMergeWithSlices(t *testing.T) {
 		assert.Equal(t, expected, merged)
 	})
 
-	t.Run("patch overwites when patch is empty struct", func(t *testing.T) {
+	t.Run("patch overwrites when patch is empty struct", func(t *testing.T) {
 		m1 := []string{"this", "will", "be", "overwritten"}
 		m2 := []string{}
 		expected := []string{}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

This is limited to tests

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes #19267 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
