### PR TITLE
remove is paid tier

### DIFF
--- a/api4/cloud_test.go
+++ b/api4/cloud_test.go
@@ -153,7 +153,6 @@ func Test_requestTrial(t *testing.T) {
 		CreateAt:   1000000000,
 		Seats:      10,
 		DNS:        "some.dns.server",
-		IsPaidTier: "false",
 	}
 
 	t.Run("NON Admin users are UNABLE to request the trial", func(t *testing.T) {

--- a/model/cloud.go
+++ b/model/cloud.go
@@ -125,7 +125,6 @@ type Subscription struct {
 	Seats       int      `json:"seats"`
 	Status      string   `json:"status"`
 	DNS         string   `json:"dns"`
-	IsPaidTier  string   `json:"is_paid_tier"`
 	LastInvoice *Invoice `json:"last_invoice"`
 	IsFreeTrial string   `json:"is_free_trial"`
 	TrialEndAt  int64    `json:"trial_end_at"`


### PR DESCRIPTION
#### Summary
mattermost-webapp [no longer uses](https://github.com/mattermost/mattermost-webapp/pull/10431) `IsPaidTier`, and the mattermost-server/enterprise layer doesn't use it either. Removing.

#### Ticket Link
side effect of implementing https://mattermost.atlassian.net/browse/MM-44440

#### Release Note

```release-note
Remove `IsPaidTier` from subscription struct.
```