### PR TITLE
Remove code duplication and move utility methods to the store utils

### DIFF
--- a/config/database.go
+++ b/config/database.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/store/sqlstore"
 	"github.com/mattermost/morph"
 
 	"github.com/mattermost/morph/drivers"
@@ -124,12 +125,12 @@ func (ds *DatabaseStore) initializeConfigurationsTable() error {
 	var driver drivers.Driver
 	switch ds.driverName {
 	case model.DatabaseDriverMysql:
-		dataSource, rErr := resetReadTimeout(ds.dataSourceName)
+		dataSource, rErr := sqlstore.ResetReadTimeout(ds.dataSourceName)
 		if rErr != nil {
 			return fmt.Errorf("failed to reset read timeout from datasource: %w", rErr)
 		}
 
-		dataSource, err = appendMultipleStatementsFlag(dataSource)
+		dataSource, err = sqlstore.AppendMultipleStatementsFlag(dataSource)
 		if err != nil {
 			return err
 		}

--- a/config/utils.go
+++ b/config/utils.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/go-sql-driver/mysql"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -261,30 +260,4 @@ func equal(oldCfg, newCfg *model.Config) (bool, error) {
 		return false, fmt.Errorf("failed to marshal new config: %w", err)
 	}
 	return !bytes.Equal(oldCfgBytes, newCfgBytes), nil
-}
-
-// appendMultipleStatementsFlag attached dsn parameters to MySQL dsn in order to make migrations work.
-func appendMultipleStatementsFlag(dataSource string) (string, error) {
-
-	config, err := mysql.ParseDSN(dataSource)
-	if err != nil {
-		return "", err
-	}
-
-	if config.Params == nil {
-		config.Params = map[string]string{}
-	}
-
-	config.Params["multiStatements"] = "true"
-	return config.FormatDSN(), nil
-}
-
-// resetReadTimeout removes the timeout contraint from the MySQL dsn.
-func resetReadTimeout(dataSource string) (string, error) {
-	config, err := mysql.ParseDSN(dataSource)
-	if err != nil {
-		return "", err
-	}
-	config.ReadTimeout = 0
-	return config.FormatDSN(), nil
 }

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -275,7 +275,7 @@ func (ss *SqlStore) initConnection() {
 		// covers that already. Ideally we'd like to do this only for the upgrade
 		// step. To be reviewed in MM-35789.
 		var err error
-		dataSource, err = resetReadTimeout(dataSource)
+		dataSource, err = ResetReadTimeout(dataSource)
 		if err != nil {
 			mlog.Fatal("Failed to reset read timeout from datasource.", mlog.Err(err), mlog.String("src", dataSource))
 		}
@@ -981,12 +981,12 @@ func (ss *SqlStore) migrate(direction migrationDirection) error {
 	var driver drivers.Driver
 	switch ss.DriverName() {
 	case model.DatabaseDriverMysql:
-		dataSource, rErr := resetReadTimeout(*ss.settings.DataSource)
+		dataSource, rErr := ResetReadTimeout(*ss.settings.DataSource)
 		if rErr != nil {
 			mlog.Fatal("Failed to reset read timeout from datasource.", mlog.Err(rErr), mlog.String("src", *ss.settings.DataSource))
 			return rErr
 		}
-		dataSource, err = ss.appendMultipleStatementsFlag(dataSource)
+		dataSource, err = AppendMultipleStatementsFlag(dataSource)
 		if err != nil {
 			return err
 		}
@@ -1027,35 +1027,6 @@ func (ss *SqlStore) migrate(direction migrationDirection) error {
 	default:
 		return engine.ApplyAll()
 	}
-}
-
-func (ss *SqlStore) appendMultipleStatementsFlag(dataSource string) (string, error) {
-	// We need to tell the MySQL driver that we want to use multiStatements
-	// in order to make migrations work.
-	if ss.DriverName() == model.DatabaseDriverMysql {
-		config, err := mysql.ParseDSN(dataSource)
-		if err != nil {
-			return "", err
-		}
-
-		if config.Params == nil {
-			config.Params = map[string]string{}
-		}
-
-		config.Params["multiStatements"] = "true"
-		return config.FormatDSN(), nil
-	}
-
-	return dataSource, nil
-}
-
-func resetReadTimeout(dataSource string) (string, error) {
-	config, err := mysql.ParseDSN(dataSource)
-	if err != nil {
-		return "", err
-	}
-	config.ReadTimeout = 0
-	return config.FormatDSN(), nil
 }
 
 func convertMySQLFullTextColumnsToPostgres(columnNames string) string {

--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -753,43 +753,6 @@ func TestReplicaLagQuery(t *testing.T) {
 	}
 }
 
-func TestAppendMultipleStatementsFlagMysql(t *testing.T) {
-	testCases := []struct {
-		Scenario    string
-		DSN         string
-		ExpectedDSN string
-		Driver      string
-	}{
-		{
-			"Should append multiStatements param to the DSN path with existing params",
-			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost?writeTimeout=30s",
-			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost?writeTimeout=30s&multiStatements=true",
-			model.DatabaseDriverMysql,
-		},
-		{
-			"Should append multiStatements param to the DSN path with no existing params",
-			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost",
-			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost?multiStatements=true",
-			model.DatabaseDriverMysql,
-		},
-		{
-			"Should not multiStatements param to the DSN when driver is not MySQL",
-			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost",
-			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost",
-			model.DatabaseDriverPostgres,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.Scenario, func(t *testing.T) {
-			store := &SqlStore{settings: &model.SqlSettings{DriverName: &tc.Driver, DataSource: &tc.DSN}}
-			res, err := store.appendMultipleStatementsFlag(*store.settings.DataSource)
-			require.NoError(t, err)
-			assert.Equal(t, tc.ExpectedDSN, res)
-		})
-	}
-}
-
 func makeSqlSettings(driver string) *model.SqlSettings {
 	switch driver {
 	case model.DatabaseDriverPostgres:

--- a/store/sqlstore/utils.go
+++ b/store/sqlstore/utils.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 var escapeLikeSearchChar = []string{
@@ -169,4 +171,29 @@ func DSNHasBinaryParam(dsn string) (bool, error) {
 // AppendBinaryFlag updates the byte slice to work using binary_parameters=yes.
 func AppendBinaryFlag(buf []byte) []byte {
 	return append([]byte{0x01}, buf...)
+}
+
+// AppendMultipleStatementsFlag attached dsn parameters to MySQL dsn in order to make migrations work.
+func AppendMultipleStatementsFlag(dataSource string) (string, error) {
+	config, err := mysql.ParseDSN(dataSource)
+	if err != nil {
+		return "", err
+	}
+
+	if config.Params == nil {
+		config.Params = map[string]string{}
+	}
+
+	config.Params["multiStatements"] = "true"
+	return config.FormatDSN(), nil
+}
+
+// ResetReadTimeout removes the timeout contraint from the MySQL dsn.
+func ResetReadTimeout(dataSource string) (string, error) {
+	config, err := mysql.ParseDSN(dataSource)
+	if err != nil {
+		return "", err
+	}
+	config.ReadTimeout = 0
+	return config.FormatDSN(), nil
 }

--- a/store/sqlstore/utils.go
+++ b/store/sqlstore/utils.go
@@ -188,7 +188,7 @@ func AppendMultipleStatementsFlag(dataSource string) (string, error) {
 	return config.FormatDSN(), nil
 }
 
-// ResetReadTimeout removes the timeout contraint from the MySQL dsn.
+// ResetReadTimeout removes the timeout constraint from the MySQL dsn.
 func ResetReadTimeout(dataSource string) (string, error) {
 	config, err := mysql.ParseDSN(dataSource)
 	if err != nil {

--- a/store/sqlstore/utils_test.go
+++ b/store/sqlstore/utils_test.go
@@ -133,3 +133,30 @@ func TestMySQLJSONArgs(t *testing.T) {
 		assert.Equal(t, test.argString, argString)
 	}
 }
+
+func TestAppendMultipleStatementsFlag(t *testing.T) {
+	testCases := []struct {
+		Scenario    string
+		DSN         string
+		ExpectedDSN string
+	}{
+		{
+			"Should append multiStatements param to the DSN path with existing params",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost?writeTimeout=30s",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost?writeTimeout=30s&multiStatements=true",
+		},
+		{
+			"Should append multiStatements param to the DSN path with no existing params",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost",
+			"user:rand?&ompasswith@character@unix(/var/run/mysqld/mysqld.sock)/mattermost?multiStatements=true",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Scenario, func(t *testing.T) {
+			res, err := AppendMultipleStatementsFlag(tc.DSN)
+			require.NoError(t, err)
+			assert.Equal(t, tc.ExpectedDSN, res)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
This PR removes code duplication around the `appendMultipleStatementsFlag` and `resetReadTimeout` methods, makes them public to be imported from other tools (namely focalboard) and moves them to the `sqlstore/utils.go` file to avoid import cycle.

#### Release Note
```release-note
NONE
```
