### PR TITLE
Mm 46416 add default random message

### DIFF
--- a/app/notification_email.go
+++ b/app/notification_email.go
@@ -114,8 +114,7 @@ func (a *App) sendNotificationEmail(c request.CTX, notification *PostNotificatio
 	}
 
 	templateString := "<%s@" + a.Srv().MailServiceConfig().Hostname + ">"
-	randomStringLength := 16
-	messageID := fmt.Sprintf(templateString, model.NewRandomString(randomStringLength)+"-"+time.Now().String())
+	messageID := ""
 	inReplyTo := ""
 	references := ""
 

--- a/app/notification_email.go
+++ b/app/notification_email.go
@@ -113,7 +113,7 @@ func (a *App) sendNotificationEmail(c request.CTX, notification *PostNotificatio
 		return errors.Wrap(err, "unable to render the email notification template")
 	}
 
-	templateString := "<%s@" + a.Srv().MailServiceConfig().Hostname + ">"
+	templateString := "<%s@" + utils.GetHostnameFromSiteURL(a.GetSiteURL()) + ">"
 	messageID := ""
 	inReplyTo := ""
 	references := ""

--- a/app/notification_email.go
+++ b/app/notification_email.go
@@ -113,8 +113,9 @@ func (a *App) sendNotificationEmail(c request.CTX, notification *PostNotificatio
 		return errors.Wrap(err, "unable to render the email notification template")
 	}
 
-	templateString := "<%s@mattermost.com>"
-	messageID := ""
+	templateString := "<%s@" + a.Srv().MailServiceConfig().Hostname + ">"
+	randomStringLength := 16
+	messageID := fmt.Sprintf(templateString, model.NewRandomString(randomStringLength)+"-"+time.Now().String())
 	inReplyTo := ""
 	references := ""
 

--- a/shared/mail/mail.go
+++ b/shared/mail/mail.go
@@ -318,12 +318,9 @@ func sendMail(c smtpClient, mail mailData, date time.Time, config *SMTPConfig) e
 	if mail.messageID != "" {
 		headers["Message-ID"] = []string{mail.messageID}
 	} else {
-		templateString := "<%s@" + config.Hostname + ">"
 		randomStringLength := 16
-		randomString := model.NewRandomString(randomStringLength)
-		timestamp := fmt.Sprint(time.Now().Unix())
-		messageID := fmt.Sprintf(templateString, randomString+"-"+timestamp)
-		headers["Message-ID"] = []string{messageID}
+		msgID := fmt.Sprintf("<%s-%d@%s>", model.NewRandomString(randomStringLength), time.Now().Unix(), config.Hostname)
+		headers["Message-ID"] = []string{msgID}
 	}
 
 	if mail.inReplyTo != "" {

--- a/shared/mail/mail.go
+++ b/shared/mail/mail.go
@@ -284,10 +284,10 @@ func sendMailUsingConfigAdvanced(mail mailData, config *SMTPConfig) error {
 	defer c.Quit()
 	defer c.Close()
 
-	return SendMail(c, mail, time.Now(), config)
+	return sendMail(c, mail, time.Now(), config)
 }
 
-func SendMail(c smtpClient, mail mailData, date time.Time, config *SMTPConfig) error {
+func sendMail(c smtpClient, mail mailData, date time.Time, config *SMTPConfig) error {
 	mlog.Debug("sending mail", mlog.String("to", mail.smtpTo), mlog.String("subject", mail.subject))
 
 	htmlMessage := mail.htmlBody

--- a/shared/mail/mail_test.go
+++ b/shared/mail/mail_test.go
@@ -409,7 +409,7 @@ func TestSendMail(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			mail := mailData{"", "", mail.Address{}, "", tc.replyTo, "", "", nil, nil, tc.messageID, tc.inReplyTo, tc.references}
 			cfg := getConfig()
-			err = SendMail(mocm, mail, time.Now(), cfg)
+			err = sendMail(mocm, mail, time.Now(), cfg)
 			require.NoError(t, err)
 			if tc.contains != "" {
 				require.Contains(t, string(mocm.data), tc.contains)

--- a/shared/mail/mail_test.go
+++ b/shared/mail/mail_test.go
@@ -408,7 +408,8 @@ func TestSendMail(t *testing.T) {
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {
 			mail := mailData{"", "", mail.Address{}, "", tc.replyTo, "", "", nil, nil, tc.messageID, tc.inReplyTo, tc.references}
-			err = SendMail(mocm, mail, time.Now())
+			cfg := getConfig()
+			err = SendMail(mocm, mail, time.Now(), cfg)
 			require.NoError(t, err)
 			if tc.contains != "" {
 				require.Contains(t, string(mocm.data), tc.contains)

--- a/shared/mail/mail_test.go
+++ b/shared/mail/mail_test.go
@@ -363,7 +363,7 @@ func TestSendMail(t *testing.T) {
 			"\r\nMessage-ID: <abc123@mattermost.com>\r\n",
 			"",
 		},
-		"doesn't add message-id header": {
+		"always adds message-id header": {
 			mail.Address{},
 			"",
 			"",

--- a/shared/mail/mail_test.go
+++ b/shared/mail/mail_test.go
@@ -368,8 +368,8 @@ func TestSendMail(t *testing.T) {
 			"",
 			"",
 			"",
+			"\r\nMessage-ID: <",
 			"",
-			"\r\nMessage-ID:",
 		},
 		"adds in-reply-to header": {
 			mail.Address{},


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Now, whenever no ```Message-ID``` is passed, smtp config is used for getting hostname and ```Message-ID``` is generated as ```< model.NewRandomString - time.Now() @ hostname >```

Unexported ```SendMail``` function and passed smtp config to it.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-server/issues/20828

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added randomly generated for default message-ID for every outgoing email.
```
