### PR TITLE
Print full error string instead of only detailed error

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -105,7 +105,7 @@ func (c *Context) LogErrorByCode(err *model.AppError) {
 	fields := []mlog.Field{
 		mlog.String("err_where", err.Where),
 		mlog.Int("http_code", err.StatusCode),
-		mlog.String("err_details", err.DetailedError),
+		mlog.String("error", err.Error()),
 	}
 	switch {
 	case (code >= http.StatusBadRequest && code < http.StatusInternalServerError) ||


### PR DESCRIPTION
Due to the recent changes in error wrapping, the DetailedError
field does not contain the full info of all the wrapped errors.

Therefore, while printing the error, we display the stringified
representation instead of only the DetailedError field.

```release-note
NONE
```
