### PR TITLE
Make three file settings editable in Cloud System Console UI

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -1401,9 +1401,9 @@ func (s *PasswordSettings) SetDefaults() {
 }
 
 type FileSettings struct {
-	EnableFileAttachments      *bool   `access:"site_file_sharing_and_downloads,cloud_restrictable"`
-	EnableMobileUpload         *bool   `access:"site_file_sharing_and_downloads,cloud_restrictable"`
-	EnableMobileDownload       *bool   `access:"site_file_sharing_and_downloads,cloud_restrictable"`
+	EnableFileAttachments      *bool   `access:"site_file_sharing_and_downloads"`
+	EnableMobileUpload         *bool   `access:"site_file_sharing_and_downloads"`
+	EnableMobileDownload       *bool   `access:"site_file_sharing_and_downloads"`
 	MaxFileSize                *int64  `access:"environment_file_storage,cloud_restrictable"`
 	MaxImageResolution         *int64  `access:"environment_file_storage,cloud_restrictable"`
 	MaxImageDecoderConcurrency *int64  `access:"environment_file_storage,cloud_restrictable"`


### PR DESCRIPTION
Make three file settings editable in Cloud System Console UI
- EnableFileAttachments
- EnableMobileUpload
- EnableMobileDownload

Context on this thread: https://community-daily.mattermost.com/private-core/pl/mcwz7e78a78ejd78a4gmqntsmw

```release-note
NONE
```