### PR TITLE
MM-45021: Fix flaky testGetFlaggedPostsForUser

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -2513,11 +2513,9 @@ func (a *App) RemoveUserFromChannel(c request.CTX, userIDToRemove string, remove
 			return err
 		}
 	} else {
-		a.Srv().Go(func() {
-			if err := a.postRemoveFromChannelMessage(c, removerUserId, user, channel); err != nil {
-				mlog.Error("Failed to post user removal message", mlog.Err(err))
-			}
-		})
+		if err := a.postRemoveFromChannelMessage(c, removerUserId, user, channel); err != nil {
+			c.Logger().Error("Failed to post user removal message", mlog.Err(err))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The method a.postRemoveFromChannelMessage was being called
from a goroutine. Therefore, when SystemAdminClient.GetFlaggedPostsForUser
was being called later in the test with a mock post store,
it would naturally fail because the store would now be a
different store but the goroutine was supposed to be finished.

A hacky solution would be to add a sleep before
starting the mocked API call. But a deeper question
is why was the method run in a goroutine in the first place.

Removing a user from a channel is not a very common operation
and even if we look at the method, if the user is trying to
remove themselves, that message happens synchronously, but if
they are removing another user, that runs in a goroutine.

This seems like a very weird behavior. Therefore, to be consistent
I have just removed the goroutine and made everything synchronous.

The next step would be to stop logging an error and just return
the error upwards instead. Because that's what happens in the other
condition. But that would be exceeding the scope too much. Maybe
in a separate PR.

https://mattermost.atlassian.net/browse/MM-45021

```release-note
NONE
```
