### PR TITLE
[MM-42878] Allow + in the timestamp for mlog tests

### DIFF
--- a/shared/mlog/global_test.go
+++ b/shared/mlog/global_test.go
@@ -128,12 +128,12 @@ func TestLoggingAfterInitialized(t *testing.T) {
 				actual := strings.TrimSpace(string(logs))
 
 				if testCase.cfg.Format == "json" {
-					reTs := regexp.MustCompile(`"timestamp":"[0-9\.\-\:\sZ]+"`)
+					reTs := regexp.MustCompile(`"timestamp":"[0-9\.\-\+\:\sZ]+"`)
 					reCaller := regexp.MustCompile(`"caller":"([^"]+):[0-9\.]+"`)
 					actual = reTs.ReplaceAllString(actual, `"timestamp":0`)
 					actual = reCaller.ReplaceAllString(actual, `"caller":"$1:0"`)
 				} else {
-					reTs := regexp.MustCompile(`\[\d\d\d\d-\d\d-\d\d\s[0-9\:\.\s\-Z]+\]`)
+					reTs := regexp.MustCompile(`\[\d\d\d\d-\d\d-\d\d\s[0-9\:\.\s\-\+Z]+\]`)
 					reCaller := regexp.MustCompile(`caller="([^"]+):[0-9\.]+"`)
 					actual = reTs.ReplaceAllString(actual, "TIME")
 					actual = reCaller.ReplaceAllString(actual, `caller="$1:0"`)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR fixes the flaky mlog test by allowing the timestamp regex to match timestamps including a "+" for the timezone.
```
2022-03-30 11:08:48.326 +03:00
                        ^
```

#### Ticket Link
[MM-42878](https://mattermost.atlassian.net/browse/MM-42878)

#### Release Note
```release-note
NONE
```
