### PR TITLE
Fixes a null pointer if the plugin requests the limits on a non-cloud server

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -1182,6 +1182,9 @@ func (api *PluginAPI) RequestTrialLicense(requesterID string, users int, termsAc
 
 // GetCloudLimits returns any limits associated with the cloud instance
 func (api *PluginAPI) GetCloudLimits() (*model.ProductLimits, error) {
+	if api.app.Cloud() == nil {
+		return &model.ProductLimits{}, nil
+	}
 	limits, err := api.app.Cloud().GetCloudLimits("")
 	return limits, err
 }


### PR DESCRIPTION
#### Summary
This PR checks if the app has the cloud interface set before trying to call it to avoid a null pointer when using the get limits plugin API endpoint in non-cloud mode.

```release-note
NONE
```
