### PR TITLE
MM-45198: Migrate app/import and api4/import

### DIFF
--- a/api4/import.go
+++ b/api4/import.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
 func (api *API) InitImport() {
@@ -26,11 +27,7 @@ func listImports(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data, err := json.Marshal(imports)
-	if err != nil {
-		c.Err = model.NewAppError("listImports", "app.import.marshal.app_error", nil, err.Error(), http.StatusInternalServerError)
-		return
+	if err := json.NewEncoder(w).Encode(imports); err != nil {
+		c.Logger.Warn("Error writing imports", mlog.Err(err))
 	}
-
-	w.Write(data)
 }

--- a/app/import.go
+++ b/app/import.go
@@ -25,13 +25,13 @@ const (
 	maxScanTokenSize             = 16 * 1024 * 1024 // Need to set a higher limit than default because some customers cross the limit. See MM-22314
 )
 
-func stopOnError(err LineImportWorkerError) bool {
+func stopOnError(c request.CTX, err LineImportWorkerError) bool {
 	switch err.Error.Id {
 	case "api.file.upload_file.large_image.app_error":
-		mlog.Warn("Large image import error", mlog.Err(err.Error))
+		c.Logger().Warn("Large image import error", mlog.Err(err.Error))
 		return false
 	case "app.import.validate_direct_channel_import_data.members_too_few.error", "app.import.validate_direct_channel_import_data.members_too_many.error":
-		mlog.Warn("Invalid direct channel import data", mlog.Err(err.Error))
+		c.Logger().Warn("Invalid direct channel import data", mlog.Err(err.Error))
 		return false
 	default:
 		return true
@@ -226,7 +226,7 @@ func (a *App) bulkImport(c *request.Context, jsonlReader io.Reader, attachmentsR
 				// Check no errors occurred while waiting for the queue to empty.
 				if len(errorsChan) != 0 {
 					err := <-errorsChan
-					if stopOnError(err) {
+					if stopOnError(c, err) {
 						return err.Error, err.LineNumber
 					}
 				}
@@ -244,7 +244,7 @@ func (a *App) bulkImport(c *request.Context, jsonlReader io.Reader, attachmentsR
 		select {
 		case linesChan <- LineImportWorkerData{line, lineNumber}:
 		case err := <-errorsChan:
-			if stopOnError(err) {
+			if stopOnError(c, err) {
 				close(linesChan)
 				wg.Wait()
 				return err.Error, err.LineNumber
@@ -261,7 +261,7 @@ func (a *App) bulkImport(c *request.Context, jsonlReader io.Reader, attachmentsR
 	// Check no errors occurred while waiting for the queue to empty.
 	if len(errorsChan) != 0 {
 		err := <-errorsChan
-		if stopOnError(err) {
+		if stopOnError(c, err) {
 			return err.Error, err.LineNumber
 		}
 	}

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -127,27 +127,30 @@ func TestImportImportLine(t *testing.T) {
 }
 
 func TestStopOnError(t *testing.T) {
-	assert.True(t, stopOnError(LineImportWorkerError{
+	th := Setup(t)
+	defer th.TearDown()
+
+	assert.True(t, stopOnError(th.Context, LineImportWorkerError{
 		model.NewAppError("test", "app.import.attachment.bad_file.error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.True(t, stopOnError(LineImportWorkerError{
+	assert.True(t, stopOnError(th.Context, LineImportWorkerError{
 		model.NewAppError("test", "app.import.attachment.file_upload.error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.False(t, stopOnError(LineImportWorkerError{
+	assert.False(t, stopOnError(th.Context, LineImportWorkerError{
 		model.NewAppError("test", "api.file.upload_file.large_image.app_error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.False(t, stopOnError(LineImportWorkerError{
+	assert.False(t, stopOnError(th.Context, LineImportWorkerError{
 		model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_few.error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.False(t, stopOnError(LineImportWorkerError{
+	assert.False(t, stopOnError(th.Context, LineImportWorkerError{
 		model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_many.error", nil, "", http.StatusBadRequest),
 		1,
 	}))

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5024,10 +5024,6 @@
     "translation": "Unable to save the team theme preferences"
   },
   {
-    "id": "app.import.marshal.app_error",
-    "translation": "Unable to marshal response."
-  },
-  {
     "id": "app.import.process_import_data_file_version_line.invalid_version.error",
     "translation": "Unable to read the version of the data import file."
   },


### PR DESCRIPTION
We migrate them to use logger context.

https://mattermost.atlassian.net/browse/MM-45198

```release-note
NONE
```
