### PR TITLE
MM-43663 - add missing words to email invite

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3341,11 +3341,11 @@
   },
   {
     "id": "api.templates.invite_team_and_channel_body.title",
-    "translation": "{{ .SenderName }} invited you to join {{ .ChannelName }} on the {{ .TeamDisplayName }} Team"
+    "translation": "{{ .SenderName }} invited you to join the {{ .ChannelName }} Channel on the {{ .TeamDisplayName }} Team"
   },
   {
     "id": "api.templates.invite_team_and_channel_subject",
-    "translation": "[{{ .SiteName }}] {{ .SenderName }} invited you to join {{ .ChannelName }} on the {{ .TeamDisplayName }} Team"
+    "translation": "[{{ .SiteName }}] {{ .SenderName }} invited you to join the {{ .ChannelName }} Channel on the {{ .TeamDisplayName }} Team"
   },
   {
     "id": "api.templates.invite_team_and_channels_body.title",


### PR DESCRIPTION
#### Summary
Add missing words to message sent when inviting someone to join a channel in a team.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43663

#### Release Note
```release-note
NONE
```
