### PR TITLE
MM-39565 - remove top option ab testing

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -41,9 +41,6 @@ type FeatureFlags struct {
 	// A dash separated list for feature flags to turn on for Boards
 	BoardsFeatureFlags string
 
-	// A/B test for the add members to channel button, possible values = ("top", "bottom")
-	AddMembersToChannel string
-
 	// Enable Create First Channel
 	GuidedChannelCreation bool
 
@@ -80,7 +77,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PermalinkPreviews = true
 	f.CallsMobile = false
 	f.BoardsFeatureFlags = ""
-	f.AddMembersToChannel = "top"
 	f.GuidedChannelCreation = false
 	f.InviteToTeam = "none"
 	f.CustomGroups = true


### PR DESCRIPTION
#### Summary
This PR removes the code that was used for the bottom option during the A/B test for adding members to channel button. The conclusion was that the top option performed better so we kept it.

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/10167

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39565

#### Release Note
```release-note
NONE
```
