### PR TITLE
[MM-47230] Apply role filters for /get/users in channel

### DIFF
--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -715,6 +715,8 @@ func (us SqlUserStore) GetProfilesInChannel(options *model.UserGetOptions) ([]*m
 		query = query.Where("u.DeleteAt = 0")
 	}
 
+	query = applyMultiRoleFilters(query, options.Roles, options.TeamRoles, options.ChannelRoles, us.DriverName() == model.DatabaseDriverPostgres)
+
 	queryString, args, err := query.ToSql()
 	if err != nil {
 		return nil, errors.Wrap(err, "get_profiles_in_channel_tosql")

--- a/store/storetest/user_store.go
+++ b/store/storetest/user_store.go
@@ -981,6 +981,36 @@ func testUserStoreGetProfilesInChannel(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 		assert.Equal(t, []*model.User{sanitized(u1)}, users)
 	})
+
+	t.Run("Filter by channel members and channel admins", func(t *testing.T) {
+		// save admin for c1
+		user2Admin, err := ss.User().Save(&model.User{
+			Email:    MakeEmail(),
+			Username: "bbb" + model.NewId(),
+		})
+		require.NoError(t, err)
+		defer func() { require.NoError(t, ss.User().PermanentDelete(user2Admin.Id)) }()
+		_, nErr = ss.Team().SaveMember(&model.TeamMember{TeamId: teamId, UserId: user2Admin.Id}, -1)
+		require.NoError(t, nErr)
+
+		_, nErr = ss.Channel().SaveMember(&model.ChannelMember{
+			ChannelId:     c1.Id,
+			UserId:        user2Admin.Id,
+			NotifyProps:   model.GetDefaultChannelNotifyProps(),
+			ExplicitRoles: "channel_admin",
+		})
+		require.NoError(t, nErr)
+		ss.Channel().UpdateMembersRole(c1.Id, []string{user2Admin.Id})
+
+		users, err := ss.User().GetProfilesInChannel(&model.UserGetOptions{
+			InChannelId:  c1.Id,
+			ChannelRoles: []string{model.ChannelAdminRoleId},
+			Page:         0,
+			PerPage:      5,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, user2Admin.Id, users[0].Id)
+	})
 }
 
 func testUserStoreGetProfilesInChannelByAdmin(t *testing.T, ss store.Store, s SqlStore) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR applies a bugfix for: role filters aren't currently being applied for [GetProfilesInChannel](https://github.com/mattermost/mattermost-server/blob/master/store/sqlstore/user_store.go#L705-L733).


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-47230
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed a bug where role filters weren't being applied to routes doing 'get users in channel'.
```
