### PR TITLE
Automated cherry pick of #19633

### DIFF
--- a/api4/group.go
+++ b/api4/group.go
@@ -297,6 +297,17 @@ func linkGroupSyncable(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	group, groupErr := c.App.GetGroup(c.Params.GroupId, nil)
+	if groupErr != nil {
+		c.Err = groupErr
+		return
+	}
+
+	if group.Source != model.GroupSourceLdap {
+		c.Err = model.NewAppError("Api4.linkGroupSyncable", "app.group.crud_permission", nil, "", http.StatusBadRequest)
+		return
+	}
+
 	auditRec := c.MakeAuditRecord("linkGroupSyncable", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	auditRec.AddMeta("group_id", c.Params.GroupId)

--- a/api4/group_test.go
+++ b/api4/group_test.go
@@ -328,6 +328,20 @@ func TestLinkGroupTeam(t *testing.T) {
 	groupTeam, response, _ := th.Client.LinkGroupSyncable(g.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
 	assert.Equal(t, http.StatusCreated, response.StatusCode)
 	assert.NotNil(t, groupTeam)
+
+	gid := model.NewId()
+	g2, app2Err := th.App.CreateGroup(&model.Group{
+		DisplayName: "dn_" + gid,
+		Name:        model.NewString("name" + gid),
+		Source:      model.GroupSourceCustom,
+		Description: "description_" + gid,
+		RemoteId:    model.NewString(model.NewId()),
+	})
+	assert.Nil(t, app2Err)
+
+	_, response, err = th.Client.LinkGroupSyncable(g2.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam, patch)
+	require.Error(t, err)
+	CheckBadRequestStatus(t, response)
 }
 
 func TestLinkGroupChannel(t *testing.T) {
@@ -370,6 +384,20 @@ func TestLinkGroupChannel(t *testing.T) {
 
 	_, _, err = th.Client.LinkGroupSyncable(g.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
 	assert.Error(t, err)
+
+	gid := model.NewId()
+	g2, app2Err := th.App.CreateGroup(&model.Group{
+		DisplayName: "dn_" + gid,
+		Name:        model.NewString("name" + gid),
+		Source:      model.GroupSourceCustom,
+		Description: "description_" + gid,
+		RemoteId:    model.NewString(model.NewId()),
+	})
+	assert.Nil(t, app2Err)
+
+	_, response, err = th.Client.LinkGroupSyncable(g2.Id, th.BasicChannel.Id, model.GroupSyncableTypeChannel, patch)
+	require.Error(t, err)
+	CheckBadRequestStatus(t, response)
 }
 
 func TestUnlinkGroupTeam(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #19633 on release-6.5.

/cc  @BenCookie95

```release-note
NONE
```