### PR TITLE
Add preferences service API for products

### DIFF
--- a/app/channels.go
+++ b/app/channels.go
@@ -226,6 +226,10 @@ func NewChannels(s *Server, services map[ServiceKey]any) (*Channels, error) {
 
 	services[UserKey] = &App{ch: ch}
 
+	services[PreferencesKey] = &preferencesServiceWrapper{
+		app: &App{ch: ch},
+	}
+
 	return ch, nil
 }
 

--- a/app/preference.go
+++ b/app/preference.go
@@ -9,7 +9,28 @@ import (
 	"net/http"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/product"
 )
+
+// Ensure preferences service wrapper implements `product.PreferencesService`
+var _ product.PreferencesService = (*preferencesServiceWrapper)(nil)
+
+// preferencesServiceWrapper provides an implementation of `product.PreferencesService` for use by products.
+type preferencesServiceWrapper struct {
+	app AppIface
+}
+
+func (w *preferencesServiceWrapper) GetPreferencesForUser(userID string) (model.Preferences, *model.AppError) {
+	return w.app.GetPreferencesForUser(userID)
+}
+
+func (w *preferencesServiceWrapper) UpdatePreferencesForUser(userID string, preferences model.Preferences) *model.AppError {
+	return w.app.UpdatePreferences(userID, preferences)
+}
+
+func (w *preferencesServiceWrapper) DeletePreferencesForUser(userID string, preferences model.Preferences) *model.AppError {
+	return w.app.DeletePreferences(userID, preferences)
+}
 
 func (a *App) GetPreferencesForUser(userID string) (model.Preferences, *model.AppError) {
 	preferences, err := a.Srv().Store.Preference().GetAll(userID)

--- a/app/server.go
+++ b/app/server.go
@@ -103,6 +103,7 @@ const (
 	KVStoreKey       ServiceKey = "kvstore"
 	StoreKey         ServiceKey = "storekey"
 	SystemKey        ServiceKey = "systemkey"
+	PreferencesKey   ServiceKey = "preferenceskey"
 )
 
 type Server struct {

--- a/product/api.go
+++ b/product/api.go
@@ -179,3 +179,12 @@ type StoreService interface {
 type SystemService interface {
 	GetDiagnosticId() string
 }
+
+// PreferencesService is the API for accessing the Preferences service APIs.
+//
+// The service shall be registered via app.PreferencesKey service key.
+type PreferencesService interface {
+	GetPreferencesForUser(userID string) (model.Preferences, *model.AppError)
+	UpdatePreferencesForUser(userID string, preferences model.Preferences) *model.AppError
+	DeletePreferencesForUser(userID string, preferences model.Preferences) *model.AppError
+}


### PR DESCRIPTION
#### Summary
This PR adds a Preferences service API which allows products to access user preferences.  Currently this service is provided by channels because preferences are implemented in App, but should be moved to server once App is refactored.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
