### PR TITLE
[MM-44329] Add a method to store.Store interface to get sql.DB object

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -67,7 +67,11 @@ type Store interface {
 	GetDBSchemaVersion() (int, error)
 	GetAppliedMigrations() ([]model.AppliedMigration, error)
 	GetDbVersion(numerical bool) (string, error)
+	// GetInternalMasterDB allows access to the raw master DB
+	// handle for the multi-product architecture.
 	GetInternalMasterDB() *sql.DB
+	// GetInternalReplicaDBs allows access to the raw replica DB
+	// handles for the multi-product architecture.
 	GetInternalReplicaDBs() []*sql.DB
 	TotalMasterDbConnections() int
 	TotalReadDbConnections() int

--- a/store/store.go
+++ b/store/store.go
@@ -7,6 +7,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -66,6 +67,8 @@ type Store interface {
 	GetDBSchemaVersion() (int, error)
 	GetAppliedMigrations() ([]model.AppliedMigration, error)
 	GetDbVersion(numerical bool) (string, error)
+	GetInternalMasterDB() *sql.DB
+	GetInternalReplicaDBs() []*sql.DB
 	TotalMasterDbConnections() int
 	TotalReadDbConnections() int
 	TotalSearchDbConnections() int

--- a/store/storetest/mocks/Store.go
+++ b/store/storetest/mocks/Store.go
@@ -10,6 +10,8 @@ import (
 	model "github.com/mattermost/mattermost-server/v6/model"
 	mock "github.com/stretchr/testify/mock"
 
+	sql "database/sql"
+
 	store "github.com/mattermost/mattermost-server/v6/store"
 
 	time "time"
@@ -285,6 +287,38 @@ func (_m *Store) GetDbVersion(numerical bool) (string, error) {
 	}
 
 	return r0, r1
+}
+
+// GetInternalMasterDB provides a mock function with given fields:
+func (_m *Store) GetInternalMasterDB() *sql.DB {
+	ret := _m.Called()
+
+	var r0 *sql.DB
+	if rf, ok := ret.Get(0).(func() *sql.DB); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*sql.DB)
+		}
+	}
+
+	return r0
+}
+
+// GetInternalReplicaDBs provides a mock function with given fields:
+func (_m *Store) GetInternalReplicaDBs() []*sql.DB {
+	ret := _m.Called()
+
+	var r0 []*sql.DB
+	if rf, ok := ret.Get(0).(func() []*sql.DB); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*sql.DB)
+		}
+	}
+
+	return r0
 }
 
 // Group provides a mock function with given fields:

--- a/store/storetest/store.go
+++ b/store/storetest/store.go
@@ -5,6 +5,7 @@ package storetest
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -103,6 +104,8 @@ func (s *Store) LockToMaster()                           { /* do nothing */ }
 func (s *Store) UnlockFromMaster()                       { /* do nothing */ }
 func (s *Store) DropAllTables()                          { /* do nothing */ }
 func (s *Store) GetDbVersion(bool) (string, error)       { return "", nil }
+func (s *Store) GetInternalMasterDB() *sql.DB            { return nil }
+func (s *Store) GetInternalReplicaDBs() []*sql.DB        { return nil }
 func (s *Store) RecycleDBConnections(time.Duration)      {}
 func (s *Store) GetDBSchemaVersion() (int, error)        { return 1, nil }
 func (s *Store) GetAppliedMigrations() ([]model.AppliedMigration, error) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds two methods to the store.Store interface. `GetInternalMasterDB()` returns the `*sql.DB` for the master database. `GetInternalReplicaDBs()` returns a slice of `*sql.DB`s for the configured replica databases (or the master, when no replicas are configured). This behavior is implemented to emulate the functionality of `GetMasterX()` and `GetReplicaX()`.
This PR also updates the mocks to include the new methods.

As an internal change, this adds a method `"sqlStore".Store.hasLicense()` which returns `true` iff the license is not `nil`. Putting it into it's own method allows for simpler (and more efficient) code.

#### Ticket Link
[MM-44329](https://mattermost.atlassian.net/browse/MM-44329)

```release-note
NONE
```
