### PR TITLE
fix: update MiniPreview in FileInfo Upsert method

### DIFF
--- a/store/sqlstore/file_info_store.go
+++ b/store/sqlstore/file_info_store.go
@@ -181,6 +181,7 @@ func (fs SqlFileInfoStore) Upsert(info *model.FileInfo) (*model.FileInfo, error)
 			"Width":           info.Width,
 			"Height":          info.Height,
 			"HasPreviewImage": info.HasPreviewImage,
+			"MiniPreview":     info.MiniPreview,
 			"Content":         info.Content,
 			"RemoteId":        info.RemoteId,
 		}).


### PR DESCRIPTION
#### Summary
There was missing field in Upsert method of file_info structure.
MiniPreview was missing in upsert.

{"timestamp":"2022-09-01 16:49:51.914 +02:00","level":"debug","msg":"creating mini preview failed","caller":"app/file.go:1121","error":"failed to save FileInfo: Error 1062: Duplicate entry 'jo61ga8i8idauf5ug5cxqi4o1h' for key 'FileInfo.PRIMARY'"}

#### Release Note
NONE

