### PR TITLE
Add .gitpod.yml to use mattermost-gitpod-config repo for Gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,1 @@
+mainConfiguration: https://github.com/mattermost/mattermost-gitpod-config


### PR DESCRIPTION
#### Summary

This PR makes it so when this repository is used to create a Gitpod workspace, the configuration used will be delegated to the [mattermost-gitpod-config](https://github.com/mattermost/mattermost-gitpod-config) repo through its [.gitpod.yml](https://github.com/mattermost/mattermost-gitpod-config/blob/master/.gitpod.yml) file.

This allows multiple repos to share the same Gitpod config, as well as keeping the commit history minimal in regards to the individual repos.

https://www.gitpod.io/docs/references/gitpod-yml
https://www.gitpod.io/docs/multi-repo-workspaces

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43384

#### Release Note

```release-note
NONE
```
