### PR TITLE
Fix incorrect dead queue clear logic

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -580,7 +580,7 @@ func (wc *WebConn) isInDeadQueue(seq int64) (bool, int) {
 func (wc *WebConn) clearDeadQueue() {
 	for i := 0; i < deadQueueSize; i++ {
 		if wc.deadQueue[i] == nil {
-			return
+			break
 		}
 		wc.deadQueue[i] = nil
 	}

--- a/app/web_conn_test.go
+++ b/app/web_conn_test.go
@@ -276,6 +276,26 @@ func TestWebConnIsInDeadQueue(t *testing.T) {
 	assert.False(t, wc.hasMsgLoss())
 }
 
+func TestWebConnClearDeadQueue(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	wc := th.App.NewWebConn(&WebConnConfig{
+		WebSocket: &websocket.Conn{},
+	})
+
+	var i int
+	for ; i < 2; i++ {
+		msg := &model.WebSocketEvent{}
+		msg = msg.SetSequence(int64(i))
+		wc.addToDeadQueue(msg)
+	}
+
+	wc.clearDeadQueue()
+
+	assert.Equal(t, 0, wc.deadQueuePointer)
+}
+
 func TestWebConnDrainDeadQueue(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()


### PR DESCRIPTION
We were incorrectly returning from the method without
resetting the pointer.

Fixes https://github.com/mattermost/mattermost-server/issues/20622

```release-note
NONE
```
