### PR TITLE
[MM-42478] Add way to invalidate cloud cache

### DIFF
--- a/einterfaces/cloud.go
+++ b/einterfaces/cloud.go
@@ -25,4 +25,5 @@ type CloudInterface interface {
 
 	// GetLicenseRenewalStatus checks on the portal whether it is possible to use token to renew a license
 	GetLicenseRenewalStatus(userID, token string) error
+	InvalidateCaches() error
 }

--- a/einterfaces/mocks/CloudInterface.go
+++ b/einterfaces/mocks/CloudInterface.go
@@ -210,6 +210,20 @@ func (_m *CloudInterface) GetSubscription(userID string) (*model.Subscription, e
 	return r0, r1
 }
 
+// InvalidateCaches provides a mock function with given fields:
+func (_m *CloudInterface) InvalidateCaches() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateCloudCustomer provides a mock function with given fields: userID, customerInfo
 func (_m *CloudInterface) UpdateCloudCustomer(userID string, customerInfo *model.CloudCustomerInfo) (*model.CloudCustomer, error) {
 	ret := _m.Called(userID, customerInfo)


### PR DESCRIPTION

#### Summary
Cloud cache needs a way to invalidate for tests in EE. This exposes that function in the interface.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42478

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
