### PR TITLE
Don't expect an interactive TTY in docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ else ifeq ($(MM_NO_DOCKER),true)
 else
 	@echo Starting docker containers
 
-	$(GO) run ./build/docker-compose-generator/main.go $(ENABLED_DOCKER_SERVICES) | docker-compose -f docker-compose.makefile.yml -f /dev/stdin $(DOCKER_COMPOSE_OVERRIDE) run --rm start_dependencies
+	$(GO) run ./build/docker-compose-generator/main.go $(ENABLED_DOCKER_SERVICES) | docker-compose -f docker-compose.makefile.yml -f /dev/stdin $(DOCKER_COMPOSE_OVERRIDE) run -T --rm start_dependencies
 ifneq (,$(findstring openldap,$(ENABLED_DOCKER_SERVICES)))
 	cat tests/${LDAP_DATA}-data.ldif | docker-compose -f docker-compose.makefile.yml $(DOCKER_COMPOSE_OVERRIDE) exec -T openldap bash -c 'ldapadd -x -D "cn=admin,dc=mm,dc=test,dc=com" -w mostest || true';
 endif


### PR DESCRIPTION
#### Summary
I upgraded to the latest version of docker for mac (v4.7), and I was unable to do a `make run`

The error I was getting: `docker the input device is not a TTY`

credit to @mickmister in https://github.com/mattermost/mattermost-gitpod-config/pull/4

```release-note
NONE
```
