### PR TITLE
Always generate a Message-ID

### DIFF
--- a/shared/mail/mail.go
+++ b/shared/mail/mail.go
@@ -296,7 +296,7 @@ func SendMail(c smtpClient, mail mailData, date time.Time) error {
 
 	// could be replaced by a call to GetSiteURL() but I have no idea how to do that...
 	siteurl := "https://matter.most"
-	re := regexp.MustCompile("^https://([^/]+).*$")
+	re := regexp.MustCompile("^https?://([^/:]+).*$")
 
 	if err != nil {
 		mlog.Warn("Unable to convert html body to text", mlog.Err(err))

--- a/shared/mail/mail.go
+++ b/shared/mail/mail.go
@@ -12,6 +12,8 @@ import (
 	"net/mail"
 	"net/smtp"
 	"time"
+	"regexp"
+	"fmt"
 
 	"github.com/jaytaylor/html2text"
 	"github.com/pkg/errors"
@@ -291,6 +293,11 @@ func SendMail(c smtpClient, mail mailData, date time.Time) error {
 	htmlMessage := mail.htmlBody
 
 	txtBody, err := html2text.FromString(mail.htmlBody)
+
+	// could be replaced by a call to GetSiteURL() but I have no idea how to do that...
+	siteurl := "https://matter.most"
+	re := regexp.MustCompile("^https://([^/]+).*$")
+
 	if err != nil {
 		mlog.Warn("Unable to convert html body to text", mlog.Err(err))
 		txtBody = ""
@@ -315,6 +322,8 @@ func SendMail(c smtpClient, mail mailData, date time.Time) error {
 
 	if mail.messageID != "" {
 		headers["Message-ID"] = []string{mail.messageID}
+	} else {
+		headers["Message-ID"] = []string{fmt.Sprintf("mattermost-notification-%d000@%s", time.Now().Unix(), re.ReplaceAllString(siteurl, "$1"))}
 	}
 
 	if mail.inReplyTo != "" {


### PR DESCRIPTION
Gmail has increased its spam prevention mechanisms and mails sent by the Mattermost server will get rejected with the following message, due to a missing Message-ID header:

`relay=aspmx.l.google.com[108.177.125.27]:25, delay=0.88, delays=0.05/0/0.41/0.42, dsn=5.7.1, status=bounced (host aspmx.l.google.com[108.177.125.27] said: 550-5.7.1 [153.120.38.130] Messages missing a valid messageId header are not 550 5.7.1 accepted. g4-20020a655944000000b0042b260400dcsi1070399pgu.507 - gsmtp (in reply to end of DATA command))`

This issue came up in this forum post: https://forum.mattermost.com/t/mattermost-wont-send-email-with-postfix/13922 (you can also check out alternative solutions there), but it's the application's duty to create a Message-ID header and the suggested fix here will generate a valid one, in the form:

mattermost-notification-<unixtimestamp>@matter.most

which is perfectly valid.
Instead of the hardcoded name `matter.most` it would be cool to use the domain name of the `SiteURL` configuration option, but I tried my best to find out how to add it here, but did not succeed, so if someone could add that functionality on top of this patch if wanted, this would be great :)

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
