### PR TITLE
[MM-44336] Add timestamp parameter to test data slash commands

### DIFF
--- a/app/slashcommands/auto_channels.go
+++ b/app/slashcommands/auto_channels.go
@@ -20,6 +20,7 @@ type AutoChannelCreator struct {
 	NameLen            utils.Range
 	NameCharset        string
 	ChannelType        model.ChannelType
+	CreateTime         int64
 }
 
 func NewAutoChannelCreator(a *app.App, team *model.Team, userID string) *AutoChannelCreator {
@@ -33,6 +34,7 @@ func NewAutoChannelCreator(a *app.App, team *model.Team, userID string) *AutoCha
 		NameLen:            ChannelNameLen,
 		NameCharset:        utils.LOWERCASE,
 		ChannelType:        ChannelType,
+		CreateTime:         0,
 	}
 }
 
@@ -51,6 +53,7 @@ func (cfg *AutoChannelCreator) createRandomChannel(c request.CTX) (*model.Channe
 		Name:        name,
 		Type:        cfg.ChannelType,
 		CreatorId:   cfg.userID,
+		CreateAt:    cfg.CreateTime,
 	}
 
 	channel, err := cfg.a.CreateChannel(c, channel, true)
@@ -73,24 +76,4 @@ func (cfg *AutoChannelCreator) CreateTestChannels(c request.CTX, num utils.Range
 	}
 
 	return channels, nil
