### PR TITLE
MM-41407_Remove FF for MM-39053 Default Notifications

### DIFF
--- a/app/users/users.go
+++ b/app/users/users.go
@@ -63,15 +63,6 @@ func (us *UserService) createUser(user *model.User) (*model.User, error) {
 		return nil, err
 	}
 
-	if us.config().FeatureFlags.NewAccountNoisy {
-		user.SetDefaultNotifications()
-		user.NotifyProps[model.DesktopNotifyProp] = model.UserNotifyAll
-		user.NotifyProps[model.PushNotifyProp] = model.UserNotifyAll
-		user.NotifyProps[model.ChannelMentionsNotifyProp] = "true"
-		user.NotifyProps[model.MentionKeysNotifyProp] = user.Username
-		user.NotifyProps[model.FirstNameNotifyProp] = "true"
-	}
-
 	ruser, err := us.store.Save(user)
 	if err != nil {
 		return nil, err

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -38,9 +38,6 @@ type FeatureFlags struct {
 
 	PermalinkPreviews bool
 
-	// Determine whether when a user gets created, they'll have noisy notifications e.g. Send desktop notifications for all activity
-	NewAccountNoisy bool
-
 	// Enable Calls plugin support in the mobile app
 	CallsMobile bool
 
@@ -85,7 +82,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PluginApps = ""
 	f.PluginFocalboard = ""
 	f.PermalinkPreviews = true
-	f.NewAccountNoisy = false
 	f.CallsMobile = false
 	f.BoardsFeatureFlags = ""
 	f.AddMembersToChannel = "top"


### PR DESCRIPTION
#### Summary
Remove `NewAccountNoisy` Feature Flag ([MM-39053](https://mattermost.atlassian.net/browse/MM-39053)) and set control or “none” as default variation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41407

#### Release Note
```release-note
NONE
```
