### PR TITLE
Makefile: Added setup-go-work to build step as well

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -82,9 +82,9 @@ else
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN)/windows_amd64 $(GOFLAGS) -trimpath -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
-build: build-linux build-windows build-osx
+build: setup-go-work build-linux build-windows build-osx
 
-build-cmd: build-cmd-linux build-cmd-windows build-cmd-osx
+build-cmd: setup-go-work build-cmd-linux build-cmd-windows build-cmd-osx
 
 build-client:
 	@echo Building mattermost web app


### PR DESCRIPTION
Without this, the go.work file would not get
generated in a fresh build.

```release-note
NONE
```
