### PR TITLE
[MM-46054] Protection against calling Unwrap on a nil error

### DIFF
--- a/model/utils.go
+++ b/model/utils.go
@@ -271,6 +271,10 @@ func (er *AppError) ToJSON() string {
 }
 
 func (er *AppError) Unwrap() error {
+	if er == nil {
+		return nil
+	}
+
 	return er.wrapped
 }
 

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -87,7 +87,7 @@ func TestAppErrorJunk(t *testing.T) {
 
 func TestAppErrorNilUnwrap(t *testing.T) {
 	var err *AppError
-	require.Nil(t, err.Unwrap())
+	require.NoError(t, err.Unwrap())
 }
 
 func TestAppErrorRender(t *testing.T) {

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -85,6 +85,11 @@ func TestAppErrorJunk(t *testing.T) {
 	require.Equal(t, "body: <html><body>This is a broken test</body></html>", rerr.DetailedError)
 }
 
+func TestAppErrorNilUnwrap(t *testing.T) {
+	var err *AppError
+	require.Nil(t, err.Unwrap())
+}
+
 func TestAppErrorRender(t *testing.T) {
 	t.Run("Minimal", func(t *testing.T) {
 		aerr := NewAppError("here", "message", nil, "", http.StatusTeapot)


### PR DESCRIPTION
#### Summary
This PR quick-fixes an issue that surfaced when AppError got the Unwrap functionality. In `app/channel.go:100` `errors.As` is called on a `nil` `*model.AppError` which causes the `Unwrap` method to be called. The original issue remains and will be dealt with in another PR.

#### Ticket Link
[MM-46054](https://mattermost.atlassian.net/browse/MM-46054)

#### Release Note
```release-note
NONE
```
