### PR TITLE
MM-45168 GraphQL: add fields to Team

### DIFF
--- a/api4/resolver_team_member_test.go
+++ b/api4/resolver_team_member_test.go
@@ -31,8 +31,14 @@ func TestGraphQLTeamMembers(t *testing.T) {
 				NickName  string `json:"nickname"`
 			} `json:"user"`
 			Team struct {
-				ID          string `json:"id"`
-				DisplayName string `json:"displayName"`
+				ID                  string  `json:"id"`
+				DisplayName         string  `json:"displayName"`
+				Name                string  `json:"name"`
+				CreateAt            float64 `json:"createAt"`
+				DeleteAt            float64 `json:"deleteAt"`
+				SchemeId            *string `json:"schemeId"`
+				PolicyId            *string `json:"policyId"`
+				CloudLimitsArchived bool    `json:"cloudLimitsArchived"`
 			} `json:"team"`
 			Roles []struct {
 				ID            string   `json:"id"`
@@ -113,6 +119,12 @@ func TestGraphQLTeamMembers(t *testing.T) {
 	  	team {
 	  		id
 	  		displayName
+			name
+			createAt
+			deleteAt
+			schemeId
+			policyId
+			cloudLimitsArchived
 	  	}
 	  	user {
 	  		id
@@ -143,6 +155,12 @@ func TestGraphQLTeamMembers(t *testing.T) {
 		tm := q.TeamMembers[0]
 		assert.Equal(t, th.BasicTeam.Id, tm.Team.ID)
 		assert.Equal(t, th.BasicTeam.DisplayName, tm.Team.DisplayName)
+		assert.Equal(t, th.BasicTeam.Name, tm.Team.Name)
+		assert.Equal(t, th.BasicTeam.CreateAt_(), tm.Team.CreateAt)
+		assert.Equal(t, th.BasicTeam.DeleteAt_(), tm.Team.DeleteAt)
+		assert.Equal(t, th.BasicTeam.SchemeId, tm.Team.SchemeId)
+		assert.Equal(t, th.BasicTeam.PolicyID, tm.Team.PolicyId)
+		assert.Equal(t, th.BasicTeam.CloudLimitsArchived, tm.Team.CloudLimitsArchived)
 
 		assert.Equal(t, th.BasicUser.Id, tm.User.ID)
 		assert.Equal(t, th.BasicUser.Username, tm.User.Username)

--- a/api4/schema.graphqls
+++ b/api4/schema.graphqls
@@ -139,7 +139,9 @@ type Team {
 	id: String!
 	displayName    :    String!
 	name           :    String!
+	createAt       :    Float!
 	updateAt       :    Float!
+	deleteAt       :    Float!
 	description    :    String!
 	email          :    String!
 	type           :    String!
@@ -149,6 +151,9 @@ type Team {
 	lastTeamIconUpdate: Float!
 	groupConstrained:   Boolean
 	allowOpenInvite:    Boolean!
+	schemeId       :    String
+	policyId       :    String
+	cloudLimitsArchived: Boolean!
 }
 
 type TeamMember {

--- a/model/team.go
+++ b/model/team.go
@@ -269,8 +269,16 @@ func (o *Team) ShallowCopy() *Team {
 // so we have to pass the data in float64. The _ at the end is
 // a hack to keep the attribute name same in GraphQL schema.
 
+func (o *Team) CreateAt_() float64 {
+	return float64(o.UpdateAt)
+}
+
 func (o *Team) UpdateAt_() float64 {
 	return float64(o.UpdateAt)
+}
+
+func (o *Team) DeleteAt_() float64 {
+	return float64(o.DeleteAt)
 }
 
 func (o *Team) LastTeamIconUpdate_() float64 {


### PR DESCRIPTION
#### Summary
This PR adds the fields `createAt`, `deleteAt`, `schemeId`, `policyId`, and `cloudLimitsArchived` to the Team returned by GraphQL.

#### Ticket Link
[MM-45168](https://mattermost.atlassian.net/browse/MM-45168)

#### Release Note
```release-note
NONE
```
