### PR TITLE
Configure gitlab pipeline to use Go 1.18.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ include:
 
 variables:
   BUILD: "yes"
-  IMAGE_BUILD_SERVER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20210810_golang-1.16.7
+  IMAGE_BUILD_SERVER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-server:20220415_golang-1.18.1
   IMAGE_BUILD_DOCKER: $CI_REGISTRY/mattermost/ci/images/mattermost-build-docker:19.03.14-1
   IMAGE_DIND: $CI_REGISTRY/mattermost/ci/images/docker-dind:19.03.14-1
 


### PR DESCRIPTION

#### Summary
Configures Gitlab pipeline to use Go.1.8.1


#### Release Note
```release-note
NONE
```
