### PR TITLE
Bumps ES minor version.

### DIFF
--- a/build/docker-compose.common.yml
+++ b/build/docker-compose.common.yml
@@ -84,7 +84,7 @@ services:
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
   elasticsearch:
-    image: "mattermost/mattermost-elasticsearch-docker:7.0.0"
+    image: "mattermost/mattermost-elasticsearch-docker:7.17.3"
     networks:
       - mm-test
     environment:

--- a/build/gitlab-dc.common.yml
+++ b/build/gitlab-dc.common.yml
@@ -23,7 +23,7 @@ services:
       LDAP_DOMAIN: "mm.test.com"
       LDAP_ADMIN_PASSWORD: "mostest"
   elasticsearch:
-    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-elasticsearch-docker:7.0.0
+    image: ${CI_REGISTRY}/mattermost/ci/images/mattermost-elasticsearch-docker:7.17.3
     environment:
       http.host: "0.0.0.0"
       http.port: 9200


### PR DESCRIPTION
#### Summary

Upgrades the minor version of the ElasticSearch development Docker image.

Related PR: https://github.com/mattermost/mattermost-elasticsearch-docker/pull/3

Tag: https://github.com/mattermost/mattermost-elasticsearch-docker/releases/tag/7.17.3

#### Ticket Link

n/a

#### Release Note

```release-note
Upgrades the minor version of the ElasticSearch development Docker image.
```
