### PR TITLE
MM-46402: Use pointer to pointer to set pointer to nil

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -2060,12 +2060,12 @@ func withMut(mut *sync.Mutex, f func()) {
 	f()
 }
 
-func cancelTask(mut *sync.Mutex, task *model.ScheduledTask) {
+func cancelTask(mut *sync.Mutex, task **model.ScheduledTask) {
 	mut.Lock()
 	defer mut.Unlock()
-	if task != nil {
-		task.Cancel()
-		task = nil
+	if *task != nil {
+		(**task).Cancel()
+		*task = nil
 	}
 }
 
@@ -2082,7 +2082,7 @@ func runDNDStatusExpireJob(a *App) {
 				a.ch.dndTask = model.CreateRecurringTaskFromNextIntervalTime("Unset DND Statuses", a.UpdateDNDStatusOfUsers, 5*time.Minute)
 			})
 		} else {
-			cancelTask(&a.ch.dndTaskMut, a.ch.dndTask)
+			cancelTask(&a.ch.dndTaskMut, &a.ch.dndTask)
 		}
 	})
 }
@@ -2100,7 +2100,7 @@ func runPostReminderJob(a *App) {
 				a.ch.postReminderTask = model.CreateRecurringTaskFromNextIntervalTime("Check Post reminders", a.CheckPostReminders, 5*time.Minute)
 			})
 		} else {
-			cancelTask(&a.ch.postReminderMut, a.ch.postReminderTask)
+			cancelTask(&a.ch.postReminderMut, &a.ch.postReminderTask)
 		}
 	})
 }

--- a/app/server.go
+++ b/app/server.go
@@ -2064,7 +2064,7 @@ func cancelTask(mut *sync.Mutex, taskPointer **model.ScheduledTask) {
 	mut.Lock()
 	defer mut.Unlock()
 	if *taskPointer != nil {
-		(**taskPointer).Cancel()
+		(*taskPointer).Cancel()
 		*taskPointer = nil
 	}
 }

--- a/app/server.go
+++ b/app/server.go
@@ -2060,12 +2060,12 @@ func withMut(mut *sync.Mutex, f func()) {
 	f()
 }
 
-func cancelTask(mut *sync.Mutex, task **model.ScheduledTask) {
+func cancelTask(mut *sync.Mutex, taskPointer **model.ScheduledTask) {
 	mut.Lock()
 	defer mut.Unlock()
-	if *task != nil {
-		(**task).Cancel()
-		*task = nil
+	if *taskPointer != nil {
+		(**taskPointer).Cancel()
+		*taskPointer = nil
 	}
 }
 

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -16,6 +16,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -564,4 +565,12 @@ func TestSentry(t *testing.T) {
 			require.Fail(t, "Sentry report didn't arrive")
 		}
 	})
+}
+
+func TestCancelTaskSetsTaskToNil(t *testing.T) {
+	var taskMut sync.Mutex
+	task := model.CreateRecurringTaskFromNextIntervalTime("a test task", func() {}, 5*time.Minute)
+	require.NotNil(t, task)
+	cancelTask(&taskMut, &task)
+	require.Nil(t, task)
 }

--- a/app/server_test.go
+++ b/app/server_test.go
@@ -573,4 +573,5 @@ func TestCancelTaskSetsTaskToNil(t *testing.T) {
 	require.NotNil(t, task)
 	cancelTask(&taskMut, &task)
 	require.Nil(t, task)
+	require.NotPanics(t, func() { cancelTask(&taskMut, &task) })
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- We need a pointer to a pointer to set the original pointer to nil
- The original task was not being set to `nil` (the local variable containing the pointer was being set to nil). The cancel func was being called even though the task had already been cancelled. This repeated cancellation was causing a panic because we were trying to close a channel that had already been closed the first time the task was cancelled.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-46402

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
