### PR TITLE
Add new /test dms command

### DIFF
--- a/app/slashcommands/auto_channels.go
+++ b/app/slashcommands/auto_channels.go
@@ -74,3 +74,23 @@ func (cfg *AutoChannelCreator) CreateTestChannels(c *request.Context, num utils.
 
 	return channels, nil
 }
+
+func (cfg *AutoChannelCreator) CreateTestDMs(c *request.Context, num utils.Range) ([]*model.Channel, error) {
+	numDMs := utils.RandIntFromRange(num)
+	dms := make([]*model.Channel, numDMs)
+
+	users, err := cfg.a.GetUsers(&model.UserGetOptions{Page: 0, PerPage: numDMs})
+	if err != nil {
+		return nil, err
+	}
+
+	for i, user := range users {
+		var err *model.AppError
+		dms[i], err = cfg.a.GetOrCreateDirectChannel(c, cfg.userID, user.Id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return dms, nil
+}

--- a/app/slashcommands/command_loadtest.go
+++ b/app/slashcommands/command_loadtest.go
@@ -45,6 +45,12 @@ var usage = `Mattermost testing commands to help configure the system
 		Example:
 			/test channels fuzz 5 10
 
+	DMs - Add a specified number of DMs for current user. Requires enough users to be loaded.
+			/test dms <Min DMs> <Max DMs>
+
+			Example:
+				/test dms 5 10
+
 	ThreadedPost - create a large threaded post
         /test threaded_post
 
@@ -143,6 +149,10 @@ func (lt *LoadTestProvider) doCommand(a *app.App, c *request.Context, args *mode
 
 	if strings.HasPrefix(message, "channels") {
 		return lt.ChannelsCommand(a, c, args, message)
+	}
+
+	if strings.HasPrefix(message, "dms") {
+		return lt.DMsCommand(a, c, args, message)
 	}
 
 	if strings.HasPrefix(message, "posts") {
@@ -331,6 +341,27 @@ func (*LoadTestProvider) ChannelsCommand(a *app.App, c *request.Context, args *m
 	}
 
 	return &model.CommandResponse{Text: "Added channels", ResponseType: model.CommandResponseTypeEphemeral}, nil
+}
+
+func (*LoadTestProvider) DMsCommand(a *app.App, c *request.Context, args *model.CommandArgs, message string) (*model.CommandResponse, error) {
+	cmd := strings.TrimSpace(strings.TrimPrefix(message, "dms"))
+
+	channelsr, ok := parseRange(cmd, "")
+	if !ok {
+		channelsr = utils.Range{Begin: 2, End: 5}
+	}
+
+	team, err := a.Srv().Store.Team().Get(args.TeamId)
+	if err != nil {
+		return &model.CommandResponse{Text: "Failed to add DMs", ResponseType: model.CommandResponseTypeEphemeral}, err
+	}
+
+	channelCreator := NewAutoChannelCreator(a, team, args.UserId)
+	if _, err := channelCreator.CreateTestDMs(c, channelsr); err != nil {
+		return &model.CommandResponse{Text: "Failed to create test DMs: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
+	}
+
+	return &model.CommandResponse{Text: "Added DMs", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
 func (*LoadTestProvider) ThreadedPostCommand(a *app.App, c *request.Context, args *model.CommandArgs, message string) (*model.CommandResponse, error) {

--- a/app/slashcommands/command_loadtest.go
+++ b/app/slashcommands/command_loadtest.go
@@ -351,12 +351,7 @@ func (*LoadTestProvider) DMsCommand(a *app.App, c *request.Context, args *model.
 		channelsr = utils.Range{Begin: 2, End: 5}
 	}
 
-	team, err := a.Srv().Store.Team().Get(args.TeamId)
-	if err != nil {
-		return &model.CommandResponse{Text: "Failed to add DMs", ResponseType: model.CommandResponseTypeEphemeral}, err
-	}
-
-	channelCreator := NewAutoChannelCreator(a, team, args.UserId)
+	channelCreator := NewAutoChannelCreator(a, nil, args.UserId)
 	if _, err := channelCreator.CreateTestDMs(c, channelsr); err != nil {
 		return &model.CommandResponse{Text: "Failed to create test DMs: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 	}


### PR DESCRIPTION
#### Summary
Added a new `/test dms` command that generates DMs.

#### Release Note
```release-note
Added a new command to `/test` for DM generation for test/development purposes.
```
