### PR TITLE
MM-47736: Add jitter to job scheduler run time

### DIFF
--- a/jobs/base_schedulers.go
+++ b/jobs/base_schedulers.go
@@ -4,6 +4,8 @@
 package jobs
 
 import (
+	"crypto/rand"
+	"math/big"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -30,7 +32,7 @@ func (scheduler *PeriodicScheduler) Enabled(cfg *model.Config) bool {
 }
 
 func (scheduler *PeriodicScheduler) NextScheduleTime(_ *model.Config, _ time.Time /* pendingJobs */, _ bool /* lastSuccessfulJob */, _ *model.Job) *time.Time {
-	nextTime := time.Now().Add(scheduler.period)
+	nextTime := time.Now().Add(getRandomDelay(jitterRange)).Add(scheduler.period)
 	return &nextTime
 }
 
@@ -69,4 +71,14 @@ func (scheduler *DailyScheduler) NextScheduleTime(cfg *model.Config, now time.Ti
 
 func (scheduler *DailyScheduler) ScheduleJob(_ *model.Config /* pendingJobs */, _ bool /* lastSuccessfulJob */, _ *model.Job) (*model.Job, *model.AppError) {
 	return scheduler.jobs.CreateJob(scheduler.jobType, nil)
+}
+
+const jitterRange = 2000 // milliseconds
+
+func getRandomDelay(limit int64) time.Duration {
+	num, err := rand.Int(rand.Reader, big.NewInt(limit))
+	if err != nil {
+		return time.Millisecond
+	}
+	return time.Millisecond*time.Duration(num.Int64())
 }

--- a/jobs/base_schedulers.go
+++ b/jobs/base_schedulers.go
@@ -80,5 +80,5 @@ func getRandomDelay(limit int64) time.Duration {
 	if err != nil {
 		return time.Millisecond
 	}
-	return time.Millisecond*time.Duration(num.Int64())
+	return time.Millisecond * time.Duration(num.Int64())
 }

--- a/jobs/schedulers_test.go
+++ b/jobs/schedulers_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin/plugintest/mock"
@@ -142,4 +143,12 @@ func TestScheduler(t *testing.T) {
 
 		wg.Wait()
 	})
+}
+
+func TestRandomDelay(t *testing.T) {
+	cases := []int64{5,10,100}
+	for _, c := range cases {
+		out := getRandomDelay(c)
+		require.Less(t, out.Milliseconds(), c)
+	}
 }

--- a/jobs/schedulers_test.go
+++ b/jobs/schedulers_test.go
@@ -146,7 +146,7 @@ func TestScheduler(t *testing.T) {
 }
 
 func TestRandomDelay(t *testing.T) {
-	cases := []int64{5,10,100}
+	cases := []int64{5, 10, 100}
 	for _, c := range cases {
 		out := getRandomDelay(c)
 		require.Less(t, out.Milliseconds(), c)


### PR DESCRIPTION
There can be a case where if a config change happened
at the same time for a large number of installations,
it can trigger a job to re-run all at the same time,
therefore causing a thundering herd issue.

To prevent this, we add a jitter.

https://mattermost.atlassian.net/browse/MM-47736

```release-note
NONE
```
