### PR TITLE
MM-43878: don't err when reply createAt before parent createAt

### DIFF
--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -1118,6 +1118,10 @@ func (a *App) importReplies(c *request.Context, data []ReplyImportData, post *mo
 		reply.RootId = post.Id
 		reply.Message = *replyData.Message
 		reply.CreateAt = *replyData.CreateAt
+		if reply.CreateAt < post.CreateAt {
+			mlog.Warn("Reply CreateAt is before parent post CreateAt, setting it to parent post CreateAt", mlog.Int64("reply_create_at", reply.CreateAt), mlog.Int64("parent_create_at", post.CreateAt))
+			reply.CreateAt = post.CreateAt
+		}
 		if replyData.Type != nil {
 			reply.Type = *replyData.Type
 		}

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -16,7 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
+	"github.com/mattermost/mattermost-server/v6/testlib"
 	"github.com/mattermost/mattermost-server/v6/utils/fileutils"
 )
 
@@ -3090,6 +3092,46 @@ func TestImportImportPost(t *testing.T) {
 		post := posts[0]
 		postBool := post.Message != *data.Post.Message || post.CreateAt != *data.Post.CreateAt || post.UserId != user.Id || post.EditAt != *data.Post.EditAt
 		require.False(t, postBool, "Post properties not as expected")
+	})
+
+	t.Run("Reply CreateAt before parent post CreateAt", func(t *testing.T) {
+		now := model.GetMillis()
+		before := now - 10
+		data := LineImportWorkerData{
+			LineImportData{
+				Post: &PostImportData{
+					Team:     &teamName,
+					Channel:  &channelName,
+					User:     &user2.Username,
+					Message:  ptrStr("Message with reply"),
+					CreateAt: &now,
+					Replies: &[]ReplyImportData{{
+						User:     &username,
+						Message:  ptrStr("Message reply 2"),
+						CreateAt: &before,
+					}},
+				},
+			},
+			1,
+		}
+
+		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		require.Nil(t, err, "Expected success.")
+		require.Equal(t, 0, errLine)
+
+		posts, nErr := th.App.Srv().Store.Post().GetPostsCreatedAt(channel.Id, now)
+		require.NoError(t, nErr)
+		require.Len(t, posts, 2, "Unexpected number of posts found.")
+		testlib.AssertLog(t, th.LogBuffer, mlog.LvlWarn.Name, "Reply CreateAt is before parent post CreateAt, setting it to parent post CreateAt")
+
+		rootPost := posts[0]
+		replyPost := posts[1]
+		if rootPost.RootId != "" {
+			replyPost = posts[0]
+			rootPost = posts[1]
+		}
+		require.Equal(t, rootPost.Id, replyPost.RootId)
+		require.Equal(t, now, replyPost.CreateAt)
 	})
 }
 

--- a/app/import_validators.go
+++ b/app/import_validators.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
 func validateSchemeImportData(data *SchemeImportData) *model.AppError {
@@ -412,7 +413,7 @@ func validateReplyImportData(data *ReplyImportData, parentCreateAt int64, maxPos
 	} else if *data.CreateAt == 0 {
 		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.create_at_zero.error", nil, "", http.StatusBadRequest)
 	} else if *data.CreateAt < parentCreateAt {
-		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.create_at_before_parent.error", nil, "", http.StatusBadRequest)
+		mlog.Warn("Reply CreateAt is before parent post CreateAt", mlog.Int64("reply_create_at", *data.CreateAt), mlog.Int64("parent_create_at", parentCreateAt))
 	}
 
 	return nil

--- a/app/import_validators_test.go
+++ b/app/import_validators_test.go
@@ -887,14 +887,6 @@ func TestImportValidateReplyImportData(t *testing.T) {
 	}
 	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
-
-	data = ReplyImportData{
-		User:     ptrStr("username"),
-		Message:  ptrStr("message"),
-		CreateAt: ptrInt64(parentCreateAt - 100),
-	}
-	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
-	require.NotNil(t, err, "Should have failed due parent with newer create-at value.")
 }
 
 func TestImportValidatePostImportData(t *testing.T) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5204,10 +5204,6 @@
     "translation": "Missing required Reaction property: User."
   },
   {
-    "id": "app.import.validate_reply_import_data.create_at_before_parent.error",
-    "translation": "Reply CreateAt property must be greater than the parent post CreateAt."
-  },
-  {
     "id": "app.import.validate_reply_import_data.create_at_missing.error",
     "translation": "Missing required Reply property: create_at."
   },


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- In a bulk import, if the createAt of a reply is older than the createAt of the parent post, then instead of erroring, we log a warning and set the createAt of the reply to that of the parent post.
- I checked the exporting logic, there doesn't appear to be away for the reply createAt to be older than the parent createAt, as a side-effect of the exporting logic.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-43878

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
