### PR TITLE
Adds websocket event for revoked sessions

### DIFF
--- a/app/session.go
+++ b/app/session.go
@@ -144,6 +144,9 @@ func (a *App) RevokeAllSessions(userID string) *model.AppError {
 		}
 	}
 
+	message := model.NewWebSocketEvent(model.WebsocketEventSessionRevoked, "", "", userID, nil)
+	a.Publish(message)
+
 	return nil
 }
 
@@ -162,6 +165,9 @@ func (a *App) RevokeSessionsFromAllUsers() *model.AppError {
 			return model.NewAppError("RevokeSessionsFromAllUsers", "app.session.remove_all_sessions_for_team.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
+
+	message := model.NewWebSocketEvent(model.WebsocketEventSessionRevoked, "", "", "", nil)
+	a.Publish(message)
 
 	return nil
 }

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -77,6 +77,7 @@ const (
 	WebsocketEventThreadReadChanged                   = "thread_read_changed"
 	WebsocketFirstAdminVisitMarketplaceStatusReceived = "first_admin_visit_marketplace_status_received"
 	WebsocketEventIntegrationsUsageChanged            = "integrations_usage_changed"
+	WebsocketEventSessionRevoked                      = "session_revoked"
 )
 
 type WebSocketMessage interface {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Introduces a simple websocket event to be emitted when sessions are revoked.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-45929

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added a new websocket event "session_revoked" for apps to handle sessions being revoked.
```
