### PR TITLE
Always regenerate go.work file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ endif
 setup-go-work: export BUILD_ENTERPRISE_READY := $(BUILD_ENTERPRISE_READY)
 setup-go-work: export BUILD_BOARDS := $(BUILD_BOARDS)
 setup-go-work: ## Sets up your go.work file
-	./scripts/setup_go_work.sh
+	./scripts/setup_go_work.sh $(IGNORE_IF_EXISTS)
 
 check-style: golangci-lint plugin-checker vet ## Runs style/lint checks
 

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ endif
 setup-go-work: export BUILD_ENTERPRISE_READY := $(BUILD_ENTERPRISE_READY)
 setup-go-work: export BUILD_BOARDS := $(BUILD_BOARDS)
 setup-go-work: ## Sets up your go.work file
-	./scripts/setup_go_work.sh $(IGNORE_IF_EXISTS)
+	./scripts/setup_go_work.sh $(IGNORE_GO_WORK_IF_EXISTS)
 
 check-style: golangci-lint plugin-checker vet ## Runs style/lint checks
 

--- a/scripts/setup_go_work.sh
+++ b/scripts/setup_go_work.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ ! -f "go.work" ]] ;
+if [[ $1 != "true" ]] ;
 then
     echo "Creating a go.work file"
 


### PR DESCRIPTION
We flip the default mode to always regenerate the file,
and expose an option to ignore if it exists.

The way to preserve the old behavior is to use an additional `IGNORE_IF_EXISTS` flag
like `make run-server IGNORE_IF_EXISTS=true`.

```release-note
NONE
```
