### PR TITLE
Automated cherry pick of #19644

### DIFF
--- a/api4/group.go
+++ b/api4/group.go
@@ -836,6 +836,8 @@ func getGroupsAssociatedToChannelsByTeam(c *Context, w http.ResponseWriter, r *h
 func getGroups(c *Context, w http.ResponseWriter, r *http.Request) {
 	var teamID, channelID string
 
+	source := c.Params.GroupSource
+
 	if id := c.Params.NotAssociatedToTeam; model.IsValidId(id) {
 		teamID = id
 	}
@@ -844,24 +846,25 @@ func getGroups(c *Context, w http.ResponseWriter, r *http.Request) {
 		channelID = id
 	}
 
+	// If they specify the group_source as custom when the feature is disabled, throw an error
+	if lcErr := licensedAndConfiguredForGroupBySource(c.App, source); lcErr != nil {
+		lcErr.Where = "Api4.getGroups"
+		c.Err = lcErr
+		return
+	}
+
+	// If they don't specify a source and custom groups are disabled, ensure they only get ldap groups in the response
+	if !c.App.Config().FeatureFlags.CustomGroups || !*c.App.Config().ServiceSettings.EnableCustomGroups {
+		source = model.GroupSourceLdap
+	}
+
 	opts := model.GroupSearchOpts{
 		Q:                         c.Params.Q,
 		IncludeMemberCount:        c.Params.IncludeMemberCount,
 		FilterAllowReference:      c.Params.FilterAllowReference,
 		FilterParentTeamPermitted: c.Params.FilterParentTeamPermitted,
-		Source:                    c.Params.GroupSource,
+		Source:                    source,
 		FilterHasMember:           c.Params.FilterHasMember,
-	}
-
-	if !c.App.Config().FeatureFlags.CustomGroups && opts.Source == model.GroupSourceCustom {
-		c.Err = model.NewAppError("getGroups", "api.custom_groups.feature_disabled", nil, "", http.StatusNotImplemented)
-		return
-	}
-
-	if lcErr := licensedAndConfiguredForGroupBySource(c.App, opts.Source); lcErr != nil {
-		lcErr.Where = "Api4.getGroups"
-		c.Err = lcErr
-		return
 	}
 
 	if teamID != "" {

--- a/api4/group_test.go
+++ b/api4/group_test.go
@@ -1201,6 +1201,30 @@ func TestGetGroups(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, groups, 1)
 	assert.Equal(t, groups[0].Id, group2.Id)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.EnableCustomGroups = false
+	})
+
+	// Specify custom groups source when feature is disabled
+	opts.Source = model.GroupSourceCustom
+	_, response, err := th.Client.GetGroups(opts)
+	require.Error(t, err)
+	CheckNotImplementedStatus(t, response)
+
+	// Specify ldap groups source when custom groups feature is disabled
+	opts.Source = model.GroupSourceLdap
+	groups, _, err = th.Client.GetGroups(opts)
+	assert.NoError(t, err)
+	assert.Len(t, groups, 1)
+	assert.Equal(t, groups[0].Source, model.GroupSourceLdap)
+
+	// don't include source and should only get ldap groups in response
+	opts.Source = ""
+	groups, _, err = th.Client.GetGroups(opts)
+	assert.NoError(t, err)
+	assert.Len(t, groups, 1)
+	assert.Equal(t, groups[0].Source, model.GroupSourceLdap)
 }
 
 func TestGetGroupsByUserId(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #19644 on release-6.5.

/cc  @BenCookie95

```release-note
NONE
```