### PR TITLE
[MM-42022] Don't break importing process on missing display name of a channel

### DIFF
--- a/app/import_validators.go
+++ b/app/import_validators.go
@@ -165,9 +165,9 @@ func validateChannelImportData(data *ChannelImportData) *model.AppError {
 		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.name_characters.error", nil, "", http.StatusBadRequest)
 	}
 
-	if data.DisplayName == nil {
-		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.display_name_missing.error", nil, "", http.StatusBadRequest)
-	} else if utf8.RuneCountInString(*data.DisplayName) == 0 || utf8.RuneCountInString(*data.DisplayName) > model.ChannelDisplayNameMaxRunes {
+	if data.DisplayName == nil || utf8.RuneCountInString(*data.DisplayName) == 0 {
+		data.DisplayName = data.Name // when displayName is missing we use name instead for displaying so we might as well convert it here.
+	} else if utf8.RuneCountInString(*data.DisplayName) > model.ChannelDisplayNameMaxRunes {
 		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.display_name_length.error", nil, "", http.StatusBadRequest)
 	}
 

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -404,11 +404,13 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		Type: &chanTypeOpen,
 	}
 	err = validateChannelImportData(&data)
-	require.NotNil(t, err, "Should have failed due to missing display_name.")
+	require.Nil(t, err, "Should have accepted having an empty display_name.")
+	require.Equal(t, data.Name, data.DisplayName, "Name and DisplayName should be the same if DisplayName is missing")
 
 	data.DisplayName = ptrStr("")
 	err = validateChannelImportData(&data)
-	require.NotNil(t, err, "Should have failed due to empty display_name.")
+	require.Nil(t, err, "Should have accepted having an empty display_name.")
+	require.Equal(t, data.Name, data.DisplayName, "Name and DisplayName should be the same if DisplayName is missing")
 
 	data.DisplayName = ptrStr(strings.Repeat("abcdefghij", 7))
 	err = validateChannelImportData(&data)


### PR DESCRIPTION
#### Summary
Import is failing when display name is missing or empty, this will allow it adding the value of name to it. 

The reason for substituting the value is because that's what the channel will show in the LHS, so we might as well provide a value instead of allowing something that might fail somewhere else (the webapp doesn't allow you to create an empty display name)

#### Ticket Link
[MM-42022](https://mattermost.atlassian.net/browse/MM-42022)

#### Release Note
```release-note
Fixed error when importing a channel missing its display name. It now uses name as display name if it is missing or empty
```
