### PR TITLE
Use a single critical section for users notified admin

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -1158,7 +1158,6 @@ func searchAllChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	includeDeleted, _ := strconv.ParseBool(r.URL.Query().Get("include_deleted"))
 	includeDeleted = includeDeleted || props.IncludeDeleted
-
 	opts := model.ChannelSearchOpts{
 		NotAssociatedToGroup:     props.NotAssociatedToGroup,
 		ExcludeDefaultChannels:   props.ExcludeDefaultChannels,
@@ -1166,6 +1165,7 @@ func searchAllChannels(c *Context, w http.ResponseWriter, r *http.Request) {
 		GroupConstrained:         props.GroupConstrained,
 		ExcludeGroupConstrained:  props.ExcludeGroupConstrained,
 		ExcludePolicyConstrained: props.ExcludePolicyConstrained,
+		IncludeSearchById:        props.IncludeSearchById,
 		Public:                   props.Public,
 		Private:                  props.Private,
 		IncludeDeleted:           includeDeleted,

--- a/app/channel.go
+++ b/app/channel.go
@@ -2780,6 +2780,7 @@ func (a *App) SearchAllChannels(term string, opts model.ChannelSearchOpts) (mode
 		ExcludeGroupConstrained:  opts.ExcludeGroupConstrained,
 		PolicyID:                 opts.PolicyID,
 		IncludePolicyID:          opts.IncludePolicyID,
+		IncludeSearchById:        opts.IncludeSearchById,
 		ExcludePolicyConstrained: opts.ExcludePolicyConstrained,
 		Public:                   opts.Public,
 		Private:                  opts.Private,

--- a/app/cloud.go
+++ b/app/cloud.go
@@ -29,11 +29,12 @@ func (a *App) NotifySystemAdminsToUpgrade(c *request.Context, currentUserTeamID 
 
 	if err != nil {
 		var errNotFound *store.ErrNotFound
-		if errors.As(err, &errNotFound) {
+		if !errors.As(err, &errNotFound) {
+			// error was because of something other than the record not existing
 			notifyLock.Unlock()
 			return model.NewAppError("app.NotifySystemAdminsToUpgrade", "api.cloud.notify_admin_to_upgrade_error.fetch", nil, "", http.StatusInternalServerError)
 		}
-		mlog.Error("Unable to get NOTIFIED_ADMIN_TO_UPGRADE", mlog.Err(err))
+		mlog.Debug("NOTIFIED_ADMIN_TO_UPGRADE system value does not exist")
 	}
 
 	alreadyNotifiedUsersInfo := &model.AlreadyCloudNotifiedAdminUsersInfo{

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -484,6 +484,10 @@
     "translation": "Already notified admin"
   },
   {
+    "id": "api.cloud.notify_admin_to_upgrade_error.fetch",
+    "translation": "Unable to check against users who already notified"
+  },
+  {
     "id": "api.cloud.request_error",
     "translation": "Error processing request to CWS."
   },

--- a/model/channel.go
+++ b/model/channel.go
@@ -123,6 +123,7 @@ type ChannelModeratedRolesPatch struct {
 // ExcludeDefaultChannels will exclude the configured default channels (ex 'town-square' and 'off-topic').
 // IncludeDeleted will include channel records where DeleteAt != 0.
 // ExcludeChannelNames will exclude channels from the results by name.
+// IncludeSearchById will include searching matches against channel IDs in the results
 // Paginate whether to paginate the results.
 // Page page requested, if results are paginated.
 // PerPage number of results per page, if paginated.
@@ -139,6 +140,7 @@ type ChannelSearchOpts struct {
 	PolicyID                 string
 	ExcludePolicyConstrained bool
 	IncludePolicyID          bool
+	IncludeSearchById        bool
 	Public                   bool
 	Private                  bool
 	Page                     *int

--- a/model/channel_search.go
+++ b/model/channel_search.go
@@ -16,6 +16,7 @@ type ChannelSearch struct {
 	Public                   bool     `json:"public"`
 	Private                  bool     `json:"private"`
 	IncludeDeleted           bool     `json:"include_deleted"`
+	IncludeSearchById        bool     `json:"include_search_by_id"`
 	Deleted                  bool     `json:"deleted"`
 	Page                     *int     `json:"page,omitempty"`
 	PerPage                  *int     `json:"per_page,omitempty"`

--- a/store/store.go
+++ b/store/store.go
@@ -939,6 +939,7 @@ type SharedChannelStore interface {
 // NotAssociatedToGroup will exclude channels that have associated, active GroupChannels records.
 // IncludeDeleted will include channel records where DeleteAt != 0.
 // ExcludeChannelNames will exclude channels from the results by name.
+// IncludeSearchById will include searching matches against channel IDs in the results
 // Paginate whether to paginate the results.
 // Page page requested, if results are paginated.
 // PerPage number of results per page, if paginated.
@@ -956,6 +957,7 @@ type ChannelSearchOpts struct {
 	ExcludePolicyConstrained bool
 	IncludePolicyID          bool
 	IncludeTeamInfo          bool
+	IncludeSearchById        bool
 	CountOnly                bool
 	Public                   bool
 	Private                  bool

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -6448,6 +6448,7 @@ func testChannelStoreSearchAllChannels(t *testing.T, ss store.Store) {
 		{"Filter team 1 and team 2, public and private and group constrained", "", store.ChannelSearchOpts{IncludeDeleted: false, TeamIds: []string{t1.Id, t2.Id}, Public: true, Private: true, GroupConstrained: true, Page: model.NewInt(0), PerPage: model.NewInt(5)}, model.ChannelList{&o5}, 1},
 		{"Filter team 1 and team 2, public and private and exclude group constrained", "", store.ChannelSearchOpts{IncludeDeleted: false, TeamIds: []string{t1.Id, t2.Id}, Public: true, Private: true, ExcludeGroupConstrained: true, Page: model.NewInt(0), PerPage: model.NewInt(5)}, model.ChannelList{&o1, &o2, &o3, &o4, &o6}, 12},
 		{"Filter deleted returns only deleted channels", "", store.ChannelSearchOpts{Deleted: true, Page: model.NewInt(0), PerPage: model.NewInt(5)}, model.ChannelList{&o13}, 1},
+		{"Search ChannelA by id", o1.Id, store.ChannelSearchOpts{IncludeDeleted: false, Page: model.NewInt(0), PerPage: model.NewInt(5), IncludeSearchById: true}, model.ChannelList{&o1}, 1},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
#### Summary
Use a single critical section. If unable to fetch system value, only proceed if the system value row did not exist.

#### Ticket Link
Supports https://github.com/mattermost/mattermost-server/pull/20338/files

#### Release Note
```release-note
NONE
```
