### PR TITLE
MM-42345: Include stdlog level in default mlog config

### DIFF
--- a/shared/mlog/levels.go
+++ b/shared/mlog/levels.go
@@ -14,7 +14,7 @@ var (
 	LvlInfo  = logr.Info  // ID = 4
 	LvlDebug = logr.Debug // ID = 5
 	LvlTrace = logr.Trace // ID = 6
-	StdAll   = []Level{LvlPanic, LvlFatal, LvlError, LvlWarn, LvlInfo, LvlDebug, LvlTrace}
+	StdAll   = []Level{LvlPanic, LvlFatal, LvlError, LvlWarn, LvlInfo, LvlDebug, LvlTrace, LvlStdLog}
 	// non-standard "critical" level
 	LvlCritical = Level{ID: 7, Name: "critical"}
 	// used by redirected standard logger


### PR DESCRIPTION
#### Summary
During server startup, the std lib logger is redirected to mlog to capture any logging from third-party libraries.  These log records are emitted using a specific log level so that they can be output to specific log targets, mixed with MM logs or separated.

It was intended this log level be included in the default mlog config but that was missed.  This PR is to add that to the default config such that all stdlib logs are included.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42345

#### Release Note
```release-note
Logs from third-party libraries are now included in default logging configuration.
```
