### PR TITLE
MM-42581: fixes unread threads on user channel add

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -2489,6 +2489,8 @@ func (a *App) UpdateThreadFollowForUserFromChannelAdd(userID, teamID, threadID s
 		mlog.Warn("Failed to encode thread to JSON")
 	}
 	message.Add("thread", string(payload))
+	message.Add("previous_unread_replies", int64(0))
+	message.Add("previous_unread_mentions", int64(0))
 
 	a.Publish(message)
 	return nil


### PR DESCRIPTION
#### Summary

Currently when we are adding a user to a channel we don't send previous
values for unread replies and mentions. This is resulting the thread to
not be marked as unread in the UI, since we rely on the previous values
for that.

This commit fixes the issue by returning previous unread values of 0.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-42581

#### Release Note

```release-note
NONE
```