-}
-
-func (cfg *AutoChannelCreator) CreateTestDMs(c request.CTX, num utils.Range) ([]*model.Channel, error) {
-	numDMs := utils.RandIntFromRange(num)
-	dms := make([]*model.Channel, numDMs)
-
-	users, err := cfg.a.GetUsersFromProfiles(&model.UserGetOptions{Page: 0, PerPage: numDMs})
-	if err != nil {
-		return nil, err
-	}
-
-	for i, user := range users {
-		var err *model.AppError
-		dms[i], err = cfg.a.GetOrCreateDirectChannel(c, cfg.userID, user.Id)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return dms, nil
 }

--- a/app/slashcommands/auto_posts.go
+++ b/app/slashcommands/auto_posts.go
@@ -107,8 +107,6 @@ func (cfg *AutoPostCreator) CreateRandomPostNested(c request.CTX, rootId string)
 		// Creating posts with the exact same timestamp results in some posts being skipped
 		// when they are retrieved by the API based on timestamp.
 		post.CreateAt = cfg.CreateTime + int64(cfg.postsCreated)
-		// We need the UpdateAt field to be in the present to beat the browser cache.
-		post.UpdateAt = model.GetMillis()
 	}
 	if len(cfg.UsersToPostFrom) != 0 {
 		i := utils.RandIntFromRange(utils.Range{Begin: 0, End: len(cfg.UsersToPostFrom)})

--- a/app/slashcommands/command_loadtest.go
+++ b/app/slashcommands/command_loadtest.go
@@ -30,7 +30,7 @@ var usage = `Mattermost testing commands to help configure the system
 		/test setup [teams] [fuzz] <Num Channels> <Num Users> <NumPosts>
 
 		Example:
-		/test setup teams fuzz 10 20 50
+			/test setup teams fuzz 10 20 50
 
 	Users - Add a specified number of random users with fuzz text to current team, at the specified time.
 		/test users [fuzz] [range=min[,max]] [time=user_join_timestamp]
@@ -46,25 +46,29 @@ var usage = `Mattermost testing commands to help configure the system
 
 		Default: range=2,5 time=
 
-		Example:
+		Examples:
 			/test channels fuzz range=5,10 time=1565076128000
 			/test channels range=1
 
-	DMs - Add a specified number of random DM messages between the current user and a specified user, at the specified time.
+	DMs - Add a specified number of random DM messages between the current user and a specified user, at the specified time. If a timestamp is provided, posts are created one millisecond apart. Note: You may need to clear your browser cache in order to see these posts in the UI.
 		/test dms u=@username [range=min[,max]] [time=dm_create_timestamp]
 
 		Default: range=2,5 time=
 
-			Example:
-				/test dms u=@user range=5,10 time=1565076128000
-				/test dms u=@user range=2
+		Examples:
+			/test dms u=@user range=5,10 time=1565076128000
+			/test dms u=@user range=2
 
-	ThreadedPost - Create a threaded post
+	ThreadedPost - Create a threaded post with a specified number of replies at the specified time. If a timestamp is provided, posts are created one millisecond apart. Note: You may need to clear your browser cache in order to see these posts in the UI.
         /test threaded_post [range=min[,max]] [time=post_timestamp]
 
 		Default: range=1000 time=
 
-	Posts - Add some random posts with fuzz text to current channel, at the specified time.
+		Examples:
+			/test threaded_post
+			/test threaded_post range=100,200 time=1565076128000
+
+	Posts - Add some random posts with fuzz text to current channel, at the specified time. If a timestamp is provided, posts are created one millisecond apart. Note: You may need to clear your browser cache in order to see these posts in the UI.
 		/test posts [fuzz] [range=min[,max]] [images=max_images] [time=post_timestamp]
 
 		Default: range=2,5 images=0 time=
@@ -85,10 +89,10 @@ var usage = `Mattermost testing commands to help configure the system
 			/test http://www.example.com/sample_file.md
 
 	Json - Add a post using the JSON file as payload to the current channel.
-	        /test json url
+	    /test json url
 
-		Example
-		/test json http://www.example.com/sample_body.json
+		Example:
+			/test json http://www.example.com/sample_body.json
 
 `
 

--- a/app/slashcommands/command_loadtest.go
+++ b/app/slashcommands/command_loadtest.go
@@ -318,7 +318,7 @@ func (*LoadTestProvider) UsersCommand(a *app.App, c request.CTX, args *model.Com
 	rng := utils.Range{Begin: 2, End: 5}
 	rangeParam := getMatch(rangeRE, cmd)
 	if rangeParam != "" {
-		rng, err = parseRangeParameter(rangeParam)
+		rng, err = parseRange(rangeParam)
 		if err != nil {
 			return &model.CommandResponse{Text: "Failed to add users: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
@@ -362,7 +362,7 @@ func (*LoadTestProvider) ChannelsCommand(a *app.App, c request.CTX, args *model.
 	rng := utils.Range{Begin: 2, End: 5}
 	rangeParam := getMatch(rangeRE, cmd)
 	if rangeParam != "" {
-		rng, err = parseRangeParameter(rangeParam)
+		rng, err = parseRange(rangeParam)
 		if err != nil {
 			return &model.CommandResponse{Text: "Failed to add channels: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
@@ -407,7 +407,7 @@ func (*LoadTestProvider) DMsCommand(a *app.App, c request.CTX, args *model.Comma
 	rng := utils.Range{Begin: 2, End: 5}
 	rangeParam := getMatch(rangeRE, cmd)
 	if rangeParam != "" {
-		rng, err = parseRangeParameter(rangeParam)
+		rng, err = parseRange(rangeParam)
 		if err != nil {
 			return &model.CommandResponse{Text: "Failed to add DMs: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
@@ -445,7 +445,7 @@ func (*LoadTestProvider) ThreadedPostCommand(a *app.App, c request.CTX, args *mo
 	rng := utils.Range{Begin: 1000, End: 1000}
 	rangeParam := getMatch(rangeRE, cmd)
 	if rangeParam != "" {
-		rng, err = parseRangeParameter(rangeParam)
+		rng, err = parseRange(rangeParam)
 		if err != nil {
 			return &model.CommandResponse{Text: "Failed to create post: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
@@ -500,7 +500,7 @@ func (*LoadTestProvider) PostsCommand(a *app.App, c request.CTX, args *model.Com
 	rng := utils.Range{Begin: 2, End: 5}
 	rangeParam := getMatch(rangeRE, cmd)
 	if rangeParam != "" {
-		rng, err = parseRangeParameter(rangeParam)
+		rng, err = parseRange(rangeParam)
 		if err != nil {
 			return &model.CommandResponse{Text: "Failed to add posts: " + err.Error(), ResponseType: model.CommandResponseTypeEphemeral}, err
 		}
@@ -705,7 +705,7 @@ func (*LoadTestProvider) JsonCommand(a *app.App, c request.CTX, args *model.Comm
 	return &model.CommandResponse{Text: "Loaded data", ResponseType: model.CommandResponseTypeEphemeral}, nil
 }
 
-func parseRangeParameter(rng string) (utils.Range, error) {
+func parseRange(rng string) (utils.Range, error) {
 	tokens := strings.Split(rng, ",")
 	var begin int
 	var end int
@@ -728,31 +728,6 @@ func parseRangeParameter(rng string) (utils.Range, error) {
 		return utils.Range{Begin: 0, End: 0}, errors.New("Invalid range parameter")
 	}
 	return utils.Range{Begin: begin, End: end}, nil
-}
-
-func parseRange(command string, cmd string) (utils.Range, bool) {
-	tokens := strings.Fields(strings.TrimPrefix(command, cmd))
-	var begin int
-	var end int
-	var err1 error
-	var err2 error
-	switch {
-	case len(tokens) == 1:
-		begin, err1 = strconv.Atoi(tokens[0])
-		end = begin
-		if err1 != nil {
-			return utils.Range{Begin: 0, End: 0}, false
-		}
-	case len(tokens) >= 2:
-		begin, err1 = strconv.Atoi(tokens[0])
-		end, err2 = strconv.Atoi(tokens[1])
-		if err1 != nil || err2 != nil {
-			return utils.Range{Begin: 0, End: 0}, false
-		}
-	default:
-		return utils.Range{Begin: 0, End: 0}, false
-	}
-	return utils.Range{Begin: begin, End: end}, true
 }
 
 func contains(items []string, token string) bool {

--- a/model/post.go
+++ b/model/post.go
@@ -438,9 +438,7 @@ func (o *Post) PreSave() {
 		o.CreateAt = GetMillis()
 	}
 
-	if o.UpdateAt == 0 {
-		o.UpdateAt = o.CreateAt
-	}
+	o.UpdateAt = o.CreateAt
 	o.PreCommit()
 }
 

--- a/model/post.go
+++ b/model/post.go
@@ -438,7 +438,9 @@ func (o *Post) PreSave() {
 		o.CreateAt = GetMillis()
 	}
 
-	o.UpdateAt = o.CreateAt
+	if o.UpdateAt == 0 {
+		o.UpdateAt = o.CreateAt
+	}
 	o.PreCommit()
 }
 

--- a/model/user.go
+++ b/model/user.go
@@ -436,7 +436,9 @@ func (u *User) PreSave() {
 	u.Username = NormalizeUsername(u.Username)
 	u.Email = NormalizeEmail(u.Email)
 
-	u.CreateAt = GetMillis()
+	if u.CreateAt == 0 {
+		u.CreateAt = GetMillis()
+	}
 	u.UpdateAt = u.CreateAt
 
 	u.LastPasswordUpdate = u.CreateAt

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -876,7 +876,7 @@ func (s SqlTeamStore) UpdateMultipleMembers(members []*model.TeamMember) ([]*mod
 		}
 
 		if _, err := s.GetMasterX().NamedExec(`UPDATE TeamMembers
-				SET Roles=:Roles, DeleteAt=:DeleteAt, SchemeGuest=:SchemeGuest,
+				SET Roles=:Roles, DeleteAt=:DeleteAt, CreateAt=:CreateAt, SchemeGuest=:SchemeGuest,
 					SchemeUser=:SchemeUser, SchemeAdmin=:SchemeAdmin
 				WHERE TeamId=:TeamId AND UserId=:UserId`, newTeamMember); err != nil {
 			return nil, errors.Wrap(err, "failed to update TeamMember")


### PR DESCRIPTION
#### Summary

Adds a timestamp parameter to the test data slash commands, so that historical test data can be generated. Technically, test data in the future can also be generated. I don't think it's necessary to check this because any accidentally generated data can be manually deleted.

The commands now use named parameters. The parameters are as follows:

- `range=<min>,<max>` or `range=<num>` for the number of data to generate
- `time=<timestamp>` for the Unix timestamp representing the time of the data
- `images=<num>` for the number of images to add to posts
- `u=@<username>` or `u=<username>` for the user to create DMs with

The parameters are easy to rename if we don't like these names. 

Additionally, the `/test dms` command now creates a number of random-text DM messages between the current user and a provided user. This is different from the previous behaviour which created empty DM channels deterministically.

Finally, there are three commands that generate posts (`/test posts`, `/test threaded_post`, and `/test dms`). Due to browser caching, it may appear that generated historical posts disappear upon a refresh, although the posts are correctly in the database. I added a note in the help text that the user may need to clear the browser cache in order to see generated historical posts.

#### Ticket Link

[Jira ticket](https://mattermost.atlassian.net/browse/MM-44336)

#### Release Note

```release-note
NONE
```
