### PR TITLE
[MM-48058] Set OwnerId for bots created via EnsureBotUser

### DIFF
--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -1018,6 +1018,9 @@ func (api *PluginAPI) PermanentDeleteBot(userID string) *model.AppError {
 }
 
 func (api *PluginAPI) EnsureBotUser(bot *model.Bot) (string, error) {
+	// Bots created by a plugin should use the plugin's ID for the creator field.
+	bot.OwnerId = api.id
+
 	return api.app.EnsureBot(api.ctx, api.id, bot)
 }
 

--- a/app/plugin_api_tests/test_bots_plugin/main.go
+++ b/app/plugin_api_tests/test_bots_plugin/main.go
@@ -22,18 +22,18 @@ func (p *MyPlugin) OnConfigurationChange() error {
 }
 
 func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model.Post, string) {
-	createdBot, err := p.API.CreateBot(&model.Bot{
+	createdBot, appErr := p.API.CreateBot(&model.Bot{
 		Username:    "bot",
 		Description: "a plugin bot",
 	})
 
-	if err != nil {
-		return nil, err.Error() + "failed to create bot"
+	if appErr != nil {
+		return nil, appErr.Error() + "failed to create bot"
 	}
 
-	fetchedBot, err := p.API.GetBot(createdBot.UserId, false)
-	if err != nil {
-		return nil, err.Error() + "failed to get bot"
+	fetchedBot, appErr := p.API.GetBot(createdBot.UserId, false)
+	if appErr != nil {
+		return nil, appErr.Error() + "failed to get bot"
 	}
 	if fetchedBot.Description != "a plugin bot" {
 		return nil, "GetBot did not return the expected bot Description"
@@ -43,16 +43,16 @@ func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model
 	}
 
 	updatedDescription := createdBot.Description + ", updated"
-	patchedBot, err := p.API.PatchBot(createdBot.UserId, &model.BotPatch{
+	patchedBot, appErr := p.API.PatchBot(createdBot.UserId, &model.BotPatch{
 		Description: &updatedDescription,
 	})
-	if err != nil {
-		return nil, err.Error() + "failed to patch bot"
+	if appErr != nil {
+		return nil, appErr.Error() + "failed to patch bot"
 	}
 
-	fetchedBot, err = p.API.GetBot(patchedBot.UserId, false)
-	if err != nil {
-		return nil, err.Error() + "failed to get bot"
+	fetchedBot, appErr = p.API.GetBot(patchedBot.UserId, false)
+	if appErr != nil {
+		return nil, appErr.Error() + "failed to get bot"
 	}
 
 	if fetchedBot.UserId != patchedBot.UserId {
@@ -62,14 +62,14 @@ func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model
 		return nil, "GetBot did not return the updated bot Description"
 	}
 
-	fetchedBots, err := p.API.GetBots(&model.BotGetOptions{
+	fetchedBots, appErr := p.API.GetBots(&model.BotGetOptions{
 		Page:           0,
 		PerPage:        1,
 		OwnerId:        "",
 		IncludeDeleted: false,
 	})
-	if err != nil {
-		return nil, err.Error() + "failed to get bots"
+	if appErr != nil {
+		return nil, appErr.Error() + "failed to get bots"
 	}
 
 	if len(fetchedBots) != 1 {
@@ -79,8 +79,16 @@ func (p *MyPlugin) MessageWillBePosted(_ *plugin.Context, _ *model.Post) (*model
 	if fetchedBot.UserId != fetchedBots[0].UserId {
 		return nil, "GetBots did not return the expected bot"
 	}
-	if _, err = p.API.UpdateBotActive(fetchedBot.UserId, false); err != nil {
-		return nil, err.Error() + "failed to disable bot"
+	if _, appErr = p.API.UpdateBotActive(fetchedBot.UserId, false); appErr != nil {
+		return nil, appErr.Error() + "failed to disable bot"
+	}
+
+	_, err := p.API.EnsureBotUser(&model.Bot{
+		Username:    "bot2",
+		Description: "another plugin bot",
+	})
+	if err != nil {
+		return nil, err.Error() + "failed to create bot"
 	}
 
 	// TODO: investigate why the following code panics


### PR DESCRIPTION
#### Summary
In https://github.com/mattermost/mattermost-server/pull/20521 an `EnsureBotUser` endpoint was added to the pluginapi. In order to mirror the existing functionality of the `github.com/mattermost/mattermost-plugin-api` `EnsureBot` method, the `OwnderId` should always be set to the pluginID. Otherwise plugins updating to a newer version of `github.com/mattermost/mattermost-plugin-api` will error on startup. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48058

#### Release Note
```release-note
Set OwnerId for bots created via EnsureBotUser
```
