### PR TITLE
Fix min server version for Custom Status Plugin API methods

### DIFF
--- a/plugin/api.go
+++ b/plugin/api.go
@@ -280,13 +280,13 @@ type API interface {
 	// The custom status have two parameters: emoji icon and custom text.
 	//
 	// @tag User
-	// Minimum server version: 5.36
+	// Minimum server version: 6.2
 	UpdateUserCustomStatus(userID string, customStatus *model.CustomStatus) *model.AppError
 
 	// RemoveUserCustomStatus will remove a user's custom status.
 	//
 	// @tag User
-	// Minimum server version: 5.36
+	// Minimum server version: 6.2
 	RemoveUserCustomStatus(userID string) *model.AppError
 
 	// GetUsersInChannel returns a page of users in a channel. Page counting starts at 0.


### PR DESCRIPTION
#### Summary
The min server version is actually 6.2 as the PR took some time to get merged.

#### Ticket Link
https://community-daily.mattermost.com/core/pl/ygi3n99ogbr18g5z6ne7gtc3qw

#### Release Note
```release-note
NONE
```
