### PR TITLE
Support emails search in Postgres

### DIFF
--- a/store/searchtest/post_layer.go
+++ b/store/searchtest/post_layer.go
@@ -37,7 +37,12 @@ var searchPostStoreTests = []searchTest{
 	{
 		Name: "Should be able to search for email addresses with or without quotes",
 		Fn:   testSearchEmailAddresses,
-		Tags: []string{EngineElasticSearch},
+		Tags: []string{EnginePostgres, EngineElasticSearch},
+	},
+	{
+		Name: "Should be able to search for email addresses with quotes",
+		Fn:   testSearchEmailAddressesWithQuotes,
+		Tags: []string{EngineMySql},
 	},
 	{
 		Name: "Should be able to search when markdown underscores are applied",
@@ -243,11 +248,6 @@ var searchPostStoreTests = []searchTest{
 		Tags: []string{EngineMySql, EngineElasticSearch},
 	},
 	{
-		Name: "Should be able to search emails without quoting them",
-		Fn:   testSearchEmailsWithoutQuotes,
-		Tags: []string{EngineElasticSearch},
-	},
-	{
 		Name: "Should be able to search in comments",
 		Fn:   testSupportSearchInComments,
 		Tags: []string{EngineAll},
@@ -366,9 +366,9 @@ func testSearchExactPhraseInQuotes(t *testing.T, th *SearchTestHelper) {
 }
 
 func testSearchEmailAddresses(t *testing.T, th *SearchTestHelper) {
-	p1, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "test email test@test.com", "", model.PostTypeDefault, 0, false)
+	p1, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "email test@test.com", "", model.PostTypeDefault, 0, false)
 	require.NoError(t, err)
-	_, err = th.createPost(th.User.Id, th.ChannelBasic.Id, "test email test2@test.com", "", model.PostTypeDefault, 0, false)
+	_, err = th.createPost(th.User.Id, th.ChannelBasic.Id, "email test2@test.com", "", model.PostTypeDefault, 0, false)
 	require.NoError(t, err)
 	defer th.deleteUserPosts(th.User.Id)
 
@@ -389,6 +389,22 @@ func testSearchEmailAddresses(t *testing.T, th *SearchTestHelper) {
 		require.Len(t, results.Posts, 1)
 		th.checkPostInSearchResults(t, p1.Id, results.Posts)
 	})
+}
+
+// MySql supports search with quotes only
+func testSearchEmailAddressesWithQuotes(t *testing.T, th *SearchTestHelper) {
+	p1, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "email test@test.com", "", model.PostTypeDefault, 0, false)
+	require.NoError(t, err)
+	_, err = th.createPost(th.User.Id, th.ChannelBasic.Id, "email test2@test.com", "", model.PostTypeDefault, 0, false)
+	require.NoError(t, err)
+	defer th.deleteUserPosts(th.User.Id)
+
+	params := &model.SearchParams{Terms: "\"test@test.com\""}
+	results, err := th.Store.Post().SearchPostsForUser([]*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
+	require.NoError(t, err)
+
+	require.Len(t, results.Posts, 1)
+	th.checkPostInSearchResults(t, p1.Id, results.Posts)
 }
 
 func testSearchMarkdownUnderscores(t *testing.T, th *SearchTestHelper) {
@@ -1763,21 +1779,6 @@ func testSlashShouldNotBeCharSeparator(t *testing.T, th *SearchTestHelper) {
 
 	params = &model.SearchParams{Terms: "alpha"}
 	results, err = th.Store.Post().SearchPostsForUser([]*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
-	require.NoError(t, err)
-
-	require.Len(t, results.Posts, 1)
-	th.checkPostInSearchResults(t, p1.Id, results.Posts)
-}
-
-func testSearchEmailsWithoutQuotes(t *testing.T, th *SearchTestHelper) {
-	p1, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "message test@test.com", "", model.PostTypeDefault, 0, false)
-	require.NoError(t, err)
-	_, err = th.createPost(th.User.Id, th.ChannelBasic.Id, "message test2@test.com", "", model.PostTypeDefault, 0, false)
-	require.NoError(t, err)
-	defer th.deleteUserPosts(th.User.Id)
-
-	params := &model.SearchParams{Terms: "test@test.com"}
-	results, err := th.Store.Post().SearchPostsForUser([]*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
 	require.NoError(t, err)
 
 	require.Len(t, results.Posts, 1)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Enables emails search for Postgres DB with or without "quotes". 
MySql already supports emails search but with "quotes" only.

Currently some special-chars including "@" gets replaced in the search-term, but not in the source string(Message column). 
This PR makes the source string more equivalent to the search-term by replacing the same set of special-chars.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA - https://mattermost.atlassian.net/browse/MM-5046

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed emails search when using Postgres DB.
```
