### PR TITLE
Automated cherry pick of #19797

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -2038,6 +2038,9 @@ func TestMarkChannelsAsViewedPanic(t *testing.T) {
 	mockPreferenceStore.On("Get", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(&model.Preference{Value: "test"}, nil)
 	mockStore.On("Channel").Return(&mockChannelStore)
 	mockStore.On("Preference").Return(&mockPreferenceStore)
+	mockThreadStore := mocks.ThreadStore{}
+	mockThreadStore.On("MarkAllAsReadByChannels", "userID", []string{"channelID"}).Return(nil)
+	mockStore.On("Thread").Return(&mockThreadStore)
 
 	_, appErr := th.App.MarkChannelsAsViewed([]string{"channelID"}, "userID", th.Context.Session().Id, false)
 	require.Nil(t, appErr)

--- a/model/config.go
+++ b/model/config.go
@@ -781,7 +781,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.ThreadAutoFollow == nil {
-		s.ThreadAutoFollow = NewBool(false)
+		s.ThreadAutoFollow = NewBool(true)
 	}
 
 	if s.CollapsedThreads == nil {


### PR DESCRIPTION
Cherry pick of #19797 on cloud.

/cc  @ashishbhate

```release-note
NONE
```