### PR TITLE
[MM-43393]: replace .Decoder() method with .Token()

### DIFF
--- a/app/imaging/svg.go
+++ b/app/imaging/svg.go
@@ -39,18 +39,17 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 					values := strings.Fields(attr.Value)
 					if len(values) == 4 {
 						width := 0
-						_, err := fmt.Sscan(values[2], &width)
-
-						if err != nil {
-							svgInfo.Width = width
-						}
+						_, widthErr := fmt.Sscan(values[2], &width)
 
 						height := 0
-						_, err = fmt.Sscan(values[3], &height)
+						_, heightErr = fmt.Sscan(values[3], &height)
 
-						if err != nil {
-							svgInfo.Height = height
+						if widthErr != nil || heightErr != nil {
+							return svgInfo, err
 						}
+
+						svgInfo.Width = width
+						svgInfo.Height = height
 
 						return svgInfo, nil
 					}

--- a/app/imaging/svg.go
+++ b/app/imaging/svg.go
@@ -42,7 +42,7 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 						_, widthErr := fmt.Sscan(values[2], &width)
 
 						height := 0
-						_, heightErr = fmt.Sscan(values[3], &height)
+						_, heightErr := fmt.Sscan(values[3], &height)
 
 						if widthErr != nil || heightErr != nil {
 							return svgInfo, err

--- a/app/imaging/svg.go
+++ b/app/imaging/svg.go
@@ -5,8 +5,8 @@ package imaging
 
 import (
 	"encoding/xml"
-	"io"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -109,6 +109,4 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 
 	// commented out the above code since IMO this is not needed anymore with the approach using decoder.Token(),
 	// but for the case it is still valid to do it I just commented it out
-
-	return svgInfo, errors.New("unable to extract SVG dimensions")
 }

--- a/app/imaging/svg.go
+++ b/app/imaging/svg.go
@@ -6,8 +6,9 @@ package imaging
 import (
 	"encoding/xml"
 	"io"
-	"strconv"
+	"fmt"
 	"strings"
+
 	"github.com/pkg/errors"
 )
 
@@ -24,9 +25,6 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 		Height: 0,
 	}
 
-	// 	viewBoxPattern := regexp.MustCompile("^([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)$")
-	// 	dimensionPattern := regexp.MustCompile("(?i)^([0-9]+)(?:px)?$")
-
 	decoder := xml.NewDecoder(svgReader)
 
 	for {
@@ -40,12 +38,16 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 				if attr.Name.Local == "viewBox" {
 					values := strings.Fields(attr.Value)
 					if len(values) == 4 {
-						width, err := strconv.Atoi(values[2])
+						width := 0
+						_, err := fmt.Sscan(values[2], &width)
+
 						if err != nil {
 							svgInfo.Width = width
 						}
 
-						height, err := strconv.Atoi(values[3])
+						height := 0
+						_, err = fmt.Sscan(values[3], &height)
+
 						if err != nil {
 							svgInfo.Height = height
 						}
@@ -54,17 +56,23 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 					}
 				}
 				if attr.Name.Local == "width" {
-					width, err := strconv.Atoi(attr.Value)
+					width := 0
+					_, err := fmt.Sscan(attr.Value, &width)
+
 					if err != nil {
 						return svgInfo, err
 					}
+
 					svgInfo.Width = width
 				}
 				if attr.Name.Local == "height" {
-					height, err := strconv.Atoi(attr.Value)
+					height := 0
+					_, err := fmt.Sscan(attr.Value, &height)
+
 					if err != nil {
 						return svgInfo, err
 					}
+
 					svgInfo.Height = height
 				}
 			}
@@ -77,7 +85,8 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 		}
 	}
 
-	return svgInfo, errors.New("unable to extract SVG dimensions")
+	// 	viewBoxPattern := regexp.MustCompile("^([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)$")
+	// 	dimensionPattern := regexp.MustCompile("(?i)^([0-9]+)(?:px)?$")
 
 	// prefer viewbox for SVG dimensions over width/height
 	// 	if viewBoxMatches := viewBoxPattern.FindStringSubmatch(parsedSVG.ViewBox); len(viewBoxMatches) == 5 {
@@ -97,4 +106,9 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 	// 		return svgInfo, errors.New("unable to extract SVG dimensions")
 	// 	}
 	// 	return svgInfo, nil
+
+	// commented out the above code since IMO this is not needed anymore with the approach using decoder.Token(),
+	// but for the case it is still valid to do it I just commented it out
+
+	return svgInfo, errors.New("unable to extract SVG dimensions")
 }

--- a/app/imaging/svg.go
+++ b/app/imaging/svg.go
@@ -84,29 +84,4 @@ func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
 			return svgInfo, nil
 		}
 	}
