### PR TITLE
MM-19336 Migrated GetMembersByIds and GetMembersByChannelIds to Squirrel

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1843,7 +1843,7 @@ func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) (
 
 		// TODO: Get this out of the transaction when is possible
 		var dbMember channelMemberWithSchemeRoles
-		if err := transaction.Get(&dbMember, sqlSelect, args); err != nil {
+		if err := transaction.Get(&dbMember, sqlSelect, args...); err != nil {
 			if err == sql.ErrNoRows {
 				return nil, store.NewErrNotFound("ChannelMember", fmt.Sprintf("channelId=%s, userId=%s", member.ChannelId, member.UserId))
 			}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1816,7 +1816,7 @@ func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) (
 			return nil, errors.Wrapf(err, "UpdateMultipleMembers_Update_ToSql ChannelID=%s UserID=%s", member.ChannelId, member.UserId)
 		}
 
-		if _, err := transaction.Exec(sqlUpdate, args...); err != nil {
+		if _, err = transaction.Exec(sqlUpdate, args...); err != nil {
 			return nil, errors.Wrap(err, "failed to update ChannelMember")
 		}
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1947,7 +1947,7 @@ func (s SqlChannelStore) GetMembers(channelID string, offset, limit int) (model.
 		Offset(uint64(offset)).
 		ToSql()
 	if err != nil {
-		return nil, errors.Wrapf(err, "GetMembers_ToSql ChannelID=%s", channelID)
+		return nil, errors.Wrapf(err, "GetMember_ToSql ChannelID=%s", channelID)
 	}
 
 	dbMembers := channelMemberWithSchemeRolesList{}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1862,14 +1862,14 @@ func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props
 	defer finalizeTransactionX(tx)
 
 	if s.DriverName() == model.DatabaseDriverPostgres {
-		sql, args, eerr := s.getQueryBuilder().
+		sql, args, err2 := s.getQueryBuilder().
 			Update("channelmembers").
 			Set("notifyprops", sq.Expr("notifyprops || ?::jsonb", model.MapToJSON(props))).
 			Where(sq.Eq{
 				"userid":    userID,
 				"channelid": channelID,
 			}).ToSql()
-		if eerr != nil {
+		if err2 != nil {
 			return nil, errors.Wrapf(err, "UpdateMemberNotifyProps_Update_Postgres_ToSql channelID=%s and userID=%s", channelID, userID)
 		}
 
@@ -1885,14 +1885,14 @@ func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props
 		// Example: UPDATE ChannelMembers
 		// SET NotifyProps = JSON_SET(NotifyProps, '$.mark_unread', '"yes"' [, ...])
 		// WHERE ...
-		sql, args, eerr := s.getQueryBuilder().
+		sql, args, err2 := s.getQueryBuilder().
 			Update("ChannelMembers").
 			Set("NotifyProps", jsonExpr).
 			Where(sq.Eq{
 				"UserId":    userID,
 				"ChannelId": channelID,
 			}).ToSql()
-		if eerr != nil {
+		if err2 != nil {
 			return nil, errors.Wrapf(err, "UpdateMemberNotifyProps_Update_MySQL_ToSql channelID=%s and userID=%s", channelID, userID)
 		}
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1161,11 +1161,9 @@ func (s SqlChannelStore) GetChannelsByUser(userId string, includeDeleted bool, l
 }
 
 func (s SqlChannelStore) GetAllChannelMembersById(channelID string) ([]string, error) {
-	query := s.channelMembersForTeamWithSchemeSelectQuery.Where(sq.Eq{
+	sql, args, err := s.channelMembersForTeamWithSchemeSelectQuery.Where(sq.Eq{
 		"ChannelId": channelID,
-	})
-
-	sql, args, err := query.ToSql()
+	}).ToSql()
 	if err != nil {
 		return nil, errors.Wrap(err, "GetAllChannelMembersById_ToSql")
 	}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -467,7 +467,7 @@ func newSqlChannelStore(sqlStore *SqlStore, metrics einterfaces.MetricsInterface
 	return s
 }
 
-func (s SqlChannelStore) initializeQueries() {
+func (s *SqlChannelStore) initializeQueries() {
 	s.channelMembersForTeamWithSchemeSelectQuery = s.getQueryBuilder().
 		Select(
 			"ChannelMembers.*",

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1874,14 +1874,14 @@ func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props
 	defer finalizeTransactionX(tx)
 
 	if s.DriverName() == model.DatabaseDriverPostgres {
-		sql, args, err := s.getQueryBuilder().
+		sql, args, eerr := s.getQueryBuilder().
 			Update("channelmembers").
 			Set("notifyprops", sq.Expr("notifyprops || ?::jsonb", model.MapToJSON(props))).
 			Where(sq.Eq{
 				"userid":    userID,
 				"channelid": channelID,
 			}).ToSql()
-		if err != nil {
+		if eerr != nil {
 			return nil, errors.Wrapf(err, "UpdateMemberNotifyProps_Update_Postgres_ToSql channelID=%s and userID=%s", channelID, userID)
 		}
 
@@ -1897,14 +1897,14 @@ func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props
 		// Example: UPDATE ChannelMembers
 		// SET NotifyProps = JSON_SET(NotifyProps, '$.mark_unread', '"yes"' [, ...])
 		// WHERE ...
-		sql, args, err := s.getQueryBuilder().
+		sql, args, eerr := s.getQueryBuilder().
 			Update("ChannelMembers").
 			Set("NotifyProps", jsonExpr).
 			Where(sq.Eq{
 				"UserId":    userID,
 				"ChannelId": channelID,
 			}).ToSql()
-		if err != nil {
+		if eerr != nil {
 			return nil, errors.Wrapf(err, "UpdateMemberNotifyProps_Update_MySQL_ToSql channelID=%s and userID=%s", channelID, userID)
 		}
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2764,9 +2764,13 @@ func (s SqlChannelStore) AnalyticsDeletedTypeCount(teamId string, channelType mo
 
 func (s SqlChannelStore) GetMembersForUser(teamID string, userID string) (model.ChannelMembers, error) {
 	sql, args, err := s.channelMembersForTeamWithSchemeSelectQuery.
-		Where(sq.Eq{
-			"ChannelMembers.UserId": userID,
-			"Teams.Id":              []interface{}{teamID, "", nil},
+		Where(sq.And{
+			sq.Eq{"ChannelMembers.UserId": userID},
+			sq.Or{
+				sq.Eq{"Teams.Id": teamID},
+				sq.Eq{"Teams.Id": ""},
+				sq.Eq{"Teams.Id": nil},
+			},
 		}).ToSql()
 	if err != nil {
 		return nil, errors.Wrapf(err, "GetMembersForUser_ToSql teamID=%s userID=%s", teamID, userID)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3444,7 +3444,9 @@ func (s SqlChannelStore) SearchGroupChannels(userId, term string) (model.Channel
 }
 
 func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (model.ChannelMembers, error) {
-	var dbMembers channelMemberWithSchemeRolesList
+	if len(userIDs) == 0 {
+		return nil, errors.New("no user IDs were provided")
+	}
 
 	query := channelMembersForTeamWithSchemeSelectQueryX.Where(
 		sq.Eq{
@@ -3461,6 +3463,8 @@ func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (mo
 		return nil, errors.Wrap(err, "GetMembersByIds_ToSql")
 	}
 
+	var dbMembers channelMemberWithSchemeRolesList
+
 	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with channelId=%s and userId in %v", channelID, userIDs)
 	}
@@ -3469,7 +3473,9 @@ func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (mo
 }
 
 func (s SqlChannelStore) GetMembersByChannelIds(channelIDs []string, userID string) (model.ChannelMembers, error) {
-	var dbMembers channelMemberWithSchemeRolesList
+	if len(channelIDs) == 0 {
+		return nil, errors.New("no channel IDs were provided")
+	}
 
 	query := channelMembersForTeamWithSchemeSelectQueryX.Where(
 		sq.Eq{
@@ -3485,6 +3491,8 @@ func (s SqlChannelStore) GetMembersByChannelIds(channelIDs []string, userID stri
 	if err != nil {
 		return nil, errors.Wrap(err, "GetMembersByChannelIds_ToSql")
 	}
+
+	var dbMembers channelMemberWithSchemeRolesList
 
 	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with userId=%s and channelId in %v", userID, channelIDs)

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3509,10 +3509,6 @@ func (s SqlChannelStore) SearchGroupChannels(userId, term string) (model.Channel
 }
 
 func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (model.ChannelMembers, error) {
-	if len(userIDs) == 0 {
-		return nil, errors.New("no user IDs were provided")
-	}
-
 	query := s.channelMembersForTeamWithSchemeSelectQuery.Where(
 		sq.Eq{
 			"ChannelMembers.ChannelId": channelID,
@@ -3526,7 +3522,6 @@ func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (mo
 	}
 
 	dbMembers := channelMemberWithSchemeRolesList{}
-
 	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with channelId=%s and userId in %v", channelID, userIDs)
 	}
@@ -3548,7 +3543,6 @@ func (s SqlChannelStore) GetMembersByChannelIds(channelIDs []string, userID stri
 	}
 
 	dbMembers := channelMemberWithSchemeRolesList{}
-
 	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with userId=%s and channelId in %v", userID, channelIDs)
 	}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1793,8 +1793,6 @@ func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) (
 		}
 	}
 
-	query := s.channelMembersForTeamWithSchemeSelectQuery
-
 	var transaction *sqlxTxWrapper
 	var err error
 
@@ -1831,7 +1829,8 @@ func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) (
 			return nil, errors.Wrap(err, "failed to update ChannelMember")
 		}
 
-		sqlSelect, args, err := query.Where(sq.Eq{
+		sqlSelect, args, err := s.channelMembersForTeamWithSchemeSelectQuery.
+			Where(sq.Eq{
 			"ChannelMembers.ChannelId": member.ChannelId,
 			"ChannelMembers.UserId":    member.UserId,
 		}).ToSql()

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3535,10 +3535,6 @@ func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (mo
 }
 
 func (s SqlChannelStore) GetMembersByChannelIds(channelIDs []string, userID string) (model.ChannelMembers, error) {
-	if len(channelIDs) == 0 {
-		return nil, errors.New("no channel IDs were provided")
-	}
-
 	query := s.channelMembersForTeamWithSchemeSelectQuery.Where(
 		sq.Eq{
 			"ChannelMembers.ChannelId": channelIDs,

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3525,7 +3525,7 @@ func (s SqlChannelStore) GetMembersByIds(channelID string, userIDs []string) (mo
 		return nil, errors.Wrap(err, "GetMembersByIds_ToSql")
 	}
 
-	var dbMembers channelMemberWithSchemeRolesList
+	dbMembers := channelMemberWithSchemeRolesList{}
 
 	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with channelId=%s and userId in %v", channelID, userIDs)
@@ -3551,7 +3551,7 @@ func (s SqlChannelStore) GetMembersByChannelIds(channelIDs []string, userID stri
 		return nil, errors.Wrap(err, "GetMembersByChannelIds_ToSql")
 	}
 
-	var dbMembers channelMemberWithSchemeRolesList
+	dbMembers := channelMemberWithSchemeRolesList{}
 
 	if err := s.GetReplicaX().Select(&dbMembers, sql, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to find ChannelMembers with userId=%s and channelId in %v", userID, channelIDs)

--- a/store/sqlstore/channel_store_test.go
+++ b/store/sqlstore/channel_store_test.go
@@ -41,12 +41,12 @@ func TestChannelSearchQuerySQLInjection(t *testing.T) {
 }
 
 func TestChannelStoreInternalDataTypes(t *testing.T) {
-	t.Run("NewChannelMemberFromModel", func(t *testing.T) { testNewChannelMemberFromModel(t) })
+	t.Run("NewMapFromChannelMemberModel", func(t *testing.T) { testNewMapFromChannelMemberModel(t) })
 	t.Run("ChannelMemberWithSchemeRolesToModel", func(t *testing.T) { testChannelMemberWithSchemeRolesToModel(t) })
 	t.Run("AllChannelMemberProcess", func(t *testing.T) { testAllChannelMemberProcess(t) })
 }
 
-func testNewChannelMemberFromModel(t *testing.T) {
+func testNewMapFromChannelMemberModel(t *testing.T) {
 	m := model.ChannelMember{
 		ChannelId:     model.NewId(),
 		UserId:        model.NewId(),
@@ -62,23 +62,20 @@ func testNewChannelMemberFromModel(t *testing.T) {
 		ExplicitRoles: "custom_role",
 	}
 
-	db := NewChannelMemberFromModel(&m)
+	db := NewMapFromChannelMemberModel(&m)
 
-	assert.Equal(t, m.ChannelId, db.ChannelId)
-	assert.Equal(t, m.UserId, db.UserId)
-	assert.Equal(t, m.LastViewedAt, db.LastViewedAt)
-	assert.Equal(t, m.MsgCount, db.MsgCount)
-	assert.Equal(t, m.MentionCount, db.MentionCount)
+	assert.Equal(t, m.ChannelId, db["ChannelId"])
+	assert.Equal(t, m.UserId, db["UserId"])
+	assert.Equal(t, m.LastViewedAt, db["LastViewedAt"])
+	assert.Equal(t, m.MsgCount, db["MsgCount"])
+	assert.Equal(t, m.MentionCount, db["MentionCount"])
 	assert.Equal(t, int64(0), m.MentionCountRoot)
-	assert.Equal(t, m.NotifyProps, db.NotifyProps)
-	assert.Equal(t, m.LastUpdateAt, db.LastUpdateAt)
-	assert.Equal(t, true, db.SchemeGuest.Valid)
-	assert.Equal(t, true, db.SchemeUser.Valid)
-	assert.Equal(t, true, db.SchemeAdmin.Valid)
-	assert.Equal(t, m.SchemeGuest, db.SchemeGuest.Bool)
-	assert.Equal(t, m.SchemeUser, db.SchemeUser.Bool)
-	assert.Equal(t, m.SchemeAdmin, db.SchemeAdmin.Bool)
-	assert.Equal(t, m.ExplicitRoles, db.Roles)
+	assert.Equal(t, m.NotifyProps, db["NotifyProps"])
+	assert.Equal(t, m.LastUpdateAt, db["LastUpdateAt"])
+	assert.Equal(t, sql.NullBool{Bool: false, Valid: true}, db["SchemeGuest"])
+	assert.Equal(t, sql.NullBool{Bool: true, Valid: true}, db["SchemeUser"])
+	assert.Equal(t, sql.NullBool{Bool: true, Valid: true}, db["SchemeAdmin"])
+	assert.Equal(t, m.ExplicitRoles, db["Roles"])
 }
 
 func testChannelMemberWithSchemeRolesToModel(t *testing.T) {

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -961,11 +961,14 @@ func (ss *SqlStore) DropAllTables() {
 }
 
 func (ss *SqlStore) getQueryBuilder() sq.StatementBuilderType {
-	builder := sq.StatementBuilder.PlaceholderFormat(sq.Question)
+	return sq.StatementBuilder.PlaceholderFormat(ss.getQueryPlaceholder())
+}
+
+func (ss *SqlStore) getQueryPlaceholder() sq.PlaceholderFormat {
 	if ss.DriverName() == model.DatabaseDriverPostgres {
-		builder = builder.PlaceholderFormat(sq.Dollar)
+		return sq.Dollar
 	}
-	return builder
+	return sq.Question
 }
 
 // getSubQueryBuilder is necessary to generate the SQL query and args to pass to sub-queries because squirrel does not support WHERE clause in sub-queries.

--- a/store/sqlstore/utils.go
+++ b/store/sqlstore/utils.go
@@ -113,14 +113,13 @@ func constructMySQLJSONArgs(props map[string]string) ([]interface{}, string) {
 	// Unpack the keys and values to pass to MySQL.
 	args := make([]interface{}, 0, len(props))
 	for k, v := range props {
-		args = append(args, "$."+k)
-		args = append(args, v)
+		args = append(args, "$."+k, v)
 	}
 
 	// We calculate the number of ? to set in the query string.
 	argString := strings.Repeat("?, ", len(props)*2)
 	// Strip off the trailing comma.
-	argString = strings.TrimSuffix(strings.TrimSpace(argString), ",")
+	argString = strings.TrimSuffix(argString, ", ")
 
 	return args, argString
 }

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -6321,8 +6321,9 @@ func testChannelStoreGetMembersByIds(t *testing.T, ss store.Store) {
 	require.NoError(t, nErr, nErr)
 	require.Len(t, members, 2, "return wrong number of results")
 
-	_, nErr = ss.Channel().GetMembersByIds(m1.ChannelId, []string{})
-	require.Error(t, nErr, "empty user ids - should have failed")
+	members, nErr = ss.Channel().GetMembersByIds(m1.ChannelId, []string{})
+	require.NoError(t, nErr)
+	require.Len(t, members, 0)
 }
 
 func testChannelStoreGetMembersByChannelIds(t *testing.T, ss store.Store) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR ports GetMembersByIds and GetMembersByChannelIds to Squirrel.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/19336

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
