### PR TITLE
[MM-42033] Fix racy TestReliableWebSocketSend

### DIFF
--- a/app/helper_test.go
+++ b/app/helper_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/config"
+	"github.com/mattermost/mattermost-server/v6/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -46,7 +47,7 @@ type TestHelper struct {
 	tempWorkspace string
 }
 
-func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer bool, tb testing.TB) *TestHelper {
+func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer bool, options []Option, tb testing.TB) *TestHelper {
 	tempWorkspace, err := ioutil.TempDir("", "apptest")
 	if err != nil {
 		panic(err)
@@ -65,7 +66,6 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 
 	buffer := &mlog.Buffer{}
 
-	var options []Option
 	options = append(options, ConfigStore(configStore))
 	if includeCacheLayer {
 		// Adds the cache layer to the test store
@@ -156,7 +156,7 @@ func Setup(tb testing.TB) *TestHelper {
 	dbStore.MarkSystemRanUnitTests()
 	mainHelper.PreloadMigrations()
 
-	return setupTestHelper(dbStore, false, true, tb)
+	return setupTestHelper(dbStore, false, true, nil, tb)
 }
 
 func SetupWithoutPreloadMigrations(tb testing.TB) *TestHelper {
@@ -167,12 +167,12 @@ func SetupWithoutPreloadMigrations(tb testing.TB) *TestHelper {
 	dbStore.DropAllTables()
 	dbStore.MarkSystemRanUnitTests()
 
-	return setupTestHelper(dbStore, false, true, tb)
+	return setupTestHelper(dbStore, false, true, nil, tb)
 }
 
 func SetupWithStoreMock(tb testing.TB) *TestHelper {
 	mockStore := testlib.GetMockStoreForSetupFunctions()
-	th := setupTestHelper(mockStore, false, false, tb)
+	th := setupTestHelper(mockStore, false, false, nil, tb)
 	statusMock := mocks.StatusStore{}
 	statusMock.On("UpdateExpiredDNDStatuses").Return([]*model.Status{}, nil)
 	statusMock.On("Get", "user1").Return(&model.Status{UserId: "user1", Status: model.StatusOnline}, nil)
@@ -187,7 +187,7 @@ func SetupWithStoreMock(tb testing.TB) *TestHelper {
 
 func SetupEnterpriseWithStoreMock(tb testing.TB) *TestHelper {
 	mockStore := testlib.GetMockStoreForSetupFunctions()
-	th := setupTestHelper(mockStore, true, false, tb)
+	th := setupTestHelper(mockStore, true, false, nil, tb)
 	statusMock := mocks.StatusStore{}
 	statusMock.On("UpdateExpiredDNDStatuses").Return([]*model.Status{}, nil)
 	statusMock.On("Get", "user1").Return(&model.Status{UserId: "user1", Status: model.StatusOnline}, nil)
@@ -198,6 +198,18 @@ func SetupEnterpriseWithStoreMock(tb testing.TB) *TestHelper {
 	emptyMockStore.On("Status").Return(&statusMock)
 	th.App.Srv().Store = &emptyMockStore
 	return th
+}
+
+func SetupWithClusterMock(tb testing.TB, cluster einterfaces.ClusterInterface) *TestHelper {
+	if testing.Short() {
+		tb.SkipNow()
+	}
+	dbStore := mainHelper.GetStore()
+	dbStore.DropAllTables()
+	dbStore.MarkSystemRanUnitTests()
+	mainHelper.PreloadMigrations()
+
+	return setupTestHelper(dbStore, true, true, []Option{setCluster(cluster)}, tb)
 }
 
 var initBasicOnce sync.Once

--- a/app/options.go
+++ b/app/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/v6/config"
+	"github.com/mattermost/mattermost-server/v6/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
@@ -109,5 +110,12 @@ type AppOptionCreator func() []AppOption
 func ServerConnector(ch *Channels) AppOption {
 	return func(a *App) {
 		a.ch = ch
+	}
+}
+
+func setCluster(cluster einterfaces.ClusterInterface) Option {
+	return func(s *Server) error {
+		s.Cluster = cluster
+		return nil
 	}
 }

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -338,24 +338,37 @@ func TestHubConnIndexInactive(t *testing.T) {
 }
 
 func TestReliableWebSocketSend(t *testing.T) {
-	th := Setup(t)
+	testCluster := &testlib.FakeClusterInterface{}
+
+	th := SetupWithClusterMock(t, testCluster)
 	defer th.TearDown()
 
-	testCluster := &testlib.FakeClusterInterface{}
-	th.Server.Cluster = testCluster
-
-	ev := model.NewWebSocketEvent("test_reliable_event", "", "", "", nil)
+	ev := model.NewWebSocketEvent("test_unreliable_event", "", "", "", nil)
 	ev = ev.SetBroadcast(&model.WebsocketBroadcast{})
 	th.App.Publish(ev)
-	ev = ev.SetBroadcast(&model.WebsocketBroadcast{
+	ev2 := model.NewWebSocketEvent("test_reliable_event", "", "", "", nil)
+	ev2 = ev2.SetBroadcast(&model.WebsocketBroadcast{
 		ReliableClusterSend: true,
 	})
-	th.App.Publish(ev)
+	th.App.Publish(ev2)
 
 	messages := testCluster.GetMessages()
-	require.Len(t, messages, 2)
-	require.Equal(t, model.ClusterSendBestEffort, messages[0].SendType)
-	require.Equal(t, model.ClusterSendReliable, messages[1].SendType)
+
+	evJSON, err := ev.ToJSON()
+	require.NoError(t, err)
+	ev2JSON, err := ev2.ToJSON()
+	require.NoError(t, err)
+
+	require.Contains(t, messages, &model.ClusterMessage{
+		Event:    model.ClusterEventPublish,
+		Data:     evJSON,
+		SendType: model.ClusterSendBestEffort,
+	})
+	require.Contains(t, messages, &model.ClusterMessage{
+		Event:    model.ClusterEventPublish,
+		Data:     ev2JSON,
+		SendType: model.ClusterSendReliable,
+	})
 }
 
 func TestHubIsRegistered(t *testing.T) {


### PR DESCRIPTION
#### Summary

PR fixes racy TestReliableWebSocketSend. I added a server option to set the cluster mock prior to initialization to avoid the race.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42033

#### Release Note

```release-note
NONE
```
