### PR TITLE
[chore] Update Node and Npm build image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   setup:
     working_directory: ~/mattermost/mattermost-server
     docker:
-      - image: mattermost/mattermost-build-webapp:20210524_node-16
+      - image: mattermost/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d
     resource_class: xlarge
     # Use `--retry-all-errors` instead of `until` after curl version >= 7.71.0; `retry` will not work, since it only retries on transient errors, 403 is not one of them.
     steps:


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does.
-->
This updates the build-images used for CI to:
- node: 16.2.0 -> 16.10.0
- npm: 7.13.0 -> 7.24.0



Internal consumed images: 
```
> docker run --platform linux/amd64 -it ${CI_REGISTRY}/mattermost/ci/devops-images/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d node -v
 v16.10.0

> docker run --platform linux/amd64 -it ${$CI_REGISTRY}/mattermost/ci/devops-images/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d npm -v
7.24.0
```

Public consumed images: 
```
> docker run --platform linux/amd64 mattermost/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d  node -v
 v16.10.0

> docker run --platform linux/amd64 mattermost/mattermost-build-webapp:20220802_node-16.10.0@sha256:3272aa759f10c2ef1719ed08cc82ddb07224bec5be86f09800c72f5e2a623c3d  npm -v
7.24.0
```


Continuation of https://github.com/mattermost/mattermost-webapp/pull/10867

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-3848