### PR TITLE
Limit GOMAXPROCS while running race tests

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -18,6 +18,11 @@ export MM_SERVER_PATH=$PWD
 echo "Packages to test: $PACKAGES"
 echo "GOFLAGS: $GOFLAGS"
 
+if [[ $GOFLAGS == "-race " && $IS_CI == "true" ]] ;
+then
+	export GOMAXPROCS=4
+fi
+
 find . -name 'cprofile*.out' -exec sh -c 'rm "{}"' \;
 find . -type d -name data -not -path './data' | xargs rm -rf
 


### PR DESCRIPTION
In CI environment, race tests take a huge amount
of memory. Since we only run it on master, there's
no rush to finish it quickly. Hence we can limit
the parallelism and throttle memory usage.

```release-note
NONE
```
