### PR TITLE
MM-45871: Do not try to extract content from images

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -751,7 +751,7 @@ func (a *App) UploadFileX(c *request.Context, channelID, name string, input io.R
 		}
 	}
 
-	if *a.Config().FileSettings.ExtractContent {
+	if *a.Config().FileSettings.ExtractContent && !t.fileinfo.IsImage() {
 		infoCopy := *t.fileinfo
 		a.Srv().Go(func() {
 			err := a.ExtractContentFromFileInfo(&infoCopy)

--- a/app/file.go
+++ b/app/file.go
@@ -751,7 +751,7 @@ func (a *App) UploadFileX(c *request.Context, channelID, name string, input io.R
 		}
 	}
 
-	if *a.Config().FileSettings.ExtractContent && !t.fileinfo.IsImage() {
+	if *a.Config().FileSettings.ExtractContent {
 		infoCopy := *t.fileinfo
 		a.Srv().Go(func() {
 			err := a.ExtractContentFromFileInfo(&infoCopy)
@@ -1327,6 +1327,11 @@ func (a *App) SearchFilesInTeamForUser(c *request.Context, terms string, userId 
 }
 
 func (a *App) ExtractContentFromFileInfo(fileInfo *model.FileInfo) error {
+	// We don't process images.
+	if fileInfo.IsImage() {
+		return nil
+	}
+
 	file, aerr := a.FileReader(fileInfo.Path)
 	if aerr != nil {
 		return errors.Wrap(aerr, "failed to open file for extract file content")

--- a/app/file_test.go
+++ b/app/file_test.go
@@ -543,3 +543,13 @@ func TestSearchFilesInTeamForUser(t *testing.T) {
 		es.AssertExpectations(t)
 	})
 }
+
+func TestExtractContentFromFileInfo(t *testing.T) {
+	app := &App{}
+	fi := &model.FileInfo{
+		MimeType: "image/jpeg",
+	}
+
+	// Test that we don't process images.
+	require.Nil(t, app.ExtractContentFromFileInfo(fi))
+}

--- a/app/file_test.go
+++ b/app/file_test.go
@@ -551,5 +551,5 @@ func TestExtractContentFromFileInfo(t *testing.T) {
 	}
 
 	// Test that we don't process images.
-	require.Nil(t, app.ExtractContentFromFileInfo(fi))
+	require.NoError(t, app.ExtractContentFromFileInfo(fi))
 }


### PR DESCRIPTION
This creates faulty requests to Bifrost and results in
errors and warnings in the logs. Even without Bifrost,
this would make unnecessary requests to S3.

We only extract info from documents and therefore we can
safely avoid this.

```release-note
NONE
```
