### PR TITLE
Run go vet before golangci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,7 @@ jobs:
       - run:
           command: |
             cd mattermost-server
+            go vet ./...
             make golangci-lint
   # Dedicate job for mattermost-vet to make more clear when the job fails
   check-mattermost-vet:


### PR DESCRIPTION
golangci has terrible error messages
if the code doesn't compile or there
are some basic errors. Doing a go vet
check is a quick way to eliminate any
head scratching.

```release-note
NONE
```
