### PR TITLE
[MM-42339] api4/license: add a nil check to not panic if server is not EE dist

### DIFF
--- a/api4/license.go
+++ b/api4/license.go
@@ -242,6 +242,11 @@ func requestRenewalLink(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if c.App.Cloud() == nil {
+		c.Err = model.NewAppError("requestRenewalLink", "api.license.upgrade_needed.app_error", nil, "", http.StatusForbidden)
+		return
+	}
+
 	// check if it is possible to renew license on the portal with generated token
 	e := c.App.Cloud().GetLicenseRenewalStatus(c.AppContext.Session().UserId, token)
 	if e != nil {


### PR DESCRIPTION

#### Summary
Adds a `nil` check to not panic if server is not compiled with `cloud` interface implementation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42339

#### Release Note

```release-note
NONE
```
