### PR TITLE
[MM-47137] Fix `active_user_count` increasing without the users themselves logging in

### DIFF
--- a/api4/status.go
+++ b/api4/status.go
@@ -111,7 +111,7 @@ func updateUserStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 	case "online":
 		c.App.SetStatusOnline(c.Params.UserId, true)
 	case "offline":
-		c.App.SetStatusOffline(c.Params.UserId, true)
+		c.App.SetStatusOffline(c.Params.UserId, true, true)
 	case "away":
 		c.App.SetStatusAwayIfNeeded(c.Params.UserId, true)
 	case "dnd":

--- a/api4/status_test.go
+++ b/api4/status_test.go
@@ -70,7 +70,7 @@ func TestGetUserStatus(t *testing.T) {
 	})
 
 	t.Run("back to offline status", func(t *testing.T) {
-		th.App.SetStatusOffline(th.BasicUser.Id, true)
+		th.App.SetStatusOffline(th.BasicUser.Id, true, true)
 		userStatus, _, err := client.GetUserStatus(th.BasicUser.Id, "")
 		require.NoError(t, err)
 		assert.Equal(t, "offline", userStatus.Status)

--- a/api4/status_test.go
+++ b/api4/status_test.go
@@ -233,6 +233,21 @@ func TestUpdateUserStatus(t *testing.T) {
 		CheckBadRequestStatus(t, resp)
 	})
 
+	t.Run("deleting a user instantly after creating creates status entry with lastactivityat = 0", func(t *testing.T) {
+		// create user
+		user := th.CreateUser()
+		status, _, err := client.GetUserStatus(user.Id, "")
+		require.NoError(t, err)
+		// GetUserStatus creates an entry in statuses table if there is none, best way to test if activity is recorded is to ensure
+		// lastactivityat field is 0
+		require.Equal(t, status.LastActivityAt, int64(0))
+		th.App.PermanentDeleteUser(th.Context, user)
+		// deleting a user shouldn't update lastactivityat
+		status, _, err = client.GetUserStatus(user.Id, "")
+		require.NoError(t, err)
+		require.Equal(t, status.LastActivityAt, int64(0))
+	})
+
 	t.Run("get statuses from logged out user", func(t *testing.T) {
 		toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser2.Id}
 		client.Logout()

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -1057,7 +1057,7 @@ type AppIface interface {
 	SetServer(srv *Server)
 	SetStatusAwayIfNeeded(userID string, manual bool)
 	SetStatusDoNotDisturb(userID string)
-	SetStatusOffline(userID string, manual bool)
+	SetStatusOffline(userID string, manual bool, updateLastActivityAt bool)
 	SetStatusOnline(userID string, manual bool)
 	SetStatusOutOfOffice(userID string)
 	SetTeamIcon(teamID string, imageData *multipart.FileHeader) *model.AppError

--- a/app/notification_test.go
+++ b/app/notification_test.go
@@ -2400,7 +2400,7 @@ func TestUserAllowsEmail(t *testing.T) {
 	t.Run("should return true", func(t *testing.T) {
 		user := th.CreateUser()
 
-		th.App.SetStatusOffline(user.Id, true)
+		th.App.SetStatusOffline(user.Id, true, true)
 
 		channelMemberNotificationProps := model.StringMap{
 			model.EmailNotifyProp:      model.ChannelNotifyDefault,
@@ -2426,7 +2426,7 @@ func TestUserAllowsEmail(t *testing.T) {
 	t.Run("should return false in case the EMAIL_NOTIFY_PROP is false", func(t *testing.T) {
 		user := th.CreateUser()
 
-		th.App.SetStatusOffline(user.Id, true)
+		th.App.SetStatusOffline(user.Id, true, true)
 
 		channelMemberNotificationProps := model.StringMap{
 			model.EmailNotifyProp:      "false",
@@ -2439,7 +2439,7 @@ func TestUserAllowsEmail(t *testing.T) {
 	t.Run("should return false in case the MARK_UNREAD_NOTIFY_PROP is CHANNEL_MARK_UNREAD_MENTION", func(t *testing.T) {
 		user := th.CreateUser()
 
-		th.App.SetStatusOffline(user.Id, true)
+		th.App.SetStatusOffline(user.Id, true, true)
 
 		channelMemberNotificationProps := model.StringMap{
 			model.EmailNotifyProp:      model.ChannelNotifyDefault,
@@ -2452,7 +2452,7 @@ func TestUserAllowsEmail(t *testing.T) {
 	t.Run("should return false in case the Post type is POST_AUTO_RESPONDER", func(t *testing.T) {
 		user := th.CreateUser()
 
-		th.App.SetStatusOffline(user.Id, true)
+		th.App.SetStatusOffline(user.Id, true, true)
 
 		channelMemberNotificationProps := model.StringMap{
 			model.EmailNotifyProp:      model.ChannelNotifyDefault,

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -15946,7 +15946,7 @@ func (a *OpenTracingAppLayer) SetStatusLastActivityAt(userID string, activityAt 
 	a.app.SetStatusLastActivityAt(userID, activityAt)
 }
 
-func (a *OpenTracingAppLayer) SetStatusOffline(userID string, manual bool) {
+func (a *OpenTracingAppLayer) SetStatusOffline(userID string, manual bool, updateLastActivityAt bool) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.SetStatusOffline")
 
@@ -15958,7 +15958,7 @@ func (a *OpenTracingAppLayer) SetStatusOffline(userID string, manual bool) {
 	}()
 
 	defer span.Finish()
-	a.app.SetStatusOffline(userID, manual)
+	a.app.SetStatusOffline(userID, manual, updateLastActivityAt)
 }
 
 func (a *OpenTracingAppLayer) SetStatusOnline(userID string, manual bool) {

--- a/app/platform/helper_test.go
+++ b/app/platform/helper_test.go
@@ -41,12 +41,12 @@ var userCache struct {
 type mockSuite struct {
 }
 
-func (ms *mockSuite) SetStatusLastActivityAt(userID string, activityAt int64) {}
-func (ms *mockSuite) SetStatusOffline(userID string, manual bool)             {}
-func (ms *mockSuite) IsUserAway(lastActivityAt int64) bool                    { return false }
-func (ms *mockSuite) SetStatusOnline(userID string, manual bool)              {}
-func (ms *mockSuite) UpdateLastActivityAtIfNeeded(session model.Session)      {}
-func (ms *mockSuite) SetStatusAwayIfNeeded(userID string, manual bool)        {}
+func (ms *mockSuite) SetStatusLastActivityAt(userID string, activityAt int64)                {}
+func (ms *mockSuite) SetStatusOffline(userID string, manual bool, updateLastActivityAt bool) {}
+func (ms *mockSuite) IsUserAway(lastActivityAt int64) bool                                   { return false }
+func (ms *mockSuite) SetStatusOnline(userID string, manual bool)                             {}
+func (ms *mockSuite) UpdateLastActivityAtIfNeeded(session model.Session)                     {}
+func (ms *mockSuite) SetStatusAwayIfNeeded(userID string, manual bool)                       {}
 func (ms *mockSuite) GetSession(token string) (*model.Session, *model.AppError) {
 	return &model.Session{}, nil
 }

--- a/app/platform/mocks/SuiteIFace.go
+++ b/app/platform/mocks/SuiteIFace.go
@@ -77,9 +77,9 @@ func (_m *SuiteIFace) SetStatusLastActivityAt(userID string, activityAt int64) {
 	_m.Called(userID, activityAt)
 }
 
-// SetStatusOffline provides a mock function with given fields: userID, manual
-func (_m *SuiteIFace) SetStatusOffline(userID string, manual bool) {
-	_m.Called(userID, manual)
+// SetStatusOffline provides a mock function with given fields: userID, manual, updateLastActivityAt
+func (_m *SuiteIFace) SetStatusOffline(userID string, manual bool, updateLastActivityAt bool) {
+	_m.Called(userID, manual, updateLastActivityAt)
 }
 
 // SetStatusOnline provides a mock function with given fields: userID, manual

--- a/app/platform/web_hub.go
+++ b/app/platform/web_hub.go
@@ -22,7 +22,7 @@ const (
 
 type SuiteIFace interface {
 	SetStatusLastActivityAt(userID string, activityAt int64)
-	SetStatusOffline(userID string, manual bool)
+	SetStatusOffline(userID string, manual bool, updateLastActivityAt bool)
 	IsUserAway(lastActivityAt int64) bool
 	SetStatusOnline(userID string, manual bool)
 	UpdateLastActivityAtIfNeeded(session model.Session)
@@ -439,7 +439,7 @@ func (h *Hub) Start(suite SuiteIFace) {
 				conns := connIndex.ForUser(webConn.UserId)
 				if len(conns) == 0 || areAllInactive(conns) {
 					h.platform.Go(func() {
-						suite.SetStatusOffline(webConn.UserId, false)
+						suite.SetStatusOffline(webConn.UserId, false, true)
 					})
 					continue
 				}
@@ -522,7 +522,7 @@ func (h *Hub) Start(suite SuiteIFace) {
 			case <-h.stop:
 				for webConn := range connIndex.All() {
 					webConn.Close()
-					suite.SetStatusOffline(webConn.UserId, false)
+					suite.SetStatusOffline(webConn.UserId, false, true)
 				}
 
 				h.explicitStop = true

--- a/app/platform/web_hub_test.go
+++ b/app/platform/web_hub_test.go
@@ -472,7 +472,7 @@ func TestHubIsRegistered(t *testing.T) {
 	mockSuite.On("UpdateLastActivityAtIfNeeded", *session).Return()
 	mockSuite.On("GetSession", session.Token).Return(session, nil)
 	mockSuite.On("IsUserAway", mock.Anything).Return(false)
-	mockSuite.On("SetStatusOffline", th.BasicUser.Id, false).Return()
+	mockSuite.On("SetStatusOffline", th.BasicUser.Id, false, true).Return()
 
 	th.Suite = mockSuite
 

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -337,7 +337,7 @@ func (api *PluginAPI) UpdateUserStatus(userID, status string) (*model.Status, *m
 	case model.StatusOnline:
 		api.app.SetStatusOnline(userID, true)
 	case model.StatusOffline:
-		api.app.SetStatusOffline(userID, true)
+		api.app.SetStatusOffline(userID, true, true)
 	case model.StatusAway:
 		api.app.SetStatusAwayIfNeeded(userID, true)
 	case model.StatusDnd:

--- a/app/slashcommands/command_offline.go
+++ b/app/slashcommands/command_offline.go
@@ -35,7 +35,7 @@ func (*OfflineProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Comm
 }
 
 func (*OfflineProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
-	a.SetStatusOffline(args.UserId, true)
+	a.SetStatusOffline(args.UserId, true, true)
 
 	return &model.CommandResponse{ResponseType: model.CommandResponseTypeEphemeral, Text: args.T("api.command_offline.success")}
 }

--- a/app/status.go
+++ b/app/status.go
@@ -94,11 +94,16 @@ func (a *App) SetStatusOffline(userID string, manual bool) {
 	}
 
 	status, err := a.GetStatus(userID)
+	lastActivityAt := model.GetMillis()
+	// if it's a user with no activity, set LastActivityAt = 0 when automatically updating status
+	if err != nil && err.Id == "app.status.get.missing.app_error" && !manual {
+		lastActivityAt = 0
+	}
 	if err == nil && status.Manual && !manual {
 		return // manually set status always overrides non-manual one
 	}
 
-	status = &model.Status{UserId: userID, Status: model.StatusOffline, Manual: manual, LastActivityAt: model.GetMillis(), ActiveChannel: ""}
+	status = &model.Status{UserId: userID, Status: model.StatusOffline, Manual: manual, LastActivityAt: lastActivityAt, ActiveChannel: ""}
 
 	a.Srv().Platform().SaveAndBroadcastStatus(status)
 }

--- a/app/user.go
+++ b/app/user.go
@@ -882,7 +882,7 @@ func (a *App) UpdatePasswordAsUser(c request.CTX, userID, currentPassword, newPa
 }
 
 func (a *App) userDeactivated(c request.CTX, userID string) *model.AppError {
-	a.SetStatusOffline(userID, false)
+	a.SetStatusOffline(userID, false, false)
 
 	user, err := a.GetUser(userID)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
`active_user_count` was being counted wrongly, when a user with no activity was deleted. This PR introduces a flag called `updateLastActivityAt` which conditionally updates `status.lastActivityAt`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-47137
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
