### PR TITLE
Fix failures for circleci ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
     working_directory: ~/mattermost/
     resource_class: xlarge
     machine:
-      image: "ubuntu-1604:201903-01"
+      image: "ubuntu-2004:202201-02"
     environment:
       COMPOSE_PROJECT_NAME: "circleci"
 
@@ -442,7 +442,7 @@ jobs:
 
   upload-s3-sha:
     docker:
-      - image: 'circleci/python:2.7'
+      - image: circleci/python:3.6
     working_directory: ~/mattermost/enterprise
     steps:
       - attach_workspace:
@@ -458,7 +458,7 @@ jobs:
 
   upload-s3:
     docker:
-      - image: 'circleci/python:2.7'
+      - image: circleci/python:3.6
     working_directory: ~/mattermost/enterprise
     steps:
       - attach_workspace:


### PR DESCRIPTION
#### Summary
CircleCI deprecated old ubuntu version and we need to bump to the recommended by CirclecCI.
In parallel bumped python to 3.7 to match with `master` branch changes.

#### Ticket Link
 https://mattermost.atlassian.net/browse/DOPS-1050

#### Release Note
```release-note
NONE
```
