### PR TITLE
[MM-42033] Fix flaky TestReliableWebSocketSend

### DIFF
--- a/app/enterprise.go
+++ b/app/enterprise.go
@@ -122,7 +122,7 @@ func (s *Server) initEnterprise() {
 		s.Metrics = metricsInterface(s)
 	}
 
-	if clusterInterface != nil {
+	if clusterInterface != nil && s.Cluster == nil {
 		s.Cluster = clusterInterface(s)
 	}
 	if elasticsearchInterface != nil {

--- a/app/web_hub_test.go
+++ b/app/web_hub_test.go
@@ -338,7 +338,6 @@ func TestHubConnIndexInactive(t *testing.T) {
 }
 
 func TestReliableWebSocketSend(t *testing.T) {
-	t.Skip("MM-42033")
 	testCluster := &testlib.FakeClusterInterface{}
 
 	th := SetupWithClusterMock(t, testCluster)


### PR DESCRIPTION
#### Summary

I believe the cluster mock was getting replaced by the `initEnterprise()` method hence failing to save the messages.
PR adds an additional check to ensure we update it only if unset.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42033

#### Release Note

```release-note
NONE
```
