### PR TITLE
File storage usage default 0 (#20454)

### DIFF
--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -739,7 +739,7 @@ func (fs SqlFileInfoStore) GetFilesBatchForIndexing(startTime int64, startFileID
 
 func (fs SqlFileInfoStore) GetStorageUsage(allowFromCache, includeDeleted bool) (int64, error) {
 	query := fs.getQueryBuilder().
-		Select("SUM(Size)").
+		Select("COALESCE(SUM(Size), 0)").
 		From("FileInfo")
 
 	if !includeDeleted {

--- a/store/storetest/file_info_store.go
+++ b/store/storetest/file_info_store.go
@@ -730,6 +730,11 @@ func testFileInfoStoreCountAll(t *testing.T, ss store.Store) {
 func testFileInfoGetStorageUsage(t *testing.T, ss store.Store) {
 	_, err := ss.FileInfo().PermanentDeleteBatch(model.GetMillis(), 100000)
 	require.NoError(t, err)
+
+	usage, err := ss.FileInfo().GetStorageUsage(false, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), usage)
+
 	f1, err := ss.FileInfo().Save(&model.FileInfo{
 		PostId:    model.NewId(),
 		CreatorId: model.NewId(),
@@ -753,7 +758,7 @@ func testFileInfoGetStorageUsage(t *testing.T, ss store.Store) {
 	})
 	require.NoError(t, err)
 
-	usage, err := ss.FileInfo().GetStorageUsage(false, false)
+	usage, err = ss.FileInfo().GetStorageUsage(false, false)
 	require.NoError(t, err)
 	require.Equal(t, int64(30), usage)
 


### PR DESCRIPTION
#### Summary
If there are no entries in the FileInfo table, then null results, which can't be cast to a number. So we add a COALESCE expression to default to 0 in that case. Because the frontend handles errors gracefully, I don't think we need to cherry-pick this for June 15 release, although we may see a few error logs in brand new installations until a file is uploaded.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45057

#### Release Note
```release-note
Fix for cloud instances that had backend errors when fetching file storage usage when no files had been uploaded.
```
