### PR TITLE
[MM-39918] System admins should be able to access all deleted channels

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -780,7 +780,12 @@ func getDeletedChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	channels, err := c.App.GetDeletedChannels(c.Params.TeamId, c.Params.Page*c.Params.PerPage, c.Params.PerPage, c.AppContext.Session().UserId)
+	channels, err := c.App.GetDeletedChannels(&model.GetDeletedChannelsOptions{
+		TeamID: c.Params.TeamId,
+		Offset: c.Params.Page * c.Params.PerPage,
+		Limit:  c.Params.PerPage,
+		UserID: c.AppContext.Session().UserId,
+	})
 	if err != nil {
 		c.Err = err
 		return

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -781,10 +781,11 @@ func getDeletedChannelsForTeam(c *Context, w http.ResponseWriter, r *http.Reques
 	}
 
 	channels, err := c.App.GetDeletedChannels(&model.GetDeletedChannelsOptions{
-		TeamID: c.Params.TeamId,
-		Offset: c.Params.Page * c.Params.PerPage,
-		Limit:  c.Params.PerPage,
-		UserID: c.AppContext.Session().UserId,
+		TeamID:  c.Params.TeamId,
+		Offset:  c.Params.Page * c.Params.PerPage,
+		Limit:   c.Params.PerPage,
+		UserID:  c.AppContext.Session().UserId,
+		IsAdmin: c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem),
 	})
 	if err != nil {
 		c.Err = err

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -798,7 +798,7 @@ func TestGetDeletedChannelsForTeam(t *testing.T) {
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		channels, _, err = client.GetDeletedChannelsForTeam(team.Id, 0, 100, "")
 		require.NoError(t, err)
-		require.Len(t, channels, numInitialChannelsForTeam+2)
+		require.Len(t, channels, numInitialChannelsForTeam+4) // system admins should have access to all deleted channels
 	})
 
 	channels, _, err = client.GetDeletedChannelsForTeam(team.Id, 0, 1, "")

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -589,7 +589,7 @@ type AppIface interface {
 	GetCookieDomain() string
 	GetCustomStatus(userID string) (*model.CustomStatus, *model.AppError)
 	GetDefaultProfileImage(user *model.User) ([]byte, *model.AppError)
-	GetDeletedChannels(teamID string, offset int, limit int, userID string) (model.ChannelList, *model.AppError)
+	GetDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, *model.AppError)
 	GetEmoji(emojiId string) (*model.Emoji, *model.AppError)
 	GetEmojiByName(emojiName string) (*model.Emoji, *model.AppError)
 	GetEmojiImage(emojiId string) ([]byte, string, *model.AppError)

