### PR TITLE
MM-19334 Ported AutocompleteInTeamForSearch to Squirrel

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3300,7 +3300,7 @@ func (s SqlChannelStore) buildLIKEClauseX(term string, searchColumns ...string) 
 	}
 
 	// add a placeholder at the beginning and end
-	likeTerm = "%" + likeTerm + "%"
+	likeTerm = wildcardSearchTerm(likeTerm)
 
 	// Prepare the LIKE portion of the query.
 	var searchFields sq.Or

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2873,7 +2873,7 @@ func (s SqlChannelStore) AutocompleteInTeamForSearch(teamID string, userID strin
 	}
 
 	var (
-		channels model.ChannelList
+		channels = model.ChannelList{}
 		sql      string
 		args     []interface{}
 	)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3338,14 +3338,10 @@ func (s SqlChannelStore) buildFulltextClause(term string, searchColumns string) 
 
 		splitTerm := strings.Fields(fulltextTerm)
 		for i, t := range strings.Fields(fulltextTerm) {
-			if i == len(splitTerm)-1 {
-				splitTerm[i] = t + ":*"
-			} else {
-				splitTerm[i] = t + ":* &"
-			}
+			splitTerm[i] = t + ":*"
 		}
 
-		fulltextTerm = strings.Join(splitTerm, " ")
+		fulltextTerm = strings.Join(splitTerm, " & ")
 
 		fulltextClause = fmt.Sprintf("((to_tsvector('english', %s)) @@ to_tsquery('english', :FulltextTerm))", convertMySQLFullTextColumnsToPostgres(searchColumns))
 	} else if s.DriverName() == model.DatabaseDriverMysql {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2868,7 +2868,7 @@ func (s SqlChannelStore) AutocompleteInTeamForSearch(teamID string, userID strin
 	}
 
 	// shared query
-	baseQuery := sq.Select("C.*").
+	baseQuery := s.getSubQueryBuilder().Select("C.*").
 		From("Channels AS C").
 		Join("ChannelMembers AS CM ON CM.ChannelId = C.Id").
 		Limit(50)
@@ -2954,7 +2954,7 @@ func (s SqlChannelStore) autocompleteInTeamForSearchDirectMessages(userID string
 	qb := s.getQueryBuilder()
 
 	// create the subquery first
-	subQuery := sq.Select("ICM.ChannelId AS ChannelId", "IU.Username AS Username").
+	subQuery := s.getSubQueryBuilder().Select("ICM.ChannelId AS ChannelId", "IU.Username AS Username").
 		From("Users AS IU").
 		Join("ChannelMembers AS ICM ON ICM.UserId = IU.Id")
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2981,7 +2981,7 @@ func (s SqlChannelStore) autocompleteInTeamForSearchDirectMessages(userID string
 	}
 
 	// query the channel list from the database using SQLX
-	var channels model.ChannelList
+	channels := model.ChannelList{}
 	err = s.GetReplicaX().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with term='%s' (%s %% %v)", term, sql, args)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3334,7 +3334,7 @@ func (s SqlChannelStore) buildFulltextClause(term string, searchColumns string) 
 
 	// Prepare the FULLTEXT portion of the query.
 	if s.DriverName() == model.DatabaseDriverPostgres {
-		fulltextTerm = strings.Replace(fulltextTerm, "|", "", -1)
+		fulltextTerm = strings.ReplaceAll(fulltextTerm, "|", "")
 
 		splitTerm := strings.Fields(fulltextTerm)
 		for i, t := range strings.Fields(fulltextTerm) {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2879,12 +2879,13 @@ func (s SqlChannelStore) AutocompleteInTeamForSearch(teamID string, userID strin
 		channels model.ChannelList
 		sql      string
 		args     []interface{}
-		err      error
 	)
 
 	// build the like clause
 	like := s.buildLIKEClauseX(term, "Name", "DisplayName", "Purpose")
 	if like == nil {
+		var err error
+
 		// use the base query for this request
 		query := baseQuery.Where(baseWhere)
 
@@ -2921,7 +2922,7 @@ func (s SqlChannelStore) AutocompleteInTeamForSearch(teamID string, userID strin
 	}
 
 	// query the database
-	err = s.GetReplicaX().Select(&channels, sql, args...)
+	err := s.GetReplicaX().Select(&channels, sql, args...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to find Channels with term='%s'", term)
 	}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2914,7 +2914,8 @@ func (s SqlChannelStore) AutocompleteInTeamForSearch(teamID string, userID strin
 			return nil, errors.Wrap(err, "AutocompleteInTeamForSearch_Full_Tosql")
 		}
 
-		// put both queries in a UNION
+		// Using a UNION results in index_merge and fulltext queries and is much faster than the ref
+		// query you would get using an OR of the LIKE and full-text clauses.
 		sql = fmt.Sprintf("(%s) UNION (%s) LIMIT 50", likeSQL, fullSQL)
 		args = append(likeArgs, fullArgs...)
 	}

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1455,21 +1455,6 @@ func (us SqlUserStore) SearchNotInGroup(groupID string, term string, options *mo
 	return us.performSearch(query, term, options)
 }
 
-var spaceFulltextSearchChar = []string{
-	"<",
-	">",
-	"+",
-	"-",
-	"(",
-	")",
-	"~",
-	":",
-	"*",
-	"\"",
-	"!",
-	"@",
-}
-
 func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string, isPostgreSQL bool) sq.SelectBuilder {
 	for _, term := range terms {
 		searchFields := []string{}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR ports "AutocompleteInTeamForSearch" and the methods it depends on to Squirrel. It also includes a small optimization for "buildFulltextClause" and moves "spaceFulltextSearchChar" to the file it's actually used in.

I've added buildLIKEClauseX and buildFulltextClauseX which generate the respective conditions for the WHERE clause. I've not removed the original methods, they seem to be used in other, not yet ported methods as well. Be aware that the arguments for these methods have slighly changed from their non-X counterparts. Instead of passing the columns as one string, they expect a list of strings. This simplifies the code.

As an optimization, "buildFulltextClause" and "buildFulltextClauseX" use the `strings.Map` function to replace the characters in "spaceFulltextSearchChars" with spaces, which itself is now just a string and not a list of one-character strings.

Squirred does not support UNIONs, so the subqueries are generated and then put into the UNION using `fmt.Sprintf`. The placeholders for Postgres need to be manually applied afterwards.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/19334

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
