### PR TITLE
MM-45994 ensure database operations return their errors

### DIFF
--- a/store/errors.go
+++ b/store/errors.go
@@ -166,8 +166,8 @@ type ErrUniqueConstraint struct {
 //
 // Examples:
 //
-//  store.NewErrUniqueConstraint("DisplayName") // single column constraint
-//  store.NewErrUniqueConstraint("Name", "Source") // multi-column constraint
+//	store.NewErrUniqueConstraint("DisplayName") // single column constraint
+//	store.NewErrUniqueConstraint("Name", "Source") // multi-column constraint
 func NewErrUniqueConstraint(columns ...string) *ErrUniqueConstraint {
 	return &ErrUniqueConstraint{
 		Columns: columns,

--- a/store/errors.go
+++ b/store/errors.go
@@ -10,9 +10,10 @@ import (
 
 // ErrInvalidInput indicates an error that has occurred due to an invalid input.
 type ErrInvalidInput struct {
-	Entity string // The entity which was sent as the input.
-	Field  string // The field of the entity which was invalid.
-	Value  any    // The actual value of the field.
+	Entity  string // The entity which was sent as the input.
+	Field   string // The field of the entity which was invalid.
+	Value   any    // The actual value of the field.
+	wrapped error  // The original error
 }
 
 func NewErrInvalidInput(entity, field string, value any) *ErrInvalidInput {
@@ -24,7 +25,20 @@ func NewErrInvalidInput(entity, field string, value any) *ErrInvalidInput {
 }
 
 func (e *ErrInvalidInput) Error() string {
+	if e.wrapped != nil {
+		return fmt.Sprintf("invalid input: entity: %s field: %s value: %s error: %s", e.Entity, e.Field, e.Value, e.wrapped)
+	}
+
 	return fmt.Sprintf("invalid input: entity: %s field: %s value: %s", e.Entity, e.Field, e.Value)
+}
+
+func (e *ErrInvalidInput) Wrap(err error) *ErrInvalidInput {
+	e.wrapped = err
+	return e
+}
+
+func (e *ErrInvalidInput) Unwrap() error {
+	return e.wrapped
 }
 
 func (e *ErrInvalidInput) InvalidInputInfo() (entity string, field string, value any) {
@@ -89,6 +103,7 @@ func (e *ErrConflict) IsErrConflict() bool {
 type ErrNotFound struct {
 	resource string
 	ID       string
+	wrapped  error
 }
 
 func NewErrNotFound(resource, id string) *ErrNotFound {
@@ -98,8 +113,17 @@ func NewErrNotFound(resource, id string) *ErrNotFound {
 	}
 }
 
+func (e *ErrNotFound) Wrap(err error) *ErrNotFound {
+	e.wrapped = err
+	return e
+}
+
 func (e *ErrNotFound) Error() string {
-	return "resource: " + e.resource + " id: " + e.ID
+	if e.wrapped != nil {
+		return fmt.Sprintf("resource: %s id: %s error: %s", e.resource, e.ID, e.wrapped)
+	}
+
+	return fmt.Sprintf("resource: %s id: %s", e.resource, e.ID)
 }
 
 // IsErrNotFound allows easy type assertion without adding store as a dependency.

--- a/store/sqlstore/adapters.go
+++ b/store/sqlstore/adapters.go
@@ -17,19 +17,25 @@ type jsonArray []string
 
 func (a jsonArray) Value() (driver.Value, error) {
 	var out bytes.Buffer
-	_ = out.WriteByte('[')
+	if err := out.WriteByte('['); err != nil {
+		return nil, err
+	}
 
 	for i, item := range a {
-		_, _ = out.WriteString(strconv.Quote(item))
+		if _, err := out.WriteString(strconv.Quote(item)); err != nil {
+			return nil, err
+		}
 
 		// Skip the last element.
 		if i < len(a)-1 {
-			_ = out.WriteByte(',')
+			if err := out.WriteByte(','); err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	_ = out.WriteByte(']')
-	return out.Bytes(), nil
+	err := out.WriteByte(']')
+	return out.Bytes(), err
 }
 
 type jsonStringVal string

--- a/store/sqlstore/adapters.go
+++ b/store/sqlstore/adapters.go
@@ -17,23 +17,18 @@ type jsonArray []string
 
 func (a jsonArray) Value() (driver.Value, error) {
 	var out bytes.Buffer
-	if err := out.WriteByte('['); err != nil {
-		return nil, err
-	}
+	_ = out.WriteByte('[')
 
 	for i, item := range a {
-		if _, err := out.WriteString(strconv.Quote(item)); err != nil {
-			return nil, err
-		}
+		_, _ = out.WriteString(strconv.Quote(item))
+
 		// Skip the last element.
 		if i < len(a)-1 {
-			out.WriteByte(',')
+			_ = out.WriteByte(',')
 		}
 	}
 
-	if err := out.WriteByte(']'); err != nil {
-		return nil, err
-	}
+	_ = out.WriteByte(']')
 	return out.Bytes(), nil
 }
 

--- a/store/sqlstore/bot_store.go
+++ b/store/sqlstore/bot_store.go
@@ -144,7 +144,7 @@ func (us SqlBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot, error)
 
 	bots := []*model.Bot{}
 	if err := us.GetReplicaX().Select(&bots, sql, args...); err != nil {
-		return nil, errors.Wrap(err, "select")
+		return nil, errors.Wrap(err, "error selecting all bots")
 	}
 
 	return bots, nil
@@ -215,7 +215,7 @@ func (us SqlBotStore) Update(bot *model.Bot) (*model.Bot, error) {
 func (us SqlBotStore) PermanentDelete(botUserId string) error {
 	query := "DELETE FROM Bots WHERE UserId = ?"
 	if _, err := us.GetMasterX().Exec(query, botUserId); err != nil {
-		return store.NewErrInvalidInput("Bot", "UserId", botUserId)
+		return store.NewErrInvalidInput("Bot", "UserId", botUserId).Wrap(err)
 	}
 	return nil
 }

--- a/store/sqlstore/channel_member_history_store.go
+++ b/store/sqlstore/channel_member_history_store.go
@@ -192,10 +192,10 @@ func (s SqlChannelMemberHistoryStore) DeleteOrphanedRows(limit int) (deleted int
 	)`
 	result, err := s.GetMasterX().Exec(query, limit)
 	if err != nil {
-		return
+		return 0, err
 	}
-	deleted, err = result.RowsAffected()
-	return
+
+	return result.RowsAffected()
 }
 
 func (s SqlChannelMemberHistoryStore) PermanentDeleteBatch(endTime int64, limit int64) (int64, error) {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -402,6 +402,7 @@ func (db allChannelMember) Process() (string, string) {
 		for _, role := range roles {
 			if role == impliedRole {
 				alreadyThere = true
+				break
 			}
 		}
 		if !alreadyThere {
@@ -554,7 +555,7 @@ func (s SqlChannelStore) upsertPublicChannelT(transaction *sqlxTxWrapper, channe
 }
 
 // Save writes the (non-direct) channel channel to the database.
-func (s SqlChannelStore) Save(channel *model.Channel, maxChannelsPerTeam int64) (*model.Channel, error) {
+func (s SqlChannelStore) Save(channel *model.Channel, maxChannelsPerTeam int64) (ch *model.Channel, err error) {
 	if channel.DeleteAt != 0 {
 		return nil, store.NewErrInvalidInput("Channel", "DeleteAt", channel.DeleteAt)
 	}
@@ -568,7 +569,7 @@ func (s SqlChannelStore) Save(channel *model.Channel, maxChannelsPerTeam int64) 
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	newChannel, err = s.saveChannelT(transaction, channel, maxChannelsPerTeam)
 	if err != nil {
@@ -619,7 +620,7 @@ func (s SqlChannelStore) CreateDirectChannel(user *model.User, otherUser *model.
 	return s.SaveDirectChannel(channel, cm1, cm2)
 }
 
-func (s SqlChannelStore) SaveDirectChannel(directChannel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (*model.Channel, error) {
+func (s SqlChannelStore) SaveDirectChannel(directChannel *model.Channel, member1 *model.ChannelMember, member2 *model.ChannelMember) (channel *model.Channel, err error) {
 	if directChannel.DeleteAt != 0 {
 		return nil, store.NewErrInvalidInput("Channel", "DeleteAt", directChannel.DeleteAt)
 	}
@@ -632,7 +633,7 @@ func (s SqlChannelStore) SaveDirectChannel(directChannel *model.Channel, member1
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	directChannel.TeamId = ""
 	newChannel, err := s.saveChannelT(transaction, directChannel, 0)
@@ -695,12 +696,12 @@ func (s SqlChannelStore) saveChannelT(transaction *sqlxTxWrapper, channel *model
 }
 
 // Update writes the updated channel to the database.
-func (s SqlChannelStore) Update(channel *model.Channel) (*model.Channel, error) {
+func (s SqlChannelStore) Update(channel *model.Channel) (ch *model.Channel, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	updatedChannel, err := s.updateChannelT(transaction, channel)
 	if err != nil {
@@ -869,14 +870,14 @@ func (s SqlChannelStore) Restore(channelId string, time int64) error {
 }
 
 // SetDeleteAt records the given deleted and updated timestamp to the channel in question.
-func (s SqlChannelStore) SetDeleteAt(channelId string, deleteAt, updateAt int64) error {
+func (s SqlChannelStore) SetDeleteAt(channelId string, deleteAt, updateAt int64) (err error) {
 	defer s.InvalidateChannel(channelId)
 
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "SetDeleteAt: begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	err = s.setDeleteAtT(transaction, channelId, deleteAt, updateAt)
 	if err != nil {
@@ -915,12 +916,12 @@ func (s SqlChannelStore) setDeleteAtT(transaction *sqlxTxWrapper, channelId stri
 }
 
 // PermanentDeleteByTeam removes all channels for the given team from the database.
-func (s SqlChannelStore) PermanentDeleteByTeam(teamId string) error {
+func (s SqlChannelStore) PermanentDeleteByTeam(teamId string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "PermanentDeleteByTeam: begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	if err := s.permanentDeleteByTeamtT(transaction, teamId); err != nil {
 		return errors.Wrap(err, "permanentDeleteByTeamtT")
@@ -952,12 +953,12 @@ func (s SqlChannelStore) permanentDeleteByTeamtT(transaction *sqlxTxWrapper, tea
 }
 
 // PermanentDelete removes the given channel from the database.
-func (s SqlChannelStore) PermanentDelete(channelId string) error {
+func (s SqlChannelStore) PermanentDelete(channelId string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "PermanentDelete: begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	if err := s.permanentDeleteT(transaction, channelId); err != nil {
 		return errors.Wrap(err, "permanentDeleteT")
@@ -1495,7 +1496,7 @@ func (s SqlChannelStore) GetByNames(teamId string, names []string, allowFromCach
 		if err := s.GetReplicaX().Select(&dbChannels, query, args...); err != nil && err != sql.ErrNoRows {
 			msg := fmt.Sprintf("failed to get channels with names=%v", names)
 			if teamId != "" {
-				msg += fmt.Sprintf("teamId=%s", teamId)
+				msg += fmt.Sprintf(" teamId=%s", teamId)
 			}
 			return nil, errors.Wrap(err, msg)
 		}
@@ -1563,8 +1564,7 @@ func (s SqlChannelStore) getByName(teamId string, name string, includeDeleted bo
 		return nil, errors.Wrapf(err, "failed to find channel with TeamId=%s and Name=%s", teamId, name)
 	}
 
-	channelByNameCache.SetWithExpiry(teamId+name, &channel, ChannelCacheDuration)
-	return &channel, nil
+	return &channel, channelByNameCache.SetWithExpiry(teamId+name, &channel, ChannelCacheDuration)
 }
 
 func (s SqlChannelStore) GetDeletedByName(teamId string, name string) (*model.Channel, error) {
@@ -1805,7 +1805,7 @@ func (s SqlChannelStore) saveMemberT(member *model.ChannelMember) (*model.Channe
 	return members[0], nil
 }
 
-func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) ([]*model.ChannelMember, error) {
+func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) (channelMembers []*model.ChannelMember, err error) {
 	for _, member := range members {
 		member.PreUpdate()
 
@@ -1815,12 +1815,11 @@ func (s SqlChannelStore) UpdateMultipleMembers(members []*model.ChannelMember) (
 	}
 
 	var transaction *sqlxTxWrapper
-	var err error
 
 	if transaction, err = s.GetMasterX().Beginx(); err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	updatedMembers := []*model.ChannelMember{}
 	for _, member := range members {
@@ -1875,12 +1874,12 @@ func (s SqlChannelStore) UpdateMember(member *model.ChannelMember) (*model.Chann
 	return updatedMembers[0], nil
 }
 
-func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props map[string]string) (*model.ChannelMember, error) {
+func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props map[string]string) (channelMember *model.ChannelMember, err error) {
 	tx, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(tx)
+	defer finalizeTransactionX(tx, &err)
 
 	if s.DriverName() == model.DatabaseDriverPostgres {
 		sql, args, err2 := s.getQueryBuilder().
@@ -1891,7 +1890,7 @@ func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props
 				"channelid": channelID,
 			}).ToSql()
 		if err2 != nil {
-			return nil, errors.Wrapf(err, "UpdateMemberNotifyProps_Update_Postgres_ToSql channelID=%s and userID=%s", channelID, userID)
+			return nil, errors.Wrapf(err2, "UpdateMemberNotifyProps_Update_Postgres_ToSql channelID=%s and userID=%s", channelID, userID)
 		}
 
 		_, err = tx.Exec(sql, args...)
@@ -1914,7 +1913,7 @@ func (s SqlChannelStore) UpdateMemberNotifyProps(channelID, userID string, props
 				"ChannelId": channelID,
 			}).ToSql()
 		if err2 != nil {
-			return nil, errors.Wrapf(err, "UpdateMemberNotifyProps_Update_MySQL_ToSql channelID=%s and userID=%s", channelID, userID)
+			return nil, errors.Wrapf(err2, "UpdateMemberNotifyProps_Update_MySQL_ToSql channelID=%s and userID=%s", channelID, userID)
 		}
 
 		_, err = tx.Exec(sql, args...)
@@ -2079,7 +2078,7 @@ func (s SqlChannelStore) GetMemberForPost(postId string, userId string) (*model.
 	return dbMember.ToModel(), nil
 }
 
-func (s SqlChannelStore) GetAllChannelMembersForUser(userId string, allowFromCache bool, includeDeleted bool) (map[string]string, error) {
+func (s SqlChannelStore) GetAllChannelMembersForUser(userId string, allowFromCache bool, includeDeleted bool) (ids map[string]string, err error) {
 	cache_key := userId
 	if includeDeleted {
 		cache_key += "_deleted"
@@ -2127,9 +2126,9 @@ func (s SqlChannelStore) GetAllChannelMembersForUser(userId string, allowFromCac
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find ChannelMembers, TeamScheme and ChannelScheme data")
 	}
+	defer deferClose(rows, &err)
 
 	var data allChannelMembers
-	defer rows.Close()
 	for rows.Next() {
 		var cm allChannelMember
 		err = rows.Scan(
@@ -2146,7 +2145,7 @@ func (s SqlChannelStore) GetAllChannelMembersForUser(userId string, allowFromCac
 	if err = rows.Err(); err != nil {
 		return nil, errors.Wrap(err, "error while iterating over rows")
 	}
-	ids := data.ToMapStringString()
+	ids = data.ToMapStringString()
 
 	if allowFromCache {
 		allChannelMembersForUserCache.SetWithExpiry(cache_key, ids, AllChannelMembersForUserCacheDuration)
@@ -2549,14 +2548,20 @@ func (s SqlChannelStore) CountPostsAfter(channelId string, timestamp int64, user
 	if userId != "" {
 		query = query.Where(sq.Eq{"UserId": userId})
 	}
-	sql, args, _ := query.ToSql()
+	sql, args, err := query.ToSql()
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "CountPostsAfter_ToSql1")
+	}
 
 	var unread int64
-	err := s.GetReplicaX().Get(&unread, sql, args...)
+	err = s.GetReplicaX().Get(&unread, sql, args...)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "failed to count Posts")
 	}
-	sql2, args2, _ := query.Where(sq.Eq{"RootId": ""}).ToSql()
+	sql2, args2, err := query.Where(sq.Eq{"RootId": ""}).ToSql()
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "CountPostsAfter_ToSql2")
+	}
 
 	var unreadRoot int64
 	err = s.GetReplicaX().Get(&unreadRoot, sql2, args2...)
@@ -2766,13 +2771,13 @@ func (s SqlChannelStore) AnalyticsTypeCount(teamId string, channelType model.Cha
 
 	sql, args, err := query.ToSql()
 	if err != nil {
-		return int64(0), errors.Wrap(err, "AnalyticsTypeCount_tosql")
+		return 0, errors.Wrap(err, "AnalyticsTypeCount_ToSql")
 	}
 
 	var value int64
 	err = s.GetReplicaX().Get(&value, sql, args...)
 	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to count Channels")
+		return 0, errors.Wrap(err, "failed to count Channels")
 	}
 	return value, nil
 }
@@ -2792,7 +2797,7 @@ func (s SqlChannelStore) AnalyticsDeletedTypeCount(teamId string, channelType mo
 
 	sql, args, err := query.ToSql()
 	if err != nil {
-		return int64(0), errors.Wrap(err, "AnalyticsDeletedTypeCount_tosql")
+		return 0, errors.Wrap(err, "AnalyticsDeletedTypeCount_ToSql")
 	}
 
 	var v int64
@@ -3195,16 +3200,14 @@ func (s SqlChannelStore) SearchArchivedInTeam(teamId string, term string, userId
 					Where(sq.Eq{"UserId": userId})),
 			})
 
-	publicChannels, publicErr := s.performSearch(publicQuery, term)
-	privateChannels, privateErr := s.performSearch(privateQuery, term)
-
-	outputErr := publicErr
-	if privateErr != nil {
-		outputErr = privateErr
+	publicChannels, err := s.performSearch(publicQuery, term)
+	if err != nil {
+		return nil, err
 	}
 
-	if outputErr != nil {
-		return nil, outputErr
+	privateChannels, err := s.performSearch(privateQuery, term)
+	if err != nil {
+		return nil, err
 	}
 
 	output := publicChannels
@@ -3740,14 +3743,13 @@ func (s SqlChannelStore) GetChannelsByScheme(schemeId string, offset int, limit 
 // in batches as a single transaction per batch to ensure consistency but to also minimise execution time to avoid
 // causing unnecessary table locks. **THIS FUNCTION SHOULD NOT BE USED FOR ANY OTHER PURPOSE.** Executing this function
 // *after* the new Schemes functionality has been used on an installation will have unintended consequences.
-func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId string) (map[string]string, error) {
+func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId string) (data map[string]string, err error) {
 	var transaction *sqlxTxWrapper
-	var err error
 
 	if transaction, err = s.GetMasterX().Beginx(); err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	channelMembers := []channelMember{}
 	if err := transaction.Select(&channelMembers, "SELECT * from ChannelMembers WHERE (ChannelId, UserId) > (?, ?) ORDER BY ChannelId, UserId LIMIT 100", fromChannelId, fromUserId); err != nil {
@@ -3807,18 +3809,18 @@ func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId 
 		return nil, errors.Wrap(err, "commit_transaction")
 	}
 
-	data := make(map[string]string)
+	data = make(map[string]string)
 	data["ChannelId"] = channelMembers[len(channelMembers)-1].ChannelId
 	data["UserId"] = channelMembers[len(channelMembers)-1].UserId
 	return data, nil
 }
 
-func (s SqlChannelStore) ResetAllChannelSchemes() error {
+func (s SqlChannelStore) ResetAllChannelSchemes() (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	err = s.resetAllChannelSchemesT(transaction)
 	if err != nil {
@@ -3840,14 +3842,13 @@ func (s SqlChannelStore) resetAllChannelSchemesT(transaction *sqlxTxWrapper) err
 	return nil
 }
 
-func (s SqlChannelStore) ClearAllCustomRoleAssignments() error {
+func (s SqlChannelStore) ClearAllCustomRoleAssignments() (err error) {
 	builtInRoles := model.MakeDefaultRoles()
 	lastUserId := strings.Repeat("0", 26)
 	lastChannelId := strings.Repeat("0", 26)
 
 	for {
 		var transaction *sqlxTxWrapper
-		var err error
 
 		if transaction, err = s.GetMasterX().Beginx(); err != nil {
 			return errors.Wrap(err, "begin_transaction")
@@ -3855,12 +3856,12 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() error {
 
 		channelMembers := []*channelMember{}
 		if err := transaction.Select(&channelMembers, "SELECT * from ChannelMembers WHERE (ChannelId, UserId) > (?, ?) ORDER BY ChannelId, UserId LIMIT 1000", lastChannelId, lastUserId); err != nil {
-			finalizeTransactionX(transaction)
+			finalizeTransactionX(transaction, &err)
 			return errors.Wrap(err, "failed to find ChannelMembers")
 		}
 
 		if len(channelMembers) == 0 {
-			finalizeTransactionX(transaction)
+			finalizeTransactionX(transaction, &err)
 			break
 		}
 
@@ -3881,15 +3882,15 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() error {
 
 			newRolesString := strings.Join(newRoles, " ")
 			if newRolesString != member.Roles {
-				if _, err := transaction.Exec("UPDATE ChannelMembers SET Roles = ? WHERE UserId = ? AND ChannelId = ?", newRolesString, member.UserId, member.ChannelId); err != nil {
-					finalizeTransactionX(transaction)
+				if _, err = transaction.Exec("UPDATE ChannelMembers SET Roles = ? WHERE UserId = ? AND ChannelId = ?", newRolesString, member.UserId, member.ChannelId); err != nil {
+					finalizeTransactionX(transaction, &err)
 					return errors.Wrap(err, "failed to update ChannelMembers")
 				}
 			}
 		}
 
-		if err := transaction.Commit(); err != nil {
-			finalizeTransactionX(transaction)
+		if err = transaction.Commit(); err != nil {
+			finalizeTransactionX(transaction, &err)
 			return errors.Wrap(err, "commit_transaction")
 		}
 	}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1557,7 +1557,7 @@ func (s SqlChannelStore) getByName(teamId string, name string, includeDeleted bo
 		return nil, errors.Wrapf(err, "getByName_tosql")
 	}
 
-	if err := s.GetReplicaX().Get(&channel, queryStr, args...); err != nil {
+	if err = s.GetReplicaX().Get(&channel, queryStr, args...); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, store.NewErrNotFound("Channel", fmt.Sprintf("TeamId=%s&Name=%s", teamId, name))
 		}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1564,7 +1564,8 @@ func (s SqlChannelStore) getByName(teamId string, name string, includeDeleted bo
 		return nil, errors.Wrapf(err, "failed to find channel with TeamId=%s and Name=%s", teamId, name)
 	}
 
-	return &channel, channelByNameCache.SetWithExpiry(teamId+name, &channel, ChannelCacheDuration)
+	err = channelByNameCache.SetWithExpiry(teamId+name, &channel, ChannelCacheDuration)
+	return &channel, err
 }
 
 func (s SqlChannelStore) GetDeletedByName(teamId string, name string) (*model.Channel, error) {

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3855,7 +3855,7 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() (err error) {
 		}
 
 		channelMembers := []*channelMember{}
-		if err := transaction.Select(&channelMembers, "SELECT * from ChannelMembers WHERE (ChannelId, UserId) > (?, ?) ORDER BY ChannelId, UserId LIMIT 1000", lastChannelId, lastUserId); err != nil {
+		if err = transaction.Select(&channelMembers, "SELECT * from ChannelMembers WHERE (ChannelId, UserId) > (?, ?) ORDER BY ChannelId, UserId LIMIT 1000", lastChannelId, lastUserId); err != nil {
 			finalizeTransactionX(transaction, &err)
 			return errors.Wrap(err, "failed to find ChannelMembers")
 		}

--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -20,7 +20,7 @@ type dbSelecter interface {
 	Select(i any, query string, args ...any) error
 }
 
-func (s SqlChannelStore) CreateInitialSidebarCategories(userId string, opts *store.SidebarCategorySearchOpts) (categories *model.OrderedSidebarCategories, err error) {
+func (s SqlChannelStore) CreateInitialSidebarCategories(userId string, opts *store.SidebarCategorySearchOpts) (_ *model.OrderedSidebarCategories, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "CreateInitialSidebarCategories: begin_transaction")
@@ -249,7 +249,7 @@ func (s SqlChannelStore) migrateFavoritesToSidebarT(transaction *sqlxTxWrapper, 
 
 // MigrateFavoritesToSidebarChannels populates the SidebarChannels table by analyzing existing user preferences for favorites
 // **IMPORTANT** This function should only be called from the migration task and shouldn't be used by itself
-func (s SqlChannelStore) MigrateFavoritesToSidebarChannels(lastUserId string, runningOrder int64) (data map[string]any, err error) {
+func (s SqlChannelStore) MigrateFavoritesToSidebarChannels(lastUserId string, runningOrder int64) (_ map[string]any, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (s SqlChannelStore) MigrateFavoritesToSidebarChannels(lastUserId string, ru
 		return nil, nil
 	}
 
-	data = make(map[string]any)
+	data := make(map[string]any)
 	data["UserId"] = userFavorites[len(userFavorites)-1].UserId
 	data["SortOrder"] = runningOrder
 	return data, nil
@@ -296,7 +296,7 @@ type sidebarCategoryForJoin struct {
 	ChannelId *string
 }
 
-func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategory *model.SidebarCategoryWithChannels) (categories *model.SidebarCategoryWithChannels, err error) {
+func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategory *model.SidebarCategoryWithChannels) (_ *model.SidebarCategoryWithChannels, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
@@ -418,7 +418,7 @@ func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategor
 	return result, nil
 }
 
-func (s SqlChannelStore) completePopulatingCategoryChannels(category *model.SidebarCategoryWithChannels) (categories *model.SidebarCategoryWithChannels, err error) {
+func (s SqlChannelStore) completePopulatingCategoryChannels(category *model.SidebarCategoryWithChannels) (_ *model.SidebarCategoryWithChannels, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
@@ -958,7 +958,7 @@ func (s SqlChannelStore) addChannelToFavoritesCategoryT(transaction *sqlxTxWrapp
 	}
 
 	categoryIds := []string{}
-	if err := transaction.Select(&categoryIds, idsQuery, idsParams...); err != nil {
+	if err = transaction.Select(&categoryIds, idsQuery, idsParams...); err != nil {
 		return errors.Wrap(err, "Failed to get Favorites sidebar categories")
 	}
 

--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -20,12 +20,12 @@ type dbSelecter interface {
 	Select(i any, query string, args ...any) error
 }
 
-func (s SqlChannelStore) CreateInitialSidebarCategories(userId string, opts *store.SidebarCategorySearchOpts) (*model.OrderedSidebarCategories, error) {
+func (s SqlChannelStore) CreateInitialSidebarCategories(userId string, opts *store.SidebarCategorySearchOpts) (categories *model.OrderedSidebarCategories, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "CreateInitialSidebarCategories: begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	teamsWithExclude, err := s.SqlStore.stores.team.GetTeamsForUser(context.Background(), userId, opts.TeamID, false)
 	if err != nil {
@@ -184,11 +184,13 @@ func (s SqlChannelStore) migrateMembershipToSidebar(transaction *sqlxTxWrapper, 
 	}
 
 	for _, favorite := range memberships {
-		sql, args, _ := s.getQueryBuilder().
+		sql, args, err := s.getQueryBuilder().
 			Insert("SidebarChannels").
 			Columns("ChannelId", "UserId", "CategoryId", "SortOrder").
 			Values(favorite.ChannelId, favorite.UserId, favorite.CategoryId, *runningOrder).ToSql()
-
+		if err != nil {
+			return nil, err
+		}
 		if _, err := transaction.Exec(sql, args...); err != nil && !IsUniqueConstraintError(err, []string{"UserId", "PRIMARY"}) {
 			return nil, err
 		}
@@ -202,7 +204,7 @@ func (s SqlChannelStore) migrateMembershipToSidebar(transaction *sqlxTxWrapper, 
 }
 
 func (s SqlChannelStore) migrateFavoritesToSidebarT(transaction *sqlxTxWrapper, userId, teamId, favoritesCategoryId string) error {
-	favoritesQuery, favoritesParams, _ := s.getQueryBuilder().
+	favoritesQuery, favoritesParams, err := s.getQueryBuilder().
 		Select("Preferences.Name").
 		From("Preferences").
 		Join("Channels on Preferences.Name = Channels.Id").
@@ -220,6 +222,9 @@ func (s SqlChannelStore) migrateFavoritesToSidebarT(transaction *sqlxTxWrapper, 
 			"Channels.DisplayName",
 			"Channels.Name ASC",
 		).ToSql()
+	if err != nil {
+		return err
+	}
 
 	favoriteChannelIds := []string{}
 	if err := transaction.Select(&favoriteChannelIds, favoritesQuery, favoritesParams...); err != nil {
@@ -244,13 +249,13 @@ func (s SqlChannelStore) migrateFavoritesToSidebarT(transaction *sqlxTxWrapper, 
 
 // MigrateFavoritesToSidebarChannels populates the SidebarChannels table by analyzing existing user preferences for favorites
 // **IMPORTANT** This function should only be called from the migration task and shouldn't be used by itself
-func (s SqlChannelStore) MigrateFavoritesToSidebarChannels(lastUserId string, runningOrder int64) (map[string]any, error) {
+func (s SqlChannelStore) MigrateFavoritesToSidebarChannels(lastUserId string, runningOrder int64) (data map[string]any, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, err
 	}
 
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	sb := s.
 		getQueryBuilder().
@@ -280,7 +285,7 @@ func (s SqlChannelStore) MigrateFavoritesToSidebarChannels(lastUserId string, ru
 		return nil, nil
 	}
 
-	data := make(map[string]any)
+	data = make(map[string]any)
 	data["UserId"] = userFavorites[len(userFavorites)-1].UserId
 	data["SortOrder"] = runningOrder
 	return data, nil
@@ -291,13 +296,13 @@ type sidebarCategoryForJoin struct {
 	ChannelId *string
 }
 
-func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategory *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
+func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategory *model.SidebarCategoryWithChannels) (categories *model.SidebarCategoryWithChannels, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
 
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	opts := &store.SidebarCategorySearchOpts{
 		TeamID:      teamId,
@@ -413,12 +418,12 @@ func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategor
 	return result, nil
 }
 
-func (s SqlChannelStore) completePopulatingCategoryChannels(category *model.SidebarCategoryWithChannels) (*model.SidebarCategoryWithChannels, error) {
+func (s SqlChannelStore) completePopulatingCategoryChannels(category *model.SidebarCategoryWithChannels) (categories *model.SidebarCategoryWithChannels, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	result, err := s.completePopulatingCategoryChannelsT(transaction, category)
 	if err != nil {
@@ -480,7 +485,7 @@ func (s SqlChannelStore) completePopulatingCategoryChannelsT(db dbSelecter, cate
 	}
 
 	if err := db.Select(&channels, sql, args...); err != nil {
-		return nil, store.NewErrNotFound("ChannelMembers", "<too many fields>")
+		return nil, store.NewErrNotFound("ChannelMembers", "<too many fields>").Wrap(err)
 	}
 
 	category.Channels = append(channels, category.Channels...)
@@ -500,7 +505,7 @@ func (s SqlChannelStore) GetSidebarCategory(categoryId string) (*model.SidebarCa
 
 	categories := []*sidebarCategoryForJoin{}
 	if err = s.GetReplicaX().Select(&categories, sql, args...); err != nil {
-		return nil, store.NewErrNotFound("SidebarCategories", categoryId)
+		return nil, store.NewErrNotFound("SidebarCategories", categoryId).Wrap(err)
 	}
 
 	if len(categories) == 0 {
@@ -547,7 +552,7 @@ func (s SqlChannelStore) getSidebarCategoriesT(db dbSelecter, userId string, opt
 	}
 
 	if err := db.Select(&categories, sql, args...); err != nil {
-		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, opts.TeamID))
+		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, opts.TeamID)).Wrap(err)
 	}
 
 	for _, category := range categories {
@@ -608,7 +613,7 @@ func (s SqlChannelStore) GetSidebarCategoryOrder(userId, teamId string) ([]strin
 	}
 
 	if err := s.GetReplicaX().Select(&ids, sql, args...); err != nil {
-		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, teamId))
+		return nil, store.NewErrNotFound("SidebarCategories", fmt.Sprintf("userId=%s,teamId=%s", userId, teamId)).Wrap(err)
 	}
 
 	return ids, nil
@@ -633,13 +638,13 @@ func (s SqlChannelStore) updateSidebarCategoryOrderT(transaction *sqlxTxWrapper,
 	return nil
 }
 
-func (s SqlChannelStore) UpdateSidebarCategoryOrder(userId, teamId string, categoryOrder []string) error {
+func (s SqlChannelStore) UpdateSidebarCategoryOrder(userId, teamId string, categoryOrder []string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
 
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	// Ensure no invalid categories are included and that no categories are left out
 	existingOrder, err := s.GetSidebarCategoryOrder(userId, teamId)
@@ -676,12 +681,12 @@ func (s SqlChannelStore) UpdateSidebarCategoryOrder(userId, teamId string, categ
 }
 
 //nolint:unparam
-func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categories []*model.SidebarCategoryWithChannels) ([]*model.SidebarCategoryWithChannels, []*model.SidebarCategoryWithChannels, error) {
+func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categories []*model.SidebarCategoryWithChannels) (updated []*model.SidebarCategoryWithChannels, original []*model.SidebarCategoryWithChannels, err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	updatedCategories := []*model.SidebarCategoryWithChannels{}
 	originalCategories := []*model.SidebarCategoryWithChannels{}
@@ -719,14 +724,16 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 		// The net effect remains the same, but it prevents deadlocks from other transactions
 		// operating on the tables in reverse order.
 
-		updateQuery, updateParams, _ := s.getQueryBuilder().
+		updateQuery, updateParams, err2 := s.getQueryBuilder().
 			Update("SidebarCategories").
 			Set("DisplayName", destCategory.DisplayName).
 			Set("Sorting", destCategory.Sorting).
 			Set("Muted", destCategory.Muted).
 			Set("Collapsed", destCategory.Collapsed).
 			Where(sq.Eq{"Id": destCategory.Id}).ToSql()
-
+		if err2 != nil {
+			return nil, nil, errors.Wrap(err2, "update_sidebar_categories_tosql1")
+		}
 		if _, err = transaction.Exec(updateQuery, updateParams...); err != nil {
 			return nil, nil, errors.Wrap(err, "failed to update SidebarCategories")
 		}
@@ -746,7 +753,7 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 				).ToSql()
 
 			if err2 != nil {
-				return nil, nil, errors.Wrap(err2, "update_sidebar_categories_tosql")
+				return nil, nil, errors.Wrap(err2, "update_sidebar_categories_tosql2")
 			}
 
 			if _, err = transaction.Exec(query, args...); err != nil {
@@ -777,13 +784,16 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 		// Update the favorites preferences based on channels moving into or out of the Favorites category for compatibility
 		if category.Type == model.SidebarCategoryFavorites {
 			// Remove any old favorites
-			sql, args, _ := s.getQueryBuilder().Delete("Preferences").Where(
+			sql, args, err2 := s.getQueryBuilder().Delete("Preferences").Where(
 				sq.Eq{
 					"UserId":   userId,
 					"Name":     srcCategory.Channels,
 					"Category": model.PreferenceCategoryFavoriteChannel,
 				},
 			).ToSql()
+			if err2 != nil {
+				return nil, nil, errors.Wrap(err2, "UpdateSidebarChannels_Tosql_DeletePreferences")
+			}
 
 			if _, err = transaction.Exec(sql, args...); err != nil {
 				return nil, nil, errors.Wrap(err, "failed to delete Preferences")
@@ -843,12 +853,12 @@ func (s SqlChannelStore) UpdateSidebarCategories(userId, teamId string, categori
 
 // UpdateSidebarChannelsByPreferences is called when the Preference table is being updated to keep SidebarCategories in sync
 // At the moment, it's only handling Favorites and NOT DMs/GMs (those will be handled client side)
-func (s SqlChannelStore) UpdateSidebarChannelsByPreferences(preferences model.Preferences) error {
+func (s SqlChannelStore) UpdateSidebarChannelsByPreferences(preferences model.Preferences) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "UpdateSidebarChannelsByPreferences: begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	for _, preference := range preferences {
 		preference := preference
@@ -942,7 +952,10 @@ func (s SqlChannelStore) addChannelToFavoritesCategoryT(transaction *sqlxTxWrapp
 		builder = builder.Where(sq.Eq{"TeamId": channel.TeamId})
 	}
 
-	idsQuery, idsParams, _ := builder.ToSql()
+	idsQuery, idsParams, err := builder.ToSql()
+	if err != nil {
+		return errors.Wrap(err, "addChannelToFavoritesCategoryT_ToSql_Select")
+	}
 
 	categoryIds := []string{}
 	if err := transaction.Select(&categoryIds, idsQuery, idsParams...); err != nil {
@@ -956,7 +969,7 @@ func (s SqlChannelStore) addChannelToFavoritesCategoryT(transaction *sqlxTxWrapp
 
 	// For each category ID, insert a row into SidebarChannels with the given channel ID and a SortOrder that's less than
 	// all existing SortOrders in the category so that the newly favorited channel comes first
-	insertQuery, insertParams, _ := s.getQueryBuilder().
+	insertQuery, insertParams, err := s.getQueryBuilder().
 		Insert("SidebarChannels").
 		Columns(
 			"ChannelId",
@@ -976,7 +989,9 @@ func (s SqlChannelStore) addChannelToFavoritesCategoryT(transaction *sqlxTxWrapp
 					"SidebarCategories.Id": categoryIds,
 				}).
 				GroupBy("SidebarCategories.Id")).ToSql()
-
+	if err != nil {
+		return errors.Wrap(err, "addChannelToFavoritesCategoryT_ToSql_Insert")
+	}
 	if _, err := transaction.Exec(insertQuery, insertParams...); err != nil {
 		return errors.Wrap(err, "Failed to add sidebar entries for favorited channel")
 	}
@@ -986,12 +1001,12 @@ func (s SqlChannelStore) addChannelToFavoritesCategoryT(transaction *sqlxTxWrapp
 
 // DeleteSidebarChannelsByPreferences is called when the Preference table is being updated to keep SidebarCategories in sync
 // At the moment, it's only handling Favorites and NOT DMs/GMs (those will be handled client side)
-func (s SqlChannelStore) DeleteSidebarChannelsByPreferences(preferences model.Preferences) error {
+func (s SqlChannelStore) DeleteSidebarChannelsByPreferences(preferences model.Preferences) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "DeleteSidebarChannelsByPreferences: begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	for _, preference := range preferences {
 		preference := preference
@@ -1053,12 +1068,12 @@ func (s SqlChannelStore) ClearSidebarOnTeamLeave(userId, teamId string) error {
 
 // DeleteSidebarCategory removes a custom category and moves any channels into it into the Channels and Direct Messages
 // categories respectively. Assumes that the provided user ID and team ID match the given category ID.
-func (s SqlChannelStore) DeleteSidebarCategory(categoryId string) error {
+func (s SqlChannelStore) DeleteSidebarCategory(categoryId string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	// Ensure that we're deleting a custom category
 	var category model.SidebarCategory

--- a/store/sqlstore/cluster_discovery_store.go
+++ b/store/sqlstore/cluster_discovery_store.go
@@ -59,10 +59,7 @@ func (s sqlClusterDiscoveryStore) Delete(ClusterDiscovery *model.ClusterDiscover
 		return false, errors.Wrap(err, "failed to count rows affected")
 	}
 
-	if count == 0 {
-		return false, nil
-	}
-	return true, nil
+	return count != 0, nil
 }
 
 func (s sqlClusterDiscoveryStore) Exists(ClusterDiscovery *model.ClusterDiscovery) (bool, error) {
@@ -82,10 +79,8 @@ func (s sqlClusterDiscoveryStore) Exists(ClusterDiscovery *model.ClusterDiscover
 	if err := s.GetMasterX().Get(&count, queryString, args...); err != nil {
 		return false, errors.Wrap(err, "failed to count ClusterDiscovery")
 	}
-	if count == 0 {
-		return false, nil
-	}
-	return true, nil
+
+	return count != 0, nil
 }
 
 func (s sqlClusterDiscoveryStore) GetAll(ClusterDiscoveryType, clusterName string) ([]*model.ClusterDiscovery, error) {

--- a/store/sqlstore/command_webhook_store.go
+++ b/store/sqlstore/command_webhook_store.go
@@ -82,8 +82,8 @@ func (s SqlCommandWebhookStore) TryUse(id string, limit int) error {
 
 	if sqlResult, err := s.GetMasterX().Exec(queryString, args...); err != nil {
 		return errors.Wrapf(err, "tryuse: id=%s limit=%d", id, limit)
-	} else if rows, _ := sqlResult.RowsAffected(); rows == 0 {
-		return store.NewErrInvalidInput("CommandWebhook", "id", id)
+	} else if rows, err := sqlResult.RowsAffected(); rows == 0 {
+		return store.NewErrInvalidInput("CommandWebhook", "id", id).Wrap(err)
 	}
 
 	return nil

--- a/store/sqlstore/emoji_store.go
+++ b/store/sqlstore/emoji_store.go
@@ -99,8 +99,8 @@ func (es SqlEmojiStore) Delete(emoji *model.Emoji, time int64) error {
 			Id = ?
 			AND DeleteAt = 0`, time, time, emoji.Id); err != nil {
 		return errors.Wrap(err, "could not delete emoji")
-	} else if rows, _ := sqlResult.RowsAffected(); rows == 0 {
-		return store.NewErrNotFound("Emoji", emoji.Id)
+	} else if rows, err := sqlResult.RowsAffected(); rows == 0 {
+		return store.NewErrNotFound("Emoji", emoji.Id).Wrap(err)
 	}
 
 	return nil

--- a/store/sqlstore/group_store.go
+++ b/store/sqlstore/group_store.go
@@ -81,18 +81,18 @@ func (s *SqlGroupStore) Create(group *model.Group) (*model.Group, error) {
 	return group, nil
 }
 
-func (s *SqlGroupStore) CreateWithUserIds(g *model.GroupWithUserIds) (grp *model.Group, err error) {
+func (s *SqlGroupStore) CreateWithUserIds(g *model.GroupWithUserIds) (_ *model.Group, err error) {
 	if g.Id != "" {
 		return nil, store.NewErrInvalidInput("Group", "id", g.Id)
 	}
 
 	// Check if group values are formatted correctly
-	if err := g.IsValidForCreate(); err != nil {
-		return nil, err
+	if appErr := g.IsValidForCreate(); appErr != nil {
+		return nil, appErr
 	}
 
 	// Check Users exist
-	if err := s.checkUsersExist(g.UserIds); err != nil {
+	if err = s.checkUsersExist(g.UserIds); err != nil {
 		return nil, err
 	}
 

--- a/store/sqlstore/integrity.go
+++ b/store/sqlstore/integrity.go
@@ -52,9 +52,12 @@ func getOrphanedRecords(ss *SqlStore, cfg relationalCheckConfig) ([]model.Orphan
 		main = main.OrderBy("CT." + cfg.parentIdAttr)
 	}
 
-	query, args, _ := main.ToSql()
+	query, args, err := main.ToSql()
+	if err != nil {
+		return nil, err
+	}
 
-	err := ss.GetMasterX().Select(&records, query, args...)
+	err = ss.GetMasterX().Select(&records, query, args...)
 	return records, err
 }
 

--- a/store/sqlstore/oauth_store.go
+++ b/store/sqlstore/oauth_store.go
@@ -124,13 +124,13 @@ func (as SqlOAuthStore) GetAuthorizedApps(userId string, offset, limit int) ([]*
 	return apps, nil
 }
 
-func (as SqlOAuthStore) DeleteApp(id string) error {
+func (as SqlOAuthStore) DeleteApp(id string) (err error) {
 	// wrap in a transaction so that if one fails, everything fails
 	transaction, err := as.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	if err := as.deleteApp(transaction, id); err != nil {
 		return err

--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -387,7 +387,7 @@ func (s *SqlPostStore) Update(newPost *model.Post, oldPost *model.Post) (*model.
 	return newPost, nil
 }
 
-func (s *SqlPostStore) OverwriteMultiple(posts []*model.Post) (psts []*model.Post, index int, err error) {
+func (s *SqlPostStore) OverwriteMultiple(posts []*model.Post) (_ []*model.Post, _ int, err error) {
 	updateAt := model.GetMillis()
 	maxPostSize := s.GetMaxPostSize()
 	for idx, post := range posts {
@@ -3178,7 +3178,7 @@ func (s *SqlPostStore) SetPostReminder(reminder *model.PostReminder) error {
 	return nil
 }
 
-func (s *SqlPostStore) GetPostReminders(now int64) (prs []*model.PostReminder, err error) {
+func (s *SqlPostStore) GetPostReminders(now int64) (_ []*model.PostReminder, err error) {
 	reminders := []*model.PostReminder{}
 
 	transaction, err := s.GetMasterX().Beginx()

--- a/store/sqlstore/preference_store.go
+++ b/store/sqlstore/preference_store.go
@@ -29,21 +29,21 @@ func (s SqlPreferenceStore) deleteUnusedFeatures() {
 		Where(sq.Eq{"Value": "false"}).
 		Where(sq.Like{"Name": store.FeatureTogglePrefix + "%"}).ToSql()
 	if err != nil {
-		mlog.Warn(errors.Wrap(err, "could not build sql query to delete unused features!").Error())
+		mlog.Warn("Could not build sql query to delete unused features", mlog.Err(err))
 	}
 	if _, err = s.GetMasterX().Exec(sql, args...); err != nil {
 		mlog.Warn("Failed to delete unused features", mlog.Err(err))
 	}
 }
 
-func (s SqlPreferenceStore) Save(preferences model.Preferences) error {
+func (s SqlPreferenceStore) Save(preferences model.Preferences) (err error) {
 	// wrap in a transaction so that if one fails, everything fails
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
 
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 	for _, preference := range preferences {
 		preference := preference
 		if upsertErr := s.saveTx(transaction, &preference); upsertErr != nil {

--- a/store/sqlstore/product_notices_store.go
+++ b/store/sqlstore/product_notices_store.go
@@ -49,19 +49,22 @@ func (s SqlProductNoticesStore) ClearOldNotices(currentNotices model.ProductNoti
 	return nil
 }
 
-func (s SqlProductNoticesStore) View(userId string, notices []string) error {
+func (s SqlProductNoticesStore) View(userId string, notices []string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	noticeStates := []model.ProductNoticeViewState{}
-	sql, args, _ := s.getQueryBuilder().
+	sql, args, err := s.getQueryBuilder().
 		Select("*").
 		From("ProductNoticeViewState").
 		Where(sq.And{sq.Eq{"UserId": userId}, sq.Eq{"NoticeId": notices}}).
 		ToSql()
+	if err != nil {
+		return errors.Wrap(err, "View_ToSql")
+	}
 	if err := transaction.Select(&noticeStates, sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to get ProductNoticeViewState with userId=%s", userId)
 	}

--- a/store/sqlstore/retention_policy_store.go
+++ b/store/sqlstore/retention_policy_store.go
@@ -39,7 +39,7 @@ func executePossiblyEmptyQuery(txn *sqlxTxWrapper, query string, args ...any) (s
 	return txn.Exec(query, args...)
 }
 
-func (s *SqlRetentionPolicyStore) Save(policy *model.RetentionPolicyWithTeamAndChannelIDs) (*model.RetentionPolicyWithTeamAndChannelCounts, error) {
+func (s *SqlRetentionPolicyStore) Save(policy *model.RetentionPolicyWithTeamAndChannelIDs) (pol *model.RetentionPolicyWithTeamAndChannelCounts, err error) {
 	// Strategy:
 	// 1. Insert new policy
 	// 2. Insert new channels into policy
@@ -82,7 +82,8 @@ func (s *SqlRetentionPolicyStore) Save(policy *model.RetentionPolicyWithTeamAndC
 	if err != nil {
 		return nil, err
 	}
-	defer finalizeTransactionX(txn)
+	defer finalizeTransactionX(txn, &err)
+
 	// Create a new policy in RetentionPolicies
 	if _, err = txn.Exec(policyInsertQuery, policyInsertArgs...); err != nil {
 		return nil, err
@@ -195,7 +196,7 @@ func (s *SqlRetentionPolicyStore) buildInsertRetentionPoliciesTeamsQuery(policyI
 	return
 }
 
-func (s *SqlRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithTeamAndChannelIDs) (*model.RetentionPolicyWithTeamAndChannelCounts, error) {
+func (s *SqlRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithTeamAndChannelIDs) (pol *model.RetentionPolicyWithTeamAndChannelCounts, err error) {
 	// Strategy:
 	// 1. Update policy attributes
 	// 2. Delete existing channels from policy
@@ -204,7 +205,6 @@ func (s *SqlRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithTeamAndC
 	// 5. Insert new teams into policy
 	// 6. Read new policy
 
-	var err error
 	if err = s.checkTeamsExist(patch.TeamIDs); err != nil {
 		return nil, err
 	}
@@ -277,7 +277,8 @@ func (s *SqlRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithTeamAndC
 	if err != nil {
 		return nil, err
 	}
-	defer finalizeTransactionX(txn)
+	defer finalizeTransactionX(txn, &err)
+
 	// Update the fields of the policy in RetentionPolicies
 	if _, err = executePossiblyEmptyQuery(txn, policyUpdateQuery, policyUpdateArgs...); err != nil {
 		return nil, err
@@ -638,7 +639,7 @@ func (s *SqlRetentionPolicyStore) RemoveTeams(policyId string, teamIds []string)
 }
 
 func subQueryIN(property string, query sq.SelectBuilder) sq.Sqlizer {
-	queryString, args, _ := query.ToSql()
+	queryString, args := query.MustSql()
 	subQuery := fmt.Sprintf("%s IN (SELECT * FROM (%s) AS A)", property, queryString)
 	return sq.Expr(subQuery, args...)
 }

--- a/store/sqlstore/retention_policy_store.go
+++ b/store/sqlstore/retention_policy_store.go
@@ -39,16 +39,16 @@ func executePossiblyEmptyQuery(txn *sqlxTxWrapper, query string, args ...any) (s
 	return txn.Exec(query, args...)
 }
 
-func (s *SqlRetentionPolicyStore) Save(policy *model.RetentionPolicyWithTeamAndChannelIDs) (pol *model.RetentionPolicyWithTeamAndChannelCounts, err error) {
+func (s *SqlRetentionPolicyStore) Save(policy *model.RetentionPolicyWithTeamAndChannelIDs) (_ *model.RetentionPolicyWithTeamAndChannelCounts, err error) {
 	// Strategy:
 	// 1. Insert new policy
 	// 2. Insert new channels into policy
 	// 3. Insert new teams into policy
 
-	if err := s.checkTeamsExist(policy.TeamIDs); err != nil {
+	if err = s.checkTeamsExist(policy.TeamIDs); err != nil {
 		return nil, err
 	}
-	if err := s.checkChannelsExist(policy.ChannelIDs); err != nil {
+	if err = s.checkChannelsExist(policy.ChannelIDs); err != nil {
 		return nil, err
 	}
 
@@ -196,7 +196,7 @@ func (s *SqlRetentionPolicyStore) buildInsertRetentionPoliciesTeamsQuery(policyI
 	return
 }
 
-func (s *SqlRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithTeamAndChannelIDs) (pol *model.RetentionPolicyWithTeamAndChannelCounts, err error) {
+func (s *SqlRetentionPolicyStore) Patch(patch *model.RetentionPolicyWithTeamAndChannelIDs) (_ *model.RetentionPolicyWithTeamAndChannelCounts, err error) {
 	// Strategy:
 	// 1. Update policy attributes
 	// 2. Delete existing channels from policy

--- a/store/sqlstore/role_store.go
+++ b/store/sqlstore/role_store.go
@@ -86,22 +86,22 @@ func newSqlRoleStore(sqlStore *SqlStore) store.RoleStore {
 	return &SqlRoleStore{sqlStore}
 }
 
-func (s *SqlRoleStore) Save(role *model.Role) (ro *model.Role, err error) {
+func (s *SqlRoleStore) Save(role *model.Role) (_ *model.Role, err error) {
 	// Check the role is valid before proceeding.
 	if !role.IsValidWithoutId() {
 		return nil, store.NewErrInvalidInput("Role", "<any>", fmt.Sprintf("%v", role))
 	}
 
 	if role.Id == "" {
-		transaction, err := s.GetMasterX().Beginx()
-		if err != nil {
-			return nil, errors.Wrap(err, "begin_transaction")
+		transaction, terr := s.GetMasterX().Beginx()
+		if terr != nil {
+			return nil, errors.Wrap(terr, "begin_transaction")
 		}
-		defer finalizeTransactionX(transaction, &err)
+		defer finalizeTransactionX(transaction, &terr)
 
-		createdRole, err := s.createRole(role, transaction)
-		if err != nil {
-			return nil, errors.Wrap(err, "unable to create Role")
+		createdRole, terr := s.createRole(role, transaction)
+		if terr != nil {
+			return nil, errors.Wrap(terr, "unable to create Role")
 		} else if err := transaction.Commit(); err != nil {
 			return nil, errors.Wrap(err, "commit_transaction")
 		}

--- a/store/sqlstore/role_store.go
+++ b/store/sqlstore/role_store.go
@@ -86,7 +86,7 @@ func newSqlRoleStore(sqlStore *SqlStore) store.RoleStore {
 	return &SqlRoleStore{sqlStore}
 }
 
-func (s *SqlRoleStore) Save(role *model.Role) (*model.Role, error) {
+func (s *SqlRoleStore) Save(role *model.Role) (ro *model.Role, err error) {
 	// Check the role is valid before proceeding.
 	if !role.IsValidWithoutId() {
 		return nil, store.NewErrInvalidInput("Role", "<any>", fmt.Sprintf("%v", role))
@@ -97,10 +97,10 @@ func (s *SqlRoleStore) Save(role *model.Role) (*model.Role, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "begin_transaction")
 		}
-		defer finalizeTransactionX(transaction)
+		defer finalizeTransactionX(transaction, &err)
+
 		createdRole, err := s.createRole(role, transaction)
 		if err != nil {
-			_ = transaction.Rollback()
 			return nil, errors.Wrap(err, "unable to create Role")
 		} else if err := transaction.Commit(); err != nil {
 			return nil, errors.Wrap(err, "commit_transaction")

--- a/store/sqlstore/role_store.go
+++ b/store/sqlstore/role_store.go
@@ -102,8 +102,8 @@ func (s *SqlRoleStore) Save(role *model.Role) (_ *model.Role, err error) {
 		createdRole, terr := s.createRole(role, transaction)
 		if terr != nil {
 			return nil, errors.Wrap(terr, "unable to create Role")
-		} else if err := transaction.Commit(); err != nil {
-			return nil, errors.Wrap(err, "commit_transaction")
+		} else if terr = transaction.Commit(); terr != nil {
+			return nil, errors.Wrap(terr, "commit_transaction")
 		}
 		return createdRole, nil
 	}

--- a/store/sqlstore/scheme_store.go
+++ b/store/sqlstore/scheme_store.go
@@ -22,20 +22,20 @@ func newSqlSchemeStore(sqlStore *SqlStore) store.SchemeStore {
 	return &SqlSchemeStore{sqlStore}
 }
 
-func (s *SqlSchemeStore) Save(scheme *model.Scheme) (sch *model.Scheme, err error) {
+func (s *SqlSchemeStore) Save(scheme *model.Scheme) (_ *model.Scheme, err error) {
 	if scheme.Id == "" {
-		transaction, err := s.GetMasterX().Beginx()
-		if err != nil {
-			return nil, errors.Wrap(err, "begin_transaction")
+		transaction, terr := s.GetMasterX().Beginx()
+		if terr != nil {
+			return nil, errors.Wrap(terr, "begin_transaction")
 		}
-		defer finalizeTransactionX(transaction, &err)
+		defer finalizeTransactionX(transaction, &terr)
 
-		newScheme, err := s.createScheme(scheme, transaction)
-		if err != nil {
-			return nil, err
+		newScheme, terr := s.createScheme(scheme, transaction)
+		if terr != nil {
+			return nil, terr
 		}
-		if err := transaction.Commit(); err != nil {
-			return nil, errors.Wrap(err, "commit_transaction")
+		if terr = transaction.Commit(); terr != nil {
+			return nil, errors.Wrap(terr, "commit_transaction")
 		}
 		return newScheme, nil
 	}

--- a/store/sqlstore/scheme_store.go
+++ b/store/sqlstore/scheme_store.go
@@ -22,13 +22,13 @@ func newSqlSchemeStore(sqlStore *SqlStore) store.SchemeStore {
 	return &SqlSchemeStore{sqlStore}
 }
 
-func (s *SqlSchemeStore) Save(scheme *model.Scheme) (*model.Scheme, error) {
+func (s *SqlSchemeStore) Save(scheme *model.Scheme) (sch *model.Scheme, err error) {
 	if scheme.Id == "" {
 		transaction, err := s.GetMasterX().Beginx()
 		if err != nil {
 			return nil, errors.Wrap(err, "begin_transaction")
 		}
-		defer finalizeTransactionX(transaction)
+		defer finalizeTransactionX(transaction, &err)
 
 		newScheme, err := s.createScheme(scheme, transaction)
 		if err != nil {
@@ -427,7 +427,7 @@ func (s *SqlSchemeStore) CountByScope(scope string) (int64, error) {
 	err := s.GetReplicaX().Get(&count, `SELECT count(*) FROM Schemes WHERE Scope = ? AND DeleteAt = 0`, scope)
 
 	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to count Schemes by scope")
+		return 0, errors.Wrap(err, "failed to count Schemes by scope")
 	}
 	return count, nil
 }
@@ -448,7 +448,7 @@ func (s *SqlSchemeStore) CountWithoutPermission(schemeScope, permissionID string
 	var count int64
 	err := s.GetReplicaX().Get(&count, query)
 	if err != nil {
-		return int64(0), errors.Wrap(err, "failed to count Schemes without permission")
+		return 0, errors.Wrap(err, "failed to count Schemes without permission")
 	}
 	return count, nil
 }

--- a/store/sqlstore/status_store.go
+++ b/store/sqlstore/status_store.go
@@ -137,13 +137,13 @@ func (s SqlStatusStore) updateExpiredStatuses(t *sqlxTxWrapper) ([]*model.Status
 	return statuses, nil
 }
 
-func (s SqlStatusStore) UpdateExpiredDNDStatuses() ([]*model.Status, error) {
+func (s SqlStatusStore) UpdateExpiredDNDStatuses() (stats []*model.Status, err error) {
 	if s.DriverName() == model.DatabaseDriverMysql {
 		transaction, err := s.GetMasterX().Beginx()
 		if err != nil {
 			return nil, errors.Wrap(err, "UpdateExpiredDNDStatuses: begin_transaction")
 		}
-		defer finalizeTransactionX(transaction)
+		defer finalizeTransactionX(transaction, &err)
 		statuses, err := s.updateExpiredStatuses(transaction)
 		if err != nil {
 			return nil, errors.Wrap(err, "UpdateExpiredDNDStatuses: updateExpiredDNDStatusesT")

--- a/store/sqlstore/status_store.go
+++ b/store/sqlstore/status_store.go
@@ -137,19 +137,19 @@ func (s SqlStatusStore) updateExpiredStatuses(t *sqlxTxWrapper) ([]*model.Status
 	return statuses, nil
 }
 
-func (s SqlStatusStore) UpdateExpiredDNDStatuses() (stats []*model.Status, err error) {
+func (s SqlStatusStore) UpdateExpiredDNDStatuses() (_ []*model.Status, err error) {
 	if s.DriverName() == model.DatabaseDriverMysql {
-		transaction, err := s.GetMasterX().Beginx()
-		if err != nil {
-			return nil, errors.Wrap(err, "UpdateExpiredDNDStatuses: begin_transaction")
+		transaction, terr := s.GetMasterX().Beginx()
+		if terr != nil {
+			return nil, errors.Wrap(terr, "UpdateExpiredDNDStatuses: begin_transaction")
 		}
-		defer finalizeTransactionX(transaction, &err)
-		statuses, err := s.updateExpiredStatuses(transaction)
-		if err != nil {
-			return nil, errors.Wrap(err, "UpdateExpiredDNDStatuses: updateExpiredDNDStatusesT")
+		defer finalizeTransactionX(transaction, &terr)
+		statuses, terr := s.updateExpiredStatuses(transaction)
+		if terr != nil {
+			return nil, errors.Wrap(terr, "UpdateExpiredDNDStatuses: updateExpiredDNDStatusesT")
 		}
-		if err := transaction.Commit(); err != nil {
-			return nil, errors.Wrap(err, "UpdateExpiredDNDStatuses: commit_transaction")
+		if terr = transaction.Commit(); terr != nil {
+			return nil, errors.Wrap(terr, "UpdateExpiredDNDStatuses: commit_transaction")
 		}
 
 		for _, status := range statuses {

--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -1118,15 +1118,15 @@ func (ss *SqlStore) ensureMinimumDBVersion(ver string) (bool, error) {
 		}
 		majorVer, err2 := strconv.Atoi(versions[0])
 		if err2 != nil {
-			return false, fmt.Errorf("cannot parse MySQL DB version: %s", err2)
+			return false, fmt.Errorf("cannot parse MySQL DB version: %w", err2)
 		}
 		minorVer, err2 := strconv.Atoi(versions[1])
 		if err2 != nil {
-			return false, fmt.Errorf("cannot parse MySQL DB version: %s", err2)
+			return false, fmt.Errorf("cannot parse MySQL DB version: %w", err2)
 		}
 		patchVer, err2 := strconv.Atoi(versions[2])
 		if err2 != nil {
-			return false, fmt.Errorf("cannot parse MySQL DB version: %s", err2)
+			return false, fmt.Errorf("cannot parse MySQL DB version: %w", err2)
 		}
 		intVer := majorVer*1000 + minorVer*100 + patchVer
 		if intVer < minimumRequiredMySQLVersion {

--- a/store/sqlstore/system_store.go
+++ b/store/sqlstore/system_store.go
@@ -124,14 +124,14 @@ func (s SqlSystemStore) PermanentDeleteByName(name string) (*model.System, error
 
 // InsertIfExists inserts a given system value if it does not already exist. If a value
 // already exists, it returns the old one, else returns the new one.
-func (s SqlSystemStore) InsertIfExists(system *model.System) (*model.System, error) {
+func (s SqlSystemStore) InsertIfExists(system *model.System) (_ *model.System, err error) {
 	tx, err := s.GetMasterX().BeginXWithIsolation(&sql.TxOptions{
 		Isolation: sql.LevelSerializable,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(tx)
+	defer finalizeTransactionX(tx, &err)
 
 	var origSystem model.System
 	if err := tx.Get(&origSystem, `SELECT * FROM Systems

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -730,12 +730,12 @@ func (s *SqlThreadStore) DeleteMembershipForUser(userId string, postId string) e
 // - post creation (mentions handling)
 // - channel marked unread
 // - user explicitly following a thread
-func (s *SqlThreadStore) MaintainMembership(userId, postId string, opts store.ThreadMembershipOpts) (*model.ThreadMembership, error) {
+func (s *SqlThreadStore) MaintainMembership(userId, postId string, opts store.ThreadMembershipOpts) (_ *model.ThreadMembership, err error) {
 	trx, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(trx)
+	defer finalizeTransactionX(trx, &err)
 
 	membership, err := s.getMembershipForUser(trx, userId, postId)
 	now := utils.MillisFromTime(time.Now())

--- a/store/sqlstore/user_access_token_store.go
+++ b/store/sqlstore/user_access_token_store.go
@@ -41,13 +41,13 @@ func (s SqlUserAccessTokenStore) Save(token *model.UserAccessToken) (*model.User
 	return token, nil
 }
 
-func (s SqlUserAccessTokenStore) Delete(tokenId string) error {
+func (s SqlUserAccessTokenStore) Delete(tokenId string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
 
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	if err := s.deleteSessionsAndTokensById(transaction, tokenId); err == nil {
 		if err := transaction.Commit(); err != nil {
@@ -85,12 +85,12 @@ func (s SqlUserAccessTokenStore) deleteTokensById(transaction *sqlxTxWrapper, to
 	return nil
 }
 
-func (s SqlUserAccessTokenStore) DeleteAllForUser(userId string) error {
+func (s SqlUserAccessTokenStore) DeleteAllForUser(userId string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 	if err := s.deleteSessionsandTokensByUser(transaction, userId); err != nil {
 		return err
 	}
@@ -197,12 +197,12 @@ func (s SqlUserAccessTokenStore) UpdateTokenEnable(tokenId string) error {
 	return nil
 }
 
-func (s SqlUserAccessTokenStore) UpdateTokenDisable(tokenId string) error {
+func (s SqlUserAccessTokenStore) UpdateTokenDisable(tokenId string) (err error) {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
-	defer finalizeTransactionX(transaction)
+	defer finalizeTransactionX(transaction, &err)
 
 	if err := s.deleteSessionsAndDisableToken(transaction, tokenId); err != nil {
 		return err

--- a/store/sqlstore/user_terms_of_service.go
+++ b/store/sqlstore/user_terms_of_service.go
@@ -54,7 +54,11 @@ func (s SqlUserTermsOfServiceStore) Save(userTermsOfService *model.UserTermsOfSe
 		return nil, errors.Wrapf(err, "failed to update UserTermsOfService with userId=%s and termsOfServiceId=%s", userTermsOfService.UserId, userTermsOfService.TermsOfServiceId)
 	}
 
-	if updatedRows, _ := result.RowsAffected(); updatedRows == 0 {
+	updatedRows, err := result.RowsAffected()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to retrieve the number of affected rows for the update of UserTermsOfService")
+	}
+	if updatedRows == 0 {
 		query := `
 			INSERT INTO UserTermsOfService
 				(UserId, TermsOfServiceId, CreateAt)

--- a/store/sqlstore/utils.go
+++ b/store/sqlstore/utils.go
@@ -82,8 +82,9 @@ func containsAlphaNumericChar(s string) bool {
 }
 
 // isQuotedWord return true if the input string is quoted, false otherwise. Ex :-
-// 		"quoted string"  -  will return true
-// 		unquoted string  -  will return false
+//
+//	"quoted string"  -  will return true
+//	unquoted string  -  will return false
 func isQuotedWord(s string) bool {
 	if len(s) < 2 {
 		return false


### PR DESCRIPTION
#### Summary
This PR adds a number of returns for previously ignored errors in the sqlstore package. It also adds functionality to report errors in the rollback of operations. In once instance, it removes the reporting of errors returned by `bytes.Buffer`, which only panics but never actually returns errors.

#### Ticket Link
[MM-45994](https://mattermost.atlassian.net/browse/MM-45994)

#### Release Note
```release-note
NONE
```
