### PR TITLE
[MM-46663] Only enable marketplace command completion when config allows it

### DIFF
--- a/app/slashcommands/command_marketplace.go
+++ b/app/slashcommands/command_marketplace.go
@@ -26,9 +26,15 @@ func (h *MarketplaceProvider) GetTrigger() string {
 }
 
 func (h *MarketplaceProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command {
+	enabled := false
+	pluginSettings := a.Config().PluginSettings
+	if *pluginSettings.Enable && *pluginSettings.EnableMarketplace {
+		enabled = true
+	}
+
 	return &model.Command{
 		Trigger:          CmdMarketplace,
-		AutoComplete:     true,
+		AutoComplete:     enabled,
 		AutoCompleteDesc: T("api.command_marketplace.desc"),
 		DisplayName:      T("api.command_marketplace.name"),
 	}

--- a/app/slashcommands/command_marketplace_test.go
+++ b/app/slashcommands/command_marketplace_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package slashcommands
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarketplaceProviderGetCommand(t *testing.T) {
+	th := setup(t).initBasic()
+	defer th.tearDown()
+
+	mp := MarketplaceProvider{}
+
+	testCases := []struct {
+		TestName string
+
+		PluginEnabled      bool
+		MarketplaceEnabled bool
+
+		MustAutocomplete bool
+	}{
+		{
+			"All true",
+			true, true,
+			true,
+		},
+		{
+			"Plugin false",
+			false, true,
+			false,
+		},
+		{
+			"Marketplace false",
+			true, false,
+			false,
+		},
+		{
+			"All false",
+			false, false,
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.TestName, func(t *testing.T) {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				*cfg.PluginSettings.Enable = tc.PluginEnabled
+				*cfg.PluginSettings.EnableMarketplace = tc.MarketplaceEnabled
+			})
+
+			cmd := mp.GetCommand(th.App, th.Context.T)
+			require.Equal(t, tc.MustAutocomplete, cmd.AutoComplete)
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Add checks on the `/marketplace` command to only allow autocomplete when the server config has plugins and marketplace enabled

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46663

#### Release Note
```release-note
NONE
```
