### PR TITLE
MM-43340: Fix racy test TestGraphQLChannelMembers

### DIFF
--- a/api4/resolver_team.go
+++ b/api4/resolver_team.go
@@ -30,6 +30,7 @@ func getGraphQLTeam(ctx context.Context, id string) (*model.Team, error) {
 		return nil, err
 	}
 	team := result.(*model.Team)
+	team = team.ShallowCopy()
 
 	if (!team.AllowOpenInvite || team.Type != model.TeamOpen) &&
 		!c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), team.Id, model.PermissionViewTeam) {

--- a/model/team.go
+++ b/model/team.go
@@ -252,6 +252,12 @@ func (o *Team) IsGroupConstrained() bool {
 	return o.GroupConstrained != nil && *o.GroupConstrained
 }
 
+// ShallowCopy returns a shallow copy of team.
+func (o *Team) ShallowCopy() *Team {
+	c := *o
+	return &c
+}
+
 // The following are some GraphQL methods necessary to return the
 // data in float64 type. The spec doesn't support 64 bit integers,
 // so we have to pass the data in float64. The _ at the end is


### PR DESCRIPTION
We take a shallow copy of the team pointer before
we pass that to the other functions.

This is because the resolvers run in separate
goroutines.

https://mattermost.atlassian.net/browse/MM-43340

```release-note
NONE
```
