### PR TITLE
Add index to impove reaction migration performance (#20773)

### DIFF
--- a/db/migrations/postgres/000089_add-channelid-to-reaction.up.sql
+++ b/db/migrations/postgres/000089_add-channelid-to-reaction.up.sql
@@ -1,3 +1,4 @@
 ALTER TABLE reactions ADD COLUMN IF NOT EXISTS channelid varchar(26) NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_posts_id_channel_id on posts (id, channelid);
 UPDATE reactions SET channelid = COALESCE((select channelid from posts where posts.id = reactions.postid), '') WHERE channelid='';
 CREATE INDEX IF NOT EXISTS idx_reactions_channel_id on reactions (channelid);


### PR DESCRIPTION
#### Summary
Without the database index, the migration performance is really bad.
3M posts couldn't finish migration in one hour.
After add index, about 3 secs.

It seems to create an index help the performance a lot.
```
CREATE INDEX IF NOT EXISTS idx_posts_id_channel_id on posts (id, channelid);
```

After create index, update 3M posts  cause 2~3 sec to update channelid.

```
mm=# UPDATE reactions SET channelid = COALESCE((select channelid from posts where posts.id = reactions.postid), '') WHERE channelid='';
UPDATE 74655
Time: 2185.623 ms (00:02.186)
```



#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/20773



#### Release Note
* Database changes
  - add index