### PR TITLE
[GH-19886] Remove ExperimentalTimezone settings from config

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -59,7 +59,6 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["EnableAppBar"] = strconv.FormatBool(*c.ExperimentalSettings.EnableAppBar)
 
 	props["ExperimentalEnableAutomaticReplies"] = strconv.FormatBool(*c.TeamSettings.ExperimentalEnableAutomaticReplies)
-	props["ExperimentalTimezone"] = strconv.FormatBool(*c.DisplaySettings.ExperimentalTimezone)
 
 	props["SendEmailNotifications"] = strconv.FormatBool(*c.EmailSettings.SendEmailNotifications)
 	props["SendPushNotifications"] = strconv.FormatBool(*c.EmailSettings.SendPushNotifications)

--- a/config/common_test.go
+++ b/config/common_test.go
@@ -80,9 +80,6 @@ func init() {
 		ServiceSettings: model.ServiceSettings{
 			SiteURL: model.NewString("http://custom.com"),
 		},
-		DisplaySettings: model.DisplaySettings{
-			ExperimentalTimezone: model.NewBool(false),
-		},
 	}
 }
 

--- a/config/database_test.go
+++ b/config/database_test.go
@@ -153,7 +153,6 @@ func TestDatabaseStoreNew(t *testing.T) {
 		defer ds.Close()
 
 		assert.Equal(t, *customConfigDefaults.ServiceSettings.SiteURL, *ds.Get().ServiceSettings.SiteURL)
-		assert.Equal(t, *customConfigDefaults.DisplaySettings.ExperimentalTimezone, *ds.Get().DisplaySettings.ExperimentalTimezone)
 	})
 
 	t.Run("existing config, initialization required", func(t *testing.T) {
@@ -181,7 +180,6 @@ func TestDatabaseStoreNew(t *testing.T) {
 		assert.Equal(t, "http://TestStoreNew", *ds.Get().ServiceSettings.SiteURL)
 		// not existing value should be overwritten by the custom
 		// default value
-		assert.Equal(t, *customConfigDefaults.DisplaySettings.ExperimentalTimezone, *ds.Get().DisplaySettings.ExperimentalTimezone)
 		assertDatabaseNotEqualsConfig(t, testConfig)
 	})
 
@@ -208,7 +206,6 @@ func TestDatabaseStoreNew(t *testing.T) {
 		// as the whole config has default values already, custom
 		// defaults should have no effect
 		assert.Equal(t, "http://minimal", *ds.Get().ServiceSettings.SiteURL)
-		assert.NotEqual(t, *customConfigDefaults.DisplaySettings.ExperimentalTimezone, *ds.Get().DisplaySettings.ExperimentalTimezone)
 		assertDatabaseEqualsConfig(t, minimalConfigNoFF)
 	})
 

--- a/config/file_test.go
+++ b/config/file_test.go
@@ -125,7 +125,6 @@ func TestFileStoreNew(t *testing.T) {
 		assert.Equal(t, "http://TestStoreNew", *configStore.Get().ServiceSettings.SiteURL)
 		// nonexisting value should be overwritten by the custom
 		// defaults
-		assert.Equal(t, *customConfigDefaults.DisplaySettings.ExperimentalTimezone, *configStore.Get().DisplaySettings.ExperimentalTimezone)
 		assertFileNotEqualsConfig(t, testConfig, path)
 	})
 
@@ -156,7 +155,6 @@ func TestFileStoreNew(t *testing.T) {
 		// as the whole config has default values already, custom
 		// defaults should have no effect
 		assert.Equal(t, "http://minimal", *configStore.Get().ServiceSettings.SiteURL)
-		assert.NotEqual(t, *customConfigDefaults.DisplaySettings.ExperimentalTimezone, *configStore.Get().DisplaySettings.ExperimentalTimezone)
 		assertFileEqualsConfig(t, minimalConfigNoFF, path)
 	})
 
@@ -195,7 +193,6 @@ func TestFileStoreNew(t *testing.T) {
 		defer configStore.Close()
 
 		assert.Equal(t, *customConfigDefaults.ServiceSettings.SiteURL, *configStore.Get().ServiceSettings.SiteURL)
-		assert.Equal(t, *customConfigDefaults.DisplaySettings.ExperimentalTimezone, *configStore.Get().DisplaySettings.ExperimentalTimezone)
 	})
 
 	t.Run("absolute path, path to file does not exist", func(t *testing.T) {

--- a/model/config.go
+++ b/model/config.go
@@ -2936,18 +2936,13 @@ func (s *MessageExportSettings) SetDefaults() {
 }
 
 type DisplaySettings struct {
-	CustomURLSchemes     []string `access:"site_customization"`
-	ExperimentalTimezone *bool    `access:"experimental_features"`
+	CustomURLSchemes []string `access:"site_customization"`
 }
 
 func (s *DisplaySettings) SetDefaults() {
 	if s.CustomURLSchemes == nil {
 		customURLSchemes := []string{}
 		s.CustomURLSchemes = customURLSchemes
-	}
-
-	if s.ExperimentalTimezone == nil {
-		s.ExperimentalTimezone = NewBool(true)
 	}
 }
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -799,7 +799,6 @@ func (ts *TelemetryService) trackConfig() {
 	})
 
 	ts.SendTelemetry(TrackConfigDisplay, map[string]any{
-		"experimental_timezone":        *cfg.DisplaySettings.ExperimentalTimezone,
 		"isdefault_custom_url_schemes": len(cfg.DisplaySettings.CustomURLSchemes) != 0,
 	})
 

--- a/tests/test-config.json
+++ b/tests/test-config.json
@@ -385,7 +385,6 @@
         }
     },
     "DisplaySettings": {
-        "CustomUrlSchemes": [],
-        "ExperimentalTimezone": false
+        "CustomUrlSchemes": []
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Removes Timezone setting from server config (deprecated per https://docs.mattermost.com/configure/deprecated-configuration-settings.html#id3) and related tests.

#### Ticket Link

Fixes #19886.

#### Release Note

```release-note
Removes deprecated ExperimentalTimezone configuration setting.
```
