### PR TITLE
Mm 43084 cache refreshing

### DIFF
--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -475,6 +475,12 @@ func handleCWSWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = appErr
 			return
 		}
+	case model.EventTypeProductLimitsChanged:
+		if err := c.App.Cloud().UpdateCloudLimitsFromHook(event.ProductLimits); err != nil {
+			c.Err = model.NewAppError("Api4.handleCWSWebhook", "api.cloud.limits.update_error", nil, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		c.Logger.Info("Updated product limits")
 
 	default:
 		c.Err = model.NewAppError("Api4.handleCWSWebhook", "api.cloud.cws_webhook_event_missing_error", nil, "", http.StatusNotFound)

--- a/einterfaces/cloud.go
+++ b/einterfaces/cloud.go
@@ -10,6 +10,7 @@ import (
 type CloudInterface interface {
 	GetCloudProducts(userID string, includeLegacyProducts bool) ([]*model.Product, error)
 	GetCloudLimits(userID string) (*model.ProductLimits, error)
+	UpdateCloudLimitsFromHook(*model.ProductLimits) error
 
 	CreateCustomerPayment(userID string) (*model.StripeSetupIntent, error)
 	ConfirmCustomerPayment(userID string, confirmRequest *model.ConfirmPaymentMethodRequest) error

--- a/einterfaces/mocks/CloudInterface.go
+++ b/einterfaces/mocks/CloudInterface.go
@@ -292,3 +292,17 @@ func (_m *CloudInterface) UpdateCloudCustomerAddress(userID string, address *mod
 
 	return r0, r1
 }
+
+// UpdateCloudLimitsFromHook provides a mock function with given fields: _a0
+func (_m *CloudInterface) UpdateCloudLimitsFromHook(_a0 *model.ProductLimits) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*model.ProductLimits) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -473,7 +473,7 @@
   },
   {
     "id": "api.cloud.limits.update_error",
-    "translation": "Error update cloud limits from webhook."
+    "translation": "Error updating cloud limits from webhook."
   },
   {
     "id": "api.cloud.request_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -472,6 +472,10 @@
     "translation": "Your license does not support cloud requests."
   },
   {
+    "id": "api.cloud.limits.update_error",
+    "translation": "Error update cloud limits from webhook."
+  },
+  {
     "id": "api.cloud.request_error",
     "translation": "Error processing request to CWS."
   },

--- a/model/cloud.go
+++ b/model/cloud.go
@@ -11,6 +11,7 @@ const (
 	EventTypeSendAdminWelcomeEmail = "send-admin-welcome-email"
 	EventTypeTrialWillEnd          = "trial-will-end"
 	EventTypeTrialEnded            = "trial-ended"
+	EventTypeProductLimitsChanged  = "product-limits-changed"
 )
 
 var MockCWS string
@@ -165,6 +166,7 @@ type CWSWebhookPayload struct {
 	Event                             string               `json:"event"`
 	FailedPayment                     *FailedPayment       `json:"failed_payment"`
 	CloudWorkspaceOwner               *CloudWorkspaceOwner `json:"cloud_workspace_owner"`
+	ProductLimits                     *ProductLimits       `json:"product_limits"`
 	SubscriptionTrialEndUnixTimeStamp int64                `json:"trial_end_time_stamp"`
 }
 

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -71,6 +71,7 @@ const (
 	WebsocketWarnMetricStatusReceived                 = "warn_metric_status_received"
 	WebsocketWarnMetricStatusRemoved                  = "warn_metric_status_removed"
 	WebsocketEventCloudPaymentStatusUpdated           = "cloud_payment_status_updated"
+	WebsocketEventCloudProductLimitsChanged           = "cloud_product_limits_changed"
 	WebsocketEventThreadUpdated                       = "thread_updated"
 	WebsocketEventThreadFollowChanged                 = "thread_follow_changed"
 	WebsocketEventThreadReadChanged                   = "thread_read_changed"


### PR DESCRIPTION
#### Summary
Receive webhook of product limit updates (for example, because the plan subscription changed), and call enterprise method to broadcast the websocket event of the update.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43084

#### Release Note
Webhooks will not be sent until feature flag is on, so no release note
```release-note
NONE
```
