### PR TITLE
Wrangler config use pointers

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2908,16 +2908,16 @@ func (w *WranglerSettings) SetDefaults() {
 		w.MoveThreadMaxCount = NewInt64(100)
 	}
 	if w.MoveThreadToAnotherTeamEnable == nil {
-		w.MoveThreadToAnotherTeamEnable = NewBool(false)
+		w.MoveThreadToAnotherTeamEnable = NewBool(true)
 	}
 	if w.MoveThreadFromPrivateChannelEnable == nil {
-		w.MoveThreadFromPrivateChannelEnable = NewBool(false)
+		w.MoveThreadFromPrivateChannelEnable = NewBool(true)
 	}
 	if w.MoveThreadFromDirectMessageChannelEnable == nil {
-		w.MoveThreadFromDirectMessageChannelEnable = NewBool(false)
+		w.MoveThreadFromDirectMessageChannelEnable = NewBool(true)
 	}
 	if w.MoveThreadFromGroupMessageChannelEnable == nil {
-		w.MoveThreadFromGroupMessageChannelEnable = NewBool(false)
+		w.MoveThreadFromGroupMessageChannelEnable = NewBool(true)
 	}
 }
 

--- a/model/config.go
+++ b/model/config.go
@@ -2890,11 +2890,11 @@ func (s *GlobalRelayMessageExportSettings) SetDefaults() {
 type WranglerSettings struct {
 	PermittedWranglerUsers                   []string
 	AllowedEmailDomain                       []string
-	MoveThreadMaxCount                       int64
-	MoveThreadToAnotherTeamEnable            bool
-	MoveThreadFromPrivateChannelEnable       bool
-	MoveThreadFromDirectMessageChannelEnable bool
-	MoveThreadFromGroupMessageChannelEnable  bool
+	MoveThreadMaxCount                       *int64
+	MoveThreadToAnotherTeamEnable            *bool
+	MoveThreadFromPrivateChannelEnable       *bool
+	MoveThreadFromDirectMessageChannelEnable *bool
+	MoveThreadFromGroupMessageChannelEnable  *bool
 }
 
 func (w *WranglerSettings) SetDefaults() {
@@ -2904,11 +2904,21 @@ func (w *WranglerSettings) SetDefaults() {
 	if w.AllowedEmailDomain == nil {
 		w.AllowedEmailDomain = make([]string, 0)
 	}
-	w.MoveThreadMaxCount = 100
-	w.MoveThreadToAnotherTeamEnable = true
-	w.MoveThreadFromPrivateChannelEnable = true
-	w.MoveThreadFromDirectMessageChannelEnable = true
-	w.MoveThreadFromGroupMessageChannelEnable = true
+	if w.MoveThreadMaxCount == nil {
+		w.MoveThreadMaxCount = NewInt64(100)
+	}
+	if w.MoveThreadToAnotherTeamEnable == nil {
+		w.MoveThreadToAnotherTeamEnable = NewBool(false)
+	}
+	if w.MoveThreadFromPrivateChannelEnable == nil {
+		w.MoveThreadFromPrivateChannelEnable = NewBool(false)
+	}
+	if w.MoveThreadFromDirectMessageChannelEnable == nil {
+		w.MoveThreadFromDirectMessageChannelEnable = NewBool(false)
+	}
+	if w.MoveThreadFromGroupMessageChannelEnable == nil {
+		w.MoveThreadFromGroupMessageChannelEnable = NewBool(false)
+	}
 }
 
 func (w *WranglerSettings) IsValid() *AppError {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note

```
