### PR TITLE
MM-44088: Add teamID filter to channelMembers

### DIFF
--- a/api4/graphql.go
+++ b/api4/graphql.go
@@ -34,7 +34,7 @@ const (
 	usersLoaderCtx    ctxKey = 4
 )
 
-const loaderBatchCapacity = web.PerPageMaximum + 100
+const loaderBatchCapacity = web.PerPageMaximum
 
 //go:embed schema.graphqls
 var schemaRaw string

--- a/api4/resolver.go
+++ b/api4/resolver.go
@@ -272,7 +272,7 @@ func (*resolver) ChannelMembers(ctx context.Context, args struct {
 			if primaryTeam != "" {
 				team, appErr := c.App.GetTeamByName(primaryTeam)
 				if appErr != nil {
-					return []*channelMember{}, nil
+					return []*channelMember{}, appErr
 				}
 				args.TeamID = team.Id
 			} else {

--- a/api4/resolver_channel_member_test.go
+++ b/api4/resolver_channel_member_test.go
@@ -319,7 +319,7 @@ func TestGraphQLChannelMembers(t *testing.T) {
 			OperationName: "channelMembers",
 			Query:         query,
 			Variables: map[string]interface{}{
-				"teamId": th.BasicTeam.Id,
+				"teamId":      th.BasicTeam.Id,
 				"excludeTeam": true,
 			},
 		}

--- a/api4/resolver_channel_member_test.go
+++ b/api4/resolver_channel_member_test.go
@@ -292,6 +292,45 @@ func TestGraphQLChannelMembers(t *testing.T) {
 		require.Len(t, resp.Errors, 1)
 	})
 
+	t.Run("team_filter", func(t *testing.T) {
+		query := `query channelMembers($teamId: String, $excludeTeam: Boolean = false) {
+	  channelMembers(userId: "me", teamId: $teamId, excludeTeam: $excludeTeam) {
+	  	channel {
+		  	id
+	  	}
+	  }
+	}
+	`
+		input := graphQLInput{
+			OperationName: "channelMembers",
+			Query:         query,
+			Variables: map[string]interface{}{
+				"teamId": th.BasicTeam.Id,
+			},
+		}
+
+		resp, err := th.MakeGraphQLRequest(&input)
+		require.NoError(t, err)
+		require.Len(t, resp.Errors, 0)
+		require.NoError(t, json.Unmarshal(resp.Data, &q))
+		assert.Len(t, q.ChannelMembers, 5)
+
+		input = graphQLInput{
+			OperationName: "channelMembers",
+			Query:         query,
+			Variables: map[string]interface{}{
+				"teamId": th.BasicTeam.Id,
+				"excludeTeam": true,
+			},
+		}
+
+		resp, err = th.MakeGraphQLRequest(&input)
+		require.NoError(t, err)
+		require.Len(t, resp.Errors, 0)
+		require.NoError(t, json.Unmarshal(resp.Data, &q))
+		assert.Len(t, q.ChannelMembers, 4)
+	})
+
 	t.Run("UpdateAt", func(t *testing.T) {
 		query := `query channelMembers($first: Int, $after: String = "", $lastUpdateAt: Float) {
 	  channelMembers(userId: "me", first: $first, after: $after, lastUpdateAt: $lastUpdateAt) {

--- a/api4/resolver_team.go
+++ b/api4/resolver_team.go
@@ -14,11 +14,6 @@ import (
 )
 
 func getGraphQLTeam(ctx context.Context, id string) (*model.Team, error) {
-	c, err := getCtx(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	loader, err := getTeamsLoader(ctx)
 	if err != nil {
 		return nil, err
@@ -30,15 +25,6 @@ func getGraphQLTeam(ctx context.Context, id string) (*model.Team, error) {
 		return nil, err
 	}
 	team := result.(*model.Team)
-	team = team.ShallowCopy()
-
-	if (!team.AllowOpenInvite || team.Type != model.TeamOpen) &&
-		!c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), team.Id, model.PermissionViewTeam) {
-		c.SetPermissionError(model.PermissionViewTeam)
-		return nil, c.Err
-	}
-
-	team = c.App.SanitizeTeam(*c.AppContext.Session(), team)
 	return team, nil
 }
 
@@ -76,6 +62,18 @@ func getGraphQLTeams(c *web.Context, teamIDs []string) ([]*model.Team, error) {
 
 	if len(teams) != len(teamIDs) {
 		return nil, fmt.Errorf("All teams were not found. Requested %d; Found %d", len(teamIDs), len(teams))
+	}
+
+	// We pre-calculate this so that it's not computed in separate goroutines outside
+	// the dataloader.
+	for _, team := range teams {
+		if (!team.AllowOpenInvite || team.Type != model.TeamOpen) &&
+			!c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), team.Id, model.PermissionViewTeam) {
+			c.SetPermissionError(model.PermissionViewTeam)
+			return nil, c.Err
+		}
+
+		team = c.App.SanitizeTeam(*c.AppContext.Session(), team)
 	}
 
 	// The teams need to be in the exact same order as the input slice.

--- a/api4/resolver_team.go
+++ b/api4/resolver_team.go
@@ -66,14 +66,14 @@ func getGraphQLTeams(c *web.Context, teamIDs []string) ([]*model.Team, error) {
 
 	// We pre-calculate this so that it's not computed in separate goroutines outside
 	// the dataloader.
-	for _, team := range teams {
-		if (!team.AllowOpenInvite || team.Type != model.TeamOpen) &&
-			!c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), team.Id, model.PermissionViewTeam) {
+	for i := range teams {
+		if (!teams[i].AllowOpenInvite || teams[i].Type != model.TeamOpen) &&
+			!c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), teams[i].Id, model.PermissionViewTeam) {
 			c.SetPermissionError(model.PermissionViewTeam)
 			return nil, c.Err
 		}
 
-		team = c.App.SanitizeTeam(*c.AppContext.Session(), team)
+		teams[i] = c.App.SanitizeTeam(*c.AppContext.Session(), teams[i])
 	}
 
 	// The teams need to be in the exact same order as the input slice.

--- a/api4/schema.graphqls
+++ b/api4/schema.graphqls
@@ -19,6 +19,8 @@ type Query {
 		since: Float!): [String!]!
 	channelMembers(userId: String!,
 		channelId: String = "",
+		teamId: String = "",
+		excludeTeam: Boolean = false,
 		first: Int = 60,
 		after: String = "",
 		lastUpdateAt: Float = 0): [ChannelMember]!

--- a/store/layer_generators/main.go
+++ b/store/layer_generators/main.go
@@ -284,8 +284,8 @@ func generateLayer(name, templateFile string) ([]byte, error) {
 				switch param.Type {
 				case "ChannelSearchOpts", "UserGetByIdsOpts", "ThreadMembershipOpts":
 					paramsWithType = append(paramsWithType, fmt.Sprintf("%s store.%s", param.Name, param.Type))
-				case "*UserGetByIdsOpts":
-					paramsWithType = append(paramsWithType, fmt.Sprintf("%s *store.UserGetByIdsOpts", param.Name))
+				case "*UserGetByIdsOpts", "*ChannelMemberGraphQLSearchOpts":
+					paramsWithType = append(paramsWithType, fmt.Sprintf("%s *store.%s", param.Name, strings.TrimPrefix(param.Type, "*")))
 				default:
 					paramsWithType = append(paramsWithType, fmt.Sprintf("%s %s", param.Name, param.Type))
 				}
@@ -298,8 +298,8 @@ func generateLayer(name, templateFile string) ([]byte, error) {
 				switch param.Type {
 				case "ChannelSearchOpts", "UserGetByIdsOpts", "ThreadMembershipOpts":
 					paramsWithType = append(paramsWithType, fmt.Sprintf("%s store.%s", param.Name, param.Type))
-				case "*UserGetByIdsOpts":
-					paramsWithType = append(paramsWithType, fmt.Sprintf("%s *store.UserGetByIdsOpts", param.Name))
+				case "*UserGetByIdsOpts", "*ChannelMemberGraphQLSearchOpts":
+					paramsWithType = append(paramsWithType, fmt.Sprintf("%s *store.%s", param.Name, strings.TrimPrefix(param.Type, "*")))
 				default:
 					paramsWithType = append(paramsWithType, fmt.Sprintf("%s %s", param.Name, param.Type))
 				}

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -1478,7 +1478,7 @@ func (s *OpenTracingLayerChannelStore) GetMembersForUser(teamID string, userID s
 	return result, err
 }
 
-func (s *OpenTracingLayerChannelStore) GetMembersForUserWithCursor(userID string, afterChannel string, afterUser string, limit int, lastUpdateAt int) (model.ChannelMembers, error) {
+func (s *OpenTracingLayerChannelStore) GetMembersForUserWithCursor(userID string, teamID string, opts *store.ChannelMemberGraphQLSearchOpts) (model.ChannelMembers, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ChannelStore.GetMembersForUserWithCursor")
 	s.Root.Store.SetContext(newCtx)
@@ -1487,7 +1487,7 @@ func (s *OpenTracingLayerChannelStore) GetMembersForUserWithCursor(userID string
 	}()
 
 	defer span.Finish()
-	result, err := s.ChannelStore.GetMembersForUserWithCursor(userID, afterChannel, afterUser, limit, lastUpdateAt)
+	result, err := s.ChannelStore.GetMembersForUserWithCursor(userID, teamID, opts)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -1660,11 +1660,11 @@ func (s *RetryLayerChannelStore) GetMembersForUser(teamID string, userID string)
 
 }
 
-func (s *RetryLayerChannelStore) GetMembersForUserWithCursor(userID string, afterChannel string, afterUser string, limit int, lastUpdateAt int) (model.ChannelMembers, error) {
+func (s *RetryLayerChannelStore) GetMembersForUserWithCursor(userID string, teamID string, opts *store.ChannelMemberGraphQLSearchOpts) (model.ChannelMembers, error) {
 
 	tries := 0
 	for {
-		result, err := s.ChannelStore.GetMembersForUserWithCursor(userID, afterChannel, afterUser, limit, lastUpdateAt)
+		result, err := s.ChannelStore.GetMembersForUserWithCursor(userID, teamID, opts)
 		if err == nil {
 			return result, nil
 		}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2814,7 +2814,7 @@ func (s SqlChannelStore) GetMembersForUser(teamID string, userID string) (model.
 	return dbMembers.ToModel(), nil
 }
 
-func (s SqlChannelStore) GetMembersForUserWithCursor(userID, afterChannel, afterUser string, limit, lastUpdateAt int) (model.ChannelMembers, error) {
+func (s SqlChannelStore) GetMembersForUserWithCursor(userID, teamID string, opts *store.ChannelMemberGraphQLSearchOpts) (model.ChannelMembers, error) {
 	query := s.getQueryBuilder().
 		Select("ChannelMembers.*",
 			"TeamScheme.DefaultChannelGuestRole TeamSchemeDefaultGuestRole",
@@ -2834,20 +2834,36 @@ func (s SqlChannelStore) GetMembersForUserWithCursor(userID, afterChannel, after
 		}).
 		OrderBy("ChannelId, UserId ASC").
 		// The limit is verified at the GraphQL layer.
-		Limit(uint64(limit))
+		Limit(uint64(opts.Limit))
 
-	if afterChannel != "" && afterUser != "" {
+	if teamID != "" {
+		if opts.ExcludeTeam {
+			// Exclude this team and DM/GMs
+			query = query.Where(sq.And{
+				sq.NotEq{"Channels.TeamId": teamID},
+				sq.NotEq{"Channels.TeamId": ""},
+			})
+		} else {
+			// Include this team and DM/GMs
+			query = query.Where(sq.Or{
+				sq.Eq{"Channels.TeamId": teamID},
+				sq.Eq{"Channels.TeamId": ""},
+			})
+		}
+	}
+
+	if opts.AfterChannel != "" && opts.AfterUser != "" {
 		query = query.Where(sq.Or{
-			sq.Gt{"ChannelMembers.ChannelId": afterChannel},
+			sq.Gt{"ChannelMembers.ChannelId": opts.AfterChannel},
 			sq.And{
-				sq.Eq{"ChannelMembers.ChannelId": afterChannel},
-				sq.Gt{"ChannelMembers.UserId": afterUser},
+				sq.Eq{"ChannelMembers.ChannelId": opts.AfterChannel},
+				sq.Gt{"ChannelMembers.UserId": opts.AfterUser},
 			},
 		})
 	}
 
-	if lastUpdateAt != 0 {
-		query = query.Where(sq.GtOrEq{"ChannelMembers.LastUpdateAt": lastUpdateAt})
+	if opts.LastUpdateAt != 0 {
+		query = query.Where(sq.GtOrEq{"ChannelMembers.LastUpdateAt": opts.LastUpdateAt})
 	}
 
 	queryString, args, err := query.ToSql()

--- a/store/store.go
+++ b/store/store.go
@@ -234,7 +234,7 @@ type ChannelStore interface {
 	GetMembersForUser(teamID string, userID string) (model.ChannelMembers, error)
 	GetTeamMembersForChannel(channelID string) ([]string, error)
 	GetMembersForUserWithPagination(userID string, page, perPage int) (model.ChannelMembersWithTeamData, error)
-	GetMembersForUserWithCursor(userID, afterChannel, afterUser string, limit, lastUpdateAt int) (model.ChannelMembers, error)
+	GetMembersForUserWithCursor(userID, teamID string, opts *ChannelMemberGraphQLSearchOpts) (model.ChannelMembers, error)
 	Autocomplete(userID, term string, includeDeleted bool) (model.ChannelListWithTeamData, error)
 	AutocompleteInTeam(teamID, userID, term string, includeDeleted bool) (model.ChannelList, error)
 	AutocompleteInTeamForSearch(teamID string, userID string, term string, includeDeleted bool) (model.ChannelList, error)
@@ -982,4 +982,14 @@ type ThreadMembershipOpts struct {
 	// UpdateParticipants indicates whether or not the thread's participants list
 	// should be updated.
 	UpdateParticipants bool
+}
+
+// ChannelMemberGraphQLSearchOpts contains the options for a graphQL query
+// to get the channel members.
+type ChannelMemberGraphQLSearchOpts struct {
+	AfterChannel string
+	AfterUser    string
+	Limit        int
+	LastUpdateAt int
+	ExcludeTeam  bool
 }

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -4549,18 +4549,18 @@ func testChannelStoreGetMembersForUserWithCursor(t *testing.T, ss store.Store) {
 		opts := &store.ChannelMemberGraphQLSearchOpts{
 			Limit: 10,
 		}
-		members, err := ss.Channel().GetMembersForUserWithCursor(m1.UserId, t2.Id, opts)
-		require.NoError(t, err)
+		members, err2 := ss.Channel().GetMembersForUserWithCursor(m1.UserId, t2.Id, opts)
+		require.NoError(t, err2)
 		assert.Len(t, members, 3)
 	})
 
 	t.Run("excluding a team", func(t *testing.T) {
 		opts := &store.ChannelMemberGraphQLSearchOpts{
-			Limit: 10,
+			Limit:       10,
 			ExcludeTeam: true,
 		}
-		members, err := ss.Channel().GetMembersForUserWithCursor(m1.UserId, t2.Id, opts)
-		require.NoError(t, err)
+		members, err2 := ss.Channel().GetMembersForUserWithCursor(m1.UserId, t2.Id, opts)
+		require.NoError(t, err2)
 		assert.Len(t, members, 2)
 	})
 

--- a/store/storetest/mocks/ChannelStore.go
+++ b/store/storetest/mocks/ChannelStore.go
@@ -1165,13 +1165,13 @@ func (_m *ChannelStore) GetMembersForUser(teamID string, userID string) (model.C
 	return r0, r1
 }
 
-// GetMembersForUserWithCursor provides a mock function with given fields: userID, afterChannel, afterUser, limit, lastUpdateAt
-func (_m *ChannelStore) GetMembersForUserWithCursor(userID string, afterChannel string, afterUser string, limit int, lastUpdateAt int) (model.ChannelMembers, error) {
-	ret := _m.Called(userID, afterChannel, afterUser, limit, lastUpdateAt)
+// GetMembersForUserWithCursor provides a mock function with given fields: userID, teamID, opts
+func (_m *ChannelStore) GetMembersForUserWithCursor(userID string, teamID string, opts *store.ChannelMemberGraphQLSearchOpts) (model.ChannelMembers, error) {
+	ret := _m.Called(userID, teamID, opts)
 
 	var r0 model.ChannelMembers
-	if rf, ok := ret.Get(0).(func(string, string, string, int, int) model.ChannelMembers); ok {
-		r0 = rf(userID, afterChannel, afterUser, limit, lastUpdateAt)
+	if rf, ok := ret.Get(0).(func(string, string, *store.ChannelMemberGraphQLSearchOpts) model.ChannelMembers); ok {
+		r0 = rf(userID, teamID, opts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(model.ChannelMembers)
@@ -1179,8 +1179,8 @@ func (_m *ChannelStore) GetMembersForUserWithCursor(userID string, afterChannel 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, string, string, int, int) error); ok {
-		r1 = rf(userID, afterChannel, afterUser, limit, lastUpdateAt)
+	if rf, ok := ret.Get(1).(func(string, string, *store.ChannelMemberGraphQLSearchOpts) error); ok {
+		r1 = rf(userID, teamID, opts)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -1365,10 +1365,10 @@ func (s *TimerLayerChannelStore) GetMembersForUser(teamID string, userID string)
 	return result, err
 }
 
-func (s *TimerLayerChannelStore) GetMembersForUserWithCursor(userID string, afterChannel string, afterUser string, limit int, lastUpdateAt int) (model.ChannelMembers, error) {
+func (s *TimerLayerChannelStore) GetMembersForUserWithCursor(userID string, teamID string, opts *store.ChannelMemberGraphQLSearchOpts) (model.ChannelMembers, error) {
 	start := timemodule.Now()
 
-	result, err := s.ChannelStore.GetMembersForUserWithCursor(userID, afterChannel, afterUser, limit, lastUpdateAt)
+	result, err := s.ChannelStore.GetMembersForUserWithCursor(userID, teamID, opts)
 
 	elapsed := float64(timemodule.Since(start)) / float64(timemodule.Second)
 	if s.Root.Metrics != nil {


### PR DESCRIPTION
We add 2 new params to channel members query.
1. Filter by teamId.
2. Negate that filter.

We include some more optimizations like:
- Moved the team role checks inside the dataloader.
- Moved the channel pretty name computation inside the loader.

Now that we load less data on initial load, we can reduce
the concurrency requirement to be a bit on the safer side.

```release-note
NONE
```
