### PR TITLE
Query optimization for top reactions.

### DIFF
--- a/store/sqlstore/reaction_store.go
+++ b/store/sqlstore/reaction_store.go
@@ -262,11 +262,10 @@ func (s *SqlReactionStore) GetTopForTeamSince(teamID string, userID string, sinc
 				FROM
 					Reactions
 					INNER JOIN Posts ON Reactions.PostId = Posts.Id
-					INNER JOIN Channels ON Posts.ChannelId = Channels.Id
+					INNER JOIN PublicChannels ON Posts.ChannelId = PublicChannels.Id
 				WHERE
 					Reactions.DeleteAt = 0
-					AND Channels.Type = 'O'
-					AND Channels.TeamId = ?
+					AND PublicChannels.TeamId = ?
 					AND Reactions.CreateAt > ?
 				GROUP BY
 					Reactions.EmojiName)) AS A


### PR DESCRIPTION
#### Summary

Switches to using `PublicChannels` instead of `Channels WHERE Channels.Type = 'O'`.

Likely more optimizations to come, this is just a small tweak with a big performance gain.

1 day:
```shell
jswithtafpdb> \i ~/Desktop/top-reactions-test.sql
+--------------+-------+
| emojiname    | count |
|--------------+-------|
| tada         | 14    |
| raised_hands | 13    |
| +1           | 11    |
| point_up     | 8     |
+--------------+-------+
SELECT 4
Time: 42.458s (42 seconds), executed in: 42.442s (42 seconds)
jswithtafpdb> \i ~/Desktop/top-reactions-rewrite.sql
+--------------+-------+
| emojiname    | count |
|--------------+-------|
| tada         | 14    |
| raised_hands | 13    |
| +1           | 11    |
| point_up     | 8     |
+--------------+-------+
SELECT 4
Time: 0.207s
```

7 days: 
```shell
jswithtafpdb> \i ~/Desktop/top-reactions-test.sql
+--------------+-------+
| emojiname    | count |
|--------------+-------|
| tada         | 42    |
| raised_hands | 39    |
| point_up     | 32    |
| +1           | 28    |
+--------------+-------+
SELECT 4
Time: 43.043s (43 seconds), executed in: 43.023s (43 seconds)
jswithtafpdb> \i ~/Desktop/top-reactions-rewrite.sql
+--------------+-------+
| emojiname    | count |
|--------------+-------|
| tada         | 42    |
| raised_hands | 39    |
| point_up     | 32    |
| +1           | 28    |
+--------------+-------+
SELECT 4
Time: 0.238s
```

28 days:
```shell
jswithtafpdb> \i ~/Desktop/top-reactions-test.sql
+--------------+--------+
| emojiname    | count  |
|--------------+--------|
| point_up     | 161466 |
| +1           | 161368 |
| raised_hands | 161332 |
| tada         | 160482 |
+--------------+--------+
SELECT 4
Time: 42.768s (42 seconds), executed in: 42.756s (42 seconds)
jswithtafpdb> \i ~/Desktop/top-reactions-rewrite.sql
+--------------+--------+
| emojiname    | count  |
|--------------+--------|
| point_up     | 161466 |
| +1           | 161368 |
| raised_hands | 161332 |
| tada         | 160482 |
+--------------+--------+
SELECT 4
Time: 6.029s (6 seconds), executed in: 6.017s (6 seconds)
```

#### Ticket Link

n/a

#### Release Note

```release-note
NONE
```
