### PR TITLE
MM-42092: Add better debugging for TestDeleteChannel

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -1737,7 +1737,6 @@ func TestSearchGroupChannels(t *testing.T) {
 }
 
 func TestDeleteChannel(t *testing.T) {
-	t.Skip("https://mattermost.atlassian.net/browse/MM-42092")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 	c := th.Client
@@ -1752,7 +1751,8 @@ func TestDeleteChannel(t *testing.T) {
 		require.NoError(t, err)
 
 		ch, appErr := th.App.GetChannel(publicChannel1.Id)
-		require.True(t, appErr != nil || ch.DeleteAt != 0, "should have failed to get deleted channel, or returned one with a populated DeleteAt.")
+		require.Nilf(t, appErr, "Expected nil, Got %v", appErr)
+		require.True(t, ch.DeleteAt != 0, "should have returned one with a populated DeleteAt.")
 
 		post1 := &model.Post{ChannelId: publicChannel1.Id, Message: "a" + GenerateTestId() + "a"}
 		_, resp, _ := client.CreatePost(post1)


### PR DESCRIPTION
When the test fails, it is not clear whether the method
returned an error or it returned a channel with DeleteAt
set to 0. The if condition was also incorrect because
if the error was not-nil the condition would evaluate
to true and the test would pass.

We split the condition into 2 separate cases which will
let us know exactly what is failing.

https://mattermost.atlassian.net/browse/MM-42092

```release-note
NONE
```
