### PR TITLE
MM-45209  Revert PR checking for GetUser returning nil,nil

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -388,12 +388,6 @@ func (a *App) GetUser(userID string) (*model.User, *model.AppError) {
 		}
 	}
 
-	// Temporary check to diagnose a SET escalation; when GetUser is called by some plugins a nil,nil is returned.
-	if user == nil {
-		mlog.Error("Unexpected nil from GetUser", mlog.String("user_id", userID))
-		return nil, model.NewAppError("GetUser", "app.user.get.app_error", nil, "Unexpected nil fetching userid "+userID, http.StatusInternalServerError)
-	}
-
 	return user, nil
 }
 


### PR DESCRIPTION
#### Summary
Reverts the PR https://github.com/mattermost/mattermost-server/pull/20501 which was added for SET escalation.

It was determined that the plugins call to GetUser never made it to the app layer.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-45209

#### Release Note
```release-note
NONE
```
