### PR TITLE
[MM-44786] Fix Trusted Header Parsing for Cloudflare

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -101,9 +101,9 @@ func GetIPAddress(r *http.Request, trustedProxyIPHeader []string) string {
 	for _, proxyHeader := range trustedProxyIPHeader {
 		header := r.Header.Get(proxyHeader)
 		if header != "" {
-			addresses := strings.Fields(header)
+			addresses := strings.Split(header, ",")
 			if len(addresses) > 0 {
-				address = strings.TrimRight(addresses[0], ",")
+				address = strings.TrimSpace(addresses[0])
 			}
 		}
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -152,6 +152,17 @@ func TestGetIPAddress(t *testing.T) {
 	}
 
 	assert.Equal(t, "10.1.0.1", GetIPAddress(&httpRequest10, []string{"X-Real-Ip", "X-Forwarded-For"}))
+
+	// Test with multiple IPs in the X-Forwarded-For with no spaces
+	httpRequest11 := http.Request{
+		Header: http.Header{
+			"X-Forwarded-For": []string{"10.0.0.1,10.0.0.2,10.0.0.3"},
+			"X-Real-Ip":       []string{"10.1.0.1"},
+		},
+		RemoteAddr: "10.2.0.1:12345",
+	}
+
+	assert.Equal(t, "10.0.0.1", GetIPAddress(&httpRequest11, []string{"X-Forwarded-For"}))
 }
 
 func TestRemoveStringFromSlice(t *testing.T) {


### PR DESCRIPTION
#### Summary
The pull request inverts the X-Forwarded-For header parsing to split on `comma` and trim white spaces. This change is backwards compatible as shown by the unit tests, but adds support for some systems such as Cloudflare.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44786

#### Release Note

```
Fixed bug in X-Forwarded-For header parsing when no whitespaces between values are provided
```