### PR TITLE
Mm 42465

### DIFF
--- a/api4/system_test.go
+++ b/api4/system_test.go
@@ -914,4 +914,20 @@ func TestCompleteOnboarding(t *testing.T) {
 		}
 
 	})
+
+	t.Run("as a system admin when plugins are disabled", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.PluginSettings.Enable = false
+		})
+
+		t.Cleanup(func() {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				*cfg.PluginSettings.Enable = true
+			})
+		})
+
+		resp, err := th.SystemAdminClient.CompleteOnboarding(req)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
 }

--- a/app/onboarding.go
+++ b/app/onboarding.go
@@ -14,19 +14,23 @@ import (
 	"github.com/mattermost/mattermost-server/v6/store"
 )
 
+func (a *App) markAdminOnboardingComplete(c *request.Context) *model.AppError {
+	firstAdminCompleteSetupObj := model.System{
+		Name:  model.SystemFirstAdminSetupComplete,
+		Value: "true",
+	}
+
+	if err := a.Srv().Store.System().SaveOrUpdate(&firstAdminCompleteSetupObj); err != nil {
+		return model.NewAppError("setFirstAdminCompleteSetup", "api.error_set_first_admin_complete_setup", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return nil
+}
+
 func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnboardingRequest) *model.AppError {
 	pluginsEnvironment := a.Channels().GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
-		firstAdminCompleteSetupObj := model.System{
-			Name:  model.SystemFirstAdminSetupComplete,
-			Value: "true",
-		}
-
-		if err := a.Srv().Store.System().SaveOrUpdate(&firstAdminCompleteSetupObj); err != nil {
-			return model.NewAppError("setFirstAdminCompleteSetup", "api.error_set_first_admin_complete_setup", nil, err.Error(), http.StatusInternalServerError)
-		}
-
-		return nil
+		return a.markAdminOnboardingComplete(c)
 	}
 
 	pluginContext := pluginContext(c)
@@ -64,16 +68,7 @@ func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnbo
 		}(pluginID)
 	}
 
-	firstAdminCompleteSetupObj := model.System{
-		Name:  model.SystemFirstAdminSetupComplete,
-		Value: "true",
-	}
-
-	if err := a.Srv().Store.System().SaveOrUpdate(&firstAdminCompleteSetupObj); err != nil {
-		return model.NewAppError("setFirstAdminCompleteSetup", "api.error_set_first_admin_complete_setup", nil, err.Error(), http.StatusInternalServerError)
-	}
-
-	return nil
+	return a.markAdminOnboardingComplete(c)
 }
 
 func (a *App) GetOnboarding() (*model.System, *model.AppError) {

--- a/app/onboarding.go
+++ b/app/onboarding.go
@@ -17,7 +17,16 @@ import (
 func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnboardingRequest) *model.AppError {
 	pluginsEnvironment := a.Channels().GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
-		return model.NewAppError("CompleteOnboarding", "app.plugin.disabled.app_error", nil, "", http.StatusNotImplemented)
+		firstAdminCompleteSetupObj := model.System{
+			Name:  model.SystemFirstAdminSetupComplete,
+			Value: "true",
+		}
+
+		if err := a.Srv().Store.System().SaveOrUpdate(&firstAdminCompleteSetupObj); err != nil {
+			return model.NewAppError("setFirstAdminCompleteSetup", "api.error_set_first_admin_complete_setup", nil, err.Error(), http.StatusInternalServerError)
+		}
+
+		return nil
 	}
 
 	pluginContext := pluginContext(c)


### PR DESCRIPTION
#### Summary
When plugins are disabled, the onboarding/complete endpoint should still succeed because it represents onboarding completion and not just plugins status. A related webapp PR (TBD) takes care of hiding the plugins selection screen if plugins are disabled.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42465

#### Release Note
No release note because this does not affect cloud and it should be cherry-picked to the latest release candidate branch before its release.
```release-note
NONE
```