### PR TITLE
MM-45168 Added GraphQL fields to channel and channel_member

### DIFF
--- a/api4/resolver_channel_member_test.go
+++ b/api4/resolver_channel_member_test.go
@@ -66,6 +66,7 @@ func TestGraphQLChannelMembers(t *testing.T) {
 			MsgCount         float64         `json:"msgCount"`
 			MentionCount     float64         `json:"mentionCount"`
 			MentionCountRoot float64         `json:"mentionCountRoot"`
+			MsgCountRoot     float64         `json:"msgCountRoot"`
 			NotifyProps      model.StringMap `json:"notifyProps"`
 			SchemeGuest      bool            `json:"schemeGuest"`
 			SchemeUser       bool            `json:"schemeUser"`
@@ -100,6 +101,7 @@ func TestGraphQLChannelMembers(t *testing.T) {
 	  	msgCount
 	  	mentionCount
 	  	mentionCountRoot
+		msgCountRoot
 	  	schemeGuest
 	  	schemeUser
 	  	schemeAdmin

--- a/api4/resolver_channel_test.go
+++ b/api4/resolver_channel_test.go
@@ -40,6 +40,8 @@ func TestGraphQLChannels(t *testing.T) {
 			Header            string            `json:"header"`
 			Purpose           string            `json:"purpose"`
 			SchemeId          string            `json:"schemeId"`
+			TotalMsgCountRoot float64           `json:"totalMsgCountRoot"`
+			LastRootPostAt    float64           `json:"lastRootPostAt"`
 			Cursor            string            `json:"cursor"`
 			Team              struct {
 				ID          string `json:"id"`
@@ -70,6 +72,8 @@ func TestGraphQLChannels(t *testing.T) {
 	    header
 	    purpose
 	    schemeId
+		totalMsgCountRoot
+		lastRootPostAt
 	    cursor
 	  }
 	}

--- a/api4/schema.graphqls
+++ b/api4/schema.graphqls
@@ -58,6 +58,8 @@ type Channel {
 	shared: Boolean
 	lastPostAt: Float!
 	totalMsgCount: Float!
+	totalMsgCountRoot: Float!
+	lastRootPostAt: Float!
 	stats: ChannelStats
 	cursor: String
 }
@@ -70,6 +72,7 @@ type ChannelMember {
 	msgCount         : Float!
 	mentionCount     : Float!
 	mentionCountRoot : Float!
+	msgCountRoot     : Float!
 	notifyProps      : StringMap!
 	lastUpdateAt     : Float!
 	schemeGuest      : Boolean!

--- a/model/channel.go
+++ b/model/channel.go
@@ -188,6 +188,14 @@ func (o *Channel) TotalMsgCount_() float64 {
 	return float64(o.TotalMsgCount)
 }
 
+func (o *Channel) TotalMsgCountRoot_() float64 {
+	return float64(o.TotalMsgCountRoot)
+}
+
+func (o *Channel) LastRootPostAt_() float64 {
+	return float64(o.LastRootPostAt)
+}
+
 func (o *Channel) DeepCopy() *Channel {
 	copy := *o
 	if copy.SchemeId != nil {

--- a/model/channel_member.go
+++ b/model/channel_member.go
@@ -81,6 +81,10 @@ func (o *ChannelMember) MentionCountRoot_() float64 {
 	return float64(o.MentionCountRoot)
 }
 
+func (o *ChannelMember) MsgCountRoot_() float64 {
+	return float64(o.MsgCountRoot)
+}
+
 func (o *ChannelMember) LastUpdateAt_() float64 {
 	return float64(o.LastUpdateAt)
 }


### PR DESCRIPTION
#### Summary
This PR adds the fields `totalMsgCountRoot` and `lastRootPosAt` to Channel, and `msgCountRoot` to ChannelMember as per [this comment](https://mattermost.atlassian.net/browse/MM-45168?focusedCommentId=129675). The `mentionCountRoot` field already exists.

#### Ticket Link
[MM-45168](https://mattermost.atlassian.net/browse/MM-45168)

#### Release Note
```release-note
NONE
```
