### PR TITLE
Clarify collation mismatch string

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1167,7 +1167,7 @@ func (ss *SqlStore) ensureDatabaseCollation() error {
 		}
 
 		if tableCollation != connCollation.Value {
-			mlog.Warn("Table collation mismatch", mlog.String("table_name", tableName), mlog.String("expected", connCollation.Value), mlog.String("found", tableCollation))
+			mlog.Warn("Table collation mismatch", mlog.String("table_name", tableName), mlog.String("connection_collation", connCollation.Value), mlog.String("table_collation", tableCollation))
 		}
 	}
 


### PR DESCRIPTION
We replace expected/received with the source of the collation.

This makes it more clear as to from where the values
were retrieved.

```release-note
NONE
```
