### PR TITLE
app: add permissions wrapper

### DIFF
--- a/app/channels.go
+++ b/app/channels.go
@@ -219,6 +219,10 @@ func NewChannels(s *Server, services map[ServiceKey]interface{}) (*Channels, err
 		app: &App{ch: ch},
 	}
 
+	services[PermissionsKey] = &permissionsServiceWrapper{
+		app: &App{ch: ch},
+	}
+
 	return ch, nil
 }
 

--- a/app/permissions.go
+++ b/app/permissions.go
@@ -19,6 +19,14 @@ import (
 const permissionsExportBatchSize = 100
 const systemSchemeName = "00000000-0000-0000-0000-000000000000" // Prevents collisions with user-created schemes.
 
+type permissionsServiceWrapper struct {
+	app AppIface
+}
+
+func (s *permissionsServiceWrapper) HasPermissionToTeam(userID string, teamID string, permission *model.Permission) bool {
+	return s.app.HasPermissionToTeam(userID, teamID, permission)
+}
+
 func (a *App) ResetPermissionsSystem() *model.AppError {
 	// Reset all Teams to not have a scheme.
 	if err := a.Srv().Store.Team().ResetAllTeamSchemes(); err != nil {

--- a/app/server.go
+++ b/app/server.go
@@ -86,13 +86,14 @@ var SentryDSN = "placeholder_sentry_dsn"
 type ServiceKey string
 
 const (
-	ChannelKey   ServiceKey = "channel"
-	ConfigKey    ServiceKey = "config"
-	LicenseKey   ServiceKey = "license"
-	FilestoreKey ServiceKey = "filestore"
-	ClusterKey   ServiceKey = "cluster"
-	PostKey      ServiceKey = "post"
-	TeamKey      ServiceKey = "team"
+	ChannelKey     ServiceKey = "channel"
+	ConfigKey      ServiceKey = "config"
+	LicenseKey     ServiceKey = "license"
+	FilestoreKey   ServiceKey = "filestore"
+	ClusterKey     ServiceKey = "cluster"
+	PostKey        ServiceKey = "post"
+	TeamKey        ServiceKey = "team"
+	PermissionsKey ServiceKey = "permissions"
 )
 
 type Server struct {


### PR DESCRIPTION

#### Summary
The plugin API provides this method under user service:

https://github.com/mattermost/mattermost-plugin-api/blob/e672b88e7c638e3a02ebc2ac0b3c8e16e4005e7f/user.go#L197

But we don't have any team scope on our user service in mattermost-server. The team service already has a dependency to user service for team membership stuff, hence it will be a cyclic dependency even if we go that direction. Since permissions does not have any application logic with other entities such as team/users rather than accessing the id and scheme, we can have a separate service/interface.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44331

#### Release Note

```release-note
NONE
```
