### PR TITLE
Add mocks, layers and generated as rules to the make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,6 +390,12 @@ email-mocks: ## Creates mocks for misc interfaces.
 pluginapi: ## Generates api and hooks glue code for plugins
 	$(GO) generate $(GOFLAGS) ./plugin
 
+mocks: store-mocks telemetry-mocks filestore-mocks ldap-mocks plugin-mocks einterfaces-mocks searchengine-mocks sharedchannel-mocks misc-mocks email-mocks
+
+layers: app-layers store-layers pluginapi
+
+generated: mocks layers
+
 check-prereqs: ## Checks prerequisite software status.
 	./scripts/prereq-check.sh
 


### PR DESCRIPTION
#### Summary
This PR adds rules to the Makefile to generate all mocks, layers and both with one command. I'd suggest to add a check in the CircleCI config to make sure the mocks are all up-to-date.

#### Ticket Link
none

#### Release Note
```release-note
NONE
```
