### PR TITLE
MM-46408: adds PostPriority feature flag

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -75,6 +75,8 @@ type FeatureFlags struct {
 	BoardsProduct bool
 
 	PlanUpgradeButtonText string
+
+	PostPriority bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -103,6 +105,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.CallsEnabled = true
 	f.BoardsProduct = false
 	f.PlanUpgradeButtonText = "upgrade"
+	f.PostPriority = false
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {


### PR DESCRIPTION
#### Summary

Adds the PostPriority feature flag. You can enable it by setting the
env variable `MM_FEATUREFLAGS_POSTPRIORITY=true`.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-46408

#### Release Note

```release-note
Added a new feature flag PostPriority.
```
