### PR TITLE
revert to status found for login cws

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1938,7 +1938,7 @@ func loginCWS(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.LogAuditWithUserId("", "failure - login_id="+loginID)
 		c.LogErrorByCode(err)
-		http.Redirect(w, r, *c.App.Config().ServiceSettings.SiteURL, http.StatusNotFound)
+		http.Redirect(w, r, *c.App.Config().ServiceSettings.SiteURL, http.StatusFound)
 		return
 	}
 	auditRec.AddMeta("user", user)
@@ -1946,12 +1946,12 @@ func loginCWS(c *Context, w http.ResponseWriter, r *http.Request) {
 	err = c.App.DoLogin(c.AppContext, w, r, user, "", false, false, false)
 	if err != nil {
 		c.LogErrorByCode(err)
-		http.Redirect(w, r, *c.App.Config().ServiceSettings.SiteURL, http.StatusNotFound)
+		http.Redirect(w, r, *c.App.Config().ServiceSettings.SiteURL, http.StatusFound)
 		return
 	}
 	c.LogAuditWithUserId(user.Id, "success")
 	c.App.AttachSessionCookies(c.AppContext, w, r)
-	http.Redirect(w, r, *c.App.Config().ServiceSettings.SiteURL, http.StatusNotFound)
+	http.Redirect(w, r, *c.App.Config().ServiceSettings.SiteURL, http.StatusFound)
 }
 
 func logout(c *Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### Summary
Revert status code to `302 Found` . This reverts an unintended change from https://github.com/mattermost/mattermost-server/pull/18839/files#diff-05b2b4c60779bc21cdec01701ac37a9b8859306a9ccdc333a79fe8a33551dee3L1906-L1921

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42018

#### Release Note

```release-note
NONE
```
