### PR TITLE
Check for nil,nil returned from GetUser

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -390,6 +390,7 @@ func (a *App) GetUser(userID string) (*model.User, *model.AppError) {
 
 	// Temporary check to diagnose a SET escalation; when GetUser is called by some plugins a nil,nil is returned.
 	if user == nil {
+		mlog.Error("Unexpected nil from GetUser", mlog.String("user_id", userID))
 		return nil, model.NewAppError("GetUser", "app.user.get.app_error", nil, "Unexpected nil fetching userid "+userID, http.StatusInternalServerError)
 	}
 

--- a/app/user.go
+++ b/app/user.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/mattermost/mattermost-server/v6/app/email"
 	"github.com/mattermost/mattermost-server/v6/app/imaging"
 	"github.com/mattermost/mattermost-server/v6/app/request"
@@ -28,7 +30,6 @@ import (
 	"github.com/mattermost/mattermost-server/v6/shared/mfa"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -385,6 +386,11 @@ func (a *App) GetUser(userID string) (*model.User, *model.AppError) {
 		default:
 			return nil, model.NewAppError("GetUser", "app.user.get_by_username.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
+	}
+
+	// Temporary check to diagnose a SET escalation; when GetUser is called by some plugins a nil,nil is returned.
+	if user == nil {
+		return nil, model.NewAppError("GetUser", "app.user.get.app_error", nil, "Unexpected nil fetching userid "+userID, http.StatusInternalServerError)
 	}
 
 	return user, nil


### PR DESCRIPTION
#### Summary
As part of an SET escalation a temporary check is added to `App.GetUser`, which seems to return `nil,nil` when called via some plugins.

#### Ticket Link
NONE     See https://community.mattermost.com/core/pl/qyd9mschzjnfmp4ecwjhy6os5c

#### Release Note
```release-note
NONE
```
