### PR TITLE
MM-45534: Fix flaky TestCreateGroupChannel

### DIFF
--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -569,7 +569,7 @@ func TestCreateGroupChannel(t *testing.T) {
 	require.Equal(t, rgc.Id, rgc2.Id, "should have returned existing channel")
 
 	m2, _ := th.App.GetChannelMembersPage(th.Context, rgc2.Id, 0, 10)
-	require.Equal(t, m, m2)
+	require.ElementsMatch(t, m, m2)
 
 	_, resp, err = client.CreateGroupChannel([]string{user2.Id})
 	require.Error(t, err)


### PR DESCRIPTION
The returned elements weren't in a specific order.
Therefore, we need to perform an order insensitive match.

https://mattermost.atlassian.net/browse/MM-45534

```release-note
NONE
```
