### PR TITLE
Revert "Use error log level for websocket timeouts (#19609)"

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -823,10 +823,6 @@ func (wc *WebConn) logSocketErr(source string, err error) {
 	if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseNoStatusReceived) {
 		mlog.Debug(source+": client side closed socket", mlog.String("user_id", wc.UserId))
 	} else {
-		logFunc := mlog.Debug
-		if e, ok := err.(net.Error); ok && e.Timeout() {
-			logFunc = mlog.Error
-		}
-		logFunc(source+": closing websocket", mlog.String("user_id", wc.UserId), mlog.Err(err))
+		mlog.Debug(source+": closing websocket", mlog.String("user_id", wc.UserId), mlog.Err(err))
 	}
 }


### PR DESCRIPTION
Apparently, this can happen in normal situations as well
and is causing confusion amongst customers. Reverting.

This reverts commit 9534efe534d09d0378e9e1f1b51b9bb8b059bb66.

```release-note
NONE
```
