### PR TITLE
Bump pre-packaged version of Zoom to v1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jenkins-v1.1.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-nps-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
-PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.5.0
+PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.6.0
 PLUGIN_PACKAGES += focalboard-v0.15.0
 PLUGIN_PACKAGES += mattermost-plugin-apps-v1.1.0
 


### PR DESCRIPTION
#### Summary
Bump pre-packaged version of Zoom to v1.6.0

#### Ticket Link
--

#### Release Note
```release-note
Updated pre-packaged Zoom plugin version to v1.6.0
```
