### PR TITLE
Send deleted posts on getPostSince when collapsed threads is enabled

### DIFF
--- a/store/sqlstore/post_store.go
+++ b/store/sqlstore/post_store.go
@@ -1226,7 +1226,6 @@ func (s *SqlPostStore) getPostsSinceCollapsedThreads(options model.GetPostsSince
 		From("Posts").
 		LeftJoin("Threads ON Threads.PostId = Posts.Id").
 		LeftJoin("ThreadMemberships ON ThreadMemberships.PostId = Posts.Id AND ThreadMemberships.UserId = ?", options.UserId).
-		Where(sq.Eq{"Posts.DeleteAt": 0}).
 		Where(sq.Eq{"Posts.ChannelId": options.ChannelId}).
 		Where(sq.Gt{"Posts.UpdateAt": options.Time}).
 		Where(sq.Eq{"Posts.RootId": ""}).


### PR DESCRIPTION
#### Summary
When we use `getPostSince`, we want to know what posts have been deleted, to properly remove them while doing the synchronization.

The way it was implemented, was omitting the deleted posts, so the posts never would get deleted on the client.

#### Ticket Link
None

#### Release Note
```release-note
`getPostSince` properly return deleted posts when CRT is enabled.
```
