### PR TITLE
MM-46610 Ignore the reader timeout for S3 files when importing

### DIFF
--- a/shared/filestore/s3store.go
+++ b/shared/filestore/s3store.go
@@ -214,9 +214,8 @@ type s3WithCancel struct {
 }
 
 func (sc *s3WithCancel) Close() error {
-	if sc.timer.Stop() {
-		sc.cancel()
-	}
+	sc.timer.Stop()
+	sc.cancel()
 	return sc.Object.Close()
 }
 

--- a/shared/filestore/s3store.go
+++ b/shared/filestore/s3store.go
@@ -209,25 +209,41 @@ func (b *S3FileBackend) MakeBucket() error {
 // when the object is closed.
 type s3WithCancel struct {
 	*s3.Object
+	timer  *time.Timer
 	cancel context.CancelFunc
 }
 
 func (sc *s3WithCancel) Close() error {
-	sc.cancel()
+	if sc.timer.Stop() {
+		sc.cancel()
+	}
 	return sc.Object.Close()
+}
+
+// CancelTimeout attempts to cancel the timeout for this reader. It allows calling
+// code to ignore the timeout in case of longer running operations. The methods returns
+// false if the timeout has already fired.
+func (sc *s3WithCancel) CancelTimeout() bool {
+	return sc.timer.Stop()
 }
 
 // Caller must close the first return value
 func (b *S3FileBackend) Reader(path string) (ReadCloseSeeker, error) {
 	path = filepath.Join(b.pathPrefix, path)
-	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	minioObject, err := b.client.GetObject(ctx, b.bucket, path, s3.GetObjectOptions{})
 	if err != nil {
 		cancel()
 		return nil, errors.Wrapf(err, "unable to open file %s", path)
 	}
 
-	return &s3WithCancel{Object: minioObject, cancel: cancel}, nil
+	sc := &s3WithCancel{
+		Object: minioObject,
+		timer:  time.AfterFunc(b.timeout, cancel),
+		cancel: cancel,
+	}
+
+	return sc, nil
 }
 
 func (b *S3FileBackend) ReadFile(path string) ([]byte, error) {

--- a/shared/filestore/s3store_test.go
+++ b/shared/filestore/s3store_test.go
@@ -200,8 +200,11 @@ func newTLSProxyServer(backend *url.URL) *httptest.Server {
 }
 
 func TestS3WithCancel(t *testing.T) {
+	// Some of these tests use time.Sleep to wait for the timeout to expire.
+	// They are run in parallel to reduce wait times.
+
 	t.Run("zero timeout", func(t *testing.T) {
-		t.Parallel() // some of these tests need to sleep, speed things up
+		t.Parallel()
 		r, ctx := newMockS3WithCancel(0, nil)
 
 		time.Sleep(10 * time.Millisecond) // give the context time to cancel
@@ -211,7 +214,7 @@ func TestS3WithCancel(t *testing.T) {
 	})
 
 	t.Run("timeout", func(t *testing.T) {
-		t.Parallel() // some of these tests need to sleep, speed things up
+		t.Parallel()
 		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
 
 		time.Sleep(100 * time.Millisecond) // give the context time to cancel
@@ -221,7 +224,7 @@ func TestS3WithCancel(t *testing.T) {
 	})
 
 	t.Run("timeout cancel", func(t *testing.T) {
-		t.Parallel() // some of these tests need to sleep, speed things up
+		t.Parallel()
 		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
 
 		time.Sleep(10 * time.Millisecond) // give the context time to cancel
@@ -237,7 +240,7 @@ func TestS3WithCancel(t *testing.T) {
 	})
 
 	t.Run("timeout closed", func(t *testing.T) {
-		t.Parallel() // some of these tests need to sleep, speed things up
+		t.Parallel()
 		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
 
 		time.Sleep(10 * time.Millisecond) // give the context time to cancel
@@ -254,7 +257,7 @@ func TestS3WithCancel(t *testing.T) {
 	})
 
 	t.Run("close cancel close", func(t *testing.T) {
-		t.Parallel() // some of these tests need to sleep, speed things up
+		t.Parallel()
 		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
 
 		time.Sleep(10 * time.Millisecond) // give the context time to cancel
@@ -268,7 +271,7 @@ func TestS3WithCancel(t *testing.T) {
 	})
 
 	t.Run("close error", func(t *testing.T) {
-		t.Parallel() // some of these tests need to sleep, speed things up
+		t.Parallel()
 		r, ctx := newMockS3WithCancel(50*time.Millisecond, errors.New("test error"))
 
 		time.Sleep(10 * time.Millisecond) // give the context time to cancel

--- a/shared/filestore/s3store_test.go
+++ b/shared/filestore/s3store_test.go
@@ -10,12 +10,14 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -195,4 +197,103 @@ func TestInsecureMakeBucket(t *testing.T) {
 }
 func newTLSProxyServer(backend *url.URL) *httptest.Server {
 	return httptest.NewTLSServer(httputil.NewSingleHostReverseProxy(backend))
+}
+
+func TestS3WithCancel(t *testing.T) {
+	t.Run("zero timeout", func(t *testing.T) {
+		t.Parallel() // some of these tests need to sleep, speed things up
+		r, ctx := newMockS3WithCancel(0, nil)
+
+		time.Sleep(10 * time.Millisecond) // give the context time to cancel
+
+		require.False(t, r.CancelTimeout())
+		require.Error(t, ctx.Err())
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		t.Parallel() // some of these tests need to sleep, speed things up
+		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
+
+		time.Sleep(100 * time.Millisecond) // give the context time to cancel
+
+		require.False(t, r.CancelTimeout())
+		require.Error(t, ctx.Err())
+	})
+
+	t.Run("timeout cancel", func(t *testing.T) {
+		t.Parallel() // some of these tests need to sleep, speed things up
+		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
+
+		time.Sleep(10 * time.Millisecond) // give the context time to cancel
+
+		require.True(t, r.CancelTimeout())
+		require.NoError(t, ctx.Err())
+
+		time.Sleep(100 * time.Millisecond) // wait for the original (canceled) timeout to expire
+
+		require.False(t, r.CancelTimeout())
+		require.NoError(t, ctx.Err())
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("timeout closed", func(t *testing.T) {
+		t.Parallel() // some of these tests need to sleep, speed things up
+		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
+
+		time.Sleep(10 * time.Millisecond) // give the context time to cancel
+
+		require.True(t, r.CancelTimeout())
+		require.NoError(t, ctx.Err())
+		require.NoError(t, r.Close())
+
+		time.Sleep(100 * time.Millisecond) // wait for the original (canceled) timeout to expire
+
+		require.False(t, r.CancelTimeout())
+		require.Error(t, ctx.Err())
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("close cancel close", func(t *testing.T) {
+		t.Parallel() // some of these tests need to sleep, speed things up
+		r, ctx := newMockS3WithCancel(50*time.Millisecond, nil)
+
+		time.Sleep(10 * time.Millisecond) // give the context time to cancel
+
+		require.True(t, r.CancelTimeout())
+		require.NoError(t, r.Close())
+		require.Error(t, ctx.Err())
+		require.False(t, r.CancelTimeout())
+		require.Error(t, ctx.Err())
+		require.NoError(t, r.Close())
+	})
+
+	t.Run("close error", func(t *testing.T) {
+		t.Parallel() // some of these tests need to sleep, speed things up
+		r, ctx := newMockS3WithCancel(50*time.Millisecond, errors.New("test error"))
+
+		time.Sleep(10 * time.Millisecond) // give the context time to cancel
+
+		require.NoError(t, ctx.Err())
+		require.Error(t, r.Close())
+		require.False(t, r.CancelTimeout())
+		require.Error(t, ctx.Err())
+	})
+}
+
+func newMockS3WithCancel(timeout time.Duration, closeErr error) (*s3WithCancel, context.Context) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &s3WithCancel{
+		ReadSeekCloser: fauxCloser{strings.NewReader("testdata"), closeErr},
+		timer:          time.AfterFunc(timeout, cancel),
+		cancel:         cancel,
+	}, ctx
+}
+
+type fauxCloser struct {
+	io.ReadSeeker
+	closeErr error
+}
+
+func (fc fauxCloser) Close() error {
+	return fc.closeErr
 }


### PR DESCRIPTION
#### Summary
Due to the size of import archives, the reader may run into timeouts when importing from an S3 file. This PR adds functionality to cancel the timeout for S3 readers. Caveat: Unreasonably low timeouts may still cancel the request before it's passed back to the import job.

#### Ticket Link
[MM-46610](https://mattermost.atlassian.net/browse/MM-46610)

#### Release Note
```release-note
NONE
```
