### PR TITLE
[MM-45135] - Mattermost Logo is outdated in Cloud welcome email

### DIFF
--- a/templates/cloud_welcome_email.html
+++ b/templates/cloud_welcome_email.html
@@ -21,7 +21,7 @@
                                 style="margin-bottom: 30px;">
                                 <tr>
                                     <td style="padding: 20px 20px 10px; text-align:center;">
-                                        <img src="{{.Props.WorkSpacePath}}/static/images/logo_email_blue.png"
+                                        <img src="{{.Props.WorkSpacePath}}/static/images/logo_email_dark.png"
                                             style="height: 21.7px;" alt="logo_email_blue">
                                     </td>
                                 </tr>


### PR DESCRIPTION
#### Summary
Update the mattermost logo in cloud welcome email

#### Ticket Link
[MM-45135](https://mattermost.atlassian.net/browse/MM-45135)

#### Screenshots
Before
-----
<img width="1792" alt="Screenshot 2022-06-27 at 08 41 39" src="https://user-images.githubusercontent.com/28563179/175867674-a93da577-c933-400e-9913-d5743a1ae0ef.png">


After
-----
<img width="1792" alt="Screenshot 2022-06-27 at 08 35 14" src="https://user-images.githubusercontent.com/28563179/175867568-91aaa351-b06e-41be-8fd4-56468470ff8a.png">



#### Release Note

```release-note
NONE
```
