### PR TITLE
Fix unchecked request when saving channel

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -584,7 +584,7 @@ func (a *App) createGroupChannel(c request.CTX, userIDs []string) (*model.Channe
 	for _, user := range users {
 		cm := &model.ChannelMember{
 			UserId:      user.Id,
-			ChannelId:   group.Id,
+			ChannelId:   channel.Id,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
 			SchemeGuest: user.IsGuest(),
 			SchemeUser:  !user.IsGuest(),

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -687,7 +687,9 @@ func (s SqlChannelStore) saveChannelT(transaction *sqlxTxWrapper, channel *model
 		(:Id, :CreateAt, :UpdateAt, :DeleteAt, :TeamId, :Type, :DisplayName, :Name, :Header, :Purpose, :LastPostAt, :TotalMsgCount, :ExtraUpdateAt, :CreatorId, :SchemeId, :GroupConstrained, :Shared, :TotalMsgCountRoot, :LastRootPostAt)`, channel); err != nil {
 		if IsUniqueConstraintError(err, []string{"Name", "channels_name_teamid_key"}) {
 			dupChannel := model.Channel{}
-			s.GetMasterX().Get(&dupChannel, "SELECT * FROM Channels WHERE TeamId = ? AND Name = ?", channel.TeamId, channel.Name)
+			if serr := s.GetMasterX().Get(&dupChannel, "SELECT * FROM Channels WHERE TeamId = ? AND Name = ?", channel.TeamId, channel.Name); serr != nil {
+				return nil, errors.Wrapf(serr, "error while retrieving existing channel %s", channel.Name) // do not return this as a *store.ErrConflict as it would be treated as a recoverable error
+			}
 			return &dupChannel, store.NewErrConflict("Channel", err, "id="+channel.Id)
 		}
 		return nil, errors.Wrapf(err, "save_channel: id=%s", channel.Id)


### PR DESCRIPTION
#### Summary
The channel store code doesn't check for the error when retrieving the info for an existing channel. Attempting to create an already existing channel may return invalid data. This PR returns a different error in that case so the calling code doesn't assume it got the info for the existing channel.

```release-note
NONE
```
