### PR TITLE
Actually build Boards product files in release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,9 +644,10 @@ workflows:
       - setup-focalboard-product:
           filters:
             branches:
-              ignore:
+              only:
                 - master
                 - /^release-.*/
+                - cloud
           requires:
             - setup-multi-product-repositories
       - check-go-mod-tidy:


### PR DESCRIPTION
When copy and pasting from the untagged-build pipeline to the release-build one, I didn't realize that the branch filters were inverted, so we weren't building the web app files for Boards before trying to copy them into the server bundle

#### Related Pull Requests
#21401
https://github.com/mattermost/enterprise/pull/1281

#### Release Note
```release-note
NONE
```
