### PR TITLE
[MM-42822] Check for and return HTTP 451 for all trial requests

### DIFF
--- a/app/license.go
+++ b/app/license.go
@@ -340,6 +340,11 @@ func (s *Server) RequestTrialLicense(trialRequest *model.TrialLicenseRequest) *m
 	}
 	defer resp.Body.Close()
 
+	// CloudFlare sitting in front of the Customer Portal will block this request with a 451 response code in the event that the request originates from a country sanctioned by the U.S. Government.
+	if resp.StatusCode == 451 {
+		return model.NewAppError("RequestTrialLicense", "api.license.request_trial_license.embargoed", nil, "Request for trial license came from an embargoed country", http.StatusUnavailableForLegalReasons)
+	}
+
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return model.NewAppError("RequestTrialLicense", "api.license.request_trial_license.app_error", nil,
 			fmt.Sprintf("Unexpected HTTP status code %q returned by server", resp.Status), http.StatusInternalServerError)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2002,6 +2002,10 @@
     "translation": "Unable to get a trial license, please try again or contact with support@mattermost.com."
   },
   {
+    "id": "api.license.request_trial_license.embargoed",
+    "translation": "We were unable to process the request due to limitations for embargoed countries. [Learn more in our documentation](https://mattermost.com/pl/limitations-for-embargoed-countries), or reach out to legal@mattermost.com for questions around export limitations."
+  },
+  {
     "id": "api.license.request_trial_license.fail_get_user_count.app_error",
     "translation": "Unable to get a trial license, please try again or contact with support@mattermost.com. Cannot obtain the number of registered users."
   },


### PR DESCRIPTION
#### Summary
Requests to generate certain licenses and trials should not be completed for those living in embargoed countries. In areas where we don't already have export compliance screening available, we will be utilizing CloudFlare to geo block IP's based on location. In the event someone hits this block, CloudFlare will respond with HTTP 451. This MR exposes this status code to the front-end, so that it can display a custom error to the user explaining why their request failed. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42822

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
