### PR TITLE
MM-42379: Do not set TrustedProxyIPHeader for new instances

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -545,13 +545,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 		s.Forward80To443 = NewBool(false)
 	}
 
-	if isUpdate {
-		// When updating an existing configuration, ensure that defaults are set.
-		if s.TrustedProxyIPHeader == nil {
-			s.TrustedProxyIPHeader = []string{HeaderForwarded, HeaderRealIP}
-		}
-	} else {
-		// When generating a blank configuration, leave the list empty.
+	if s.TrustedProxyIPHeader == nil {
 		s.TrustedProxyIPHeader = []string{}
 	}
 


### PR DESCRIPTION
We move away with the update logic and just set an empty
slice always.

```release-note
The value of ServiceSettings.TrustedProxyIPHeader will default
to empty from now on. A previous bug prevented this from happening
in certain conditions. Customers are requested to check for these
values in their config and set them to nil if necessary.
```
