### PR TITLE
fix typo in the app/export_test.go

### DIFF
--- a/app/export_test.go
+++ b/app/export_test.go
@@ -717,7 +717,7 @@ func TestExportDeletedTeams(t *testing.T) {
 	require.Nil(t, err)
 
 	var b bytes.Buffer
-	err = th1.App.BulkExport(&b, "somePath", BulkExportOpts{})
+	err = th1.App.BulkExport(&b, "somePath", model.BulkExportOpts{})
 	require.Nil(t, err)
 
 	th2 := Setup(t)


### PR DESCRIPTION

#### Summary
The build is failing due to a typo in the `app/export_test.go`

#19205 Might have caused this. As it went in later than #19494

#### Release Note

```release-note
NONE
```
