### PR TITLE
[MM-45769] Properly initialize the request.Context for imports and tests

### DIFF
--- a/app/product_notices_test.go
+++ b/app/product_notices_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/store/storetest/mocks"
 )
@@ -720,7 +719,7 @@ func TestNoticeFetch(t *testing.T) {
 	require.Nil(t, appErr)
 
 	// get them for specified user
-	messages, appErr := th.App.GetProductNotices(&request.Context{}, th.BasicUser.Id, th.BasicTeam.Id, model.NoticeClientTypeAll, "1.2.3", "en")
+	messages, appErr := th.App.GetProductNotices(th.Context, th.BasicUser.Id, th.BasicTeam.Id, model.NoticeClientTypeAll, "1.2.3", "en")
 	require.Nil(t, appErr)
 	require.Len(t, messages, 1)
 
@@ -729,7 +728,7 @@ func TestNoticeFetch(t *testing.T) {
 	require.Nil(t, appErr)
 
 	// get them again, see that none are returned
-	messages, appErr = th.App.GetProductNotices(&request.Context{}, th.BasicUser.Id, th.BasicTeam.Id, model.NoticeClientTypeAll, "1.2.3", "en")
+	messages, appErr = th.App.GetProductNotices(th.Context, th.BasicUser.Id, th.BasicTeam.Id, model.NoticeClientTypeAll, "1.2.3", "en")
 	require.Nil(t, appErr)
 	require.Len(t, messages, 0)
 
@@ -748,7 +747,7 @@ func TestNoticeFetch(t *testing.T) {
 	require.Nil(t, appErr)
 
 	// get them again, since conditions don't match we should be zero
-	messages, appErr = th.App.GetProductNotices(&request.Context{}, th.BasicUser.Id, th.BasicTeam.Id, model.NoticeClientTypeAll, "1.2.3", "en")
+	messages, appErr = th.App.GetProductNotices(th.Context, th.BasicUser.Id, th.BasicTeam.Id, model.NoticeClientTypeAll, "1.2.3", "en")
 	require.Nil(t, appErr)
 	require.Len(t, messages, 0)
 

--- a/app/teams/helper_test.go
+++ b/app/teams/helper_test.go
@@ -81,7 +81,7 @@ func setupTestHelper(s store.Store, includeCacheLayer bool, tb testing.TB) *Test
 			},
 			wh: &mockWebHub{},
 		},
-		Context:     &request.Context{},
+		Context:     request.EmptyContext(nil),
 		configStore: configStore,
 		dbStore:     s,
 		LogBuffer:   buffer,

--- a/app/users/helper_test.go
+++ b/app/users/helper_test.go
@@ -96,7 +96,7 @@ func setupTestHelper(s store.Store, includeCacheLayer bool, tb testing.TB) *Test
 				},
 			},
 		},
-		Context:     &request.Context{},
+		Context:     request.EmptyContext(nil),
 		configStore: configStore,
 		dbStore:     s,
 		LogBuffer:   buffer,

--- a/cmd/mattermost/commands/import.go
+++ b/cmd/mattermost/commands/import.go
@@ -79,7 +79,7 @@ func slackImportCmdF(command *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("Running Slack Import. This may take a long time for large teams or teams with many messages.")
 
-	importErr, log := a.SlackImport(&request.Context{}, fileReader, fileInfo.Size(), team.Id)
+	importErr, log := a.SlackImport(request.EmptyContext(nil), fileReader, fileInfo.Size(), team.Id)
 
 	if importErr != nil {
 		return err
@@ -152,7 +152,7 @@ func bulkImportCmdF(command *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("")
 
-	if err, lineNumber := a.BulkImportWithPath(&request.Context{}, fileReader, nil, !apply, workers, importPath); err != nil {
+	if err, lineNumber := a.BulkImportWithPath(request.EmptyContext(nil), fileReader, nil, !apply, workers, importPath); err != nil {
 		CommandPrintErrorln(err.Error())
 		if lineNumber != 0 {
 			CommandPrintErrorln(fmt.Sprintf("Error occurred on data file line %v", lineNumber))

--- a/cmd/mattermost/commands/init.go
+++ b/cmd/mattermost/commands/init.go
@@ -21,7 +21,7 @@ func initDBCommandContextCobra(command *cobra.Command, readOnlyConfigStore bool)
 		panic(err)
 	}
 
-	a.InitPlugins(&request.Context{}, *a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
+	a.InitPlugins(request.EmptyContext(a.Log()), *a.Config().PluginSettings.Directory, *a.Config().PluginSettings.ClientDirectory)
 	a.DoAppMigrations()
 
 	return a, nil

--- a/jobs/import_process/worker.go
+++ b/jobs/import_process/worker.go
@@ -31,7 +31,7 @@ type AppIface interface {
 }
 
 func MakeWorker(jobServer *jobs.JobServer, app AppIface) model.Worker {
-	appContext := &request.Context{}
+	appContext := request.EmptyContext(nil)
 	isEnabled := func(cfg *model.Config) bool {
 		return true
 	}

--- a/services/slackimport/slackimport_test.go
+++ b/services/slackimport/slackimport_test.go
@@ -327,7 +327,7 @@ func TestOldImportChannel(t *testing.T) {
 	store := &mocks.Store{}
 	config := &model.Config{}
 	config.SetDefaults()
-	ctx := &request.Context{}
+	ctx := request.EmptyContext(nil)
 	ctx.SetLogger(mlog.CreateConsoleTestLogger(true, mlog.LvlDebug))
 
 	t.Run("No panic on direct channel", func(t *testing.T) {

--- a/web/context_test.go
+++ b/web/context_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin/plugintest/mock"
 	"github.com/mattermost/mattermost-server/v6/store/storetest/mocks"
@@ -43,7 +42,7 @@ func TestCloudKeyRequired(t *testing.T) {
 
 	c := &Context{
 		App:        th.App,
-		AppContext: &request.Context{},
+		AppContext: th.Context,
 	}
 
 	c.CloudKeyRequired()

--- a/web/oauth_test.go
+++ b/web/oauth_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
@@ -368,7 +367,7 @@ func TestMobileLoginWithOAuth(t *testing.T) {
 	defer th.TearDown()
 	c := &Context{
 		App:        th.App,
-		AppContext: &request.Context{},
+		AppContext: th.Context,
 		Params: &Params{
 			Service: "gitlab",
 		},
@@ -573,7 +572,7 @@ func TestOAuthComplete_ErrorMessages(t *testing.T) {
 	defer th.TearDown()
 	c := &Context{
 		App:        th.App,
-		AppContext: &request.Context{},
+		AppContext: th.Context,
 		Params: &Params{
 			Service: "gitlab",
 		},


### PR DESCRIPTION
#### Summary
Some imports and tests just initialize an empty context, causing nil pointer dereferences is the server. This PR initializes them.
Thanks to @josephbaylon for reporting this issue.

#### Ticket Link
[MM-45769](https://mattermost.atlassian.net/browse/MM-45769)

#### Release Note
```release-note
NONE
```
