### PR TITLE
MM-43848: Fix flaky TestUserStore/LocalCache+MySQL/UpdateUpdateAt

### DIFF
--- a/store/storetest/file_info_store.go
+++ b/store/storetest/file_info_store.go
@@ -635,7 +635,7 @@ func testFileInfoStoreGetFilesBatchForIndexing(t *testing.T, ss store.Store) {
 	defer func() {
 		ss.FileInfo().PermanentDelete(f1.Id)
 	}()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 
 	o2 := &model.Post{}
 	o2.ChannelId = c2.Id
@@ -653,7 +653,7 @@ func testFileInfoStoreGetFilesBatchForIndexing(t *testing.T, ss store.Store) {
 	defer func() {
 		ss.FileInfo().PermanentDelete(f2.Id)
 	}()
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 
 	o3 := &model.Post{}
 	o3.ChannelId = c1.Id

--- a/store/storetest/group_store.go
+++ b/store/storetest/group_store.go
@@ -1120,7 +1120,7 @@ func testUpsertMember(t *testing.T, ss store.Store) {
 
 	// Duplicate composite key (GroupId, UserId)
 	// Ensure new CreateAt > previous CreateAt for the same (groupId, userId)
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 	_, err = ss.Group().UpsertMember(group.Id, user.Id)
 	require.NoError(t, err)
 
@@ -1131,7 +1131,7 @@ func testUpsertMember(t *testing.T, ss store.Store) {
 
 	// Restores a deleted member
 	// Ensure new CreateAt > previous CreateAt for the same (groupId, userId)
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 	_, err = ss.Group().UpsertMember(group.Id, user.Id)
 	require.NoError(t, err)
 
@@ -1186,7 +1186,7 @@ func testUpsertMembers(t *testing.T, ss store.Store) {
 
 	// Duplicate composite key (GroupId, UserId)
 	// Ensure new CreateAt > previous CreateAt for the same (groupId, userId)
-	// time.Sleep(1 * time.Millisecond)
+	// time.Sleep(2 * time.Millisecond)
 	_, err = ss.Group().UpsertMembers(group.Id, []string{user.Id})
 	require.NoError(t, err)
 
@@ -1197,7 +1197,7 @@ func testUpsertMembers(t *testing.T, ss store.Store) {
 
 	// Restores a deleted member
 	// Ensure new CreateAt > previous CreateAt for the same (groupId, userId)
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 	_, err = ss.Group().UpsertMembers(group.Id, []string{user.Id, user2.Id})
 	require.NoError(t, err)
 

--- a/store/storetest/shared_channel_store.go
+++ b/store/storetest/shared_channel_store.go
@@ -1189,7 +1189,7 @@ func testUpsertSharedChannelAttachment(t *testing.T, ss store.Store) {
 		require.NoError(t, err, "couldn't save shared channel attachment", err)
 
 		// make sure enough time passed that GetMillis returns a different value
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
 
 		_, err = ss.SharedChannel().UpsertAttachment(saved)
 		require.NoError(t, err, "couldn't upsert shared channel attachment", err)

--- a/store/storetest/thread_store.go
+++ b/store/storetest/thread_store.go
@@ -858,7 +858,7 @@ func testVarious(t *testing.T, ss store.Store) {
 	viewThread(user1ID, dm1post1.Id)
 
 	// Add reply to a viewed thread to confirm it's unread again.
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 	threadStoreCreateReply(t, ss, team1channel1.Id, team1channel1post2.Id, user2ID, model.GetMillis())
 
 	// Actually make team2channel1post2deleted deleted

--- a/store/storetest/upload_session_store.go
+++ b/store/storetest/upload_session_store.go
@@ -158,7 +158,7 @@ func testUploadSessionStoreGetForUser(t *testing.T, ss store.Store) {
 		require.NotNil(t, us)
 		require.NotEmpty(t, us)
 		// We need this to make sure the ordering is consistent.
-		time.Sleep(1 * time.Millisecond)
+		time.Sleep(2 * time.Millisecond)
 	}
 
 	t.Run("should return existing sessions", func(t *testing.T) {

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -236,7 +236,6 @@ func testUserStoreUpdate(t *testing.T, ss store.Store) {
 }
 
 func testUserStoreUpdateUpdateAt(t *testing.T, ss store.Store) {
-	t.Skip("MM-43848")
 	u1 := &model.User{}
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(u1)
@@ -246,7 +245,7 @@ func testUserStoreUpdateUpdateAt(t *testing.T, ss store.Store) {
 	require.NoError(t, nErr)
 
 	// Ensure UpdateAt has a change to be different below.
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(2 * time.Millisecond)
 
 	_, err = ss.User().UpdateUpdateAt(u1.Id)
 	require.NoError(t, err)


### PR DESCRIPTION
Because of the fact that t.Unix() family of methods do not
contain the monotonic time, there is no guarantee that
consecutive methods will increase in time.

This is more of a best effort to double the time slept,
but in reality there is no way to control this unless
you specifically control your servers, which is hard to achieve
in a CI environment.

https://mattermost.atlassian.net/browse/MM-43848

```release-note
NONE
```
