### PR TITLE
Extract binary_parameters handle logic into public methods for external use

### DIFF
--- a/store/sqlstore/job_store.go
+++ b/store/sqlstore/job_store.go
@@ -35,7 +35,7 @@ func (jss SqlJobStore) Save(job *model.Job) (*model.Job, error) {
 		return nil, errors.Wrap(err, "failed marshalling job data")
 	}
 	if jss.IsBinaryParamEnabled() {
-		jsonData = jss.AppendBinaryFlag(jsonData)
+		jsonData = AppendBinaryFlag(jsonData)
 	}
 	query := jss.getQueryBuilder().
 		Insert("Jobs").
@@ -60,7 +60,7 @@ func (jss SqlJobStore) UpdateOptimistically(job *model.Job, currentStatus string
 		return false, errors.Wrap(jsonErr, "failed to encode job's data to JSON")
 	}
 	if jss.IsBinaryParamEnabled() {
-		dataJSON = jss.AppendBinaryFlag(dataJSON)
+		dataJSON = AppendBinaryFlag(dataJSON)
 	}
 	query, args, err := jss.getQueryBuilder().
 		Update("Jobs").

--- a/store/sqlstore/link_metadata_store.go
+++ b/store/sqlstore/link_metadata_store.go
@@ -33,7 +33,7 @@ func (s SqlLinkMetadataStore) Save(metadata *model.LinkMetadata) (*model.LinkMet
 		return nil, errors.Wrap(err, "could not serialize metadataBytes to JSON")
 	}
 	if s.IsBinaryParamEnabled() {
-		metadataBytes = s.AppendBinaryFlag(metadataBytes)
+		metadataBytes = AppendBinaryFlag(metadataBytes)
 	}
 
 	query := s.getQueryBuilder().

--- a/store/sqlstore/session_store.go
+++ b/store/sqlstore/session_store.go
@@ -44,7 +44,7 @@ func (me SqlSessionStore) Save(session *model.Session) (*model.Session, error) {
 	}
 
 	if me.IsBinaryParamEnabled() {
-		jsonProps = me.AppendBinaryFlag(jsonProps)
+		jsonProps = AppendBinaryFlag(jsonProps)
 	}
 
 	query, args, err := me.getQueryBuilder().
@@ -268,7 +268,7 @@ func (me SqlSessionStore) UpdateProps(session *model.Session) error {
 		return errors.Wrap(err, "failed marshalling session props")
 	}
 	if me.IsBinaryParamEnabled() {
-		jsonProps = me.AppendBinaryFlag(jsonProps)
+		jsonProps = AppendBinaryFlag(jsonProps)
 	}
 	query, args, err := me.getQueryBuilder().
 		Update("Sessions").

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -9,7 +9,6 @@ import (
 	dbsql "database/sql"
 	"fmt"
 	"log"
-	"net/url"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -338,20 +337,11 @@ func (ss *SqlStore) computeBinaryParam() (bool, error) {
 		return false, nil
 	}
 
-	url, err := url.Parse(*ss.settings.DataSource)
-	if err != nil {
-		return false, err
-	}
-	return url.Query().Get("binary_parameters") == "yes", nil
+	return DSNHasBinaryParam(*ss.settings.DataSource)
 }
 
 func (ss *SqlStore) IsBinaryParamEnabled() bool {
 	return ss.isBinaryParam
-}
-
-// AppendBinaryFlag updates the byte slice to work using binary_parameters=yes.
-func (ss *SqlStore) AppendBinaryFlag(buf []byte) []byte {
-	return append([]byte{0x01}, buf...)
 }
 
 func (ss *SqlStore) getCurrentSchemaVersion() (string, error) {

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -233,7 +233,7 @@ func (us SqlUserStore) UpdateNotifyProps(userID string, props map[string]string)
 		return errors.Wrap(err, "failed marshalling session props")
 	}
 	if us.IsBinaryParamEnabled() {
-		buf = us.AppendBinaryFlag(buf)
+		buf = AppendBinaryFlag(buf)
 	}
 
 	if _, err := us.GetMasterX().Exec(`UPDATE Users

--- a/store/sqlstore/utils.go
+++ b/store/sqlstore/utils.go
@@ -5,6 +5,7 @@ package sqlstore
 
 import (
 	"database/sql"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode"
@@ -155,4 +156,17 @@ type morphWriter struct {
 func (l *morphWriter) Write(in []byte) (int, error) {
 	mlog.Debug(string(in))
 	return len(in), nil
+}
+
+func DSNHasBinaryParam(dsn string) (bool, error) {
+	url, err := url.Parse(dsn)
+	if err != nil {
+		return false, err
+	}
+	return url.Query().Get("binary_parameters") == "yes", nil
+}
+
+// AppendBinaryFlag updates the byte slice to work using binary_parameters=yes.
+func AppendBinaryFlag(buf []byte) []byte {
+	return append([]byte{0x01}, buf...)
 }


### PR DESCRIPTION
#### Summary
This PR moves the `binary_parameters` logic into public util methods to be used on external tools.

```release-note
NONE
```
