### PR TITLE
MM-43077  Allow inline json for advanced logging config

### DIFF
--- a/app/audit.go
+++ b/app/audit.go
@@ -108,14 +108,14 @@ func (s *Server) configureAudit(adt *audit.Audit, bAllowAdvancedLogging bool) er
 	adt.OnError = s.onAuditError
 
 	var logConfigSrc config.LogConfigSrc
-	dsn := *s.Config().ExperimentalAuditSettings.AdvancedLoggingConfig
-	if bAllowAdvancedLogging && dsn != "" {
+	dsn := s.Config().ExperimentalAuditSettings.AdvancedLoggingConfig
+	if bAllowAdvancedLogging && len(dsn) > 2 {
 		var err error
 		logConfigSrc, err = config.NewLogConfigSrc(dsn, s.configStore.Store)
 		if err != nil {
 			return fmt.Errorf("invalid config source for audit, %w", err)
 		}
-		mlog.Debug("Loaded audit configuration", mlog.String("source", dsn))
+		mlog.Debug("Loaded audit configuration", mlog.String("source", string(dsn)))
 	}
 
 	// ExperimentalAuditSettings provides basic file audit (E0, E10); logConfigSrc provides advanced config (E20).

--- a/app/server.go
+++ b/app/server.go
@@ -817,14 +817,14 @@ func (s *Server) configureLogger(name string, logger *mlog.Logger, logSettings *
 	// file is loaded.  If no valid E20 license exists then advanced logging will be
 	// shutdown once license is loaded/checked.
 	var err error
-	dsn := *logSettings.AdvancedLoggingConfig
+	dsn := logSettings.AdvancedLoggingConfig
 	var logConfigSrc config.LogConfigSrc
-	if dsn != "" {
+	if len(dsn) > 2 {
 		logConfigSrc, err = config.NewLogConfigSrc(dsn, configStore)
 		if err != nil {
 			return fmt.Errorf("invalid config source for %s, %w", name, err)
 		}
-		mlog.Info("Loaded configuration for "+name, mlog.String("source", dsn))
+		mlog.Info("Loaded configuration for "+name, mlog.String("source", logConfigSrc.String()))
 	}
 
 	cfg, err := config.MloggerConfigFromLoggerConfig(logSettings, logConfigSrc, getPath)

--- a/config/migrate.go
+++ b/config/migrate.go
@@ -33,8 +33,8 @@ func Migrate(from, to string) error {
 	}
 
 	// Only migrate advanced logging config if it is not embedded JSON.
-	if !isJSONMap(*sourceConfig.LogSettings.AdvancedLoggingConfig) {
-		files = append(files, *sourceConfig.LogSettings.AdvancedLoggingConfig)
+	if !isJSONMap(sourceConfig.LogSettings.AdvancedLoggingConfig) {
+		files = append(files, string(sourceConfig.LogSettings.AdvancedLoggingConfig))
 	}
 
 	files = append(files, sourceConfig.PluginSettings.SignaturePublicKeyFiles...)

--- a/model/config.go
+++ b/model/config.go
@@ -1163,18 +1163,18 @@ func (s *SqlSettings) SetDefaults(isUpdate bool) {
 }
 
 type LogSettings struct {
-	EnableConsole          *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	ConsoleLevel           *string `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	ConsoleJson            *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	EnableColor            *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"` // telemetry: none
-	EnableFile             *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	FileLevel              *string `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	FileJson               *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	FileLocation           *string `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	EnableWebhookDebugging *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"`
-	EnableDiagnostics      *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"` // telemetry: none
-	EnableSentry           *bool   `access:"environment_logging,write_restrictable,cloud_restrictable"` // telemetry: none
-	AdvancedLoggingConfig  *string `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	EnableConsole          *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	ConsoleLevel           *string         `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	ConsoleJson            *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	EnableColor            *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"` // telemetry: none
+	EnableFile             *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	FileLevel              *string         `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	FileJson               *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	FileLocation           *string         `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	EnableWebhookDebugging *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"`
+	EnableDiagnostics      *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"` // telemetry: none
+	EnableSentry           *bool           `access:"environment_logging,write_restrictable,cloud_restrictable"` // telemetry: none
+	AdvancedLoggingConfig  json.RawMessage `access:"environment_logging,write_restrictable,cloud_restrictable"`
 }
 
 func NewLogSettings() *LogSettings {
@@ -1229,19 +1229,19 @@ func (s *LogSettings) SetDefaults() {
 	}
 
 	if s.AdvancedLoggingConfig == nil {
-		s.AdvancedLoggingConfig = NewString("")
+		s.AdvancedLoggingConfig = json.RawMessage("{}")
 	}
 }
 
 type ExperimentalAuditSettings struct {
-	FileEnabled           *bool   `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	FileName              *string `access:"experimental_features,write_restrictable,cloud_restrictable"` // telemetry: none
-	FileMaxSizeMB         *int    `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	FileMaxAgeDays        *int    `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	FileMaxBackups        *int    `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	FileCompress          *bool   `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	FileMaxQueueSize      *int    `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	AdvancedLoggingConfig *string `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	FileEnabled           *bool           `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	FileName              *string         `access:"experimental_features,write_restrictable,cloud_restrictable"` // telemetry: none
+	FileMaxSizeMB         *int            `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	FileMaxAgeDays        *int            `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	FileMaxBackups        *int            `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	FileCompress          *bool           `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	FileMaxQueueSize      *int            `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	AdvancedLoggingConfig json.RawMessage `access:"experimental_features,write_restrictable,cloud_restrictable"`
 }
 
 func (s *ExperimentalAuditSettings) SetDefaults() {
@@ -1274,20 +1274,20 @@ func (s *ExperimentalAuditSettings) SetDefaults() {
 	}
 
 	if s.AdvancedLoggingConfig == nil {
-		s.AdvancedLoggingConfig = NewString("")
+		s.AdvancedLoggingConfig = json.RawMessage("{}")
 	}
 }
 
 type NotificationLogSettings struct {
-	EnableConsole         *bool   `access:"write_restrictable,cloud_restrictable"`
-	ConsoleLevel          *string `access:"write_restrictable,cloud_restrictable"`
-	ConsoleJson           *bool   `access:"write_restrictable,cloud_restrictable"`
-	EnableColor           *bool   `access:"write_restrictable,cloud_restrictable"` // telemetry: none
-	EnableFile            *bool   `access:"write_restrictable,cloud_restrictable"`
-	FileLevel             *string `access:"write_restrictable,cloud_restrictable"`
-	FileJson              *bool   `access:"write_restrictable,cloud_restrictable"`
-	FileLocation          *string `access:"write_restrictable,cloud_restrictable"`
-	AdvancedLoggingConfig *string `access:"write_restrictable,cloud_restrictable"`
+	EnableConsole         *bool           `access:"write_restrictable,cloud_restrictable"`
+	ConsoleLevel          *string         `access:"write_restrictable,cloud_restrictable"`
+	ConsoleJson           *bool           `access:"write_restrictable,cloud_restrictable"`
+	EnableColor           *bool           `access:"write_restrictable,cloud_restrictable"` // telemetry: none
+	EnableFile            *bool           `access:"write_restrictable,cloud_restrictable"`
+	FileLevel             *string         `access:"write_restrictable,cloud_restrictable"`
+	FileJson              *bool           `access:"write_restrictable,cloud_restrictable"`
+	FileLocation          *string         `access:"write_restrictable,cloud_restrictable"`
+	AdvancedLoggingConfig json.RawMessage `access:"write_restrictable,cloud_restrictable"`
 }
 
 func (s *NotificationLogSettings) SetDefaults() {
@@ -1324,7 +1324,7 @@ func (s *NotificationLogSettings) SetDefaults() {
 	}
 
 	if s.AdvancedLoggingConfig == nil {
-		s.AdvancedLoggingConfig = NewString("")
+		s.AdvancedLoggingConfig = json.RawMessage("{}")
 	}
 }
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -492,7 +492,7 @@ func (ts *TelemetryService) trackConfig() {
 		"file_json":                cfg.LogSettings.FileJson,
 		"enable_webhook_debugging": cfg.LogSettings.EnableWebhookDebugging,
 		"isdefault_file_location":  isDefault(cfg.LogSettings.FileLocation, ""),
-		"advanced_logging_config":  *cfg.LogSettings.AdvancedLoggingConfig != "",
+		"advanced_logging_config":  len(cfg.LogSettings.AdvancedLoggingConfig) > 2,
 	})
 
 	ts.SendTelemetry(TrackConfigAudit, map[string]interface{}{
@@ -502,7 +502,7 @@ func (ts *TelemetryService) trackConfig() {
 		"file_max_backups":        *cfg.ExperimentalAuditSettings.FileMaxBackups,
 		"file_compress":           *cfg.ExperimentalAuditSettings.FileCompress,
 		"file_max_queue_size":     *cfg.ExperimentalAuditSettings.FileMaxQueueSize,
-		"advanced_logging_config": *cfg.ExperimentalAuditSettings.AdvancedLoggingConfig != "",
+		"advanced_logging_config": len(cfg.ExperimentalAuditSettings.AdvancedLoggingConfig) > 2,
 	})
 
 	ts.SendTelemetry(TrackConfigNotificationLog, map[string]interface{}{
@@ -513,7 +513,7 @@ func (ts *TelemetryService) trackConfig() {
 		"file_level":              *cfg.NotificationLogSettings.FileLevel,
 		"file_json":               *cfg.NotificationLogSettings.FileJson,
 		"isdefault_file_location": isDefault(*cfg.NotificationLogSettings.FileLocation, ""),
-		"advanced_logging_config": *cfg.NotificationLogSettings.AdvancedLoggingConfig != "",
+		"advanced_logging_config": len(cfg.NotificationLogSettings.AdvancedLoggingConfig) > 2,
 	})
 
 	ts.SendTelemetry(TrackConfigPassword, map[string]interface{}{


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR addresses an issue that several customers and internal folks have tripped over.  Advanced logging allows for configuration to be inlined in config.json but the inlined JSON had to be escaped into a string.  

A better experience is to allow non-escaped inline JSON as people expect.  This requires backwards compatibility for any config using escaped JSON.  Note, inline JSON is also important for cloud config where ENV vars are used.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43077

#### Release Note
NONE