### PR TITLE
app/platform: move failover config initialization to platform

### DIFF
--- a/app/platform/config.go
+++ b/app/platform/config.go
@@ -36,15 +36,6 @@ type ServiceConfig struct {
 	Cluster einterfaces.ClusterInterface
 }
 
-func (c *ServiceConfig) validate() error {
-	// Mandatory fields need to be checked here
-	if c.ConfigStore == nil {
-		return errors.New("ConfigStore is required")
-	}
-
-	return nil
-}
-
 // ensure the config wrapper implements `product.ConfigService`
 var _ product.ConfigService = (*PlatformService)(nil)
 

--- a/app/platform/service.go
+++ b/app/platform/service.go
@@ -97,10 +97,6 @@ type PlatformService struct {
 
 // New creates a new PlatformService.
 func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
-	if err := sc.validate(); err != nil {
-		return nil, err
-	}
-
 	// Step 0: Create the PlatformService.
 	// ConfigStore is and should be handled on a upper level.
 	ps := &PlatformService{
@@ -136,6 +132,21 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 		if err := option(ps); err != nil {
 			return nil, fmt.Errorf("failed to apply option: %w", err)
 		}
+	}
+
+	// the config store is not set, we need to create a new one
+	if ps.configStore == nil {
+		innerStore, err := config.NewFileStore("config.json", true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load config from file: %w", err)
+		}
+
+		configStore, err := config.NewStoreFromBacking(innerStore, nil, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load config from file: %w", err)
+		}
+
+		ps.configStore = configStore
 	}
 
 	// Step 2: Start logging.

--- a/app/server.go
+++ b/app/server.go
@@ -201,20 +201,7 @@ func NewServer(options ...Option) (*Server, error) {
 	//
 	// Step 1: Platform.
 	if s.platform == nil {
-		innerStore, err := config.NewFileStore("config.json", true)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to load config")
-		}
-		configStore, err := config.NewStoreFromBacking(innerStore, nil, false)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to load config")
-		}
-
-		platformCfg := platform.ServiceConfig{
-			ConfigStore: configStore,
-		}
-
-		ps, sErr := platform.New(platformCfg, s.platformOptions...)
+		ps, sErr := platform.New(platform.ServiceConfig{}, s.platformOptions...)
 		if sErr != nil {
 			return nil, errors.Wrap(sErr, "failed to initialize platform")
 		}


### PR DESCRIPTION
#### Summary
There was an issue in the app startup sequence:
We initialize the config first then pass it to the platform service. But, disregardless we create a failover config store (we need to create that once it's required) and try to validate it. It didn't fail so far because we either had a valid config as backup or empty one (which is created with valid values). On the community, probably we had an invalid `config.json` somewhere and it made this bug come to surface.

We now moved config store failover logic into platform service.

#### Release Note

```release-note
NONE
```
