### PR TITLE
Added schema migration template to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,16 +23,17 @@ Otherwise, link the JIRA ticket.
 <!--
 Add a release note for each of the following conditions:
 
-* Config changes (additions, deletions, updates)
-* API additions—new endpoint, new response fields, or newly accepted request parameters
-* Database changes (any)
-* Websocket additions or changes
-* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
-* New features and improvements, including behavioural changes, UI changes and CLI changes
-* Bug fixes and fixes of previous known issues
-* Deprecation warnings, breaking changes, or compatibility notes
+* Config changes (additions, deletions, updates).
+* API additions—new endpoint, new response fields, or newly accepted request parameters.
+* Database changes (any).
+* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
+* Websocket additions or changes.
+* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
+* New features and improvements, including behavioral changes, UI changes, and CLI changes.
+* Bug fixes and fixes of previous known issues.
+* Deprecation warnings, breaking changes, or compatibility notes.
 
-If no release notes are required write NONE. Use past-tense. Newlines are stripped.
+If no release notes are required, write NONE. Use past-tense. Newlines are stripped.
 
 Examples:
 


### PR DESCRIPTION
A schema migration template is now available to help guide release note development.

```release-note
NONE
```