### PR TITLE
[MM-41579] Remove FF guided channel creation

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -53,9 +53,6 @@ type FeatureFlags struct {
 	// A/B test for the add members to channel button, possible values = ("top", "bottom")
 	AddMembersToChannel string
 
-	// Enable Create First Channel
-	GuidedChannelCreation bool
-
 	// Determine after which duration in hours to send a second invitation to someone that didn't join after the initial invite, possible values = ("48", "72")
 	ResendInviteEmailInterval string
 
@@ -100,7 +97,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.CallsMobile = false
 	f.BoardsFeatureFlags = ""
 	f.AddMembersToChannel = "top"
-	f.GuidedChannelCreation = false
 	f.ResendInviteEmailInterval = ""
 	f.InviteToTeam = "none"
 	f.CustomGroups = true


### PR DESCRIPTION
#### Summary
Removes the Feature Flag allowing admin to create a channel as part of the previous onboarding experience. The new Use Case Onboarding still has it active.

QA will be done on the webapp part

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41579

#### Release Note
```release-note
NONE
```
