### PR TITLE
MM-40450: Follow redirects in image proxy

### DIFF
--- a/services/imageproxy/local.go
+++ b/services/imageproxy/local.go
@@ -64,9 +64,6 @@ func makeLocalBackend(proxy *ImageProxy) *LocalBackend {
 	}
 
 	client := proxy.HTTPService.MakeClient(false)
-	client.CheckRedirect = func(newreq *http.Request, via []*http.Request) error {
-		return http.ErrUseLastResponse
-	}
 
 	return &LocalBackend{
 		proxy:   proxy,


### PR DESCRIPTION
For the local proxy, we weren't following redirects.
We remove the CheckRedirect function and use the default
function, which is good enough for our purposes.

https://mattermost.atlassian.net/browse/MM-40450

```release-note
NONE
```
