### PR TITLE
MM-41796: Sentry crash: use the correct error variable

### DIFF
--- a/app/team.go
+++ b/app/team.go
@@ -1161,7 +1161,7 @@ func (a *App) LeaveTeam(c *request.Context, team *model.Team, user *model.User, 
 	}
 
 	if err := a.ch.srv.teamService.RemoveTeamMember(teamMember); err != nil {
-		return model.NewAppError("RemoveTeamMemberFromTeam", "app.team.save_member.save.app_error", nil, nErr.Error(), http.StatusInternalServerError)
+		return model.NewAppError("RemoveTeamMemberFromTeam", "app.team.save_member.save.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	if err := a.postProcessTeamMemberLeave(c, teamMember, requestorId); err != nil {


### PR DESCRIPTION
We use the correct error variable while checking
for the error

https://mattermost.atlassian.net/browse/MM-41796

```release-note
NONE
```
