### PR TITLE
MM-47238 Add MM_BOARDS_DEV_SERVER_URL environment variable for MPA

### DIFF
--- a/web/handlers.go
+++ b/web/handlers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -133,8 +134,13 @@ func generateDevCSP(c Context) string {
 
 	// Add flags for Webpack dev servers used by other products during development
 	if model.BuildNumber == "dev" {
-		// Focalboard runs on http://localhost:9006
-		devCSP = append(devCSP, "http://localhost:9006")
+		boardsURL, ok := os.LookupEnv("MM_BOARDS_DEV_SERVER_URL")
+		if !ok {
+			// Focalboard runs on http://localhost:9006 by default
+			boardsURL = "http://localhost:9006"
+		}
+
+		devCSP = append(devCSP, boardsURL)
 	}
 
 	if len(devCSP) == 0 {

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -134,8 +134,8 @@ func generateDevCSP(c Context) string {
 
 	// Add flags for Webpack dev servers used by other products during development
 	if model.BuildNumber == "dev" {
-		boardsURL, ok := os.LookupEnv("MM_BOARDS_DEV_SERVER_URL")
-		if !ok {
+		boardsURL := os.Getenv("MM_BOARDS_DEV_SERVER_URL")
+		if boardsURL == "" {
 			// Focalboard runs on http://localhost:9006 by default
 			boardsURL = "http://localhost:9006"
 		}


### PR DESCRIPTION
This PR is based on https://github.com/mattermost/mattermost-server/pull/21401. Changes specific to it are here: https://github.com/mattermost/mattermost-server/compare/MM-46981_production-mpa...MM-47238_boards-dev-server-url

This makes it so that people who develop MM on a URL other than `http://localhost` can redefine the URL, port, and protocol that the Boards Webpack dev server runs on for MPA development. Without it sets, it still defaults to running the dev server on `http://localhost:9006`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47238

#### Related Pull Requests
https://github.com/mattermost/mattermost-server/pull/21401
https://github.com/mattermost/focalboard/pull/4026
https://github.com/mattermost/mattermost-webapp/pull/11381

#### Release Note
```release-note
NONE
```
