### PR TITLE
[MM-44056] Make Calls plugin's state on Cloud controllable by feature flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ TEMPLATES_DIR=templates
 PLUGIN_PACKAGES ?= mattermost-plugin-antivirus-v0.1.2
 PLUGIN_PACKAGES += mattermost-plugin-autolink-v1.2.2
 PLUGIN_PACKAGES += mattermost-plugin-aws-SNS-v1.2.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v0.4.9
 PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.0.0
 PLUGIN_PACKAGES += mattermost-plugin-custom-attributes-v1.3.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.0.1

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -98,11 +98,8 @@ func (ch *Channels) syncPluginsActiveState() {
 				pluginEnabled = state.Enable
 			}
 
-			// Tie Apps proxy disabled status to the feature flag.
-			if pluginID == "com.mattermost.apps" {
-				if !ch.cfgSvc.Config().FeatureFlags.AppsEnabled {
-					pluginEnabled = false
-				}
+			if overrides, value := ch.getPluginStateOverride(pluginID); overrides {
+				pluginEnabled = value
 			}
 
 			if pluginEnabled {
@@ -1063,4 +1060,20 @@ func getIcon(iconPath string) (string, error) {
 	}
 
 	return fmt.Sprintf("data:image/svg+xml;base64,%s", base64.StdEncoding.EncodeToString(icon)), nil
+}
+
+func (ch *Channels) getPluginStateOverride(pluginID string) (bool, bool) {
+	switch pluginID {
+	case "com.mattermost.apps":
+		// Tie Apps proxy disabled status to the feature flag.
+		if !ch.cfgSvc.Config().FeatureFlags.AppsEnabled {
+			return true, false
+		}
+	case "com.mattermost.calls":
+		if model.IsCloud() {
+			return true, ch.cfgSvc.Config().FeatureFlags.CallsEnabled
+		}
+	}
+
+	return false, false
 }

--- a/app/plugin_install.go
+++ b/app/plugin_install.go
@@ -393,9 +393,10 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 	// Activate the plugin if enabled.
 	pluginState := ch.cfgSvc.Config().PluginSettings.PluginStates[manifest.Id]
 	if pluginState != nil && pluginState.Enable {
-		if manifest.Id == "com.mattermost.apps" && !ch.cfgSvc.Config().FeatureFlags.AppsEnabled {
+		if overrides, value := ch.getPluginStateOverride(manifest.Id); overrides && !value {
 			return manifest, nil
 		}
+
 		updatedManifest, _, err := pluginsEnvironment.Activate(manifest.Id)
 		if err != nil {
 			return nil, model.NewAppError("installExtractedPlugin", "app.plugin.restart.app_error", nil, err.Error(), http.StatusInternalServerError)

--- a/build/release.mk
+++ b/build/release.mk
@@ -170,6 +170,11 @@ else
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH=$(PLUGIN_ARCH); \
+		if [ "$$ARCH" != "linux-amd64" ]; then \
+			case $$plugin_package in \
+				"mattermost-plugin-calls"*) continue ;; \
+			esac; \
+		fi; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH_GENERIC)/prepackaged_plugins; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_GENERIC)/prepackaged_plugins; \
 		HAS_ARCH=`tar -tf $(DIST_PATH_GENERIC)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \
@@ -234,6 +239,9 @@ endif
 	@# Prepackage plugins
 	@for plugin_package in $(PLUGIN_PACKAGES) ; do \
 		ARCH="windows-amd64"; \
+		case $$plugin_package in \
+			"mattermost-plugin-calls"*) continue ;; \
+		esac; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz $(DIST_PATH_WIN)/prepackaged_plugins; \
 		cp tmpprepackaged/$$plugin_package-$$ARCH.tar.gz.sig $(DIST_PATH_WIN)/prepackaged_plugins; \
 		HAS_ARCH=`tar -tf $(DIST_PATH_WIN)/prepackaged_plugins/$$plugin_package-$$ARCH.tar.gz | grep -oE "dist/plugin-.*"`; \

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -816,6 +816,9 @@ func TestDiff(t *testing.T) {
 						"com.mattermost.apps": {
 							Enable: true,
 						},
+						"com.mattermost.calls": {
+							Enable: true,
+						},
 					},
 				},
 			},
@@ -851,6 +854,9 @@ func TestDiff(t *testing.T) {
 						"com.mattermost.apps": {
 							Enable: true,
 						},
+						"com.mattermost.calls": {
+							Enable: true,
+						},
 					},
 				},
 			},
@@ -876,6 +882,9 @@ func TestDiff(t *testing.T) {
 							Enable: true,
 						},
 						"com.mattermost.apps": {
+							Enable: true,
+						},
+						"com.mattermost.calls": {
 							Enable: true,
 						},
 					},

--- a/model/config.go
+++ b/model/config.go
@@ -2810,6 +2810,11 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates["com.mattermost.apps"] = &PluginState{Enable: true}
 	}
 
+	if s.PluginStates["com.mattermost.calls"] == nil && IsCloud() {
+		// Enable the calls plugin by default on Cloud only
+		s.PluginStates["com.mattermost.calls"] = &PluginState{Enable: true}
+	}
+
 	if s.EnableMarketplace == nil {
 		s.EnableMarketplace = NewBool(PluginSettingsDefaultEnableMarketplace)
 	}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -1491,3 +1491,27 @@ func TestConfigServiceSettingsIsValid(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, "model.config.is_valid.collapsed_threads.autofollow.app_error", err.Id)
 }
+
+func TestConfigDefaultCallsPluginState(t *testing.T) {
+	t.Run("should enable Calls plugin by default", func(t *testing.T) {
+		c1 := Config{}
+		c1.SetDefaults()
+
+		assert.True(t, c1.PluginSettings.PluginStates["com.mattermost.calls"].Enable)
+	})
+
+	t.Run("should not re-enable Calls plugin after it has been disabled", func(t *testing.T) {
+		c1 := Config{
+			PluginSettings: PluginSettings{
+				PluginStates: map[string]*PluginState{
+					"com.mattermost.calls": {
+						Enable: false,
+					},
+				},
+			},
+		}
+
+		c1.SetDefaults()
+		assert.False(t, c1.PluginSettings.PluginStates["com.mattermost.calls"].Enable)
+	})
+}

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 
@@ -1493,7 +1494,16 @@ func TestConfigServiceSettingsIsValid(t *testing.T) {
 }
 
 func TestConfigDefaultCallsPluginState(t *testing.T) {
-	t.Run("should enable Calls plugin by default", func(t *testing.T) {
+	t.Run("should not enable Calls plugin by default when not in Cloud", func(t *testing.T) {
+		c1 := Config{}
+		c1.SetDefaults()
+
+		assert.Nil(t, c1.PluginSettings.PluginStates["com.mattermost.calls"])
+	})
+
+	t.Run("should enable Calls plugin by default on Cloud", func(t *testing.T) {
+		os.Setenv("MM_CLOUD_INSTALLATION_ID", "test")
+		defer os.Unsetenv("MM_CLOUD_INSTALLATION_ID")
 		c1 := Config{}
 		c1.SetDefaults()
 
@@ -1501,6 +1511,8 @@ func TestConfigDefaultCallsPluginState(t *testing.T) {
 	})
 
 	t.Run("should not re-enable Calls plugin after it has been disabled", func(t *testing.T) {
+		os.Setenv("MM_CLOUD_INSTALLATION_ID", "test")
+		defer os.Unsetenv("MM_CLOUD_INSTALLATION_ID")
 		c1 := Config{
 			PluginSettings: PluginSettings{
 				PluginStates: map[string]*PluginState{

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -32,11 +32,15 @@ type FeatureFlags struct {
 	PluginPlaybooks  string `plugin_id:"playbooks"`
 	PluginApps       string `plugin_id:"com.mattermost.apps"`
 	PluginFocalboard string `plugin_id:"focalboard"`
+	PluginCalls      string `plugin_id:"com.mattermost.calls"`
 
 	PermalinkPreviews bool
 
 	// Enable Calls plugin support in the mobile app
 	CallsMobile bool
+
+	// CallsEnabled controls whether or not the Calls plugin should be enabled
+	CallsEnabled bool
 
 	// A dash separated list for feature flags to turn on for Boards
 	BoardsFeatureFlags string
@@ -93,6 +97,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.CloudFree = false
 	f.CommandPalette = false
 }
+
 func (f *FeatureFlags) Plugins() map[string]string {
 	rFFVal := reflect.ValueOf(f).Elem()
 	rFFType := reflect.TypeOf(f).Elem()

--- a/model/utils.go
+++ b/model/utils.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/mail"
 	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -690,4 +691,8 @@ func filterBlocklist(r rune) rune {
 	}
 
 	return r
+}
+
+func IsCloud() bool {
+	return os.Getenv("MM_CLOUD_INSTALLATION_ID") != ""
 }


### PR DESCRIPTION
#### Summary

Fortunately it looks like Apps solved our problem already so I am following a similar approach.

- Calls will be pre-packaged and set to enabled by default which means it gets installed automatically on first server start.
- Upon actual plugin's activation we check whether the `CallsEnabled` feature flag is set to true and only in that case we allow the plugin to be started.

None of this should impact on-prem as all the checks are guarded by the `IsCloud` util (leveraging `MM_CLOUD_INSTALLATION_ID`).

Since we are here, I also added the code to pre-package as it will make it easier to test this PR. Just bear in mind I may have to bump the plugin's version before merging to get the latest changes necessary for it to work properly on Cloud.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44056

#### Release Note

```release-note
Prepackage Calls v0.4.9
```