-
-	// 	viewBoxPattern := regexp.MustCompile("^([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)$")
-	// 	dimensionPattern := regexp.MustCompile("(?i)^([0-9]+)(?:px)?$")
-
-	// prefer viewbox for SVG dimensions over width/height
-	// 	if viewBoxMatches := viewBoxPattern.FindStringSubmatch(parsedSVG.ViewBox); len(viewBoxMatches) == 5 {
-	// 		svgInfo.Width, _ = strconv.Atoi(viewBoxMatches[3])
-	// 		svgInfo.Height, _ = strconv.Atoi(viewBoxMatches[4])
-	// 	} else if parsedSVG.Width != "" && parsedSVG.Height != "" {
-	// 		widthMatches := dimensionPattern.FindStringSubmatch(parsedSVG.Width)
-	// 		heightMatches := dimensionPattern.FindStringSubmatch(parsedSVG.Height)
-	// 		if len(widthMatches) == 2 && len(heightMatches) == 2 {
-	// 			svgInfo.Width, _ = strconv.Atoi(widthMatches[1])
-	// 			svgInfo.Height, _ = strconv.Atoi(heightMatches[1])
-	// 		}
-	// 	}
-	//
-	// 	// if width and/or height are still zero, create new error
-	// 	if svgInfo.Width == 0 || svgInfo.Height == 0 {
-	// 		return svgInfo, errors.New("unable to extract SVG dimensions")
-	// 	}
-	// 	return svgInfo, nil
-
-	// commented out the above code since IMO this is not needed anymore with the approach using decoder.Token(),
-	// but for the case it is still valid to do it I just commented it out
 }

--- a/app/imaging/svg.go
+++ b/app/imaging/svg.go
@@ -6,9 +6,8 @@ package imaging
 import (
 	"encoding/xml"
 	"io"
-	"regexp"
 	"strconv"
-
+	"strings"
 	"github.com/pkg/errors"
 )
 
