### PR TITLE
MM-42725: exclude channels from teams user has left

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2893,6 +2893,7 @@ func (s SqlChannelStore) Autocomplete(userID, term string, includeDeleted bool) 
 		Where(sq.And{
 			sq.Expr("c.TeamId = t.id"),
 			sq.Expr("t.id = tm.TeamId"),
+			sq.Eq{"tm.DeleteAt": 0},
 			sq.Eq{"tm.UserId": userID},
 			sq.Or{
 				sq.NotEq{"c.Type": model.ChannelTypePrivate},

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2893,7 +2893,6 @@ func (s SqlChannelStore) Autocomplete(userID, term string, includeDeleted bool) 
 		Where(sq.And{
 			sq.Expr("c.TeamId = t.id"),
 			sq.Expr("t.id = tm.TeamId"),
-			sq.Eq{"tm.DeleteAt": 0},
 			sq.Eq{"tm.UserId": userID},
 			sq.Or{
 				sq.NotEq{"c.Type": model.ChannelTypePrivate},
@@ -2908,7 +2907,10 @@ func (s SqlChannelStore) Autocomplete(userID, term string, includeDeleted bool) 
 		OrderBy("c.DisplayName")
 
 	if !includeDeleted {
-		query = query.Where(sq.Eq{"c.DeleteAt": 0})
+		query = query.Where(sq.And{
+			sq.Eq{"c.DeleteAt": 0},
+			sq.Eq{"tm.DeleteAt": 0},
+		})
 	}
 	searchClause := s.searchClause(term)
 	if searchClause != nil {

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -5903,6 +5903,44 @@ func testAutocomplete(t *testing.T, ss store.Store) {
 	_, err = ss.Channel().SaveMember(m5)
 	require.NoError(t, err)
 
+	t3 := &model.Team{
+		DisplayName: "t3",
+		Name:        NewTestId(),
+		Email:       MakeEmail(),
+		Type:        model.TeamOpen,
+	}
+	t3, err = ss.Team().Save(t3)
+	require.NoError(t, err)
+	leftTeamId := t3.Id
+
+	o5 := model.Channel{
+		TeamId:      leftTeamId,
+		DisplayName: "ChannelA3",
+		Name:        NewTestId(),
+		Type:        model.ChannelTypeOpen,
+	}
+	_, err = ss.Channel().Save(&o5, -1)
+	require.NoError(t, err)
+
+	m6 := model.ChannelMember{
+		ChannelId:   o5.Id,
+		UserId:      m1.UserId,
+		NotifyProps: model.GetDefaultChannelNotifyProps(),
+	}
+	_, err = ss.Channel().SaveMember(&m6)
+	require.NoError(t, err)
+
+	tm5 := &model.TeamMember{TeamId: leftTeamId, UserId: m1.UserId}
+	_, err = ss.Team().SaveMember(tm5, -1)
+	require.NoError(t, err)
+
+	err = ss.Channel().RemoveMember(o5.Id, m1.UserId)
+	require.NoError(t, err)
+	tm5.Roles = ""
+	tm5.DeleteAt = model.GetMillis()
+	_, err = ss.Team().UpdateMember(tm5)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		Description        string
 		UserID             string


### PR DESCRIPTION
#### Summary

Currently the channel switcher will display channels even from the teams you have left.

This commit excludes channels from "left" teams to be shown in the switcher.

PS: When a user leaves a team we soft-delete the TeamMembers entry for user-team.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42725

#### Release Note

```release-note
Fixes channel switcher showing channels from team the user is no longer part of
```
