### PR TITLE
Fix broken master; ensure all product service APIs have correct implementations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -176,7 +176,7 @@ func (a *App) UpdateExpiredDNDStatuses() ([]*model.Status, error) {
 }
 
 // Ensure system service adapter implements `product.SystemService`
-var _ product.SystemService = &systemServiceAdapter{}
+var _ product.SystemService = (*systemServiceAdapter)(nil)
 
 // systemServiceAdapter provides a collection of system APIs for use by products.
 type systemServiceAdapter struct {

--- a/app/app.go
+++ b/app/app.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/services/httpservice"
 	"github.com/mattermost/mattermost-server/v6/services/imageproxy"
 	"github.com/mattermost/mattermost-server/v6/services/searchengine"
@@ -173,6 +174,9 @@ func (a *App) SetServer(srv *Server) {
 func (a *App) UpdateExpiredDNDStatuses() ([]*model.Status, error) {
 	return a.Srv().Store.Status().UpdateExpiredDNDStatuses()
 }
+
+// Ensure system service adapter implements `product.SystemService`
+var _ product.SystemService = &systemServiceAdapter{}
 
 // systemServiceAdapter provides a collection of system APIs for use by products.
 type systemServiceAdapter struct {

--- a/app/bot.go
+++ b/app/bot.go
@@ -23,7 +23,7 @@ const (
 )
 
 // Ensure bot service wrapper implements `product.BotService`
-var _ product.BotService = &botServiceWrapper{}
+var _ product.BotService = (*botServiceWrapper)(nil)
 
 // botServiceWrapper provides an implementation of `product.BotService` for use by products.
 type botServiceWrapper struct {

--- a/app/bot.go
+++ b/app/bot.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
@@ -21,6 +22,10 @@ const (
 	botUserKey        = internalKeyPrefix + "botid"
 )
 
+// Ensure bot service wrapper implements `product.BotService`
+var _ product.BotService = &botServiceWrapper{}
+
+// botServiceWrapper provides an implementation of `product.BotService` for use by products.
 type botServiceWrapper struct {
 	app AppIface
 }

--- a/app/channel.go
+++ b/app/channel.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
@@ -22,27 +23,31 @@ import (
 	"github.com/mattermost/mattermost-server/v6/utils"
 )
 
+// channelsWrapper provides an implementation of `product.ChannelService` to be used by products.
 type channelsWrapper struct {
 	srv *Server
 }
 
-func (s *channelsWrapper) GetDirectChannel(c request.CTX, userID1, userID2 string) (*model.Channel, *model.AppError) {
-	return s.srv.getDirectChannel(c, userID1, userID2)
+func (s *channelsWrapper) GetDirectChannel(userID1, userID2 string) (*model.Channel, *model.AppError) {
+	return s.srv.getDirectChannel(request.EmptyContext(s.srv.GetLogger()), userID1, userID2)
 }
 
 // GetChannelByID gets a Channel by its ID.
-func (s *channelsWrapper) GetChannelByID(c request.CTX, channelID string) (*model.Channel, *model.AppError) {
-	return s.srv.getChannel(c, channelID)
+func (s *channelsWrapper) GetChannelByID(channelID string) (*model.Channel, *model.AppError) {
+	return s.srv.getChannel(request.EmptyContext(s.srv.GetLogger()), channelID)
 }
 
 // GetChannelMember gets a channel member by userID.
-func (s *channelsWrapper) GetChannelMember(c request.CTX, channelID string, userID string) (*model.ChannelMember, *model.AppError) {
-	return s.srv.getChannelMember(c, channelID, userID)
+func (s *channelsWrapper) GetChannelMember(channelID string, userID string) (*model.ChannelMember, *model.AppError) {
+	return s.srv.getChannelMember(request.EmptyContext(s.srv.GetLogger()), channelID, userID)
 }
 
-func (s *channelsWrapper) GetChannelsForTeamForUser(c request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
-	return s.srv.getChannelsForTeamForUser(c, teamID, userID, opts)
+func (s *channelsWrapper) GetChannelsForTeamForUser(teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
+	return s.srv.getChannelsForTeamForUser(request.EmptyContext(s.srv.GetLogger()), teamID, userID, opts)
 }
+
+// Ensure the wrapper implements the product service.
+var _ product.ChannelService = &channelsWrapper{}
 
 // DefaultChannelNames returns the list of system-wide default channel names.
 //

--- a/app/channel.go
+++ b/app/channel.go
@@ -47,7 +47,7 @@ func (s *channelsWrapper) GetChannelsForTeamForUser(teamID string, userID string
 }
 
 // Ensure the wrapper implements the product service.
-var _ product.ChannelService = &channelsWrapper{}
+var _ product.ChannelService = (*channelsWrapper)(nil)
 
 // DefaultChannelNames returns the list of system-wide default channel names.
 //

--- a/app/channels.go
+++ b/app/channels.go
@@ -312,6 +312,9 @@ func (ch *Channels) RequestTrialLicense(requesterID string, users int, termsAcce
 		receiveEmailsAccepted)
 }
 
+// Ensure hooksService implements `product.HooksService`
+var _ product.HooksService = &hooksService{}
+
 type hooksService struct {
 	ch *Channels
 }

--- a/app/channels.go
+++ b/app/channels.go
@@ -313,7 +313,7 @@ func (ch *Channels) RequestTrialLicense(requesterID string, users int, termsAcce
 }
 
 // Ensure hooksService implements `product.HooksService`
-var _ product.HooksService = &hooksService{}
+var _ product.HooksService = (*hooksService)(nil)
 
 type hooksService struct {
 	ch *Channels

--- a/app/cloud.go
+++ b/app/cloud.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
@@ -106,6 +107,10 @@ func (a *App) NotifySystemAdminsToUpgrade(c *request.Context, currentUserTeamID 
 	return nil
 }
 
+// Ensure cloud service wrapper implements `product.CloudService`
+var _ product.CloudService = &cloudWrapper{}
+
+// cloudWrapper provides an implementation of `product.CloudService` for use by products.
 type cloudWrapper struct {
 	cloud einterfaces.CloudInterface
 }

--- a/app/cloud.go
+++ b/app/cloud.go
@@ -108,7 +108,7 @@ func (a *App) NotifySystemAdminsToUpgrade(c *request.Context, currentUserTeamID 
 }
 
 // Ensure cloud service wrapper implements `product.CloudService`
-var _ product.CloudService = &cloudWrapper{}
+var _ product.CloudService = (*cloudWrapper)(nil)
 
 // cloudWrapper provides an implementation of `product.CloudService` for use by products.
 type cloudWrapper struct {

--- a/app/cluster.go
+++ b/app/cluster.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ensure cluster service wrapper implements `product.ClusterService`
-var _ product.ClusterService = &clusterWrapper{}
+var _ product.ClusterService = (*clusterWrapper)(nil)
 
 // clusterWrapper provides an implementation of `product.ClusterService` for use by products.
 type clusterWrapper struct {

--- a/app/cluster.go
+++ b/app/cluster.go
@@ -7,8 +7,13 @@ import (
 	"fmt"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 )
 
+// ensure cluster service wrapper implements `product.ClusterService`
+var _ product.ClusterService = &clusterWrapper{}
+
+// clusterWrapper provides an implementation of `product.ClusterService` for use by products.
 type clusterWrapper struct {
 	srv *Server
 }

--- a/app/config.go
+++ b/app/config.go
@@ -33,7 +33,7 @@ const (
 )
 
 // ensure the config wrapper implements `product.ConfigService`
-var _ product.ConfigService = &configWrapper{}
+var _ product.ConfigService = (*configWrapper)(nil)
 
 // configWrapper is an adapter struct that only exposes the
 // config related functionality to be passed down to other products.

--- a/app/config.go
+++ b/app/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/config"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/shared/mail"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/utils"
@@ -30,6 +31,9 @@ import (
 const (
 	ErrorTermsOfServiceNoRowsFound = "app.terms_of_service.get.no_rows.app_error"
 )
+
+// ensure the config wrapper implements `product.ConfigService`
+var _ product.ConfigService = &configWrapper{}
 
 // configWrapper is an adapter struct that only exposes the
 // config related functionality to be passed down to other products.

--- a/app/file.go
+++ b/app/file.go
@@ -49,7 +49,7 @@ const (
 )
 
 // Ensure fileInfo service wrapper implements `product.FileInfoStoreService`
-var _ product.FileInfoStoreService = &fileInfoWrapper{}
+var _ product.FileInfoStoreService = (*fileInfoWrapper)(nil)
 
 // fileInfoWrapper implements `product.FileInfoStoreService` for use by products.
 type fileInfoWrapper struct {

--- a/app/file.go
+++ b/app/file.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/services/docextractor"
 	"github.com/mattermost/mattermost-server/v6/shared/filestore"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -47,6 +48,10 @@ const (
 	maxContentExtractionSize   = 1024 * 1024 // 1MB
 )
 
+// Ensure fileInfo service wrapper implements `product.FileInfoStoreService`
+var _ product.FileInfoStoreService = &fileInfoWrapper{}
+
+// fileInfoWrapper implements `product.FileInfoStoreService` for use by products.
 type fileInfoWrapper struct {
 	srv *Server
 }

--- a/app/license.go
+++ b/app/license.go
@@ -31,7 +31,7 @@ const (
 var RequestTrialURL = "https://customers.mattermost.com/api/v1/trials"
 
 // ensure the license service wrapper implements `product.LicenseService`
-var _ product.LicenseService = &licenseWrapper{}
+var _ product.LicenseService = (*licenseWrapper)(nil)
 
 // licenseWrapper is an adapter struct that only exposes the
 // config related functionality to be passed down to other products.

--- a/app/license.go
+++ b/app/license.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/jobs"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
 	"github.com/mattermost/mattermost-server/v6/utils"
@@ -28,6 +29,9 @@ const (
 )
 
 var RequestTrialURL = "https://customers.mattermost.com/api/v1/trials"
+
+// ensure the license service wrapper implements `product.LicenseService`
+var _ product.LicenseService = &licenseWrapper{}
 
 // licenseWrapper is an adapter struct that only exposes the
 // config related functionality to be passed down to other products.

--- a/app/permissions.go
+++ b/app/permissions.go
@@ -22,7 +22,7 @@ const permissionsExportBatchSize = 100
 const systemSchemeName = "00000000-0000-0000-0000-000000000000" // Prevents collisions with user-created schemes.
 
 // Ensure permissions service wrapper implements `product.PermissionService`
-var _ product.PermissionService = &permissionsServiceWrapper{}
+var _ product.PermissionService = (*permissionsServiceWrapper)(nil)
 
 // permissionsServiceWrapper provides an implementation of `product.PermissionService` for use by products.
 type permissionsServiceWrapper struct {

--- a/app/permissions.go
+++ b/app/permissions.go
@@ -15,11 +15,16 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 )
 
 const permissionsExportBatchSize = 100
 const systemSchemeName = "00000000-0000-0000-0000-000000000000" // Prevents collisions with user-created schemes.
 
+// Ensure permissions service wrapper implements `product.PermissionService`
+var _ product.PermissionService = &permissionsServiceWrapper{}
+
+// permissionsServiceWrapper provides an implementation of `product.PermissionService` for use by products.
 type permissionsServiceWrapper struct {
 	app AppIface
 }
@@ -28,8 +33,8 @@ func (s *permissionsServiceWrapper) HasPermissionToTeam(userID string, teamID st
 	return s.app.HasPermissionToTeam(userID, teamID, permission)
 }
 
-func (s *permissionsServiceWrapper) HasPermissionToChannel(c request.CTX, askingUserID string, channelID string, permission *model.Permission) bool {
-	return s.app.HasPermissionToChannel(c, askingUserID, channelID, permission)
+func (s *permissionsServiceWrapper) HasPermissionToChannel(askingUserID string, channelID string, permission *model.Permission) bool {
+	return s.app.HasPermissionToChannel(request.EmptyContext(s.app.Log()), askingUserID, channelID, permission)
 }
 
 func (a *App) ResetPermissionsSystem() *model.AppError {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -24,6 +24,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/services/marketplace"
 	"github.com/mattermost/mattermost-server/v6/shared/filestore"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -37,6 +38,9 @@ type pluginSignaturePath struct {
 	path          string
 	signaturePath string
 }
+
+//Ensure routerService implements `product.RouterService`
+var _ product.RouterService = &routerService{}
 
 type routerService struct {
 	mu        sync.Mutex

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -40,7 +40,7 @@ type pluginSignaturePath struct {
 }
 
 //Ensure routerService implements `product.RouterService`
-var _ product.RouterService = &routerService{}
+var _ product.RouterService = (*routerService)(nil)
 
 type routerService struct {
 	mu        sync.Mutex

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -10,10 +10,15 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
 )
 
+// Ensure KV store wrapper implements `product.KVStoreService`
+var _ product.KVStoreService = &kvStoreWrapper{}
+
+// kvStoreWrapper provides an implementation of `product.KVStoreService` for use by products.
 type kvStoreWrapper struct {
 	srv *Server
 }

--- a/app/plugin_key_value_store.go
+++ b/app/plugin_key_value_store.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Ensure KV store wrapper implements `product.KVStoreService`
-var _ product.KVStoreService = &kvStoreWrapper{}
+var _ product.KVStoreService = (*kvStoreWrapper)(nil)
 
 // kvStoreWrapper provides an implementation of `product.KVStoreService` for use by products.
 type kvStoreWrapper struct {

--- a/app/post.go
+++ b/app/post.go
@@ -18,6 +18,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/services/cache"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -33,6 +34,10 @@ const (
 
 var atMentionPattern = regexp.MustCompile(`\B@`)
 
+// Ensure post service wrapper implements `product.PostService`
+var _ product.PostService = &postServiceWrapper{}
+
+// postServiceWrapper provides an implementation of `product.PostService` for use by products.
 type postServiceWrapper struct {
 	app AppIface
 }

--- a/app/post.go
+++ b/app/post.go
@@ -35,7 +35,7 @@ const (
 var atMentionPattern = regexp.MustCompile(`\B@`)
 
 // Ensure post service wrapper implements `product.PostService`
-var _ product.PostService = &postServiceWrapper{}
+var _ product.PostService = (*postServiceWrapper)(nil)
 
 // postServiceWrapper provides an implementation of `product.PostService` for use by products.
 type postServiceWrapper struct {

--- a/app/server.go
+++ b/app/server.go
@@ -396,7 +396,7 @@ func NewServer(options ...Option) (*Server, error) {
 	}
 
 	// ensure app implements `product.UserService`
-	var _ product.UserService = &App{}
+	var _ product.UserService = (*App)(nil)
 
 	serviceMap := map[ServiceKey]any{
 		ChannelKey:       &channelsWrapper{srv: s},

--- a/app/server.go
+++ b/app/server.go
@@ -55,6 +55,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/jobs/resend_invitation_email"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin/scheduler"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/services/awsmeter"
 	"github.com/mattermost/mattermost-server/v6/services/cache"
 	"github.com/mattermost/mattermost-server/v6/services/httpservice"
@@ -393,6 +394,9 @@ func NewServer(options ...Option) (*Server, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to create teams service")
 	}
+
+	// ensure app implements `product.UserService`
+	var _ product.UserService = &App{}
 
 	serviceMap := map[ServiceKey]any{
 		ChannelKey:       &channelsWrapper{srv: s},

--- a/app/team.go
+++ b/app/team.go
@@ -45,7 +45,7 @@ func (w *teamServiceWrapper) CreateMember(ctx *request.Context, teamID, userID s
 }
 
 // Ensure the wrapper implements the product service.
-var _ product.TeamService = &teamServiceWrapper{}
+var _ product.TeamService = (*teamServiceWrapper)(nil)
 
 func (a *App) AdjustTeamsFromProductLimits(teamLimits *model.TeamsLimits) *model.AppError {
 	maxActiveTeams := *teamLimits.Active

--- a/app/team.go
+++ b/app/team.go
@@ -24,12 +24,14 @@ import (
 	"github.com/mattermost/mattermost-server/v6/app/users"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
+	"github.com/mattermost/mattermost-server/v6/product"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
 	"github.com/mattermost/mattermost-server/v6/store/sqlstore"
 )
 
+// teamServiceWrapper provides an implementation of `product.TeamService` to be used by products.
 type teamServiceWrapper struct {
 	app AppIface
 }
@@ -41,6 +43,9 @@ func (w *teamServiceWrapper) GetMember(teamID, userID string) (*model.TeamMember
 func (w *teamServiceWrapper) CreateMember(ctx *request.Context, teamID, userID string) (*model.TeamMember, *model.AppError) {
 	return w.app.AddTeamMember(ctx, teamID, userID)
 }
+
+// Ensure the wrapper implements the product service.
+var _ product.TeamService = &teamServiceWrapper{}
 
 func (a *App) AdjustTeamsFromProductLimits(teamLimits *model.TeamsLimits) *model.AppError {
 	maxActiveTeams := *teamLimits.Active

--- a/product/api.go
+++ b/product/api.go
@@ -5,7 +5,6 @@ package product
 
 import (
 	"database/sql"
-	"io"
 
 	"github.com/gorilla/mux"
 
@@ -136,12 +135,7 @@ type HooksService interface {
 //
 // The service shall be registered via app.FilestoreKey service key.
 type FilestoreService interface {
-	Reader(path string) (filestore.ReadCloseSeeker, error)
-	FileExists(path string) (bool, error)
-	CopyFile(oldPath, newPath string) error
-	MoveFile(oldPath, newPath string) error
-	WriteFile(fr io.Reader, path string) (int64, error)
-	RemoveFile(path string) error
+	filestore.FileBackend
 }
 
 // FileInfoStoreService is the API for accessing the file info store.

--- a/store/store.go
+++ b/store/store.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 )
 
 type StoreResult struct {
@@ -1024,6 +1025,9 @@ type SidebarCategorySearchOpts struct {
 	TeamID      string
 	ExcludeTeam bool
 }
+
+// Ensure store service adapter implements `product.StoreService`
+var _ product.StoreService = &StoreServiceAdapter{}
 
 // StoreServiceAdapter provides a simple Store wrapper for use with products.
 type StoreServiceAdapter struct {

--- a/store/store.go
+++ b/store/store.go
@@ -1027,7 +1027,7 @@ type SidebarCategorySearchOpts struct {
 }
 
 // Ensure store service adapter implements `product.StoreService`
-var _ product.StoreService = &StoreServiceAdapter{}
+var _ product.StoreService = (*StoreServiceAdapter)(nil)
 
 // StoreServiceAdapter provides a simple Store wrapper for use with products.
 type StoreServiceAdapter struct {


### PR DESCRIPTION
#### Summary
This PR fixes a breaking change introduced via https://github.com/mattermost/mattermost-server/pull/20575.  The structs passed during product init must implements the interfaces defined in `product/api.go`.  Unfortunately, when the method signatures are changed the failures happen at run-time via type assertions.

Additionally, this PR adds compile-time checks to ensure changes to method signatures are detected immediately.

#### Ticket Link
NONE 

#### Release Note
```release-note
NONE
```
