### PR TITLE
app/products: add dependency resolver

### DIFF
--- a/app/channels.go
+++ b/app/channels.go
@@ -96,13 +96,15 @@ type Channels struct {
 }
 
 func init() {
-	RegisterProduct("channels", func(s *Server, services map[ServiceKey]interface{}) (Product, error) {
-		return NewChannels(s, services)
-	})
-	RegisterProductDependencies("channels", map[ServiceKey]struct{}{
-		ConfigKey:    {},
-		LicenseKey:   {},
-		FilestoreKey: {},
+	RegisterProduct("channels", ProductManifest{
+		Initializer: func(s *Server, services map[ServiceKey]interface{}) (Product, error) {
+			return NewChannels(s, services)
+		},
+		Dependencies: map[ServiceKey]struct{}{
+			ConfigKey:    {},
+			LicenseKey:   {},
+			FilestoreKey: {},
+		},
 	})
 }
 

--- a/app/channels.go
+++ b/app/channels.go
@@ -99,10 +99,14 @@ func init() {
 	RegisterProduct("channels", func(s *Server, services map[ServiceKey]interface{}) (Product, error) {
 		return NewChannels(s, services)
 	})
+	RegisterProductDependencies("channels", map[ServiceKey]struct{}{
+		ConfigKey:    {},
+		LicenseKey:   {},
+		FilestoreKey: {},
+	})
 }
 
 func NewChannels(s *Server, services map[ServiceKey]interface{}) (*Channels, error) {
-
 	ch := &Channels{
 		srv:           s,
 		imageProxy:    imageproxy.MakeImageProxy(s, s.httpService, s.Log),

--- a/app/product.go
+++ b/app/product.go
@@ -3,13 +3,75 @@
 
 package app
 
+import (
+	"github.com/pkg/errors"
+)
+
 type Product interface {
 	Start() error
 	Stop() error
 }
 
-var products = make(map[string]func(*Server, map[ServiceKey]interface{}) (Product, error))
+type ProductInitializer func(*Server, map[ServiceKey]interface{}) (Product, error)
 
-func RegisterProduct(name string, f func(*Server, map[ServiceKey]interface{}) (Product, error)) {
+var products = make(map[string]ProductInitializer)
+
+var dependencies = make(map[string]map[ServiceKey]struct{})
+
+func RegisterProduct(name string, f ProductInitializer) {
 	products[name] = f
+}
+
+func RegisterProductDependencies(name string, dependencyMap map[ServiceKey]struct{}) {
+	dependencies[name] = dependencyMap
+}
+
+func (s *Server) initializeProducts(
+	productMap map[string]ProductInitializer,
+	serviceMap map[ServiceKey]interface{},
+	dependencyMap map[string]map[ServiceKey]struct{},
+) error {
+	// create a product map to consume
+	pmap := make(map[string]struct{})
+	for name := range productMap {
+		pmap[name] = struct{}{}
+	}
+
+	maxTry := len(pmap) * len(pmap)
+
+	for len(pmap) > 0 && maxTry != 0 {
+	initLoop:
+		for product := range pmap {
+			productDependencies, ok := dependencyMap[product]
+			if ok {
+				// we have dependencies defined. Here we check if the serviceMap
+				// has all the dependencies registered. If not, we continue to the
+				// loop to let other products initialize and register their services
+				// if they have any.
+				for key := range productDependencies {
+					if _, ok := serviceMap[key]; !ok {
+						maxTry--
+						continue initLoop
+					}
+				}
+			}
+
+			// some products can register themselves/their services
+			initializer := productMap[product]
+			prod, err2 := initializer(s, serviceMap)
+			if err2 != nil {
+				return errors.Wrapf(err2, "error initializing product: %s", product)
+			}
+			s.products[product] = prod
+
+			// we remove this product from the map to not try to initialize it again
+			delete(pmap, product)
+		}
+	}
+
+	if maxTry == 0 && len(pmap) != 0 {
+		return errors.New("could not initialize products, possible circular dependency occurred")
+	}
+
+	return nil
 }

--- a/app/product_test.go
+++ b/app/product_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testSrvKey1 = "test_1"
+	testSrvKey2 = "test_2"
+)
+
+type productA struct{}
+
+func newProductA(s *Server, m map[ServiceKey]interface{}) (Product, error) {
+	m[testSrvKey1] = nil
+	return &productA{}, nil
+}
+
+func (p *productA) Start() error { return nil }
+func (p *productA) Stop() error  { return nil }
+
+type productB struct{}
+
+func newProductB(s *Server, m map[ServiceKey]interface{}) (Product, error) {
+	m[testSrvKey2] = nil
+	return &productB{}, nil
+}
+
+func (p *productB) Start() error { return nil }
+func (p *productB) Stop() error  { return nil }
+
+func TestInitializeProducts(t *testing.T) {
+	t.Run("2 products and no circular dependency", func(t *testing.T) {
+		serviceMap := map[ServiceKey]interface{}{
+			ConfigKey:    nil,
+			LicenseKey:   nil,
+			FilestoreKey: nil,
+			ClusterKey:   nil,
+		}
+
+		dependencies := map[string]map[ServiceKey]struct{}{
+			"productA": {
+				ConfigKey:    {},
+				LicenseKey:   {},
+				FilestoreKey: {},
+				ClusterKey:   {},
+			},
+			"productB": {
+				ConfigKey:    {},
+				testSrvKey1:  {},
+				FilestoreKey: {},
+				ClusterKey:   {},
+			},
+		}
+
+		products := map[string]ProductInitializer{
+			"productA": newProductA,
+			"productB": newProductB,
+		}
+		server := &Server{
+			products: make(map[string]Product),
+		}
+
+		err := server.initializeProducts(products, serviceMap, dependencies)
+		require.NoError(t, err)
+		require.Len(t, server.products, 2)
+	})
+
+	t.Run("2 products and circular dependency", func(t *testing.T) {
+		serviceMap := map[ServiceKey]interface{}{
+			ConfigKey:    nil,
+			LicenseKey:   nil,
+			FilestoreKey: nil,
+			ClusterKey:   nil,
+		}
+
+		dependencies := map[string]map[ServiceKey]struct{}{
+			"productA": {
+				ConfigKey:    {},
+				LicenseKey:   {},
+				FilestoreKey: {},
+				ClusterKey:   {},
+				testSrvKey2:  {},
+			},
+			"productB": {
+				ConfigKey:    {},
+				testSrvKey1:  {},
+				FilestoreKey: {},
+				ClusterKey:   {},
+			},
+		}
+
+		products := map[string]ProductInitializer{
+			"productA": newProductA,
+			"productB": newProductB,
+		}
+		server := &Server{
+			products: make(map[string]Product),
+		}
+
+		err := server.initializeProducts(products, serviceMap, dependencies)
+		require.Error(t, err)
+	})
+
+	t.Run("2 products and one w/o any dependency", func(t *testing.T) {
+		serviceMap := map[ServiceKey]interface{}{
+			ConfigKey:    nil,
+			LicenseKey:   nil,
+			FilestoreKey: nil,
+			ClusterKey:   nil,
+		}
+
+		dependencies := map[string]map[ServiceKey]struct{}{
+			"productA": {
+				ConfigKey:  {},
+				LicenseKey: {},
+			},
+		}
+
+		products := map[string]ProductInitializer{
+			"productA": newProductA,
+			"productB": newProductB,
+		}
+		server := &Server{
+			products: make(map[string]Product),
+		}
+
+		err := server.initializeProducts(products, serviceMap, dependencies)
+		require.NoError(t, err)
+		require.Len(t, server.products, 2)
+	})
+}

--- a/app/product_test.go
+++ b/app/product_test.go
@@ -43,30 +43,31 @@ func TestInitializeProducts(t *testing.T) {
 			ClusterKey:   nil,
 		}
 
-		dependencies := map[string]map[ServiceKey]struct{}{
+		products := map[string]ProductManifest{
 			"productA": {
-				ConfigKey:    {},
-				LicenseKey:   {},
-				FilestoreKey: {},
-				ClusterKey:   {},
+				Initializer: newProductA,
+				Dependencies: map[ServiceKey]struct{}{
+					ConfigKey:    {},
+					LicenseKey:   {},
+					FilestoreKey: {},
+					ClusterKey:   {},
+				},
 			},
 			"productB": {
-				ConfigKey:    {},
-				testSrvKey1:  {},
-				FilestoreKey: {},
-				ClusterKey:   {},
+				Initializer: newProductB,
+				Dependencies: map[ServiceKey]struct{}{
+					ConfigKey:    {},
+					testSrvKey1:  {},
+					FilestoreKey: {},
+					ClusterKey:   {},
+				},
 			},
-		}
-
-		products := map[string]ProductInitializer{
-			"productA": newProductA,
-			"productB": newProductB,
 		}
 		server := &Server{
 			products: make(map[string]Product),
 		}
 
-		err := server.initializeProducts(products, serviceMap, dependencies)
+		err := server.initializeProducts(products, serviceMap)
 		require.NoError(t, err)
 		require.Len(t, server.products, 2)
 	})
@@ -79,31 +80,32 @@ func TestInitializeProducts(t *testing.T) {
 			ClusterKey:   nil,
 		}
 
-		dependencies := map[string]map[ServiceKey]struct{}{
+		products := map[string]ProductManifest{
 			"productA": {
-				ConfigKey:    {},
-				LicenseKey:   {},
-				FilestoreKey: {},
-				ClusterKey:   {},
-				testSrvKey2:  {},
+				Initializer: newProductA,
+				Dependencies: map[ServiceKey]struct{}{
+					ConfigKey:    {},
+					LicenseKey:   {},
+					FilestoreKey: {},
+					ClusterKey:   {},
+					testSrvKey2:  {},
+				},
 			},
 			"productB": {
-				ConfigKey:    {},
-				testSrvKey1:  {},
-				FilestoreKey: {},
-				ClusterKey:   {},
+				Initializer: newProductB,
+				Dependencies: map[ServiceKey]struct{}{
+					ConfigKey:    {},
+					testSrvKey1:  {},
+					FilestoreKey: {},
+					ClusterKey:   {},
+				},
 			},
-		}
-
-		products := map[string]ProductInitializer{
-			"productA": newProductA,
-			"productB": newProductB,
 		}
 		server := &Server{
 			products: make(map[string]Product),
 		}
 
-		err := server.initializeProducts(products, serviceMap, dependencies)
+		err := server.initializeProducts(products, serviceMap)
 		require.Error(t, err)
 	})
 
@@ -115,22 +117,23 @@ func TestInitializeProducts(t *testing.T) {
 			ClusterKey:   nil,
 		}
 
-		dependencies := map[string]map[ServiceKey]struct{}{
+		products := map[string]ProductManifest{
 			"productA": {
-				ConfigKey:  {},
-				LicenseKey: {},
+				Initializer: newProductA,
+				Dependencies: map[ServiceKey]struct{}{
+					ConfigKey:  {},
+					LicenseKey: {},
+				},
 			},
-		}
-
-		products := map[string]ProductInitializer{
-			"productA": newProductA,
-			"productB": newProductB,
+			"productB": {
+				Initializer: newProductB,
+			},
 		}
 		server := &Server{
 			products: make(map[string]Product),
 		}
 
-		err := server.initializeProducts(products, serviceMap, dependencies)
+		err := server.initializeProducts(products, serviceMap)
 		require.NoError(t, err)
 		require.Len(t, server.products, 2)
 	})

--- a/app/server.go
+++ b/app/server.go
@@ -378,7 +378,7 @@ func NewServer(options ...Option) (*Server, error) {
 
 	// Step 8: Initialize products.
 	// Depends on s.httpService.
-	err = s.initializeProducts(products, serviceMap, dependencies)
+	err = s.initializeProducts(products, serviceMap)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize products")
 	}

--- a/app/server.go
+++ b/app/server.go
@@ -378,13 +378,9 @@ func NewServer(options ...Option) (*Server, error) {
 
 	// Step 8: Initialize products.
 	// Depends on s.httpService.
-	for name, initializer := range products {
-		prod, err2 := initializer(s, serviceMap)
-		if err2 != nil {
-			return nil, errors.Wrapf(err2, "error initializing product: %s", name)
-		}
-
-		s.products[name] = prod
+	err = s.initializeProducts(products, serviceMap, dependencies)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize products")
 	}
 
 	// It is important to initialize the hub only after the global logger is set


### PR DESCRIPTION
#### Summary
Introduced another app function `RegisterProductDependencies(name, dependencyMap)` to let products register their dependencies and the dependency map will be resolved during product initialization. It automatically figures out the initialization order by trial and error fashion.

I looked at the literature and this was being made with implementing a sorting algorithm on a tree data structure. I implemented this before checking literature but it's more or less the same with different data structures. 

#### Release Note
```release-note
NONE
```
