### PR TITLE
Deprecate ioutil

### DIFF
--- a/app/platform/helper_test.go
+++ b/app/platform/helper_test.go
@@ -4,7 +4,7 @@
 package platform
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -127,7 +127,7 @@ func SetupWithCluster(tb testing.TB, cluster einterfaces.ClusterInterface) *Test
 }
 
 func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer bool, tb testing.TB, options ...Option) *TestHelper {
-	tempWorkspace, err := ioutil.TempDir("", "apptest")
+	tempWorkspace, err := os.TempDir("", "apptest")
 	if err != nil {
 		panic(err)
 	}

--- a/app/platform/helper_test.go
+++ b/app/platform/helper_test.go
@@ -127,7 +127,7 @@ func SetupWithCluster(tb testing.TB, cluster einterfaces.ClusterInterface) *Test
 }
 
 func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer bool, tb testing.TB, options ...Option) *TestHelper {
-	tempWorkspace, err := os.TempDir("", "apptest")
+	tempWorkspace, err := os.MkdirTemp("", "apptest")
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
#### Summary
This was the last ioutil of the whole codebase... bye!

ioutil is officially deprecated since go 1.16 - our target is 1.18

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
