### PR TITLE
Update Chrome supported version to 100+

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -9225,7 +9225,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 89+"
+    "translation": "Version 100+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",


### PR DESCRIPTION
Desktop app v5.1 includes major version upgrade of Electron to v18.0.3. 

This version of Electron https://www.electronjs.org/releases/stable?#18.0.3 supports Chrome v100.

Will add to release notes.