### PR TITLE
MM-42877: Fix TestGetFileHeaders

### DIFF
--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -818,10 +818,10 @@ func TestGetFileHeaders(t *testing.T) {
 	t.Run("txt", testHeaders(data, "test.txt", "text/plain", false, false))
 	t.Run("html", testHeaders(data, "test.html", "text/plain", false, false))
 	t.Run("js", testHeaders(data, "test.js", "text/plain", false, false))
-	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-		t.Run("go", testHeaders(data, "test.go", "text/x-go; charset=utf-8", false, false))
-	} else {
+	if os.Getenv("IS_CI") == "true" {
 		t.Run("go", testHeaders(data, "test.go", "application/octet-stream", false, false))
+	} else if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		t.Run("go", testHeaders(data, "test.go", "text/x-go; charset=utf-8", false, false))
 	}
 	t.Run("zip", testHeaders(data, "test.zip", "application/zip", false, false))
 	// Not every platform can recognize these

--- a/api4/file_test.go
+++ b/api4/file_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -817,7 +818,11 @@ func TestGetFileHeaders(t *testing.T) {
 	t.Run("txt", testHeaders(data, "test.txt", "text/plain", false, false))
 	t.Run("html", testHeaders(data, "test.html", "text/plain", false, false))
 	t.Run("js", testHeaders(data, "test.js", "text/plain", false, false))
-	t.Run("go", testHeaders(data, "test.go", "application/octet-stream", false, false))
+	if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
+		t.Run("go", testHeaders(data, "test.go", "text/x-go; charset=utf-8", false, false))
+	} else {
+		t.Run("go", testHeaders(data, "test.go", "application/octet-stream", false, false))
+	}
 	t.Run("zip", testHeaders(data, "test.zip", "application/zip", false, false))
 	// Not every platform can recognize these
 	//t.Run("exe", testHeaders(data, "test.exe", "application/x-ms", false))


### PR DESCRIPTION
The issue seems to be that different distros
have different set of included mime types
built-in. Go looks into those directories
and it looks like our CI systems don't have
those files.

https://mattermost.atlassian.net/browse/MM-42877

```release-note
NONE
```
