### PR TITLE
Include binary parameters in default data source

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -114,7 +114,7 @@ const (
 	TeamSettingsDefaultCustomDescriptionText = ""
 	TeamSettingsDefaultUserStatusAwayTimeout = 300
 
-	SqlSettingsDefaultDataSource = "postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable&connect_timeout=10"
+	SqlSettingsDefaultDataSource = "postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes"
 
 	FileSettingsDefaultDirectory = "./data/"
 


### PR DESCRIPTION
This is to make the default more consistent with
what we have in our cloud production. It should
help in surfacing bugs more quickly.

```release-note
NONE
```
