### PR TITLE
platform/service: fix a flaky test for metrics

### DIFF
--- a/app/platform/service.go
+++ b/app/platform/service.go
@@ -173,7 +173,7 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 	ps.initEnterprise()
 
 	// Step 5: Init Metrics
-	if metricsInterfaceFn != nil {
+	if metricsInterfaceFn != nil && ps.metricsIFace == nil { // if the metrics interface is set by options, do not override it
 		ps.metricsIFace = metricsInterfaceFn(ps, *ps.configStore.Get().SqlSettings.DriverName, *ps.configStore.Get().SqlSettings.DataSource)
 	}
 


### PR DESCRIPTION
#### Summary
The `metricsInterfaceFn` was being used once the `metrics` package initialized in the EE build. We also need to check if the metrics interface is set beforehand to run `metricsInterfaceFn` function.

The reason it didn't get caught on CI still unknown to me. Because we have `EE` builds and this should've cause tests with EE to fail. Something to look at. cc @phoinixgrr 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47635

#### Release Note

```release-note
NONE
```
