### PR TITLE
Fix download mmctl script for cherry pick branches

### DIFF
--- a/scripts/download_mmctl_release.sh
+++ b/scripts/download_mmctl_release.sh
@@ -19,7 +19,7 @@ BIN_PATH=${2:-bin}
 THIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$THIS_BRANCH" =~ 'release-'[0-9] ]];
 then
-  RELEASE_TO_DOWNLOAD=$(echo $THIS_BRANCH | grep -Eo 'release-.*')
+  RELEASE_TO_DOWNLOAD=$(echo $THIS_BRANCH | grep -Eo 'release-([0-9](\.){0,1})+')
 else
   RELEASE_TO_DOWNLOAD=master
 fi


### PR DESCRIPTION
For cherry pick branches like `release-6.5-a4aa586`, mmctl download script tries to download artifacts from https://releases.mattermost.com/mmctl/release-6.5-a4aa586, however it should donwload artifacts from https://releases.mattermost.com/mmctl/release-6.5.

Fixed regex line to identify correct release name

```release-note
NONE
```
