### PR TITLE
MM-46450: Enable skipped test

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -1027,8 +1027,9 @@ func TestGetUserByEmail(t *testing.T) {
 	})
 }
 
+// This test can flake if two calls to model.NewId can return the same value.
+// Not much can be done about it.
 func TestSearchUsers(t *testing.T) {
-	t.Skip("MM-46450")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 


### PR DESCRIPTION
After looking at this for some time, I don't see
any way for this test to fail other than model.NewId
returning the same value for BasicUser and BasicUser2.

I think edge cases like this can exist from time to time.
Nothing much we can do about it.

https://mattermost.atlassian.net/browse/MM-46450

```release-note
NONE
```
