### PR TITLE
db/migrations: ensure to drop parentid from posts table

### DIFF
--- a/db/migrations/migrations.list
+++ b/db/migrations/migrations.list
@@ -188,6 +188,8 @@ db/migrations/mysql/000093_notify_admin.down.sql
 db/migrations/mysql/000093_notify_admin.up.sql
 db/migrations/mysql/000094_threads_teamid.down.sql
 db/migrations/mysql/000094_threads_teamid.up.sql
+db/migrations/mysql/000095_remove_posts_parentid.down.sql
+db/migrations/mysql/000095_remove_posts_parentid.up.sql
 db/migrations/postgres/000001_create_teams.down.sql
 db/migrations/postgres/000001_create_teams.up.sql
 db/migrations/postgres/000002_create_team_members.down.sql
@@ -376,3 +378,5 @@ db/migrations/postgres/000093_notify_admin.down.sql
 db/migrations/postgres/000093_notify_admin.up.sql
 db/migrations/postgres/000094_threads_teamid.down.sql
 db/migrations/postgres/000094_threads_teamid.up.sql
+db/migrations/postgres/000095_remove_posts_parentid.down.sql
+db/migrations/postgres/000095_remove_posts_parentid.up.sql

--- a/db/migrations/mysql/000095_remove_posts_parentid.down.sql
+++ b/db/migrations/mysql/000095_remove_posts_parentid.down.sql
@@ -1,0 +1,1 @@
+-- Intentionally left blank as forward migration is not reversible.

--- a/db/migrations/mysql/000095_remove_posts_parentid.up.sql
+++ b/db/migrations/mysql/000095_remove_posts_parentid.up.sql
@@ -1,0 +1,17 @@
+-- While upgrading from 5.x to 6.x with manual queries, there is a chance that this
+-- migration is skipped. In that case, we need to make sure that the column is dropped.
+
+SET @preparedStatement = (SELECT IF(
+    (
+        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE table_name = 'Posts'
+        AND table_schema = DATABASE()
+        AND column_name = 'ParentId'
+    ) > 0,
+    'ALTER TABLE Posts DROP COLUMN ParentId;',
+    'SELECT 1'
+));
+
+PREPARE alterIfExists FROM @preparedStatement;
+EXECUTE alterIfExists;
+DEALLOCATE PREPARE alterIfExists;

--- a/db/migrations/postgres/000095_remove_posts_parentid.down.sql
+++ b/db/migrations/postgres/000095_remove_posts_parentid.down.sql
@@ -1,0 +1,1 @@
+-- Intentionally left blank as forward migration is not reversible.

--- a/db/migrations/postgres/000095_remove_posts_parentid.up.sql
+++ b/db/migrations/postgres/000095_remove_posts_parentid.up.sql
@@ -1,0 +1,4 @@
+-- While upgrading from 5.x to 6.x with manual queries, there is a chance that this
+-- migration is skipped. In that case, we need to make sure that the column is dropped.
+
+ALTER TABLE posts DROP COLUMN IF EXISTS parentid;


### PR DESCRIPTION
#### Summary
Ensure that `ParentId` column is dropped from the `Posts` table. There is a chance that `ParentId` column is not dropped if a mattermost administrator runs manual queries while upgrading from `5.x` to future versions. To avoid any inconsistencies in the schema, we run the `DROP COLUMN ParentId` query anyway. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-46973

#### Release Note

```release-note
Adds a new schema migration to ensure ParentId column is dropped from the Posts table. Depending on the table size, if the column is not dropped before; A significant spike in DB CPU usage is expected on MySQL databases. Writes to the table will be limited during the migration.  
```
