### PR TITLE
MM-44806: Avoid pointers in JSON parsing in updateCategoryForTeamForUser

### DIFF
--- a/api4/channel_category.go
+++ b/api4/channel_category.go
@@ -275,21 +275,21 @@ func updateCategoryForTeamForUser(c *Context, w http.ResponseWriter, r *http.Req
 	auditRec := c.MakeAuditRecord("updateCategoryForTeamForUser", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 
-	var categoryUpdateRequest *model.SidebarCategoryWithChannels
+	var categoryUpdateRequest model.SidebarCategoryWithChannels
 	err := json.NewDecoder(r.Body).Decode(&categoryUpdateRequest)
 	if err != nil || categoryUpdateRequest.TeamId != c.Params.TeamId || categoryUpdateRequest.UserId != c.Params.UserId {
 		c.SetInvalidParam("category")
 		return
 	}
 
-	if appErr := validateSidebarCategory(c, c.Params.TeamId, c.Params.UserId, categoryUpdateRequest); appErr != nil {
+	if appErr := validateSidebarCategory(c, c.Params.TeamId, c.Params.UserId, &categoryUpdateRequest); appErr != nil {
 		c.Err = appErr
 		return
 	}
 
 	categoryUpdateRequest.Id = c.Params.CategoryId
 
-	categories, appErr := c.App.UpdateSidebarCategories(c.Params.UserId, c.Params.TeamId, []*model.SidebarCategoryWithChannels{categoryUpdateRequest})
+	categories, appErr := c.App.UpdateSidebarCategories(c.Params.UserId, c.Params.TeamId, []*model.SidebarCategoryWithChannels{&categoryUpdateRequest})
 	if appErr != nil {
 		c.Err = appErr
 		return

--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -434,7 +434,7 @@ func TestUpdateCategoryForTeamForUser(t *testing.T) {
 			route := fmt.Sprintf("/users/%s/teams/%s/channels/categories/%s", user.Id, th.BasicTeam.Id, dmsCategory.Id)
 			r, err := client.DoAPIPutBytes(route, payload)
 			require.Error(t, err)
-			defer closeBody(r)
+			closeBody(r)
 		})
 	})
 }

--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -5,6 +5,7 @@ package api4
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -416,6 +417,25 @@ func TestUpdateCategoryForTeamForUser(t *testing.T) {
 		member, _, err := client.GetChannelMember(dmChannel.Id, user.Id, "")
 		require.NoError(t, err)
 		assert.False(t, member.IsChannelMuted())
+	})
+
+	t.Run("should not crash with null input", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			user, client := setupUserForSubtest(t, th)
+
+			categories, _, err := client.GetSidebarCategoriesForTeamForUser(user.Id, th.BasicTeam.Id, "")
+			require.NoError(t, err)
+			require.Len(t, categories.Categories, 3)
+			require.Len(t, categories.Order, 3)
+
+			dmsCategory := categories.Categories[2]
+
+			payload := []byte(`null`)
+			route := fmt.Sprintf("/users/%s/teams/%s/channels/categories/%s", user.Id, th.BasicTeam.Id, dmsCategory.Id)
+			r, err := client.DoAPIPutBytes(route, payload)
+			require.Error(t, err)
+			defer closeBody(r)
+		})
 	})
 }
 


### PR DESCRIPTION
Passing null is a valid JSON input for a pointer struct. So we avoid
passing pointer to pointer.

https://mattermost.atlassian.net/browse/MM-44806
```release-note
NONE
```
