### PR TITLE
app/plugin: add product middleware and allow products register routers

### DIFF
--- a/app/channels.go
+++ b/app/channels.go
@@ -51,6 +51,7 @@ type Channels struct {
 	cfgSvc     configSvc
 	filestore  filestore.FileBackend
 	licenseSvc licenseSvc
+	routerSvc  *routerService
 
 	postActionCookieSecret []byte
 
@@ -209,6 +210,9 @@ func NewChannels(s *Server, services map[ServiceKey]interface{}) (*Channels, err
 		return nil, errors.Wrap(imgErr, "failed to create image encoder")
 	}
 
+	ch.routerSvc = newRouterService()
+	services[RouterKey] = ch.routerSvc
+
 	// Setup routes.
 	pluginsRoute := ch.srv.Router.PathPrefix("/plugins/{plugin_id:[A-Za-z0-9\\_\\-\\.]+}").Subrouter()
 	pluginsRoute.HandleFunc("", ch.ServePluginRequest)
@@ -267,6 +271,7 @@ func (ch *Channels) Start() error {
 	if err := ch.ensurePostActionCookieSecret(); err != nil {
 		return errors.Wrapf(err, "unable to ensure PostAction cookie secret")
 	}
+
 	return nil
 }
 

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
+	"github.com/gorilla/mux"
 	svg "github.com/h2non/go-is-svg"
 	"github.com/pkg/errors"
 
@@ -35,6 +36,28 @@ type pluginSignaturePath struct {
 	pluginID      string
 	path          string
 	signaturePath string
+}
+
+type routerService struct {
+	mu        sync.Mutex
+	routerMap map[string]*mux.Router
+}
+
+func newRouterService() *routerService {
+	return &routerService{
+		routerMap: make(map[string]*mux.Router),
+	}
+}
+
+func (rs *routerService) RegisterRouter(productID string, sub *mux.Router) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	rs.routerMap[productID] = sub
+}
+
+func (rs *routerService) getHandler(productID string) (http.Handler, bool) {
+	handler, ok := rs.routerMap[productID]
+	return handler, ok
 }
 
 // GetPluginsEnvironment returns the plugin environment for use if plugins are enabled and

--- a/app/plugin_requests.go
+++ b/app/plugin_requests.go
@@ -21,6 +21,14 @@ import (
 )
 
 func (ch *Channels) ServePluginRequest(w http.ResponseWriter, r *http.Request) {
+	params := mux.Vars(r)
+	if handler, ok := ch.routerSvc.getHandler(params["plugin_id"]); ok {
+		ch.servePluginRequest(w, r, func(*plugin.Context, http.ResponseWriter, *http.Request) {
+			handler.ServeHTTP(w, r)
+		})
+		return
+	}
+
 	pluginsEnvironment := ch.GetPluginsEnvironment()
 	if pluginsEnvironment == nil {
 		err := model.NewAppError("ServePluginRequest", "app.plugin.disabled.app_error", nil, "Enable plugins to serve plugin requests", http.StatusNotImplemented)
@@ -31,7 +39,6 @@ func (ch *Channels) ServePluginRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	params := mux.Vars(r)
 	hooks, err := pluginsEnvironment.HooksForPlugin(params["plugin_id"])
 	if err != nil {
 		mlog.Debug("Access to route for non-existent plugin",

--- a/app/server.go
+++ b/app/server.go
@@ -95,6 +95,7 @@ const (
 	TeamKey        ServiceKey = "team"
 	UserKey        ServiceKey = "user"
 	PermissionsKey ServiceKey = "permissions"
+	RouterKey      ServiceKey = "router"
 )
 
 type Server struct {


### PR DESCRIPTION


#### Summary
Add router service to enable products register their existing router to the main router. We use the same logic as plugins, so that plugins wouldn't need to change anything on their end.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44330

#### Release Note

```release-note
NONE
```
