### PR TITLE
cherrypick-50eaec6

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -2855,7 +2855,7 @@ func (a *App) SearchChannelsUserNotIn(teamID string, userID string, term string)
 func (a *App) MarkChannelsAsViewed(channelIDs []string, userID string, currentSessionId string, collapsedThreadsSupported bool) (map[string]int64, *model.AppError) {
 	// I start looking for channels with notifications before I mark it as read, to clear the push notifications if needed
 	channelsToClearPushNotifications := []string{}
-	if *a.Config().EmailSettings.SendPushNotifications {
+	if a.canSendPushNotifications() {
 		for _, channelID := range channelIDs {
 			channel, errCh := a.Srv().Store.Channel().Get(channelID, true)
 			if errCh != nil {

--- a/app/expirynotify.go
+++ b/app/expirynotify.go
@@ -16,13 +16,9 @@ const (
 )
 
 // NotifySessionsExpired is called periodically from the job server to notify any mobile sessions that have expired.
-func (a *App) NotifySessionsExpired() *model.AppError {
-	if *a.Config().EmailSettings.SendPushNotifications {
-		pushServer := *a.Config().EmailSettings.PushNotificationServer
-		if license := a.ch.srv.License(); pushServer == model.MHPNS && (license == nil || !*license.Features.MHPNS) {
-			mlog.Warn("Push notifications are disabled. Go to System Console > Notifications > Mobile Push to enable them.")
-			return nil
-		}
+func (a *App) NotifySessionsExpired() error {
+	if !a.canSendPushNotifications() {
+		return nil
 	}
 
 	// Get all mobile sessions that expired within the last hour.

--- a/app/expirynotify.go
+++ b/app/expirynotify.go
@@ -16,7 +16,7 @@ const (
 )
 
 // NotifySessionsExpired is called periodically from the job server to notify any mobile sessions that have expired.
-func (a *App) NotifySessionsExpired() error {
+func (a *App) NotifySessionsExpired() *model.AppError {
 	if !a.canSendPushNotifications() {
 		return nil
 	}

--- a/app/notification.go
+++ b/app/notification.go
@@ -22,6 +22,20 @@ import (
 	"github.com/mattermost/mattermost-server/v6/store"
 )
 
+func (a *App) canSendPushNotifications() bool {
+	if !*a.Config().EmailSettings.SendPushNotifications {
+		return false
+	}
+
+	pushServer := *a.Config().EmailSettings.PushNotificationServer
+	if license := a.Srv().License(); pushServer == model.MHPNS && (license == nil || !*license.Features.MHPNS) {
+		mlog.Warn("Push notifications have been disabled. Update your license or go to System Console > Environment > Push Notification Server to use a different server")
+		return false
+	}
+
+	return true
+}
+
 func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *model.Channel, sender *model.User, parentPostList *model.PostList, setOnline bool) ([]string, error) {
 	// Do not send notifications in archived channels
 	if channel.DeleteAt > 0 {
@@ -405,18 +419,7 @@ func (a *App) SendNotifications(post *model.Post, team *model.Team, channel *mod
 		}
 	}
 
-	sendPushNotifications := false
-	if *a.Config().EmailSettings.SendPushNotifications {
-		pushServer := *a.Config().EmailSettings.PushNotificationServer
-		if license := a.Srv().License(); pushServer == model.MHPNS && (license == nil || !*license.Features.MHPNS) {
-			mlog.Warn("Push notifications are disabled. Go to System Console > Notifications > Mobile Push to enable them.")
-			sendPushNotifications = false
-		} else {
-			sendPushNotifications = true
-		}
-	}
-
-	if sendPushNotifications {
+	if a.canSendPushNotifications() {
 		for _, id := range mentionedUsersList {
 			if profileMap[id] == nil || notificationsForCRT.Push.Contains(id) {
 				continue

--- a/app/notification_push.go
+++ b/app/notification_push.go
@@ -578,6 +578,10 @@ func (a *App) BuildPushNotificationMessage(contentsConfig string, post *model.Po
 }
 
 func (a *App) SendTestPushNotification(deviceID string) string {
+	if !a.canSendPushNotifications() {
+		return "false"
+	}
+
 	msg := &model.PushNotification{
 		Version:  "2",
 		Type:     model.PushTypeTest,


### PR DESCRIPTION

```release-note
Fix bug that allow to send test (empty) notifications even if the `SendPushNotifications` config is set to false.
```
