### PR TITLE
[6.3 Backport] - Exclude deleted group members

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -2153,7 +2153,7 @@ func (s SqlChannelStore) GetMemberCountsByGroup(ctx context.Context, channelID s
 	query := s.getQueryBuilder().
 		Select(selectStr).
 		From("ChannelMembers").
-		Join("GroupMembers ON GroupMembers.UserId = ChannelMembers.UserId")
+		Join("GroupMembers ON GroupMembers.UserId = ChannelMembers.UserId AND GroupMembers.DeleteAt = 0")
 
 	if includeTimezones {
 		query = query.Join("Users ON Users.Id = GroupMembers.UserId")


### PR DESCRIPTION
This is a backport which was originally part of
https://github.com/mattermost/mattermost-server/pull/18839.

But we extract it out specially to fix the correctness
of this query.

```release-note
NONE
```
