### PR TITLE
[MM-44925] simplified the ID generator

### DIFF
--- a/model/utils.go
+++ b/model/utils.go
@@ -4,7 +4,6 @@
 package model
 
 import (
-	"bytes"
 	"crypto/rand"
 	"database/sql/driver"
 	"encoding/base32"
@@ -268,18 +267,13 @@ func NewAppError(where string, id string, params map[string]interface{}, details
 	return ap
 }
 
-var encoding = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769")
+var encoding = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769").WithPadding(base32.NoPadding)
 
 // NewId is a globally unique identifier.  It is a [A-Z0-9] string 26
 // characters long.  It is a UUID version 4 Guid that is zbased32 encoded
-// with the padding stripped off.
+// without the padding.
 func NewId() string {
-	var b bytes.Buffer
-	encoder := base32.NewEncoder(encoding, &b)
-	encoder.Write(uuid.NewRandom())
-	encoder.Close()
-	b.Truncate(26) // removes the '==' padding
-	return b.String()
+	return encoding.EncodeToString(uuid.NewRandom())
 }
 
 // NewRandomTeamName is a NewId that will be a valid team name.


### PR DESCRIPTION
#### Summary
This PR improves the ID generation. Instead of generating the base32 encoding with the padding and then stripping the padding off, we just generate it without the padding to begin with. The result is exactly the same but without the need to allocate a byte buffer and with much simpler code.

#### Ticket
[MM-44925](https://mattermost.atlassian.net/browse/MM-44925)

#### Release Note
```release-note
NONE
```
