### PR TITLE
MM-41655: Prevent mmctl import into cloud instances

### DIFF
--- a/api4/upload.go
+++ b/api4/upload.go
@@ -48,6 +48,11 @@ func createUpload(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetPermissionError(model.PermissionManageSystem)
 			return
 		}
+		if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
+			c.Err = model.NewAppError("createUpload", "api.file.cloud_upload.app_error", nil, "", http.StatusBadRequest)
+			return
+		}
+
 	} else {
 		if !c.App.SessionHasPermissionToChannel(*c.AppContext.Session(), us.ChannelId, model.PermissionUploadFile) {
 			c.SetPermissionError(model.PermissionUploadFile)
@@ -120,6 +125,10 @@ func uploadData(c *Context, w http.ResponseWriter, r *http.Request) {
 	if us.Type == model.UploadTypeImport {
 		if !c.IsSystemAdmin() {
 			c.SetPermissionError(model.PermissionManageSystem)
+			return
+		}
+		if c.App.Srv().License() != nil && *c.App.Srv().License().Features.Cloud {
+			c.Err = model.NewAppError("UploadData", "api.file.cloud_upload.app_error", nil, "", http.StatusBadRequest)
 			return
 		}
 	} else {

--- a/api4/upload_test.go
+++ b/api4/upload_test.go
@@ -242,7 +242,7 @@ func TestUploadData(t *testing.T) {
 		th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
 		defer th.App.Srv().RemoveLicense()
 
-		us := &model.UploadSession{
+		us2 := &model.UploadSession{
 			Id:        model.NewId(),
 			Type:      model.UploadTypeImport,
 			CreateAt:  model.GetMillis(),
@@ -251,10 +251,10 @@ func TestUploadData(t *testing.T) {
 			Filename:  "upload",
 			FileSize:  8 * 1024 * 1024,
 		}
-		_, appErr := th.App.CreateUploadSession(us)
+		_, appErr := th.App.CreateUploadSession(us2)
 		require.Nil(t, appErr)
 
-		info, resp, err := th.SystemAdminClient.UploadData(us.Id, bytes.NewReader(data))
+		info, resp, err := th.SystemAdminClient.UploadData(us2.Id, bytes.NewReader(data))
 		require.Nil(t, info)
 		CheckErrorID(t, err, "api.file.cloud_upload.app_error")
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)

--- a/api4/upload_test.go
+++ b/api4/upload_test.go
@@ -45,6 +45,21 @@ func TestCreateUpload(t *testing.T) {
 		require.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
 
+	t.Run("not allowed in cloud", func(t *testing.T) {
+		th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
+		defer th.App.Srv().RemoveLicense()
+
+		u, resp, err := th.SystemAdminClient.CreateUpload(&model.UploadSession{
+			ChannelId: th.BasicChannel.Id,
+			Filename:  "upload",
+			FileSize:  8 * 1024 * 1024,
+			Type:      model.UploadTypeImport,
+		})
+		require.Nil(t, u)
+		CheckErrorID(t, err, "api.file.cloud_upload.app_error")
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
 	t.Run("valid", func(t *testing.T) {
 		us.ChannelId = th.BasicChannel.Id
 		u, resp, err := th.Client.CreateUpload(us)
@@ -221,6 +236,28 @@ func TestUploadData(t *testing.T) {
 		info, _, err := th.Client.UploadData(us.Id, bytes.NewReader(data))
 		require.Nil(t, info)
 		CheckErrorID(t, err, "api.context.permissions.app_error")
+	})
+
+	t.Run("not allowed in cloud", func(t *testing.T) {
+		th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
+		defer th.App.Srv().RemoveLicense()
+
+		us := &model.UploadSession{
+			Id:        model.NewId(),
+			Type:      model.UploadTypeImport,
+			CreateAt:  model.GetMillis(),
+			UserId:    th.BasicUser2.Id,
+			ChannelId: th.BasicChannel.Id,
+			Filename:  "upload",
+			FileSize:  8 * 1024 * 1024,
+		}
+		_, appErr := th.App.CreateUploadSession(us)
+		require.Nil(t, appErr)
+
+		info, resp, err := th.SystemAdminClient.UploadData(us.Id, bytes.NewReader(data))
+		require.Nil(t, info)
+		CheckErrorID(t, err, "api.file.cloud_upload.app_error")
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
 	t.Run("bad content-length", func(t *testing.T) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1742,6 +1742,10 @@
     "translation": "File attachments have been disabled on this server."
   },
   {
+    "id": "api.file.cloud_upload.app_error",
+    "translation": "Uploading via mmctl to a Cloud instance is not supported. Please check the documentation here: https://docs.mattermost.com/manage/cloud-data-export.html."
+  },
+  {
     "id": "api.file.file_exists.app_error",
     "translation": "Unable to check if the file exists."
   },


### PR DESCRIPTION
mmctl import is not supported and therefore we stop it.

https://mattermost.atlassian.net/browse/MM-41655

```release-note
NONE
```
