### PR TITLE
add PeopleProduct feature flag

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -75,6 +75,8 @@ type FeatureFlags struct {
 	PlanUpgradeButtonText string
 
 	PostPriority bool
+
+	PeopleProduct bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -103,6 +105,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.BoardsProduct = false
 	f.PlanUpgradeButtonText = "upgrade"
 	f.PostPriority = false
+	f.PeopleProduct = false
 }
 
 func (f *FeatureFlags) Plugins() map[string]string {


### PR DESCRIPTION
#### Summary
Adds basic support for `MM_FEATUREFLAGS_PEOPLEPRODUCT`

Relates to: 
- #21108
- https://github.com/mattermost/mattermost-webapp/pull/11147

#### Ticket Link
None

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
