### PR TITLE
Fixes: make run-server command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -473,7 +473,7 @@ validate-go-version: ## Validates the installed version of go against Mattermost
 build-templates: ## Compile all mjml email templates
 	cd $(TEMPLATES_DIR) && $(MAKE) build
 
-run-server: prepackaged-binaries validate-go-version start-docker setup-go-work ## Starts the server.
+run-server: setup-go-work prepackaged-binaries validate-go-version start-docker ## Starts the server.
 	@echo Running mattermost for development
 
 	mkdir -p $(BUILD_WEBAPP_DIR)/dist/files


### PR DESCRIPTION
#### Summary

Moves setup-go-work as the first target for run-server to solve
"go: inconsistent vendoring error"

#### Release Note

```release-note
NONE
```
