### PR TITLE
[MM-44263] Only include user posts in post count

### DIFF
--- a/api4/usage_test.go
+++ b/api4/usage_test.go
@@ -24,11 +24,13 @@ func TestGetPostsUsage(t *testing.T) {
 	})
 
 	t.Run("good request returns response", func(t *testing.T) {
-		// Following calls create a total of 15 posts
+		// Following calls create a total of (12 system + 15 user) posts
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
-		th.CreatePost()
-		th.CreatePost()
+
+		for i := 0; i < 14; i++ {
+			th.CreatePost()
+		}
 
 		usage, r, err := th.Client.GetPostsUsage()
 		assert.NoError(t, err)

--- a/app/usage.go
+++ b/app/usage.go
@@ -12,7 +12,7 @@ import (
 
 // GetPostsUsage returns "rounded off" total posts count like returns 900 instead of 987
 func (a *App) GetPostsUsage() (int64, *model.AppError) {
-	count, err := a.Srv().Store.Post().AnalyticsPostCount(&model.PostCountOptions{ExcludeDeleted: true})
+	count, err := a.Srv().Store.Post().AnalyticsPostCount(&model.PostCountOptions{ExcludeDeleted: true, UsersPostsOnly: true})
 	if err != nil {
 		return 0, model.NewAppError("GetPostsUsage", "app.post.analytics_posts_count.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}

--- a/model/post.go
+++ b/model/post.go
@@ -280,6 +280,7 @@ type PostCountOptions struct {
 	MustHaveFile    bool
 	MustHaveHashtag bool
 	ExcludeDeleted  bool
+	UsersPostsOnly  bool
 }
 
 func (o *Post) Etag() string {

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -2142,7 +2142,7 @@ func (s *SqlPostStore) AnalyticsPostCount(options *model.PostCountOptions) (int6
 	if options.UsersPostsOnly {
 		query = query.Where(sq.And{
 			sq.Eq{"p.Type": ""},
-			sq.Expr("p.UserId NOT IN (SELECT Userid FROM Bots)"),
+			sq.Expr("p.UserId NOT IN (SELECT UserId FROM Bots)"),
 		})
 	}
 

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -2139,6 +2139,13 @@ func (s *SqlPostStore) AnalyticsPostCount(options *model.PostCountOptions) (int6
 			Where(sq.Eq{"c.TeamId": options.TeamId})
 	}
 
+	if options.UsersPostsOnly {
+		query = query.Where(sq.And{
+			sq.Eq{"p.Type": ""},
+			sq.Expr("p.UserId NOT IN (SELECT Userid FROM Bots)"),
+		})
+	}
+
 	if options.MustHaveFile {
 		query = query.Where(sq.Or{sq.NotEq{"p.FileIds": "[]"}, sq.NotEq{"p.Filenames": "[]"}})
 	}

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -2148,6 +2148,11 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	r2, err = ss.Post().AnalyticsPostCount(&model.PostCountOptions{TeamId: t1.Id, ExcludeDeleted: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), r2)
+
+	// total users only posts for single team with the deleted post excluded
+	r2, err = ss.Post().AnalyticsPostCount(&model.PostCountOptions{TeamId: t1.Id, ExcludeDeleted: true, UsersPostsOnly: true})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), r2)
 }
 
 func testPostStoreGetFlaggedPostsForTeam(t *testing.T, ss store.Store, s SqlStore) {

--- a/store/storetest/post_store.go
+++ b/store/storetest/post_store.go
@@ -2135,7 +2135,7 @@ func testPostCountsByDay(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, r2, int64(2))
 
-	// total across teams with hastags and files
+	// total across teams with hashtags and files
 	r2, err = ss.Post().AnalyticsPostCount(&model.PostCountOptions{MustHaveFile: true, MustHaveHashtag: true})
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, r2, int64(1))


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
When fetching count, include user posts only in post count. i.e., exclude "system" and "bots" messages.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA - https://mattermost.atlassian.net/browse/MM-44263

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed API - GET /api/v4/usage/posts, to include user posts only.
```
