### PR TITLE
[MM-45715] Check for correct permission when requesting teams

### DIFF
--- a/api4/resolver_team.go
+++ b/api4/resolver_team.go
@@ -71,7 +71,7 @@ func getGraphQLTeams(c *web.Context, teamIDs []string) ([]*model.Team, error) {
 		}
 	}
 
-	if !c.App.SessionHasPermissionToTeams(c.AppContext, *c.AppContext.Session(), teamsToCheck, model.PermissionViewMembers) {
+	if !c.App.SessionHasPermissionToTeams(c.AppContext, *c.AppContext.Session(), teamsToCheck, model.PermissionViewTeam) {
 		c.SetPermissionError(model.PermissionViewTeam)
 		return nil, c.Err
 	}

--- a/api4/resolver_team_member_test.go
+++ b/api4/resolver_team_member_test.go
@@ -289,3 +289,103 @@ func TestGraphQLTeamMembers(t *testing.T) {
 		assert.Len(t, q.TeamMembers, 1)
 	})
 }
+
+func TestGraphQLTeamMembersAsGuest(t *testing.T) {
+	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
+	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	th.App.DemoteUserToGuest(th.Context, th.BasicUser)
+	th.BasicUser, _ = th.App.UpdateUserRoles(th.BasicUser.Id, model.SystemGuestRoleId, false)
+
+	var q struct {
+		TeamMembers []struct {
+			User struct {
+				ID        string `json:"id"`
+				Username  string `json:"username"`
+				Email     string `json:"email"`
+				FirstName string `json:"firstName"`
+				LastName  string `json:"lastName"`
+				NickName  string `json:"nickname"`
+			} `json:"user"`
+			Team struct {
+				ID                  string  `json:"id"`
+				DisplayName         string  `json:"displayName"`
+				Name                string  `json:"name"`
+				CreateAt            float64 `json:"createAt"`
+				DeleteAt            float64 `json:"deleteAt"`
+				SchemeId            *string `json:"schemeId"`
+				PolicyId            *string `json:"policyId"`
+				CloudLimitsArchived bool    `json:"cloudLimitsArchived"`
+			} `json:"team"`
+			Roles []struct {
+				ID            string   `json:"id"`
+				Name          string   `json:"Name"`
+				Permissions   []string `json:"permissions"`
+				SchemeManaged bool     `json:"schemeManaged"`
+				BuiltIn       bool     `json:"builtIn"`
+			} `json:"roles"`
+			DeleteAt    float64 `json:"deleteAt"`
+			SchemeGuest bool    `json:"schemeGuest"`
+			SchemeUser  bool    `json:"schemeUser"`
+			SchemeAdmin bool    `json:"schemeAdmin"`
+		} `json:"teamMembers"`
+	}
+
+	t.Run("User", func(t *testing.T) {
+		input := graphQLInput{
+			OperationName: "teamMembers",
+			Query: `
+	query teamMembers($userId: String = "", $teamId: String = "") {
+	  teamMembers(userId: $userId, teamId: $teamId) {
+	  	team {
+	  		id
+	  		displayName
+	  	}
+	  	user {
+	  		id
+	  		username
+	  		email
+	  		firstName
+	  		lastName
+	  	}
+	  	roles {
+	  		id
+	  		name
+	  	}
+	  	schemeGuest
+	  	schemeUser
+	  	schemeAdmin
+	  }
+	}
+	`,
+			Variables: map[string]any{
+				"userId": "me",
+			},
+		}
+
+		resp, err := th.MakeGraphQLRequest(&input)
+		require.NoError(t, err)
+		require.Len(t, resp.Errors, 0)
+		require.NoError(t, json.Unmarshal(resp.Data, &q))
+		assert.Len(t, q.TeamMembers, 1)
+
+		tm := q.TeamMembers[0]
+		assert.Equal(t, th.BasicTeam.Id, tm.Team.ID)
+		assert.Equal(t, th.BasicTeam.DisplayName, tm.Team.DisplayName)
+
+		assert.Equal(t, th.BasicUser.Id, tm.User.ID)
+		assert.Equal(t, th.BasicUser.Username, tm.User.Username)
+		assert.Equal(t, th.BasicUser.Email, tm.User.Email)
+		assert.Equal(t, th.BasicUser.FirstName, tm.User.FirstName)
+		assert.Equal(t, th.BasicUser.LastName, tm.User.LastName)
+
+		require.Len(t, tm.Roles, 1)
+		assert.NotEmpty(t, tm.Roles[0].ID)
+		assert.Equal(t, "team_guest", tm.Roles[0].Name)
+		assert.True(t, tm.SchemeGuest)
+		assert.False(t, tm.SchemeUser)
+		assert.False(t, tm.SchemeAdmin)
+	})
+}


### PR DESCRIPTION
#### Summary
GraphQL checked the wrong permission when requesting teams. This prevented guest users from successfully logging in when GraphQL was in use.

#### Ticket Link
[MM-45715](https://mattermost.atlassian.net/browse/MM-45715)

#### Release Note
```release-note
NONE
```
