### PR TITLE
[MM-42703] - Add configuration setting to disable Inactive Server email notification

### DIFF
--- a/app/server_inactivity.go
+++ b/app/server_inactivity.go
@@ -116,8 +116,6 @@ func (s *Server) takeInactivityAction() {
 		return
 	}
 
-	mlog.Debug("Sending...")
-
 	for _, user := range users {
 
 		// See https://go.dev/doc/faq#closures_and_goroutines for why we make this assignment

--- a/app/server_inactivity.go
+++ b/app/server_inactivity.go
@@ -17,6 +17,11 @@ import (
 const serverInactivityHours = 100
 
 func (s *Server) doInactivityCheck() {
+	if !*s.Config().EmailSettings.EnableInactivityEmail {
+		mlog.Info("No activity check because EnableInactivityEmail is false")
+		return
+	}
+
 	if !s.Config().FeatureFlags.EnableInactivityCheckJob {
 		mlog.Info("No activity check because EnableInactivityCheckJob feature flag is disabled")
 		return
@@ -110,6 +115,8 @@ func (s *Server) takeInactivityAction() {
 		mlog.Error("Failed to get system admins for inactivity check from Mattermost.")
 		return
 	}
+
+	mlog.Debug("Sending...")
 
 	for _, user := range users {
 

--- a/model/config.go
+++ b/model/config.go
@@ -1541,6 +1541,7 @@ type EmailSettings struct {
 	LoginButtonColor                  *string `access:"experimental_features"`
 	LoginButtonBorderColor            *string `access:"experimental_features"`
 	LoginButtonTextColor              *string `access:"experimental_features"`
+	EnableInactivityEmail             *bool
 }
 
 func (s *EmailSettings) SetDefaults(isUpdate bool) {
@@ -1682,6 +1683,10 @@ func (s *EmailSettings) SetDefaults(isUpdate bool) {
 
 	if s.LoginButtonTextColor == nil {
 		s.LoginButtonTextColor = NewString("#2389D7")
+	}
+
+	if s.EnableInactivityEmail == nil {
+		s.EnableInactivityEmail = NewBool(true)
 	}
 }
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -567,7 +567,7 @@ func (ts *TelemetryService) trackConfig() {
 		"isdefault_login_button_border_color":  isDefault(*cfg.EmailSettings.LoginButtonBorderColor, ""),
 		"isdefault_login_button_text_color":    isDefault(*cfg.EmailSettings.LoginButtonTextColor, ""),
 		"smtp_server_timeout":                  *cfg.EmailSettings.SMTPServerTimeout,
-		"enable_inactivity_email":              *&cfg.EmailSettings.EnableInactivityEmail,
+		"enable_inactivity_email":              *cfg.EmailSettings.EnableInactivityEmail,
 	})
 
 	ts.SendTelemetry(TrackConfigRate, map[string]interface{}{

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -567,6 +567,7 @@ func (ts *TelemetryService) trackConfig() {
 		"isdefault_login_button_border_color":  isDefault(*cfg.EmailSettings.LoginButtonBorderColor, ""),
 		"isdefault_login_button_text_color":    isDefault(*cfg.EmailSettings.LoginButtonTextColor, ""),
 		"smtp_server_timeout":                  *cfg.EmailSettings.SMTPServerTimeout,
+		"enable_inactivity_email":              *&cfg.EmailSettings.EnableInactivityEmail,
 	})
 
 	ts.SendTelemetry(TrackConfigRate, map[string]interface{}{

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -164,7 +164,8 @@
         "EmailNotificationContentsType": "full",
         "LoginButtonColor": "",
         "LoginButtonBorderColor": "",
-        "LoginButtonTextColor": ""
+        "LoginButtonTextColor": "",
+        "EnableInactivityEmail": true
     },
     "RateLimitSettings": {
         "Enable": false,


### PR DESCRIPTION
#### Summary
This PR adds a configuration in the config.json file , `EnableInactivityEmail` to toggle the ability to send inactivity email notifications

#### Ticket Link

```release-note
Added configuration `EmailSettings.EnableInactivityEmail` to toggle ability to send inactivity email notification to admins
```
