### PR TITLE
[MM-43831] removed the parallel marker from the subtests

### DIFF
--- a/app/post_test.go
+++ b/app/post_test.go
@@ -571,7 +571,6 @@ func TestImageProxy(t *testing.T) {
 }
 
 func TestMaxPostSize(t *testing.T) {
-	t.Skip("TODO: fix flaky test")
 	t.Parallel()
 
 	testCases := []struct {
@@ -599,8 +598,6 @@ func TestMaxPostSize(t *testing.T) {
 	for _, testCase := range testCases {
 		testCase := testCase
 		t.Run(testCase.Description, func(t *testing.T) {
-			t.Parallel()
-
 			mockStore := &storetest.Store{}
 			defer mockStore.AssertExpectations(t)
 


### PR DESCRIPTION
#### Summary
Removed the skip for the main test and the parallel markers for the sub-tests. I tried running it multiple times and multiple ways and it seems to work now. Running the sub-tests in parallel triggered a fail once but I couldn't reproduce it again.

#### Ticket Link
[MM-43831](https://mattermost.atlassian.net/browse/MM-43831)

#### Release Note
```release-note
NONE
```
