### PR TITLE
Skip flaky test TestRequestTrialLicense/trial_license_user_count_less_than_current_users

### DIFF
--- a/api4/license_test.go
+++ b/api4/license_test.go
@@ -242,6 +242,7 @@ func TestRequestTrialLicense(t *testing.T) {
 	})
 
 	t.Run("trial license user count less than current users", func(t *testing.T) {
+		t.Skip("MM-48416")
 		nUsers := 1
 		license := model.NewTestLicense()
 		license.Features.Users = model.NewInt(nUsers)


### PR DESCRIPTION
#### Summary
Skip flaky test.

Ticket to fix it assigned to Suite Users team, who created it [last year](https://github.com/mattermost/mattermost-server/pull/17359): https://mattermost.atlassian.net/browse/MM-48416

#### Ticket Link
--
#### Release Note
```release-note
NONE
```
