### PR TITLE
Update Safari minimum recommended version

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9257,7 +9257,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.safari",
-    "translation": "Version 12+"
+    "translation": "Version 14.1+"
   },
   {
     "id": "web.error.unsupported_browser.min_os_version.mac",


### PR DESCRIPTION
Updating Safari recommended minimum version to v14.1+. This version comes with MacOS 10.14+ which is our minimum recommended version for MacOS.


```release-note
Updated Safari recommended minimum version to v14.1+
```
