### PR TITLE
MM-44863 - update trial details in product menu

### DIFF
--- a/api4/cloud_test.go
+++ b/api4/cloud_test.go
@@ -154,7 +154,7 @@ func Test_GetSubscription(t *testing.T) {
 
 		cloud := mocks.CloudInterface{}
 
-		cloud.Mock.On("GetSubscription", mock.Anything).Return(userFacingSubscription, nil)
+		cloud.Mock.On("GetSubscription", mock.Anything).Return(subscription, nil)
 
 		cloudImpl := th.App.Srv().Cloud
 		defer func() {


### PR DESCRIPTION
#### Summary
This PR make the getSubscription endpoint available with restricted and containing non-sensitive information to non-admin users so we can start implementing the functionalities where end users will be able to notify admins about "starting a trial" or "subscribing" depending on the subscription status.

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/10609

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44863

#### Release Note
```release-note
NONE
```
