### PR TITLE
Stop applying server lint rules to focalbard repo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,6 @@ endif
 # Prepare optional Boards build.
 BOARDS_PACKAGES=$(shell $(GO) list $(BUILD_BOARDS_DIR)/server/...)
 ifeq ($(BUILD_BOARDS),true)
-    ALL_PACKAGES += $(BOARDS_PACKAGES)
 	IGNORE:=$(shell echo Boards build selected, preparing)
 	IGNORE:=$(shell rm -f imports/boards_imports.go)
 	IGNORE:=$(shell cp $(BUILD_BOARDS_DIR)/mattermost-plugin/product/imports/boards_imports.go imports/)

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,10 @@ endif
 # Prepare optional Boards build.
 BOARDS_PACKAGES=$(shell $(GO) list $(BUILD_BOARDS_DIR)/server/...)
 ifeq ($(BUILD_BOARDS),true)
+# We removed `ALL_PACKAGES += $(BOARDS_PACKAGES)` since board tests needs `-tag 'json1'` in the tests.
+# Adding that flag to server breaks the build with unsupported flag error.
+# PR: https://github.com/mattermost/mattermost-server/pull/20772
+# Ticket: https://mattermost.atlassian.net/browse/CLD-3800
 	IGNORE:=$(shell echo Boards build selected, preparing)
 	IGNORE:=$(shell rm -f imports/boards_imports.go)
 	IGNORE:=$(shell cp $(BUILD_BOARDS_DIR)/mattermost-plugin/product/imports/boards_imports.go imports/)

--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 endif
 ifeq ($(BUILD_BOARDS),true)
   ifneq ($(MM_NO_BOARDS_LINT),true)
-		$(GOBIN)/golangci-lint run $(BUILD_BOARDS_DIR)/server/...
+		cd $(BUILD_BOARDS_DIR); make server-lint
   endif
 endif
 


### PR DESCRIPTION
#### Summary
Whenever we execute golangci-lint it activates rules of mattermost-server at focalboard repo.
We should not apply server lint rules to that repo. PR contains changes to execute lint on focalboard repo with it's own rules.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-3800

#### Release Note
```release-note
NONE
```
