### PR TITLE
Automated cherry pick of #20565

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -523,6 +523,35 @@ func getPostThread(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rPost, err := c.App.GetSinglePost(c.Params.PostId, false)
+	if err != nil {
+		c.Err = err
+		return
+	}
+	hasPermission := false
+	becauseCompliance := false
+	if c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), rPost.ChannelId, model.PermissionReadChannel) {
+		hasPermission = true
+	} else if channel, cErr := c.App.GetChannel(c.AppContext, rPost.ChannelId); cErr == nil {
+		if channel.Type == model.ChannelTypeOpen &&
+			c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), channel.TeamId, model.PermissionReadPublicChannel) {
+			hasPermission = true
+			if *c.App.Config().MessageExportSettings.EnableExport {
+				hasPermission = false
+				becauseCompliance = true
+			}
+		}
+	}
+
+	if !hasPermission {
+		if becauseCompliance {
+			c.Err = model.NewAppError("getPostThread", "api.post.compliance_enabled.join_channel_to_view_post", nil, "", http.StatusForbidden)
+		} else {
+			c.SetPermissionError(model.PermissionReadChannel)
+		}
+		return
+	}
+
 	// For now, by default we return all items unless it's set to maintain
 	// backwards compatibility with mobile. But when the next ESR passes, we need to
 	// change this to web.PerPageDefault.

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -2191,9 +2191,25 @@ func TestGetPostThread(t *testing.T) {
 
 	client.RemoveUserFromChannel(th.BasicChannel.Id, th.BasicUser.Id)
 
-	// Channel is public, should be able to read post
+	messageExportEnabled := *th.App.Config().MessageExportSettings.EnableExport
+	// Channel is public, and compliance export is OFF, should be able to read post
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.MessageExportSettings.EnableExport = false
+	})
 	_, _, err = client.GetPostThread(th.BasicPost.Id, "", false)
 	require.NoError(t, err)
+
+	// channel is public, and compliance export is ON, should NOT be able to read post
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.MessageExportSettings.EnableExport = true
+	})
+	_, resp, err = client.GetPostThread(th.BasicPost.Id, "", false)
+	require.Error(t, err)
+	CheckForbiddenStatus(t, resp)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.MessageExportSettings.EnableExport = messageExportEnabled
+	})
 
 	privatePost := th.CreatePostWithClient(client, th.BasicPrivateChannel)
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2242,6 +2242,10 @@
     "translation": "@{{.Username}} did not get notified by this mention because they are not in the channel."
   },
   {
+    "id": "api.post.compliance_enabled.join_channel_to_view_post",
+    "translation": "Due to compliance rules configured on this instance the channel must be joined before its posts can be read."
+  },
+  {
     "id": "api.post.create_post.can_not_post_to_deleted.error",
     "translation": "Can not post to deleted channel."
   },


### PR DESCRIPTION
Cherry pick of #20565 on release-7.2.

/cc  @ashishbhate

```release-note
NONE
```