### PR TITLE
MM-43464  Enable timestamp for default audit config

### DIFF
--- a/config/logger.go
+++ b/config/logger.go
@@ -80,7 +80,7 @@ func MloggerConfigFromAuditConfig(auditSettings model.ExperimentalAuditSettings,
 		targetCfg.Levels = []mlog.Level{mlog.LvlAuditAPI, mlog.LvlAuditContent, mlog.LvlAuditPerms, mlog.LvlAuditCLI}
 
 		// apply audit specific formatting
-		targetCfg.FormatOptions = json.RawMessage(`{"disable_timestamp": true, "disable_msg": true, "disable_stacktrace": true, "disable_level": true}`)
+		targetCfg.FormatOptions = json.RawMessage(`{"disable_timestamp": false, "disable_msg": true, "disable_stacktrace": true, "disable_level": true}`)
 
 		cfg["_defAudit"] = targetCfg
 	}

--- a/config/logger_test.go
+++ b/config/logger_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
+func TestMloggerConfigFromAuditConfig(t *testing.T) {
+	auditSettings := model.ExperimentalAuditSettings{
+		FileEnabled:      model.NewBool(true),
+		FileName:         model.NewString("audit.log"),
+		FileMaxSizeMB:    model.NewInt(20),
+		FileMaxAgeDays:   model.NewInt(1),
+		FileMaxBackups:   model.NewInt(5),
+		FileCompress:     model.NewBool(true),
+		FileMaxQueueSize: model.NewInt(5000),
+	}
+
+	t.Run("validate default audit settings", func(t *testing.T) {
+		cfg, err := MloggerConfigFromAuditConfig(auditSettings, nil)
+		require.NoError(t, err, "audit config should not error")
+		require.Len(t, cfg, 1, "default audit config should have one target")
+
+		targetCfg := cfg["_defAudit"]
+
+		// check general
+		assert.Equal(t, targetCfg.Type, "file")
+		assert.Equal(t, targetCfg.Format, "json")
+		assert.ElementsMatch(t, targetCfg.Levels, []mlog.Level{mlog.LvlAuditAPI, mlog.LvlAuditContent, mlog.LvlAuditPerms, mlog.LvlAuditCLI})
+
+		// check format options
+		optionsExpected := map[string]interface{}{
+			"disable_timestamp":  false,
+			"disable_msg":        true,
+			"disable_stacktrace": true,
+			"disable_level":      true,
+		}
+		var optionsReceived map[string]interface{}
+		err = json.Unmarshal(targetCfg.FormatOptions, &optionsReceived)
+		require.NoError(t, err, "unmarshal should not fail")
+		assert.Equal(t, optionsExpected, optionsReceived)
+	})
+
+}


### PR DESCRIPTION
#### Summary
This PR fixes a customer reported issue where timestamps are not appearing in their audit logs.  This is a bug in the default audit config i.e. using the `FileEnabled` setting:
```
"ExperimentalAuditSettings": {
        "FileEnabled": true,
        "FileName": "audit.log",
        "FileMaxSizeMB": 100,
        "FileMaxAgeDays": 0,
        "FileMaxBackups": 10,
        "FileCompress": true,
        "FileMaxQueueSize": 1000,
        "AdvancedLoggingConfig": ""
    },
```
The AdvancedLoggingConfig works as expected and includes timestamps.



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43464

#### Release Note
```release-note
Timestamps are enabled in the default audit configuration.
```
