### PR TITLE
MM-43137: Fix racy test TestUpdateActiveBotsSideEffect

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -912,7 +912,7 @@ func (a *App) UpdateActive(c *request.Context, user *model.User, active bool) (*
 			return nil, model.NewAppError("UpdateActive", "app.user.update.finding.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
-	ruser := userUpdate.New
+	ruser := userUpdate.New.DeepCopy()
 
 	if !active {
 		if err := a.RevokeAllSessions(ruser.Id); err != nil {

--- a/app/user.go
+++ b/app/user.go
@@ -912,7 +912,7 @@ func (a *App) UpdateActive(c *request.Context, user *model.User, active bool) (*
 			return nil, model.NewAppError("UpdateActive", "app.user.update.finding.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
-	ruser := userUpdate.New.DeepCopy()
+	ruser := userUpdate.New
 
 	if !active {
 		if err := a.RevokeAllSessions(ruser.Id); err != nil {

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -224,7 +224,7 @@ func (us SqlUserStore) Update(user *model.User, trustedUpdateData bool) (*model.
 
 	user.Sanitize(map[string]bool{})
 	oldUser.Sanitize(map[string]bool{})
-	return &model.UserUpdate{New: user, Old: &oldUser}, nil
+	return &model.UserUpdate{New: user.DeepCopy(), Old: &oldUser}, nil
 }
 
 func (us SqlUserStore) UpdateNotifyProps(userID string, props map[string]string) error {


### PR DESCRIPTION
This was introduced with https://github.com/mattermost/mattermost-server/commit/2e027ae9278d60f318e7c286fcbe5c88895cc23f.

We fix it by deep copying the user struct before sending
it to the websocket hub.

Sample failures:
https://app.circleci.com/pipelines/github/mattermost/mattermost-server/32721/workflows/50d2ac52-4ff8-4116-ab50-7eae7a3306e8/jobs/257286
https://app.circleci.com/pipelines/github/mattermost/mattermost-server/32721/workflows/50d2ac52-4ff8-4116-ab50-7eae7a3306e8/jobs/257287

https://mattermost.atlassian.net/browse/MM-43137

```release-note
NONE
```
