### PR TITLE
Mm 44954 regenerate default avatar

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -3401,8 +3401,15 @@ func TestSetDefaultProfileImage(t *testing.T) {
 	defer th.TearDown()
 	user := th.BasicUser
 
+	startTime := model.GetMillis()
+	time.Sleep(time.Millisecond)
+
 	_, err := th.Client.SetDefaultProfileImage(user.Id)
 	require.NoError(t, err)
+
+	iuser, getUserErr := th.App.GetUser(user.Id)
+	require.Nil(t, getUserErr)
+	assert.Less(t, iuser.LastPictureUpdate, -startTime, "LastPictureUpdate should be set to -(current time in milliseconds)")
 
 	resp, err := th.Client.SetDefaultProfileImage(model.NewId())
 	require.Error(t, err)
@@ -3421,12 +3428,14 @@ func TestSetDefaultProfileImage(t *testing.T) {
 		require.Fail(t, "Should have failed either forbidden or unauthorized")
 	}
 
+	time.Sleep(time.Millisecond)
+
 	_, err = th.SystemAdminClient.SetDefaultProfileImage(user.Id)
 	require.NoError(t, err)
 
 	ruser, appErr := th.App.GetUser(user.Id)
 	require.Nil(t, appErr)
-	assert.Equal(t, int64(0), ruser.LastPictureUpdate, "Picture should have reset to default")
+	assert.Less(t, ruser.LastPictureUpdate, iuser.LastPictureUpdate, "LastPictureUpdate should be updated to a lower negative number")
 
 	info := &model.FileInfo{Path: "users/" + user.Id + "/profile.png"}
 	err = th.cleanupTestFile(info)

--- a/app/user.go
+++ b/app/user.go
@@ -762,21 +762,8 @@ func (a *App) UpdateDefaultProfileImage(user *model.User) *model.AppError {
 }
 
 func (a *App) SetDefaultProfileImage(user *model.User) *model.AppError {
-	img, appErr := a.GetDefaultProfileImage(user)
-	if appErr != nil {
-		return appErr
-	}
 
-	path := getProfileImagePath(user.Id)
-	if _, err := a.WriteFile(bytes.NewReader(img), path); err != nil {
-		return err
-	}
-
-	if err := a.Srv().Store.User().ResetLastPictureUpdate(user.Id); err != nil {
-		mlog.Warn("Failed to reset last picture update", mlog.Err(err))
-	}
-
-	a.InvalidateCacheForUser(user.Id)
+	a.UpdateDefaultProfileImage(user)
 
 	updatedUser, appErr := a.GetUser(user.Id)
 	if appErr != nil {

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -258,7 +258,7 @@ func (us SqlUserStore) UpdateLastPictureUpdate(userId string) error {
 func (us SqlUserStore) ResetLastPictureUpdate(userId string) error {
 	curTime := model.GetMillis()
 
-	if _, err := us.GetMasterX().Exec("UPDATE Users SET LastPictureUpdate = ?, UpdateAt = ? WHERE Id = ?", 0, curTime, userId); err != nil {
+	if _, err := us.GetMasterX().Exec("UPDATE Users SET LastPictureUpdate = ?, UpdateAt = ? WHERE Id = ?", -curTime, curTime, userId); err != nil {
 		return errors.Wrapf(err, "failed to update User with userId=%s", userId)
 	}
 

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -5704,6 +5704,7 @@ func testDeactivateGuests(t *testing.T, ss store.Store) {
 }
 
 func testUserStoreResetLastPictureUpdate(t *testing.T, ss store.Store) {
+	startTime := model.GetMillis()
 	u1 := &model.User{}
 	u1.Email = MakeEmail()
 	_, err := ss.User().Save(u1)
@@ -5718,8 +5719,8 @@ func testUserStoreResetLastPictureUpdate(t *testing.T, ss store.Store) {
 	user, err := ss.User().Get(context.Background(), u1.Id)
 	require.NoError(t, err)
 
-	assert.NotZero(t, user.LastPictureUpdate)
-	assert.NotZero(t, user.UpdateAt)
+	assert.GreaterOrEqual(t, user.LastPictureUpdate, startTime)
+	assert.GreaterOrEqual(t, user.LastPictureUpdate, startTime)
 
 	// Ensure update at timestamp changes
 	time.Sleep(time.Millisecond)
@@ -5732,8 +5733,8 @@ func testUserStoreResetLastPictureUpdate(t *testing.T, ss store.Store) {
 	user2, err := ss.User().Get(context.Background(), u1.Id)
 	require.NoError(t, err)
 
-	assert.True(t, user2.UpdateAt > user.UpdateAt)
-	assert.Zero(t, user2.LastPictureUpdate)
+	assert.Greater(t, user2.UpdateAt, user.UpdateAt)
+	assert.Less(t, user2.LastPictureUpdate, -startTime)
 }
 
 func testGetKnownUsers(t *testing.T, ss store.Store) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds the ability to regenerate the default profile picture for a user when their username is changed. 

In order to support this operation an adjustment needed to be made to how we determine a user has a default profile picture. Before this change this was done by checking `lastPictureUpdate == 0`, this change alters the logic to instead be `lastPictureUpdate <= 0` to support updating client applications with the new profile picture automatically when the username is changed. 

To support automagically updating the profile picture for a user on the client application it is necessary that that `lastPictureUpdate` field has changed from the client's previously known value when a `user_updated` websocket event is encountered. 
In order to support this instead of setting `lastPictureUpdate` to `0` when `ResetLastPictureUpdate` is called we instead set it to the current time (in milliseconds since epoch) cast to a negative number. This way we can still easily differentiate between a default profile image and one set by a user, but retain the ability to detect "updates" to this field when regenerating the default image.

#### Ticket Link
[Github Issue 20471](https://github.com/mattermost/mattermost-server/issues/20471)
[MM-44954](https://mattermost.atlassian.net/browse/MM-44954)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
