### PR TITLE
[MM-45684] - Self Managed: Add pricing modal + Upgrade button

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -56,6 +56,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 
 	props["ExperimentalCloudBilling"] = strconv.FormatBool(*c.ExperimentalSettings.CloudBilling)
 	props["EnableAppBar"] = strconv.FormatBool(*c.ExperimentalSettings.EnableAppBar)
+	props["EnableUpgradeForSelfHostedStarter"] = strconv.FormatBool(*c.ExperimentalSettings.EnableUpgradeForSelfHostedStarter)
 
 	props["ExperimentalEnableAutomaticReplies"] = strconv.FormatBool(*c.TeamSettings.ExperimentalEnableAutomaticReplies)
 	props["ExperimentalTimezone"] = strconv.FormatBool(*c.DisplaySettings.ExperimentalTimezone)

--- a/model/config.go
+++ b/model/config.go
@@ -940,15 +940,16 @@ func (s *MetricsSettings) SetDefaults() {
 }
 
 type ExperimentalSettings struct {
-	ClientSideCertEnable            *bool   `access:"experimental_features,cloud_restrictable"`
-	ClientSideCertCheck             *string `access:"experimental_features,cloud_restrictable"`
-	LinkMetadataTimeoutMilliseconds *int64  `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	RestrictSystemAdmin             *bool   `access:"experimental_features,write_restrictable"`
-	UseNewSAMLLibrary               *bool   `access:"experimental_features,cloud_restrictable"`
-	CloudBilling                    *bool   `access:"experimental_features,write_restrictable"`
-	EnableSharedChannels            *bool   `access:"experimental_features"`
-	EnableRemoteClusterService      *bool   `access:"experimental_features"`
-	EnableAppBar                    *bool   `access:"experimental_features"`
+	ClientSideCertEnable              *bool   `access:"experimental_features,cloud_restrictable"`
+	ClientSideCertCheck               *string `access:"experimental_features,cloud_restrictable"`
+	LinkMetadataTimeoutMilliseconds   *int64  `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	RestrictSystemAdmin               *bool   `access:"experimental_features,write_restrictable"`
+	UseNewSAMLLibrary                 *bool   `access:"experimental_features,cloud_restrictable"`
+	CloudBilling                      *bool   `access:"experimental_features,write_restrictable"`
+	EnableSharedChannels              *bool   `access:"experimental_features"`
+	EnableRemoteClusterService        *bool   `access:"experimental_features"`
+	EnableAppBar                      *bool   `access:"experimental_features"`
+	EnableUpgradeForSelfHostedStarter *bool   `access:"experimental_features"`
 }
 
 func (s *ExperimentalSettings) SetDefaults() {
@@ -986,6 +987,10 @@ func (s *ExperimentalSettings) SetDefaults() {
 
 	if s.EnableAppBar == nil {
 		s.EnableAppBar = NewBool(false)
+	}
+
+	if s.EnableUpgradeForSelfHostedStarter == nil {
+		s.EnableUpgradeForSelfHostedStarter = NewBool(true)
 	}
 }
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -720,15 +720,16 @@ func (ts *TelemetryService) trackConfig() {
 	})
 
 	ts.SendTelemetry(TrackConfigExperimental, map[string]any{
-		"client_side_cert_enable":            *cfg.ExperimentalSettings.ClientSideCertEnable,
-		"isdefault_client_side_cert_check":   isDefault(*cfg.ExperimentalSettings.ClientSideCertCheck, model.ClientSideCertCheckPrimaryAuth),
-		"link_metadata_timeout_milliseconds": *cfg.ExperimentalSettings.LinkMetadataTimeoutMilliseconds,
-		"restrict_system_admin":              *cfg.ExperimentalSettings.RestrictSystemAdmin,
-		"use_new_saml_library":               *cfg.ExperimentalSettings.UseNewSAMLLibrary,
-		"cloud_billing":                      *cfg.ExperimentalSettings.CloudBilling,
-		"enable_shared_channels":             *cfg.ExperimentalSettings.EnableSharedChannels,
-		"enable_remote_cluster_service":      *cfg.ExperimentalSettings.EnableRemoteClusterService && cfg.FeatureFlags.EnableRemoteClusterService,
-		"enable_app_bar":                     *cfg.ExperimentalSettings.EnableAppBar,
+		"client_side_cert_enable":                *cfg.ExperimentalSettings.ClientSideCertEnable,
+		"isdefault_client_side_cert_check":       isDefault(*cfg.ExperimentalSettings.ClientSideCertCheck, model.ClientSideCertCheckPrimaryAuth),
+		"link_metadata_timeout_milliseconds":     *cfg.ExperimentalSettings.LinkMetadataTimeoutMilliseconds,
+		"restrict_system_admin":                  *cfg.ExperimentalSettings.RestrictSystemAdmin,
+		"use_new_saml_library":                   *cfg.ExperimentalSettings.UseNewSAMLLibrary,
+		"cloud_billing":                          *cfg.ExperimentalSettings.CloudBilling,
+		"enable_shared_channels":                 *cfg.ExperimentalSettings.EnableSharedChannels,
+		"enable_remote_cluster_service":          *cfg.ExperimentalSettings.EnableRemoteClusterService && cfg.FeatureFlags.EnableRemoteClusterService,
+		"enable_app_bar":                         *cfg.ExperimentalSettings.EnableAppBar,
+		"enable_upgrade_for_self_hosted_starter": *cfg.ExperimentalSettings.EnableUpgradeForSelfHostedStarter,
 	})
 
 	ts.SendTelemetry(TrackConfigAnalytics, map[string]any{


### PR DESCRIPTION
#### Summary
This PR adds the ability to configure showing of the upgrade button to self hosted admins
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45684

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/10764

#### Release Note

```release-note
Added a new config setting ExperimentalSettings.EnableUpgradeForSelfHostedStarter
```
