### PR TITLE
[15921] Disable email notifications for the bot user

### DIFF
--- a/app/bot.go
+++ b/app/bot.go
@@ -131,6 +131,11 @@ func (a *App) CreateBot(c request.CTX, bot *model.Bot) (*model.Bot, *model.AppEr
 			return nil, model.NewAppError("CreateBot", "app.user.save.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 		}
 	}
+
+	if err := a.ch.srv.userService.ToggleEmailNotifications(user.Id, "disable"); err != nil {
+		return nil, model.NewAppError("ToggleEmailNotifications", "app.bot.toggleemailnotify.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
 	bot.UserId = user.Id
 
 	savedBot, nErr := a.Srv().Store.Bot().Save(bot)
@@ -266,6 +271,11 @@ func (a *App) getOrCreateBot(botDef *model.Bot) (*model.Bot, *model.AppError) {
 				return nil, model.NewAppError("getOrCreateBot", "app.user.save.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 			}
 		}
+
+		if err := a.ch.srv.userService.ToggleEmailNotifications(user.Id, "disable"); err != nil {
+			return nil, model.NewAppError("ToggleEmailNotifications", "app.bot.toggleemailnotify.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
+
 		botDef.UserId = user.Id
 
 		//save the bot
@@ -654,5 +664,10 @@ func (a *App) ConvertUserToBot(user *model.User) (*model.Bot, *model.AppError) {
 			return nil, model.NewAppError("CreateBot", "app.bot.createbot.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 	}
+
+	if err := a.ch.srv.userService.ToggleEmailNotifications(user.Id, "enable"); err != nil {
+		return nil, model.NewAppError("ToggleEmailNotifications", "app.bot.toggleemailnotify.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
 	return bot, nil
 }

--- a/app/bot.go
+++ b/app/bot.go
@@ -132,8 +132,8 @@ func (a *App) CreateBot(c request.CTX, bot *model.Bot) (*model.Bot, *model.AppEr
 		}
 	}
 
-	if err := a.ch.srv.userService.ToggleEmailNotifications(user.Id, "disable"); err != nil {
-		return nil, model.NewAppError("ToggleEmailNotifications", "app.bot.toggleemailnotify.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	if err := a.ch.srv.userService.SetEmailNotificationsState(user.Id, "disable"); err != nil {
+		return nil, model.NewAppError("SetEmailNotificationsState", "app.bot.setemailnotificationstate.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	bot.UserId = user.Id
@@ -272,8 +272,8 @@ func (a *App) getOrCreateBot(botDef *model.Bot) (*model.Bot, *model.AppError) {
 			}
 		}
 
-		if err := a.ch.srv.userService.ToggleEmailNotifications(user.Id, "disable"); err != nil {
-			return nil, model.NewAppError("ToggleEmailNotifications", "app.bot.toggleemailnotify.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		if err := a.ch.srv.userService.SetEmailNotificationsState(user.Id, "disable"); err != nil {
+			return nil, model.NewAppError("SetEmailNotificationsState", "app.bot.setemailnotificationstate.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
 
 		botDef.UserId = user.Id
@@ -665,8 +665,8 @@ func (a *App) ConvertUserToBot(user *model.User) (*model.Bot, *model.AppError) {
 		}
 	}
 
-	if err := a.ch.srv.userService.ToggleEmailNotifications(user.Id, "enable"); err != nil {
-		return nil, model.NewAppError("ToggleEmailNotifications", "app.bot.toggleemailnotify.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	if err := a.ch.srv.userService.SetEmailNotificationsState(user.Id, "enable"); err != nil {
+		return nil, model.NewAppError("SetEmailNotificationsState", "app.bot.setemailnotificationstate.internal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	return bot, nil

--- a/app/users/users.go
+++ b/app/users/users.go
@@ -263,7 +263,7 @@ func (us *UserService) DemoteUserToGuest(user *model.User) (*model.User, error) 
 	return us.store.DemoteUserToGuest(user.Id)
 }
 
-func (us *UserService) ToggleEmailNotifications(userId string, action string) error {
+func (us *UserService) SetEmailNotificationsState(userId string, action string) error {
 	notifyProps, err := us.store.GetNotifyProps(userId)
 	if err != nil {
 		return err

--- a/app/users/users.go
+++ b/app/users/users.go
@@ -193,6 +193,10 @@ func (us *UserService) GetUsersWithoutTeam(options *model.UserGetOptions) ([]*mo
 	return users, nil
 }
 
+func (us *UserService) GetUserNotifyProps(userID string) (map[string]string, error) {
+	return us.store.GetNotifyProps(userID)
+}
+
 func (us *UserService) UpdateUser(user *model.User, allowRoleUpdate bool) (*model.UserUpdate, error) {
 	return us.store.Update(user, allowRoleUpdate)
 }
@@ -257,4 +261,23 @@ func (us *UserService) PromoteGuestToUser(user *model.User) error {
 
 func (us *UserService) DemoteUserToGuest(user *model.User) (*model.User, error) {
 	return us.store.DemoteUserToGuest(user.Id)
+}
+
+func (us *UserService) ToggleEmailNotifications(userId string, action string) error {
+	notifyProps, err := us.store.GetNotifyProps(userId)
+	if err != nil {
+		return err
+	}
+
+	if action == "enable" {
+		notifyProps["email"] = "true"
+	} else {
+		notifyProps["email"] = "false"
+	}
+
+	if err = us.store.UpdateNotifyProps(userId, notifyProps); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4500,8 +4500,8 @@
     "translation": "Unable to save the bot."
   },
   {
-    "id": "app.bot.toggleemailnotify.internal_error",
-    "translation": "Unable to toggle email notification status for the user."
+    "id": "app.bot.setemailnotificationstate.internal_error",
+    "translation": "Unable to set email notification status for the user."
   },
   {
     "id": "app.bot.get_disable_bot_sysadmin_message",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4500,6 +4500,10 @@
     "translation": "Unable to save the bot."
   },
   {
+    "id": "app.bot.toggleemailnotify.internal_error",
+    "translation": "Unable to toggle email notification status for the user."
+  },
+  {
     "id": "app.bot.get_disable_bot_sysadmin_message",
     "translation": "{{if .disableBotsSetting}}{{if .printAllBots}}{{.UserName}} was deactivated. They managed the following bot accounts which have now been disabled.\n\n{{.BotNames}}{{else}}{{.UserName}} was deactivated. They managed {{.NumBots}} bot accounts which have now been disabled, including the following:\n\n{{.BotNames}}{{end}}You can take ownership of each bot by enabling it at **Integrations > Bot Accounts** and creating new tokens for the bot.\n\nFor more information, see our [documentation](https://docs.mattermost.com/developer/bot-accounts.html#what-happens-when-a-user-who-owns-bot-accounts-is-disabled).{{else}}{{if .printAllBots}}{{.UserName}} was deactivated. They managed the following bot accounts which are still enabled.\n\n{{.BotNames}}\n{{else}}{{.UserName}} was deactivated. They managed {{.NumBots}} bot accounts which are still enabled, including the following:\n\n{{.BotNames}}{{end}}We strongly recommend you to take ownership of each bot by re-enabling it at **Integrations > Bot Accounts** and creating new tokens for the bot.\n\nFor more information, see our [documentation](https://docs.mattermost.com/developer/bot-accounts.html#what-happens-when-a-user-who-owns-bot-accounts-is-disabled).\n\nIf you want bot accounts to disable automatically after owner deactivation, set “Disable bot accounts when owner is deactivated” in **System Console > Integrations > Bot Accounts** to true.{{end}}"
   },

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -10855,6 +10855,24 @@ func (s *OpenTracingLayerUserStore) GetNewUsersForTeam(teamID string, offset int
 	return result, err
 }
 
+func (s *OpenTracingLayerUserStore) GetNotifyProps(userID string) (map[string]string, error) {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "UserStore.GetNotifyProps")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	result, err := s.UserStore.GetNotifyProps(userID)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return result, err
+}
+
 func (s *OpenTracingLayerUserStore) GetProfileByGroupChannelIdsForUser(userID string, channelIds []string) (map[string][]*model.User, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "UserStore.GetProfileByGroupChannelIdsForUser")

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -12387,6 +12387,27 @@ func (s *RetryLayerUserStore) GetNewUsersForTeam(teamID string, offset int, limi
 
 }
 
+func (s *RetryLayerUserStore) GetNotifyProps(userID string) (map[string]string, error) {
+
+	tries := 0
+	for {
+		result, err := s.UserStore.GetNotifyProps(userID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerUserStore) GetProfileByGroupChannelIdsForUser(userID string, channelIds []string) (map[string][]*model.User, error) {
 
 	tries := 0

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -458,6 +458,15 @@ func (us SqlUserStore) GetAll() ([]*model.User, error) {
 	return data, nil
 }
 
+func (us SqlUserStore) GetNotifyProps(userId string) (map[string]string, error) {
+	user, err := us.Get(context.Background(), userId)
+	if err != nil {
+		return nil, errors.Wrap(err, "get_notify_props")
+	}
+
+	return user.NotifyProps, nil
+}
+
 func (us SqlUserStore) GetAllAfter(limit int, afterId string) ([]*model.User, error) {
 	query := us.usersQuery.
 		Where("Id > ?", afterId).

--- a/store/store.go
+++ b/store/store.go
@@ -418,6 +418,7 @@ type UserStore interface {
 	Get(ctx context.Context, id string) (*model.User, error)
 	GetMany(ctx context.Context, ids []string) ([]*model.User, error)
 	GetAll() ([]*model.User, error)
+	GetNotifyProps(userID string) (map[string]string, error)
 	ClearCaches()
 	InvalidateProfilesInChannelCacheByUser(userID string)
 	InvalidateProfilesInChannelCache(channelID string)
@@ -972,7 +973,6 @@ type SharedChannelStore interface {
 // Paginate whether to paginate the results.
 // Page page requested, if results are paginated.
 // PerPage number of results per page, if paginated.
-//
 type ChannelSearchOpts struct {
 	Term                     string
 	NotAssociatedToGroup     string

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -661,6 +661,29 @@ func (_m *UserStore) GetNewUsersForTeam(teamID string, offset int, limit int, vi
 	return r0, r1
 }
 
+// GetNotifyProps provides a mock function with given fields: userID
+func (_m *UserStore) GetNotifyProps(userID string) (map[string]string, error) {
+	ret := _m.Called(userID)
+
+	var r0 map[string]string
+	if rf, ok := ret.Get(0).(func(string) map[string]string); ok {
+		r0 = rf(userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetProfileByGroupChannelIdsForUser provides a mock function with given fields: userID, channelIds
 func (_m *UserStore) GetProfileByGroupChannelIdsForUser(userID string, channelIds []string) (map[string][]*model.User, error) {
 	ret := _m.Called(userID, channelIds)
@@ -1529,27 +1552,6 @@ func (_m *UserStore) VerifyEmail(userID string, email string) (string, error) {
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, string) error); ok {
 		r1 = rf(userID, email)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetNotifyProps provides a mock function with given field: userID
-func (_m *UserStore) GetNotifyProps(userID string) (map[string]string, error)  {
-	ret := _m.Called(userID)
-
-	var r0 map[string]string
-	if rf, ok := ret.Get(0).(func(string) map[string]string); ok {
-		r0 = rf(userID)
-	} else {
-		r0 = ret.Get(0).(map[string]string)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/store/storetest/mocks/UserStore.go
+++ b/store/storetest/mocks/UserStore.go
@@ -1535,3 +1535,24 @@ func (_m *UserStore) VerifyEmail(userID string, email string) (string, error) {
 
 	return r0, r1
 }
+
+// GetNotifyProps provides a mock function with given field: userID
+func (_m *UserStore) GetNotifyProps(userID string) (map[string]string, error)  {
+	ret := _m.Called(userID)
+
+	var r0 map[string]string
+	if rf, ok := ret.Get(0).(func(string) map[string]string); ok {
+		r0 = rf(userID)
+	} else {
+		r0 = ret.Get(0).(map[string]string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -49,6 +49,7 @@ func TestUserStore(t *testing.T, ss store.Store, s SqlStore) {
 	t.Run("UpdateUpdateAt", func(t *testing.T) { testUserStoreUpdateUpdateAt(t, ss) })
 	t.Run("UpdateFailedPasswordAttempts", func(t *testing.T) { testUserStoreUpdateFailedPasswordAttempts(t, ss) })
 	t.Run("Get", func(t *testing.T) { testUserStoreGet(t, ss) })
+	t.Run("GetNotifyProps", func(t *testing.T) { testUserStoreGetNotifyProps(t, ss) })
 	t.Run("GetAllUsingAuthService", func(t *testing.T) { testGetAllUsingAuthService(t, ss) })
 	t.Run("GetAllProfiles", func(t *testing.T) { testUserStoreGetAllProfiles(t, ss) })
 	t.Run("GetProfiles", func(t *testing.T) { testUserStoreGetProfiles(t, ss) })
@@ -319,6 +320,26 @@ func testUserStoreGet(t *testing.T, ss store.Store) {
 		require.Equal(t, u2, actual)
 		require.True(t, actual.IsBot)
 		require.Equal(t, "bot description", actual.BotDescription)
+	})
+}
+
+func testUserStoreGetNotifyProps(t *testing.T, ss store.Store) {
+	u1 := &model.User{
+		Email: MakeEmail(),
+	}
+	_, err := ss.User().Save(u1)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ss.User().PermanentDelete(u1.Id)) }()
+
+	t.Run("fetch empty id", func(t *testing.T) {
+		_, err := ss.User().GetNotifyProps("")
+		require.Error(t, err)
+	})
+
+	t.Run("fetch user 1", func(t *testing.T) {
+		actual, err := ss.User().GetNotifyProps(u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, u1, actual)
 	})
 }
 

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -9775,6 +9775,22 @@ func (s *TimerLayerUserStore) GetNewUsersForTeam(teamID string, offset int, limi
 	return result, err
 }
 
+func (s *TimerLayerUserStore) GetNotifyProps(userID string) (map[string]string, error) {
+	start := time.Now()
+
+	result, err := s.UserStore.GetNotifyProps(userID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("UserStore.GetNotifyProps", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerUserStore) GetProfileByGroupChannelIdsForUser(userID string, channelIds []string) (map[string][]*model.User, error) {
 	start := time.Now()
 


### PR DESCRIPTION
#### Summary
This commit disables the email notifications for the bot accounts. Currently, they are set to `true` which caused bounce back messages when someone DM's the bot.

Additionally, when a user is converted to bot, the email notifications are disabled and when a bot is converted to user, email  notifications are enabled.

#### Ticket Link

  Fixes https://github.com/mattermost/mattermost-server/issues/15921

#### Release Notes
```release-note

* Disable email notifications for bot users by default. Also, disable email notifications if a user is converted to bot and enable if vice-versa.
```