### PR TITLE
[MM-46468] Change /help and add /marketplace

### DIFF
--- a/api4/command_help_test.go
+++ b/api4/command_help_test.go
@@ -25,11 +25,11 @@ func TestHelpCommand(t *testing.T) {
 
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.SupportSettings.HelpLink = "" })
 	rs1, _, _ := client.ExecuteCommand(channel.Id, "/help ")
-	assert.Equal(t, rs1.GotoLocation, model.SupportSettingsDefaultHelpLink, "failed to default help link")
+	assert.Contains(t, rs1.Text, model.SupportSettingsDefaultHelpLink, "failed to default help link")
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.SupportSettings.HelpLink = "https://docs.mattermost.com/guides/user.html"
 	})
 	rs2, _, _ := client.ExecuteCommand(channel.Id, "/help ")
-	assert.Equal(t, rs2.GotoLocation, "https://docs.mattermost.com/guides/user.html", "failed to help link")
+	assert.Contains(t, rs2.Text, "https://docs.mattermost.com/guides/user.html", "failed to help link")
 }

--- a/app/slashcommands/command_help.go
+++ b/app/slashcommands/command_help.go
@@ -41,5 +41,10 @@ func (h *HelpProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandA
 		helpLink = model.SupportSettingsDefaultHelpLink
 	}
 
-	return &model.CommandResponse{GotoLocation: helpLink}
+	return &model.CommandResponse{
+		ResponseType: model.CommandResponseTypeEphemeral,
+		Text: args.T("api.command_help.success", map[string]any{
+			"HelpLink": helpLink,
+		}),
+	}
 }

