### PR TITLE
GraphQL: Remove channel stats from the API

### DIFF
--- a/api4/resolver_channel.go
+++ b/api4/resolver_channel.go
@@ -29,36 +29,6 @@ func (ch *channel) Team(ctx context.Context) (*model.Team, error) {
 	return getGraphQLTeam(ctx, ch.TeamId)
 }
 
-// match with api4.getChannelStats
-func (ch *channel) Stats(ctx context.Context) (*model.ChannelStats, error) {
-	c, err := getCtx(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), ch.Id, model.PermissionReadChannel) {
-		c.SetPermissionError(model.PermissionReadChannel)
-		return nil, c.Err
-	}
-
-	memberCount, appErr := c.App.GetChannelMemberCount(c.AppContext, ch.Id)
-	if appErr != nil {
-		return nil, appErr
-	}
-
-	guestCount, appErr := c.App.GetChannelGuestCount(c.AppContext, ch.Id)
-	if appErr != nil {
-		return nil, appErr
-	}
-
-	pinnedPostCount, appErr := c.App.GetChannelPinnedPostCount(c.AppContext, ch.Id)
-	if appErr != nil {
-		return nil, appErr
-	}
-
-	return &model.ChannelStats{ChannelId: ch.Id, MemberCount: memberCount, GuestCount: guestCount, PinnedPostCount: pinnedPostCount}, nil
-}
-
 func (ch *channel) Cursor() *string {
 	cursor := string(channelCursorPrefix) + "-" + ch.Id
 	encoded := base64.StdEncoding.EncodeToString([]byte(cursor))

--- a/api4/resolver_channel_test.go
+++ b/api4/resolver_channel_test.go
@@ -48,12 +48,6 @@ func TestGraphQLChannels(t *testing.T) {
 				ID          string `json:"id"`
 				DisplayName string `json:"displayName"`
 			} `json:"team"`
-			Stats struct {
-				ChannelId       string  `json:"channelId"`
-				MemberCount     float64 `json:"memberCount"`
-				GuestCount      float64 `json:"guestCount"`
-				PinnedPostCount float64 `json:"pinnedpostCount"`
-			} `json:"stats"`
 		} `json:"channels"`
 	}
 
@@ -387,39 +381,6 @@ func TestGraphQLChannels(t *testing.T) {
 		require.Len(t, resp.Errors, 0)
 		require.NoError(t, json.Unmarshal(resp.Data, &q))
 		assert.Len(t, q.Channels, 5)
-	})
-
-	t.Run("stats", func(t *testing.T) {
-		query := `query channels($teamId: String, $first: Int) {
-	  channels(userId: "me", teamId: $teamId, first: $first) {
-		id
-		stats {
-		  channelId
-		  memberCount
-		}
-	  }
-	}
-	`
-		input := graphQLInput{
-			OperationName: "channels",
-			Query:         query,
-			Variables: map[string]any{
-				"first":  10,
-				"teamId": myTeam.Id,
-			},
-		}
-
-		resp, err := th.MakeGraphQLRequest(&input)
-		require.NoError(t, err)
-		require.Len(t, resp.Errors, 0)
-		require.NoError(t, json.Unmarshal(resp.Data, &q))
-		require.Len(t, q.Channels, 3)
-		for _, ch := range q.Channels {
-			require.Equal(t, ch.ID, ch.Stats.ChannelId)
-			count, appErr := th.App.GetChannelMemberCount(th.Context, ch.Stats.ChannelId)
-			require.Nil(t, appErr)
-			require.Equal(t, float64(count), ch.Stats.MemberCount)
-		}
 	})
 }
 

--- a/api4/schema.graphqls
+++ b/api4/schema.graphqls
@@ -62,7 +62,6 @@ type Channel {
 	totalMsgCount: Float!
 	totalMsgCountRoot: Float!
 	lastRootPostAt: Float!
-	stats: ChannelStats
 	extraUpdateAt: Float!
 	props: StringInterface!
 	policyId: String
@@ -219,11 +218,4 @@ type Session {
 	expiredNotify: Boolean!
 	props: StringMap!
 	local: Boolean!
-}
-
-type ChannelStats {
-	channelId: String!
-	memberCount: Float!
-	guestCount: Float!
-	pinnedPostCount: Float!
 }


### PR DESCRIPTION
Channel Stats isn't optimized with dataloaders.

And it's a heavy call, therefore clients
can mistakenly call this with multiple channels
and bring down the server.

Since there is no advantage compared to a REST API,
let's just remove it and keep things safe.

```release-note
NONE
```
