### PR TITLE
escape parenthesis in postgres search query

### DIFF
--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1505,6 +1505,8 @@ func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string
 		if isPostgreSQL {
 			// Escaping the : in case of a Postgres search.
 			term = strings.ReplaceAll(term, ":", "\\:")
+			term = strings.ReplaceAll(term, "(", "\\(")
+			term = strings.ReplaceAll(term, ")", "\\)")
 		}
 
 		for _, field := range fields {

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -2808,6 +2808,13 @@ func testUserStoreSearch(t *testing.T, ss store.Store) {
 			[]*model.User{},
 		},
 		{
+			"escape ( and )",
+			t1id,
+			"ji(bah)",
+			&model.UserSearchOptions{},
+			[]*model.User{},
+		},
+		{
 			"wildcard search",
 			t1id,
 			"@",


### PR DESCRIPTION
#### Summary
Escape parenthesis in postgres sql queries to avoid returning a 500 error.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46871

#### Release Note
```release-note
NONE
```
