### PR TITLE
MM-44642 hide insights per license

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -204,7 +204,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 			props["EnableCustomGroups"] = strconv.FormatBool(*c.ServiceSettings.EnableCustomGroups)
 		}
 
-		if license.SkuShortName == model.LicenseShortSkuProfessional || license.SkuShortName == model.LicenseShortSkuEnterprise {
+		if (license.SkuShortName == model.LicenseShortSkuProfessional || license.SkuShortName == model.LicenseShortSkuEnterprise) && c.FeatureFlags.InsightsEnabled {
 			props["InsightsEnabled"] = "true"
 		}
 	}

--- a/config/client.go
+++ b/config/client.go
@@ -129,6 +129,8 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["IsDefaultMarketplace"] = strconv.FormatBool(*c.PluginSettings.MarketplaceURL == model.PluginSettingsDefaultMarketplaceURL)
 	props["ExperimentalSharedChannels"] = "false"
 	props["CollapsedThreads"] = *c.ServiceSettings.CollapsedThreads
+	props["EnableCustomGroups"] = "false"
+	props["InsightsEnabled"] = "false"
 
 	if license != nil {
 		props["ExperimentalEnableAuthenticationTransfer"] = strconv.FormatBool(*c.ServiceSettings.ExperimentalEnableAuthenticationTransfer)

--- a/config/client.go
+++ b/config/client.go
@@ -203,6 +203,10 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 		if license.SkuShortName == model.LicenseShortSkuProfessional || license.SkuShortName == model.LicenseShortSkuEnterprise {
 			props["EnableCustomGroups"] = strconv.FormatBool(*c.ServiceSettings.EnableCustomGroups)
 		}
+
+		if license.SkuShortName == model.LicenseShortSkuProfessional || license.SkuShortName == model.LicenseShortSkuEnterprise {
+			props["InsightsEnabled"] = "true"
+		}
 	}
 
 	return props

--- a/config/client_test.go
+++ b/config/client_test.go
@@ -214,6 +214,54 @@ func TestGetClientConfig(t *testing.T) {
 				"InsightsEnabled": "false",
 			},
 		},
+		{
+			"Custom groups professional license",
+			&model.Config{
+				FeatureFlags: &model.FeatureFlags{
+					CustomGroups: true,
+				},
+			},
+			"",
+			&model.License{
+				Features:     &model.Features{},
+				SkuShortName: model.LicenseShortSkuProfessional,
+			},
+			map[string]string{
+				"EnableCustomGroups": "true",
+			},
+		},
+		{
+			"Custom groups enterprise license",
+			&model.Config{
+				FeatureFlags: &model.FeatureFlags{
+					CustomGroups: true,
+				},
+			},
+			"",
+			&model.License{
+				Features:     &model.Features{},
+				SkuShortName: model.LicenseShortSkuEnterprise,
+			},
+			map[string]string{
+				"EnableCustomGroups": "true",
+			},
+		},
+		{
+			"Custom groups other license",
+			&model.Config{
+				FeatureFlags: &model.FeatureFlags{
+					InsightsEnabled: true,
+				},
+			},
+			"",
+			&model.License{
+				Features:     &model.Features{},
+				SkuShortName: "other",
+			},
+			map[string]string{
+				"EnableCustomGroups": "false",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/config/client_test.go
+++ b/config/client_test.go
@@ -15,12 +15,11 @@ import (
 func TestGetClientConfig(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		description       string
-		config            *model.Config
-		telemetryID       string
-		license           *model.License
-		expectedFields    map[string]string
-		shouldNotHaveKeys []string
+		description    string
+		config         *model.Config
+		telemetryID    string
+		license        *model.License
+		expectedFields map[string]string
 	}{
 		{
 			"unlicensed",
@@ -49,7 +48,6 @@ func TestGetClientConfig(t *testing.T) {
 				"WebsocketPort":                    "80",
 				"WebsocketSecurePort":              "443",
 			},
-			nil,
 		},
 		{
 			"licensed, but not for theme management",
@@ -73,7 +71,6 @@ func TestGetClientConfig(t *testing.T) {
 				"EmailNotificationContentsType": "full",
 				"AllowCustomThemes":             "true",
 			},
-			nil,
 		},
 		{
 			"licensed for theme management",
@@ -96,7 +93,6 @@ func TestGetClientConfig(t *testing.T) {
 				"EmailNotificationContentsType": "full",
 				"AllowCustomThemes":             "false",
 			},
-			nil,
 		},
 		{
 			"licensed for enforcement",
@@ -114,7 +110,6 @@ func TestGetClientConfig(t *testing.T) {
 			map[string]string{
 				"EnforceMultifactorAuthentication": "true",
 			},
-			nil,
 		},
 		{
 			"default marketplace",
@@ -128,7 +123,6 @@ func TestGetClientConfig(t *testing.T) {
 			map[string]string{
 				"IsDefaultMarketplace": "true",
 			},
-			nil,
 		},
 		{
 			"non-default marketplace",
@@ -142,7 +136,6 @@ func TestGetClientConfig(t *testing.T) {
 			map[string]string{
 				"IsDefaultMarketplace": "false",
 			},
-			nil,
 		},
 		{
 			"enable ShowFullName prop",
@@ -156,7 +149,6 @@ func TestGetClientConfig(t *testing.T) {
 			map[string]string{
 				"ShowFullName": "true",
 			},
-			nil,
 		},
 		{
 			"Insights professional license",
@@ -173,7 +165,6 @@ func TestGetClientConfig(t *testing.T) {
 			map[string]string{
 				"InsightsEnabled": "true",
 			},
-			nil,
 		},
 		{
 			"Insights enterprise license",
@@ -190,7 +181,6 @@ func TestGetClientConfig(t *testing.T) {
 			map[string]string{
 				"InsightsEnabled": "true",
 			},
-			nil,
 		},
 		{
 			"Insights other license",
@@ -204,8 +194,9 @@ func TestGetClientConfig(t *testing.T) {
 				Features:     &model.Features{},
 				SkuShortName: "other",
 			},
-			nil,
-			[]string{"InsightsEnabled"},
+			map[string]string{
+				"InsightsEnabled": "false",
+			},
 		},
 		{
 			"Insights professional license, feature flag disabled",
@@ -219,8 +210,9 @@ func TestGetClientConfig(t *testing.T) {
 				Features:     &model.Features{},
 				SkuShortName: model.LicenseShortSkuProfessional,
 			},
-			nil,
-			[]string{"InsightsEnabled"},
+			map[string]string{
+				"InsightsEnabled": "false",
+			},
 		},
 	}
 
@@ -240,10 +232,6 @@ func TestGetClientConfig(t *testing.T) {
 				if assert.True(t, ok, fmt.Sprintf("config does not contain %v", expectedField)) {
 					assert.Equal(t, expectedValue, actualValue)
 				}
-			}
-
-			for _, key := range testCase.shouldNotHaveKeys {
-				assert.NotContains(t, configMap, key)
 			}
 		})
 	}


### PR DESCRIPTION
#### Summary

Couldn't check for SKU short name directly on the chat-facing frontend because system users (ie non-admins) are not authorized to read the SKU short name. Added a new client config setting instead.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44642

#### Release Note

```release-note
Added new client config setting to indicate if the Insights feature is accessible based to clients.
```

#### Related PR

* https://github.com/mattermost/mattermost-webapp/pull/10584