### PR TITLE
Check for cloud license and CWS error when checking integration freemium limits

### DIFF
--- a/api4/config_test.go
+++ b/api4/config_test.go
@@ -250,6 +250,8 @@ func TestUpdateConfig(t *testing.T) {
 	})
 
 	t.Run("Should not be able to save config if the new config exceeds Freemium limits", func(t *testing.T) {
+		th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
+		defer th.App.Srv().RemoveLicense()
 		os.Setenv("MM_FEATUREFLAGS_CLOUDFREE", "true")
 		defer os.Unsetenv("MM_FEATUREFLAGS_CLOUDFREE")
 		th.App.ReloadConfig()
@@ -853,6 +855,8 @@ func TestPatchConfig(t *testing.T) {
 	})
 
 	t.Run("Should not be able to save config if the new config exceeds Freemium limits", func(t *testing.T) {
+		th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
+		defer th.App.Srv().RemoveLicense()
 		os.Setenv("MM_FEATUREFLAGS_CLOUDFREE", "true")
 		defer os.Unsetenv("MM_FEATUREFLAGS_CLOUDFREE")
 		th.App.ReloadConfig()

--- a/app/integrations.go
+++ b/app/integrations.go
@@ -97,7 +97,8 @@ func (a *App) checkIfIntegrationsMeetFreemiumLimits(originalPluginIds []string) 
 
 	installed, appErr := a.ch.getInstalledIntegrations()
 	if appErr != nil {
-		return appErr
+		a.Log().Error("Failed to get installed integrations to check cloud limit", mlog.Err(appErr))
+		return nil
 	}
 
 	enableCount := len(pluginIds)

--- a/app/integrations.go
+++ b/app/integrations.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
 func (a *App) checkIntegrationLimitsForConfigSave(oldConfig, newConfig *model.Config) *model.AppError {
@@ -86,7 +87,8 @@ func (a *App) checkIfIntegrationsMeetFreemiumLimits(originalPluginIds []string) 
 
 	limits, err := a.Cloud().GetCloudLimits("")
 	if err != nil {
-		return model.NewAppError("checkIfIntegrationMeetsFreemiumLimits", "api.cloud.request_error", nil, err.Error(), http.StatusInternalServerError)
+		a.Log().Error("Error fetching cloud limits for enabled integrations", mlog.Err(err))
+		return nil
 	}
 
 	if limits == nil || limits.Integrations == nil || limits.Integrations.Enabled == nil {

--- a/app/integrations.go
+++ b/app/integrations.go
@@ -73,6 +73,10 @@ func (a *App) checkIfIntegrationsMeetFreemiumLimits(originalPluginIds []string) 
 		return nil
 	}
 
+	if a.License() == nil || !*a.License().Features.Cloud {
+		return nil
+	}
+
 	pluginIds := map[string]bool{}
 	for _, pluginId := range originalPluginIds {
 		if _, ok := model.InstalledIntegrationsIgnoredPlugins[pluginId]; !ok {


### PR DESCRIPTION
#### Summary

When checking the freemium limits for enabling an integration, we check the Cloud Freemium feature flag, but we don't check for a Cloud license. This is not an issue in production, but testing servers are having issues when the feature flag is set, but a Cloud license is not installed. An error occurs when we request limits from the CWS server in this case.

This PR makes it so we check for the Cloud license, and avoid checking limits when there is not one present.

This PR also treats the case where we receive an error from the CWS server as a pass. The only time we will block an integration enable is when we have proof that a server has reached its limit.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-44905

#### Release Note

```release-note
NONE
```