### PR TITLE
[MM-47378] Respond with bad requests for wrong query parameters 'roles' in getUsers

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -709,11 +709,22 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetInvalidParam("channelRoles")
 			return
 		}
+		channelRolesValid := model.AreValidChannelRoleNames(strings.Split(channelRolesString, ","))
+		if !channelRolesValid {
+			c.SetInvalidParam("channelRoles")
+			return
+		}
 	}
 	teamRoles := []string{}
 	if teamRolesString != "" && inTeamId != "" {
 		teamRoles, rolesValid = model.CleanRoleNames(strings.Split(teamRolesString, ","))
 		if !rolesValid {
+			c.SetInvalidParam("teamRoles")
+			return
+		}
+
+		teamRolesValid := model.AreValidTeamRoleNames(strings.Split(teamRolesString, ","))
+		if !teamRolesValid {
 			c.SetInvalidParam("teamRoles")
 			return
 		}

--- a/api4/user.go
+++ b/api4/user.go
@@ -699,7 +699,7 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		// fetch all role names
 		rolesAll, err := c.App.GetAllRoles()
 		if err != nil {
-			c.Err = model.NewAppError("Api4.getUsers", "api.user.get_users.app_error", nil, "Error fetching roles during validation.", http.StatusBadRequest)
+			c.Err = model.NewAppError("Api4.getUsers", "api.user.get_users.validation.app_error", nil, "Error fetching roles during validation.", http.StatusBadRequest)
 			return
 		}
 		for _, role := range rolesAll {

--- a/api4/user.go
+++ b/api4/user.go
@@ -706,9 +706,20 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			roleNamesAll = append(roleNamesAll, role.Name)
 		}
 	}
-
 	roles := []string{}
 	var rolesValid bool
