### PR TITLE
[MM-38705] Move import validators into own package

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -481,7 +481,7 @@ func (a *App) buildPostReplies(ctx request.CTX, postID string, withAttachments b
 	return replies, attachments, nil
 }
 
-func (a *App) BuildPostReactions(ctx request.CTX, postID string) (*[]imports.ReactionImportData, *model.AppError) {
+func (a *App) BuildPostReactions(ctx request.CTX, postID string) (*[]ReactionImportData, *model.AppError) {
 	var reactionsOfPost []imports.ReactionImportData
 
 	reactions, nErr := a.Srv().Store.Reaction().GetForPost(postID, true)

--- a/app/export.go
+++ b/app/export.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/mattermost/mattermost-server/v6/app/imports"
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
@@ -23,7 +24,7 @@ import (
 
 // We use this map to identify the exportable preferences.
 // Here we link the preference category and name, to the name of the relevant field in the import struct.
-var exportablePreferences = map[ComparablePreference]string{{
+var exportablePreferences = map[imports.ComparablePreference]string{{
 	Category: model.PreferenceCategoryTheme,
 	Name:     "",
 }: "Theme", {
@@ -141,7 +142,7 @@ func (a *App) BulkExport(ctx request.CTX, writer io.Writer, outPath string, opts
 	return nil
 }
 
-func (a *App) exportWriteLine(w io.Writer, line *LineImportData) *model.AppError {
+func (a *App) exportWriteLine(w io.Writer, line *imports.LineImportData) *model.AppError {
 	b, err := json.Marshal(line)
 	if err != nil {
 		return model.NewAppError("BulkExport", "app.export.export_write_line.json_marshall.error", nil, "", http.StatusBadRequest).Wrap(err)
@@ -156,7 +157,7 @@ func (a *App) exportWriteLine(w io.Writer, line *LineImportData) *model.AppError
 
 func (a *App) exportVersion(writer io.Writer) *model.AppError {
 	version := 1
-	versionLine := &LineImportData{
+	versionLine := &imports.LineImportData{
 		Type:    "version",
 		Version: &version,
 	}
@@ -271,7 +272,7 @@ func (a *App) exportAllUsers(writer io.Writer) *model.AppError {
 						pref.Value = ""
 					}
 				}
-				id, ok := exportablePreferences[ComparablePreference{
+				id, ok := exportablePreferences[imports.ComparablePreference{
 					Category: pref.Category,
 					Name:     pref.Name,
 				}]
@@ -306,8 +307,8 @@ func (a *App) exportAllUsers(writer io.Writer) *model.AppError {
 	return nil
 }
 
-func (a *App) buildUserTeamAndChannelMemberships(userID string) (*[]UserTeamImportData, *model.AppError) {
-	var memberships []UserTeamImportData
+func (a *App) buildUserTeamAndChannelMemberships(userID string) (*[]imports.UserTeamImportData, *model.AppError) {
+	var memberships []imports.UserTeamImportData
 
 	members, err := a.Srv().Store.Team().GetTeamMembersForExport(userID)
 
@@ -343,8 +344,8 @@ func (a *App) buildUserTeamAndChannelMemberships(userID string) (*[]UserTeamImpo
 	return &memberships, nil
 }
 
-func (a *App) buildUserChannelMemberships(userID string, teamID string) (*[]UserChannelImportData, *model.AppError) {
-	var memberships []UserChannelImportData
+func (a *App) buildUserChannelMemberships(userID string, teamID string) (*[]imports.UserChannelImportData, *model.AppError) {
+	var memberships []imports.UserChannelImportData
 
 	members, nErr := a.Srv().Store.Channel().GetChannelMembersForExport(userID, teamID)
 	if nErr != nil {
@@ -363,7 +364,7 @@ func (a *App) buildUserChannelMemberships(userID string, teamID string) (*[]User
 	return &memberships, nil
 }
 
-func (a *App) buildUserNotifyProps(notifyProps model.StringMap) *UserNotifyPropsImportData {
+func (a *App) buildUserNotifyProps(notifyProps model.StringMap) *imports.UserNotifyPropsImportData {
 
 	getProp := func(key string) *string {
 		if v, ok := notifyProps[key]; ok {
@@ -372,7 +373,7 @@ func (a *App) buildUserNotifyProps(notifyProps model.StringMap) *UserNotifyProps
 		return nil
 	}
 
-	return &UserNotifyPropsImportData{
+	return &imports.UserNotifyPropsImportData{
 		Desktop:          getProp(model.DesktopNotifyProp),
 		DesktopSound:     getProp(model.DesktopSoundNotifyProp),
 		Email:            getProp(model.EmailNotifyProp),
@@ -384,8 +385,8 @@ func (a *App) buildUserNotifyProps(notifyProps model.StringMap) *UserNotifyProps
 	}
 }
 
-func (a *App) exportAllPosts(ctx request.CTX, writer io.Writer, withAttachments bool) ([]AttachmentImportData, *model.AppError) {
-	var attachments []AttachmentImportData
+func (a *App) exportAllPosts(ctx request.CTX, writer io.Writer, withAttachments bool) ([]imports.AttachmentImportData, *model.AppError) {
+	var attachments []imports.AttachmentImportData
 	afterId := strings.Repeat("0", 26)
 
 	for {
@@ -418,7 +419,7 @@ func (a *App) exportAllPosts(ctx request.CTX, writer io.Writer, withAttachments 
 			}
 
 			postLine.Post.Replies = &replies
-			postLine.Post.Reactions = &[]ReactionImportData{}
+			postLine.Post.Reactions = &[]imports.ReactionImportData{}
 			if post.HasReactions {
 				postLine.Post.Reactions, err = a.BuildPostReactions(ctx, post.Id)
 				if err != nil {
@@ -445,9 +446,9 @@ func (a *App) exportAllPosts(ctx request.CTX, writer io.Writer, withAttachments 
 	}
 }
 
-func (a *App) buildPostReplies(ctx request.CTX, postID string, withAttachments bool) ([]ReplyImportData, []AttachmentImportData, *model.AppError) {
-	var replies []ReplyImportData
-	var attachments []AttachmentImportData
+func (a *App) buildPostReplies(ctx request.CTX, postID string, withAttachments bool) ([]imports.ReplyImportData, []imports.AttachmentImportData, *model.AppError) {
+	var replies []imports.ReplyImportData
+	var attachments []imports.AttachmentImportData
 
 	replyPosts, nErr := a.Srv().Store.Post().GetRepliesForExport(postID)
 	if nErr != nil {
@@ -480,8 +481,8 @@ func (a *App) buildPostReplies(ctx request.CTX, postID string, withAttachments b
 	return replies, attachments, nil
 }
 
-func (a *App) BuildPostReactions(ctx request.CTX, postID string) (*[]ReactionImportData, *model.AppError) {
-	var reactionsOfPost []ReactionImportData
+func (a *App) BuildPostReactions(ctx request.CTX, postID string) (*[]imports.ReactionImportData, *model.AppError) {
+	var reactionsOfPost []imports.ReactionImportData
 
 	reactions, nErr := a.Srv().Store.Reaction().GetForPost(postID, true)
 	if nErr != nil {
@@ -505,15 +506,15 @@ func (a *App) BuildPostReactions(ctx request.CTX, postID string) (*[]ReactionImp
 
 }
 
-func (a *App) buildPostAttachments(postID string) ([]AttachmentImportData, *model.AppError) {
+func (a *App) buildPostAttachments(postID string) ([]imports.AttachmentImportData, *model.AppError) {
 	infos, nErr := a.Srv().Store.FileInfo().GetForPost(postID, false, false, false)
 	if nErr != nil {
 		return nil, model.NewAppError("buildPostAttachments", "app.file_info.get_for_post.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
 
-	attachments := make([]AttachmentImportData, 0, len(infos))
+	attachments := make([]imports.AttachmentImportData, 0, len(infos))
 	for _, info := range infos {
-		attachments = append(attachments, AttachmentImportData{Path: &info.Path})
+		attachments = append(attachments, imports.AttachmentImportData{Path: &info.Path})
 	}
 
 	return attachments, nil
@@ -635,8 +636,8 @@ func (a *App) exportAllDirectChannels(writer io.Writer) *model.AppError {
 	return nil
 }
 
-func (a *App) exportAllDirectPosts(ctx request.CTX, writer io.Writer, withAttachments bool) ([]AttachmentImportData, *model.AppError) {
-	var attachments []AttachmentImportData
+func (a *App) exportAllDirectPosts(ctx request.CTX, writer io.Writer, withAttachments bool) ([]imports.AttachmentImportData, *model.AppError) {
+	var attachments []imports.AttachmentImportData
 	afterId := strings.Repeat("0", 26)
 	for {
 		posts, err := a.Srv().Store.Post().GetDirectPostParentsForExportAfter(1000, afterId)
@@ -657,7 +658,7 @@ func (a *App) exportAllDirectPosts(ctx request.CTX, writer io.Writer, withAttach
 			}
 
 			// Handle attachments.
-			var postAttachments []AttachmentImportData
+			var postAttachments []imports.AttachmentImportData
 			var err *model.AppError
 			if len(post.FileIds) > 0 {
 				postAttachments, err = a.buildPostAttachments(post.Id)

--- a/app/export_converters.go
+++ b/app/export_converters.go
@@ -6,13 +6,14 @@ package app
 import (
 	"strings"
 
+	"github.com/mattermost/mattermost-server/v6/app/imports"
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
-func ImportLineFromTeam(team *model.TeamForExport) *LineImportData {
-	return &LineImportData{
+func ImportLineFromTeam(team *model.TeamForExport) *imports.LineImportData {
+	return &imports.LineImportData{
 		Type: "team",
-		Team: &TeamImportData{
+		Team: &imports.TeamImportData{
 			Name:            &team.Name,
 			DisplayName:     &team.DisplayName,
 			Type:            &team.Type,
@@ -23,10 +24,10 @@ func ImportLineFromTeam(team *model.TeamForExport) *LineImportData {
 	}
 }
 
-func ImportLineFromChannel(channel *model.ChannelForExport) *LineImportData {
-	return &LineImportData{
+func ImportLineFromChannel(channel *model.ChannelForExport) *imports.LineImportData {
+	return &imports.LineImportData{
 		Type: "channel",
-		Channel: &ChannelImportData{
+		Channel: &imports.ChannelImportData{
 			Team:        &channel.TeamName,
 			Name:        &channel.Name,
 			DisplayName: &channel.DisplayName,
@@ -38,30 +39,30 @@ func ImportLineFromChannel(channel *model.ChannelForExport) *LineImportData {
 	}
 }
 
-func ImportLineFromDirectChannel(channel *model.DirectChannelForExport) *LineImportData {
+func ImportLineFromDirectChannel(channel *model.DirectChannelForExport) *imports.LineImportData {
 	channelMembers := *channel.Members
 	if len(channelMembers) == 1 {
 		channelMembers = []string{channelMembers[0], channelMembers[0]}
 	}
-	return &LineImportData{
+	return &imports.LineImportData{
 		Type: "direct_channel",
-		DirectChannel: &DirectChannelImportData{
+		DirectChannel: &imports.DirectChannelImportData{
 			Header:  &channel.Header,
 			Members: &channelMembers,
 		},
 	}
 }
 
-func ImportLineFromUser(user *model.User, exportedPrefs map[string]*string) *LineImportData {
+func ImportLineFromUser(user *model.User, exportedPrefs map[string]*string) *imports.LineImportData {
 	// Bulk Importer doesn't accept "empty string" for AuthService.
 	var authService *string
 	if user.AuthService != "" {
 		authService = &user.AuthService
 	}
 
-	return &LineImportData{
+	return &imports.LineImportData{
 		Type: "user",
-		User: &UserImportData{
+		User: &imports.UserImportData{
 			Username:           &user.Username,
 			Email:              &user.Email,
 			AuthService:        authService,
@@ -88,7 +89,7 @@ func ImportLineFromUser(user *model.User, exportedPrefs map[string]*string) *Lin
 	}
 }
 
-func ImportUserTeamDataFromTeamMember(member *model.TeamMemberForExport) *UserTeamImportData {
+func ImportUserTeamDataFromTeamMember(member *model.TeamMemberForExport) *imports.UserTeamImportData {
 	rolesList := strings.Fields(member.Roles)
 	if member.SchemeAdmin {
 		rolesList = append(rolesList, model.TeamAdminRoleId)
@@ -100,13 +101,13 @@ func ImportUserTeamDataFromTeamMember(member *model.TeamMemberForExport) *UserTe
 		rolesList = append(rolesList, model.TeamGuestRoleId)
 	}
 	roles := strings.Join(rolesList, " ")
-	return &UserTeamImportData{
+	return &imports.UserTeamImportData{
 		Name:  &member.TeamName,
 		Roles: &roles,
 	}
 }
 
-func ImportUserChannelDataFromChannelMemberAndPreferences(member *model.ChannelMemberForExport, preferences *model.Preferences) *UserChannelImportData {
+func ImportUserChannelDataFromChannelMemberAndPreferences(member *model.ChannelMemberForExport, preferences *model.Preferences) *imports.UserChannelImportData {
 	rolesList := strings.Fields(member.Roles)
 	if member.SchemeAdmin {
 		rolesList = append(rolesList, model.ChannelAdminRoleId)
@@ -118,7 +119,7 @@ func ImportUserChannelDataFromChannelMemberAndPreferences(member *model.ChannelM
 		rolesList = append(rolesList, model.ChannelGuestRoleId)
 	}
 	props := member.NotifyProps
-	notifyProps := UserChannelNotifyPropsImportData{}
+	notifyProps := imports.UserChannelNotifyPropsImportData{}
 
 	desktop, exist := props[model.DesktopNotifyProp]
 	if exist {
@@ -141,7 +142,7 @@ func ImportUserChannelDataFromChannelMemberAndPreferences(member *model.ChannelM
 	}
 
 	roles := strings.Join(rolesList, " ")
-	return &UserChannelImportData{
+	return &imports.UserChannelImportData{
 		Name:        &member.ChannelName,
 		Roles:       &roles,
 		NotifyProps: &notifyProps,
@@ -149,10 +150,10 @@ func ImportUserChannelDataFromChannelMemberAndPreferences(member *model.ChannelM
 	}
 }
 
-func ImportLineForPost(post *model.PostForExport) *LineImportData {
-	return &LineImportData{
+func ImportLineForPost(post *model.PostForExport) *imports.LineImportData {
+	return &imports.LineImportData{
 		Type: "post",
-		Post: &PostImportData{
+		Post: &imports.PostImportData{
 			Team:     &post.TeamName,
 			Channel:  &post.ChannelName,
 			User:     &post.Username,
@@ -165,14 +166,14 @@ func ImportLineForPost(post *model.PostForExport) *LineImportData {
 	}
 }
 
-func ImportLineForDirectPost(post *model.DirectPostForExport) *LineImportData {
+func ImportLineForDirectPost(post *model.DirectPostForExport) *imports.LineImportData {
 	channelMembers := *post.ChannelMembers
 	if len(channelMembers) == 1 {
 		channelMembers = []string{channelMembers[0], channelMembers[0]}
 	}
-	return &LineImportData{
+	return &imports.LineImportData{
 		Type: "direct_post",
-		DirectPost: &DirectPostImportData{
+		DirectPost: &imports.DirectPostImportData{
 			ChannelMembers: &channelMembers,
 			User:           &post.User,
 			Type:           &post.Type,
@@ -184,8 +185,8 @@ func ImportLineForDirectPost(post *model.DirectPostForExport) *LineImportData {
 	}
 }
 
-func ImportReplyFromPost(post *model.ReplyForExport) *ReplyImportData {
-	return &ReplyImportData{
+func ImportReplyFromPost(post *model.ReplyForExport) *imports.ReplyImportData {
+	return &imports.ReplyImportData{
 		User:     &post.Username,
 		Type:     &post.Type,
 		Message:  &post.Message,
@@ -194,18 +195,18 @@ func ImportReplyFromPost(post *model.ReplyForExport) *ReplyImportData {
 	}
 }
 
-func ImportReactionFromPost(user *model.User, reaction *model.Reaction) *ReactionImportData {
-	return &ReactionImportData{
+func ImportReactionFromPost(user *model.User, reaction *model.Reaction) *imports.ReactionImportData {
+	return &imports.ReactionImportData{
 		User:      &user.Username,
 		EmojiName: &reaction.EmojiName,
 		CreateAt:  &reaction.CreateAt,
 	}
 }
 
-func ImportLineFromEmoji(emoji *model.Emoji, filePath string) *LineImportData {
-	return &LineImportData{
+func ImportLineFromEmoji(emoji *model.Emoji, filePath string) *imports.LineImportData {
+	return &imports.LineImportData{
 		Type: "emoji",
-		Emoji: &EmojiImportData{
+		Emoji: &imports.EmojiImportData{
 			Name:  &emoji.Name,
 			Image: &filePath,
 		},

--- a/app/import.go
+++ b/app/import.go
@@ -15,17 +15,20 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/mattermost/mattermost-server/v6/app/imports"
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
+
+type ReactionImportData = imports.ReactionImportData // part of the app interface
 
 const (
 	importMultiplePostsThreshold = 1000
 	maxScanTokenSize             = 16 * 1024 * 1024 // Need to set a higher limit than default because some customers cross the limit. See MM-22314
 )
 
-func stopOnError(c request.CTX, err LineImportWorkerError) bool {
+func stopOnError(c request.CTX, err imports.LineImportWorkerError) bool {
 	switch err.Error.Id {
 	case "api.file.upload_file.large_image.app_error":
 		c.Logger().Warn("Large image import error", mlog.Err(err.Error))
@@ -38,7 +41,7 @@ func stopOnError(c request.CTX, err LineImportWorkerError) bool {
 	}
 }
 
-func processAttachmentPaths(files *[]AttachmentImportData, basePath string, filesMap map[string]*zip.File) error {
+func processAttachmentPaths(files *[]imports.AttachmentImportData, basePath string, filesMap map[string]*zip.File) error {
 	if files == nil {
 		return nil
 	}
@@ -58,11 +61,11 @@ func processAttachmentPaths(files *[]AttachmentImportData, basePath string, file
 	return nil
 }
 
-func processAttachments(line *LineImportData, basePath string, filesMap map[string]*zip.File) error {
+func processAttachments(line *imports.LineImportData, basePath string, filesMap map[string]*zip.File) error {
 	var ok bool
 	switch line.Type {
 	case "post", "direct_post":
-		var replies []ReplyImportData
+		var replies []imports.ReplyImportData
 		if line.Type == "direct_post" {
 			if err := processAttachmentPaths(line.DirectPost.Attachments, basePath, filesMap); err != nil {
 				return err
@@ -108,48 +111,48 @@ func processAttachments(line *LineImportData, basePath string, filesMap map[stri
 	return nil
 }
 
-func (a *App) bulkImportWorker(c request.CTX, dryRun bool, wg *sync.WaitGroup, lines <-chan LineImportWorkerData, errors chan<- LineImportWorkerError) {
-	postLines := []LineImportWorkerData{}
-	directPostLines := []LineImportWorkerData{}
+func (a *App) bulkImportWorker(c request.CTX, dryRun bool, wg *sync.WaitGroup, lines <-chan imports.LineImportWorkerData, errors chan<- imports.LineImportWorkerError) {
+	postLines := []imports.LineImportWorkerData{}
+	directPostLines := []imports.LineImportWorkerData{}
 	for line := range lines {
 		switch {
 		case line.LineImportData.Type == "post":
 			postLines = append(postLines, line)
 			if line.Post == nil {
-				errors <- LineImportWorkerError{model.NewAppError("BulkImport", "app.import.import_line.null_post.error", nil, "", http.StatusBadRequest), line.LineNumber}
+				errors <- imports.LineImportWorkerError{model.NewAppError("BulkImport", "app.import.import_line.null_post.error", nil, "", http.StatusBadRequest), line.LineNumber}
 			}
 			if len(postLines) >= importMultiplePostsThreshold {
 				if errLine, err := a.importMultiplePostLines(c, postLines, dryRun); err != nil {
-					errors <- LineImportWorkerError{err, errLine}
+					errors <- imports.LineImportWorkerError{err, errLine}
 				}
-				postLines = []LineImportWorkerData{}
+				postLines = []imports.LineImportWorkerData{}
 			}
 		case line.LineImportData.Type == "direct_post":
 			directPostLines = append(directPostLines, line)
 			if line.DirectPost == nil {
-				errors <- LineImportWorkerError{model.NewAppError("BulkImport", "app.import.import_line.null_direct_post.error", nil, "", http.StatusBadRequest), line.LineNumber}
+				errors <- imports.LineImportWorkerError{model.NewAppError("BulkImport", "app.import.import_line.null_direct_post.error", nil, "", http.StatusBadRequest), line.LineNumber}
 			}
 			if len(directPostLines) >= importMultiplePostsThreshold {
 				if errLine, err := a.importMultipleDirectPostLines(c, directPostLines, dryRun); err != nil {
-					errors <- LineImportWorkerError{err, errLine}
+					errors <- imports.LineImportWorkerError{err, errLine}
 				}
-				directPostLines = []LineImportWorkerData{}
+				directPostLines = []imports.LineImportWorkerData{}
 			}
 		default:
 			if err := a.importLine(c, line.LineImportData, dryRun); err != nil {
-				errors <- LineImportWorkerError{err, line.LineNumber}
+				errors <- imports.LineImportWorkerError{err, line.LineNumber}
 			}
 		}
 	}
 
 	if len(postLines) > 0 {
 		if errLine, err := a.importMultiplePostLines(c, postLines, dryRun); err != nil {
-			errors <- LineImportWorkerError{err, errLine}
+			errors <- imports.LineImportWorkerError{err, errLine}
 		}
 	}
 	if len(directPostLines) > 0 {
 		if errLine, err := a.importMultipleDirectPostLines(c, directPostLines, dryRun); err != nil {
-			errors <- LineImportWorkerError{err, errLine}
+			errors <- imports.LineImportWorkerError{err, errLine}
 		}
 	}
 	wg.Done()
@@ -177,9 +180,9 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 	a.Srv().Store.LockToMaster()
 	defer a.Srv().Store.UnlockFromMaster()
 
-	errorsChan := make(chan LineImportWorkerError, (2*workers)+1) // size chosen to ensure it never gets filled up completely.
+	errorsChan := make(chan imports.LineImportWorkerError, (2*workers)+1) // size chosen to ensure it never gets filled up completely.
 	var wg sync.WaitGroup
-	var linesChan chan LineImportWorkerData
+	var linesChan chan imports.LineImportWorkerData
 	lastLineType := ""
 
 	var attachedFiles map[string]*zip.File
@@ -194,7 +197,7 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 		decoder := json.NewDecoder(bytes.NewReader(scanner.Bytes()))
 		lineNumber++
 
-		var line LineImportData
+		var line imports.LineImportData
 		if err := decoder.Decode(&line); err != nil {
 			return model.NewAppError("BulkImport", "app.import.bulk_import.json_decode.error", nil, "", http.StatusBadRequest).Wrap(err), lineNumber
 		}
@@ -234,7 +237,7 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 
 			// Set up the workers and channel for this type.
 			lastLineType = line.Type
-			linesChan = make(chan LineImportWorkerData, workers)
+			linesChan = make(chan imports.LineImportWorkerData, workers)
 			for i := 0; i < workers; i++ {
 				wg.Add(1)
 				go a.bulkImportWorker(c, dryRun, &wg, linesChan, errorsChan)
@@ -242,7 +245,7 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 		}
 
 		select {
-		case linesChan <- LineImportWorkerData{line, lineNumber}:
+		case linesChan <- imports.LineImportWorkerData{line, lineNumber}:
 		case err := <-errorsChan:
 			if stopOnError(c, err) {
 				close(linesChan)
@@ -273,7 +276,7 @@ func (a *App) bulkImport(c request.CTX, jsonlReader io.Reader, attachmentsReader
 	return nil, 0
 }
 
-func processImportDataFileVersionLine(line LineImportData) (int, *model.AppError) {
+func processImportDataFileVersionLine(line imports.LineImportData) (int, *model.AppError) {
 	if line.Type != "version" || line.Version == nil {
 		return -1, model.NewAppError("BulkImport", "app.import.process_import_data_file_version_line.invalid_version.error", nil, "", http.StatusBadRequest)
 	}
@@ -281,7 +284,7 @@ func processImportDataFileVersionLine(line LineImportData) (int, *model.AppError
 	return *line.Version, nil
 }
 
-func (a *App) importLine(c request.CTX, line LineImportData, dryRun bool) *model.AppError {
+func (a *App) importLine(c request.CTX, line imports.LineImportData, dryRun bool) *model.AppError {
 	switch {
 	case line.Type == "scheme":
 		if line.Scheme == nil {

--- a/app/import_functions.go
+++ b/app/import_functions.go
@@ -15,6 +15,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/mattermost/mattermost-server/v6/app/imports"
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/app/teams"
 	"github.com/mattermost/mattermost-server/v6/app/users"
@@ -30,8 +31,8 @@ import (
 // still enforced.
 //
 
-func (a *App) importScheme(data *SchemeImportData, dryRun bool) *model.AppError {
-	if err := validateSchemeImportData(data); err != nil {
+func (a *App) importScheme(data *imports.SchemeImportData, dryRun bool) *model.AppError {
+	if err := imports.ValidateSchemeImportData(data); err != nil {
 		return err
 	}
 
@@ -77,7 +78,7 @@ func (a *App) importScheme(data *SchemeImportData, dryRun bool) *model.AppError 
 		}
 
 		if data.DefaultTeamGuestRole == nil {
-			data.DefaultTeamGuestRole = &RoleImportData{
+			data.DefaultTeamGuestRole = &imports.RoleImportData{
 				DisplayName: model.NewString("Team Guest Role for Scheme"),
 			}
 		}
@@ -99,7 +100,7 @@ func (a *App) importScheme(data *SchemeImportData, dryRun bool) *model.AppError 
 		}
 
 		if data.DefaultChannelGuestRole == nil {
-			data.DefaultChannelGuestRole = &RoleImportData{
+			data.DefaultChannelGuestRole = &imports.RoleImportData{
 				DisplayName: model.NewString("Channel Guest Role for Scheme"),
 			}
 		}
@@ -112,9 +113,9 @@ func (a *App) importScheme(data *SchemeImportData, dryRun bool) *model.AppError 
 	return nil
 }
 
-func (a *App) importRole(data *RoleImportData, dryRun bool, isSchemeRole bool) *model.AppError {
+func (a *App) importRole(data *imports.RoleImportData, dryRun bool, isSchemeRole bool) *model.AppError {
 	if !isSchemeRole {
-		if err := validateRoleImportData(data); err != nil {
+		if err := imports.ValidateRoleImportData(data); err != nil {
 			return err
 		}
 	}
@@ -158,8 +159,8 @@ func (a *App) importRole(data *RoleImportData, dryRun bool, isSchemeRole bool) *
 	return err
 }
 
-func (a *App) importTeam(c request.CTX, data *TeamImportData, dryRun bool) *model.AppError {
-	if err := validateTeamImportData(data); err != nil {
+func (a *App) importTeam(c request.CTX, data *imports.TeamImportData, dryRun bool) *model.AppError {
+	if err := imports.ValidateTeamImportData(data); err != nil {
 		return err
 	}
 
@@ -226,8 +227,8 @@ func (a *App) importTeam(c request.CTX, data *TeamImportData, dryRun bool) *mode
 	return nil
 }
 
-func (a *App) importChannel(c request.CTX, data *ChannelImportData, dryRun bool) *model.AppError {
-	if err := validateChannelImportData(data); err != nil {
+func (a *App) importChannel(c request.CTX, data *imports.ChannelImportData, dryRun bool) *model.AppError {
+	if err := imports.ValidateChannelImportData(data); err != nil {
 		return err
 	}
 
@@ -291,8 +292,8 @@ func (a *App) importChannel(c request.CTX, data *ChannelImportData, dryRun bool)
 	return nil
 }
 
-func (a *App) importUser(c request.CTX, data *UserImportData, dryRun bool) *model.AppError {
-	if err := validateUserImportData(data); err != nil {
+func (a *App) importUser(c request.CTX, data *imports.UserImportData, dryRun bool) *model.AppError {
+	if err := imports.ValidateUserImportData(data); err != nil {
 		return err
 	}
 
@@ -730,7 +731,7 @@ func (a *App) importUser(c request.CTX, data *UserImportData, dryRun bool) *mode
 	return a.importUserTeams(c, savedUser, data.Teams)
 }
 
-func (a *App) importUserTeams(c request.CTX, user *model.User, data *[]UserTeamImportData) *model.AppError {
+func (a *App) importUserTeams(c request.CTX, user *model.User, data *[]imports.UserTeamImportData) *model.AppError {
 	if data == nil {
 		return nil
 	}
@@ -745,7 +746,7 @@ func (a *App) importUserTeams(c request.CTX, user *model.User, data *[]UserTeamI
 	}
 
 	teamThemePreferencesByID := map[string]model.Preferences{}
-	channels := map[string][]UserChannelImportData{}
+	channels := map[string][]imports.UserChannelImportData{}
 	teamsByID := map[string]*model.Team{}
 	teamMemberByTeamID := map[string]*model.TeamMember{}
 	newTeamMembers := []*model.TeamMember{}
@@ -820,7 +821,7 @@ func (a *App) importUserTeams(c request.CTX, user *model.User, data *[]UserTeamI
 			channels[team.Id] = append(channels[team.Id], *tdata.Channels...)
 		}
 		if !user.IsGuest() {
-			channels[team.Id] = append(channels[team.Id], UserChannelImportData{Name: model.NewString(model.DefaultChannelName)})
+			channels[team.Id] = append(channels[team.Id], imports.UserChannelImportData{Name: model.NewString(model.DefaultChannelName)})
 		}
 
 		teamsByID[team.Id] = team
@@ -890,7 +891,7 @@ func (a *App) importUserTeams(c request.CTX, user *model.User, data *[]UserTeamI
 	return nil
 }
 
-func (a *App) importUserChannels(c request.CTX, user *model.User, team *model.Team, data *[]UserChannelImportData) *model.AppError {
+func (a *App) importUserChannels(c request.CTX, user *model.User, team *model.Team, data *[]imports.UserChannelImportData) *model.AppError {
 	if data == nil {
 		return nil
 	}
@@ -1060,8 +1061,8 @@ func (a *App) importUserChannels(c request.CTX, user *model.User, team *model.Te
 	return nil
 }
 
-func (a *App) importReaction(data *ReactionImportData, post *model.Post) *model.AppError {
-	if err := validateReactionImportData(data, post.CreateAt); err != nil {
+func (a *App) importReaction(data *imports.ReactionImportData, post *model.Post) *model.AppError {
+	if err := imports.ValidateReactionImportData(data, post.CreateAt); err != nil {
 		return err
 	}
 
@@ -1090,12 +1091,12 @@ func (a *App) importReaction(data *ReactionImportData, post *model.Post) *model.
 	return nil
 }
 
-func (a *App) importReplies(c request.CTX, data []ReplyImportData, post *model.Post, teamID string) *model.AppError {
+func (a *App) importReplies(c request.CTX, data []imports.ReplyImportData, post *model.Post, teamID string) *model.AppError {
 	var err *model.AppError
 	usernames := []string{}
 	for _, replyData := range data {
 		replyData := replyData
-		if err = validateReplyImportData(&replyData, post.CreateAt, a.MaxPostSize()); err != nil {
+		if err = imports.ValidateReplyImportData(&replyData, post.CreateAt, a.MaxPostSize()); err != nil {
 			return err
 		}
 		usernames = append(usernames, *replyData.User)
@@ -1192,7 +1193,7 @@ func (a *App) importReplies(c request.CTX, data []ReplyImportData, post *model.P
 	return nil
 }
 
-func (a *App) importAttachment(c request.CTX, data *AttachmentImportData, post *model.Post, teamID string) (*model.FileInfo, *model.AppError) {
+func (a *App) importAttachment(c request.CTX, data *imports.AttachmentImportData, post *model.Post, teamID string) (*model.FileInfo, *model.AppError) {
 	var (
 		name string
 		file io.Reader
@@ -1264,9 +1265,9 @@ func (a *App) importAttachment(c request.CTX, data *AttachmentImportData, post *
 
 type postAndData struct {
 	post           *model.Post
-	postData       *PostImportData
-	directPostData *DirectPostImportData
-	replyData      *ReplyImportData
+	postData       *imports.PostImportData
+	directPostData *imports.DirectPostImportData
+	replyData      *imports.ReplyImportData
 	team           *model.Team
 	lineNumber     int
 }
@@ -1316,7 +1317,7 @@ func (a *App) getChannelsByNames(names []string, teamID string) (map[string]*mod
 }
 
 // getChannelsForPosts returns map[teamName]map[channelName]*model.Channel
-func (a *App) getChannelsForPosts(teams map[string]*model.Team, data []*PostImportData) (map[string]map[string]*model.Channel, *model.AppError) {
+func (a *App) getChannelsForPosts(teams map[string]*model.Team, data []*imports.PostImportData) (map[string]map[string]*model.Channel, *model.AppError) {
 	teamChannels := make(map[string]map[string]*model.Channel)
 	for _, postData := range data {
 		teamName := *postData.Team
@@ -1343,13 +1344,13 @@ func getPostStrID(post *model.Post) string {
 
 // importMultiplePostLines will return an error and the line that
 // caused it whenever possible
-func (a *App) importMultiplePostLines(c request.CTX, lines []LineImportWorkerData, dryRun bool) (int, *model.AppError) {
+func (a *App) importMultiplePostLines(c request.CTX, lines []imports.LineImportWorkerData, dryRun bool) (int, *model.AppError) {
 	if len(lines) == 0 {
 		return 0, nil
 	}
 
 	for _, line := range lines {
-		if err := validatePostImportData(line.Post, a.MaxPostSize()); err != nil {
+		if err := imports.ValidatePostImportData(line.Post, a.MaxPostSize()); err != nil {
 			return line.LineNumber, err
 		}
 	}
@@ -1361,7 +1362,7 @@ func (a *App) importMultiplePostLines(c request.CTX, lines []LineImportWorkerDat
 
 	usernames := []string{}
 	teamNames := make([]string, len(lines))
-	postsData := make([]*PostImportData, len(lines))
+	postsData := make([]*imports.PostImportData, len(lines))
 	for i, line := range lines {
 		usernames = append(usernames, *line.Post.User)
 		if line.Post.FlaggedBy != nil {
@@ -1532,7 +1533,7 @@ func (a *App) importMultiplePostLines(c request.CTX, lines []LineImportWorkerDat
 }
 
 // uploadAttachments imports new attachments and returns current attachments of the post as a map
-func (a *App) uploadAttachments(c request.CTX, attachments *[]AttachmentImportData, post *model.Post, teamID string) map[string]bool {
+func (a *App) uploadAttachments(c request.CTX, attachments *[]imports.AttachmentImportData, post *model.Post, teamID string) map[string]bool {
 	if attachments == nil {
 		return nil
 	}
@@ -1564,9 +1565,9 @@ func (a *App) updateFileInfoWithPostId(post *model.Post) {
 		}
 	}
 }
-func (a *App) importDirectChannel(c request.CTX, data *DirectChannelImportData, dryRun bool) *model.AppError {
+func (a *App) importDirectChannel(c request.CTX, data *imports.DirectChannelImportData, dryRun bool) *model.AppError {
 	var err *model.AppError
-	if err = validateDirectChannelImportData(data); err != nil {
+	if err = imports.ValidateDirectChannelImportData(data); err != nil {
 		return err
 	}
 
@@ -1645,13 +1646,13 @@ func (a *App) importDirectChannel(c request.CTX, data *DirectChannelImportData, 
 
 // importMultipleDirectPostLines will return an error and the line
 // that caused it whenever possible
-func (a *App) importMultipleDirectPostLines(c request.CTX, lines []LineImportWorkerData, dryRun bool) (int, *model.AppError) {
+func (a *App) importMultipleDirectPostLines(c request.CTX, lines []imports.LineImportWorkerData, dryRun bool) (int, *model.AppError) {
 	if len(lines) == 0 {
 		return 0, nil
 	}
 
 	for _, line := range lines {
-		if err := validateDirectPostImportData(line.DirectPost, a.MaxPostSize()); err != nil {
+		if err := imports.ValidateDirectPostImportData(line.DirectPost, a.MaxPostSize()); err != nil {
 			return line.LineNumber, err
 		}
 	}
@@ -1840,8 +1841,8 @@ func (a *App) importMultipleDirectPostLines(c request.CTX, lines []LineImportWor
 	return 0, nil
 }
 
-func (a *App) importEmoji(data *EmojiImportData, dryRun bool) *model.AppError {
-	aerr := validateEmojiImportData(data)
+func (a *App) importEmoji(data *imports.EmojiImportData, dryRun bool) *model.AppError {
+	aerr := imports.ValidateEmojiImportData(data)
 	if aerr != nil {
 		if aerr.Id == "model.emoji.system_emoji_name.app_error" {
 			mlog.Warn("Skipping emoji import due to name conflict with system emoji", mlog.String("emoji_name", *data.Name))

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -1976,14 +1976,14 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding an invalid post in dry run mode.
 	data := imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:    &teamName,
 				Channel: &channelName,
 				User:    &username,
 			},
 		},
-		25,
+		LineNumber: 25,
 	}
 	errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 	assert.NotNil(t, err)
@@ -1992,7 +1992,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding a valid post in dry run mode.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2001,7 +2001,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: ptrInt64(model.GetMillis()),
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 	assert.Nil(t, err)
@@ -2010,7 +2010,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding an invalid post in apply mode.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2018,7 +2018,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: ptrInt64(model.GetMillis()),
 			},
 		},
-		35,
+		LineNumber: 35,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
@@ -2027,7 +2027,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding a valid post with invalid team in apply mode.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     ptrStr(NewTestId()),
 				Channel:  &channelName,
@@ -2036,7 +2036,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: ptrInt64(model.GetMillis()),
 			},
 		},
-		10,
+		LineNumber: 10,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
@@ -2047,7 +2047,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding a valid post with invalid channel in apply mode.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  ptrStr(NewTestId()),
@@ -2056,7 +2056,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: ptrInt64(model.GetMillis()),
 			},
 		},
-		7,
+		LineNumber: 7,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
@@ -2067,7 +2067,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding a valid post with invalid user in apply mode.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2076,7 +2076,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: ptrInt64(model.GetMillis()),
 			},
 		},
-		2,
+		LineNumber: 2,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
@@ -2088,7 +2088,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	// Try adding a valid post in apply mode.
 	time := model.GetMillis()
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2097,7 +2097,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: &time,
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
@@ -2116,7 +2116,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Update the post.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2125,7 +2125,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: &time,
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
@@ -2145,7 +2145,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	// Save the post with a different time.
 	newTime := time + 1
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2154,7 +2154,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: &newTime,
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
@@ -2163,7 +2163,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Save the post with a different message.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2172,7 +2172,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: &time,
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
@@ -2182,7 +2182,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	// Test with hashtags
 	hashtagTime := time + 2
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2191,7 +2191,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: &hashtagTime,
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
@@ -2220,7 +2220,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	flagsTime := hashtagTime + 1
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2233,7 +2233,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				},
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
@@ -2259,7 +2259,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	reactionPostTime := hashtagTime + 2
 	reactionTime := hashtagTime + 3
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2273,7 +2273,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				}},
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
@@ -2300,7 +2300,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	replyPostTime := hashtagTime + 4
 	replyTime := hashtagTime + 5
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2314,7 +2314,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				}},
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
@@ -2346,7 +2346,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Update post with replies.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2360,7 +2360,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				}},
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
@@ -2370,7 +2370,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Create new post with replies based on the previous one.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2384,7 +2384,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				}},
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
@@ -2394,7 +2394,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Create new reply for existing post with replies.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2408,7 +2408,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				}},
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
@@ -2424,7 +2424,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	editedReplyEditTime := hashtagTime + 8
 
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2440,7 +2440,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				}},
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
@@ -2482,7 +2482,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding two valid posts in apply mode.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2491,10 +2491,10 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: &time,
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	data2 := imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName2,
 				Channel:  &channelName,
@@ -2503,7 +2503,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				CreateAt: &time,
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data, data2}, false)
 	assert.Nil(t, err)
@@ -2511,7 +2511,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Create a pinned message.
 	data = imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
@@ -2521,7 +2521,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 				IsPinned: ptrBool(true),
 			},
 		},
-		1,
+		LineNumber: 1,
 	}
 	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	require.Nil(t, err)
@@ -2596,14 +2596,14 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Try adding an invalid post in dry run mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:    &teamName,
 					Channel: &channelName,
 					User:    &username,
 				},
 			},
-			12,
+			LineNumber: 12,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		assert.NotNil(t, err)
@@ -2613,7 +2613,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Try adding a valid post in dry run mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2622,7 +2622,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		assert.Nil(t, err)
@@ -2632,7 +2632,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Try adding an invalid post in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2640,7 +2640,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			2,
+			LineNumber: 2,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
@@ -2650,7 +2650,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Try adding a valid post with invalid team in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     ptrStr(NewTestId()),
 					Channel:  &channelName,
@@ -2659,7 +2659,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			7,
+			LineNumber: 7,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
@@ -2669,7 +2669,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Try adding a valid post with invalid channel in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  ptrStr(NewTestId()),
@@ -2678,7 +2678,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			8,
+			LineNumber: 8,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
@@ -2688,7 +2688,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Try adding a valid post with invalid user in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2697,7 +2697,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			9,
+			LineNumber: 9,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
@@ -2707,7 +2707,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Try adding a valid post in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2716,7 +2716,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: &time,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
@@ -2736,7 +2736,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Update the post", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2745,7 +2745,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: &time,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
@@ -2766,7 +2766,7 @@ func TestImportImportPost(t *testing.T) {
 	t.Run("Save the post with a different time", func(t *testing.T) {
 		newTime := time + 1
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2775,7 +2775,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: &newTime,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
@@ -2785,7 +2785,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Save the post with a different message", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2794,7 +2794,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: &time,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
@@ -2804,7 +2804,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Test with hashtag", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2813,7 +2813,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: &hashtagTime,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
@@ -2835,7 +2835,7 @@ func TestImportImportPost(t *testing.T) {
 	t.Run("Post with flags", func(t *testing.T) {
 		flagsTime := hashtagTime + 1
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2848,7 +2848,7 @@ func TestImportImportPost(t *testing.T) {
 					},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
@@ -2875,7 +2875,7 @@ func TestImportImportPost(t *testing.T) {
 		reactionPostTime := hashtagTime + 2
 		reactionTime := hashtagTime + 3
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2889,7 +2889,7 @@ func TestImportImportPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -2915,7 +2915,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Post with reply", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2929,7 +2929,7 @@ func TestImportImportPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -2962,7 +2962,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Update post with replies", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -2976,7 +2976,7 @@ func TestImportImportPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -2987,7 +2987,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Create new post with replies based on the previous one", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -3001,7 +3001,7 @@ func TestImportImportPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -3012,7 +3012,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Create new reply for existing post with replies", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -3026,7 +3026,7 @@ func TestImportImportPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -3037,7 +3037,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Post with Type", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -3047,7 +3047,7 @@ func TestImportImportPost(t *testing.T) {
 					CreateAt: &posttypeTime,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
@@ -3069,7 +3069,7 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Post with EditAt", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -3079,7 +3079,7 @@ func TestImportImportPost(t *testing.T) {
 					EditAt:   &editatEditTime,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
@@ -3103,7 +3103,7 @@ func TestImportImportPost(t *testing.T) {
 		now := model.GetMillis()
 		before := now - 10
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
@@ -3117,7 +3117,7 @@ func TestImportImportPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 
 		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
@@ -3341,7 +3341,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding an invalid post in dry run mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3351,7 +3351,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			7,
+			LineNumber: 7,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.NotNil(t, err)
@@ -3361,7 +3361,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding a valid post in dry run mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3372,7 +3372,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.Nil(t, err)
@@ -3382,7 +3382,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding an invalid post in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3393,7 +3393,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			9,
+			LineNumber: 9,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.NotNil(t, err)
@@ -3403,7 +3403,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding a valid post in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3414,7 +3414,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3434,7 +3434,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Import the post again", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3445,7 +3445,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3465,7 +3465,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Save the post with a different time", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3476,7 +3476,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 1),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3486,7 +3486,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Save the post with a different message", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3497,7 +3497,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 1),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3507,7 +3507,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Test with hashtag", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3518,7 +3518,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 2),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3538,7 +3538,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Test with some flags", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3553,7 +3553,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
@@ -3573,7 +3573,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Test with Type", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3585,7 +3585,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(posttypeDate),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3605,7 +3605,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Test with EditAt", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3617,7 +3617,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					EditAt:   ptrInt64(editatEditDate),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3639,7 +3639,7 @@ func TestImportImportDirectPost(t *testing.T) {
 		pinnedValue := true
 		creationTime := model.GetMillis()
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3651,7 +3651,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					IsPinned: &pinnedValue,
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3698,7 +3698,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding an invalid post in dry run mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3709,7 +3709,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			4,
+			LineNumber: 4,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.NotNil(t, err)
@@ -3719,7 +3719,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding a valid post in dry run mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3731,7 +3731,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.Nil(t, err)
@@ -3741,7 +3741,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding an invalid post in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3754,7 +3754,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			8,
+			LineNumber: 8,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.NotNil(t, err)
@@ -3764,7 +3764,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Try adding a valid post in apply mode", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3776,7 +3776,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 10),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3796,7 +3796,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Import the post again", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3808,7 +3808,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 10),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3828,7 +3828,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Save the post with a different time", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3840,7 +3840,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 11),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3850,7 +3850,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Save the post with a different message", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3862,7 +3862,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 11),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3872,7 +3872,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Test with hashtag", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3884,7 +3884,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(initialDate + 12),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
@@ -3904,7 +3904,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	t.Run("Test with some flags", func(t *testing.T) {
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3920,7 +3920,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					CreateAt: ptrInt64(model.GetMillis()),
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
@@ -3943,7 +3943,7 @@ func TestImportImportDirectPost(t *testing.T) {
 		reactionPostTime := ptrInt64(initialDate + 22)
 		reactionTime := ptrInt64(initialDate + 23)
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -3960,7 +3960,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -3988,7 +3988,7 @@ func TestImportImportDirectPost(t *testing.T) {
 		replyPostTime := ptrInt64(initialDate + 25)
 		replyTime := ptrInt64(initialDate + 26)
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -4005,7 +4005,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -4040,7 +4040,7 @@ func TestImportImportDirectPost(t *testing.T) {
 		replyPostTime := ptrInt64(initialDate + 25)
 		replyTime := ptrInt64(initialDate + 26)
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -4057,7 +4057,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -4070,7 +4070,7 @@ func TestImportImportDirectPost(t *testing.T) {
 		replyPostTime := ptrInt64(initialDate + 27)
 		replyTime := ptrInt64(initialDate + 28)
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -4087,7 +4087,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -4101,7 +4101,7 @@ func TestImportImportDirectPost(t *testing.T) {
 		replyTime := ptrInt64(initialDate + 30)
 		replyEditTime := ptrInt64(initialDate + 31)
 		data := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
@@ -4120,7 +4120,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					}},
 				},
 			},
-			1,
+			LineNumber: 1,
 		}
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
@@ -4284,7 +4284,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	testImage := filepath.Join(testsDir, "test.png")
 	testMarkDown := filepath.Join(testsDir, "test-attachments.md")
 	data := imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:        &teamName,
 				Channel:     &channelName,
@@ -4300,7 +4300,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 				}},
 			},
 		},
-		19,
+		LineNumber: 19,
 	}
 
 	t.Run("import with attachment", func(t *testing.T) {
@@ -4339,7 +4339,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	t.Run("Reply with Attachments in Direct Post", func(t *testing.T) {
 		directImportData := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user3.Username,
@@ -4356,7 +4356,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 					}},
 				},
 			},
-			7,
+			LineNumber: 7,
 		}
 
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData}, false)
@@ -4404,7 +4404,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get user2 from database.")
 
 	directImportData := imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			DirectPost: &imports.DirectPostImportData{
 				ChannelMembers: &[]string{
 					user1.Username,
@@ -4416,7 +4416,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 				Attachments: &[]imports.AttachmentImportData{{Path: &testImage}},
 			},
 		},
-		3,
+		LineNumber: 3,
 	}
 
 	t.Run("Regular import of attachment", func(t *testing.T) {
@@ -4441,7 +4441,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 
 	t.Run("Attempt to import again with same name and size but different content, SHOULD add an attachment", func(t *testing.T) {
 		directImportDataFake := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user1.Username,
@@ -4453,7 +4453,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 					Attachments: &[]imports.AttachmentImportData{{Path: &testImageFake}},
 				},
 			},
-			2,
+			LineNumber: 2,
 		}
 
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportDataFake}, false)
@@ -4466,7 +4466,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 
 	t.Run("Attempt to import again with same data, SHOULD add an attachment, since it's different name", func(t *testing.T) {
 		directImportData2 := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user1.Username,
@@ -4478,7 +4478,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 					Attachments: &[]imports.AttachmentImportData{{Path: &testImage2}},
 				},
 			},
-			2,
+			LineNumber: 2,
 		}
 
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData2}, false)
@@ -4563,7 +4563,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	testMarkDown := filepath.Join(testsDir, "test-attachments.md")
 	data := imports.LineImportWorkerData{
-		imports.LineImportData{
+		LineImportData: imports.LineImportData{
 			Post: &imports.PostImportData{
 				Team:        &teamName,
 				Channel:     &channelName,
@@ -4579,7 +4579,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 				}},
 			},
 		},
-		19,
+		LineNumber: 19,
 	}
 
 	t.Run("import with attachment", func(t *testing.T) {
@@ -4618,7 +4618,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	t.Run("Reply with Attachments in Direct Post", func(t *testing.T) {
 		directImportData := imports.LineImportWorkerData{
-			imports.LineImportData{
+			LineImportData: imports.LineImportData{
 				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user3.Username,
@@ -4635,7 +4635,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 					}},
 				},
 			},
-			7,
+			LineNumber: 7,
 		}
 
 		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData}, false)

--- a/app/import_functions_test.go
+++ b/app/import_functions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v6/app/imports"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/store"
@@ -34,30 +35,30 @@ func TestImportImportScheme(t *testing.T) {
 	}()
 
 	// Try importing an invalid scheme in dryRun mode.
-	data := SchemeImportData{
+	data := imports.SchemeImportData{
 		Name:  ptrStr(model.NewId()),
 		Scope: ptrStr("team"),
-		DefaultTeamGuestRole: &RoleImportData{
+		DefaultTeamGuestRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultTeamUserRole: &RoleImportData{
+		DefaultTeamUserRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultTeamAdminRole: &RoleImportData{
+		DefaultTeamAdminRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelGuestRole: &RoleImportData{
+		DefaultChannelGuestRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelUserRole: &RoleImportData{
+		DefaultChannelUserRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelAdminRole: &RoleImportData{
+		DefaultChannelAdminRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
@@ -229,22 +230,22 @@ func TestImportImportSchemeWithoutGuestRoles(t *testing.T) {
 	}()
 
 	// Try importing an invalid scheme in dryRun mode.
-	data := SchemeImportData{
+	data := imports.SchemeImportData{
 		Name:  ptrStr(model.NewId()),
 		Scope: ptrStr("team"),
-		DefaultTeamUserRole: &RoleImportData{
+		DefaultTeamUserRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultTeamAdminRole: &RoleImportData{
+		DefaultTeamAdminRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelUserRole: &RoleImportData{
+		DefaultChannelUserRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelAdminRole: &RoleImportData{
+		DefaultChannelAdminRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
@@ -409,7 +410,7 @@ func TestImportImportRole(t *testing.T) {
 
 	// Try importing an invalid role in dryRun mode.
 	rid1 := model.NewId()
-	data := RoleImportData{
+	data := imports.RoleImportData{
 		Name: &rid1,
 	}
 
@@ -474,7 +475,7 @@ func TestImportImportRole(t *testing.T) {
 	assert.True(t, role.SchemeManaged)
 
 	// Check that re-importing with only required fields doesn't update the others.
-	data2 := RoleImportData{
+	data2 := imports.RoleImportData{
 		Name:        &rid1,
 		DisplayName: ptrStr("new display name again"),
 	}
@@ -511,7 +512,7 @@ func TestImportImportTeam(t *testing.T) {
 	teamsCount, err := th.App.Srv().Store.Team().AnalyticsTeamCount(nil)
 	require.NoError(t, err, "Failed to get team count.")
 
-	data := TeamImportData{
+	data := imports.TeamImportData{
 		Name:            ptrStr(model.NewId()),
 		DisplayName:     ptrStr("Display Name"),
 		Type:            ptrStr("XYZ"),
@@ -599,7 +600,7 @@ func TestImportImportChannel(t *testing.T) {
 
 	// Import a Team.
 	teamName := model.NewRandomTeamName()
-	th.App.importTeam(th.Context, &TeamImportData{
+	th.App.importTeam(th.Context, &imports.TeamImportData{
 		Name:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
@@ -613,7 +614,7 @@ func TestImportImportChannel(t *testing.T) {
 
 	// Do an invalid channel in dry-run mode.
 	chanOpen := model.ChannelTypeOpen
-	data := ChannelImportData{
+	data := imports.ChannelImportData{
 		Team:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        &chanOpen,
@@ -718,7 +719,7 @@ func TestImportImportUser(t *testing.T) {
 	require.NoError(t, err, "Failed to get user count.")
 
 	// Do an invalid user in dry-run mode.
-	data := UserImportData{
+	data := imports.UserImportData{
 		Username: ptrStr(model.NewId()),
 	}
 	err = th.App.importUser(th.Context, &data, true)
@@ -733,7 +734,7 @@ func TestImportImportUser(t *testing.T) {
 	assert.Equal(t, userCount, userCount2, "Unexpected number of users")
 
 	// Do a valid user in dry-run mode.
-	data = UserImportData{
+	data = imports.UserImportData{
 		Username: ptrStr(model.NewId()),
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}
@@ -749,7 +750,7 @@ func TestImportImportUser(t *testing.T) {
 	assert.Equal(t, userCount, userCount3, "Unexpected number of users")
 
 	// Do an invalid user in apply mode.
-	data = UserImportData{
+	data = imports.UserImportData{
 		Username: ptrStr(model.NewId()),
 	}
 	err = th.App.importUser(th.Context, &data, false)
@@ -766,7 +767,7 @@ func TestImportImportUser(t *testing.T) {
 	// Do a valid user in apply mode.
 	username := model.NewId()
 	testsDir, _ := fileutils.FindDir("tests")
-	data = UserImportData{
+	data = imports.UserImportData{
 		ProfileImage: ptrStr(filepath.Join(testsDir, "test.png")),
 		Username:     &username,
 		Email:        ptrStr(model.NewId() + "@example.com"),
@@ -870,7 +871,7 @@ func TestImportImportUser(t *testing.T) {
 
 	// Test team and channel memberships
 	teamName := model.NewRandomTeamName()
-	th.App.importTeam(th.Context, &TeamImportData{
+	th.App.importTeam(th.Context, &imports.TeamImportData{
 		Name:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
@@ -880,7 +881,7 @@ func TestImportImportUser(t *testing.T) {
 
 	channelName := model.NewId()
 	chanTypeOpen := model.ChannelTypeOpen
-	th.App.importChannel(th.Context, &ChannelImportData{
+	th.App.importChannel(th.Context, &imports.ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,
 		DisplayName: ptrStr("Display Name"),
@@ -890,7 +891,7 @@ func TestImportImportUser(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get channel from database.")
 
 	username = model.NewId()
-	data = UserImportData{
+	data = imports.UserImportData{
 		Username:  &username,
 		Email:     ptrStr(model.NewId() + "@example.com"),
 		Nickname:  ptrStr(model.NewId()),
@@ -907,10 +908,10 @@ func TestImportImportUser(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get channel member count")
 
 	// Test with an invalid team & channel membership in dry-run mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Roles: ptrStr("invalid"),
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Roles: ptrStr("invalid"),
 				},
@@ -921,10 +922,10 @@ func TestImportImportUser(t *testing.T) {
 	assert.NotNil(t, appErr)
 
 	// Test with an unknown team name & invalid channel membership in dry-run mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: ptrStr(model.NewId()),
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Roles: ptrStr("invalid"),
 				},
@@ -935,10 +936,10 @@ func TestImportImportUser(t *testing.T) {
 	assert.NotNil(t, appErr)
 
 	// Test with a valid team & invalid channel membership in dry-run mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: &teamName,
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Roles: ptrStr("invalid"),
 				},
@@ -949,10 +950,10 @@ func TestImportImportUser(t *testing.T) {
 	assert.NotNil(t, appErr)
 
 	// Test with a valid team & unknown channel name in dry-run mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: &teamName,
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Name: ptrStr(model.NewId()),
 				},
@@ -963,10 +964,10 @@ func TestImportImportUser(t *testing.T) {
 	assert.Nil(t, appErr)
 
 	// Test with a valid team & valid channel name in dry-run mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: &teamName,
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Name: &channelName,
 				},
@@ -986,10 +987,10 @@ func TestImportImportUser(t *testing.T) {
 	require.Equal(t, channelMemberCount, cmc, "Number of channel members not as expected")
 
 	// Test with an invalid team & channel membership in apply mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Roles: ptrStr("invalid"),
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Roles: ptrStr("invalid"),
 				},
@@ -1000,10 +1001,10 @@ func TestImportImportUser(t *testing.T) {
 	assert.NotNil(t, appErr)
 
 	// Test with an unknown team name & invalid channel membership in apply mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: ptrStr(model.NewId()),
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Roles: ptrStr("invalid"),
 				},
@@ -1014,10 +1015,10 @@ func TestImportImportUser(t *testing.T) {
 	assert.NotNil(t, appErr)
 
 	// Test with a valid team & invalid channel membership in apply mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: &teamName,
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Roles: ptrStr("invalid"),
 				},
@@ -1037,10 +1038,10 @@ func TestImportImportUser(t *testing.T) {
 	require.Equal(t, channelMemberCount, cmc)
 
 	// Test with a valid team & unknown channel name in apply mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: &teamName,
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Name: ptrStr(model.NewId()),
 				},
@@ -1068,10 +1069,10 @@ func TestImportImportUser(t *testing.T) {
 	require.Equal(t, "team_user", teamMember.Roles)
 
 	// Test with a valid team & valid channel name in apply mode.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name: &teamName,
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Name: &channelName,
 				},
@@ -1099,16 +1100,16 @@ func TestImportImportUser(t *testing.T) {
 	assert.Equal(t, "all", channelMember.NotifyProps[model.MarkUnreadNotifyProp])
 
 	// Test with the properties of the team and channel membership changed.
-	data.Teams = &[]UserTeamImportData{
+	data.Teams = &[]imports.UserTeamImportData{
 		{
 			Name:  &teamName,
 			Theme: ptrStr(`{"awayIndicator":"#DBBD4E","buttonBg":"#23A1FF","buttonColor":"#FFFFFF","centerChannelBg":"#ffffff","centerChannelColor":"#333333","codeTheme":"github","image":"/static/files/a4a388b38b32678e83823ef1b3e17766.png","linkColor":"#2389d7","mentionBg":"#2389d7","mentionColor":"#ffffff","mentionHighlightBg":"#fff2bb","mentionHighlightLink":"#2f81b7","newMessageSeparator":"#FF8800","onlineIndicator":"#7DBE00","sidebarBg":"#fafafa","sidebarHeaderBg":"#3481B9","sidebarHeaderTextColor":"#ffffff","sidebarText":"#333333","sidebarTextActiveBorder":"#378FD2","sidebarTextActiveColor":"#111111","sidebarTextHoverBg":"#e6f2fa","sidebarUnreadText":"#333333","type":"Mattermost"}`),
 			Roles: ptrStr("team_user team_admin"),
-			Channels: &[]UserChannelImportData{
+			Channels: &[]imports.UserChannelImportData{
 				{
 					Name:  &channelName,
 					Roles: ptrStr("channel_user channel_admin"),
-					NotifyProps: &UserChannelNotifyPropsImportData{
+					NotifyProps: &imports.UserChannelNotifyPropsImportData{
 						Desktop:    ptrStr(model.UserNotifyMention),
 						Mobile:     ptrStr(model.UserNotifyMention),
 						MarkUnread: ptrStr(model.UserNotifyMention),
@@ -1147,7 +1148,7 @@ func TestImportImportUser(t *testing.T) {
 
 	// Add a user with some preferences.
 	username = model.NewId()
-	data = UserImportData{
+	data = imports.UserImportData{
 		Username:           &username,
 		Email:              ptrStr(model.NewId() + "@example.com"),
 		Theme:              ptrStr(`{"awayIndicator":"#DCBD4E","buttonBg":"#23A2FF","buttonColor":"#FFFFFF","centerChannelBg":"#ffffff","centerChannelColor":"#333333","codeTheme":"github","image":"/static/files/a4a388b38b32678e83823ef1b3e17766.png","linkColor":"#2389d7","mentionBg":"#2389d7","mentionColor":"#ffffff","mentionHighlightBg":"#fff2bb","mentionHighlightLink":"#2f81b7","newMessageSeparator":"#FF8800","onlineIndicator":"#7DBE00","sidebarBg":"#fafafa","sidebarHeaderBg":"#3481B9","sidebarHeaderTextColor":"#ffffff","sidebarText":"#333333","sidebarTextActiveBorder":"#378FD2","sidebarTextActiveColor":"#111111","sidebarTextHoverBg":"#e6f2fa","sidebarUnreadText":"#333333","type":"Mattermost"}`),
@@ -1182,7 +1183,7 @@ func TestImportImportUser(t *testing.T) {
 	checkPreference(t, th.App, user.Id, model.PreferenceCategoryNotifications, model.PreferenceNameEmailInterval, "30")
 
 	// Change those preferences.
-	data = UserImportData{
+	data = imports.UserImportData{
 		Username:           &username,
 		Email:              ptrStr(model.NewId() + "@example.com"),
 		Theme:              ptrStr(`{"awayIndicator":"#123456","buttonBg":"#23A2FF","buttonColor":"#FFFFFF","centerChannelBg":"#ffffff","centerChannelColor":"#333333","codeTheme":"github","image":"/static/files/a4a388b38b32678e83823ef1b3e17766.png","linkColor":"#2389d7","mentionBg":"#2389d7","mentionColor":"#ffffff","mentionHighlightBg":"#fff2bb","mentionHighlightLink":"#2f81b7","newMessageSeparator":"#FF8800","onlineIndicator":"#7DBE00","sidebarBg":"#fafafa","sidebarHeaderBg":"#3481B9","sidebarHeaderTextColor":"#ffffff","sidebarText":"#333333","sidebarTextActiveBorder":"#378FD2","sidebarTextActiveColor":"#111111","sidebarTextHoverBg":"#e6f2fa","sidebarUnreadText":"#333333","type":"Mattermost"}`),
@@ -1208,7 +1209,7 @@ func TestImportImportUser(t *testing.T) {
 	checkPreference(t, th.App, user.Id, model.PreferenceCategoryNotifications, model.PreferenceNameEmailInterval, "3600")
 
 	// Set Notify Without mention keys
-	data.NotifyProps = &UserNotifyPropsImportData{
+	data.NotifyProps = &imports.UserNotifyPropsImportData{
 		Desktop:          ptrStr(model.UserNotifyAll),
 		DesktopSound:     ptrStr("true"),
 		Email:            ptrStr("true"),
@@ -1233,7 +1234,7 @@ func TestImportImportUser(t *testing.T) {
 	checkNotifyProp(t, user, model.MentionKeysNotifyProp, "")
 
 	// Set Notify Props with Mention keys
-	data.NotifyProps = &UserNotifyPropsImportData{
+	data.NotifyProps = &imports.UserNotifyPropsImportData{
 		Desktop:          ptrStr(model.UserNotifyAll),
 		DesktopSound:     ptrStr("true"),
 		Email:            ptrStr("true"),
@@ -1259,7 +1260,7 @@ func TestImportImportUser(t *testing.T) {
 	checkNotifyProp(t, user, model.MentionKeysNotifyProp, "valid,misc")
 
 	// Change Notify Props with mention keys
-	data.NotifyProps = &UserNotifyPropsImportData{
+	data.NotifyProps = &imports.UserNotifyPropsImportData{
 		Desktop:          ptrStr(model.UserNotifyMention),
 		DesktopSound:     ptrStr("false"),
 		Email:            ptrStr("false"),
@@ -1285,7 +1286,7 @@ func TestImportImportUser(t *testing.T) {
 	checkNotifyProp(t, user, model.MentionKeysNotifyProp, "misc")
 
 	// Change Notify Props without mention keys
-	data.NotifyProps = &UserNotifyPropsImportData{
+	data.NotifyProps = &imports.UserNotifyPropsImportData{
 		Desktop:          ptrStr(model.UserNotifyMention),
 		DesktopSound:     ptrStr("false"),
 		Email:            ptrStr("false"),
@@ -1311,11 +1312,11 @@ func TestImportImportUser(t *testing.T) {
 
 	// Check Notify Props get set on *create* user.
 	username = model.NewId()
-	data = UserImportData{
+	data = imports.UserImportData{
 		Username: &username,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}
-	data.NotifyProps = &UserNotifyPropsImportData{
+	data.NotifyProps = &imports.UserNotifyPropsImportData{
 		Desktop:          ptrStr(model.UserNotifyMention),
 		DesktopSound:     ptrStr("false"),
 		Email:            ptrStr("false"),
@@ -1352,31 +1353,31 @@ func TestImportImportUser(t *testing.T) {
 		th.App.Srv().Store.System().PermanentDeleteByName(model.MigrationKeyAdvancedPermissionsPhase2)
 	}()
 
-	teamSchemeData := &SchemeImportData{
+	teamSchemeData := &imports.SchemeImportData{
 		Name:        ptrStr(model.NewId()),
 		DisplayName: ptrStr(model.NewId()),
 		Scope:       ptrStr("team"),
-		DefaultTeamGuestRole: &RoleImportData{
+		DefaultTeamGuestRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultTeamUserRole: &RoleImportData{
+		DefaultTeamUserRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultTeamAdminRole: &RoleImportData{
+		DefaultTeamAdminRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelGuestRole: &RoleImportData{
+		DefaultChannelGuestRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelUserRole: &RoleImportData{
+		DefaultChannelUserRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
-		DefaultChannelAdminRole: &RoleImportData{
+		DefaultChannelAdminRole: &imports.RoleImportData{
 			Name:        ptrStr(model.NewId()),
 			DisplayName: ptrStr(model.NewId()),
 		},
@@ -1389,7 +1390,7 @@ func TestImportImportUser(t *testing.T) {
 	teamScheme, nErr := th.App.Srv().Store.Scheme().GetByName(*teamSchemeData.Name)
 	require.NoError(t, nErr, "Failed to import scheme")
 
-	teamData := &TeamImportData{
+	teamData := &imports.TeamImportData{
 		Name:            ptrStr(NewTestId()),
 		DisplayName:     ptrStr("Display Name"),
 		Type:            ptrStr("O"),
@@ -1402,7 +1403,7 @@ func TestImportImportUser(t *testing.T) {
 	team, appErr = th.App.GetTeamByName(teamName)
 	require.Nil(t, appErr, "Failed to get team from database.")
 
-	channelData := &ChannelImportData{
+	channelData := &imports.ChannelImportData{
 		Team:        &teamName,
 		Name:        ptrStr(NewTestId()),
 		DisplayName: ptrStr("Display Name"),
@@ -1416,14 +1417,14 @@ func TestImportImportUser(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get channel from database")
 
 	// Test with a valid team & valid channel name in apply mode.
-	userData := &UserImportData{
+	userData := &imports.UserImportData{
 		Username: &username,
 		Email:    ptrStr(model.NewId() + "@example.com"),
-		Teams: &[]UserTeamImportData{
+		Teams: &[]imports.UserTeamImportData{
 			{
 				Name:  &team.Name,
 				Roles: ptrStr("team_user team_admin"),
-				Channels: &[]UserChannelImportData{
+				Channels: &[]imports.UserChannelImportData{
 					{
 						Name:  &channel.Name,
 						Roles: ptrStr("channel_admin channel_user"),
@@ -1457,15 +1458,15 @@ func TestImportImportUser(t *testing.T) {
 	// Test importing deleted user with a valid team & valid channel name in apply mode.
 	username = model.NewId()
 	deleteAt := model.GetMillis()
-	deletedUserData := &UserImportData{
+	deletedUserData := &imports.UserImportData{
 		Username: &username,
 		DeleteAt: &deleteAt,
 		Email:    ptrStr(model.NewId() + "@example.com"),
-		Teams: &[]UserTeamImportData{
+		Teams: &[]imports.UserTeamImportData{
 			{
 				Name:  &team.Name,
 				Roles: ptrStr("team_user"),
-				Channels: &[]UserChannelImportData{
+				Channels: &[]imports.UserChannelImportData{
 					{
 						Name:  &channel.Name,
 						Roles: ptrStr("channel_user"),
@@ -1499,15 +1500,15 @@ func TestImportImportUser(t *testing.T) {
 	// Test importing deleted guest with a valid team & valid channel name in apply mode.
 	username = model.NewId()
 	deleteAt = model.GetMillis()
-	deletedGuestData := &UserImportData{
+	deletedGuestData := &imports.UserImportData{
 		Username: &username,
 		DeleteAt: &deleteAt,
 		Email:    ptrStr(model.NewId() + "@example.com"),
-		Teams: &[]UserTeamImportData{
+		Teams: &[]imports.UserTeamImportData{
 			{
 				Name:  &team.Name,
 				Roles: ptrStr("team_guest"),
-				Channels: &[]UserChannelImportData{
+				Channels: &[]imports.UserChannelImportData{
 					{
 						Name:  &channel.Name,
 						Roles: ptrStr("channel_guest"),
@@ -1550,7 +1551,7 @@ func TestImportUserTeams(t *testing.T) {
 
 	tt := []struct {
 		name                  string
-		data                  *[]UserTeamImportData
+		data                  *[]imports.UserTeamImportData
 		expectedError         bool
 		expectedUserTeams     int
 		expectedUserChannels  int
@@ -1560,7 +1561,7 @@ func TestImportUserTeams(t *testing.T) {
 	}{
 		{
 			name: "Not existing team should fail",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name: model.NewString("not-existing-team-name"),
 				},
@@ -1575,7 +1576,7 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Should fail if one of the roles doesn't exists",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name:  &th.BasicTeam.Name,
 					Roles: model.NewString("not-existing-role"),
@@ -1589,7 +1590,7 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Should success to import explicit role",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name:  &th.BasicTeam.Name,
 					Roles: &customRole.Name,
@@ -1603,7 +1604,7 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Should success to import admin role",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name:  &th.BasicTeam.Name,
 					Roles: model.NewString(model.TeamAdminRoleId),
@@ -1617,7 +1618,7 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Should success to import with theme",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name:  &th.BasicTeam.Name,
 					Theme: &sampleTheme,
@@ -1632,7 +1633,7 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Team without channels must add the default channel",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name: &th.BasicTeam.Name,
 				},
@@ -1645,10 +1646,10 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Team with default channel must add only the default channel",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name: &th.BasicTeam.Name,
-					Channels: &[]UserChannelImportData{
+					Channels: &[]imports.UserChannelImportData{
 						{
 							Name: ptrStr(model.DefaultChannelName),
 						},
@@ -1663,10 +1664,10 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Team with non default channel must add default channel and the other channel",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name: &th.BasicTeam.Name,
-					Channels: &[]UserChannelImportData{
+					Channels: &[]imports.UserChannelImportData{
 						{
 							Name: &th.BasicChannel.Name,
 						},
@@ -1681,10 +1682,10 @@ func TestImportUserTeams(t *testing.T) {
 		},
 		{
 			name: "Multiple teams with multiple channels each",
-			data: &[]UserTeamImportData{
+			data: &[]imports.UserTeamImportData{
 				{
 					Name: &th.BasicTeam.Name,
-					Channels: &[]UserChannelImportData{
+					Channels: &[]imports.UserChannelImportData{
 						{
 							Name: &th.BasicChannel.Name,
 						},
@@ -1695,7 +1696,7 @@ func TestImportUserTeams(t *testing.T) {
 				},
 				{
 					Name: &team2.Name,
-					Channels: &[]UserChannelImportData{
+					Channels: &[]imports.UserChannelImportData{
 						{
 							Name: &channel3.Name,
 						},
@@ -1749,7 +1750,7 @@ func TestImportUserTeams(t *testing.T) {
 
 	t.Run("Should fail if the MaxUserPerTeam is reached", func(t *testing.T) {
 		user := th.CreateUser()
-		data := &[]UserTeamImportData{
+		data := &[]imports.UserTeamImportData{
 			{
 				Name: &th.BasicTeam.Name,
 			},
@@ -1766,7 +1767,7 @@ func TestImportUserChannels(t *testing.T) {
 	defer th.TearDown()
 	channel2 := th.CreateChannel(th.Context, th.BasicTeam)
 	customRole := th.CreateRole("test_custom_role")
-	sampleNotifyProps := UserChannelNotifyPropsImportData{
+	sampleNotifyProps := imports.UserChannelNotifyPropsImportData{
 		Desktop:    model.NewString("all"),
 		Mobile:     model.NewString("none"),
 		MarkUnread: model.NewString("all"),
@@ -1774,16 +1775,16 @@ func TestImportUserChannels(t *testing.T) {
 
 	tt := []struct {
 		name                  string
-		data                  *[]UserChannelImportData
+		data                  *[]imports.UserChannelImportData
 		expectedError         bool
 		expectedUserChannels  int
 		expectedExplicitRoles string
 		expectedRoles         string
-		expectedNotifyProps   *UserChannelNotifyPropsImportData
+		expectedNotifyProps   *imports.UserChannelNotifyPropsImportData
 	}{
 		{
 			name: "Not existing channel should fail",
-			data: &[]UserChannelImportData{
+			data: &[]imports.UserChannelImportData{
 				{
 					Name: model.NewString("not-existing-channel-name"),
 				},
@@ -1797,7 +1798,7 @@ func TestImportUserChannels(t *testing.T) {
 		},
 		{
 			name: "Should fail if one of the roles doesn't exists",
-			data: &[]UserChannelImportData{
+			data: &[]imports.UserChannelImportData{
 				{
 					Name:  &th.BasicChannel.Name,
 					Roles: model.NewString("not-existing-role"),
@@ -1810,7 +1811,7 @@ func TestImportUserChannels(t *testing.T) {
 		},
 		{
 			name: "Should success to import explicit role",
-			data: &[]UserChannelImportData{
+			data: &[]imports.UserChannelImportData{
 				{
 					Name:  &th.BasicChannel.Name,
 					Roles: &customRole.Name,
@@ -1823,7 +1824,7 @@ func TestImportUserChannels(t *testing.T) {
 		},
 		{
 			name: "Should success to import admin role",
-			data: &[]UserChannelImportData{
+			data: &[]imports.UserChannelImportData{
 				{
 					Name:  &th.BasicChannel.Name,
 					Roles: model.NewString(model.ChannelAdminRoleId),
@@ -1836,7 +1837,7 @@ func TestImportUserChannels(t *testing.T) {
 		},
 		{
 			name: "Should success to import with notifyProps",
-			data: &[]UserChannelImportData{
+			data: &[]imports.UserChannelImportData{
 				{
 					Name:        &th.BasicChannel.Name,
 					NotifyProps: &sampleNotifyProps,
@@ -1850,7 +1851,7 @@ func TestImportUserChannels(t *testing.T) {
 		},
 		{
 			name: "Should import properly multiple channels",
-			data: &[]UserChannelImportData{
+			data: &[]imports.UserChannelImportData{
 				{
 					Name: &th.BasicChannel.Name,
 				},
@@ -1901,10 +1902,10 @@ func TestImportUserDefaultNotifyProps(t *testing.T) {
 
 	// Create a valid new user with some, but not all, notify props populated.
 	username := model.NewId()
-	data := UserImportData{
+	data := imports.UserImportData{
 		Username: &username,
 		Email:    ptrStr(model.NewId() + "@example.com"),
-		NotifyProps: &UserNotifyPropsImportData{
+		NotifyProps: &imports.UserNotifyPropsImportData{
 			Email:       ptrStr("false"),
 			MentionKeys: ptrStr(""),
 		},
@@ -1940,7 +1941,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Create a Team.
 	teamName := model.NewRandomTeamName()
-	th.App.importTeam(th.Context, &TeamImportData{
+	th.App.importTeam(th.Context, &imports.TeamImportData{
 		Name:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
@@ -1951,7 +1952,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	// Create a Channel.
 	channelName := NewTestId()
 	chanTypeOpen := model.ChannelTypeOpen
-	th.App.importChannel(th.Context, &ChannelImportData{
+	th.App.importChannel(th.Context, &imports.ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,
 		DisplayName: ptrStr("Display Name"),
@@ -1962,7 +1963,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Create a user.
 	username := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -1974,9 +1975,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	require.NoError(t, nErr)
 
 	// Try adding an invalid post in dry run mode.
-	data := LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data := imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:    &teamName,
 				Channel: &channelName,
 				User:    &username,
@@ -1984,15 +1985,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		25,
 	}
-	errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, true)
+	errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 	assert.NotNil(t, err)
 	assert.Equal(t, data.LineNumber, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 
 	// Try adding a valid post in dry run mode.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2002,15 +2003,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, true)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 
 	// Try adding an invalid post in apply mode.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2019,15 +2020,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		35,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
 	assert.Equal(t, data.LineNumber, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 
 	// Try adding a valid post with invalid team in apply mode.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     ptrStr(NewTestId()),
 				Channel:  &channelName,
 				User:     &username,
@@ -2037,7 +2038,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		10,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
 	// Batch will fail when searching for teams, so no specific line
 	// is associated with the error
@@ -2045,9 +2046,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 
 	// Try adding a valid post with invalid channel in apply mode.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  ptrStr(NewTestId()),
 				User:     &username,
@@ -2057,7 +2058,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		7,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
 	// Batch will fail when searching for channels, so no specific
 	// line is associated with the error
@@ -2065,9 +2066,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 
 	// Try adding a valid post with invalid user in apply mode.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     ptrStr(model.NewId()),
@@ -2077,7 +2078,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		2,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.NotNil(t, err)
 	// Batch will fail when searching for users, so no specific line
 	// is associated with the error
@@ -2086,9 +2087,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Try adding a valid post in apply mode.
 	time := model.GetMillis()
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2098,7 +2099,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 1, team.Id)
@@ -2114,9 +2115,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	require.False(t, postBool, "Post properties not as expected")
 
 	// Update the post.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2126,7 +2127,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 1, team.Id)
@@ -2143,9 +2144,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Save the post with a different time.
 	newTime := time + 1
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2155,15 +2156,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 2, team.Id)
 
 	// Save the post with a different message.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2173,16 +2174,16 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 3, team.Id)
 
 	// Test with hashtags
 	hashtagTime := time + 2
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2192,7 +2193,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, errLine)
 	AssertAllPostsCount(t, th.App, initialPostCount, 4, team.Id)
@@ -2210,7 +2211,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Post with flags.
 	username2 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username2,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -2218,9 +2219,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	require.Nil(t, err, "Failed to get user from database.")
 
 	flagsTime := hashtagTime + 1
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2235,7 +2236,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		1,
 	}
 
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
 	assert.Equal(t, 0, errLine)
 
@@ -2257,15 +2258,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	// Post with reaction.
 	reactionPostTime := hashtagTime + 2
 	reactionTime := hashtagTime + 3
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
 				Message:  ptrStr("Message with reaction"),
 				CreateAt: &reactionPostTime,
-				Reactions: &[]ReactionImportData{{
+				Reactions: &[]imports.ReactionImportData{{
 					User:      &user2.Username,
 					EmojiName: ptrStr("+1"),
 					CreateAt:  &reactionTime,
@@ -2274,7 +2275,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
 	assert.Equal(t, 0, errLine)
 
@@ -2298,15 +2299,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	// Post with reply.
 	replyPostTime := hashtagTime + 4
 	replyTime := hashtagTime + 5
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
 				Message:  ptrStr("Message with reply"),
 				CreateAt: &replyPostTime,
-				Replies: &[]ReplyImportData{{
+				Replies: &[]imports.ReplyImportData{{
 					User:     &user2.Username,
 					Message:  ptrStr("Message reply"),
 					CreateAt: &replyTime,
@@ -2315,7 +2316,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
 	assert.Equal(t, 0, errLine)
 
@@ -2344,15 +2345,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	require.Equal(t, post.Id, reply.RootId, "Unexpected reply RootId")
 
 	// Update post with replies.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &user2.Username,
 				Message:  ptrStr("Message with reply"),
 				CreateAt: &replyPostTime,
-				Replies: &[]ReplyImportData{{
+				Replies: &[]imports.ReplyImportData{{
 					User:     &username,
 					Message:  ptrStr("Message reply"),
 					CreateAt: &replyTime,
@@ -2361,22 +2362,22 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
 	assert.Equal(t, 0, errLine)
 
 	AssertAllPostsCount(t, th.App, initialPostCount, 8, team.Id)
 
 	// Create new post with replies based on the previous one.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &user2.Username,
 				Message:  ptrStr("Message with reply 2"),
 				CreateAt: &replyPostTime,
-				Replies: &[]ReplyImportData{{
+				Replies: &[]imports.ReplyImportData{{
 					User:     &username,
 					Message:  ptrStr("Message reply"),
 					CreateAt: &replyTime,
@@ -2385,22 +2386,22 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
 	assert.Equal(t, 0, errLine)
 
 	AssertAllPostsCount(t, th.App, initialPostCount, 10, team.Id)
 
 	// Create new reply for existing post with replies.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &user2.Username,
 				Message:  ptrStr("Message with reply"),
 				CreateAt: &replyPostTime,
-				Replies: &[]ReplyImportData{{
+				Replies: &[]imports.ReplyImportData{{
 					User:     &username,
 					Message:  ptrStr("Message reply 2"),
 					CreateAt: &replyTime,
@@ -2409,7 +2410,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
 	assert.Equal(t, 0, errLine)
 
@@ -2422,15 +2423,15 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	editedReplyTime := hashtagTime + 7
 	editedReplyEditTime := hashtagTime + 8
 
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &user2.Username,
 				Message:  ptrStr("Message with reply"),
 				CreateAt: &editedReplyPostTime,
-				Replies: &[]ReplyImportData{{
+				Replies: &[]imports.ReplyImportData{{
 					User:     &username,
 					Type:     ptrStr(model.PostTypeSystemGeneric),
 					Message:  ptrStr("Message reply 3"),
@@ -2441,7 +2442,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	assert.Nil(t, err, "Expected success.")
 	assert.Equal(t, 0, errLine)
 
@@ -2457,7 +2458,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 
 	// Create another Team.
 	teamName2 := model.NewRandomTeamName()
-	th.App.importTeam(th.Context, &TeamImportData{
+	th.App.importTeam(th.Context, &imports.TeamImportData{
 		Name:        &teamName2,
 		DisplayName: ptrStr("Display Name 2"),
 		Type:        ptrStr("O"),
@@ -2466,7 +2467,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	require.Nil(t, err, "Failed to get team from database.")
 
 	// Create another Channel for the another team.
-	th.App.importChannel(th.Context, &ChannelImportData{
+	th.App.importChannel(th.Context, &imports.ChannelImportData{
 		Team:        &teamName2,
 		Name:        &channelName,
 		DisplayName: ptrStr("Display Name"),
@@ -2480,9 +2481,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 	require.NoError(t, nErr)
 
 	// Try adding two valid posts in apply mode.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &username,
@@ -2492,9 +2493,9 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	data2 := LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data2 := imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName2,
 				Channel:  &channelName,
 				User:     &username,
@@ -2504,14 +2505,14 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data, data2}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data, data2}, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, errLine)
 
 	// Create a pinned message.
-	data = LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data = imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:     &teamName,
 				Channel:  &channelName,
 				User:     &user2.Username,
@@ -2522,7 +2523,7 @@ func TestImportimportMultiplePostLines(t *testing.T) {
 		},
 		1,
 	}
-	errLine, err = th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+	errLine, err = th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 	require.Nil(t, err)
 	require.Equal(t, 0, errLine)
 
@@ -2544,7 +2545,7 @@ func TestImportImportPost(t *testing.T) {
 
 	// Create a Team.
 	teamName := model.NewRandomTeamName()
-	th.App.importTeam(th.Context, &TeamImportData{
+	th.App.importTeam(th.Context, &imports.TeamImportData{
 		Name:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
@@ -2555,7 +2556,7 @@ func TestImportImportPost(t *testing.T) {
 	// Create a Channel.
 	channelName := NewTestId()
 	chanTypeOpen := model.ChannelTypeOpen
-	th.App.importChannel(th.Context, &ChannelImportData{
+	th.App.importChannel(th.Context, &imports.ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,
 		DisplayName: ptrStr("Display Name"),
@@ -2566,7 +2567,7 @@ func TestImportImportPost(t *testing.T) {
 
 	// Create a user.
 	username := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -2574,7 +2575,7 @@ func TestImportImportPost(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get user from database.")
 
 	username2 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username2,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -2594,9 +2595,9 @@ func TestImportImportPost(t *testing.T) {
 	editatEditTime := hashtagTime + 8
 
 	t.Run("Try adding an invalid post in dry run mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:    &teamName,
 					Channel: &channelName,
 					User:    &username,
@@ -2604,16 +2605,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			12,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, true)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		assert.NotNil(t, err)
 		assert.Equal(t, data.LineNumber, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 	})
 
 	t.Run("Try adding a valid post in dry run mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -2623,16 +2624,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, true)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		assert.Nil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 	})
 
 	t.Run("Try adding an invalid post in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -2641,16 +2642,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			2,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
 		assert.Equal(t, data.LineNumber, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 	})
 
 	t.Run("Try adding a valid post with invalid team in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     ptrStr(NewTestId()),
 					Channel:  &channelName,
 					User:     &username,
@@ -2660,16 +2661,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			7,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 	})
 
 	t.Run("Try adding a valid post with invalid channel in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  ptrStr(NewTestId()),
 					User:     &username,
@@ -2679,16 +2680,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			8,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 	})
 
 	t.Run("Try adding a valid post with invalid user in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     ptrStr(model.NewId()),
@@ -2698,16 +2699,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			9,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.NotNil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, team.Id)
 	})
 
 	t.Run("Try adding a valid post in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -2717,7 +2718,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 1, team.Id)
@@ -2734,9 +2735,9 @@ func TestImportImportPost(t *testing.T) {
 	})
 
 	t.Run("Update the post", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username2,
@@ -2746,7 +2747,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 1, team.Id)
@@ -2764,9 +2765,9 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Save the post with a different time", func(t *testing.T) {
 		newTime := time + 1
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -2776,16 +2777,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 2, team.Id)
 	})
 
 	t.Run("Save the post with a different message", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -2795,16 +2796,16 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 3, team.Id)
 	})
 
 	t.Run("Test with hashtag", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -2814,7 +2815,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 4, team.Id)
@@ -2833,9 +2834,9 @@ func TestImportImportPost(t *testing.T) {
 
 	t.Run("Post with flags", func(t *testing.T) {
 		flagsTime := hashtagTime + 1
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -2850,7 +2851,7 @@ func TestImportImportPost(t *testing.T) {
 			1,
 		}
 
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -2873,15 +2874,15 @@ func TestImportImportPost(t *testing.T) {
 	t.Run("Post with reaction", func(t *testing.T) {
 		reactionPostTime := hashtagTime + 2
 		reactionTime := hashtagTime + 3
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
 					Message:  ptrStr("Message with reaction"),
 					CreateAt: &reactionPostTime,
-					Reactions: &[]ReactionImportData{{
+					Reactions: &[]imports.ReactionImportData{{
 						User:      &user2.Username,
 						EmojiName: ptrStr("+1"),
 						CreateAt:  &reactionTime,
@@ -2890,7 +2891,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -2913,15 +2914,15 @@ func TestImportImportPost(t *testing.T) {
 	})
 
 	t.Run("Post with reply", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
 					Message:  ptrStr("Message with reply"),
 					CreateAt: &replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     &user2.Username,
 						Message:  ptrStr("Message reply"),
 						CreateAt: &replyTime,
@@ -2930,7 +2931,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -2960,15 +2961,15 @@ func TestImportImportPost(t *testing.T) {
 	})
 
 	t.Run("Update post with replies", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &user2.Username,
 					Message:  ptrStr("Message with reply"),
 					CreateAt: &replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     &username,
 						Message:  ptrStr("Message reply"),
 						CreateAt: &replyTime,
@@ -2977,7 +2978,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -2985,15 +2986,15 @@ func TestImportImportPost(t *testing.T) {
 	})
 
 	t.Run("Create new post with replies based on the previous one", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &user2.Username,
 					Message:  ptrStr("Message with reply 2"),
 					CreateAt: &replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     &username,
 						Message:  ptrStr("Message reply"),
 						CreateAt: &replyTime,
@@ -3002,7 +3003,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -3010,15 +3011,15 @@ func TestImportImportPost(t *testing.T) {
 	})
 
 	t.Run("Create new reply for existing post with replies", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &user2.Username,
 					Message:  ptrStr("Message with reply"),
 					CreateAt: &replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     &username,
 						Message:  ptrStr("Message reply 2"),
 						CreateAt: &replyTime,
@@ -3027,7 +3028,7 @@ func TestImportImportPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -3035,9 +3036,9 @@ func TestImportImportPost(t *testing.T) {
 	})
 
 	t.Run("Post with Type", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -3049,7 +3050,7 @@ func TestImportImportPost(t *testing.T) {
 			1,
 		}
 
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -3067,9 +3068,9 @@ func TestImportImportPost(t *testing.T) {
 	})
 
 	t.Run("Post with EditAt", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &username,
@@ -3081,7 +3082,7 @@ func TestImportImportPost(t *testing.T) {
 			1,
 		}
 
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -3101,15 +3102,15 @@ func TestImportImportPost(t *testing.T) {
 	t.Run("Reply CreateAt before parent post CreateAt", func(t *testing.T) {
 		now := model.GetMillis()
 		before := now - 10
-		data := LineImportWorkerData{
-			LineImportData{
-				Post: &PostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				Post: &imports.PostImportData{
 					Team:     &teamName,
 					Channel:  &channelName,
 					User:     &user2.Username,
 					Message:  ptrStr("Message with reply"),
 					CreateAt: &now,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     &username,
 						Message:  ptrStr("Message reply 2"),
 						CreateAt: &before,
@@ -3119,7 +3120,7 @@ func TestImportImportPost(t *testing.T) {
 			1,
 		}
 
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -3152,7 +3153,7 @@ func TestImportImportDirectChannel(t *testing.T) {
 	require.NoError(t, err, "Failed to get group channel count.")
 
 	// Do an invalid channel in dry-run mode.
-	data := DirectChannelImportData{
+	data := imports.DirectChannelImportData{
 		Members: &[]string{
 			model.NewId(),
 		},
@@ -3313,7 +3314,7 @@ func TestImportImportDirectPost(t *testing.T) {
 	defer th.TearDown()
 
 	// Create the DIRECT channel.
-	channelData := DirectChannelImportData{
+	channelData := imports.DirectChannelImportData{
 		Members: &[]string{
 			th.BasicUser.Username,
 			th.BasicUser2.Username,
@@ -3339,9 +3340,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	editatEditDate := initialDate + 5
 
 	t.Run("Try adding an invalid post in dry run mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3352,16 +3353,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			7,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, true)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.NotNil(t, err)
 		require.Equal(t, data.LineNumber, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, "")
 	})
 
 	t.Run("Try adding a valid post in dry run mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3373,16 +3374,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, true)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, "")
 	})
 
 	t.Run("Try adding an invalid post in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						model.NewId(),
@@ -3394,16 +3395,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			9,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.NotNil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, "")
 	})
 
 	t.Run("Try adding a valid post in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3415,7 +3416,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 1, "")
@@ -3432,9 +3433,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Import the post again", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3446,7 +3447,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 1, "")
@@ -3463,9 +3464,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Save the post with a different time", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3477,16 +3478,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 2, "")
 	})
 
 	t.Run("Save the post with a different message", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3498,16 +3499,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 3, "")
 	})
 
 	t.Run("Test with hashtag", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3519,7 +3520,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 4, "")
@@ -3536,9 +3537,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Test with some flags", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3555,7 +3556,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			1,
 		}
 
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 5, "")
@@ -3571,9 +3572,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Test with Type", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3586,7 +3587,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 6, "")
@@ -3603,9 +3604,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Test with EditAt", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3618,7 +3619,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 7, "")
@@ -3637,9 +3638,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	t.Run("Test with IsPinned", func(t *testing.T) {
 		pinnedValue := true
 		creationTime := model.GetMillis()
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3652,7 +3653,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 8, "")
@@ -3669,7 +3670,7 @@ func TestImportImportDirectPost(t *testing.T) {
 
 	// Create the GROUP channel.
 	user3 := th.CreateUser()
-	channelData = DirectChannelImportData{
+	channelData = imports.DirectChannelImportData{
 		Members: &[]string{
 			th.BasicUser.Username,
 			th.BasicUser2.Username,
@@ -3696,9 +3697,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	initialPostCount = result
 
 	t.Run("Try adding an invalid post in dry run mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3710,16 +3711,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			4,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, true)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.NotNil(t, err)
 		require.Equal(t, data.LineNumber, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, "")
 	})
 
 	t.Run("Try adding a valid post in dry run mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3732,16 +3733,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, true)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, true)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, "")
 	})
 
 	t.Run("Try adding an invalid post in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3755,16 +3756,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			8,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.NotNil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 0, "")
 	})
 
 	t.Run("Try adding a valid post in apply mode", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3777,7 +3778,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 1, "")
@@ -3794,9 +3795,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Import the post again", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3809,7 +3810,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 1, "")
@@ -3826,9 +3827,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Save the post with a different time", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3841,16 +3842,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 2, "")
 	})
 
 	t.Run("Save the post with a different message", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3863,16 +3864,16 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 3, "")
 	})
 
 	t.Run("Test with hashtag", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3885,7 +3886,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 		AssertAllPostsCount(t, th.App, initialPostCount, 4, "")
@@ -3902,9 +3903,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	})
 
 	t.Run("Test with some flags", func(t *testing.T) {
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3922,7 +3923,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			1,
 		}
 
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 
@@ -3941,9 +3942,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	t.Run("Post with reaction", func(t *testing.T) {
 		reactionPostTime := ptrInt64(initialDate + 22)
 		reactionTime := ptrInt64(initialDate + 23)
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3952,7 +3953,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					User:     ptrStr(th.BasicUser.Username),
 					Message:  ptrStr("Message with reaction"),
 					CreateAt: reactionPostTime,
-					Reactions: &[]ReactionImportData{{
+					Reactions: &[]imports.ReactionImportData{{
 						User:      ptrStr(th.BasicUser2.Username),
 						EmojiName: ptrStr("+1"),
 						CreateAt:  reactionTime,
@@ -3961,7 +3962,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -3986,9 +3987,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	t.Run("Post with reply", func(t *testing.T) {
 		replyPostTime := ptrInt64(initialDate + 25)
 		replyTime := ptrInt64(initialDate + 26)
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -3997,7 +3998,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					User:     ptrStr(th.BasicUser.Username),
 					Message:  ptrStr("Message with reply"),
 					CreateAt: replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     ptrStr(th.BasicUser2.Username),
 						Message:  ptrStr("Message reply"),
 						CreateAt: replyTime,
@@ -4006,7 +4007,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4038,9 +4039,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	t.Run("Update post with replies", func(t *testing.T) {
 		replyPostTime := ptrInt64(initialDate + 25)
 		replyTime := ptrInt64(initialDate + 26)
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -4049,7 +4050,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					User:     ptrStr(th.BasicUser2.Username),
 					Message:  ptrStr("Message with reply"),
 					CreateAt: replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     ptrStr(th.BasicUser.Username),
 						Message:  ptrStr("Message reply"),
 						CreateAt: replyTime,
@@ -4058,7 +4059,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4068,9 +4069,9 @@ func TestImportImportDirectPost(t *testing.T) {
 	t.Run("Create new post with replies based on the previous one", func(t *testing.T) {
 		replyPostTime := ptrInt64(initialDate + 27)
 		replyTime := ptrInt64(initialDate + 28)
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -4079,7 +4080,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					User:     ptrStr(th.BasicUser2.Username),
 					Message:  ptrStr("Message with reply 2"),
 					CreateAt: replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     ptrStr(th.BasicUser.Username),
 						Message:  ptrStr("Message reply"),
 						CreateAt: replyTime,
@@ -4088,7 +4089,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4099,9 +4100,9 @@ func TestImportImportDirectPost(t *testing.T) {
 		replyPostTime := ptrInt64(initialDate + 29)
 		replyTime := ptrInt64(initialDate + 30)
 		replyEditTime := ptrInt64(initialDate + 31)
-		data := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		data := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						th.BasicUser.Username,
 						th.BasicUser2.Username,
@@ -4110,7 +4111,7 @@ func TestImportImportDirectPost(t *testing.T) {
 					User:     ptrStr(th.BasicUser2.Username),
 					Message:  ptrStr("Message with reply"),
 					CreateAt: replyPostTime,
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:     ptrStr(th.BasicUser.Username),
 						Type:     ptrStr(model.PostTypeSystemGeneric),
 						Message:  ptrStr("Message reply 2"),
@@ -4121,7 +4122,7 @@ func TestImportImportDirectPost(t *testing.T) {
 			},
 			1,
 		}
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4149,7 +4150,7 @@ func TestImportImportEmoji(t *testing.T) {
 	testsDir, _ := fileutils.FindDir("tests")
 	testImage := filepath.Join(testsDir, "test.png")
 
-	data := EmojiImportData{Name: ptrStr(model.NewId())}
+	data := imports.EmojiImportData{Name: ptrStr(model.NewId())}
 	appErr := th.App.importEmoji(&data, true)
 	assert.NotNil(t, appErr, "Invalid emoji should have failed dry run")
 
@@ -4161,7 +4162,7 @@ func TestImportImportEmoji(t *testing.T) {
 	appErr = th.App.importEmoji(&data, true)
 	assert.Nil(t, appErr, "Valid emoji should have passed dry run")
 
-	data = EmojiImportData{Name: ptrStr(model.NewId())}
+	data = imports.EmojiImportData{Name: ptrStr(model.NewId())}
 	appErr = th.App.importEmoji(&data, false)
 	assert.NotNil(t, appErr, "Invalid emoji should have failed apply mode")
 
@@ -4180,12 +4181,12 @@ func TestImportImportEmoji(t *testing.T) {
 	appErr = th.App.importEmoji(&data, false)
 	assert.Nil(t, appErr, "Second run should have succeeded apply mode")
 
-	data = EmojiImportData{Name: ptrStr("smiley"), Image: ptrStr(testImage)}
+	data = imports.EmojiImportData{Name: ptrStr("smiley"), Image: ptrStr(testImage)}
 	appErr = th.App.importEmoji(&data, false)
 	assert.Nil(t, appErr, "System emoji should not fail")
 
 	largeImage := filepath.Join(testsDir, "large_image_file.jpg")
-	data = EmojiImportData{Name: ptrStr(model.NewId()), Image: ptrStr(largeImage)}
+	data = imports.EmojiImportData{Name: ptrStr(model.NewId()), Image: ptrStr(largeImage)}
 	appErr = th.App.importEmoji(&data, false)
 	require.NotNil(t, appErr)
 	require.ErrorIs(t, appErr.Unwrap(), utils.SizeLimitExceeded)
@@ -4200,14 +4201,14 @@ func TestImportAttachment(t *testing.T) {
 	invalidPath := "some-invalid-path"
 
 	userID := model.NewId()
-	data := AttachmentImportData{Path: &testImage}
+	data := imports.AttachmentImportData{Path: &testImage}
 	_, err := th.App.importAttachment(th.Context, &data, &model.Post{UserId: userID, ChannelId: "some-channel"}, "some-team")
 	assert.Nil(t, err, "sample run without errors")
 
 	attachments := GetAttachments(userID, th, t)
 	assert.Len(t, attachments, 1)
 
-	data = AttachmentImportData{Path: &invalidPath}
+	data = imports.AttachmentImportData{Path: &invalidPath}
 	_, err = th.App.importAttachment(th.Context, &data, &model.Post{UserId: model.NewId(), ChannelId: "some-channel"}, "some-team")
 	assert.NotNil(t, err, "should have failed when opening the file")
 	assert.Equal(t, err.Id, "app.import.attachment.bad_file.error")
@@ -4219,7 +4220,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	// Create a Team.
 	teamName := model.NewRandomTeamName()
-	th.App.importTeam(th.Context, &TeamImportData{
+	th.App.importTeam(th.Context, &imports.TeamImportData{
 		Name:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
@@ -4230,7 +4231,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	// Create a Channel.
 	channelName := NewTestId()
 	chanTypeOpen := model.ChannelTypeOpen
-	th.App.importChannel(th.Context, &ChannelImportData{
+	th.App.importChannel(th.Context, &imports.ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,
 		DisplayName: ptrStr("Display Name"),
@@ -4241,7 +4242,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	// Create a user3.
 	username := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4250,7 +4251,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	require.NotNil(t, user3)
 
 	username2 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username2,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4259,7 +4260,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	// Create direct post users.
 	username3 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username3,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4267,7 +4268,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get user3 from database.")
 
 	username4 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username4,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4282,20 +4283,20 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	testsDir, _ := fileutils.FindDir("tests")
 	testImage := filepath.Join(testsDir, "test.png")
 	testMarkDown := filepath.Join(testsDir, "test-attachments.md")
-	data := LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data := imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:        &teamName,
 				Channel:     &channelName,
 				User:        &username3,
 				Message:     ptrStr("Message with reply"),
 				CreateAt:    &attachmentsPostTime,
-				Attachments: &[]AttachmentImportData{{Path: &testImage}, {Path: &testMarkDown}},
-				Replies: &[]ReplyImportData{{
+				Attachments: &[]imports.AttachmentImportData{{Path: &testImage}, {Path: &testMarkDown}},
+				Replies: &[]imports.ReplyImportData{{
 					User:        &user4.Username,
 					Message:     ptrStr("Message reply"),
 					CreateAt:    &attachmentsReplyTime,
-					Attachments: &[]AttachmentImportData{{Path: &testImage}},
+					Attachments: &[]imports.AttachmentImportData{{Path: &testImage}},
 				}},
 			},
 		},
@@ -4303,7 +4304,7 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	}
 
 	t.Run("import with attachment", func(t *testing.T) {
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 
@@ -4320,8 +4321,8 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	})
 
 	t.Run("import existing post with new attachment", func(t *testing.T) {
-		data.Post.Attachments = &[]AttachmentImportData{{Path: &testImage}}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		data.Post.Attachments = &[]imports.AttachmentImportData{{Path: &testImage}}
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 
@@ -4337,9 +4338,9 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 	})
 
 	t.Run("Reply with Attachments in Direct Post", func(t *testing.T) {
-		directImportData := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		directImportData := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user3.Username,
 						user2.Username,
@@ -4347,18 +4348,18 @@ func TestImportPostAndRepliesWithAttachments(t *testing.T) {
 					User:     &user3.Username,
 					Message:  ptrStr("Message with Replies"),
 					CreateAt: ptrInt64(model.GetMillis()),
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:        &user2.Username,
 						Message:     ptrStr("Message reply with attachment"),
 						CreateAt:    ptrInt64(model.GetMillis()),
-						Attachments: &[]AttachmentImportData{{Path: &testImage}},
+						Attachments: &[]imports.AttachmentImportData{{Path: &testImage}},
 					}},
 				},
 			},
 			7,
 		}
 
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{directImportData}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4386,7 +4387,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 
 	// Create a user.
 	username := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4394,7 +4395,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get user1 from database.")
 
 	username2 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username2,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4402,9 +4403,9 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 	user2, appErr := th.App.GetUserByUsername(username2)
 	require.Nil(t, appErr, "Failed to get user2 from database.")
 
-	directImportData := LineImportWorkerData{
-		LineImportData{
-			DirectPost: &DirectPostImportData{
+	directImportData := imports.LineImportWorkerData{
+		imports.LineImportData{
+			DirectPost: &imports.DirectPostImportData{
 				ChannelMembers: &[]string{
 					user1.Username,
 					user2.Username,
@@ -4412,14 +4413,14 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 				User:        &user1.Username,
 				Message:     ptrStr("Direct message"),
 				CreateAt:    ptrInt64(model.GetMillis()),
-				Attachments: &[]AttachmentImportData{{Path: &testImage}},
+				Attachments: &[]imports.AttachmentImportData{{Path: &testImage}},
 			},
 		},
 		3,
 	}
 
 	t.Run("Regular import of attachment", func(t *testing.T) {
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{directImportData}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4430,7 +4431,7 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 	})
 
 	t.Run("Attempt to import again with same file entirely, should NOT add an attachment", func(t *testing.T) {
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{directImportData}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4439,9 +4440,9 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 	})
 
 	t.Run("Attempt to import again with same name and size but different content, SHOULD add an attachment", func(t *testing.T) {
-		directImportDataFake := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		directImportDataFake := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user1.Username,
 						user2.Username,
@@ -4449,13 +4450,13 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 					User:        &user1.Username,
 					Message:     ptrStr("Direct message"),
 					CreateAt:    ptrInt64(model.GetMillis()),
-					Attachments: &[]AttachmentImportData{{Path: &testImageFake}},
+					Attachments: &[]imports.AttachmentImportData{{Path: &testImageFake}},
 				},
 			},
 			2,
 		}
 
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{directImportDataFake}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportDataFake}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4464,9 +4465,9 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 	})
 
 	t.Run("Attempt to import again with same data, SHOULD add an attachment, since it's different name", func(t *testing.T) {
-		directImportData2 := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		directImportData2 := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user1.Username,
 						user2.Username,
@@ -4474,13 +4475,13 @@ func TestImportDirectPostWithAttachments(t *testing.T) {
 					User:        &user1.Username,
 					Message:     ptrStr("Direct message"),
 					CreateAt:    ptrInt64(model.GetMillis()),
-					Attachments: &[]AttachmentImportData{{Path: &testImage2}},
+					Attachments: &[]imports.AttachmentImportData{{Path: &testImage2}},
 				},
 			},
 			2,
 		}
 
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{directImportData2}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData2}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 
@@ -4495,7 +4496,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	// Create a Team.
 	teamName := model.NewRandomTeamName()
-	th.App.importTeam(th.Context, &TeamImportData{
+	th.App.importTeam(th.Context, &imports.TeamImportData{
 		Name:        &teamName,
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
@@ -4506,7 +4507,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 	// Create a Channel.
 	channelName := NewTestId()
 	chanTypeOpen := model.ChannelTypeOpen
-	th.App.importChannel(th.Context, &ChannelImportData{
+	th.App.importChannel(th.Context, &imports.ChannelImportData{
 		Team:        &teamName,
 		Name:        &channelName,
 		DisplayName: ptrStr("Display Name"),
@@ -4517,7 +4518,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	// Create users
 	username2 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username2,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4526,7 +4527,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 
 	// Create direct post users.
 	username3 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username3,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4534,7 +4535,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 	require.Nil(t, appErr, "Failed to get user3 from database.")
 
 	username4 := model.NewId()
-	th.App.importUser(th.Context, &UserImportData{
+	th.App.importUser(th.Context, &imports.UserImportData{
 		Username: &username4,
 		Email:    ptrStr(model.NewId() + "@example.com"),
 	}, false)
@@ -4561,20 +4562,20 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 	require.NoError(t, err, "failed to copy test Image file into zip")
 
 	testMarkDown := filepath.Join(testsDir, "test-attachments.md")
-	data := LineImportWorkerData{
-		LineImportData{
-			Post: &PostImportData{
+	data := imports.LineImportWorkerData{
+		imports.LineImportData{
+			Post: &imports.PostImportData{
 				Team:        &teamName,
 				Channel:     &channelName,
 				User:        &username3,
 				Message:     ptrStr("Message with reply"),
 				CreateAt:    &attachmentsPostTime,
-				Attachments: &[]AttachmentImportData{{Path: &testImage}, {Path: &testMarkDown}},
-				Replies: &[]ReplyImportData{{
+				Attachments: &[]imports.AttachmentImportData{{Path: &testImage}, {Path: &testMarkDown}},
+				Replies: &[]imports.ReplyImportData{{
 					User:        &user4.Username,
 					Message:     ptrStr("Message reply"),
 					CreateAt:    &attachmentsReplyTime,
-					Attachments: &[]AttachmentImportData{{Path: &testImage, Data: imageData}},
+					Attachments: &[]imports.AttachmentImportData{{Path: &testImage, Data: imageData}},
 				}},
 			},
 		},
@@ -4582,7 +4583,7 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 	}
 
 	t.Run("import with attachment", func(t *testing.T) {
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 
@@ -4599,8 +4600,8 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 	})
 
 	t.Run("import existing post with new attachment", func(t *testing.T) {
-		data.Post.Attachments = &[]AttachmentImportData{{Path: &testImage}}
-		errLine, err := th.App.importMultiplePostLines(th.Context, []LineImportWorkerData{data}, false)
+		data.Post.Attachments = &[]imports.AttachmentImportData{{Path: &testImage}}
+		errLine, err := th.App.importMultiplePostLines(th.Context, []imports.LineImportWorkerData{data}, false)
 		require.Nil(t, err)
 		require.Equal(t, 0, errLine)
 
@@ -4616,9 +4617,9 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 	})
 
 	t.Run("Reply with Attachments in Direct Post", func(t *testing.T) {
-		directImportData := LineImportWorkerData{
-			LineImportData{
-				DirectPost: &DirectPostImportData{
+		directImportData := imports.LineImportWorkerData{
+			imports.LineImportData{
+				DirectPost: &imports.DirectPostImportData{
 					ChannelMembers: &[]string{
 						user3.Username,
 						user2.Username,
@@ -4626,18 +4627,18 @@ func TestZippedImportPostAndRepliesWithAttachments(t *testing.T) {
 					User:     &user3.Username,
 					Message:  ptrStr("Message with Replies"),
 					CreateAt: ptrInt64(model.GetMillis()),
-					Replies: &[]ReplyImportData{{
+					Replies: &[]imports.ReplyImportData{{
 						User:        &user2.Username,
 						Message:     ptrStr("Message reply with attachment"),
 						CreateAt:    ptrInt64(model.GetMillis()),
-						Attachments: &[]AttachmentImportData{{Path: &testImage}},
+						Attachments: &[]imports.AttachmentImportData{{Path: &testImage}},
 					}},
 				},
 			},
 			7,
 		}
 
-		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []LineImportWorkerData{directImportData}, false)
+		errLine, err := th.App.importMultipleDirectPostLines(th.Context, []imports.LineImportWorkerData{directImportData}, false)
 		require.Nil(t, err, "Expected success.")
 		require.Equal(t, 0, errLine)
 

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -132,28 +132,28 @@ func TestStopOnError(t *testing.T) {
 	defer th.TearDown()
 
 	assert.True(t, stopOnError(th.Context, imports.LineImportWorkerError{
-		model.NewAppError("test", "app.import.attachment.bad_file.error", nil, "", http.StatusBadRequest),
-		1,
+		Error:      model.NewAppError("test", "app.import.attachment.bad_file.error", nil, "", http.StatusBadRequest),
+		LineNumber: 1,
 	}))
 
 	assert.True(t, stopOnError(th.Context, imports.LineImportWorkerError{
-		model.NewAppError("test", "app.import.attachment.file_upload.error", nil, "", http.StatusBadRequest),
-		1,
+		Error:      model.NewAppError("test", "app.import.attachment.file_upload.error", nil, "", http.StatusBadRequest),
+		LineNumber: 1,
 	}))
 
 	assert.False(t, stopOnError(th.Context, imports.LineImportWorkerError{
-		model.NewAppError("test", "api.file.upload_file.large_image.app_error", nil, "", http.StatusBadRequest),
-		1,
+		Error:      model.NewAppError("test", "api.file.upload_file.large_image.app_error", nil, "", http.StatusBadRequest),
+		LineNumber: 1,
 	}))
 
 	assert.False(t, stopOnError(th.Context, imports.LineImportWorkerError{
-		model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_few.error", nil, "", http.StatusBadRequest),
-		1,
+		Error:      model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_few.error", nil, "", http.StatusBadRequest),
+		LineNumber: 1,
 	}))
 
 	assert.False(t, stopOnError(th.Context, imports.LineImportWorkerError{
-		model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_many.error", nil, "", http.StatusBadRequest),
-		1,
+		Error:      model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_many.error", nil, "", http.StatusBadRequest),
+		LineNumber: 1,
 	}))
 }
 

--- a/app/import_test.go
+++ b/app/import_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v6/app/imports"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/utils"
 	"github.com/mattermost/mattermost-server/v6/utils/fileutils"
@@ -83,7 +84,7 @@ func TestImportImportLine(t *testing.T) {
 	defer th.TearDown()
 
 	// Try import line with an invalid type.
-	line := LineImportData{
+	line := imports.LineImportData{
 		Type: "gibberish",
 	}
 
@@ -130,27 +131,27 @@ func TestStopOnError(t *testing.T) {
 	th := Setup(t)
 	defer th.TearDown()
 
-	assert.True(t, stopOnError(th.Context, LineImportWorkerError{
+	assert.True(t, stopOnError(th.Context, imports.LineImportWorkerError{
 		model.NewAppError("test", "app.import.attachment.bad_file.error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.True(t, stopOnError(th.Context, LineImportWorkerError{
+	assert.True(t, stopOnError(th.Context, imports.LineImportWorkerError{
 		model.NewAppError("test", "app.import.attachment.file_upload.error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.False(t, stopOnError(th.Context, LineImportWorkerError{
+	assert.False(t, stopOnError(th.Context, imports.LineImportWorkerError{
 		model.NewAppError("test", "api.file.upload_file.large_image.app_error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.False(t, stopOnError(th.Context, LineImportWorkerError{
+	assert.False(t, stopOnError(th.Context, imports.LineImportWorkerError{
 		model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_few.error", nil, "", http.StatusBadRequest),
 		1,
 	}))
 
-	assert.False(t, stopOnError(th.Context, LineImportWorkerError{
+	assert.False(t, stopOnError(th.Context, imports.LineImportWorkerError{
 		model.NewAppError("test", "app.import.validate_direct_channel_import_data.members_too_many.error", nil, "", http.StatusBadRequest),
 		1,
 	}))
@@ -246,7 +247,7 @@ func TestImportBulkImport(t *testing.T) {
 }
 
 func TestImportProcessImportDataFileVersionLine(t *testing.T) {
-	data := LineImportData{
+	data := imports.LineImportData{
 		Type:    "version",
 		Version: ptrInt(1),
 	}
@@ -284,8 +285,8 @@ func AssertFileIdsInPost(files []*model.FileInfo, th *TestHelper, t *testing.T) 
 }
 
 func TestProcessAttachments(t *testing.T) {
-	genAttachments := func() *[]AttachmentImportData {
-		return &[]AttachmentImportData{
+	genAttachments := func() *[]imports.AttachmentImportData {
+		return &[]imports.AttachmentImportData{
 			{
 				Path: model.NewString("file.jpg"),
 			},
@@ -295,36 +296,36 @@ func TestProcessAttachments(t *testing.T) {
 		}
 	}
 
-	line := LineImportData{
+	line := imports.LineImportData{
 		Type: "post",
-		Post: &PostImportData{
+		Post: &imports.PostImportData{
 			Attachments: genAttachments(),
 		},
 	}
 
-	line2 := LineImportData{
+	line2 := imports.LineImportData{
 		Type: "direct_post",
-		DirectPost: &DirectPostImportData{
+		DirectPost: &imports.DirectPostImportData{
 			Attachments: genAttachments(),
 		},
 	}
 
-	userLine := LineImportData{
+	userLine := imports.LineImportData{
 		Type: "user",
-		User: &UserImportData{
+		User: &imports.UserImportData{
 			ProfileImage: model.NewString("profile.jpg"),
 		},
 	}
 
-	emojiLine := LineImportData{
+	emojiLine := imports.LineImportData{
 		Type: "emoji",
-		Emoji: &EmojiImportData{
+		Emoji: &imports.EmojiImportData{
 			Image: model.NewString("emoji.png"),
 		},
 	}
 
 	t.Run("empty path", func(t *testing.T) {
-		expected := &[]AttachmentImportData{
+		expected := &[]imports.AttachmentImportData{
 			{
 				Path: model.NewString("file.jpg"),
 			},
@@ -341,7 +342,7 @@ func TestProcessAttachments(t *testing.T) {
 	})
 
 	t.Run("valid path", func(t *testing.T) {
-		expected := &[]AttachmentImportData{
+		expected := &[]imports.AttachmentImportData{
 			{
 				Path: model.NewString("/tmp/file.jpg"),
 			},

--- a/app/imports/import_types.go
+++ b/app/imports/import_types.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package app
+package imports
 
 import (
 	"archive/zip"

--- a/app/imports/import_validators.go
+++ b/app/imports/import_validators.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package app
+package imports
 
 import (
 	"encoding/json"
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
-func validateSchemeImportData(data *SchemeImportData) *model.AppError {
+func ValidateSchemeImportData(data *SchemeImportData) *model.AppError {
 
 	if data.Scope == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_scheme_import_data.null_scope.error", nil, "", http.StatusBadRequest)
@@ -46,37 +46,37 @@ func validateSchemeImportData(data *SchemeImportData) *model.AppError {
 	}
 
 	if data.DefaultTeamAdminRole != nil {
-		if err := validateRoleImportData(data.DefaultTeamAdminRole); err != nil {
+		if err := ValidateRoleImportData(data.DefaultTeamAdminRole); err != nil {
 			return err
 		}
 	}
 
 	if data.DefaultTeamUserRole != nil {
-		if err := validateRoleImportData(data.DefaultTeamUserRole); err != nil {
+		if err := ValidateRoleImportData(data.DefaultTeamUserRole); err != nil {
 			return err
 		}
 	}
 
 	if data.DefaultTeamGuestRole != nil {
-		if err := validateRoleImportData(data.DefaultTeamGuestRole); err != nil {
+		if err := ValidateRoleImportData(data.DefaultTeamGuestRole); err != nil {
 			return err
 		}
 	}
 
 	if data.DefaultChannelAdminRole != nil {
-		if err := validateRoleImportData(data.DefaultChannelAdminRole); err != nil {
+		if err := ValidateRoleImportData(data.DefaultChannelAdminRole); err != nil {
 			return err
 		}
 	}
 
 	if data.DefaultChannelUserRole != nil {
-		if err := validateRoleImportData(data.DefaultChannelUserRole); err != nil {
+		if err := ValidateRoleImportData(data.DefaultChannelUserRole); err != nil {
 			return err
 		}
 	}
 
 	if data.DefaultChannelGuestRole != nil {
-		if err := validateRoleImportData(data.DefaultChannelGuestRole); err != nil {
+		if err := ValidateRoleImportData(data.DefaultChannelGuestRole); err != nil {
 			return err
 		}
 	}
@@ -84,7 +84,7 @@ func validateSchemeImportData(data *SchemeImportData) *model.AppError {
 	return nil
 }
 
-func validateRoleImportData(data *RoleImportData) *model.AppError {
+func ValidateRoleImportData(data *RoleImportData) *model.AppError {
 
 	if data.Name == nil || !model.IsValidRoleName(*data.Name) {
 		return model.NewAppError("BulkImport", "app.import.validate_role_import_data.name_invalid.error", nil, "", http.StatusBadRequest)
@@ -117,7 +117,7 @@ func validateRoleImportData(data *RoleImportData) *model.AppError {
 	return nil
 }
 
-func validateTeamImportData(data *TeamImportData) *model.AppError {
+func ValidateTeamImportData(data *TeamImportData) *model.AppError {
 
 	if data.Name == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_team_import_data.name_missing.error", nil, "", http.StatusBadRequest)
@@ -152,7 +152,7 @@ func validateTeamImportData(data *TeamImportData) *model.AppError {
 	return nil
 }
 
-func validateChannelImportData(data *ChannelImportData) *model.AppError {
+func ValidateChannelImportData(data *ChannelImportData) *model.AppError {
 
 	if data.Team == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_channel_import_data.team_missing.error", nil, "", http.StatusBadRequest)
@@ -193,7 +193,7 @@ func validateChannelImportData(data *ChannelImportData) *model.AppError {
 	return nil
 }
 
-func validateUserImportData(data *UserImportData) *model.AppError {
+func ValidateUserImportData(data *UserImportData) *model.AppError {
 	if data.ProfileImage != nil {
 		if _, err := os.Stat(*data.ProfileImage); os.IsNotExist(err) {
 			return model.NewAppError("BulkImport", "app.import.validate_user_import_data.profile_image.error", nil, "", http.StatusBadRequest)
@@ -306,13 +306,13 @@ func validateUserImportData(data *UserImportData) *model.AppError {
 	}
 
 	if data.Teams != nil {
-		return validateUserTeamsImportData(data.Teams)
+		return ValidateUserTeamsImportData(data.Teams)
 	}
 
 	return nil
 }
 
-func validateUserTeamsImportData(data *[]UserTeamImportData) *model.AppError {
+func ValidateUserTeamsImportData(data *[]UserTeamImportData) *model.AppError {
 	if data == nil {
 		return nil
 	}
@@ -327,7 +327,7 @@ func validateUserTeamsImportData(data *[]UserTeamImportData) *model.AppError {
 		}
 
 		if tdata.Channels != nil {
-			if err := validateUserChannelsImportData(tdata.Channels); err != nil {
+			if err := ValidateUserChannelsImportData(tdata.Channels); err != nil {
 				return err
 			}
 		}
@@ -343,7 +343,7 @@ func validateUserTeamsImportData(data *[]UserTeamImportData) *model.AppError {
 	return nil
 }
 
-func validateUserChannelsImportData(data *[]UserChannelImportData) *model.AppError {
+func ValidateUserChannelsImportData(data *[]UserChannelImportData) *model.AppError {
 	if data == nil {
 		return nil
 	}
@@ -375,7 +375,7 @@ func validateUserChannelsImportData(data *[]UserChannelImportData) *model.AppErr
 	return nil
 }
 
-func validateReactionImportData(data *ReactionImportData, parentCreateAt int64) *model.AppError {
+func ValidateReactionImportData(data *ReactionImportData, parentCreateAt int64) *model.AppError {
 	if data.User == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.user_missing.error", nil, "", http.StatusBadRequest)
 	}
@@ -397,7 +397,7 @@ func validateReactionImportData(data *ReactionImportData, parentCreateAt int64) 
 	return nil
 }
 
-func validateReplyImportData(data *ReplyImportData, parentCreateAt int64, maxPostSize int) *model.AppError {
+func ValidateReplyImportData(data *ReplyImportData, parentCreateAt int64, maxPostSize int) *model.AppError {
 	if data.User == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_reply_import_data.user_missing.error", nil, "", http.StatusBadRequest)
 	}
@@ -419,7 +419,7 @@ func validateReplyImportData(data *ReplyImportData, parentCreateAt int64, maxPos
 	return nil
 }
 
-func validatePostImportData(data *PostImportData, maxPostSize int) *model.AppError {
+func ValidatePostImportData(data *PostImportData, maxPostSize int) *model.AppError {
 	if data.Team == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_post_import_data.team_missing.error", nil, "", http.StatusBadRequest)
 	}
@@ -447,14 +447,14 @@ func validatePostImportData(data *PostImportData, maxPostSize int) *model.AppErr
 	if data.Reactions != nil {
 		for _, reaction := range *data.Reactions {
 			reaction := reaction
-			validateReactionImportData(&reaction, *data.CreateAt)
+			ValidateReactionImportData(&reaction, *data.CreateAt)
 		}
 	}
 
 	if data.Replies != nil {
 		for _, reply := range *data.Replies {
 			reply := reply
-			validateReplyImportData(&reply, *data.CreateAt, maxPostSize)
+			ValidateReplyImportData(&reply, *data.CreateAt, maxPostSize)
 		}
 	}
 
@@ -465,7 +465,7 @@ func validatePostImportData(data *PostImportData, maxPostSize int) *model.AppErr
 	return nil
 }
 
-func validateDirectChannelImportData(data *DirectChannelImportData) *model.AppError {
+func ValidateDirectChannelImportData(data *DirectChannelImportData) *model.AppError {
 	if data.Members == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_direct_channel_import_data.members_required.error", nil, "", http.StatusBadRequest)
 	}
@@ -500,7 +500,7 @@ func validateDirectChannelImportData(data *DirectChannelImportData) *model.AppEr
 	return nil
 }
 
-func validateDirectPostImportData(data *DirectPostImportData, maxPostSize int) *model.AppError {
+func ValidateDirectPostImportData(data *DirectPostImportData, maxPostSize int) *model.AppError {
 	if data.ChannelMembers == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_direct_post_import_data.channel_members_required.error", nil, "", http.StatusBadRequest)
 	}
@@ -547,23 +547,23 @@ func validateDirectPostImportData(data *DirectPostImportData, maxPostSize int) *
 	if data.Reactions != nil {
 		for _, reaction := range *data.Reactions {
 			reaction := reaction
-			validateReactionImportData(&reaction, *data.CreateAt)
+			ValidateReactionImportData(&reaction, *data.CreateAt)
 		}
 	}
 
 	if data.Replies != nil {
 		for _, reply := range *data.Replies {
 			reply := reply
-			validateReplyImportData(&reply, *data.CreateAt, maxPostSize)
+			ValidateReplyImportData(&reply, *data.CreateAt, maxPostSize)
 		}
 	}
 
 	return nil
 }
 
-// validateEmojiImportData validates emoji data and returns if the import name
+// ValidateEmojiImportData validates emoji data and returns if the import name
 // conflicts with a system emoji.
-func validateEmojiImportData(data *EmojiImportData) *model.AppError {
+func ValidateEmojiImportData(data *EmojiImportData) *model.AppError {
 	if data == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_emoji_import_data.empty.error", nil, "", http.StatusBadRequest)
 	}

--- a/app/imports/import_validators_test.go
+++ b/app/imports/import_validators_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package app
+package imports
 
 import (
 	"fmt"
@@ -54,46 +54,46 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		},
 	}
 
-	err := validateSchemeImportData(&data)
+	err := ValidateSchemeImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with various invalid names.
 	data.Name = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	// Test with empty string
 	data.Name = ptrStr("")
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	// Test with numbers
 	data.Name = ptrStr(strings.Repeat("1234567890", 100))
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr("name")
 
 	// Test with invalid display name.
 	data.DisplayName = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	// Test with display name.
 	data.DisplayName = ptrStr("")
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	// Test display name with numbers
 	data.DisplayName = ptrStr(strings.Repeat("1234567890", 100))
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr("display name")
 
 	// Test with various missing roles.
 	data.DefaultTeamAdminRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultTeamAdminRole = &RoleImportData{
@@ -103,7 +103,7 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 	}
 
 	data.DefaultTeamUserRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultTeamUserRole = &RoleImportData{
@@ -112,7 +112,7 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultChannelAdminRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultChannelAdminRole = &RoleImportData{
@@ -121,7 +121,7 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultChannelUserRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing role.")
 
 	data.DefaultChannelUserRole = &RoleImportData{
@@ -132,22 +132,22 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 
 	// Test with various invalid roles.
 	data.DefaultTeamAdminRole.Name = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultTeamAdminRole.Name = ptrStr("name")
 	data.DefaultTeamUserRole.Name = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultTeamUserRole.Name = ptrStr("name")
 	data.DefaultChannelAdminRole.Name = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultChannelAdminRole.Name = ptrStr("name")
 	data.DefaultChannelUserRole.Name = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid role.")
 
 	data.DefaultChannelUserRole.Name = ptrStr("name")
@@ -155,7 +155,7 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 	// Change to a Channel scope role, and check with missing or extra roles again.
 	data.Scope = ptrStr("channel")
 	data.DefaultTeamAdminRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to spurious role.")
 
 	data.DefaultTeamAdminRole = &RoleImportData{
@@ -164,7 +164,7 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultTeamUserRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to spurious role.")
 
 	data.DefaultTeamUserRole = &RoleImportData{
@@ -173,22 +173,22 @@ func TestImportValidateSchemeImportData(t *testing.T) {
 		Permissions: &[]string{"invite_user"},
 	}
 	data.DefaultTeamGuestRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to spurious role.")
 
 	data.DefaultTeamGuestRole = nil
 	data.DefaultTeamUserRole = nil
 	data.DefaultTeamAdminRole = nil
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.Nil(t, err, "Should have succeeded.")
 
 	// Test with all combinations of optional parameters.
 	data.Description = ptrStr(strings.Repeat("1234567890", 1024))
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid description.")
 
 	data.Description = ptrStr("description")
-	err = validateSchemeImportData(&data)
+	err = ValidateSchemeImportData(&data)
 	require.Nil(t, err, "Should have succeeded.")
 }
 
@@ -198,61 +198,61 @@ func TestImportValidateRoleImportData(t *testing.T) {
 		Name:        ptrStr("name"),
 		DisplayName: ptrStr("display name"),
 	}
-	err := validateRoleImportData(&data)
+	err := ValidateRoleImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with various invalid names.
 	data.Name = nil
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr("")
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr(strings.Repeat("1234567890", 100))
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data.Name = ptrStr("name")
 
 	// Test with invalid display name.
 	data.DisplayName = nil
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr("")
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr(strings.Repeat("1234567890", 100))
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid display name.")
 
 	data.DisplayName = ptrStr("display name")
 
 	// Test with various valid/invalid permissions.
 	data.Permissions = &[]string{}
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	data.Permissions = &[]string{"invite_user", "add_user_to_team"}
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	data.Permissions = &[]string{"invite_user", "add_user_to_team", "derp"}
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to invalid permission.")
 
 	data.Permissions = &[]string{"invite_user", "add_user_to_team"}
 
 	// Test with various valid/invalid descriptions.
 	data.Description = ptrStr(strings.Repeat("1234567890", 1024))
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to invalid description.")
 
 	data.Description = ptrStr("description")
-	err = validateRoleImportData(&data)
+	err = ValidateRoleImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 }
 
@@ -264,7 +264,7 @@ func TestImportValidateTeamImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 	}
-	err := validateTeamImportData(&data)
+	err := ValidateTeamImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with various invalid names.
@@ -272,23 +272,23 @@ func TestImportValidateTeamImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        ptrStr("O"),
 	}
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing name.")
 
 	data.Name = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long name.")
 
 	data.Name = ptrStr("login")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to reserved word in name.")
 
 	data.Name = ptrStr("Test::''ASD")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to non alphanum characters in name.")
 
 	data.Name = ptrStr("A")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to short name.")
 
 	// Test team various invalid display names.
@@ -296,15 +296,15 @@ func TestImportValidateTeamImportData(t *testing.T) {
 		Name: ptrStr("teamname"),
 		Type: ptrStr("O"),
 	}
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing display_name.")
 
 	data.DisplayName = ptrStr("")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to empty display_name.")
 
 	data.DisplayName = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long display_name.")
 
 	// Test with various valid and invalid types.
@@ -312,15 +312,15 @@ func TestImportValidateTeamImportData(t *testing.T) {
 		Name:        ptrStr("teamname"),
 		DisplayName: ptrStr("Display Name"),
 	}
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing type.")
 
 	data.Type = ptrStr("A")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid type.")
 
 	data.Type = ptrStr("I")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid type.")
 
 	// Test with all the combinations of optional parameters.
@@ -331,26 +331,26 @@ func TestImportValidateTeamImportData(t *testing.T) {
 		Description:     ptrStr("The team description."),
 		AllowOpenInvite: ptrBool(true),
 	}
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid optional properties.")
 
 	data.AllowOpenInvite = ptrBool(false)
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.Nil(t, err, "Should have succeeded with allow open invites false.")
 
 	data.Description = ptrStr(strings.Repeat("abcdefghij ", 26))
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long description.")
 
 	// Test with an empty scheme name.
 	data.Description = ptrStr("abcdefg")
 	data.Scheme = ptrStr("")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.NotNil(t, err, "Should have failed due to empty scheme name.")
 
 	// Test with a valid scheme name.
 	data.Scheme = ptrStr("abcdefg")
-	err = validateTeamImportData(&data)
+	err = ValidateTeamImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid scheme name.")
 }
 
@@ -364,7 +364,7 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        &chanTypeOpen,
 	}
-	err := validateChannelImportData(&data)
+	err := ValidateChannelImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing team.
@@ -373,7 +373,7 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        &chanTypeOpen,
 	}
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing team.")
 
 	// Test with various invalid names.
@@ -382,19 +382,19 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		DisplayName: ptrStr("Display Name"),
 		Type:        &chanTypeOpen,
 	}
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing name.")
 
 	data.Name = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long name.")
 
 	data.Name = ptrStr("Test::''ASD")
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to non alphanum characters in name.")
 
 	data.Name = ptrStr("A")
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to short name.")
 
 	// Test team various invalid display names.
@@ -403,17 +403,17 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		Name: ptrStr("channelname"),
 		Type: &chanTypeOpen,
 	}
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.Nil(t, err, "Should have accepted having an empty display_name.")
 	require.Equal(t, data.Name, data.DisplayName, "Name and DisplayName should be the same if DisplayName is missing")
 
 	data.DisplayName = ptrStr("")
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.Nil(t, err, "Should have accepted having an empty display_name.")
 	require.Equal(t, data.Name, data.DisplayName, "Name and DisplayName should be the same if DisplayName is missing")
 
 	data.DisplayName = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long display_name.")
 
 	// Test with various valid and invalid types.
@@ -422,17 +422,17 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		Name:        ptrStr("channelname"),
 		DisplayName: ptrStr("Display Name"),
 	}
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to missing type.")
 
 	invalidType := model.ChannelType("A")
 	data.Type = &invalidType
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid type.")
 
 	chanTypePr := model.ChannelTypePrivate
 	data.Type = &chanTypePr
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid type.")
 
 	// Test with all the combinations of optional parameters.
@@ -444,27 +444,27 @@ func TestImportValidateChannelImportData(t *testing.T) {
 		Header:      ptrStr("Channel Header Here"),
 		Purpose:     ptrStr("Channel Purpose Here"),
 	}
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid optional properties.")
 
 	data.Header = ptrStr(strings.Repeat("abcdefghij ", 103))
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long header.")
 
 	data.Header = ptrStr("Channel Header Here")
 	data.Purpose = ptrStr(strings.Repeat("abcdefghij ", 26))
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long purpose.")
 
 	// Test with an empty scheme name.
 	data.Purpose = ptrStr("abcdefg")
 	data.Scheme = ptrStr("")
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to empty scheme name.")
 
 	// Test with a valid scheme name.
 	data.Scheme = ptrStr("abcdefg")
-	err = validateChannelImportData(&data)
+	err = ValidateChannelImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid scheme name.")
 }
 
@@ -475,61 +475,61 @@ func TestImportValidateUserImportData(t *testing.T) {
 		Username: ptrStr("bob"),
 		Email:    ptrStr("bob@example.com"),
 	}
-	err := validateUserImportData(&data)
+	err := ValidateUserImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Invalid Usernames.
 	data.Username = nil
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to nil Username.")
 
 	data.Username = ptrStr("")
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to 0 length Username.")
 
 	data.Username = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to too long Username.")
 
 	data.Username = ptrStr("i am a username with spaces and !!!")
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to invalid characters in Username.")
 
 	data.Username = ptrStr("bob")
 
 	// Unexisting Picture Image
 	data.ProfileImage = ptrStr("not-existing-file")
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to not existing profile image file.")
 
 	data.ProfileImage = nil
 
 	// Invalid Emails
 	data.Email = nil
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to nil Email.")
 
 	data.Email = ptrStr("")
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to 0 length Email.")
 
 	data.Email = ptrStr(strings.Repeat("abcdefghij", 13))
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to too long Email.")
 
 	data.Email = ptrStr("bob@example.com")
 
 	// Empty AuthService indicates user/password auth.
 	data.AuthService = ptrStr("")
-	checkNoError(t, validateUserImportData(&data))
+	checkNoError(t, ValidateUserImportData(&data))
 
 	data.AuthService = ptrStr("saml")
 	data.AuthData = ptrStr(strings.Repeat("abcdefghij", 15))
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to too long auth data.")
 
 	data.AuthData = ptrStr("bobbytables")
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.Nil(t, err, "Validation should have succeeded with valid auth service and auth data.")
 
 	// Test a valid User with all fields populated.
@@ -547,40 +547,40 @@ func TestImportValidateUserImportData(t *testing.T) {
 		Roles:        ptrStr("system_user"),
 		Locale:       ptrStr("en"),
 	}
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test various invalid optional field values.
 	data.Nickname = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to too long Nickname.")
 
 	data.Nickname = ptrStr("BobNick")
 
 	data.FirstName = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to too long First Name.")
 
 	data.FirstName = ptrStr("Bob")
 
 	data.LastName = ptrStr(strings.Repeat("abcdefghij", 7))
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to too long Last name.")
 
 	data.LastName = ptrStr("Blob")
 
 	data.Position = ptrStr(strings.Repeat("abcdefghij", 13))
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to too long Position.")
 
 	data.Position = ptrStr("The Boss")
 
 	data.Roles = nil
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	data.Roles = ptrStr("")
-	err = validateUserImportData(&data)
+	err = ValidateUserImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	data.Roles = ptrStr("system_user")
@@ -589,53 +589,53 @@ func TestImportValidateUserImportData(t *testing.T) {
 	data.NotifyProps = &UserNotifyPropsImportData{}
 
 	data.NotifyProps.Desktop = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.NotifyProps.Desktop = ptrStr(model.UserNotifyAll)
 	data.NotifyProps.DesktopSound = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.NotifyProps.DesktopSound = ptrStr("true")
 	data.NotifyProps.Email = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.NotifyProps.Email = ptrStr("true")
 	data.NotifyProps.Mobile = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.NotifyProps.Mobile = ptrStr(model.UserNotifyAll)
 	data.NotifyProps.MobilePushStatus = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.NotifyProps.MobilePushStatus = ptrStr(model.StatusOnline)
 	data.NotifyProps.ChannelTrigger = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.NotifyProps.ChannelTrigger = ptrStr("true")
 	data.NotifyProps.CommentsTrigger = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.NotifyProps.CommentsTrigger = ptrStr(model.CommentsNotifyRoot)
 	data.NotifyProps.MentionKeys = ptrStr("valid")
-	checkNoError(t, validateUserImportData(&data))
+	checkNoError(t, ValidateUserImportData(&data))
 
 	//Test the email batching interval validators
 	//Happy paths
 	data.EmailInterval = ptrStr("immediately")
-	checkNoError(t, validateUserImportData(&data))
+	checkNoError(t, ValidateUserImportData(&data))
 
 	data.EmailInterval = ptrStr("fifteen")
-	checkNoError(t, validateUserImportData(&data))
+	checkNoError(t, ValidateUserImportData(&data))
 
 	data.EmailInterval = ptrStr("hour")
-	checkNoError(t, validateUserImportData(&data))
+	checkNoError(t, ValidateUserImportData(&data))
 
 	//Invalid values
 	data.EmailInterval = ptrStr("invalid")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 
 	data.EmailInterval = ptrStr("")
-	checkError(t, validateUserImportData(&data))
+	checkError(t, ValidateUserImportData(&data))
 }
 
 func TestImportValidateUserAuth(t *testing.T) {
@@ -663,7 +663,7 @@ func TestImportValidateUserAuth(t *testing.T) {
 			AuthService: test.authService,
 			AuthData:    test.authData,
 		}
-		err := validateUserImportData(&data)
+		err := ValidateUserImportData(&data)
 
 		if test.isValid {
 			require.Nil(t, err, fmt.Sprintf("authService: %v, authData: %v", test.authService, test.authData))
@@ -683,39 +683,39 @@ func TestImportValidateUserTeamsImportData(t *testing.T) {
 			Roles: ptrStr("team_admin team_user"),
 		},
 	}
-	err := validateUserTeamsImportData(&data)
+	err := ValidateUserTeamsImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 
 	data[0].Name = ptrStr("teamname")
 
 	// Valid (nil roles)
 	data[0].Roles = nil
-	err = validateUserTeamsImportData(&data)
+	err = ValidateUserTeamsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (empty roles)
 	data[0].Roles = ptrStr("")
-	err = validateUserTeamsImportData(&data)
+	err = ValidateUserTeamsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (with roles)
 	data[0].Roles = ptrStr("team_admin team_user")
-	err = validateUserTeamsImportData(&data)
+	err = ValidateUserTeamsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid roles.")
 
 	// Valid (with JSON string of theme)
 	data[0].Theme = ptrStr(`{"awayIndicator":"#DBBD4E","buttonBg":"#23A1FF","buttonColor":"#FFFFFF","centerChannelBg":"#ffffff","centerChannelColor":"#333333","codeTheme":"github","image":"/static/files/a4a388b38b32678e83823ef1b3e17766.png","linkColor":"#2389d7","mentionBg":"#2389d7","mentionColor":"#ffffff","mentionHighlightBg":"#fff2bb","mentionHighlightLink":"#2f81b7","newMessageSeparator":"#FF8800","onlineIndicator":"#7DBE00","sidebarBg":"#fafafa","sidebarHeaderBg":"#3481B9","sidebarHeaderTextColor":"#ffffff","sidebarText":"#333333","sidebarTextActiveBorder":"#378FD2","sidebarTextActiveColor":"#111111","sidebarTextHoverBg":"#e6f2fa","sidebarUnreadText":"#333333","type":"Mattermost"}`)
-	err = validateUserTeamsImportData(&data)
+	err = ValidateUserTeamsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid theme.")
 
 	// Invalid (invalid JSON string of theme)
 	data[0].Theme = ptrStr(`This is the invalid string which cannot be marshalled to JSON object :) + {"#DBBD4E","buttonBg", "#23A1FF", buttonColor`)
-	err = validateUserTeamsImportData(&data)
+	err = ValidateUserTeamsImportData(&data)
 	require.NotNil(t, err, "Should have fail with invalid JSON string of theme.")
 
 	// Invalid (valid JSON but invalid theme description)
 	data[0].Theme = ptrStr(`{"somekey": 25, "json_obj1": {"color": "#DBBD4E","buttonBg": "#23A1FF"}}`)
-	err = validateUserTeamsImportData(&data)
+	err = ValidateUserTeamsImportData(&data)
 	require.NotNil(t, err, "Should have fail with valid JSON which contains invalid string of theme description.")
 
 	data[0].Theme = nil
@@ -729,50 +729,50 @@ func TestImportValidateUserChannelsImportData(t *testing.T) {
 			Roles: ptrStr("channel_admin channel_user"),
 		},
 	}
-	err := validateUserChannelsImportData(&data)
+	err := ValidateUserChannelsImportData(&data)
 	require.NotNil(t, err, "Should have failed due to invalid name.")
 	data[0].Name = ptrStr("channelname")
 
 	// Valid (nil roles)
 	data[0].Roles = nil
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (empty roles)
 	data[0].Roles = ptrStr("")
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with empty roles.")
 
 	// Valid (with roles)
 	data[0].Roles = ptrStr("channel_admin channel_user")
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid roles.")
 
 	// Empty notify props.
 	data[0].NotifyProps = &UserChannelNotifyPropsImportData{}
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with empty notify props.")
 
 	// Invalid desktop notify props.
 	data[0].NotifyProps.Desktop = ptrStr("invalid")
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.NotNil(t, err, "Should have failed with invalid desktop notify props.")
 
 	// Invalid mobile notify props.
 	data[0].NotifyProps.Desktop = ptrStr("mention")
 	data[0].NotifyProps.Mobile = ptrStr("invalid")
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.NotNil(t, err, "Should have failed with invalid mobile notify props.")
 
 	// Invalid mark_unread notify props.
 	data[0].NotifyProps.Mobile = ptrStr("mention")
 	data[0].NotifyProps.MarkUnread = ptrStr("invalid")
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.NotNil(t, err, "Should have failed with invalid mark_unread notify props.")
 
 	// Valid notify props.
 	data[0].NotifyProps.MarkUnread = ptrStr("mention")
-	err = validateUserChannelsImportData(&data)
+	err = ValidateUserChannelsImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid notify props.")
 }
 
@@ -784,7 +784,7 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}
-	err := validateReactionImportData(&data, parentCreateAt)
+	err := ValidateReactionImportData(&data, parentCreateAt)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing required properties.
@@ -792,21 +792,21 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}
-	err = validateReactionImportData(&data, parentCreateAt)
+	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = ReactionImportData{
 		User:     ptrStr("username"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateReactionImportData(&data, parentCreateAt)
+	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = ReactionImportData{
 		User:      ptrStr("username"),
 		EmojiName: ptrStr("emoji"),
 	}
-	err = validateReactionImportData(&data, parentCreateAt)
+	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	// Test with invalid emoji name.
@@ -815,7 +815,7 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr(strings.Repeat("1234567890", 500)),
 		CreateAt:  ptrInt64(model.GetMillis()),
 	}
-	err = validateReactionImportData(&data, parentCreateAt)
+	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to too long emoji name.")
 
 	// Test with invalid CreateAt
@@ -824,7 +824,7 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(0),
 	}
-	err = validateReactionImportData(&data, parentCreateAt)
+	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 
 	data = ReactionImportData{
@@ -832,7 +832,7 @@ func TestImportValidateReactionImportData(t *testing.T) {
 		EmojiName: ptrStr("emoji"),
 		CreateAt:  ptrInt64(parentCreateAt - 100),
 	}
-	err = validateReactionImportData(&data, parentCreateAt)
+	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due parent with newer create-at value.")
 }
 
@@ -845,7 +845,7 @@ func TestImportValidateReplyImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err := validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	err := ValidateReplyImportData(&data, parentCreateAt, maxPostSize)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing required properties.
@@ -853,21 +853,21 @@ func TestImportValidateReplyImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	err = ValidateReplyImportData(&data, parentCreateAt, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = ReplyImportData{
 		User:     ptrStr("username"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	err = ValidateReplyImportData(&data, parentCreateAt, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = ReplyImportData{
 		User:    ptrStr("username"),
 		Message: ptrStr("message"),
 	}
-	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	err = ValidateReplyImportData(&data, parentCreateAt, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	// Test with invalid message.
@@ -876,7 +876,7 @@ func TestImportValidateReplyImportData(t *testing.T) {
 		Message:  ptrStr(strings.Repeat("0", maxPostSize+1)),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	err = ValidateReplyImportData(&data, parentCreateAt, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to too long message.")
 
 	// Test with invalid CreateAt
@@ -885,7 +885,7 @@ func TestImportValidateReplyImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(0),
 	}
-	err = validateReplyImportData(&data, parentCreateAt, maxPostSize)
+	err = ValidateReplyImportData(&data, parentCreateAt, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 }
 
@@ -900,7 +900,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Message:  ptrStr("message"),
 			CreateAt: ptrInt64(model.GetMillis()),
 		}
-		err := validatePostImportData(&data, maxPostSize)
+		err := ValidatePostImportData(&data, maxPostSize)
 		require.Nil(t, err, "Validation failed but should have been valid.")
 	})
 
@@ -911,7 +911,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Message:  ptrStr("message"),
 			CreateAt: ptrInt64(model.GetMillis()),
 		}
-		err := validatePostImportData(&data, maxPostSize)
+		err := ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to missing required property.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.team_missing.error")
 
@@ -921,7 +921,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Message:  ptrStr("message"),
 			CreateAt: ptrInt64(model.GetMillis()),
 		}
-		err = validatePostImportData(&data, maxPostSize)
+		err = ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to missing required property.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.channel_missing.error")
 
@@ -931,7 +931,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Message:  ptrStr("message"),
 			CreateAt: ptrInt64(model.GetMillis()),
 		}
-		err = validatePostImportData(&data, maxPostSize)
+		err = ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to missing required property.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.user_missing.error")
 
@@ -941,7 +941,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			User:     ptrStr("username"),
 			CreateAt: ptrInt64(model.GetMillis()),
 		}
-		err = validatePostImportData(&data, maxPostSize)
+		err = ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to missing required property.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.message_missing.error")
 
@@ -951,7 +951,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			User:    ptrStr("username"),
 			Message: ptrStr("message"),
 		}
-		err = validatePostImportData(&data, maxPostSize)
+		err = ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to missing required property.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.create_at_missing.error")
 	})
@@ -964,7 +964,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Message:  ptrStr(strings.Repeat("0", maxPostSize+1)),
 			CreateAt: ptrInt64(model.GetMillis()),
 		}
-		err := validatePostImportData(&data, maxPostSize)
+		err := ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to too long message.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.message_length.error")
 	})
@@ -977,7 +977,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Message:  ptrStr("message"),
 			CreateAt: ptrInt64(0),
 		}
-		err := validatePostImportData(&data, maxPostSize)
+		err := ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.create_at_zero.error")
 	})
@@ -1004,7 +1004,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Reactions: &reactions,
 			Replies:   &replies,
 		}
-		err := validatePostImportData(&data, maxPostSize)
+		err := ValidatePostImportData(&data, maxPostSize)
 		require.Nil(t, err, "Should have succeeded.")
 	})
 
@@ -1021,7 +1021,7 @@ func TestImportValidatePostImportData(t *testing.T) {
 			Props:    &props,
 			CreateAt: ptrInt64(model.GetMillis()),
 		}
-		err := validatePostImportData(&data, maxPostSize)
+		err := ValidatePostImportData(&data, maxPostSize)
 		require.NotNil(t, err, "Should have failed due to long props.")
 		assert.Equal(t, err.Id, "app.import.validate_post_import_data.props_too_large.error")
 	})
@@ -1036,7 +1036,7 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	err := validateDirectChannelImportData(&data)
+	err := ValidateDirectChannelImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with valid number of members for group message.
@@ -1047,7 +1047,7 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with all the combinations of optional parameters.
@@ -1058,19 +1058,19 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 		},
 		Header: ptrStr("Channel Header Here"),
 	}
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.Nil(t, err, "Should have succeeded with valid optional properties.")
 
 	// Test with invalid Header.
 	data.Header = ptrStr(strings.Repeat("abcdefghij ", 103))
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.NotNil(t, err, "Should have failed due to too long header.")
 
 	// Test with different combinations of invalid member counts.
 	data = DirectChannelImportData{
 		Members: &[]string{},
 	}
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to invalid number of members.")
 
 	data = DirectChannelImportData{
@@ -1078,7 +1078,7 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to invalid number of members.")
 
 	data = DirectChannelImportData{
@@ -1094,7 +1094,7 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to invalid number of members.")
 
 	// Test with invalid FavoritedBy
@@ -1110,7 +1110,7 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			model.NewId(),
 		},
 	}
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.NotNil(t, err, "Validation should have failed due to non-member favorited.")
 
 	// Test with valid FavoritedBy
@@ -1124,7 +1124,7 @@ func TestImportValidateDirectChannelImportData(t *testing.T) {
 			member2,
 		},
 	}
-	err = validateDirectChannelImportData(&data)
+	err = ValidateDirectChannelImportData(&data)
 	require.Nil(t, err, "Validation should succeed with valid favorited member")
 }
 
@@ -1141,7 +1141,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err := validateDirectPostImportData(&data, maxPostSize)
+	err := ValidateDirectPostImportData(&data, maxPostSize)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with missing required properties.
@@ -1150,7 +1150,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = DirectPostImportData{
@@ -1161,7 +1161,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = DirectPostImportData{
@@ -1172,7 +1172,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		User:     ptrStr("username"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	data = DirectPostImportData{
@@ -1183,7 +1183,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		User:    ptrStr("username"),
 		Message: ptrStr("message"),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
 	// Test with invalid numbers of channel members.
@@ -1193,7 +1193,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:        ptrStr("message"),
 		CreateAt:       ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to unsuitable number of members.")
 
 	data = DirectPostImportData{
@@ -1204,7 +1204,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to unsuitable number of members.")
 
 	data = DirectPostImportData{
@@ -1224,7 +1224,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to unsuitable number of members.")
 
 	// Test with group message number of members.
@@ -1238,7 +1238,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with invalid message.
@@ -1251,7 +1251,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr(strings.Repeat("0", maxPostSize+1)),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to too long message.")
 
 	// Test with invalid CreateAt
@@ -1264,7 +1264,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(0),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Should have failed due to 0 create-at value.")
 
 	// Test with invalid FlaggedBy
@@ -1283,7 +1283,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.NotNil(t, err, "Validation should have failed due to non-member flagged.")
 
 	// Test with valid FlaggedBy
@@ -1300,7 +1300,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Message:  ptrStr("message"),
 		CreateAt: ptrInt64(model.GetMillis()),
 	}
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.Nil(t, err, "Validation should succeed with post flagged by members")
 
 	// Test with valid all optional parameters.
@@ -1332,7 +1332,7 @@ func TestImportValidateDirectPostImportData(t *testing.T) {
 		Replies:   &replies,
 	}
 
-	err = validateDirectPostImportData(&data, maxPostSize)
+	err = ValidateDirectPostImportData(&data, maxPostSize)
 	require.Nil(t, err, "Validation should succeed with valid optional parameters")
 }
 
@@ -1361,7 +1361,7 @@ func TestImportValidateEmojiImportData(t *testing.T) {
 				Image: tc.image,
 			}
 
-			err := validateEmojiImportData(&data)
+			err := ValidateEmojiImportData(&data)
 			if tc.expectError {
 				require.NotNil(t, err)
 				assert.Equal(t, tc.expectSystemEmoji, err.Id == "model.emoji.system_emoji_name.app_error")
@@ -1370,4 +1370,24 @@ func TestImportValidateEmojiImportData(t *testing.T) {
 			}
 		})
 	}
+}
+
+func ptrStr(s string) *string {
+	return &s
+}
+
+func ptrInt64(i int64) *int64 {
+	return &i
+}
+
+func ptrBool(b bool) *bool {
+	return &b
+}
+
+func checkError(t *testing.T, err *model.AppError) {
+	require.NotNil(t, err, "Should have returned an error.")
+}
+
+func checkNoError(t *testing.T, err *model.AppError) {
+	require.Nil(t, err, "Unexpected Error: %v", err)
 }


### PR DESCRIPTION
#### Summary
In order for the validators in the server and in `mmctl` to share code, we need to put it into a separate package. This PR moves the import validators and types into the `app/imports` package. In order for this change to be a non-invasive as possible, it creates one type alias to prevent two interface changes (`AppIface` and `OpenTracing Layer`).

The linter insisted on not allowing anonymous fields in struct literals, so there are a few changes for this as well.

#### Ticket Link
[MM-38705](https://mattermost.atlassian.net/browse/MM-38705)

#### Release Note
```release-note
NONE
```
