### PR TITLE
[MM-42184] app: add plugin-api/cluster interface provider

### DIFF
--- a/app/cluster.go
+++ b/app/cluster.go
@@ -4,8 +4,64 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
+
+type clusterWrapper struct {
+	srv *Server
+}
+
+func (s *clusterWrapper) PublishPluginClusterEvent(productID string, ev model.PluginClusterEvent,
+	opts model.PluginClusterEventSendOptions) error {
+	if s.srv.Cluster == nil {
+		return nil
+	}
+
+	msg := &model.ClusterMessage{
+		Event:            model.ClusterEventPluginEvent,
+		SendType:         opts.SendType,
+		WaitForAllToSend: false,
+		Props: map[string]string{
+			"ProductID": productID,
+			"EventID":   ev.Id,
+		},
+		Data: ev.Data,
+	}
+
+	// If TargetId is empty we broadcast to all other cluster nodes.
+	if opts.TargetId == "" {
+		s.srv.Cluster.SendClusterMessage(msg)
+	} else {
+		if err := s.srv.Cluster.SendClusterMessageToNode(opts.TargetId, msg); err != nil {
+			return fmt.Errorf("failed to send message to cluster node %q: %w", opts.TargetId, err)
+		}
+	}
+
+	return nil
+}
+
+func (s *clusterWrapper) SetPluginKeyWithOptions(productID string, key string, value []byte, options model.PluginKVSetOptions) (bool, *model.AppError) {
+	return s.srv.setPluginKeyWithOptions(productID, key, value, options)
+}
+
+func (s *clusterWrapper) LogError(productID, msg string, keyValuePairs ...interface{}) {
+	s.srv.Log.Error(msg, mlog.String("product_id", productID), mlog.Map("key-value pairs", keyValuePairs))
+}
+
+func (s *clusterWrapper) KVGet(productID, key string) ([]byte, *model.AppError) {
+	return s.srv.getPluginKey(productID, key)
+}
+
+func (s *clusterWrapper) KVDelete(productID, key string) *model.AppError {
+	return s.srv.deletePluginKey(productID, key)
+}
+
+func (s *clusterWrapper) KVList(productID string, page, perPage int) ([]string, *model.AppError) {
+	return s.srv.listPluginKeys(productID, page, perPage)
+}
 
 // Registers a given function to be called when the cluster leader may have changed. Returns a unique ID for the
 // listener which can later be used to remove it. If clustering is not enabled in this build, the callback will never

--- a/app/server.go
+++ b/app/server.go
@@ -91,6 +91,7 @@ type ServiceKey string
 const (
 	ConfigKey  ServiceKey = "config"
 	LicenseKey ServiceKey = "license"
+	ClusterKey ServiceKey = "cluster"
 )
 
 type Server struct {
@@ -138,6 +139,7 @@ type Server struct {
 	Jobs             *jobs.JobServer
 
 	clusterLeaderListeners sync.Map
+	clusterWrapper         *clusterWrapper
 
 	licenseValue       atomic.Value
 	clientLicenseValue atomic.Value
@@ -337,10 +339,16 @@ func NewServer(options ...Option) (*Server, error) {
 		srv: s,
 	}
 
+	s.clusterWrapper = &clusterWrapper{
+		srv: s,
+	}
+
 	serviceMap := map[ServiceKey]interface{}{
 		ConfigKey:  s.configStore,
 		LicenseKey: s.licenseWrapper,
+		ClusterKey: s.clusterWrapper,
 	}
+
 	// Step 8: Initialize products.
 	// Depends on s.httpService.
 	for name, initializer := range products {


### PR DESCRIPTION
#### Summary
Adds clustering related methods to the wrapper. Since the service is initialized within the `app.Server`, we now pass `productID` (formerly `pluginID`) as a argument in the methods.

The KV related methods are required to initiate plugin mutexes and jobs. These were grouped under clustering in the original API, therefore kept them attached here as well.  See https://github.com/mattermost/mattermost-plugin-api/tree/master/cluster

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42184

#### Release Note

```release-note
NONE
```
