### PR TITLE
bugfix: post edit time limit is not a licensed feature anymore

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -598,11 +598,9 @@ func (a *App) UpdatePost(c *request.Context, post *model.Post, safeUpdate bool) 
 		return nil, err
 	}
 
-	if a.Srv().License() != nil {
-		if *a.Config().ServiceSettings.PostEditTimeLimit != -1 && model.GetMillis() > oldPost.CreateAt+int64(*a.Config().ServiceSettings.PostEditTimeLimit*1000) && post.Message != oldPost.Message {
-			err = model.NewAppError("UpdatePost", "api.post.update_post.permissions_time_limit.app_error", map[string]interface{}{"timeLimit": *a.Config().ServiceSettings.PostEditTimeLimit}, "", http.StatusBadRequest)
-			return nil, err
-		}
+	if *a.Config().ServiceSettings.PostEditTimeLimit != -1 && model.GetMillis() > oldPost.CreateAt+int64(*a.Config().ServiceSettings.PostEditTimeLimit*1000) && post.Message != oldPost.Message {
+		err = model.NewAppError("UpdatePost", "api.post.update_post.permissions_time_limit.app_error", map[string]interface{}{"timeLimit": *a.Config().ServiceSettings.PostEditTimeLimit}, "", http.StatusBadRequest)
+		return nil, err
 	}
 
 	channel, err := a.GetChannel(oldPost.ChannelId)


### PR DESCRIPTION
#### Summary
According to the [docs](https://docs.mattermost.com/configure/deprecated-configuration-settings.html#allow-users-to-edit-their-messages) the time limit on post editing is not a feature you need a license for. 

So this PR removes the license guard around the handling for this.

There is a related bug regarding the post edit time limit setting here: [MM-42961](https://mattermost.atlassian.net/browse/MM-42961)

#### Screenshots of the UI
**unlicensed server**
![Screenshot 2022-04-01 at 11 12 03](https://user-images.githubusercontent.com/32863416/161233454-246c8975-87f4-44b2-9b2c-42e193a3729c.png)

**ui is not guarded** 
![Screenshot 2022-04-01 at 11 12 15](https://user-images.githubusercontent.com/32863416/161233478-f76fa086-dcd5-4836-beba-d183ee2927b7.png)

#### Ticket Link
n/a

#### Release Note
```release-note
PostEditTimelimit setting now works without a license
```
