### PR TITLE
[MM-45817] Set cloud cookies whenever user gets logged in

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -1881,11 +1881,6 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.App.AttachSessionCookies(c.AppContext, w, r)
 	}
 
-	// For context see: https://mattermost.atlassian.net/browse/MM-39583
-	if c.App.Channels().License() != nil && *c.App.Channels().License().Features.Cloud {
-		c.App.AttachCloudSessionCookie(c.AppContext, w, r)
-	}
-
 	userTermsOfService, err := c.App.GetUserTermsOfService(user.Id)
 	if err != nil && err.StatusCode != http.StatusNotFound {
 		c.Err = err

--- a/app/login.go
+++ b/app/login.go
@@ -331,6 +331,11 @@ func (a *App) AttachSessionCookies(c *request.Context, w http.ResponseWriter, r 
 	http.SetCookie(w, sessionCookie)
 	http.SetCookie(w, userCookie)
 	http.SetCookie(w, csrfCookie)
+
+	// For context see: https://mattermost.atlassian.net/browse/MM-39583
+	if a.Channels().License() != nil && *a.Channels().License().Features.Cloud {
+		a.AttachCloudSessionCookie(c, w, r)
+	}
 }
 
 func GetProtocol(r *http.Request) string {


### PR DESCRIPTION
#### Summary
Right now, we only attached the cloud cookie (`MMCLOUDURL`) when the user was logging in using email/password.

I was trying to copy this same way to every login place before realizing that every single time I was inserting new code just behind `AttachSessionCookies`, so I moved the call to set the cloud cookie inside of `AttachSessionCookies`, this also allows us to be future proof.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45817

#### Release Note
```release-note
NONE
```
