### PR TITLE
Exclude bots when restricting DMs to team members.

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -440,7 +440,7 @@ func TestGetOrCreateDirectChannel(t *testing.T) {
 
 		channel, appErr := th.App.GetOrCreateDirectChannel(th.Context, user1.Id, user2.Id)
 		require.Nil(t, channel, "channel should be nil")
-		require.Error(t, appErr)
+		require.NotNil(t, appErr)
 	})
 }
 

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -400,6 +400,50 @@ func TestUpdateChannelPrivacy(t *testing.T) {
 	assert.Equal(t, publicChannel.Type, model.ChannelTypeOpen)
 }
 
+func TestGetOrCreateDirectChannel(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	team1 := th.CreateTeam()
+	team2 := th.CreateTeam()
+
+	user1 := th.CreateUser()
+	th.LinkUserToTeam(user1, team1)
+
+	user2 := th.CreateUser()
+	th.LinkUserToTeam(user2, team2)
+
+	bot1 := th.CreateBot()
+
+	t.Run("Bot can create with restriction", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			setting := model.DirectMessageTeam
+			cfg.TeamSettings.RestrictDirectMessage = &setting
+		})
+
+		// check with bot in first userid param
+		channel, appErr := th.App.GetOrCreateDirectChannel(th.Context, bot1.UserId, user1.Id)
+		require.NotNil(t, channel, "channel should be non-nil")
+		require.Nil(t, appErr)
+
+		// check with bot in second userid param
+		channel, appErr = th.App.GetOrCreateDirectChannel(th.Context, user1.Id, bot1.UserId)
+		require.NotNil(t, channel, "channel should be non-nil")
+		require.Nil(t, appErr)
+	})
+
+	t.Run("User from other team cannot create with restriction", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			setting := model.DirectMessageTeam
+			cfg.TeamSettings.RestrictDirectMessage = &setting
+		})
+
+		channel, appErr := th.App.GetOrCreateDirectChannel(th.Context, user1.Id, user2.Id)
+		require.Nil(t, channel, "channel should be nil")
+		require.Error(t, appErr)
+	})
+}
+
 func TestCreateGroupChannelCreatesChannelMemberHistoryRecord(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()


### PR DESCRIPTION
#### Summary
This PR excludes bots when restricting DMs to members of a team.

#### Background
https://mattermost.atlassian.net/browse/MM-7968 provided a setting that allowed administrators to restrict DMs to team members only.  A side affect of this is that bots cannot create DM channels with users unless the bots are added to the user’s team.

It was decided (https://community.mattermost.com/core/pl/57ia5zdm7i8epyrbgyyx5xr8fo) to exclude bots from this restriction.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42318

#### Release Note
```release-note
When restricting direct messages to users on the same team, bots are now excluded from that restriction.
```
