### PR TITLE
[MM-42355] Prepackage Calls v0.4.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ TEMPLATES_DIR=templates
 PLUGIN_PACKAGES ?= mattermost-plugin-antivirus-v0.1.2
 PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.2.2
 PLUGIN_PACKAGES += mattermost-plugin-aws-SNS-v1.2.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v0.4.8
 PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.3.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.0.1

--- a/build/release.mk
+++ b/build/release.mk
@@ -170,6 +170,11 @@ else
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH=$(PLUGIN_ARCH); \
+		if [ "$$ARCH" != "linux-amd64" ]; then \
+			case $$plugin_package in \
+				"mattermost-plugin-calls"*) continue ;; \
+			esac; \
+		fi; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH_GENERIC)/prepackaged_plugins; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_GENERIC)/prepackaged_plugins; \
 		HAS_ARCH=`tar -tf $(DIST_PATH_GENERIC)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
@@ -234,6 +239,9 @@ endif
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="windows-amd64"; \
+		case $$plugin_package in \
+			"mattermost-plugin-calls"*) continue ;; \
+		esac; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH_WIN)/prepackaged_plugins; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_WIN)/prepackaged_plugins; \
 		HAS_ARCH=`tar -tf $(DIST_PATH_WIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \


### PR DESCRIPTION
#### Summary

Adding Calls as pre-packaged plugin. PR is purposely targeting `release-6.6` branch as this is only expected to land on self-managed deployment for the time being in order to unblock some of our closed beta customers.

Had to add a couple of additional checks since Calls currently supports Linux platforms only as backend.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42355

#### Release Note

```release-note
Pre-package Calls v0.4.8
```
