### PR TITLE
Coalesce migration of Reactions.ChannelId to '' if Post does not exist.

### DIFF
--- a/db/migrations/mysql/000089_add-channelid-to-reaction.up.sql
+++ b/db/migrations/mysql/000089_add-channelid-to-reaction.up.sql
@@ -14,7 +14,7 @@ EXECUTE addColumnIfNotExists;
 DEALLOCATE PREPARE addColumnIfNotExists;
 
 
-UPDATE Reactions SET ChannelId = (select ChannelId from Posts where Posts.Id = Reactions.PostId) WHERE ChannelId="";
+UPDATE Reactions SET ChannelId = COALESCE((select ChannelId from Posts where Posts.Id = Reactions.PostId), '') WHERE ChannelId="";
 
 
 SET @preparedStatement = (SELECT IF(

--- a/db/migrations/postgres/000089_add-channelid-to-reaction.up.sql
+++ b/db/migrations/postgres/000089_add-channelid-to-reaction.up.sql
@@ -1,3 +1,3 @@
 ALTER TABLE reactions ADD COLUMN IF NOT EXISTS channelid varchar(26) NOT NULL DEFAULT '';
-UPDATE reactions SET channelid = (select channelid from posts where posts.id = reactions.postid) WHERE channelid='';
+UPDATE reactions SET channelid = COALESCE((select channelid from posts where posts.id = reactions.postid), '') WHERE channelid='';
 CREATE INDEX IF NOT EXISTS idx_reactions_channel_id on reactions (channelid);


### PR DESCRIPTION
#### Summary

When populating Reactions.ChannelId via the migration some Reactions have no associated Post and since the ChannelId column is `NOT NULL` the migration fails unless we coalesce to `''`.

#### Ticket Link

n/a

#### Release Note

```release-note
NONE
```
