### PR TITLE
MM-44148: fix race in CRT settings test

### DIFF
--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -2512,7 +2512,8 @@ func TestIsCRTEnabledForUser(t *testing.T) {
 			th := SetupWithStoreMock(t)
 			defer th.TearDown()
 
-			th.App.Config().ServiceSettings.CollapsedThreads = &tc.appCRT
+			crtSetting := tc.appCRT
+			th.App.Config().ServiceSettings.CollapsedThreads = &crtSetting
 
 			mockStore := th.App.Srv().Store.(*mocks.Store)
 			mockPreferenceStore := mocks.PreferenceStore{}

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -2448,7 +2448,6 @@ func TestMarkUnreadWithThreads(t *testing.T) {
 }
 
 func TestIsCRTEnabledForUser(t *testing.T) {
-	t.Skip("MM-44148")
 	type preference struct {
 		val string
 		err error
@@ -2509,9 +2508,7 @@ func TestIsCRTEnabledForUser(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
 			th := SetupWithStoreMock(t)
 			defer th.TearDown()
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
-  Our i18n package init/setup isn't amenable to being run in parallel tests. Removed test parallelization for now to fix the race. 
- Don't export pointer to loop variable

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-44148

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
