### PR TITLE
fix string constants

### DIFF
--- a/app/migrations.go
+++ b/app/migrations.go
@@ -17,7 +17,7 @@ const GuestRolesCreationMigrationKey = "GuestRolesCreationMigrationComplete"
 const SystemConsoleRolesCreationMigrationKey = "SystemConsoleRolesCreationMigrationComplete"
 const ContentExtractionConfigDefaultTrueMigrationKey = "ContentExtractionConfigDefaultTrueMigrationComplete"
 const PlaybookRolesCreationMigrationKey = "PlaybookRolesCreationMigrationComplete"
-const FirstAdminSetupCompleteKey = "FirstAdminSetupComplete"
+const FirstAdminSetupCompleteKey = model.SystemFirstAdminSetupComplete
 
 // This function migrates the default built in roles from code/config to the database.
 func (a *App) DoAdvancedPermissionsMigration() {

--- a/app/onboarding.go
+++ b/app/onboarding.go
@@ -56,7 +56,7 @@ func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnbo
 	}
 
 	firstAdminCompleteSetupObj := model.System{
-		Name:  model.SystemFirstAdminCompleteSetup,
+		Name:  model.SystemFirstAdminSetupComplete,
 		Value: "true",
 	}
 
@@ -68,13 +68,13 @@ func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnbo
 }
 
 func (a *App) GetOnboarding() (*model.System, *model.AppError) {
-	firstAdminCompleteSetupObj, err := a.Srv().Store.System().GetByName(model.SystemFirstAdminCompleteSetup)
+	firstAdminCompleteSetupObj, err := a.Srv().Store.System().GetByName(model.SystemFirstAdminSetupComplete)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
 		case errors.As(err, &nfErr):
 			return &model.System{
-				Name:  model.SystemFirstAdminCompleteSetup,
+				Name:  model.SystemFirstAdminSetupComplete,
 				Value: "false",
 			}, nil
 		default:

--- a/model/system.go
+++ b/model/system.go
@@ -31,7 +31,7 @@ const (
 	SystemWarnMetricNumberOfPosts2m        = "warn_metric_number_of_posts_2M"
 	SystemWarnMetricLastRunTimestampKey    = "LastWarnMetricRunTimestamp"
 	SystemFirstAdminVisitMarketplace       = "FirstAdminVisitMarketplace"
-	SystemFirstAdminCompleteSetup          = "FirstAdminCompleteSetup"
+	SystemFirstAdminSetupComplete          = "FirstAdminSetupComplete"
 	AwsMeteringReportInterval              = 1
 	AwsMeteringDimensionUsageHrs           = "UsageHrs"
 	UserLimitOverageCycleEndDate           = "UserLimitOverageCycleEndDate"


### PR DESCRIPTION
#### Summary
Mismatched key name between the migration code and the status fetching code meant that even the migration completed successfully, when the client tried to fetch the status of whether admin onboarding had been completed, they falsely saw it reported as `false`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42103

#### Release Note

```release-note
NONE
```