### PR TITLE
MM-42201: Enforce group is not the same as username.

### DIFF
--- a/api4/group_test.go
+++ b/api4/group_test.go
@@ -119,6 +119,16 @@ func TestCreateGroup(t *testing.T) {
 	require.NoError(t, err)
 	CheckCreatedStatus(t, response)
 
+	usernameGroup := &model.Group{
+		DisplayName:    "dn_" + model.NewId(),
+		Name:           &th.BasicUser.Username,
+		Source:         model.GroupSourceCustom,
+		AllowReference: true,
+	}
+	_, response, err = th.SystemAdminClient.CreateGroup(usernameGroup)
+	require.Error(t, err)
+	CheckBadRequestStatus(t, response)
+
 	unReferenceableCustomGroup := &model.Group{
 		DisplayName:    "dn_" + model.NewId(),
 		Name:           model.NewString("name" + model.NewId()),

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -93,7 +93,7 @@ func TestCreateGroup(t *testing.T) {
 	}
 	g, err = th.App.CreateGroup(usernameGroup)
 	require.NotNil(t, err)
-	require.Equal(t, "app.custom_group.username_conflict", err.Id)
+	require.Equal(t, "app.group.username_conflict", err.Id)
 	require.Nil(t, g)
 }
 
@@ -111,7 +111,7 @@ func TestUpdateGroup(t *testing.T) {
 	g.Name = &user.Username
 	g, err = th.App.UpdateGroup(g)
 	require.NotNil(t, err)
-	require.Equal(t, "app.custom_group.username_conflict", err.Id)
+	require.Equal(t, "app.group.username_conflict", err.Id)
 	require.Nil(t, g)
 }
 

--- a/app/group_test.go
+++ b/app/group_test.go
@@ -83,6 +83,18 @@ func TestCreateGroup(t *testing.T) {
 	g, err = th.App.CreateGroup(group)
 	require.NotNil(t, err)
 	require.Nil(t, g)
+
+	user := th.CreateUser()
+	usernameGroup := &model.Group{
+		DisplayName: "dn_" + model.NewId(),
+		Name:        &user.Username,
+		Source:      model.GroupSourceLdap,
+		RemoteId:    model.NewString(model.NewId()),
+	}
+	g, err = th.App.CreateGroup(usernameGroup)
+	require.NotNil(t, err)
+	require.Equal(t, "app.custom_group.username_conflict", err.Id)
+	require.Nil(t, g)
 }
 
 func TestUpdateGroup(t *testing.T) {
@@ -94,6 +106,13 @@ func TestUpdateGroup(t *testing.T) {
 	g, err := th.App.UpdateGroup(group)
 	require.Nil(t, err)
 	require.NotNil(t, g)
+
+	user := th.CreateUser()
+	g.Name = &user.Username
+	g, err = th.App.UpdateGroup(g)
+	require.NotNil(t, err)
+	require.Equal(t, "app.custom_group.username_conflict", err.Id)
+	require.Nil(t, g)
 }
 
 func TestDeleteGroup(t *testing.T) {

--- a/app/user.go
+++ b/app/user.go
@@ -219,6 +219,11 @@ func (a *App) CreateGuest(c *request.Context, user *model.User) (*model.User, *m
 }
 
 func (a *App) createUserOrGuest(c *request.Context, user *model.User, guest bool) (*model.User, *model.AppError) {
+	if err := a.isUniqueToGroupNames(user.Username); err != nil {
+		err.Where = "createUserOrGuest"
+		return nil, err
+	}
+
 	ruser, nErr := a.ch.srv.userService.CreateUser(user, users.UserCreateOptions{Guest: guest})
 	if nErr != nil {
 		var appErr *model.AppError
@@ -1053,6 +1058,21 @@ func (a *App) sendUpdatedUserEvent(user model.User) {
 	a.Publish(sourceUserMessage)
 }
 
+func (a *App) isUniqueToGroupNames(val string) *model.AppError {
+	if val == "" {
+		return nil
+	}
+	var notFoundErr *store.ErrNotFound
+	group, err := a.Srv().Store.Group().GetByName(val, model.GroupSearchOpts{})
+	if err != nil && !errors.As(err, &notFoundErr) {
+		return model.NewAppError("", "app.user.get_by_name_failure", nil, err.Error(), http.StatusInternalServerError)
+	}
+	if group != nil {
+		return model.NewAppError("", "app.user.group_name_conflict", nil, "", http.StatusBadRequest)
+	}
+	return nil
+}
+
 func (a *App) UpdateUser(user *model.User, sendNotifications bool) (*model.User, *model.AppError) {
 	prev, err := a.ch.srv.userService.GetUser(user.Id)
 	if err != nil {
@@ -1062,6 +1082,13 @@ func (a *App) UpdateUser(user *model.User, sendNotifications bool) (*model.User,
 			return nil, model.NewAppError("UpdateUser", MissingAccountError, nil, nfErr.Error(), http.StatusNotFound)
 		default:
 			return nil, model.NewAppError("UpdateUser", "app.user.get.app_error", nil, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+	if user.Username != prev.Username {
+		if err := a.isUniqueToGroupNames(user.Username); err != nil {
+			err.Where = "UpdateUser"
+			return nil, err
 		}
 	}
 

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -180,6 +180,46 @@ func TestUpdateUserToRestrictedDomain(t *testing.T) {
 	})
 }
 
+func TestUpdateUser(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	user := th.CreateUser()
+	group := th.CreateGroup()
+
+	t.Run("fails if the username matches a group name", func(t *testing.T) {
+		user.Username = *group.Name
+		u, err := th.App.UpdateUser(user, false)
+		require.NotNil(t, err)
+		require.Equal(t, "app.user.group_name_conflict", err.Id)
+		require.Nil(t, u)
+	})
+}
+
+func TestCreateUser(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	group := th.CreateGroup()
+
+	id := model.NewId()
+	user := &model.User{
+		Email:         "success+" + id + "@simulator.amazonses.com",
+		Username:      *group.Name,
+		Nickname:      "nn_" + id,
+		Password:      "Password1",
+		EmailVerified: true,
+	}
+
+	t.Run("fails if the username matches a group name", func(t *testing.T) {
+		user.Username = *group.Name
+		u, err := th.App.CreateUser(th.Context, user)
+		require.NotNil(t, err)
+		require.Equal(t, "app.user.group_name_conflict", err.Id)
+		require.Nil(t, u)
+	})
+}
+
 func TestUpdateUserActive(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4928,6 +4928,10 @@
     "translation": "Unable to perform operation for that source type."
   },
   {
+    "id": "app.group.get_by_username_failure",
+    "translation": " "
+  },
+  {
     "id": "app.group.group_syncable_already_deleted",
     "translation": "group syncable was already deleted"
   },
@@ -4946,6 +4950,10 @@
   {
     "id": "app.group.uniqueness_error",
     "translation": "group member already exists"
+  },
+  {
+    "id": "app.group.username_conflict",
+    "translation": " "
   },
   {
     "id": "app.import.attachment.bad_file.error",
@@ -6464,6 +6472,10 @@
     "translation": "We encountered an error trying to find the account by authentication type."
   },
   {
+    "id": "app.user.get_by_name_failure",
+    "translation": " "
+  },
+  {
     "id": "app.user.get_by_username.app_error",
     "translation": "Unable to find an existing account matching your username for this team. This team may require an invite from the team owner to join."
   },
@@ -6518,6 +6530,10 @@
   {
     "id": "app.user.get_users_batch_for_indexing.get_users.app_error",
     "translation": "Unable to get the users batch for indexing."
+  },
+  {
+    "id": "app.user.group_name_conflict",
+    "translation": " "
   },
   {
     "id": "app.user.missing_account.const",

--- a/model/group.go
+++ b/model/group.go
@@ -211,6 +211,13 @@ func (group *Group) IsValidName() *AppError {
 	return nil
 }
 
+func (group *Group) GetName() string {
+	if group.Name == nil {
+		return ""
+	}
+	return *group.Name
+}
+
 func (group *Group) GetRemoteId() string {
 	if group.RemoteId == nil {
 		return ""


### PR DESCRIPTION
#### Summary

Validates that...
* creating or updating a group the `Name` ("Mention" on the front-end) isn't the same as any user `Username` values
* creating or updating a user the `Username` isn't the same as any group `Name` ("Mention" on the front-end) values

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42201

#### Related

https://github.com/mattermost/mattermost-webapp/pull/9923

#### Release Note

```release-note
NONE
```
