### PR TITLE
GraphQL: Adding a defaultTeamFallback flag

### DIFF
--- a/api4/resolver_channel_member_test.go
+++ b/api4/resolver_channel_member_test.go
@@ -331,6 +331,35 @@ func TestGraphQLChannelMembers(t *testing.T) {
 		assert.Len(t, q.ChannelMembers, 4)
 	})
 
+	t.Run("default_team_fallback", func(t *testing.T) {
+		query := `query channelMembers($teamId: String, $excludeTeam: Boolean = false, $defaultTeamFallback: Boolean = false) {
+	  channelMembers(userId: "me", teamId: $teamId, excludeTeam: $excludeTeam, defaultTeamFallback: $defaultTeamFallback) {
+	  	channel {
+		  	id
+	  	}
+	  }
+	}
+	`
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.TeamSettings.ExperimentalPrimaryTeam = th.BasicTeam.Name
+		})
+
+		input := graphQLInput{
+			OperationName: "channelMembers",
+			Query:         query,
+			Variables: map[string]interface{}{
+				"teamId":      "",
+				"defaultTeamFallback": true,
+			},
+		}
+
+		resp, err := th.MakeGraphQLRequest(&input)
+		require.NoError(t, err)
+		require.Len(t, resp.Errors, 0)
+		require.NoError(t, json.Unmarshal(resp.Data, &q))
+		assert.Len(t, q.ChannelMembers, 5)
+	})
+
 	t.Run("UpdateAt", func(t *testing.T) {
 		query := `query channelMembers($first: Int, $after: String = "", $lastUpdateAt: Float) {
 	  channelMembers(userId: "me", first: $first, after: $after, lastUpdateAt: $lastUpdateAt) {

--- a/api4/schema.graphqls
+++ b/api4/schema.graphqls
@@ -24,9 +24,11 @@ type Query {
 		excludeTeam: Boolean = false,
 		first: Int = 60,
 		after: String = "",
-		lastUpdateAt: Float = 0): [ChannelMember]!
+		lastUpdateAt: Float = 0,
+		defaultTeamFallback: Boolean = false): [ChannelMember]!
 	sidebarCategories(userId: String!,
-		teamId: String!): [SidebarCategory]!
+		teamId: String!
+		defaultTeamFallback: Boolean = false): [SidebarCategory]!
 }
 
 scalar ChannelType


### PR DESCRIPTION
This flag selects the default team if no team is passed.

And in channel_members case, if no team is passed and the
flag is false, it returns members from all teams.

```release-note
NONE
```
