### PR TITLE
Automated cherry pick of #19604

### DIFF
--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -1088,6 +1088,7 @@ func TestAllowChannelMentions(t *testing.T) {
 }
 
 func TestAllowGroupMentions(t *testing.T) {
+	t.Skip("MM-41972")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 


### PR DESCRIPTION
Cherry pick of #19604 on cloud.

/cc  @agnivade

```release-note
NONE
```