### PR TITLE
MM-46869: Fix channel props not appearing in GraphQL

### DIFF
--- a/api4/resolver_channel.go
+++ b/api4/resolver_channel.go
@@ -87,12 +87,18 @@ func postProcessChannels(c *web.Context, channels []*model.Channel) ([]*channel,
 	// This approach becomes effectively similar to a dataloader if the displayName computation
 	// were to be done at the field level per channel.
 
-	// Get DM/GM channelIDs
+	// Get DM/GM channelIDs and set empty maps as well.
 	var channelIDs []string
 	for _, ch := range channels {
 		if ch.IsGroupOrDirect() {
 			channelIDs = append(channelIDs, ch.Id)
 		}
+
+		// This is needed to avoid sending null, which
+		// does not match with the schema since props is not nullable.
+		// And making it nullable would mean taking pointer of a map,
+		// which is not very idiomatic.
+		ch.MakeNonNil()
 	}
 
 	var nameFormat string

--- a/api4/resolver_channel_test.go
+++ b/api4/resolver_channel_test.go
@@ -43,6 +43,7 @@ func TestGraphQLChannels(t *testing.T) {
 			TotalMsgCountRoot float64           `json:"totalMsgCountRoot"`
 			LastRootPostAt    float64           `json:"lastRootPostAt"`
 			Cursor            string            `json:"cursor"`
+			Props             map[string]any    `json:"props"`
 			Team              struct {
 				ID          string `json:"id"`
 				DisplayName string `json:"displayName"`
@@ -75,6 +76,7 @@ func TestGraphQLChannels(t *testing.T) {
 		totalMsgCountRoot
 		lastRootPostAt
 	    cursor
+	    props
 	  }
 	}
 	`,
@@ -97,6 +99,7 @@ func TestGraphQLChannels(t *testing.T) {
 			assert.NotEmpty(t, ch.PrettyDisplayName)
 			assert.NotEmpty(t, ch.CreateAt)
 			assert.NotEmpty(t, ch.UpdateAt)
+			assert.NotNil(t, ch.Props)
 			if ch.Type == model.ChannelTypeOpen {
 				numPublic++
 			} else if ch.Type == model.ChannelTypePrivate {

--- a/model/utils.go
+++ b/model/utils.go
@@ -190,6 +190,10 @@ func (StringInterface) ImplementsGraphQLType(name string) bool {
 	return name == "StringInterface"
 }
 
+func (si StringInterface) MarshalJSON() ([]byte, error) {
+	return json.Marshal((map[string]any)(si))
+}
+
 func (si *StringInterface) UnmarshalGraphQL(input any) error {
 	json, ok := input.(map[string]any)
 	if !ok {


### PR DESCRIPTION
The props map was being null, but the schema did not
allow nulls. Therefore, the whole response was being
set to null. There was no error which created more
confusion.

To avoid making the property nillable, which would
mean sending pointers to maps, we just create
empty maps if they are nil.

https://mattermost.atlassian.net/browse/MM-46869

```release-note
NONE
```
