### PR TITLE
MM-47403: Populate the productHooks field

### DIFF
--- a/plugin/interface_generator/main.go
+++ b/plugin/interface_generator/main.go
@@ -406,6 +406,7 @@ type hooksAdapter struct {
 func newAdapter(productHooks any) (*hooksAdapter, error) {
 	a := &hooksAdapter{
 		implemented:  make(map[int]struct{}),
+		productHooks: productHooks,
 	}
 	var tt reflect.Type
 	ft := reflect.TypeOf(productHooks)

--- a/plugin/product_hooks_generated.go
+++ b/plugin/product_hooks_generated.go
@@ -121,7 +121,8 @@ type hooksAdapter struct {
 
 func newAdapter(productHooks any) (*hooksAdapter, error) {
 	a := &hooksAdapter{
-		implemented: make(map[int]struct{}),
+		implemented:  make(map[int]struct{}),
+		productHooks: productHooks,
 	}
 	var tt reflect.Type
 	ft := reflect.TypeOf(productHooks)


### PR DESCRIPTION
We need to do this to pass the hooked events
to the products.

https://mattermost.atlassian.net/browse/MM-47403

```release-note
NONE
```
