### PR TITLE
Add inject-test-data to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,9 @@ cover: ## Runs the golang coverage tool. You must run the unit tests first.
 	$(GO) tool cover -html=cover.out
 	$(GO) tool cover -html=ecover.out
 
-test-data: run-server ## Add test data to the local instance.
+test-data: run-server inject-test-data ## start a local instance and add test data to it.
+
+inject-test-data: # add test data to the local instance.
 	@if ! ./scripts/wait-for-system-start.sh; then \
 		make stop; \
 	fi


### PR DESCRIPTION
#### Summary
Adds a Makefile target to inject the test-data into a local instance without trying to start the server.

Context: I run my Makefile with `RUN_SERVER_IN_BACKGROUND=true`, and because the `test-data` target depends on `run-server`, it starts the server in the foreground thus never reaches the injection part.

Also, I did not want to break anybody's workflow so simply extracting the injection part in its own target ensured that everything would work the same as before for people relying on `test-data` to start their server.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
