### PR TITLE
app: add posts wrapper

### DIFF
--- a/app/channels.go
+++ b/app/channels.go
@@ -209,6 +209,10 @@ func NewChannels(s *Server, services map[ServiceKey]interface{}) (*Channels, err
 	pluginsRoute.HandleFunc("/public/{public_file:.*}", ch.ServePluginPublicRequest)
 	pluginsRoute.HandleFunc("/{anything:.*}", ch.ServePluginRequest)
 
+	services[PostKey] = &postServiceWrapper{
+		app: &App{ch: ch},
+	}
+
 	return ch, nil
 }
 

--- a/app/post.go
+++ b/app/post.go
@@ -32,6 +32,14 @@ const (
 
 var atMentionPattern = regexp.MustCompile(`\B@`)
 
+type postServiceWrapper struct {
+	app AppIface
+}
+
+func (s *postServiceWrapper) CreatePost(ctx *request.Context, post *model.Post) (*model.Post, *model.AppError) {
+	return s.app.CreatePostMissingChannel(ctx, post, true)
+}
+
 func (a *App) CreatePostAsUser(c *request.Context, post *model.Post, currentSessionId string, setOnline bool) (*model.Post, *model.AppError) {
 	// Check that channel has not been deleted
 	channel, errCh := a.Srv().Store.Channel().Get(post.ChannelId, true)

--- a/app/server.go
+++ b/app/server.go
@@ -94,6 +94,7 @@ const (
 	LicenseKey   ServiceKey = "license"
 	FilestoreKey ServiceKey = "filestore"
 	ClusterKey   ServiceKey = "cluster"
+	PostKey      ServiceKey = "post"
 )
 
 type Server struct {


### PR DESCRIPTION
#### Summary
Basically the `CreatePost` path is almost travels through the half of our codebase 😅 So I tried to refactor it as a separate standalone service, I had to throw almost every store in it as it would be a `Channels` product itself. My proposal is to expose this API from `Channels` product. Which will require a creation order for the products.

The creation order should use a dependency resolution and it may have it's own PR. Let me know if you think we should include that effort in this PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42185

#### Release Note

```release-note
NONE
```
