### PR TITLE
Killing dyatlov/go-opengraph with fire

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -185,6 +185,6 @@ require (
 exclude (
 	github.com/RoaringBitmap/roaring v0.7.0
 	github.com/RoaringBitmap/roaring v0.7.1
-	github.com/willf/bitset v1.2.0
 	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
+	github.com/willf/bitset v1.2.0
 )

--- a/go.mod
+++ b/go.mod
@@ -186,4 +186,5 @@ exclude (
 	github.com/RoaringBitmap/roaring v0.7.0
 	github.com/RoaringBitmap/roaring v0.7.1
 	github.com/willf/bitset v1.2.0
+	github.com/dyatlov/go-opengraph v0.0.0-20210112100619-dae8665a5b09
 )


### PR DESCRIPTION
Correctly updating this requires PRs
in multiple repositories. Fixing this
with a hammer for now to unblock server.

```release-note
NONE
```
