### PR TITLE
[GraphQL POC] Omit self from pretty display name

### DIFF
--- a/api4/resolver_channel_test.go
+++ b/api4/resolver_channel_test.go
@@ -374,12 +374,14 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 	t.Run("nickname_full_name", func(t *testing.T) {
 		users := []*model.User{
 			{
+				Id:        "user1",
 				Nickname:  "nick1",
 				Username:  "user1",
 				FirstName: "first1",
 				LastName:  "last1",
 			},
 			{
+				Id:        "user2",
 				Nickname:  "nick2",
 				Username:  "user2",
 				FirstName: "first2",
@@ -390,11 +392,13 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 
 		users = []*model.User{
 			{
+				Id:        "user1",
 				Username:  "user1",
 				FirstName: "first1",
 				LastName:  "last1",
 			},
 			{
+				Id:        "user2",
 				Username:  "user2",
 				FirstName: "first2",
 				LastName:  "last2",
@@ -406,12 +410,14 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 	t.Run("full_name", func(t *testing.T) {
 		users := []*model.User{
 			{
+				Id:        "user1",
 				Nickname:  "nick1",
 				Username:  "user1",
 				FirstName: "first1",
 				LastName:  "last1",
 			},
 			{
+				Id:        "user2",
 				Nickname:  "nick2",
 				Username:  "user2",
 				FirstName: "first2",
@@ -422,9 +428,11 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 
 		users = []*model.User{
 			{
+				Id:       "user1",
 				Username: "user1",
 			},
 			{
+				Id:       "user2",
 				Username: "user2",
 			},
 		}
@@ -434,12 +442,14 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 	t.Run("username", func(t *testing.T) {
 		users := []*model.User{
 			{
+				Id:        "user1",
 				Nickname:  "nick1",
 				Username:  "user1",
 				FirstName: "first1",
 				LastName:  "last1",
 			},
 			{
+				Id:        "user2",
 				Nickname:  "nick2",
 				Username:  "user2",
 				FirstName: "first2",

--- a/api4/resolver_channel_test.go
+++ b/api4/resolver_channel_test.go
@@ -386,7 +386,7 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 				LastName:  "last2",
 			},
 		}
-		assert.Equal(t, "nick1, nick2", getPrettyDNForUsers("nickname_full_name", users))
+		assert.Equal(t, "nick2", getPrettyDNForUsers("nickname_full_name", users, "user1"))
 
 		users = []*model.User{
 			{
@@ -400,7 +400,7 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 				LastName:  "last2",
 			},
 		}
-		assert.Equal(t, "first1 last1, first2 last2", getPrettyDNForUsers("nickname_full_name", users))
+		assert.Equal(t, "first2 last2", getPrettyDNForUsers("nickname_full_name", users, "user1"))
 	})
 
 	t.Run("full_name", func(t *testing.T) {
@@ -418,7 +418,7 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 				LastName:  "last2",
 			},
 		}
-		assert.Equal(t, "first1 last1, first2 last2", getPrettyDNForUsers("full_name", users))
+		assert.Equal(t, "first2 last2", getPrettyDNForUsers("full_name", users, "user1"))
 
 		users = []*model.User{
 			{
@@ -428,7 +428,7 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 				Username: "user2",
 			},
 		}
-		assert.Equal(t, "user1, user2", getPrettyDNForUsers("full_name", users))
+		assert.Equal(t, "user2", getPrettyDNForUsers("full_name", users, "user1"))
 	})
 
 	t.Run("username", func(t *testing.T) {
@@ -446,7 +446,7 @@ func TestGetPrettyDNForUsers(t *testing.T) {
 				LastName:  "last2",
 			},
 		}
-		assert.Equal(t, "user1, user2", getPrettyDNForUsers("username", users))
+		assert.Equal(t, "user2", getPrettyDNForUsers("username", users, "user1"))
 	})
 }
 


### PR DESCRIPTION
#### Summary
When we are creating the pretty display name for a DM or GM, we omit the requester name, unless it is a DM to himself.

For the POC this is enough but:
- The names are not ordered based on the locale. This can be done in the client, but then we have to send the names in a format that the client can easily separate (we could separate by commas, but if the name has commas, then it is not possible...).
- We probably want to add the "(you)" string to the pretty display name of a DM to himself.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
