### PR TITLE
Remove wait group for onboarding complete code

### DIFF
--- a/app/onboarding.go
+++ b/app/onboarding.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"net/http"
-	"sync"
 
 	"github.com/pkg/errors"
 
@@ -23,12 +22,9 @@ func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnbo
 
 	pluginContext := pluginContext(c)
 
-	var wg sync.WaitGroup
 	for _, pluginID := range request.InstallPlugins {
-		wg.Add(1)
 
 		go func(id string) {
-			defer wg.Done()
 			installRequest := &model.InstallMarketplacePluginRequest{
 				Id: id,
 			}
@@ -67,8 +63,6 @@ func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnbo
 	if err := a.Srv().Store.System().SaveOrUpdate(&firstAdminCompleteSetupObj); err != nil {
 		return model.NewAppError("setFirstAdminCompleteSetup", "api.error_set_first_admin_complete_setup", nil, err.Error(), http.StatusInternalServerError)
 	}
-
-	wg.Wait()
 
 	return nil
 }


### PR DESCRIPTION
#### Summary
Remove wait group on onboarding complete code so that user doesn't have to wait for plugins to install before seeing channels view. More context is available in this chat: https://community-daily.mattermost.com/core/pl/re7krpx76jrcpx497wdrmxs73y .

Waiting for plugins (e.g. github, gitlab, zoom, jira, and todo) took about 13 seconds. Not waiting is basically instantaneous, and doesn't seem to have a downside:

before:

https://user-images.githubusercontent.com/13738432/154403180-263625f0-3c25-4ab2-a580-b267b4b2461c.mp4

after:

https://user-images.githubusercontent.com/13738432/154403192-19708ec6-396d-4cf1-9919-045189f9af92.mp4


#### Ticket Link
https://community-daily.mattermost.com/boards/workspace/fpbb7orqpiyfxqgg6fcu91y5xo/b6ropkdiowj8eugbt8kifrew79h/vptcho591nfry8rgfygxe8f7tbr/cyg1wqa6j97gat86c6ursd7hcqa

#### Release Note
The code this modified is not released and is not yet called anywhere.

```release-note
NONE
```