### PR TITLE
[CLD-3942] Container Image used for e2e testing, migration from Alpine to Debian Linux

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:3.14.6@sha256:06b5d462c92fc39303e6363c65e074559f8d6b1363250027ed5053557e3398c5
+FROM debian:buster-slim@sha256:5b0b1a9a54651bbe9d4d3ee96bbda2b2a1da3d2fa198ddebbced46dfdca7f216
+
+# Setting bash as our shell, and enabling pipefail option
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Some ENV variables
 ENV PATH="/mattermost/bin:${PATH}"
@@ -6,37 +9,27 @@ ARG PUID=2000
 ARG PGID=2000
 ARG MM_PACKAGE="https://releases.mattermost.com/7.1.2/mattermost-7.1.2-linux-amd64.tar.gz?src=docker"
 
+# # Install needed packages
+RUN apt-get update \
+  && apt-get install --no-install-recommends -y \
+  ca-certificates=20200601~deb10u2 \
+  curl=7.64.0-4+deb10u2 \
+  && rm -rf /var/lib/apt/lists/*
 
-# Install some needed packages
-RUN apk add --no-cache \
-  ca-certificates \
-  curl \
-  libc6-compat \
-  libffi-dev \
-  linux-headers \
-  mailcap \
-  netcat-openbsd \
-  xmlsec-dev \
-  tzdata \
-  wv \
-  poppler-utils \
-  tidyhtml \
-  && rm -rf /tmp/*
-
-# Get Mattermost
+# Set mattermost group/user and download Mattermost
 RUN mkdir -p /mattermost/data /mattermost/plugins /mattermost/client/plugins \
-  && if [ ! -z "$MM_PACKAGE" ]; then curl $MM_PACKAGE | tar -xvz ; \
-  else echo "please set the MM_PACKAGE" ; fi \
-  && addgroup -g ${PGID} mattermost \
-  && adduser -D -u ${PUID} -G mattermost -h /mattermost -D mattermost \
-  && chown -R mattermost:mattermost /mattermost /mattermost/plugins /mattermost/client/plugins
+    && addgroup -gid ${PGID} mattermost \
+    && adduser -q --disabled-password --uid ${PUID} --gid ${PGID} --gecos "" --home /mattermost mattermost \
+    && if [ -n "$MM_PACKAGE" ]; then curl $MM_PACKAGE | tar -xvz ; \
+    else echo "please set the MM_PACKAGE" ; exit 127 ; fi \
+    && chown -R mattermost:mattermost /mattermost /mattermost/data /mattermost/plugins /mattermost/client/plugins
 
+# We should refrain from running as privileged user
 USER mattermost
 
 #Healthcheck to make sure container is ready
 HEALTHCHECK --interval=30s --timeout=10s \
   CMD curl -f http://localhost:8065/api/v4/system/ping || exit 1
-
 
 # Configure entrypoint and command
 COPY entrypoint.sh /
@@ -48,3 +41,4 @@ EXPOSE 8065 8067 8074 8075
 
 # Declare volumes for mount point directories
 VOLUME ["/mattermost/data", "/mattermost/logs", "/mattermost/config", "/mattermost/plugins", "/mattermost/client/plugins"]
+

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-get update \
   && apt-get install --no-install-recommends -y \
   ca-certificates=20200601~deb10u2 \
   curl=7.64.0-4+deb10u2 \
+  mime-support=3.62 \
+  unrtf=0.21.10-clean-1 \
+  wv=1.2.9-4.2+b2 \
+  poppler-utils=0.71.0-5 \
+  tidy=2:5.6.0-10 \
   && rm -rf /var/lib/apt/lists/*
 
 # Set mattermost group/user and download Mattermost

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "${1:0:1}" = '-' ]; then
     set -- mattermost "$@"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

We are proposing switching to building docker container for `matermmost-server` & `enterprise` from Alpine Linux(unsupported) to Debian(supported).

For context, this image is actually used for e2e testing.

### Rationalle

Alpine is actually an [unsupported distribution](https://docs.mattermost.com/install/software-hardware-requirements.html#mattermost-server-operating-system) for mattermost-server. On top of that, Alpine linux uses **musl libc** vs **glibc**, which can introduce several challenges, that can be difficult to actually troubleshoot. 
https://github.com/golang/go/issues/51280

Finally We got to a point of being unable to run Alpine based mattermost instances with: `Error relocating ./mattermost: fcntl64: symbol not found`, caused by using Alpine linux. 
PR affected by the issue : https://github.com/mattermost/mattermost-server/pull/20735


In detail, the following changes are introduced:

- switching to using Debian Buster as being a supported linux flavor for Mattermost
- pinning the Debian base image with SHA hash
- defining Shell as bash, and enabling pipefail
- pinning additional packages installed using apt
- removing unused cache
- improving MM_PACKAGE variable checking logic introducing non zero exit code (127) when failing
- migrating adduser and addgroup command, to debian compatible ones
- switching to a more capable shell for `entrypoint.sh` 


### Image Size considerations 

Alpine linux image: 
```
REPOSITORY                                         TAG           IMAGE ID       CREATED          SIZE
mattermost/mm-te-test                              1eaedd1       5457abe5de09   2 hours ago      535MB
```

Debian/Buster-slim image created: 
```
mattermost/mm-te-test                              bf14fb2       1f974ef41090   4 minutes ago    541MB
```
There is a negligible 6Mb difference
Either way, a better approach to this, would be to introduce a multi-stage build, with debian being the builder stage, and google's [distroless](https://github.com/GoogleContainerTools/distroless) being the runner stage. That would considerably reduce the size. 
We can introduce this at a second iteration if needed. 


### Fixing the Alpine image issue : 
Enterprise [build using debian](https://app.circleci.com/pipelines/github/mattermost/enterprise/17920/workflows/d012e12b-a031-4773-8640-da79688f1d11/jobs/112306) successfully runs `docker.io/mattermost/mm-ee-test:d7a7174` 

```bash
docker run --platform linux/amd64 mattermost/mm-ee-test:d7a7174                                                                  
{"timestamp":"2022-08-11 16:41:34.992 Z","level":"info","msg":"Server is initializing...","caller":"app/server.go:276","go_version":"go1.18.1"}
{"timestamp":"2022-08-11 16:41:34.994 Z","level":"info","msg":"Pinging SQL","caller":"sqlstore/store.go:228","database":"master"}
{"timestamp":"2022-08-11 16:41:35.019 Z","level":"error","msg":"Failed to ping DB","caller":"sqlstore/store.go:238","error":"dial tcp 127.0.0.1:5432: connect: connection refused","retrying in seconds":10}
```

Review by commit is recommended. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-3942

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
