### PR TITLE
Adds api tests for the moveThread endpoint

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -927,7 +927,7 @@ func unpinPost(c *Context, w http.ResponseWriter, _ *http.Request) {
 }
 
 func moveThread(c *Context, w http.ResponseWriter, _ *http.Request) {
-	c.RequirePostId().RequireChannelId()
+	c.RequirePostId()
 	if c.Err != nil {
 		return
 	}

--- a/api4/post.go
+++ b/api4/post.go
@@ -38,6 +38,8 @@ func (api *API) InitPost() {
 
 	api.BaseRoutes.Post.Handle("/pin", api.APISessionRequired(pinPost)).Methods("POST")
 	api.BaseRoutes.Post.Handle("/unpin", api.APISessionRequired(unpinPost)).Methods("POST")
+
+	api.BaseRoutes.Post.Handle("/move", api.APISessionRequired(moveThread)).Methods("POST")
 }
 
 func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -922,6 +924,15 @@ func pinPost(c *Context, w http.ResponseWriter, _ *http.Request) {
 
 func unpinPost(c *Context, w http.ResponseWriter, _ *http.Request) {
 	saveIsPinnedPost(c, w, false)
+}
+
+func moveThread(c *Context, w http.ResponseWriter, _ *http.Request) {
+	c.RequirePostId().RequireChannelId()
+	if c.Err != nil {
+		return
+	}
+
+	ReturnStatusOK(w)
 }
 
 func getFileInfosForPost(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -3229,3 +3229,205 @@ func TestPostReminder(t *testing.T) {
 
 	require.Truef(t, caught, "User should have received %s event", model.WebsocketEventEphemeralMessage)
 }
+
+func TestMovePost(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	client := th.Client
+	userWSClient, err := th.CreateWebSocketClient()
+	require.NoError(t, err)
+	defer userWSClient.Close()
+	userWSClient.Listen()
+
+	t.Run("Users should receive post deleted event for the root post being moved", func(t *testing.T) {
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		var caught bool
+		func() {
+			for {
+				select {
+				case ev := <-userWSClient.EventChannel:
+					if ev.EventType() == model.WebsocketEventPostDeleted {
+						caught = true
+						data := ev.GetData()
+
+						post, ok := data["post"].(string)
+						require.True(t, ok)
+
+						var parsedPost model.Post
+						err := json.Unmarshal([]byte(post), &parsedPost)
+						require.NoError(t, err)
+
+						assert.Equal(t, th.BasicPost.Id, parsedPost.Id)
+						assert.NotEqual(t, 0, parsedPost.DeleteAt)
+						return
+					}
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+		require.Truef(t, caught, "User should have received %s event", model.WebsocketEventPosted)
+	})
+
+	t.Run("Users should receive a single posted event when a post with no replies is being moved", func(t *testing.T) {
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		var caught bool
+		func() {
+			for {
+				select {
+				case ev := <-userWSClient.EventChannel:
+					if ev.EventType() == model.WebsocketEventPosted {
+						caught = true
+						data := ev.GetData()
+
+						post, ok := data["post"].(string)
+						require.True(t, ok)
+
+						var parsedPost model.Post
+						err := json.Unmarshal([]byte(post), &parsedPost)
+						require.NoError(t, err)
+
+						assert.Equal(t, th.BasicUser.Id, parsedPost.UserId)
+						assert.Equal(t, th.BasicPost.Message, parsedPost.Message)
+						assert.Equal(t, th.BasicChannel2.Id, parsedPost.ChannelId)
+						assert.NotEqual(t, th.BasicPost.Id, parsedPost.Id)
+						return
+					}
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+		require.Truef(t, caught, "User should have received %s event", model.WebsocketEventPosted)
+	})
+
+	t.Run("Users should receive multiple posted events when a root post with replies is being moved", func(t *testing.T) {
+		reply1 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 1", RootId: th.BasicPost.Id}
+		_, resp, err := client.CreatePost(reply1)
+		require.NoError(t, err)
+
+		reply2 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 2", RootId: th.BasicPost.Id}
+		_, resp, err = client.CreatePost(reply2)
+		require.NoError(t, err)
+
+		reply3 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 3", RootId: th.BasicPost.Id}
+		_, resp, err = client.CreatePost(reply3)
+		require.NoError(t, err)
+		resp, err = client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		var caught int
+		func() {
+			for {
+				select {
+				case ev := <-userWSClient.EventChannel:
+					if ev.EventType() == model.WebsocketEventPosted {
+						caught++
+						data := ev.GetData()
+
+						post, ok := data["post"].(string)
+						require.True(t, ok)
+
+						var parsedPost model.Post
+						err := json.Unmarshal([]byte(post), &parsedPost)
+						require.NoError(t, err)
+
+						assert.Equal(t, th.BasicChannel2.Id, parsedPost.ChannelId)
+						return
+					}
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+		require.Equal(t, 4, caught, "User should have received $d %s events", 4, model.WebsocketEventPosted)
+	})
+
+	t.Run("Users should not receive a thread updated event when a single post is being moved", func(t *testing.T) {
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		var caught bool
+		func() {
+			for {
+				select {
+				case ev := <-userWSClient.EventChannel:
+					if ev.EventType() == model.WebsocketEventThreadUpdated {
+						caught = true
+						return
+					}
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+		require.Truef(t, !caught, "User should not have received %s event", model.WebsocketEventThreadUpdated)
+	})
+
+	t.Run("Users should receive thread updated events when a root post with replies is being moved", func(t *testing.T) {
+		client := th.Client
+
+		reply1 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 1", RootId: th.BasicPost.Id}
+		_, resp, err := client.CreatePost(reply1)
+		require.NoError(t, err)
+
+		reply2 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 2", RootId: th.BasicPost.Id}
+		_, resp, err = client.CreatePost(reply2)
+		require.NoError(t, err)
+
+		reply3 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 3", RootId: th.BasicPost.Id}
+		_, resp, err = client.CreatePost(reply3)
+		require.NoError(t, err)
+
+		resp, err = client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		var caught int
+		func() {
+			for {
+				select {
+				case ev := <-userWSClient.EventChannel:
+					if ev.EventType() == model.WebsocketEventThreadUpdated {
+						caught++
+						var parsedThread model.ThreadResponse
+						data := ev.GetData()
+						jsonErr := json.Unmarshal([]byte(data["thread"].(string)), &parsedThread)
+						require.NoError(t, jsonErr)
+
+						require.EqualValues(t, th.BasicChannel2, parsedThread.Post.ChannelId)
+						require.EqualValues(t, caught, parsedThread.ReplyCount)
+						return
+					}
+				case <-time.After(1 * time.Second):
+					return
+				}
+			}
+		}()
+		require.Equalf(t, caught, "User should have received %s event", model.WebsocketEventThreadUpdated)
+	})
+}

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -3318,14 +3318,18 @@ func TestMovePost(t *testing.T) {
 		reply1 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 1", RootId: th.BasicPost.Id}
 		_, resp, err := client.CreatePost(reply1)
 		require.NoError(t, err)
+		CheckOKStatus(t, resp)
 
 		reply2 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 2", RootId: th.BasicPost.Id}
 		_, resp, err = client.CreatePost(reply2)
 		require.NoError(t, err)
+		CheckOKStatus(t, resp)
 
 		reply3 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 3", RootId: th.BasicPost.Id}
 		_, resp, err = client.CreatePost(reply3)
 		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
 		resp, err = client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
 			ChannelId: th.BasicChannel2.Id,
 		})
@@ -3391,14 +3395,17 @@ func TestMovePost(t *testing.T) {
 		reply1 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 1", RootId: th.BasicPost.Id}
 		_, resp, err := client.CreatePost(reply1)
 		require.NoError(t, err)
+		CheckOKStatus(t, resp)
 
 		reply2 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 2", RootId: th.BasicPost.Id}
 		_, resp, err = client.CreatePost(reply2)
 		require.NoError(t, err)
+		CheckOKStatus(t, resp)
 
 		reply3 := &model.Post{ChannelId: th.BasicChannel.Id, Message: "reply 3", RootId: th.BasicPost.Id}
 		_, resp, err = client.CreatePost(reply3)
 		require.NoError(t, err)
+		CheckOKStatus(t, resp)
 
 		resp, err = client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
 			ChannelId: th.BasicChannel2.Id,

--- a/model/client4.go
+++ b/model/client4.go
@@ -4116,7 +4116,7 @@ func (c *Client4) GetPostsAroundLastUnread(userId, channelId string, limitBefore
 func (c *Client4) MoveThread(postId string, params *MoveThreadParams) (*Response, error) {
 	js, err := json.Marshal(params)
 	if err != nil {
-		return nil, nil, NewAppError("MoveThread", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return nil, NewAppError("MoveThread", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	r, err := c.DoAPIPost(c.postRoute(postId)+"/move", string(js))

--- a/model/client4.go
+++ b/model/client4.go
@@ -4112,6 +4112,18 @@ func (c *Client4) GetPostsAroundLastUnread(userId, channelId string, limitBefore
 	return &list, BuildResponse(r), nil
 }
 
+// MoveThread moves a thread based on provided post id, and channel id string.
+func (c *Client4) MoveThread(postId string, params *MoveThreadParams) (*Response, error) {
+	js, err := json.Marshal(params)
+
+	r, err := c.DoAPIPost(c.postRoute(postId)+"/move", string(js))
+	if err != nil {
+		return BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return BuildResponse(r), nil
+}
+
 // SearchFiles returns any posts with matching terms string.
 func (c *Client4) SearchFiles(teamId string, terms string, isOrSearch bool) (*FileInfoList, *Response, error) {
 	params := SearchParameter{

--- a/model/client4.go
+++ b/model/client4.go
@@ -4115,6 +4115,9 @@ func (c *Client4) GetPostsAroundLastUnread(userId, channelId string, limitBefore
 // MoveThread moves a thread based on provided post id, and channel id string.
 func (c *Client4) MoveThread(postId string, params *MoveThreadParams) (*Response, error) {
 	js, err := json.Marshal(params)
+	if err != nil {
+		return nil, nil, NewAppError("MoveThread", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
 
 	r, err := c.DoAPIPost(c.postRoute(postId)+"/move", string(js))
 	if err != nil {

--- a/model/post.go
+++ b/model/post.go
@@ -157,6 +157,10 @@ type PostReminder struct {
 	UserId string `json:",omitempty"`
 }
 
+type MoveThreadParams struct {
+	ChannelId string `json:"channel_id"`
+}
+
 type SearchParameter struct {
 	Terms                  *string `json:"terms"`
 	IsOrSearch             *bool   `json:"is_or_search"`


### PR DESCRIPTION
#### Summary

When we move a thread we should receive:
- a post deleted event for the root post
- a posted event for the root post in another channel
- as many posted events as replies in the thread
- as many thread updated events as replies in the thread

#### Ticket Link

#### Release Note

```release-note
NONE
```
