### PR TITLE
Stop applying server lint rules to focalbard repo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 endif
 ifeq ($(BUILD_BOARDS),true)
   ifneq ($(MM_NO_BOARDS_LINT),true)
-		$(GOBIN)/golangci-lint run $(BUILD_BOARDS_DIR)/server/...
+		cd $(BUILD_BOARDS_DIR); make server-lint
   endif
 endif
 


### PR DESCRIPTION
#### Summary
Whenever we execute golangci-lint it activates rules of mattermost-server at focalboard repo.
We should not apply server lint rules to that repo. PR contains changes to execute lint on focalboard repo with it's own rules.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-3800

#### Release Note
```release-note
NONE
```
