### PR TITLE
[MM-47468] Fix store metrics initialization

### DIFF
--- a/app/platform/cluster.go
+++ b/app/platform/cluster.go
@@ -180,8 +180,8 @@ func (ps *PlatformService) InvokeClusterLeaderChangedListeners() {
 }
 
 func (ps *PlatformService) Publish(message *model.WebSocketEvent) {
-	if ps.metricsImpl() != nil {
-		ps.metricsImpl().IncrementWebsocketEvent(message.EventType())
+	if ps.metricsIFace != nil {
+		ps.metricsIFace.IncrementWebsocketEvent(message.EventType())
 	}
 
 	ps.PublishSkipClusterSend(message)

--- a/app/platform/config.go
+++ b/app/platform/config.go
@@ -32,7 +32,6 @@ type ServiceConfig struct {
 	ConfigStore *config.Store
 	Store       store.Store
 	// Optional fields
-	Metrics einterfaces.MetricsInterface
 	Cluster einterfaces.ClusterInterface
 }
 

--- a/app/platform/enterprise.go
+++ b/app/platform/enterprise.go
@@ -26,8 +26,8 @@ func RegisterLicenseInterface(f func(*PlatformService) einterfaces.LicenseInterf
 	licenseInterface = f
 }
 
-var metricsInterface func(*PlatformService, string, string) einterfaces.MetricsInterface
+var metricsInterfaceFn func(*PlatformService, string, string) einterfaces.MetricsInterface
 
 func RegisterMetricsInterface(f func(*PlatformService, string, string) einterfaces.MetricsInterface) {
-	metricsInterface = f
+	metricsInterfaceFn = f
 }

--- a/app/platform/log.go
+++ b/app/platform/log.go
@@ -89,11 +89,11 @@ func (ps *PlatformService) NotificationsLogger() *mlog.Logger {
 }
 
 func (ps *PlatformService) EnableLoggingMetrics() {
-	if ps.metrics == nil || ps.metricsImpl() == nil {
+	if ps.metrics == nil || ps.metricsIFace == nil {
 		return
 	}
 
-	ps.logger.SetMetricsCollector(ps.metricsImpl().GetLoggerMetricsCollector(), mlog.DefaultMetricsUpdateFreqMillis)
+	ps.logger.SetMetricsCollector(ps.metricsIFace.GetLoggerMetricsCollector(), mlog.DefaultMetricsUpdateFreqMillis)
 
 	// logging config needs to be reloaded when metrics collector is added or changed.
 	if err := ps.initLogging(); err != nil {

--- a/app/platform/metrics.go
+++ b/app/platform/metrics.go
@@ -181,7 +181,7 @@ func (ps *PlatformService) HandleMetrics(route string, h http.Handler) {
 }
 
 func (ps *PlatformService) RestartMetrics() error {
-	return ps.resetMetrics(ps.serviceConfig.Metrics, ps.configStore.Get)
+	return ps.resetMetrics(ps.metricsIFace, ps.configStore.Get)
 }
 
 func (ps *PlatformService) Metrics() einterfaces.MetricsInterface {

--- a/app/platform/metrics.go
+++ b/app/platform/metrics.go
@@ -36,13 +36,8 @@ type platformMetrics struct {
 	listenAddr string
 }
 
-func (ps *PlatformService) metricsImpl() einterfaces.MetricsInterface {
-	return ps.metricsIFace
-}
-
 // resetMetrics resets the metrics server. Clears the metrics if the metrics are disabled by the config.
 func (ps *PlatformService) resetMetrics() error {
-	fmt.Println("resetMetrics")
 	if !*ps.Config().MetricsSettings.Enable {
 		if ps.metrics != nil {
 			return ps.metrics.stopMetricsServer()
@@ -188,5 +183,5 @@ func (ps *PlatformService) Metrics() einterfaces.MetricsInterface {
 		return nil
 	}
 
-	return ps.metricsImpl()
+	return ps.metricsIFace
 }

--- a/app/platform/options.go
+++ b/app/platform/options.go
@@ -46,7 +46,7 @@ func StoreOverride(override any) Option {
 func StoreOverrideWithCache(override store.Store) Option {
 	return func(ps *PlatformService) error {
 		ps.newStore = func() (store.Store, error) {
-			lcl, err := localcachelayer.NewLocalCacheLayer(override, ps.metricsImpl(), ps.clusterIFace, ps.cacheProvider)
+			lcl, err := localcachelayer.NewLocalCacheLayer(override, ps.metricsIFace, ps.clusterIFace, ps.cacheProvider)
 			if err != nil {
 				return nil, err
 			}

--- a/app/platform/service.go
+++ b/app/platform/service.go
@@ -214,12 +214,10 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 	}
 
 	var err error
-	// if ps.Store == nil {
 	ps.Store, err = ps.newStore()
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %w", err)
 	}
-	// }
 
 	// Needed before loading license
 	ps.statusCache, err = ps.cacheProvider.NewCache(&cache.CacheOptions{

--- a/app/platform/service_test.go
+++ b/app/platform/service_test.go
@@ -4,12 +4,16 @@
 package platform
 
 import (
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v6/config"
+	"github.com/mattermost/mattermost-server/v6/einterfaces/mocks"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/store/storetest"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,5 +85,71 @@ func TestReadReplicaDisabledBasedOnLicense(t *testing.T) {
 		require.NoError(t, err)
 		require.NotSame(t, ps.sqlStore.GetMasterX(), ps.sqlStore.GetSearchReplicaX())
 		require.Len(t, ps.Config().SqlSettings.DataSourceSearchReplicas, 1)
+	})
+}
+
+func TestMetrics(t *testing.T) {
+	t.Run("ensure the metrics server is not started by default", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+
+		require.Nil(t, th.Service.metrics)
+	})
+
+	t.Run("ensure the metrics server is started", func(t *testing.T) {
+		th := Setup(t, StartMetrics())
+		defer th.TearDown()
+
+		// there is no config listener for the metrics
+		// we handle it on config save step
+		th.Service.UpdateConfig(func(c *model.Config) {
+			c.MetricsSettings.Enable = model.NewBool(true)
+		})
+		th.Service.SaveConfig(th.Service.Config(), false)
+
+		require.NotNil(t, th.Service.metrics)
+		metricsAddr := strings.Replace(th.Service.metrics.listenAddr, "[::]", "http://localhost", 1)
+
+		resp, err := http.Get(metricsAddr)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		th.Service.UpdateConfig(func(c *model.Config) {
+			c.MetricsSettings.Enable = model.NewBool(false)
+		})
+		th.Service.SaveConfig(th.Service.Config(), false)
+
+		_, err = http.Get(metricsAddr)
+		require.Error(t, err)
+	})
+
+	t.Run("ensure the metrics server is started with advanced metrics", func(t *testing.T) {
+		th := Setup(t, StartMetrics())
+		defer th.TearDown()
+
+		mockMetricsImpl := &mocks.MetricsInterface{}
+		mockMetricsImpl.On("Register").Return()
+
+		th.Service.metricsIFace = mockMetricsImpl
+		err := th.Service.resetMetrics()
+		require.NoError(t, err)
+
+		mockMetricsImpl.AssertExpectations(t)
+	})
+
+	t.Run("ensure advanced metrics have database metrics", func(t *testing.T) {
+		mockMetricsImpl := &mocks.MetricsInterface{}
+		mockMetricsImpl.On("Register").Return()
+		mockMetricsImpl.On("ObserveStoreMethodDuration", mock.Anything, mock.Anything, mock.Anything).Return()
+
+		th := Setup(t, StartMetrics(), func(ps *PlatformService) error {
+			ps.metricsIFace = mockMetricsImpl
+			return nil
+		})
+		defer th.TearDown()
+
+		_ = th.CreateUserOrGuest(false)
+
+		mockMetricsImpl.AssertExpectations(t)
 	})
 }

--- a/app/platform/session.go
+++ b/app/platform/session.go
@@ -59,7 +59,7 @@ func (ps *PlatformService) ClearUserSessionCacheLocal(userID string) {
 			if err := ps.sessionCache.Get(key, &session); err == nil {
 				if session.UserId == userID {
 					ps.sessionCache.Remove(key)
-					if m := ps.metricsImpl(); m != nil {
+					if m := ps.metricsIFace; m != nil {
 						m.IncrementMemCacheInvalidationCounterSession()
 					}
 				}
@@ -100,11 +100,11 @@ func (ps *PlatformService) ClearAllUsersSessionCache() {
 func (ps *PlatformService) GetSession(token string) (*model.Session, error) {
 	var session = ps.sessionPool.Get().(*model.Session)
 	if err := ps.sessionCache.Get(token, session); err == nil {
-		if m := ps.metricsImpl(); m != nil {
+		if m := ps.metricsIFace; m != nil {
 			m.IncrementMemCacheHitCounterSession()
 		}
 	} else {
-		if m := ps.metricsImpl(); m != nil {
+		if m := ps.metricsIFace; m != nil {
 			m.IncrementMemCacheMissCounterSession()
 		}
 	}

--- a/app/platform/web_conn.go
+++ b/app/platform/web_conn.go
@@ -409,7 +409,7 @@ func (wc *WebConn) writePump() {
 				wc.logSocketErr("websocket.drainDeadQueue", err)
 				return
 			}
-			if m := wc.Platform.metricsImpl(); m != nil {
+			if m := wc.Platform.metricsIFace; m != nil {
 				m.IncrementWebsocketReconnectEvent(reconnectFound)
 			}
 		} else if wc.hasMsgLoss() {
@@ -427,11 +427,11 @@ func (wc *WebConn) writePump() {
 				wc.logSocketErr("websocket.sendHello", err)
 				return
 			}
-			if m := wc.Platform.metricsImpl(); m != nil {
+			if m := wc.Platform.metricsIFace; m != nil {
 				m.IncrementWebsocketReconnectEvent(reconnectNotFound)
 			}
 		} else {
-			if m := wc.Platform.metricsImpl(); m != nil {
+			if m := wc.Platform.metricsIFace; m != nil {
 				m.IncrementWebsocketReconnectEvent(reconnectLossless)
 			}
 		}
@@ -488,7 +488,7 @@ func (wc *WebConn) writePump() {
 				return
 			}
 
-			if m := wc.Platform.metricsImpl(); m != nil {
+			if m := wc.Platform.metricsIFace; m != nil {
 				m.IncrementWebSocketBroadcast(msg.EventType())
 			}
 		case <-ticker.C:

--- a/app/platform/web_hub.go
+++ b/app/platform/web_hub.go
@@ -142,7 +142,7 @@ func (ps *PlatformService) GetHubForUserId(userID string) *Hub {
 func (ps *PlatformService) HubRegister(webConn *WebConn) {
 	hub := ps.GetHubForUserId(webConn.UserId)
 	if hub != nil {
-		if metrics := ps.metricsImpl(); metrics != nil {
+		if metrics := ps.metricsIFace; metrics != nil {
 			metrics.IncrementWebSocketBroadcastUsersRegistered(strconv.Itoa(hub.connectionIndex), 1)
 		}
 		hub.Register(webConn)
@@ -153,7 +153,7 @@ func (ps *PlatformService) HubRegister(webConn *WebConn) {
 func (ps *PlatformService) HubUnregister(webConn *WebConn) {
 	hub := ps.GetHubForUserId(webConn.UserId)
 	if hub != nil {
-		if metrics := ps.metricsImpl(); metrics != nil {
+		if metrics := ps.metricsIFace; metrics != nil {
 			metrics.DecrementWebSocketBroadcastUsersRegistered(strconv.Itoa(hub.connectionIndex), 1)
 		}
 		hub.Unregister(webConn)
@@ -317,7 +317,7 @@ func (h *Hub) Broadcast(message *model.WebSocketEvent) {
 	// And possibly, we can look into doing the hub initialization inside
 	// NewServer itself.
 	if h != nil && message != nil {
-		if metrics := h.platform.metricsImpl(); metrics != nil {
+		if metrics := h.platform.metricsIFace; metrics != nil {
 			metrics.IncrementWebSocketBroadcastBufferSize(strconv.Itoa(h.connectionIndex), 1)
 		}
 		select {
@@ -483,7 +483,7 @@ func (h *Hub) Start(suite SuiteIFace) {
 					connIndex.Remove(directMsg.conn)
 				}
 			case msg := <-h.broadcast:
-				if metrics := h.platform.metricsImpl(); metrics != nil {
+				if metrics := h.platform.metricsIFace; metrics != nil {
 					metrics.DecrementWebSocketBroadcastBufferSize(strconv.Itoa(h.connectionIndex), 1)
 				}
 				msg = msg.PrecomputeJSON()


### PR DESCRIPTION

#### Summary
There was a regression in database metrics due to a bug in the server initialization. We need to initialize metrics implementation before database gets initialized. Did some re-arrangement and added a test for this.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47468

#### Release Note

```release-note
NONE
```
