### PR TITLE
MM-44805: Avoid pointers in JSON parsing in createCategoryForTeamForUser

### DIFF
--- a/api4/channel_category.go
+++ b/api4/channel_category.go
@@ -52,19 +52,19 @@ func createCategoryForTeamForUser(c *Context, w http.ResponseWriter, r *http.Req
 	auditRec := c.MakeAuditRecord("createCategoryForTeamForUser", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 
-	var categoryCreateRequest *model.SidebarCategoryWithChannels
+	var categoryCreateRequest model.SidebarCategoryWithChannels
 	err := json.NewDecoder(r.Body).Decode(&categoryCreateRequest)
 	if err != nil || c.Params.UserId != categoryCreateRequest.UserId || c.Params.TeamId != categoryCreateRequest.TeamId {
 		c.SetInvalidParam("category")
 		return
 	}
 
-	if appErr := validateSidebarCategory(c, c.Params.TeamId, c.Params.UserId, categoryCreateRequest); appErr != nil {
+	if appErr := validateSidebarCategory(c, c.Params.TeamId, c.Params.UserId, &categoryCreateRequest); appErr != nil {
 		c.Err = appErr
 		return
 	}
 
-	category, appErr := c.App.CreateSidebarCategory(c.Params.UserId, c.Params.TeamId, categoryCreateRequest)
+	category, appErr := c.App.CreateSidebarCategory(c.Params.UserId, c.Params.TeamId, &categoryCreateRequest)
 	if appErr != nil {
 		c.Err = appErr
 		return

--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -5,6 +5,7 @@ package api4
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -88,6 +89,17 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 
 		// Initial new category sort order is 10 (first)
 		require.Equal(t, int64(10), customCategory.SortOrder)
+	})
+
+	t.Run("should not crash with null input", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			user, client := setupUserForSubtest(t, th)
+			payload := []byte(`null`)
+			route := fmt.Sprintf("/users/%s/teams/%s/channels/categories", user.Id, th.BasicTeam.Id)
+			r, err := client.DoAPIPostBytes(route, payload)
+			require.Error(t, err)
+			defer closeBody(r)
+		})
 	})
 
 	t.Run("should publish expected WS payload", func(t *testing.T) {

--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -98,7 +98,7 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 			route := fmt.Sprintf("/users/%s/teams/%s/channels/categories", user.Id, th.BasicTeam.Id)
 			r, err := client.DoAPIPostBytes(route, payload)
 			require.Error(t, err)
-			defer closeBody(r)
+			closeBody(r)
 		})
 	})
 


### PR DESCRIPTION
Passing null is a valid JSON input for a pointer struct. So we avoid
passing pointer to pointer.

https://mattermost.atlassian.net/browse/MM-44805

```release-note
NONE
```
