### PR TITLE
MM-35344: Trust Requester for webhook endpoints

### DIFF
--- a/web/webhook.go
+++ b/web/webhook.go
@@ -18,8 +18,8 @@ import (
 )
 
 func (w *Web) InitWebhooks() {
-	w.MainRouter.Handle("/hooks/commands/{id:[A-Za-z0-9]+}", w.NewHandler(commandWebhook)).Methods("POST")
-	w.MainRouter.Handle("/hooks/{id:[A-Za-z0-9]+}", w.NewHandler(incomingWebhook)).Methods("POST")
+	w.MainRouter.Handle("/hooks/commands/{id:[A-Za-z0-9]+}", w.APIHandlerTrustRequester(commandWebhook)).Methods("POST")
+	w.MainRouter.Handle("/hooks/{id:[A-Za-z0-9]+}", w.APIHandlerTrustRequester(incomingWebhook)).Methods("POST")
 }
 
 func incomingWebhook(c *Context, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Without this, the endpoint throws CSRF warnings
if a token is passed.

https://mattermost.atlassian.net/browse/MM-35344

```release-note
NONE
```
