### PR TITLE
config/diff: add utility function to get diffs scoped with struct tags

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2250,7 +2250,7 @@ func (s *LdapSettings) SetDefaults() {
 
 type ComplianceSettings struct {
 	Enable      *bool   `access:"compliance_compliance_monitoring"`
-	Directory   *string `access:"compliance_compliance_monitoring"` // telemetry: none
+	Directory   *string `access:"compliance_compliance_monitoring,cloud_restrictable"` // telemetry: none
 	EnableDaily *bool   `access:"compliance_compliance_monitoring"`
 	BatchSize   *int    `access:"compliance_compliance_monitoring"` // telemetry: none
 }
@@ -3115,18 +3115,18 @@ type Config struct {
 	ExperimentalSettings      ExperimentalSettings
 	AnalyticsSettings         AnalyticsSettings
 	ElasticsearchSettings     ElasticsearchSettings
-	BleveSettings             BleveSettings
+	BleveSettings             BleveSettings `access:"cloud_restrictable"`
 	DataRetentionSettings     DataRetentionSettings
 	MessageExportSettings     MessageExportSettings
 	JobSettings               JobSettings
 	PluginSettings            PluginSettings
 	DisplaySettings           DisplaySettings
 	GuestAccountsSettings     GuestAccountsSettings
-	ImageProxySettings        ImageProxySettings
-	CloudSettings             CloudSettings  // telemetry: none
-	FeatureFlags              *FeatureFlags  `access:"*_read" json:",omitempty"`
-	ImportSettings            ImportSettings // telemetry: none
-	ExportSettings            ExportSettings
+	ImageProxySettings        ImageProxySettings `access:"cloud_restrictable"`
+	CloudSettings             CloudSettings      // telemetry: none
+	FeatureFlags              *FeatureFlags      `access:"*_read" json:",omitempty"`
+	ImportSettings            ImportSettings     `access:"cloud_restrictable"` // telemetry: none
+	ExportSettings            ExportSettings     `access:"cloud_restrictable"`
 }
 
 func (o *Config) Clone() *Config {


### PR DESCRIPTION
#### Summary
Added `config.DiffTags` utility function to get diffs according to specific sturct tags. Also added some struct tags to `model.Config` to restrict access.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41660

#### Release Note

```release-note
NONE
```
