### PR TITLE
[MM-41026] Fix flaky TestUploadDataConcurrent

### DIFF
--- a/app/upload_test.go
+++ b/app/upload_test.go
@@ -270,7 +270,7 @@ func TestUploadDataConcurrent(t *testing.T) {
 			}
 			u := *us
 			_, err := th.App.UploadData(th.Context, &u, rd)
-			if err != nil && err.Id == "app.upload.upload_data.concurrent.app_error" {
+			if err != nil {
 				atomic.AddInt32(&nErrs, 1)
 			}
 		}()
@@ -294,7 +294,7 @@ func TestUploadDataConcurrent(t *testing.T) {
 			u := *us
 			u.FileOffset = 5 * 1024 * 1024
 			_, err := th.App.UploadData(th.Context, &u, rd)
-			if err != nil && err.Id == "app.upload.upload_data.concurrent.app_error" {
+			if err != nil {
 				atomic.AddInt32(&nErrs, 1)
 			}
 		}()


### PR DESCRIPTION
#### Summary

Removing the error id check should reduce flakiness as there is a rare edge case in which one upload attempt completes before others could get a chance to grab the lock.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-41026

#### Release Note

```release-note
NONE
```
