### PR TITLE
Fix broken lock ci automation

### DIFF
--- a/scripts/download_mmctl_release.sh
+++ b/scripts/download_mmctl_release.sh
@@ -19,7 +19,9 @@ BIN_PATH=${2:-bin}
 THIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$THIS_BRANCH" =~ 'release-'[0-9] ]];
 then
-  RELEASE_TO_DOWNLOAD="$THIS_BRANCH"
+  # prefix to remove for lock release branches
+  PREFIX_REMOVE="lock-"
+  RELEASE_TO_DOWNLOAD=${THIS_BRANCH#"$PREFIX_REMOVE"}
 else
   RELEASE_TO_DOWNLOAD=master
 fi


### PR DESCRIPTION
#### Summary
The Lock CI PRs was broken for really long time and we were handling these with manual commits. Now the bug should be fixed and won't block the automation anymore.

#### Ticket Link
https://mattermost.atlassian.net/browse/DOPS-848

#### Release Note
```release-note
NONE
```
