### PR TITLE
MM-47865 - remove deprecated guided channel creation ff

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -42,9 +42,6 @@ type FeatureFlags struct {
 	// A dash separated list for feature flags to turn on for Boards
 	BoardsFeatureFlags string
 
-	// Enable Create First Channel
-	GuidedChannelCreation bool
-
 	// A/B test for whether radio buttons or toggle button is more effective in in-screen invite to team modal ("none", "toggle")
 	InviteToTeam string
 
@@ -98,7 +95,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PermalinkPreviews = true
 	f.CallsMobile = false
 	f.BoardsFeatureFlags = ""
-	f.GuidedChannelCreation = false
 	f.InviteToTeam = "none"
 	f.CustomGroups = true
 	f.BoardsDataRetention = false


### PR DESCRIPTION
#### Summary
remove deprecated guided channel creation ff

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47865

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/11551

#### Release Note
```release-note
NONE
```
