### PR TITLE
Check wrangler config

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -5,6 +5,7 @@ package api4
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -947,7 +948,8 @@ func moveThread(c *Context, w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	if !userHasRole {
+	// Sysadmins are always permitted
+	if !userHasRole && !user.IsSystemAdmin() {
 		c.Err = model.NewAppError("moveThread", "api.post.move_thread.no_permission", nil, "", http.StatusForbidden)
 		return
 	}
@@ -960,8 +962,8 @@ func moveThread(c *Context, w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
-	if !userHasEmailDomain {
-		c.Err = model.NewAppError("moveThread", "api.post.move_thread.no_permission", nil, "", http.StatusForbidden)
+	if !userHasEmailDomain && !user.IsSystemAdmin() {
+		c.Err = model.NewAppError("moveThread", "api.post.move_thread.no_permission", nil, fmt.Sprintf("User: %+v", user), http.StatusForbidden)
 		return
 	}
 

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -3443,6 +3443,8 @@ func TestMovePost(t *testing.T) {
 			cfg.WranglerSettings.PermittedWranglerUsers = []string{"system_admin"}
 		})
 
+		th.LoginBasicWithClient(th.Client)
+
 		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
 			ChannelId: th.BasicChannel2.Id,
 		})
@@ -3455,6 +3457,8 @@ func TestMovePost(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.WranglerSettings.PermittedWranglerUsers = []string{"system_admin", "system_user"}
 		})
+
+		th.LoginBasicWithClient(th.Client)
 
 		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
 			ChannelId: th.BasicChannel2.Id,

--- a/api4/post_test.go
+++ b/api4/post_test.go
@@ -3437,4 +3437,84 @@ func TestMovePost(t *testing.T) {
 		}()
 		require.Equalf(t, caught, "User should have received %s event", model.WebsocketEventThreadUpdated)
 	})
+
+	t.Run("Users with role not in PermittedWranglerUsers aren't allowed to move posts", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.WranglerSettings.PermittedWranglerUsers = []string{"system_admin"}
+		})
+
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("Users with role in PermittedWranglerUsers are able to move posts", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.WranglerSettings.PermittedWranglerUsers = []string{"system_admin", "system_user"}
+		})
+
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
+
+	t.Run("System admins with role not in PermittedWranglerUsers are allowed to move posts", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.WranglerSettings.PermittedWranglerUsers = []string{"random_role"}
+		})
+
+		th.LoginSystemAdminWithClient(th.Client)
+
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
+
+	t.Run("Users with email address in AllowedEmailDomain are able to move posts", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.WranglerSettings.AllowedEmailDomain = []string{"localhost"}
+		})
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
+
+	t.Run("Users with email address not in AllowedEmailDomain aren't allowed to move posts", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.WranglerSettings.AllowedEmailDomain = []string{"example.com"}
+		})
+
+		th.LoginBasicWithClient(th.Client)
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("System Admin with email address not in AllowedEmailDomains are allowed to move posts", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.WranglerSettings.AllowedEmailDomain = []string{"example.com"}
+		})
+		th.LoginSystemAdminWithClient(th.Client)
+		resp, err := client.MoveThread(th.BasicPost.Id, &model.MoveThreadParams{
+			ChannelId: th.BasicChannel2.Id,
+		})
+
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
 }

--- a/model/config.go
+++ b/model/config.go
@@ -2914,7 +2914,7 @@ func (w *WranglerSettings) SetDefaults() {
 func (w *WranglerSettings) IsValid() *AppError {
 	validDomainRegex := regexp.MustCompile(`^(([a-zA-Z]{1})|([a-zA-Z]{1}[a-zA-Z]{1})|([a-zA-Z]{1}[0-9]{1})|([0-9]{1}[a-zA-Z]{1})|([a-zA-Z0-9][a-zA-Z0-9-_]{1,61}[a-zA-Z0-9]))\.([a-zA-Z]{2,6}|[a-zA-Z0-9-]{2,30}\.[a-zA-Z]{2,3})$`)
 	for _, domain := range w.AllowedEmailDomain {
-		if !validDomainRegex.MatchString(domain) {
+		if !validDomainRegex.MatchString(domain) && domain != "localhost" {
 			return NewAppError("Config.IsValid", "model.config.is_valid.wrangler_settings.domain_invalid.app_error", nil, "", http.StatusBadRequest)
 		}
 	}

--- a/model/user.go
+++ b/model/user.go
@@ -314,6 +314,10 @@ func (u *User) DeepCopy() *User {
 	return &copyUser
 }
 
+func (u *User) EmailDomain() string {
+	return strings.Split(u.Email, "@")[0]
+}
+
 // IsValid validates the user and returns an error if it isn't configured
 // correctly.
 func (u *User) IsValid() *AppError {


### PR DESCRIPTION

#### Summary
Adds logic to actually check the wrangler config and apply it to the current user to determine if they should be able to move threads or not.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
