### PR TITLE
[MM-44995] remove reference to 30 days trial in welcome email

### DIFF
--- a/app/email/email.go
+++ b/app/email/email.go
@@ -315,7 +315,7 @@ func (es *Service) SendCloudWelcomeEmail(userEmail, locale, teamInviteID, workSp
 	subject := T("api.templates.cloud_welcome_email.subject")
 
 	data := es.NewEmailTemplateData(locale)
-	data.Props["Title"] = T("api.templates.cloud_welcome_email.title", map[string]interface{}{"WorkSpace": workSpaceName})
+	data.Props["Title"] = T("api.templates.cloud_welcome_email.title")
 	data.Props["SubTitle"] = T("api.templates.cloud_welcome_email.subtitle")
 	data.Props["SubTitleInfo"] = T("api.templates.cloud_welcome_email.subtitle_info")
 	data.Props["Info"] = T("api.templates.cloud_welcome_email.info")

--- a/app/email/email_test.go
+++ b/app/email/email_test.go
@@ -301,6 +301,44 @@ func TestSendCloudUpgradedEmail(t *testing.T) {
 	})
 }
 
+func TestSendCloudWelcomeEmail(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	th.ConfigureInbucketMail()
+
+	emailTo := "testclouduser@example.com"
+
+	t.Run("TestSendCloudWelcomeEmail", func(t *testing.T) {
+		verifyMailbox := func(t *testing.T) {
+			t.Helper()
+
+			var resultsMailbox mail.JSONMessageHeaderInbucket
+			err2 := mail.RetryInbucket(5, func() error {
+				var err error
+				resultsMailbox, err = mail.GetMailBox(emailTo)
+				return err
+			})
+			if err2 != nil {
+				t.Skipf("No email was received, maybe due load on the server: %v", err2)
+			}
+
+			require.Len(t, resultsMailbox, 1)
+			require.Contains(t, resultsMailbox[0].To[0], emailTo, "Wrong To: recipient")
+			resultsEmail, err := mail.GetMessageFromMailbox(emailTo, resultsMailbox[0].ID)
+			require.NoError(t, err, "Could not get message from mailbox")
+			require.Contains(t, resultsEmail.Subject, "Congratulations!", "Wrong subject message %s", resultsEmail.Subject)
+			require.Contains(t, resultsEmail.Body.Text, "Your workspace is ready to go", "Wrong body %s", resultsEmail.Body.Text)
+
+		}
+		mail.DeleteMailBox(emailTo)
+
+		err := th.service.SendCloudWelcomeEmail(emailTo, th.BasicUser.Locale, "inviteID", "SomeName", "example.com", "https://example.com")
+		require.NoError(t, err)
+
+		verifyMailbox(t)
+	})
+}
+
 func TestMailServiceConfig(t *testing.T) {
 	configuredReplyTo := "feedbackexample@test.com"
 	customReplyTo := "customreplyto@test.com"

--- a/app/email/email_test.go
+++ b/app/email/email_test.go
@@ -327,7 +327,7 @@ func TestSendCloudWelcomeEmail(t *testing.T) {
 			resultsEmail, err := mail.GetMessageFromMailbox(emailTo, resultsMailbox[0].ID)
 			require.NoError(t, err, "Could not get message from mailbox")
 			require.Contains(t, resultsEmail.Subject, "Congratulations!", "Wrong subject message %s", resultsEmail.Subject)
-			require.Contains(t, resultsEmail.Body.Text, "Your workspace is ready to go", "Wrong body %s", resultsEmail.Body.Text)
+			require.Contains(t, resultsEmail.Body.Text, "Your workspace is ready to go!", "Wrong body %s", resultsEmail.Body.Text)
 
 		}
 		mail.DeleteMailBox(emailTo)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3237,7 +3237,7 @@
   },
   {
     "id": "api.templates.cloud_welcome_email.title",
-    "translation": "Your 30-day trial of the {{.WorkSpace}} workspace is ready to go!"
+    "translation": "Your workspace is ready to go!"
   },
   {
     "id": "api.templates.copyright",


### PR DESCRIPTION
#### Summary
Removes reference to 30 days trial in cloud welcome email + add test

The QA should be done post-merge as the email will not get triggered on a spinwick

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44995

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
