### PR TITLE
[MM-44475] Team Unarchive: Do not allow to unarchive if they have reached the limit of teams

### DIFF
--- a/api4/team.go
+++ b/api4/team.go
@@ -258,6 +258,28 @@ func restoreTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetPermissionError(model.PermissionManageTeam)
 		return
 	}
+	// Freemium enabled, on a cloud license. We must check limits before allowing to restore
+	if c.App.Config().FeatureFlags != nil && c.App.Config().FeatureFlags.CloudFree && (c.App.Channels().License() != nil && c.App.Channels().License().Features != nil && *c.App.Channels().License().Features.Cloud) {
+		limits, err := c.App.Cloud().GetCloudLimits(c.AppContext.Session().UserId)
+		if err != nil {
+			c.Err = model.NewAppError("Api4.restoreTeam", "api.cloud.app_error", nil, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// If there are no limits for teams, for active teams, or the limit for active teams is less than 0, do nothing
+		if !(limits == nil || limits.Teams == nil || limits.Teams.Active == nil || *limits.Teams.Active <= 0) {
+			activeTeams, appErr := c.App.GetTeamsUsage()
+			if err != nil {
+				c.Err = appErr
+				return
+			}
+			// if the number of active teams is greater than or equal to the limit, return 400
+			if activeTeams >= int64(*limits.Teams.Active) {
+				c.Err = model.NewAppError("Api4.restoreTeam", "api.cloud.teams_limit_reached.restore", nil, "", http.StatusBadRequest)
+				return
+			}
+		}
+	}
 
 	err := c.App.RestoreTeam(c.Params.TeamId)
 	if err != nil {

--- a/api4/usage.go
+++ b/api4/usage.go
@@ -13,6 +13,8 @@ import (
 func (api *API) InitUsage() {
 	// GET /api/v4/usage/posts
 	api.BaseRoutes.Usage.Handle("/posts", api.APISessionRequired(getPostsUsage)).Methods("GET")
+	// GET /api/v4/usage/teams
+	api.BaseRoutes.Usage.Handle("/teams", api.APISessionRequired(getTeamsUsage)).Methods("GET")
 }
 
 func getPostsUsage(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -26,6 +28,21 @@ func getPostsUsage(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		c.Err = model.NewAppError("Api4.getPostsUsage", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError)
 		return
+	}
+
+	w.Write(json)
+}
+
+func getTeamsUsage(c *Context, w http.ResponseWriter, r *http.Request) {
+	count, appErr := c.App.GetTeamsUsage()
+	if appErr != nil {
+		c.Err = model.NewAppError("Api4.getTeamsUsage", "app.teams.analytics_teams_count.app_error", nil, appErr.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json, err := json.Marshal(&model.TeamsUsage{Active: count})
+	if err != nil {
+		c.Err = model.NewAppError("Api4.getTeamsUsage", "api.marshal_error", nil, err.Error(), http.StatusInternalServerError)
 	}
 
 	w.Write(json)

--- a/api4/usage_test.go
+++ b/api4/usage_test.go
@@ -37,3 +37,31 @@ func TestGetPostsUsage(t *testing.T) {
 		assert.Equal(t, int64(10), usage.Count)
 	})
 }
+
+func TestGetTeamsUsage(t *testing.T) {
+	t.Run("unauthenticated users can not access", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		th.Client.Logout()
+
+		usage, r, err := th.Client.GetTeamsUsage()
+		assert.Error(t, err)
+		assert.Nil(t, usage)
+		assert.Equal(t, http.StatusUnauthorized, r.StatusCode)
+	})
+
+	t.Run("good request returns response", func(t *testing.T) {
+		// Following calls create a total of 3 teams
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+		th.CreateTeam()
+		th.CreateTeam()
+
+		usage, r, err := th.Client.GetTeamsUsage()
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, r.StatusCode)
+		assert.NotNil(t, usage)
+		assert.Equal(t, int64(3), usage.Active)
+	})
+}

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -753,6 +753,7 @@ type AppIface interface {
 	GetTeamsForSchemePage(scheme *model.Scheme, page int, perPage int) ([]*model.Team, *model.AppError)
 	GetTeamsForUser(userID string) ([]*model.Team, *model.AppError)
 	GetTeamsUnreadForUser(excludeTeamId string, userID string, includeCollapsedThreads bool) ([]*model.TeamUnread, *model.AppError)
+	GetTeamsUsage() (int64, *model.AppError)
 	GetTermsOfService(id string) (*model.TermsOfService, *model.AppError)
 	GetThreadForUser(teamID string, threadMembership *model.ThreadMembership, extended bool) (*model.ThreadResponse, *model.AppError)
 	GetThreadMembershipForUser(userId, threadId string) (*model.ThreadMembership, *model.AppError)

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -9552,6 +9552,28 @@ func (a *OpenTracingAppLayer) GetTeamsUnreadForUser(excludeTeamId string, userID
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) GetTeamsUsage() (int64, *model.AppError) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetTeamsUsage")
+
+	a.ctx = newCtx
+	a.app.Srv().Store.SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store.SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetTeamsUsage()
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetTermsOfService(id string) (*model.TermsOfService, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetTermsOfService")

--- a/app/usage.go
+++ b/app/usage.go
@@ -19,3 +19,13 @@ func (a *App) GetPostsUsage() (int64, *model.AppError) {
 
 	return utils.RoundOffToZeroes(float64(count)), nil
 }
+
+func (a *App) GetTeamsUsage() (int64, *model.AppError) {
+	includeDeleted := false
+	teamCount, err := a.Srv().Store.Team().AnalyticsTeamCount(&model.TeamSearch{IncludeDeleted: &(includeDeleted)})
+	if err != nil {
+		return 0, model.NewAppError("GetTeamsUsage", "app.post.analytics_teams_count.app_error", nil, err.Error(), http.StatusInternalServerError)
+	}
+
+	return teamCount, nil
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -464,6 +464,10 @@
     "translation": "Internal error during cloud api request."
   },
   {
+    "id": "api.cloud.teams_limit_reached.restore",
+    "translation": "Unable to restore team because limit has been reached"
+  },
+  {
     "id": "api.cloud.cloud_free_feature_flag_off_error",
     "translation": "CloudFree feature flag is off."
   },
@@ -5802,6 +5806,10 @@
   {
     "id": "app.post.analytics_posts_count_by_day.app_error",
     "translation": "Unable to get post counts by day."
+  },
+  {
+    "id": "app.teams.analytics_teams_count.app_error",
+    "translation": "Unable to get team count"
   },
   {
     "id": "app.post.analytics_user_counts_posts_by_day.app_error",

--- a/model/client4.go
+++ b/model/client4.go
@@ -8110,3 +8110,16 @@ func (c *Client4) GetPostsUsage() (*PostsUsage, *Response, error) {
 	err = json.NewDecoder(r.Body).Decode(&usage)
 	return usage, BuildResponse(r), err
 }
+
+// GetTeamsUsage returns rounded off total usage of teams for the instance
+func (c *Client4) GetTeamsUsage() (*TeamsUsage, *Response, error) {
+	r, err := c.DoAPIGet(c.usageRoute()+"/teams", "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+
+	var usage *TeamsUsage
+	err = json.NewDecoder(r.Body).Decode(&usage)
+	return usage, BuildResponse(r), err
+}

--- a/model/usage.go
+++ b/model/usage.go
@@ -6,3 +6,7 @@ package model
 type PostsUsage struct {
 	Count int64 `json:"count"`
 }
+
+type TeamsUsage struct {
+	Active int64 `json:"active"`
+}


### PR DESCRIPTION
#### Summary
If a user attempts to "restore" (ie, "unarchive") a team, we must check if they are at or over the limit, and disallow them to do so. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44475

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
User's will be prevented from unarchiving teams if they're at or over the teams limit for their plan.
```
