### PR TITLE
[WIP] Audit logging v2

### DIFF
--- a/api4/bleve.go
+++ b/api4/bleve.go
@@ -33,6 +33,7 @@ func purgeBleveIndexes(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec.AddMetadata(nil, nil, nil, "")
 	auditRec.Success()
 
 	ReturnStatusOK(w)

--- a/api4/bot.go
+++ b/api4/bot.go
@@ -66,6 +66,7 @@ func createBot(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 	auditRec.AddMeta("bot", createdBot) // overwrite meta
+	auditRec.AddMetadata(botPatch, nil, bot, "bot")
 
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(createdBot); err != nil {
@@ -96,6 +97,7 @@ func patchBot(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	oldBot, _ := c.App.GetBot(botUserId, false)
 	updatedBot, appErr := c.App.PatchBot(botUserId, botPatch)
 	if appErr != nil {
 		c.Err = appErr
@@ -104,6 +106,7 @@ func patchBot(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 	auditRec.AddMeta("bot", updatedBot)
+	auditRec.AddMetadata(botPatch, oldBot, updatedBot, "bot")
 
 	if err := json.NewEncoder(w).Encode(updatedBot); err != nil {
 		mlog.Warn("Error while writing response", mlog.Err(err))
@@ -213,6 +216,8 @@ func updateBotActive(c *Context, w http.ResponseWriter, active bool) {
 		return
 	}
 
+	oldBot, _ := c.App.GetBot(botUserId, false)
+
 	bot, err := c.App.UpdateBotActive(c.AppContext, botUserId, active)
 	if err != nil {
 		c.Err = err
@@ -221,6 +226,7 @@ func updateBotActive(c *Context, w http.ResponseWriter, active bool) {
 
 	auditRec.Success()
 	auditRec.AddMeta("bot", bot)
+	auditRec.AddMetadata(c.Params, oldBot, bot, "bot")
 
 	if err := json.NewEncoder(w).Encode(bot); err != nil {
 		mlog.Warn("Error while writing response", mlog.Err(err))
@@ -261,6 +267,7 @@ func assignBot(c *Context, w http.ResponseWriter, _ *http.Request) {
 
 	auditRec.Success()
 	auditRec.AddMeta("bot", bot)
+	auditRec.AddMetadata(c.Params, nil, bot, "bot")
 
 	if err := json.NewEncoder(w).Encode(bot); err != nil {
 		mlog.Warn("Error while writing response", mlog.Err(err))
@@ -307,6 +314,7 @@ func convertBotToUser(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 	auditRec.AddMeta("convertedTo", user)
+	auditRec.AddMetadata(userPatch, bot, user, "user")
 
 	if err := json.NewEncoder(w).Encode(user); err != nil {
 		mlog.Warn("Error while writing response", mlog.Err(err))

--- a/api4/brand.go
+++ b/api4/brand.go
@@ -71,6 +71,7 @@ func uploadBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec.AddMetadata(nil, nil, nil, "")
 	auditRec.Success()
 	c.LogAudit("")
 
@@ -92,6 +93,7 @@ func deleteBrandImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec.AddMetadata(nil, nil, nil, "")
 	auditRec.Success()
 
 	ReturnStatusOK(w)

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -85,6 +85,7 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidParam("channel")
 		return
 	}
+	uploadedChannel := channel.DeepCopy()
 
 	auditRec := c.MakeAuditRecord("createChannel", audit.Fail)
 	defer c.LogAuditRec(auditRec)
@@ -108,6 +109,7 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 	auditRec.AddMeta("channel", sc) // overwrite meta
+	auditRec.AddMetadata(uploadedChannel, nil, channel, "channel")
 	c.LogAudit("name=" + channel.Name)
 
 	w.WriteHeader(http.StatusCreated)
@@ -128,6 +130,7 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidParam("channel")
 		return
 	}
+	uploadedChannel := channel.DeepCopy()
 
 	// The channel being updated in the payload must be the same one as indicated in the URL.
 	if channel.Id != c.Params.ChannelId {
@@ -221,6 +224,7 @@ func updateChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec.Success()
+	auditRec.AddMetadata(uploadedChannel, oldChannel, updatedChannel, "channel")
 	c.LogAudit("name=" + channel.Name)
 
 	if err := json.NewEncoder(w).Encode(oldChannel); err != nil {
@@ -246,6 +250,7 @@ func updateChannelPrivacy(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
+	priorChannel := channel.DeepCopy()
 
 	auditRec := c.MakeAuditRecord("updateChannelPrivacy", audit.Fail)
 	defer c.LogAuditRec(auditRec)
@@ -280,9 +285,10 @@ func updateChannelPrivacy(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.Err = err
 		return
-	}
+}
 
 	auditRec.Success()
+	auditRec.AddMetadata(props, priorChannel, updatedChannel, "channel")
 	c.LogAudit("name=" + updatedChannel.Name)
 
 	if err := json.NewEncoder(w).Encode(updatedChannel); err != nil {

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -358,7 +358,7 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddMetadata("", patch, oldChannelForAuditLog.Id, oldChannelForAuditLog, rchannel.Id, rchannel)
+	auditRec.AddMetadata(patch, oldChannelForAuditLog, rchannel, "channel")
 
 	auditRec.Success()
 	c.LogAudit("")

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -308,6 +308,7 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	oldChannel := originalOldChannel.DeepCopy()
+	oldChannelForAuditLog := originalOldChannel.DeepCopy()
 
 	auditRec := c.MakeAuditRecord("patchChannel", audit.Fail)
 	defer c.LogAuditRec(auditRec)
@@ -356,6 +357,8 @@ func patchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = appErr
 		return
 	}
+
+	auditRec.AddMetadata("", patch, oldChannelForAuditLog.Id, oldChannelForAuditLog, rchannel.Id, rchannel)
 
 	auditRec.Success()
 	c.LogAudit("")

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -97,8 +97,6 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	priorChannel, _ := c.App.GetChannel(channel.Id)
-
 	auditRec := c.MakeAuditRecord("createChannel", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	auditRec.AddMeta("channel", channel)
@@ -121,7 +119,7 @@ func createChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 	auditRec.AddMeta("channel", sc) // overwrite meta
-	auditRec.AddMetadata(postPayload, priorChannel, channel, "channel")
+	auditRec.AddMetadata(postPayload, nil, sc, "channel")
 	c.LogAudit("name=" + channel.Name)
 
 	w.WriteHeader(http.StatusCreated)

--- a/api4/channel.go
+++ b/api4/channel.go
@@ -612,7 +612,7 @@ func createGroupChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 	auditRec.AddMeta("channel", groupChannel)
-	auditRec.AddMetadata(postBody, nil, groupChannel, "channel")
+	auditRec.AddMetadata(postPayload, nil, groupChannel, "channel")
 
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(groupChannel); err != nil {

--- a/api4/channel_category.go
+++ b/api4/channel_category.go
@@ -155,7 +155,7 @@ func updateCategoryOrderForTeamForUser(c *Context, w http.ResponseWriter, r *htt
 
 	resultingOrder, _ := c.App.GetSidebarCategoryOrder(c.Params.UserId, c.Params.TeamId)
 
-	auditRec.AddMetadata(postBody, &audit.AuditableStringArray{Array: priorOrder}, &audit.AuditableStringArray{Array: resultingOrder}, "category")
+	auditRec.AddMetadata(postPayload, &audit.AuditableStringArray{Array: priorOrder}, &audit.AuditableStringArray{Array: resultingOrder}, "category")
 	auditRec.Success()
 	w.Write([]byte(model.ArrayToJSON(categoryOrder)))
 }

--- a/api4/channel_local.go
+++ b/api4/channel_local.go
@@ -305,6 +305,8 @@ func localPatchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec.AddMetadata(originalOldChannel.Id, originalOldChannel, "", patch, channel.Id, channel)
+
 	auditRec.Success()
 	c.LogAudit("")
 	auditRec.AddMeta("patch", rchannel)

--- a/api4/channel_local.go
+++ b/api4/channel_local.go
@@ -305,7 +305,7 @@ func localPatchChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddMetadata(originalOldChannel.Id, originalOldChannel, "", patch, channel.Id, channel)
+	auditRec.AddMetadata(patch, originalOldChannel, channel, "channel")
 
 	auditRec.Success()
 	c.LogAudit("")

--- a/api4/channel_local.go
+++ b/api4/channel_local.go
@@ -460,6 +460,8 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	priorChannel := channel.DeepCopy()
+
 	auditRec := c.MakeAuditRecord("localDeleteChannel", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	auditRec.AddMeta("channeld", channel)
@@ -479,6 +481,7 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec.AddMetadata(nil, priorChannel, channel, "channel")
 	auditRec.Success()
 	c.LogAudit("name=" + channel.Name)
 

--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -375,6 +375,9 @@ func confirmCustomerPayment(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	var postPayload interface{}
+	_ = json.NewDecoder(bytes.NewBuffer(bodyBytes)).Decode(&postPayload)
+
 	var confirmRequest *model.ConfirmPaymentMethodRequest
 	if err = json.Unmarshal(bodyBytes, &confirmRequest); err != nil {
 		c.Err = model.NewAppError("Api4.confirmCustomerPayment", "api.cloud.app_error", nil, err.Error(), http.StatusInternalServerError)
@@ -387,6 +390,7 @@ func confirmCustomerPayment(c *Context, w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	auditRec.AddMetadata(postPayload, nil, nil, "")
 	auditRec.Success()
 
 	ReturnStatusOK(w)

--- a/api4/command_local.go
+++ b/api4/command_local.go
@@ -42,6 +42,7 @@ func localCreateCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.Success()
 	c.LogAudit("success")
 	auditRec.AddMeta("command", rcmd)
+	auditRec.AddMetadata(cmd, nil, rcmd, "command")
 
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(rcmd); err != nil {

--- a/api4/config.go
+++ b/api4/config.go
@@ -4,8 +4,10 @@
 package api4
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -107,7 +109,16 @@ func configReload(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
-	cfg := model.ConfigFromJSON(r.Body)
+	postBody, readErr := ioutil.ReadAll(r.Body)
+	if readErr != nil {
+		return
+	}
+	defer r.Body.Close()
+
+	var postPayload interface{}
+	_ = json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&postPayload)
+
+	cfg := model.ConfigFromJSON(bytes.NewBuffer(postBody))
 	if cfg == nil {
 		c.SetInvalidParam("config")
 		return

--- a/api4/group.go
+++ b/api4/group.go
@@ -189,7 +189,7 @@ func createGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddMetadata(postBody, nil, newGroup, "group")
+	auditRec.AddMetadata(postPayload, nil, newGroup, "group")
 	auditRec.Success()
 	w.WriteHeader(http.StatusCreated)
 	w.Write(js)
@@ -285,7 +285,7 @@ func patchGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	auditRec.AddMeta("patch", group)
-	auditRec.AddMetadata(postBody, priorGroup, group, "group")
+	auditRec.AddMetadata(postPayload, priorGroup, group, "group")
 
 	b, marshalErr := json.Marshal(group)
 	if marshalErr != nil {

--- a/api4/post.go
+++ b/api4/post.go
@@ -4,7 +4,9 @@
 package api4
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
@@ -39,13 +41,20 @@ func (api *API) InitPost() {
 }
 
 func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
+	postBody, readErr := ioutil.ReadAll(r.Body)
+	if readErr != nil {
+		return
+	}
+	defer r.Body.Close()
+
+	var postPayload interface{}
+	_ = json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&postPayload)
+
 	var post model.Post
-	if jsonErr := json.NewDecoder(r.Body).Decode(&post); jsonErr != nil {
+	if jsonErr := json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&post); jsonErr != nil {
 		c.SetInvalidParam("post")
 		return
 	}
-	var postPayload model.Post
-	post.ShallowCopy(&postPayload)
 
 	// Strip away delete_at if passed
 	post.DeleteAt = 0

--- a/api4/post.go
+++ b/api4/post.go
@@ -44,6 +44,8 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidParam("post")
 		return
 	}
+	var postPayload model.Post
+	post.ShallowCopy(&postPayload)
 
 	// Strip away delete_at if passed
 	post.DeleteAt = 0
@@ -99,7 +101,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.App.UpdateLastActivityAtIfNeeded(*c.AppContext.Session())
 	c.ExtendSessionExpiryIfNeeded(w, r)
 
-	auditRec.AddMetadata(post, nil, rp, "post")
+	auditRec.AddMetadata(postPayload, nil, rp, "post")
 
 	w.WriteHeader(http.StatusCreated)
 

--- a/api4/post.go
+++ b/api4/post.go
@@ -99,6 +99,8 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.App.UpdateLastActivityAtIfNeeded(*c.AppContext.Session())
 	c.ExtendSessionExpiryIfNeeded(w, r)
 
+	auditRec.AddMetadata(post.PendingPostId, post, "", nil, rp.Id, rp.AuditLoggablePost())
+
 	w.WriteHeader(http.StatusCreated)
 
 	// Note that rp has already had PreparePostForClient called on it by App.CreatePost

--- a/api4/post.go
+++ b/api4/post.go
@@ -99,7 +99,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.App.UpdateLastActivityAtIfNeeded(*c.AppContext.Session())
 	c.ExtendSessionExpiryIfNeeded(w, r)
 
-	auditRec.AddMetadata(post.PendingPostId, post, "", nil, rp.Id, rp.AuditLoggablePost())
+	auditRec.AddMetadata(post, nil, rp, "post")
 
 	w.WriteHeader(http.StatusCreated)
 

--- a/api4/post.go
+++ b/api4/post.go
@@ -111,6 +111,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.ExtendSessionExpiryIfNeeded(w, r)
 
 	auditRec.AddMetadata(postPayload, nil, rp, "post")
+	auditRec.AddMetadataWithParameters(postPayload, c.Params, nil, rp, "post")
 
 	w.WriteHeader(http.StatusCreated)
 

--- a/api4/post.go
+++ b/api4/post.go
@@ -111,7 +111,6 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	c.ExtendSessionExpiryIfNeeded(w, r)
 
 	auditRec.AddMetadata(postPayload, nil, rp, "post")
-	auditRec.AddMetadataWithParameters(postPayload, c.Params, nil, rp, "post")
 
 	w.WriteHeader(http.StatusCreated)
 

--- a/api4/user.go
+++ b/api4/user.go
@@ -4,6 +4,7 @@
 package api4
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -107,8 +108,17 @@ func (api *API) InitUser() {
 }
 
 func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
+	postBody, readErr := ioutil.ReadAll(r.Body)
+	if readErr != nil {
+		return
+	}
+	defer r.Body.Close()
+
+	var postPayload interface{}
+	_ = json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&postPayload)
+
 	var user model.User
-	if jsonErr := json.NewDecoder(r.Body).Decode(&user); jsonErr != nil {
+	if jsonErr := json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&user); jsonErr != nil {
 		c.SetInvalidParam("user")
 		return
 	}
@@ -161,7 +171,7 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddMetadata(user, nil, ruser, "user")
+	auditRec.AddMetadata(postPayload, nil, ruser, "user")
 
 	auditRec.Success()
 	auditRec.AddMeta("user", ruser) // overwrite meta
@@ -1245,8 +1255,17 @@ func patchUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	postBody, readErr := ioutil.ReadAll(r.Body)
+	if readErr != nil {
+		return
+	}
+	defer r.Body.Close()
+
+	var postPayload interface{}
+	_ = json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&postPayload)
+
 	var patch model.UserPatch
-	if jsonErr := json.NewDecoder(r.Body).Decode(&patch); jsonErr != nil {
+	if jsonErr := json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&patch); jsonErr != nil {
 		c.SetInvalidParam("user")
 		return
 	}
@@ -1309,7 +1328,7 @@ func patchUser(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	c.App.SetAutoResponderStatus(ruser, ouser.NotifyProps)
 
-	auditRec.AddMetadata(patch, ouser, ruser, "user")
+	auditRec.AddMetadata(postPayload, ouser, ruser, "user")
 
 	auditRec.Success()
 	auditRec.AddMeta("patch", ruser)

--- a/app/audit.go
+++ b/app/audit.go
@@ -90,7 +90,7 @@ func (a *App) MakeAuditRecord(event string, initialStatus string) *audit.Record 
 
 	rec := &audit.Record{
 		APIPath:   "",
-		Event:     event,
+		EventName: event,
 		Status:    initialStatus,
 		UserID:    userID,
 		SessionID: "",

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -33,12 +33,13 @@ func (a *Audit) Init(maxQueueSize int) {
 func (a *Audit) LogRecord(level mlog.Level, rec Record) {
 	flds := []mlog.Field{
 		mlog.String(KeyAPIPath, rec.APIPath),
-		mlog.String(KeyEvent, rec.Event),
+		mlog.String(KeyEventName, rec.EventName),
 		mlog.String(KeyStatus, rec.Status),
 		mlog.String(KeyUserID, rec.UserID),
 		mlog.String(KeySessionID, rec.SessionID),
 		mlog.String(KeyClient, rec.Client),
 		mlog.String(KeyIPAddress, rec.IPAddress),
+		mlog.Any(KeyEventData, rec.EventData),
 	}
 
 	for k, v := range rec.Meta {
@@ -51,7 +52,7 @@ func (a *Audit) LogRecord(level mlog.Level, rec Record) {
 func (a *Audit) Log(level mlog.Level, path string, evt string, status string, userID string, sessionID string, meta Meta) {
 	a.LogRecord(level, Record{
 		APIPath:   path,
-		Event:     evt,
+		EventName: evt,
 		Status:    status,
 		UserID:    userID,
 		SessionID: sessionID,

--- a/audit/const.go
+++ b/audit/const.go
@@ -7,7 +7,11 @@ const (
 	DefMaxQueueSize = 1000
 
 	KeyAPIPath   = "api_path"
-	KeyEvent     = "event"
+	KeyEventName = "event_name"
+	KeyEventData = "event_data"
+	KeyObject    = "object"
+	KeyOrigin    = "origin"
+	KeyResult    = "result"
 	KeyStatus    = "status"
 	KeyUserID    = "user_id"
 	KeySessionID = "session_id"

--- a/audit/record.go
+++ b/audit/record.go
@@ -31,6 +31,7 @@ type EventResult struct {
 }
 
 type EventData struct {
+	Parameters       interface{} `json:"parameters"`
 	Change           interface{} `json:"new_data"`
 	PriorState       interface{} `json:"prior_state"`
 	ResultingState   interface{} `json:"resulting_state"`
@@ -93,29 +94,22 @@ func (rec *Record) AddMetadata(newObject interface{},
 	priorObject interface{},
 	resultObject Auditable,
 	resultObjectType string) {
-
-	//var priorAuditable interface{}
-	//var resultAuditable interface{}
-
-	//switch priorObject.(type) {
-	//case model.User:
-	//	user := priorObject.(model.User)
-	//	rec.UserID = user.Id
-	//	priorAuditable = user.AuditableUser()
-	//default:
-	//	priorAuditable = priorObject
-	//}
-
-	//switch resultObject.(type) {
-	//case model.User:
-	//	user := resultObject.(model.User)
-	//	rec.UserID = user.Id
-	//	resultAuditable = user.AuditableUser()
-	//default:
-	//	resultAuditable = resultObject
-	//}
-
 	eventData := EventData{
+		Change:           newObject,
+		PriorState:       priorObject,
+		ResultingState:   resultObject.AuditableObject(),
+		ResultObjectType: resultObjectType,
+	}
+	rec.EventData = eventData
+}
+
+func (rec *Record) AddMetadataWithParameters(newObject interface{},
+	parameters interface{},
+	priorObject interface{},
+	resultObject Auditable,
+	resultObjectType string) {
+	eventData := EventData{
+		Parameters:       parameters,
 		Change:           newObject,
 		PriorState:       priorObject,
 		ResultingState:   resultObject.AuditableObject(),

--- a/audit/record.go
+++ b/audit/record.go
@@ -57,6 +57,23 @@ type Record struct {
 	metaConv  []FuncMetaTypeConv
 }
 
+// wrap string arrays
+type AuditableStringArray struct {
+	Array []string `json:"array"`
+}
+
+func (a *AuditableStringArray) AuditableObject() interface{} {
+	return a.Array
+}
+
+type AuditableArray struct {
+	Array []interface{} `json:"array"`
+}
+
+func (a *AuditableArray) AuditableObject() interface{} {
+	return a.Array
+}
+
 // Success marks the audit record status as successful.
 func (rec *Record) Success() {
 	rec.Status = Success
@@ -92,31 +109,31 @@ func (rec *Record) AddMeta(name string, val interface{}) {
 
 func (rec *Record) AddMetadata(newObject interface{},
 	priorObject interface{},
-	resultObject Auditable,
+	resultObject interface{},
 	resultObjectType string) {
 	eventData := EventData{
 		Change:           newObject,
 		PriorState:       priorObject,
-		ResultingState:   resultObject.AuditableObject(),
+		ResultingState:   resultObject,
 		ResultObjectType: resultObjectType,
 	}
 	rec.EventData = eventData
 }
 
-func (rec *Record) AddMetadataWithParameters(newObject interface{},
-	parameters interface{},
-	priorObject interface{},
-	resultObject Auditable,
-	resultObjectType string) {
-	eventData := EventData{
-		Parameters:       parameters,
-		Change:           newObject,
-		PriorState:       priorObject,
-		ResultingState:   resultObject.AuditableObject(),
-		ResultObjectType: resultObjectType,
-	}
-	rec.EventData = eventData
-}
+//func (rec *Record) AddMetadataWithParameters(newObject interface{},
+//	parameters interface{},
+//	priorObject interface{},
+//	resultObject Auditable,
+//	resultObjectType string) {
+//	eventData := EventData{
+//		Parameters:       parameters,
+//		Change:           newObject,
+//		PriorState:       priorObject,
+//		ResultingState:   resultObject.AuditableObject(),
+//		ResultObjectType: resultObjectType,
+//	}
+//	rec.EventData = eventData
+//}
 
 // AddMetaTypeConverter adds a function capable of converting meta field types
 // into something more suitable for serialization.

--- a/audit/record.go
+++ b/audit/record.go
@@ -107,7 +107,7 @@ func (rec *Record) AddMeta(name string, val interface{}) {
 	rec.Meta[name] = val
 }
 
-func (rec *Record) AddPriorObject(priorObject in)
+//func (rec *Record) AddPriorObject(priorObject in)
 
 func (rec *Record) AddMetadata(newObject interface{},
 	priorObject interface{},

--- a/audit/record.go
+++ b/audit/record.go
@@ -107,6 +107,8 @@ func (rec *Record) AddMeta(name string, val interface{}) {
 	rec.Meta[name] = val
 }
 
+func (rec *Record) AddPriorObject(priorObject in)
+
 func (rec *Record) AddMetadata(newObject interface{},
 	priorObject interface{},
 	resultObject interface{},

--- a/model/bot.go
+++ b/model/bot.go
@@ -33,6 +33,10 @@ type Bot struct {
 	DeleteAt       int64  `json:"delete_at"`
 }
 
+func (b *Bot) AuditableObject() interface{} {
+	return b
+}
+
 // BotPatch is a description of what fields to update on an existing bot.
 type BotPatch struct {
 	Username    *string `json:"username"`

--- a/model/channel.go
+++ b/model/channel.go
@@ -61,6 +61,11 @@ type Channel struct {
 	LastRootPostAt    int64                  `json:"last_root_post_at"`
 }
 
+func (c *Channel) AuditableObject() interface{} {
+	a := c.DeepCopy()
+	return *a
+}
+
 type ChannelWithTeamData struct {
 	Channel
 	TeamDisplayName string `json:"team_display_name"`

--- a/model/channel_sidebar.go
+++ b/model/channel_sidebar.go
@@ -55,6 +55,10 @@ type SidebarCategoryWithChannels struct {
 	Channels []string `json:"channel_ids"`
 }
 
+func (s *SidebarCategoryWithChannels) AuditableObject() interface{} {
+	return s
+}
+
 func (sc SidebarCategoryWithChannels) ChannelIds() []string {
 	return sc.Channels
 }
@@ -65,6 +69,10 @@ type SidebarCategoryOrder []string
 type OrderedSidebarCategories struct {
 	Categories SidebarCategoriesWithChannels `json:"categories"`
 	Order      SidebarCategoryOrder          `json:"order"`
+}
+
+func (o *OrderedSidebarCategories) AuditableObject() interface{} {
+	return o
 }
 
 type SidebarChannel struct {

--- a/model/command.go
+++ b/model/command.go
@@ -41,6 +41,10 @@ type Command struct {
 	AutocompleteIconData string `db:"-" json:"autocomplete_icon_data,omitempty"`
 }
 
+func (c *Command) AuditableObject() interface{} {
+	return c
+}
+
 func (o *Command) IsValid() *AppError {
 	if !IsValidId(o.Id) {
 		return NewAppError("Command.IsValid", "model.command.is_valid.id.app_error", nil, "", http.StatusBadRequest)

--- a/model/post.go
+++ b/model/post.go
@@ -221,6 +221,15 @@ func (o *Post) ShallowCopy(dst *Post) error {
 	return nil
 }
 
+func (p *Post) AuditableObject() interface{} {
+	var a Post
+	err := p.ShallowCopy(&a)
+	if err != nil {
+		return Post{}
+	}
+	return a
+}
+
 // Clone shallowly copies the post and returns the copy.
 func (o *Post) Clone() *Post {
 	copy := &Post{}
@@ -747,8 +756,8 @@ func (p *Post) AuditLoggablePost() audit.EventMetadataObject {
 		Id: p.Id,
 		Metadata: map[string]interface{}{
 			"channel_id": p.ChannelId,
-			"user_id": p.UserId,
-			"message": p.Message,
+			"user_id":    p.UserId,
+			"message":    p.Message,
 		},
 	}
 	return r

--- a/model/post.go
+++ b/model/post.go
@@ -6,6 +6,7 @@ package model
 import (
 	"encoding/json"
 	"errors"
+	"github.com/mattermost/mattermost-server/v6/audit"
 	"io"
 	"net/http"
 	"regexp"
@@ -739,4 +740,16 @@ func (o *Post) GetPreviewedPostProp() string {
 		return val
 	}
 	return ""
+}
+
+func (p *Post) AuditLoggablePost() audit.EventMetadataObject {
+	r := audit.EventMetadataObject{
+		Id: p.Id,
+		Metadata: map[string]interface{}{
+			"channel_id": p.ChannelId,
+			"user_id": p.UserId,
+			"message": p.Message,
+		},
+	}
+	return r
 }

--- a/model/user.go
+++ b/model/user.go
@@ -924,6 +924,17 @@ func IsValidLocale(locale string) bool {
 	return true
 }
 
+func (u *User) AuditableObject() interface{} {
+	a := u.DeepCopy()
+	a.Password = "[redacted]"
+	return *a
+}
+
+func (p *UserPatch) AuditableObject() interface{} {
+	a := p
+	*a.Password = "[redacted]"
+}
+
 //msgp:ignore UserWithGroups
 type UserWithGroups struct {
 	User

--- a/model/user.go
+++ b/model/user.go
@@ -931,8 +931,7 @@ func (u *User) AuditableObject() interface{} {
 }
 
 func (p *UserPatch) AuditableObject() interface{} {
-	a := p
-	*a.Password = "[redacted]"
+	return p // TODO!!!!
 }
 
 //msgp:ignore UserWithGroups

--- a/web/context.go
+++ b/web/context.go
@@ -54,7 +54,7 @@ func (c *Context) LogAuditRecWithLevel(rec *audit.Record, level mlog.Level) {
 func (c *Context) MakeAuditRecord(event string, initialStatus string) *audit.Record {
 	rec := &audit.Record{
 		APIPath:   c.AppContext.Path(),
-		Event:     event,
+		EventName: event,
 		Status:    initialStatus,
 		UserID:    c.AppContext.Session().UserId,
 		SessionID: c.AppContext.Session().Id,


### PR DESCRIPTION
## Audit logs implementation v2

:warning: This is still work in progress

The main requirements for the new audit logs are

* all audit log messages have the same format
* audit log messages contain new information, and the state of the target object before and after applying the new information
* note, not all audit-loggable events change state (eg. requesting information)

See [record.go](audit/record.go) -- the `AddMetadata` function adds the change object, and prior and post states.

## Howto

To modify an existing function to log using the new format:

* put the POST body aside
```
	postBody, readErr := ioutil.ReadAll(r.Body)
	if readErr != nil {
		return
	}
	defer r.Body.Close()

	var postPayload interface{}
	_ = json.NewDecoder(bytes.NewBuffer(postBody)).Decode(&postPayload)
```
* (Now you can to access the postBody by calling `bytes.NewBuffer(postBody)` when deserializing to the model object)
* put the model object aside before doing whatever the function does on the model object, eg
```
	priorChannelForAudit, _ := c.App.GetChannel(c.Params.ChannelId)
```
* at the end of the function,, call `AddMetadata` on the record object
```
	auditRec.AddMetadata(c.Params, priorChannelForAudit, channel, "channel")
```


