### PR TITLE
Return empty list of channels when requested more channels at the end of cursor

### DIFF
--- a/api4/resolver_channel_test.go
+++ b/api4/resolver_channel_test.go
@@ -310,7 +310,7 @@ func TestGraphQLChannels(t *testing.T) {
 
 		resp, err = th.MakeGraphQLRequest(&input)
 		require.NoError(t, err)
-		require.Len(t, resp.Errors, 1) // no channels found
+		require.Len(t, resp.Errors, 0) // no errors for no channels found
 
 		th.BasicChannel.Purpose = "newpurpose"
 		_, _, err = th.Client.UpdateChannel(th.BasicChannel)

--- a/app/channel.go
+++ b/app/channel.go
@@ -1876,15 +1876,8 @@ func (a *App) GetChannelsForTeamForUser(c request.CTX, teamID string, userID str
 func (a *App) GetChannelsForTeamForUserWithCursor(c request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts, afterChannelID string) (model.ChannelList, *model.AppError) {
 	list, err := a.Srv().Store().Channel().GetChannelsWithCursor(teamID, userID, opts, afterChannelID)
 	if err != nil {
-		var nfErr *store.ErrNotFound
-		switch {
-		case errors.As(err, &nfErr):
-			return nil, model.NewAppError("GetChannelsForUser", "app.channel.get_channels.not_found.app_error", nil, "", http.StatusNotFound).Wrap(err)
-		default:
-			return nil, model.NewAppError("GetChannelsForUser", "app.channel.get_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
-		}
+		return nil, model.NewAppError("GetChannelsForUser", "app.channel.get_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-
 	return list, nil
 }
 

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -1110,10 +1110,6 @@ func (s SqlChannelStore) GetChannelsWithCursor(teamId string, userId string, opt
 		return nil, errors.Wrapf(err, "failed to get channels with TeamId=%s and UserId=%s", teamId, userId)
 	}
 
-	if len(channels) == 0 {
-		return nil, store.NewErrNotFound("Channel", "userId="+userId)
-	}
-
 	return channels, nil
 }
 

--- a/store/storetest/channel_store.go
+++ b/store/storetest/channel_store.go
@@ -3566,6 +3566,22 @@ func testChannelStoreGetChannelsWithCursor(t *testing.T, ss store.Store) {
 	require.Len(t, list, 1)
 	require.Equal(t, teamID, list[0].TeamId, "incorrect teamID")
 
+	// all channels should be returned
+	list, nErr = ss.Channel().GetChannelsWithCursor(o1.TeamId, m1.UserId, &model.ChannelSearchOpts{
+		IncludeDeleted: false,
+		LastDeleteAt:   0,
+	}, "")
+	require.NoError(t, nErr)
+	require.Len(t, list, 3)
+
+	// should return empty list
+	list, nErr = ss.Channel().GetChannelsWithCursor(o1.TeamId, m1.UserId, &model.ChannelSearchOpts{
+		IncludeDeleted: false,
+		LastDeleteAt:   0,
+	}, list[2].Id)
+	require.NoError(t, nErr)
+	require.Len(t, list, 0)
+
 	// Sleeping to guarantee that the
 	// UpdateAt is different.
 	// The proper way would be to set UpdateAt during channel creation itself,


### PR DESCRIPTION
#### Summary
In the scenario of getting channels with cursor at the last channel, no error should be thrown. Instead it should return empty array of channels to indicate no more channels are left for pagination.

Discussion https://community.mattermost.com/core/pl/ijqe8oanc7nt7k6hyis8hfk89c

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
