### PR TITLE
[MM-19267] Add GetPluginStatuses plugin API method and OnPluginStatusesChanged hook

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -893,6 +893,10 @@ func (api *PluginAPI) GetPluginStatus(id string) (*model.PluginStatus, *model.Ap
 	return api.app.GetPluginStatus(id)
 }
 
+func (api *PluginAPI) GetPluginStatuses() ([]*model.PluginStatus, *model.AppError) {
+	return api.app.GetPluginStatuses()
+}
+
 func (api *PluginAPI) InstallPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError) {
 	if !*api.app.Config().PluginSettings.Enable || !*api.app.Config().PluginSettings.EnableUploads {
 		return nil, model.NewAppError("installPlugin", "app.plugin.upload_disabled.app_error", nil, "", http.StatusNotImplemented)

--- a/app/plugin_api_tests/test_get_plugin_statuses_plugin/main.go
+++ b/app/plugin_api_tests/test_get_plugin_statuses_plugin/main.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package main
+
+import (
+	"github.com/mattermost/mattermost-server/v6/app/plugin_api_tests"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
+)
+
+type MyPlugin struct {
+	plugin.MattermostPlugin
+	configuration plugin_api_tests.BasicConfig
+}
+
+func (p *MyPlugin) OnConfigurationChange() error {
+	if err := p.API.LoadPluginConfiguration(&p.configuration); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model.Post, string) {
+	statuses, err := p.API.GetPluginStatuses()
+	if err != nil {
+		return nil, err.Error()
+	}
+
+	if len(statuses) != 1 {
+		return nil, "Returned invalid number of plugin statuses"
+	}
+
+	return nil, "OK"
+}
+
+func main() {
+	plugin.ClientMain(&MyPlugin{})
+}

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -859,6 +859,12 @@ type API interface {
 	// Minimum server version: 5.6
 	GetPluginStatus(id string) (*model.PluginStatus, *model.AppError)
 
+	// GetPluginStatuses will return a list of statuses of a plugin.
+	//
+	// @tag Plugin
+	// Minimum server version: 7.4
+	GetPluginStatuses() ([]*model.PluginStatus, *model.AppError)
+
 	// InstallPlugin will upload another plugin with tar.gz file.
 	// Previous version will be replaced on replace true.
 	//

--- a/plugin/api_timer_layer_generated.go
+++ b/plugin/api_timer_layer_generated.go
@@ -937,6 +937,13 @@ func (api *apiTimerLayer) GetPluginStatus(id string) (*model.PluginStatus, *mode
 	return _returnsA, _returnsB
 }
 
+func (api *apiTimerLayer) GetPluginStatuses() ([]*model.PluginStatus, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.GetPluginStatuses()
+	api.recordTime(startTime, "GetPluginStatuses", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
 func (api *apiTimerLayer) InstallPlugin(file io.Reader, replace bool) (*model.Manifest, *model.AppError) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.InstallPlugin(file, replace)

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -4587,6 +4587,34 @@ func (s *apiRPCServer) GetPluginStatus(args *Z_GetPluginStatusArgs, returns *Z_G
 	return nil
 }
 
+type Z_GetPluginStatusesArgs struct {
+}
+
+type Z_GetPluginStatusesReturns struct {
+	A []*model.PluginStatus
+	B *model.AppError
+}
+
+func (g *apiRPCClient) GetPluginStatuses() ([]*model.PluginStatus, *model.AppError) {
+	_args := &Z_GetPluginStatusesArgs{}
+	_returns := &Z_GetPluginStatusesReturns{}
+	if err := g.client.Call("Plugin.GetPluginStatuses", _args, _returns); err != nil {
+		log.Printf("RPC call to GetPluginStatuses API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetPluginStatuses(args *Z_GetPluginStatusesArgs, returns *Z_GetPluginStatusesReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetPluginStatuses() ([]*model.PluginStatus, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.GetPluginStatuses()
+	} else {
+		return encodableError(fmt.Errorf("API GetPluginStatuses called but not implemented."))
+	}
+	return nil
+}
+
 type Z_KVSetArgs struct {
 	A string
 	B []byte

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -1564,6 +1564,31 @@ func (_m *API) GetPluginStatus(id string) (*model.PluginStatus, *model.AppError)
 	return r0, r1
 }
 
+// GetPluginStatuses provides a mock function with given fields:
+func (_m *API) GetPluginStatuses() ([]*model.PluginStatus, *model.AppError) {
+	ret := _m.Called()
+
+	var r0 []*model.PluginStatus
+	if rf, ok := ret.Get(0).(func() []*model.PluginStatus); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.PluginStatus)
+		}
+	}
+
+	var r1 *model.AppError
+	if rf, ok := ret.Get(1).(func() *model.AppError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // GetPlugins provides a mock function with given fields:
 func (_m *API) GetPlugins() ([]*model.Manifest, *model.AppError) {
 	ret := _m.Called()


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Add GetPluginStatuses for plugin API.

Pull Request to fix [MM-19267](https://mattermost.atlassian.net/browse/MM-19267).

#### To-Do

- [x] Add GetPluginStatuses plugin API method
- [ ] Add OnPluginStatusesChanged hook

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes [#13945](https://github.com/mattermost/mattermost-server/issues/13945)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
