### PR TITLE
[MM-45666] - A/B Test: Nav Bar Upgrade button

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -99,7 +99,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.AdvancedTextEditor = true
 	f.CallsEnabled = true
 	f.BoardsProduct = false
-	f.ServerUpgradeButtonText = "A"
+	f.ServerUpgradeButtonText = "Upgrade"
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -72,7 +72,7 @@ type FeatureFlags struct {
 	// Enable Boards as a product (multi-product architecture)
 	BoardsProduct bool
 
-	ServerUpgradeButtonText string
+	PlanUpgradeButtonText string
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -99,7 +99,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.AdvancedTextEditor = true
 	f.CallsEnabled = true
 	f.BoardsProduct = false
-	f.ServerUpgradeButtonText = "Upgrade"
+	f.PlanUpgradeButtonText = "Upgrade"
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -71,6 +71,8 @@ type FeatureFlags struct {
 
 	// Enable Boards as a product (multi-product architecture)
 	BoardsProduct bool
+
+	ServerUpgradeButtonText string
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -97,6 +99,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.AdvancedTextEditor = true
 	f.CallsEnabled = true
 	f.BoardsProduct = false
+	f.ServerUpgradeButtonText = "A"
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {


### PR DESCRIPTION
#### Summary
This adds a feature flag, FeatureFlagServerUpgradeButtonText to control the text to be shown on Plan Upgrade Button for cloud workspaces

FeatureFlagServerUpgradeButtonText = A , the button reads "Upgrade"
FeatureFlagServerUpgradeButtonText = B, the button reads "View plans"

https://app.split.io/org/e23fa240-f3b6-11ea-b78e-12a8e42e6081/ws/e244d260-f3b6-11ea-b78e-12a8e42e6081/splits/70a0aef0-0745-11ed-a805-0e7877c91061/env/e24b3b00-f3b6-11ea-b78e-12a8e42e6081/definition

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45666

#### Related Pull Requests

- Has webapp changes (https://github.com/mattermost/mattermost-webapp/pull/10798)



#### Release Note

```release-note
NONE
```
