### PR TITLE
re-assign cluster interface after initializing enterprise interfaces

### DIFF
--- a/app/enterprise.go
+++ b/app/enterprise.go
@@ -114,6 +114,7 @@ func RegisterLicenseInterface(f func(*Server) einterfaces.LicenseInterface) {
 func (s *Server) initEnterprise() {
 	if clusterInterface != nil && s.Cluster == nil {
 		s.Cluster = clusterInterface(s)
+		s.platform.SetCluster(s.Cluster)
 	}
 	if elasticsearchInterface != nil {
 		s.SearchEngine.RegisterElasticsearchEngine(elasticsearchInterface(s))

--- a/app/platform/cluster.go
+++ b/app/platform/cluster.go
@@ -3,10 +3,16 @@
 
 package platform
 
+import "github.com/mattermost/mattermost-server/v6/einterfaces"
+
 func (ps *PlatformService) IsLeader() bool {
 	if ps.License() != nil && *ps.Config().ClusterSettings.Enable && ps.cluster != nil {
 		return ps.cluster.IsLeader()
 	}
 
 	return true
+}
+
+func (ps *PlatformService) SetCluster(impl einterfaces.ClusterInterface) {
+	ps.cluster = impl
 }

--- a/app/platform/config_test.go
+++ b/app/platform/config_test.go
@@ -60,7 +60,10 @@ func TestConfigSave(t *testing.T) {
 		newCfg := oldCfg.Clone()
 		newCfg.ServiceSettings.SiteURL = model.NewString("http://newhost.me")
 
-		cm.On("ConfigChanged", oldCfg, newCfg, true).Return(nil)
+		sanitizedOldCfg := th.Service.configStore.RemoveEnvironmentOverrides(oldCfg)
+		sanitizedNewCfg := th.Service.configStore.RemoveEnvironmentOverrides(newCfg)
+
+		cm.On("ConfigChanged", sanitizedOldCfg, sanitizedNewCfg, true).Return(nil)
 
 		_, _, appErr := th.Service.SaveConfig(newCfg, true)
 		require.Nil(t, appErr)

--- a/app/platform/config_test.go
+++ b/app/platform/config_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v6/einterfaces/mocks"
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
@@ -44,4 +46,26 @@ func TestConfigListener(t *testing.T) {
 
 	assert.True(t, listenerCalled, "listener should've been called")
 	assert.True(t, listener2Called, "listener 2 should've been called")
+}
+
+func TestConfigSave(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	cm := &mocks.ClusterInterface{}
+	th.Service.SetCluster(cm)
+
+	t.Run("trigger a config changed event for the cluster", func(t *testing.T) {
+		oldCfg := th.Service.Config()
+		newCfg := oldCfg.Clone()
+		newCfg.ServiceSettings.SiteURL = model.NewString("http://newhost.me")
+
+		cm.On("ConfigChanged", oldCfg, newCfg, true).Return(nil)
+
+		_, _, appErr := th.Service.SaveConfig(newCfg, true)
+		require.Nil(t, appErr)
+
+		updatedCfg := th.Service.Config()
+		assert.Equal(t, "http://newhost.me", *updatedCfg.ServiceSettings.SiteURL)
+	})
 }


### PR DESCRIPTION
#### Summary
Fixes an issue where cluster interface was not passed to platform service after initialized.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46426

#### Release Note

```release-note
NONE
```