--- a/app/slashcommands/command_marketplace.go
+++ b/app/slashcommands/command_marketplace.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package slashcommands
+
+import (
+	"github.com/mattermost/mattermost-server/v6/app"
+	"github.com/mattermost/mattermost-server/v6/app/request"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/i18n"
+)
+
+type MarketplaceProvider struct {
+}
+
+const (
+	CmdMarketplace = "marketplace"
+)
+
+func init() {
+	app.RegisterCommandProvider(&MarketplaceProvider{})
+}
+
+func (h *MarketplaceProvider) GetTrigger() string {
+	return CmdMarketplace
+}
+
+func (h *MarketplaceProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command {
+	return &model.Command{
+		Trigger:          CmdMarketplace,
+		AutoComplete:     true,
+		AutoCompleteDesc: T("api.command_marketplace.desc"),
+		DisplayName:      T("api.command_marketplace.name"),
+	}
+}
+
+func (h *MarketplaceProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	// This command is handled client-side and shouldn't hit the server.
+	return &model.CommandResponse{
+		Text:         args.T("api.command_marketplace.unsupported.app_error"),
+		ResponseType: model.CommandResponseTypeEphemeral,
+	}
+}

--- a/app/team.go
+++ b/app/team.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/mattermost/mattermost-server/v6/app/email"
 	"github.com/mattermost/mattermost-server/v6/app/imaging"
@@ -198,6 +199,71 @@ func (a *App) CreateTeamWithUser(c *request.Context, team *model.Team, userID st
 	}
 
 	if _, err := a.JoinUserToTeam(c, rteam, user, ""); err != nil {
+		return nil, err
+	}
+
+	// TODO: check if this is the first team
+	// a.ch.srv.GetStore().Team().AnalyticsTeamCount(nil)
+
+	// Find the default channel
+	c.Logger().Debug("===================")
+	c.Logger().Debug("===================")
+	c.Logger().Debug("===================")
+	c.Logger().Debug("===================")
+	c.Logger().Debug("===================")
+	c.Logger().Debug("Get Channel By Name")
+	defaultChannel, err := a.GetChannelByName(c, model.DefaultChannelName, rteam.Id, false)
+	if err != nil {
+		c.Logger().Debug("ERROR Get Channel By Name")
+		return nil, err
+	}
+
+	c.Logger().Debug("Send Ephemeral Post")
+	// post an ephemeral message to the default channel by System User
+	if a.SendEphemeralPost(c, user.Id, &model.Post{
+		ChannelId: defaultChannel.Id,
+		Message:   "Yop eph",
+		Type:      model.PostTypeEphemeral,
+	}); err != nil {
+		c.Logger().Debug("ERROR Send Ephemeral Post")
+		return nil, err
+	}
+
+	go func() {
+		time.Sleep(time.Second * 10)
+		c.Logger().Debug("GO Send Ephemeral Post")
+		// post an ephemeral message to the default channel by System User
+		if a.SendEphemeralPost(c, user.Id, &model.Post{
+			UserId:    user.Id,
+			ChannelId: defaultChannel.Id,
+			Message:   "Yop go eph post",
+			Type:      model.PostTypeEphemeral,
+		}); err != nil {
+			c.Logger().Debug("ERROR GO Send Ephemeral Post")
+		}
+	}()
+
+	c.Logger().Debug("Send Post 1")
+	// post an ephemeral message to the default channel by System User
+	if a.CreatePost(c, &model.Post{
+		UserId:    user.Id,
+		ChannelId: defaultChannel.Id,
+		Message:   "Yop eph post",
+		Type:      model.PostTypeEphemeral,
+	}, defaultChannel, false, false); err != nil {
+		c.Logger().Debug("ERROR Send Post 1")
+		return nil, err
+	}
+
+	c.Logger().Debug("Send Post 2")
+	// post an ephemeral message to the default channel by System User
+	if a.CreatePost(c, &model.Post{
+		UserId:    user.Id,
+		ChannelId: defaultChannel.Id,
+		Message:   "Yop",
+		Type:      model.PostTypeDefault,
+	}, defaultChannel, false, false); err != nil {
+		c.Logger().Debug("ERROR Send Post 2")
 		return nil, err
 	}
 

--- a/app/team.go
+++ b/app/team.go
@@ -16,7 +16,6 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/mattermost/mattermost-server/v6/app/email"
 	"github.com/mattermost/mattermost-server/v6/app/imaging"
@@ -199,71 +198,6 @@ func (a *App) CreateTeamWithUser(c *request.Context, team *model.Team, userID st
 	}
 
 	if _, err := a.JoinUserToTeam(c, rteam, user, ""); err != nil {
-		return nil, err
-	}
-
-	// TODO: check if this is the first team
-	// a.ch.srv.GetStore().Team().AnalyticsTeamCount(nil)
-
-	// Find the default channel
-	c.Logger().Debug("===================")
-	c.Logger().Debug("===================")
-	c.Logger().Debug("===================")
-	c.Logger().Debug("===================")
-	c.Logger().Debug("===================")
-	c.Logger().Debug("Get Channel By Name")
-	defaultChannel, err := a.GetChannelByName(c, model.DefaultChannelName, rteam.Id, false)
-	if err != nil {
-		c.Logger().Debug("ERROR Get Channel By Name")
-		return nil, err
-	}
-
-	c.Logger().Debug("Send Ephemeral Post")
-	// post an ephemeral message to the default channel by System User
-	if a.SendEphemeralPost(c, user.Id, &model.Post{
-		ChannelId: defaultChannel.Id,
-		Message:   "Yop eph",
-		Type:      model.PostTypeEphemeral,
-	}); err != nil {
-		c.Logger().Debug("ERROR Send Ephemeral Post")
-		return nil, err
-	}
-
-	go func() {
-		time.Sleep(time.Second * 10)
-		c.Logger().Debug("GO Send Ephemeral Post")
-		// post an ephemeral message to the default channel by System User
-		if a.SendEphemeralPost(c, user.Id, &model.Post{
-			UserId:    user.Id,
-			ChannelId: defaultChannel.Id,
-			Message:   "Yop go eph post",
-			Type:      model.PostTypeEphemeral,
-		}); err != nil {
-			c.Logger().Debug("ERROR GO Send Ephemeral Post")
-		}
-	}()
-
-	c.Logger().Debug("Send Post 1")
-	// post an ephemeral message to the default channel by System User
-	if a.CreatePost(c, &model.Post{
-		UserId:    user.Id,
-		ChannelId: defaultChannel.Id,
-		Message:   "Yop eph post",
-		Type:      model.PostTypeEphemeral,
-	}, defaultChannel, false, false); err != nil {
-		c.Logger().Debug("ERROR Send Post 1")
-		return nil, err
-	}
-
-	c.Logger().Debug("Send Post 2")
-	// post an ephemeral message to the default channel by System User
-	if a.CreatePost(c, &model.Post{
-		UserId:    user.Id,
-		ChannelId: defaultChannel.Id,
-		Message:   "Yop",
-		Type:      model.PostTypeDefault,
-	}, defaultChannel, false, false); err != nil {
-		c.Logger().Debug("ERROR Send Post 2")
 		return nil, err
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -856,11 +856,15 @@
   },
   {
     "id": "api.command_help.desc",
-    "translation": "Open the Mattermost help page"
+    "translation": "Show Mattermost help message"
   },
   {
     "id": "api.command_help.name",
     "translation": "help"
+  },
+  {
+    "id": "api.command_help.success",
+    "translation": "Mattermost is an open source platform for secure communication, collaboration, and orchestration of work across tools and teams.\r\nMattermost contains three key tools:\r\n\r\n**Channels** - Stay connected with your team via 1:1 and group messaging.\r\n**[Playbooks](/playbooks)** - Build and configure repeatable processes to achieve specific and predictable outcomes.\r\n**[Boards](/boards)** - Manage projects and tasks in a Kanban board structure to help your team hit key milestones.\r\n\r\n[View documentation and guides]({{.HelpLink}})"
   },
   {
     "id": "api.command_invite.channel.app_error",
@@ -973,6 +977,18 @@
   {
     "id": "api.command_logout.name",
     "translation": "logout"
+  },
+  {
+    "id": "api.command_marketplace.desc",
+    "translation": "Open the Marketplace"
+  },
+  {
+    "id": "api.command_marketplace.name",
+    "translation": "marketplace"
+  },
+  {
+    "id": "api.command_marketplace.unsupported.app_error",
+    "translation": "The marketplace command is not supported on your device."
   },
   {
     "id": "api.command_me.desc",


### PR DESCRIPTION
#### Summary
This PR changes the behavior of /help (previously opened a link in a new tab, now print an ephemeral message), and also introduce the new /marketplace command (which has no effect on the server)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46468

#### Release Note
```release-note
NONE
```
