### PR TITLE
MM-31353: Fix flaky TestNoticeValidation/notice_with_specific_date_check

### DIFF
--- a/app/product_notices_test.go
+++ b/app/product_notices_test.go
@@ -360,7 +360,7 @@ func TestNoticeValidation(t *testing.T) {
 			args: args{
 				notice: &model.ProductNotice{
 					Conditions: model.Conditions{
-						DisplayDate: model.NewString(fmt.Sprintf("= %sT00:00:00Z", time.Now().Format("2006-01-02"))),
+						DisplayDate: model.NewString(fmt.Sprintf("= %sT00:00:00Z", time.Now().UTC().Format("2006-01-02"))),
 					},
 				},
 			},


### PR DESCRIPTION
We now generate the current time in UTC to avoid date transitions
when running the tests at different local times.

https://mattermost.atlassian.net/browse/MM-31353

```release-note
NONE
```
