### PR TITLE
[MM-45862] Set size and extension to fileinfo

### DIFF
--- a/api4/upload_test.go
+++ b/api4/upload_test.go
@@ -207,7 +207,7 @@ func TestUploadData(t *testing.T) {
 		CreateAt:  model.GetMillis(),
 		UserId:    th.BasicUser2.Id,
 		ChannelId: th.BasicChannel.Id,
-		Filename:  "upload",
+		Filename:  "upload.zip",
 		FileSize:  8 * 1024 * 1024,
 	}
 	us, err := th.App.CreateUploadSession(th.Context, us)
@@ -281,6 +281,9 @@ func TestUploadData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, info)
 		require.Equal(t, u.Filename, info.Name)
+		require.Equal(t, u.FileSize, info.Size)
+		require.Equal(t, "zip", info.Extension)
+		require.Equal(t, "application/zip", info.MimeType)
 
 		file, _, err := th.Client.GetFile(info.Id)
 		require.NoError(t, err)

--- a/app/upload.go
+++ b/app/upload.go
@@ -32,7 +32,7 @@ func (a *App) genFileInfoFromReader(name string, file io.ReadSeeker, size int64)
 		Extension: ext,
 	}
 
-	if ext != "" && ext[0] == '.' {
+	if ext != "" {
 		// The client expects a file extension without the leading period
 		info.Extension = ext[1:]
 	}

--- a/app/upload.go
+++ b/app/upload.go
@@ -24,10 +24,19 @@ const minFirstPartSize = 5 * 1024 * 1024 // 5MB
 
 func (a *App) genFileInfoFromReader(name string, file io.ReadSeeker, size int64) (*model.FileInfo, error) {
 	ext := strings.ToLower(filepath.Ext(name))
+
 	info := &model.FileInfo{
-		Name:     name,
-		MimeType: mime.TypeByExtension(ext),
+		Name:      name,
+		MimeType:  mime.TypeByExtension(ext),
+		Size:      size,
+		Extension: ext,
 	}
+
+	if ext != "" && ext[0] == '.' {
+		// The client expects a file extension without the leading period
+		info.Extension = ext[1:]
+	}
+
 	if info.IsImage() {
 		config, _, err := a.ch.imgDecoder.DecodeConfig(file)
 		if err != nil {

--- a/model/file_info.go
+++ b/model/file_info.go
@@ -141,7 +141,7 @@ func GetInfoForBytes(name string, data io.ReadSeeker, size int) (*FileInfo, *App
 	extension := strings.ToLower(filepath.Ext(name))
 	info.MimeType = mime.TypeByExtension(extension)
 
-	if extension != "" && extension[0] == '.' {
+	if extension != "" {
 		// The client expects a file extension without the leading period
 		info.Extension = extension[1:]
 	} else {


### PR DESCRIPTION
#### Summary

Some code was missing from https://github.com/mattermost/mattermost-server/pull/20595 which generated fileinfos with missing size and extension.

![image](https://user-images.githubusercontent.com/1832946/179935430-9287ee80-463a-427b-bf9a-63eee93f56e6.png)

Interestingly this was not caught by any test. I updated them here but it may be worth having something on the e2e side as well, like checking that the filesize is correctly displayed.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45862

#### Release Note

```release-note
NONE
```
