### PR TITLE
[MM-41712] Allow sending intra-cluster WS events reliably

### DIFF
--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -178,7 +178,8 @@ func (s *Server) Publish(message *model.WebSocketEvent) {
 			message.EventType() == model.WebsocketEventPostEdited ||
 			message.EventType() == model.WebsocketEventDirectAdded ||
 			message.EventType() == model.WebsocketEventGroupAdded ||
-			message.EventType() == model.WebsocketEventAddedToTeam {
+			message.EventType() == model.WebsocketEventAddedToTeam ||
+			message.GetBroadcast().ReliableClusterSend {
 			cm.SendType = model.ClusterSendReliable
 		}
 

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/store/storetest/mocks"
+	"github.com/mattermost/mattermost-server/v6/testlib"
 )
 
 func dummyWebsocketHandler(t *testing.T) http.HandlerFunc {
@@ -334,6 +335,27 @@ func TestHubConnIndexInactive(t *testing.T) {
 	assert.False(t, connIndex.Has(wc3))
 	assert.Len(t, connIndex.ForUser(wc2.UserId), 1)
 	assert.Len(t, connIndex.All(), 2)
+}
+
+func TestReliableWebSocketSend(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	testCluster := &testlib.FakeClusterInterface{}
+	th.Server.Cluster = testCluster
+
+	ev := model.NewWebSocketEvent("test_reliable_event", "", "", "", nil)
+	ev = ev.SetBroadcast(&model.WebsocketBroadcast{})
+	th.App.Publish(ev)
+	ev = ev.SetBroadcast(&model.WebsocketBroadcast{
+		ReliableClusterSend: true,
+	})
+	th.App.Publish(ev)
+
+	messages := testCluster.GetMessages()
+	require.Len(t, messages, 2)
+	require.Equal(t, model.ClusterSendBestEffort, messages[0].SendType)
+	require.Equal(t, model.ClusterSendReliable, messages[1].SendType)
 }
 
 func TestHubIsRegistered(t *testing.T) {

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -90,6 +90,9 @@ type WebsocketBroadcast struct {
 	TeamId                string          `json:"team_id"`    // broadcast only occurs for users in this team
 	ContainsSanitizedData bool            `json:"-"`
 	ContainsSensitiveData bool            `json:"-"`
+	// ReliableClusterSend indicates whether or not the message should
+	// be sent through the cluster using the reliable, TCP backed channel.
+	ReliableClusterSend bool `json:"-"`
 }
 
 func (wb *WebsocketBroadcast) copy() *WebsocketBroadcast {


### PR DESCRIPTION
#### Summary

The current implementation of plugin's API `PublishWebSocketEvent()` will eventually send messages across the cluster using the unreliable (UDP backed) channel. This can lead to unexpected message loss or ordering issues. It also imposes some hard limitations on maximum payload size (~64KB).

PR adds an option to allow for broadcasting WS events through the cluster using the reliable, TCP backed channel.

I've opted to extend `model.WebsocketBroadcast` to avoid either breaking the plugin's API or adding a new almost identical method just for this case. Please let me know if it makes sense or if you prefer a new method.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-41712

#### Release Note

```release-note
Added a new ReliableClusterSend field to model.WebsocketBroadcast to allow sending events through the cluster using the reliable channel.
```


