### PR TITLE
MM-41969: Sends notifications of group mentions without LDAPGroups license feature.

### DIFF
--- a/app/notification.go
+++ b/app/notification.go
@@ -1041,7 +1041,7 @@ func (a *App) allowChannelMentions(post *model.Post, numProfiles int) bool {
 
 // allowGroupMentions returns whether or not the group mentions are allowed for the given post.
 func (a *App) allowGroupMentions(post *model.Post) bool {
-	if license := a.Srv().License(); license == nil || !*license.Features.LDAPGroups {
+	if license := a.Srv().License(); license == nil || (license.SkuShortName != model.LicenseShortSkuProfessional && license.SkuShortName != model.LicenseShortSkuEnterprise) {
 		return false
 	}
 

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1048,12 +1048,21 @@ func TestAllowGroupMentions(t *testing.T) {
 
 	post := &model.Post{ChannelId: th.BasicChannel.Id, UserId: th.BasicUser.Id}
 
-	t.Run("should return false without ldap groups license", func(t *testing.T) {
+	t.Run("should return false without professional or enterprise license", func(t *testing.T) {
 		allowGroupMentions := th.App.allowGroupMentions(post)
 		assert.False(t, allowGroupMentions)
 	})
 
-	th.App.Srv().SetLicense(model.NewTestLicense("ldap_groups"))
+	lic := &model.License{}
+	lic.Features = &model.Features{}
+	lic.Customer = &model.Customer{}
+	lic.Customer.Name = "TestName"
+	lic.Customer.Email = "test@example.com"
+	lic.SkuName = "SKU NAME"
+	lic.SkuShortName = model.LicenseShortSkuProfessional
+	lic.StartsAt = model.GetMillis() - 1000
+	lic.ExpiresAt = model.GetMillis() + 100000
+	th.App.Srv().SetLicense(lic)
 
 	t.Run("should return true for a regular post with few channel members", func(t *testing.T) {
 		allowGroupMentions := th.App.allowGroupMentions(post)


### PR DESCRIPTION
#### Summary

We now send group mention notifications for any license, not just if the license contains the `LDAPGroups` feature.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-41969

#### Release Note

```release-note
NONE
```