--- a/app/channel.go
+++ b/app/channel.go
@@ -1899,8 +1899,6 @@ func (a *App) GetAllChannelsCount(opts model.ChannelSearchOpts) (int64, *model.A
 }
 
 func (a *App) GetDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, *model.AppError) {
-	// TODO: change the interface for GetDeleted to also accept struct..
-
 	var (
 		list model.ChannelList
 		err  error

--- a/app/channel.go
+++ b/app/channel.go
@@ -1899,7 +1899,20 @@ func (a *App) GetAllChannelsCount(opts model.ChannelSearchOpts) (int64, *model.A
 }
 
 func (a *App) GetDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, *model.AppError) {
-	list, err := a.Srv().Store.Channel().GetDeleted(options.TeamID, options.Offset, options.Limit, options.UserID)
+	// TODO: change the interface for GetDeleted to also accept struct..
+
+	var (
+		list model.ChannelList
+		err  error
+	)
+
+	if options.IsAdmin {
+		list, err = a.Srv().Store.Channel().GetAllDeletedChannels(options)
+	} else {
+		// TODO: change the interface for GetDeleted to also accept struct..
+		list, err = a.Srv().Store.Channel().GetDeleted(options.TeamID, options.Offset, options.Limit, options.UserID)
+	}
+
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/app/channel.go
+++ b/app/channel.go
@@ -1898,8 +1898,8 @@ func (a *App) GetAllChannelsCount(opts model.ChannelSearchOpts) (int64, *model.A
 	return count, nil
 }
 
-func (a *App) GetDeletedChannels(teamID string, offset int, limit int, userID string) (model.ChannelList, *model.AppError) {
-	list, err := a.Srv().Store.Channel().GetDeleted(teamID, offset, limit, userID)
+func (a *App) GetDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, *model.AppError) {
+	list, err := a.Srv().Store.Channel().GetDeleted(options.TeamID, options.Offset, options.Limit, options.UserID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -5645,7 +5645,7 @@ func (a *OpenTracingAppLayer) GetDefaultProfileImage(user *model.User) ([]byte, 
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) GetDeletedChannels(teamID string, offset int, limit int, userID string) (model.ChannelList, *model.AppError) {
+func (a *OpenTracingAppLayer) GetDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetDeletedChannels")
 
@@ -5657,7 +5657,7 @@ func (a *OpenTracingAppLayer) GetDeletedChannels(teamID string, offset int, limi
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.GetDeletedChannels(teamID, offset, limit, userID)
+	resultVar0, resultVar1 := a.app.GetDeletedChannels(options)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))

--- a/model/channel.go
+++ b/model/channel.go
@@ -161,6 +161,14 @@ func WithID(ID string) ChannelOption {
 	}
 }
 
+type GetDeletedChannelsOptions struct {
+	TeamID  string
+	Offset  int
+	Limit   int
+	UserID  string
+	IsAdmin bool
+}
+
 // The following are some GraphQL methods necessary to return the
 // data in float64 type. The spec doesn't support 64 bit integers,
 // so we have to pass the data in float64. The _ at the end is

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -943,6 +943,24 @@ func (s *OpenTracingLayerChannelStore) GetAllChannelsForExportAfter(limit int, a
 	return result, err
 }
 
+func (s *OpenTracingLayerChannelStore) GetAllDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.GetAllDeletedChannels")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.ChannelStore.GetAllDeletedChannels(options)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
+}
+
 func (s *OpenTracingLayerChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterID string) ([]*model.DirectChannelForExport, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.GetAllDirectChannelsForExportAfter")

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1599,7 +1599,7 @@ func (s SqlChannelStore) GetDeleted(teamId string, offset int, limit int, userId
 }
 
 // This method returns all deleted channels irrespective of the channel membership
-func (s SqlChannelStore) GetAllDeletedChannels(teamId string, offset int, limit int) (model.ChannelList, error) {
+func (s SqlChannelStore) GetAllDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, error) {
 	channels := model.ChannelList{}
 
 	query := `
@@ -1609,11 +1609,11 @@ func (s SqlChannelStore) GetAllDeletedChannels(teamId string, offset int, limit 
 		ORDER BY DisplayName LIMIT ? OFFSET ?
 	`
 
-	if err := s.GetReplicaX().Select(&channels, query, teamId, limit, offset); err != nil {
+	if err := s.GetReplicaX().Select(&channels, query, options.TeamID, options.Limit, options.Offset); err != nil {
 		if err == sql.ErrNoRows {
-			return nil, store.NewErrNotFound("Channel", fmt.Sprintf("TeamId=%s", teamId))
+			return nil, store.NewErrNotFound("Channel", fmt.Sprintf("TeamId=%s", options.TeamID))
 		}
-		return nil, errors.Wrapf(err, "failed to get deleted channels with TeamId=%s", teamId)
+		return nil, errors.Wrapf(err, "failed to get deleted channels with TeamId=%s", options.TeamID)
 	}
 	return channels, nil
 }

--- a/store/store.go
+++ b/store/store.go
@@ -180,6 +180,7 @@ type ChannelStore interface {
 	GetByNameIncludeDeleted(team_id string, name string, allowFromCache bool) (*model.Channel, error)
 	GetDeletedByName(team_id string, name string) (*model.Channel, error)
 	GetDeleted(team_id string, offset int, limit int, userID string) (model.ChannelList, error)
+	GetAllDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, error)
 	GetChannels(teamID, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, error)
 	GetChannelsWithCursor(teamId string, userId string, opts *model.ChannelSearchOpts, afterChannelID string) (model.ChannelList, error)
 	GetChannelsByUser(userID string, includeDeleted bool, lastDeleteAt, pageSize int, fromChannelID string) (model.ChannelList, error)

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -490,6 +490,29 @@ func (_m *ChannelStore) GetAllChannelsForExportAfter(limit int, afterID string) 
 	return r0, r1
 }
 
+// GetAllDeletedChannels provides a mock function with given fields: options
+func (_m *ChannelStore) GetAllDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, error) {
+	ret := _m.Called(options)
+
+	var r0 model.ChannelList
+	if rf, ok := ret.Get(0).(func(*model.GetDeletedChannelsOptions) model.ChannelList); ok {
+		r0 = rf(options)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(model.ChannelList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*model.GetDeletedChannelsOptions) error); ok {
+		r1 = rf(options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAllDirectChannelsForExportAfter provides a mock function with given fields: limit, afterID
 func (_m *ChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterID string) ([]*model.DirectChannelForExport, error) {
 	ret := _m.Called(limit, afterID)

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -885,6 +885,22 @@ func (s *TimerLayerChannelStore) GetAllChannelsForExportAfter(limit int, afterID
 	return result, err
 }
 
+func (s *TimerLayerChannelStore) GetAllDeletedChannels(options *model.GetDeletedChannelsOptions) (model.ChannelList, error) {
+	start := timemodule.Now()
+
+	result, err := s.ChannelStore.GetAllDeletedChannels(options)
+
+	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.GetAllDeletedChannels", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerChannelStore) GetAllDirectChannelsForExportAfter(limit int, afterID string) ([]*model.DirectChannelForExport, error) {
 	start := timemodule.Now()
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

System admin users should be ale to access all deleted channels irrespective of their membership status. Right now , they aren't able to access archived private channels where they aren't members. This PR fixes this issue.

In addition to the fix , I also refactored the code to make our APIs backward compatible by changing the interface to a struct option. This makes future changes easy to make.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

Otherwise, link the JIRA ticket.
-->
  Fixes https://github.com/mattermost/mattermost-server/issues/19913


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
System admin users should be able to access all deleted channels

```
