### PR TITLE
[MM-42522] - The reply-to email address in our Cloud trial emails is no-reply@mattermost.com instead of feedback-cloud@mattermost.com

### DIFF
--- a/app/email/email.go
+++ b/app/email/email.go
@@ -244,9 +244,10 @@ func (es *Service) SendCloudTrialEndWarningEmail(userEmail, name, trialEndDate, 
 		return err
 	}
 
-	if err := es.sendMail(userEmail, subject, body); err != nil {
+	if err := es.sendEmailWithCustomReplyTo(userEmail, subject, body, *es.config().SupportSettings.SupportEmail); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -271,9 +272,10 @@ func (es *Service) SendCloudTrialEndedEmail(userEmail, name, locale, siteURL str
 		return err
 	}
 
-	if err := es.sendMail(userEmail, subject, body); err != nil {
+	if err := es.sendEmailWithCustomReplyTo(userEmail, subject, body, *es.config().SupportSettings.SupportEmail); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -832,7 +834,7 @@ func (es *Service) SendPaymentFailedEmail(email string, locale string, failedPay
 		return false, err
 	}
 
-	if err := es.sendMail(email, subject, body); err != nil {
+	if err := es.sendEmailWithCustomReplyTo(email, subject, body, *es.config().SupportSettings.SupportEmail); err != nil {
 		return false, err
 	}
 
@@ -859,7 +861,7 @@ func (es *Service) SendNoCardPaymentFailedEmail(email string, locale string, sit
 		return err
 	}
 
-	if err := es.sendMail(email, subject, body); err != nil {
+	if err := es.sendEmailWithCustomReplyTo(email, subject, body, *es.config().SupportSettings.SupportEmail); err != nil {
 		return err
 	}
 

--- a/app/email/email.go
+++ b/app/email/email.go
@@ -310,7 +310,7 @@ func (es *Service) SendCloudWelcomeEmail(userEmail, locale, teamInviteID, workSp
 		return err
 	}
 
-	if err := es.sendMail(userEmail, subject, body); err != nil {
+	if err := es.sendEmailWithCustomReplyTo(userEmail, subject, body, *es.config().SupportSettings.SupportEmail); err != nil {
 		return err
 	}
 
@@ -671,16 +671,23 @@ func (es *Service) sendMail(to, subject, htmlBody string) error {
 	return es.sendMailWithCC(to, subject, htmlBody, "")
 }
 
+func (es *Service) sendEmailWithCustomReplyTo(to, subject, htmlBody, replyToAddress string) error {
+	license := es.license()
+	mailConfig := es.mailServiceConfig(replyToAddress)
+
+	return mail.SendMailUsingConfig(to, subject, htmlBody, mailConfig, license != nil && *license.Features.Compliance, "")
+}
+
 func (es *Service) sendMailWithCC(to, subject, htmlBody string, ccMail string) error {
 	license := es.license()
-	mailConfig := es.mailServiceConfig()
+	mailConfig := es.mailServiceConfig("")
 
 	return mail.SendMailUsingConfig(to, subject, htmlBody, mailConfig, license != nil && *license.Features.Compliance, ccMail)
 }
 
 func (es *Service) SendMailWithEmbeddedFiles(to, subject, htmlBody string, embeddedFiles map[string]io.Reader) error {
 	license := es.license()
-	mailConfig := es.mailServiceConfig()
+	mailConfig := es.mailServiceConfig("")
 
 	return mail.SendMailWithEmbeddedFilesUsingConfig(to, subject, htmlBody, embeddedFiles, mailConfig, license != nil && *license.Features.Compliance, "")
 }

--- a/app/email/email_test.go
+++ b/app/email/email_test.go
@@ -260,3 +260,61 @@ func TestSendCloudTrialEndedEmail(t *testing.T) {
 		verifyMailbox(t)
 	})
 }
+
+func TestMailServiceConfig(t *testing.T) {
+	configuredReplyTo := "feedbackexample@test.com"
+	customReplyTo := "customreplyto@test.com"
+
+	emailService := Service{
+		config: func() *model.Config {
+			return &model.Config{
+				ServiceSettings: model.ServiceSettings{
+					SiteURL: model.NewString(""),
+				},
+				EmailSettings: model.EmailSettings{
+					EnableSignUpWithEmail:             new(bool),
+					EnableSignInWithEmail:             new(bool),
+					EnableSignInWithUsername:          new(bool),
+					SendEmailNotifications:            new(bool),
+					UseChannelInEmailNotifications:    new(bool),
+					RequireEmailVerification:          new(bool),
+					FeedbackName:                      new(string),
+					FeedbackEmail:                     new(string),
+					ReplyToAddress:                    model.NewString(configuredReplyTo),
+					FeedbackOrganization:              new(string),
+					EnableSMTPAuth:                    new(bool),
+					SMTPUsername:                      new(string),
+					SMTPPassword:                      new(string),
+					SMTPServer:                        new(string),
+					SMTPPort:                          new(string),
+					SMTPServerTimeout:                 new(int),
+					ConnectionSecurity:                new(string),
+					SendPushNotifications:             new(bool),
+					PushNotificationServer:            new(string),
+					PushNotificationContents:          new(string),
+					PushNotificationBuffer:            new(int),
+					EnableEmailBatching:               new(bool),
+					EmailBatchingBufferSize:           new(int),
+					EmailBatchingInterval:             new(int),
+					EnablePreviewModeBanner:           new(bool),
+					SkipServerCertificateVerification: new(bool),
+					EmailNotificationContentsType:     new(string),
+					LoginButtonColor:                  new(string),
+					LoginButtonBorderColor:            new(string),
+					LoginButtonTextColor:              new(string),
+					EnableInactivityEmail:             new(bool),
+				},
+			}
+		},
+	}
+
+	t.Run("use custom replyto instead of configured replyto", func(t *testing.T) {
+		mailConfig := emailService.mailServiceConfig(customReplyTo)
+		require.Equal(t, customReplyTo, mailConfig.ReplyToAddress)
+	})
+
+	t.Run("use configured replyto", func(t *testing.T) {
+		mailConfig := emailService.mailServiceConfig("")
+		require.Equal(t, configuredReplyTo, mailConfig.ReplyToAddress)
+	})
+}

--- a/app/email/utils.go
+++ b/app/email/utils.go
@@ -8,9 +8,14 @@ import (
 	"github.com/mattermost/mattermost-server/v6/utils"
 )
 
-func (es *Service) mailServiceConfig() *mail.SMTPConfig {
+func (es *Service) mailServiceConfig(replyToAddress string) *mail.SMTPConfig {
 	emailSettings := es.config().EmailSettings
 	hostname := utils.GetHostnameFromSiteURL(*es.config().ServiceSettings.SiteURL)
+
+	if replyToAddress == "" {
+		replyToAddress = *emailSettings.ReplyToAddress
+	}
+
 	cfg := mail.SMTPConfig{
 		Hostname:                          hostname,
 		ConnectionSecurity:                *emailSettings.ConnectionSecurity,
@@ -25,7 +30,7 @@ func (es *Service) mailServiceConfig() *mail.SMTPConfig {
 		SendEmailNotifications:            *emailSettings.SendEmailNotifications,
 		FeedbackName:                      *emailSettings.FeedbackName,
 		FeedbackEmail:                     *emailSettings.FeedbackEmail,
-		ReplyToAddress:                    *emailSettings.ReplyToAddress,
+		ReplyToAddress:                    replyToAddress,
 	}
 	return &cfg
 }


### PR DESCRIPTION
#### Summary
We need to customize the reply to address for some cloud emails like the welcome email. This PR makes it possible.

#### Ticket Link
[MM-42522](https://mattermost.atlassian.net/browse/MM-42522)

#### Release Note

```release-note
NONE
```