+	if role != "" {
+		roles, rolesValid = model.CleanRoleNames([]string{role})
+		if !rolesValid {
+			c.SetInvalidParam("role")
+			return
+		}
+		roleValid := utils.StringInSlice(role, roleNamesAll)
+		if !roleValid {
+			c.SetInvalidParam("role")
+			return
+		}
+	}
 	if rolesString != "" {
 		roles, rolesValid = model.CleanRoleNames(strings.Split(rolesString, ","))
 		if !rolesValid {

--- a/api4/user.go
+++ b/api4/user.go
@@ -709,22 +709,11 @@ func getUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetInvalidParam("channelRoles")
 			return
 		}
-		channelRolesValid := model.AreValidChannelRoleNames(strings.Split(channelRolesString, ","))
-		if !channelRolesValid {
-			c.SetInvalidParam("channelRoles")
-			return
-		}
 	}
 	teamRoles := []string{}
 	if teamRolesString != "" && inTeamId != "" {
 		teamRoles, rolesValid = model.CleanRoleNames(strings.Split(teamRolesString, ","))
 		if !rolesValid {
-			c.SetInvalidParam("teamRoles")
-			return
-		}
-
-		teamRolesValid := model.AreValidTeamRoleNames(strings.Split(teamRolesString, ","))
-		if !teamRolesValid {
 			c.SetInvalidParam("teamRoles")
 			return
 		}

--- a/api4/user_local.go
+++ b/api4/user_local.go
@@ -78,6 +78,20 @@ func localGetUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var roles []string
 	var rolesValid bool
+
+	if role != "" {
+		_, rolesValid = model.CleanRoleNames([]string{role})
+		if !rolesValid {
+			c.SetInvalidParam("role")
+			return
+		}
+		roleValid := utils.StringInSlice(role, roleNamesAll)
+		if !roleValid {
+			c.SetInvalidParam("role")
+			return
+		}
+	}
+
 	if rolesString != "" {
 		roles, rolesValid = model.CleanRoleNames(strings.Split(rolesString, ","))
 		if !rolesValid {

--- a/api4/user_local.go
+++ b/api4/user_local.go
@@ -68,7 +68,7 @@ func localGetUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		// fetch all role names
 		rolesAll, err := c.App.GetAllRoles()
 		if err != nil {
-			c.Err = model.NewAppError("Api4.getUsers", "api.user.get_users.app_error", nil, "Error fetching roles during validation.", http.StatusBadRequest)
+			c.Err = model.NewAppError("Api4.getUsers", "api.user.get_users.validation.app_error", nil, "Error fetching roles during validation.", http.StatusBadRequest)
 			return
 		}
 		for _, role := range rolesAll {

--- a/api4/user_local.go
+++ b/api4/user_local.go
@@ -76,7 +76,7 @@ func localGetUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	roles := []string{}
+	var roles []string
 	var rolesValid bool
 	if rolesString != "" {
 		roles, rolesValid = model.CleanRoleNames(strings.Split(rolesString, ","))
@@ -90,7 +90,7 @@ func localGetUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	channelRoles := []string{}
+	var channelRoles []string
 	if channelRolesString != "" && inChannelId != "" {
 		channelRoles, rolesValid = model.CleanRoleNames(strings.Split(channelRolesString, ","))
 		if !rolesValid {
@@ -103,7 +103,7 @@ func localGetUsers(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	teamRoles := []string{}
+	var teamRoles []string
 	if teamRolesString != "" && inTeamId != "" {
 		teamRoles, rolesValid = model.CleanRoleNames(strings.Split(teamRolesString, ","))
 		if !rolesValid {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2369,6 +2369,10 @@ func TestGetUsers(t *testing.T) {
 		// Check default params for page and per_page
 		_, err = client.DoAPIGet("/users", "")
 		require.NoError(t, err)
+
+		// Check role params validity
+		_, _, err = client.GetUsersWithChannelRoles(0, 5, "random_role_which_doesntexist", "random_channel_id", "")
+		require.Error(t, err)
 	})
 
 	th.Client.Logout()

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2371,8 +2371,15 @@ func TestGetUsers(t *testing.T) {
 		require.NoError(t, err)
 
 		// Check role params validity
-		_, _, err = client.GetUsersWithChannelRoles(0, 5, "random_role_which_doesntexist", "random_channel_id", "")
+		_, _, err = client.GetUsersWithCustomQueryParameters(0, 5, "in_channel=random_channel_id&channel_roles=random_role_doesnt_exist", "")
 		require.Error(t, err)
+		require.Equal(t, err.Error(), ": Invalid or missing channelRoles in request body.")
+		_, _, err = client.GetUsersWithCustomQueryParameters(0, 5, "in_team=random_channel_id&team_roles=random_role_doesnt_exist", "")
+		require.Error(t, err)
+		require.Equal(t, err.Error(), ": Invalid or missing teamRoles in request body.")
+		_, _, err = client.GetUsersWithCustomQueryParameters(0, 5, "roles=random_role_doesnt_exist", "")
+		require.Error(t, err)
+		require.Equal(t, err.Error(), ": Invalid or missing roles in request body.")
 	})
 
 	th.Client.Logout()

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -2377,9 +2377,12 @@ func TestGetUsers(t *testing.T) {
 		_, _, err = client.GetUsersWithCustomQueryParameters(0, 5, "in_team=random_channel_id&team_roles=random_role_doesnt_exist", "")
 		require.Error(t, err)
 		require.Equal(t, err.Error(), ": Invalid or missing teamRoles in request body.")
-		_, _, err = client.GetUsersWithCustomQueryParameters(0, 5, "roles=random_role_doesnt_exist", "")
+		_, _, err = client.GetUsersWithCustomQueryParameters(0, 5, "roles=random_role_doesnt_exist%2Csystem_user", "")
 		require.Error(t, err)
 		require.Equal(t, err.Error(), ": Invalid or missing roles in request body.")
+		_, _, err = client.GetUsersWithCustomQueryParameters(0, 5, "role=random_role_doesnt_exist", "")
+		require.Error(t, err)
+		require.Equal(t, err.Error(), ": Invalid or missing role in request body.")
 	})
 
 	th.Client.Logout()

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4096,6 +4096,10 @@
     "translation": "Unable to get user by email."
   },
   {
+    "id": "api.user.get_users.validation.app_error",
+    "translation": "Error fetching roles during validation."
+  },
+  {
     "id": "api.user.invalidate_verify_email_tokens.error",
     "translation": "Unable to get tokens by type when invalidating email verification tokens"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -1051,6 +1051,24 @@ func (c *Client4) GetUsers(page int, perPage int, etag string) ([]*User, *Respon
 	return list, BuildResponse(r), nil
 }
 
+// GetUsersWithChannelRoles returns a page of users on the system. Page counting starts at 0.
+func (c *Client4) GetUsersWithChannelRoles(page int, perPage int, channelRoles, channelId, etag string) ([]*User, *Response, error) {
+	query := fmt.Sprintf("?page=%v&per_page=%v&channel_roles=%v&in_channel=%v", page, perPage, channelRoles, channelId)
+	r, err := c.DoAPIGet(c.usersRoute()+query, etag)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	var list []*User
+	if r.StatusCode == http.StatusNotModified {
+		return list, BuildResponse(r), nil
+	}
+	if err := json.NewDecoder(r.Body).Decode(&list); err != nil {
+		return nil, nil, NewAppError("GetUsers", "api.unmarshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	return list, BuildResponse(r), nil
+}
+
 // GetUsersInTeam returns a page of users on a team. Page counting starts at 0.
 func (c *Client4) GetUsersInTeam(teamId string, page int, perPage int, etag string) ([]*User, *Response, error) {
 	query := fmt.Sprintf("?in_team=%v&page=%v&per_page=%v", teamId, page, perPage)

--- a/model/client4.go
+++ b/model/client4.go
@@ -1052,8 +1052,8 @@ func (c *Client4) GetUsers(page int, perPage int, etag string) ([]*User, *Respon
 }
 
 // GetUsersWithChannelRoles returns a page of users on the system. Page counting starts at 0.
-func (c *Client4) GetUsersWithChannelRoles(page int, perPage int, channelRoles, channelId, etag string) ([]*User, *Response, error) {
-	query := fmt.Sprintf("?page=%v&per_page=%v&channel_roles=%v&in_channel=%v", page, perPage, channelRoles, channelId)
+func (c *Client4) GetUsersWithCustomQueryParameters(page int, perPage int, queryParameters, etag string) ([]*User, *Response, error) {
+	query := fmt.Sprintf("?page=%v&per_page=%v&%v", page, perPage, queryParameters)
 	r, err := c.DoAPIGet(c.usersRoute()+query, etag)
 	if err != nil {
 		return nil, BuildResponse(r), err

--- a/model/role.go
+++ b/model/role.go
@@ -726,24 +726,6 @@ func IsValidRoleName(roleName string) bool {
 	return true
 }
 
-func AreValidChannelRoleNames(roleNames []string) bool {
-	for _, roleName := range roleNames {
-		if stringNotInSlice(roleName, []string{ChannelGuestRoleId, ChannelUserRoleId, ChannelAdminRoleId}) {
-			return false
-		}
-	}
-	return true
-}
-
-func AreValidTeamRoleNames(roleNames []string) bool {
-	for _, roleName := range roleNames {
-		if stringNotInSlice(roleName, []string{TeamGuestRoleId, TeamUserRoleId, TeamAdminRoleId}) {
-			return false
-		}
-	}
-	return true
-}
-
 func MakeDefaultRoles() map[string]*Role {
 	roles := make(map[string]*Role)
 

--- a/model/role.go
+++ b/model/role.go
@@ -726,6 +726,24 @@ func IsValidRoleName(roleName string) bool {
 	return true
 }
 
+func AreValidChannelRoleNames(roleNames []string) bool {
+	for _, roleName := range roleNames {
+		if stringNotInSlice(roleName, []string{ChannelGuestRoleId, ChannelUserRoleId, ChannelAdminRoleId}) {
+			return false
+		}
+	}
+	return true
+}
+
+func AreValidTeamRoleNames(roleNames []string) bool {
+	for _, roleName := range roleNames {
+		if stringNotInSlice(roleName, []string{TeamGuestRoleId, TeamUserRoleId, TeamAdminRoleId}) {
+			return false
+		}
+	}
+	return true
+}
+
 func MakeDefaultRoles() map[string]*Role {
 	roles := make(map[string]*Role)
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
In `getUsers` API handler, we currently only check if parameters `role, roles, channelRoles, teamRoles` are checked for alphanumeric characters and `_`, but not for validity.

The endpoint returns empty result, while it should return 4xx. This PR adds validity checks to these parameters.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-47378
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added validity checks for role related parameters in GET /users
```