@@ -20,39 +19,82 @@ type SVGInfo struct {
 
 // ParseSVG returns information for the given SVG input data.
 func ParseSVG(svgReader io.Reader) (SVGInfo, error) {
-	var parsedSVG struct {
-		Width   string `xml:"width,attr,omitempty"`
-		Height  string `xml:"height,attr,omitempty"`
-		ViewBox string `xml:"viewBox,attr,omitempty"`
-	}
 	svgInfo := SVGInfo{
 		Width:  0,
 		Height: 0,
 	}
-	viewBoxPattern := regexp.MustCompile("^([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)$")
-	dimensionPattern := regexp.MustCompile("(?i)^([0-9]+)(?:px)?$")
 
-	// decode provided SVG
-	if err := xml.NewDecoder(svgReader).Decode(&parsedSVG); err != nil {
-		return svgInfo, err
-	}
+	// 	viewBoxPattern := regexp.MustCompile("^([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)[, ]+([0-9]+)$")
+	// 	dimensionPattern := regexp.MustCompile("(?i)^([0-9]+)(?:px)?$")
 
-	// prefer viewbox for SVG dimensions over width/height
-	if viewBoxMatches := viewBoxPattern.FindStringSubmatch(parsedSVG.ViewBox); len(viewBoxMatches) == 5 {
-		svgInfo.Width, _ = strconv.Atoi(viewBoxMatches[3])
-		svgInfo.Height, _ = strconv.Atoi(viewBoxMatches[4])
-	} else if parsedSVG.Width != "" && parsedSVG.Height != "" {
-		widthMatches := dimensionPattern.FindStringSubmatch(parsedSVG.Width)
-		heightMatches := dimensionPattern.FindStringSubmatch(parsedSVG.Height)
-		if len(widthMatches) == 2 && len(heightMatches) == 2 {
-			svgInfo.Width, _ = strconv.Atoi(widthMatches[1])
-			svgInfo.Height, _ = strconv.Atoi(heightMatches[1])
+	decoder := xml.NewDecoder(svgReader)
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return svgInfo, err
+		}
+		switch t := token.(type) {
+		case xml.StartElement:
+			for _, attr := range t.Attr {
+				if attr.Name.Local == "viewBox" {
+					values := strings.Fields(attr.Value)
+					if len(values) == 4 {
+						width, err := strconv.Atoi(values[2])
+						if err != nil {
+							svgInfo.Width = width
+						}
+
+						height, err := strconv.Atoi(values[3])
+						if err != nil {
+							svgInfo.Height = height
+						}
+
+						return svgInfo, nil
+					}
+				}
+				if attr.Name.Local == "width" {
+					width, err := strconv.Atoi(attr.Value)
+					if err != nil {
+						return svgInfo, err
+					}
+					svgInfo.Width = width
+				}
+				if attr.Name.Local == "height" {
+					height, err := strconv.Atoi(attr.Value)
+					if err != nil {
+						return svgInfo, err
+					}
+					svgInfo.Height = height
+				}
+			}
+
+			if svgInfo.Width == 0 || svgInfo.Height == 0 {
+				return svgInfo, errors.New("unable to extract SVG dimensions")
+			}
+
+			return svgInfo, nil
 		}
 	}
 
-	// if width and/or height are still zero, create new error
-	if svgInfo.Width == 0 || svgInfo.Height == 0 {
-		return svgInfo, errors.New("unable to extract SVG dimensions")
-	}
-	return svgInfo, nil
+	return svgInfo, errors.New("unable to extract SVG dimensions")
+
+	// prefer viewbox for SVG dimensions over width/height
+	// 	if viewBoxMatches := viewBoxPattern.FindStringSubmatch(parsedSVG.ViewBox); len(viewBoxMatches) == 5 {
+	// 		svgInfo.Width, _ = strconv.Atoi(viewBoxMatches[3])
+	// 		svgInfo.Height, _ = strconv.Atoi(viewBoxMatches[4])
+	// 	} else if parsedSVG.Width != "" && parsedSVG.Height != "" {
+	// 		widthMatches := dimensionPattern.FindStringSubmatch(parsedSVG.Width)
+	// 		heightMatches := dimensionPattern.FindStringSubmatch(parsedSVG.Height)
+	// 		if len(widthMatches) == 2 && len(heightMatches) == 2 {
+	// 			svgInfo.Width, _ = strconv.Atoi(widthMatches[1])
+	// 			svgInfo.Height, _ = strconv.Atoi(heightMatches[1])
+	// 		}
+	// 	}
+	//
+	// 	// if width and/or height are still zero, create new error
+	// 	if svgInfo.Width == 0 || svgInfo.Height == 0 {
+	// 		return svgInfo, errors.New("unable to extract SVG dimensions")
+	// 	}
+	// 	return svgInfo, nil
 }

--- a/app/imaging/svg_test.go
+++ b/app/imaging/svg_test.go
@@ -81,6 +81,6 @@ func TestParseProcInstOnlySVGData(t *testing.T) {
 	svg := strings.NewReader("<?xml version='1.0' encoding='utf-8'?>")
 	svgInfo, err := ParseSVG(svg)
 	require.NoError(t, err)
-    require.Equal(t, 0, svgInfo.Width)
-    require.Equal(t, 0, svgInfo.Height)
+	require.Equal(t, 0, svgInfo.Width)
+	require.Equal(t, 0, svgInfo.Height)
 }

--- a/app/imaging/svg_test.go
+++ b/app/imaging/svg_test.go
@@ -80,7 +80,7 @@ func TestParseInvalidSVGData(t *testing.T) {
 func TestParseProcInstOnlySVGData(t *testing.T) {
 	svg := strings.NewReader("<?xml version='1.0' encoding='utf-8'?>")
 	svgInfo, err := ParseSVG(svg)
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Equal(t, 0, svgInfo.Width)
 	require.Equal(t, 0, svgInfo.Height)
 }

--- a/app/imaging/svg_test.go
+++ b/app/imaging/svg_test.go
@@ -78,7 +78,7 @@ func TestParseInvalidSVGData(t *testing.T) {
 func TestParseProcInstOnlySVGData(t *testing.T) {
 	svg := strings.NewReader("<?xml version='1.0' encoding='utf-8'?>")
 	svgInfo, err := ParseSVG(svg)
-	if err == nil || svgInfo.Width != 0 || svgInfo.Height != 0 {
-		t.Errorf("Should not be able to parse SVG attributes, but was definitely able to!")
-	}
+	require.NoError(t, err)
+    require.Equal(t, 0, svgInfo.Width)
+    require.Equal(t, 0, svgInfo.Height)
 }

--- a/app/imaging/svg_test.go
+++ b/app/imaging/svg_test.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 //nolint:unparam

--- a/app/imaging/svg_test.go
+++ b/app/imaging/svg_test.go
@@ -74,3 +74,11 @@ func TestParseInvalidSVGData(t *testing.T) {
 		}
 	}
 }
+
+func TestParseProcInstOnlySVGData(t *testing.T) {
+	svg := strings.NewReader("<?xml version='1.0' encoding='utf-8'?>")
+	svgInfo, err := ParseSVG(svg)
+	if err == nil || svgInfo.Width != 0 || svgInfo.Height != 0 {
+		t.Errorf("Should not be able to parse SVG attributes, but was definitely able to!")
+	}
+}


### PR DESCRIPTION
#### Summary
title says it all.
This might need more polishing from someone more proficient in GO.

I commented out and left the block of code where it was checking with regexes for occurences of `viewbox` or `width`/`height` values as a fallback, since afaik a `SVG` with those attributes missing is broken anways.

#### Ticket Link
[MM-43393](https://mattermost.atlassian.net/browse/MM-43393)

#### Release Note
```release-note
NONE
```
