### PR TITLE
MM-42919: avoid sequential scan on Posts

### DIFF
--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -358,12 +358,13 @@ func (s *SqlThreadStore) GetTeamsUnreadForUser(userID string, teamIDs []string) 
 	go func() {
 		defer wg.Done()
 		repliesQuery, repliesQueryArgs, err := s.getQueryBuilder().
-			Select("COUNT(DISTINCT(Posts.RootId)) AS Count, TeamId").
-			From("Posts").
-			LeftJoin("ThreadMemberships ON Posts.RootId = ThreadMemberships.PostId").
-			LeftJoin("Channels ON Posts.ChannelId = Channels.Id").
+			Select("COUNT(Threads.PostId) AS Count, TeamId").
+			From("Threads").
+			LeftJoin("ThreadMemberships ON Threads.PostId = ThreadMemberships.PostId").
+			LeftJoin("Channels ON Threads.ChannelId = Channels.Id").
+			LeftJoin("Posts ON Posts.Id = Threads.PostId").
 			Where(fetchConditions).
-			Where("Posts.CreateAt > ThreadMemberships.LastViewed").
+			Where("Threads.LastReplyAt > ThreadMemberships.LastViewed").
 			GroupBy("Channels.TeamId").
 			ToSql()
 		if err != nil {


### PR DESCRIPTION
#### Summary
On Postgres, `GetTeamsUnreadForUser` triggers a sequential scan on `Posts`. We can avoid this by querying the `Threads` table directly and only joining to `Posts` to eliminate deleted threads. (We could avoid the latter if we later denormalize `DeleteAt` onto `Threads`.)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-42919

#### Release Note
```release-note
Improve performance of GetTeamsUnreadForUser when collapsed reply threads is enabled.
```
