### PR TITLE
MM-42148: Bump golangci to use 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
   check-golangci-lint:
     docker:
       # Keep the version in sync with the command in Makefile
-      - image: golangci/golangci-lint:v1.39.0
+      - image: golangci/golangci-lint:v1.45.2
     steps:
       - checkout
       - run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -48,3 +48,7 @@ issues:
     - linters:
       - misspell
       path: "shared/markdown/html_entities.go"
+
+    - linters:
+      - staticcheck
+      text: SA1019

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ endif
 
 golangci-lint: ## Run golangci-lint on codebase
 	@# Keep the version in sync with the command in .circleci/config.yml
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.39.0
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2
 
 	@echo Running golangci-lint
 	$(GOBIN)/golangci-lint run ./...

--- a/app/webhub_fuzz.go
+++ b/app/webhub_fuzz.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.

--- a/cmd/mattermost/main_test.go
+++ b/cmd/mattermost/main_test.go
@@ -1,3 +1,4 @@
+//go:build maincoverage
 // +build maincoverage
 
 package main

--- a/utils/markdown.go
+++ b/utils/markdown.go
@@ -141,7 +141,7 @@ func (r *notificationRenderer) renderText(w util.BufWriter, source []byte, node 
 
 func (r *notificationRenderer) renderTextBlock(w util.BufWriter, _ []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
 	if !entering {
-		if _, ok := node.NextSibling().(ast.Node); ok && node.FirstChild() != nil {
+		if node.NextSibling() != nil && node.FirstChild() != nil {
 			_ = w.WriteByte(' ')
 		}
 	}


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-42148

```release-note
NONE
```
