### PR TITLE
Put wrapped errors into the detailed field on serialization

### DIFF
--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -928,7 +928,7 @@ func TestPatchPost(t *testing.T) {
 
 	t.Run("invalid requests", func(t *testing.T) {
 		r, err := client.DoAPIPut("/posts/"+post.Id+"/patch", "garbage")
-		require.EqualError(t, err, ": Invalid or missing post in request body.")
+		require.EqualError(t, err, ": Invalid or missing post in request body., invalid character 'g' looking for beginning of value")
 		require.Equal(t, http.StatusBadRequest, r.StatusCode, "wrong status code")
 
 		patch := &model.PostPatch{}

--- a/model/utils.go
+++ b/model/utils.go
@@ -266,8 +266,28 @@ func (er *AppError) SystemMessage(T i18n.TranslateFunc) string {
 }
 
 func (er *AppError) ToJSON() string {
+	// turn the wrapped error into a detailed message
+	detailed := er.DetailedError
+	defer func() {
+		er.DetailedError = detailed
+	}()
+
+	er.wrappedToDetailed()
+
 	b, _ := json.Marshal(er)
 	return string(b)
+}
+
+func (er *AppError) wrappedToDetailed() {
+	if er.wrapped == nil {
+		return
+	}
+
+	if er.DetailedError != "" {
+		er.DetailedError += ", "
+	}
+
+	er.DetailedError += er.wrapped.Error()
 }
 
 func (er *AppError) Unwrap() error {

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -5,6 +5,7 @@ package model
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -109,6 +110,52 @@ func TestAppErrorRender(t *testing.T) {
 	t.Run("DetailedWrappedMultiple", func(t *testing.T) {
 		aerr := NewAppError("here", "message", nil, "details", http.StatusTeapot).Wrap(fmt.Errorf("my error (%w)", fmt.Errorf("inner error")))
 		assert.EqualError(t, aerr, "here: message, details, my error (inner error), inner error")
+	})
+}
+
+func TestAppErrorSerialize(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		aerr := NewAppError("", "message", nil, "", http.StatusTeapot)
+		js := aerr.ToJSON()
+		berr := AppErrorFromJSON(strings.NewReader(js))
+		require.Equal(t, "message", berr.Id)
+		require.Empty(t, berr.DetailedError)
+		require.Equal(t, http.StatusTeapot, berr.StatusCode)
+
+		require.EqualError(t, berr, aerr.Error())
+	})
+
+	t.Run("Detailed", func(t *testing.T) {
+		aerr := NewAppError("", "message", nil, "detail", http.StatusTeapot)
+		js := aerr.ToJSON()
+		berr := AppErrorFromJSON(strings.NewReader(js))
+		require.Equal(t, "message", berr.Id)
+		require.Equal(t, "detail", berr.DetailedError)
+		require.Equal(t, http.StatusTeapot, berr.StatusCode)
+
+		require.EqualError(t, berr, aerr.Error())
+	})
+
+	t.Run("Wrapped", func(t *testing.T) {
+		aerr := NewAppError("", "message", nil, "", http.StatusTeapot).Wrap(errors.New("wrapped"))
+		js := aerr.ToJSON()
+		berr := AppErrorFromJSON(strings.NewReader(js))
+		require.Equal(t, "message", berr.Id)
+		require.Equal(t, "wrapped", berr.DetailedError)
+		require.Equal(t, http.StatusTeapot, berr.StatusCode)
+
+		require.EqualError(t, berr, aerr.Error())
+	})
+
+	t.Run("Detailed + Wrapped", func(t *testing.T) {
+		aerr := NewAppError("", "message", nil, "detail", http.StatusTeapot).Wrap(errors.New("wrapped"))
+		js := aerr.ToJSON()
+		berr := AppErrorFromJSON(strings.NewReader(js))
+		require.Equal(t, "message", berr.Id)
+		require.Equal(t, "detail, wrapped", berr.DetailedError)
+		require.Equal(t, http.StatusTeapot, berr.StatusCode)
+
+		require.EqualError(t, berr, aerr.Error())
 	})
 }
 


### PR DESCRIPTION
#### Summary
Wrapped errors would be lost once the AppError is serialized and deserialized. To prevent the error message from being lost, it's added to the detailed field on serialization.

#### Release Note
```release-note
NONE
```
