### PR TITLE
fix flaky busy test

### DIFF
--- a/app/busy_test.go
+++ b/app/busy_test.go
@@ -23,12 +23,13 @@ func TestBusySet(t *testing.T) {
 	}
 
 	require.False(t, busy.IsBusy())
+
+	busy.Set(time.Millisecond * 500)
+	require.True(t, busy.IsBusy())
 	require.True(t, compareBusyState(t, busy, cluster.Busy))
 
-	busy.Set(time.Millisecond * 100)
-	require.True(t, busy.IsBusy())
-	// should automatically expire after 100ms.
-	require.Eventually(t, isNotBusy, time.Second*15, time.Millisecond*20)
+	// should automatically expire after 500ms.
+	require.Eventually(t, isNotBusy, time.Second*15, time.Millisecond*100)
 	// allow a moment for cluster to sync.
 	require.Eventually(t, func() bool { return compareBusyState(t, busy, cluster.Busy) }, time.Second*15, time.Millisecond*20)
 

--- a/app/busy_test.go
+++ b/app/busy_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestBusySet(t *testing.T) {
-	t.Skip("MM-45725")
 	cluster := &ClusterMock{Busy: &Busy{}}
 	busy := NewBusy(cluster)
 
@@ -24,10 +23,10 @@ func TestBusySet(t *testing.T) {
 	}
 
 	require.False(t, busy.IsBusy())
+	require.True(t, compareBusyState(t, busy, cluster.Busy))
 
 	busy.Set(time.Millisecond * 100)
 	require.True(t, busy.IsBusy())
-	require.True(t, compareBusyState(t, busy, cluster.Busy))
 	// should automatically expire after 100ms.
 	require.Eventually(t, isNotBusy, time.Second*15, time.Millisecond*20)
 	// allow a moment for cluster to sync.


### PR DESCRIPTION


#### Summary
I think the ordering for the check and compare was wrong as `cluster.Busy` is never set to be busy.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-45725

#### Release Note

```release-note
NONE
```
