### PR TITLE
Enable plugins for ARM64

### DIFF
--- a/model/manifest.go
+++ b/model/manifest.go
@@ -117,6 +117,7 @@ type PluginSettingsSchema struct {
 //      "server": {
 //        "executables": {
 //          "linux-amd64": "server/dist/plugin-linux-amd64",
+//          "linux-arm64": "server/dist/plugin-linux-arm64",
 //          "darwin-amd64": "server/dist/plugin-darwin-amd64",
 //          "windows-amd64": "server/dist/plugin-windows-amd64.exe"
 //        }
@@ -211,6 +212,8 @@ type ManifestServer struct {
 type ManifestExecutables struct {
 	// LinuxAmd64 is the path to your executable binary for the corresponding platform
 	LinuxAmd64 string `json:"linux-amd64,omitempty" yaml:"linux-amd64,omitempty"`
+	// LinuxArm64 is the path to your executable binary for the corresponding platform
+	LinuxArm64 string `json:"linux-arm64,omitempty" yaml:"linux-arm64,omitempty"`
 	// DarwinAmd64 is the path to your executable binary for the corresponding platform
 	DarwinAmd64 string `json:"darwin-amd64,omitempty" yaml:"darwin-amd64,omitempty"`
 	// WindowsAmd64 is the path to your executable binary for the corresponding platform


### PR DESCRIPTION

#### Summary
Enable building of ARM64 plugins

#### Ticket Link

#### Release Note

```release-note
Added a new config setting linux-arm64 for building plugins.
```