### PR TITLE
Initialize the logger for imports

### DIFF
--- a/jobs/import_process/worker.go
+++ b/jobs/import_process/worker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/services/configservice"
 	"github.com/mattermost/mattermost-server/v6/shared/filestore"
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
 const jobName = "ImportProcess"
@@ -31,7 +32,8 @@ type AppIface interface {
 }
 
 func MakeWorker(jobServer *jobs.JobServer, app AppIface) model.Worker {
-	appContext := request.EmptyContext(nil)
+	logger, _ := mlog.NewLogger()
+	appContext := request.EmptyContext(logger)
 	isEnabled := func(cfg *model.Config) bool {
 		return true
 	}

--- a/jobs/import_process/worker.go
+++ b/jobs/import_process/worker.go
@@ -29,11 +29,11 @@ type AppIface interface {
 	FileSize(path string) (int64, *model.AppError)
 	FileReader(path string) (filestore.ReadCloseSeeker, *model.AppError)
 	BulkImportWithPath(c *request.Context, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun bool, workers int, importPath string) (*model.AppError, int)
+	Log() *mlog.Logger
 }
 
 func MakeWorker(jobServer *jobs.JobServer, app AppIface) model.Worker {
-	logger, _ := mlog.NewLogger()
-	appContext := request.EmptyContext(logger)
+	appContext := request.EmptyContext(app.Log())
 	isEnabled := func(cfg *model.Config) bool {
 		return true
 	}


### PR DESCRIPTION
#### Summary
Import workers may crash when trying to log due to the logger not being configured in the context. This PR takes the logger from the `*App` and uses it to initialize the context.

#### Ticket Link
[MM-46928](https://mattermost.atlassian.net/browse/MM-46928)

#### Release Note
```release-note
NONE
```
