### PR TITLE
workspace optimization dashboard feature flag default value

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -105,7 +105,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.NormalizeLdapDNs = false
 	f.EnableInactivityCheckJob = true
 	f.UseCaseOnboarding = true
-	f.WorkspaceOptimizationDashboard = false
+	f.WorkspaceOptimizationDashboard = true
 	f.GraphQL = false
 }
 func (f *FeatureFlags) Plugins() map[string]string {


### PR DESCRIPTION
#### Summary
set default value for workspace optimization dashboard feature flag to `true`

#### Ticket Link
[MM-42236](https://mattermost.atlassian.net/browse/MM-42236)

#### Release Note
```release-note
sets default value for `MM_FEATUREFLAGS_WORKSPACEOPTIMIZATIONDASHBOARD` to `true`
```
