### PR TITLE
[MM-46054] Log missing default channels

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -91,17 +91,10 @@ func (a *App) JoinDefaultChannels(c request.CTX, teamID string, user *model.User
 		}
 	}
 
-	var err *model.AppError
 	for _, channelName := range a.DefaultChannelNames(c) {
 		channel, channelErr := a.Srv().Store.Channel().GetByName(teamID, channelName, true)
 		if channelErr != nil {
-			var nfErr *store.ErrNotFound
-			switch {
-			case errors.As(err, &nfErr):
-				err = model.NewAppError("JoinDefaultChannels", "app.channel.get_by_name.missing.app_error", nil, nfErr.Error(), http.StatusNotFound)
-			default:
-				err = model.NewAppError("JoinDefaultChannels", "app.channel.get_by_name.existing.app_error", nil, channelErr.Error(), http.StatusInternalServerError)
-			}
+			c.Logger().Warn("No default channel with this name", mlog.String("channelName", channelName), mlog.String("teamID", teamID), mlog.Err(channelErr))
 			continue
 		}
 

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -347,6 +347,29 @@ func TestJoinDefaultChannelsExperimentalDefaultChannels(t *testing.T) {
 	}
 }
 
+func TestJoinDefaultChannelsExperimentalDefaultChannelsMissing(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	basicChannel2 := th.CreateChannel(th.Context, th.BasicTeam)
+	defer th.App.PermanentDeleteChannel(th.Context, basicChannel2)
+	defaultChannelList := []string{th.BasicChannel.Name, basicChannel2.Name, basicChannel2.Name}
+	th.App.Config().TeamSettings.ExperimentalDefaultChannels = append(defaultChannelList, "thischanneldoesnotexist")
+
+	user := th.CreateUser()
+	require.Nil(t, th.App.JoinDefaultChannels(th.Context, th.BasicTeam.Id, user, false, ""))
+
+	for _, channelName := range defaultChannelList {
+		channel, err := th.App.GetChannelByName(th.Context, channelName, th.BasicTeam.Id, false)
+		require.Nil(t, err, "Expected nil, didn't receive nil")
+
+		member, err := th.App.GetChannelMember(th.Context, channel.Id, user.Id)
+
+		require.NotNil(t, member, "Expected member object, got nil")
+		require.Nil(t, err, "Expected nil object, didn't receive nil")
+	}
+}
+
 func TestCreateChannelPublicCreatesChannelMemberHistoryRecord(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -353,13 +353,17 @@ func TestJoinDefaultChannelsExperimentalDefaultChannelsMissing(t *testing.T) {
 
 	basicChannel2 := th.CreateChannel(th.Context, th.BasicTeam)
 	defer th.App.PermanentDeleteChannel(th.Context, basicChannel2)
-	defaultChannelList := []string{th.BasicChannel.Name, basicChannel2.Name, basicChannel2.Name}
-	th.App.Config().TeamSettings.ExperimentalDefaultChannels = append(defaultChannelList, "thischanneldoesnotexist")
+	defaultChannelList := []string{th.BasicChannel.Name, basicChannel2.Name, "thischanneldoesnotexist", basicChannel2.Name}
+	th.App.Config().TeamSettings.ExperimentalDefaultChannels = defaultChannelList
 
 	user := th.CreateUser()
 	require.Nil(t, th.App.JoinDefaultChannels(th.Context, th.BasicTeam.Id, user, false, ""))
 
 	for _, channelName := range defaultChannelList {
+		if channelName == "thischanneldoesnotexist" {
+			continue // skip the non-existent channel
+		}
+
 		channel, err := th.App.GetChannelByName(th.Context, channelName, th.BasicTeam.Id, false)
 		require.Nil(t, err, "Expected nil, didn't receive nil")
 


### PR DESCRIPTION
#### Summary
A weird code fragment in `channel.go` caused MM to call `errors.As` on a `(*model.AppError)(nil)` which lead to a crash in the `Unwrap` method. The code effectively only skipped missing channels and did nothing useful. This PR removes the code and replaces it with a log statement.

#### Ticket Link
[MM-46054](https://mattermost.atlassian.net/browse/MM-46054)

#### Release Note
```release-note
NONE
```
