### PR TITLE
MM-46475: Disable sending content sha in bifrost mode

### DIFF
--- a/shared/filestore/s3store.go
+++ b/shared/filestore/s3store.go
@@ -368,6 +368,9 @@ func (b *S3FileBackend) WriteFile(fr io.Reader, path string) (int64, error) {
 
 	objSize := -1
 	isCloud := os.Getenv("MM_CLOUD_FILESTORE_BIFROST") != ""
+	if isCloud {
+		options.DisableContentSha256 = true
+	}
 	// We pass an object size only in situations where bifrost is not
 	// used. Bifrost needs to run in HTTPS, which is not yet deployed.
 	if buf, ok := fr.(*bytes.Buffer); ok && !isCloud {
@@ -404,6 +407,9 @@ func (b *S3FileBackend) AppendFile(fr io.Reader, path string) (int64, error) {
 	defer cancel2()
 	objSize := -1
 	isCloud := os.Getenv("MM_CLOUD_FILESTORE_BIFROST") != ""
+	if isCloud {
+		options.DisableContentSha256 = true
+	}
 	// We pass an object size only in situations where bifrost is not
 	// used. Bifrost needs to run in HTTPS, which is not yet deployed.
 	if buf, ok := fr.(*bytes.Buffer); ok && !isCloud {


### PR DESCRIPTION
PR https://github.com/minio/minio-go/pull/1668 introduced
an option to disable sha256, which by default was disabled.
This meant all content was always hashed and this broke
in bifrost because the key signing fails in streaming
mode.

So for cloud installations, we disable sha256.

https://mattermost.atlassian.net/browse/MM-46475

```release-note
NONE
```
