### PR TITLE
[MM-48523] Expose resumable uploads API to plugins

### DIFF
--- a/api4/upload.go
+++ b/api4/upload.go
@@ -65,6 +65,13 @@ func createUpload(c *Context, w http.ResponseWriter, r *http.Request) {
 	if c.AppContext.Session().UserId != "" {
 		us.UserId = c.AppContext.Session().UserId
 	}
+
+	if us.FileSize > *c.App.Config().FileSettings.MaxFileSize {
+		c.Err = model.NewAppError("createUpload", "api.upload.create.upload_too_large.app_error",
+			map[string]any{"channelId": us.ChannelId}, "", http.StatusRequestEntityTooLarge)
+		return
+	}
+
 	rus, err := c.App.CreateUploadSession(c.AppContext, &us)
 	if err != nil {
 		c.Err = err

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -1237,3 +1237,27 @@ func (api *PluginAPI) GetCloudLimits() (*model.ProductLimits, error) {
 func (api *PluginAPI) RegisterCollectionAndTopic(collectionType, topicType string) error {
 	return api.app.registerCollectionAndTopic(api.id, collectionType, topicType)
 }
+
+func (api *PluginAPI) CreateUploadSession(us *model.UploadSession) (*model.UploadSession, error) {
+	us, err := api.app.CreateUploadSession(api.ctx, us)
+	if err != nil {
+		return nil, err
+	}
+	return us, nil
+}
+
+func (api *PluginAPI) UploadData(us *model.UploadSession, rd io.Reader) (*model.FileInfo, error) {
+	fi, err := api.app.UploadData(api.ctx, us, rd)
+	if err != nil {
+		return nil, err
+	}
+	return fi, nil
+}
+
+func (api *PluginAPI) GetUploadSession(uploadID string) (*model.UploadSession, error) {
+	fi, err := api.app.GetUploadSession(uploadID)
+	if err != nil {
+		return nil, err
+	}
+	return fi, nil
+}

--- a/app/upload.go
+++ b/app/upload.go
@@ -127,11 +127,6 @@ func (a *App) runPluginsHook(c *request.Context, info *model.FileInfo, file io.R
 }
 
 func (a *App) CreateUploadSession(c request.CTX, us *model.UploadSession) (*model.UploadSession, *model.AppError) {
-	if us.FileSize > *a.Config().FileSettings.MaxFileSize {
-		return nil, model.NewAppError("CreateUploadSession", "app.upload.create.upload_too_large.app_error",
-			map[string]any{"channelId": us.ChannelId}, "", http.StatusRequestEntityTooLarge)
-	}
-
 	us.FileOffset = 0
 	now := time.Now()
 	us.CreateAt = model.GetMillisForTime(now)

--- a/app/upload_test.go
+++ b/app/upload_test.go
@@ -32,16 +32,6 @@ func TestCreateUploadSession(t *testing.T) {
 		FileSize:  8 * 1024 * 1024,
 	}
 
-	t.Run("FileSize over limit", func(t *testing.T) {
-		maxFileSize := *th.App.Config().FileSettings.MaxFileSize
-		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.MaxFileSize = us.FileSize - 1 })
-		defer th.App.UpdateConfig(func(cfg *model.Config) { *cfg.FileSettings.MaxFileSize = maxFileSize })
-		u, err := th.App.CreateUploadSession(th.Context, us)
-		require.NotNil(t, err)
-		require.Equal(t, "app.upload.create.upload_too_large.app_error", err.Id)
-		require.Nil(t, u)
-	})
-
 	t.Run("invalid Id", func(t *testing.T) {
 		u, err := th.App.CreateUploadSession(th.Context, us)
 		require.NotNil(t, err)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3908,6 +3908,10 @@
     "translation": "Mattermost was unable to upgrade to Enterprise Edition. The digital signature of the downloaded binary file could not be verified."
   },
   {
+    "id": "api.upload.create.upload_too_large.app_error",
+    "translation": "Unable to upload file. File is too large."
+  },
+  {
     "id": "api.upload.get_upload.forbidden.app_error",
     "translation": "Failed to get upload."
   },
@@ -6534,10 +6538,6 @@
   {
     "id": "app.upload.create.save.app_error",
     "translation": "Failed to save upload."
-  },
-  {
-    "id": "app.upload.create.upload_too_large.app_error",
-    "translation": "Unable to upload file. File is too large."
   },
   {
     "id": "app.upload.get.app_error",

--- a/plugin/api.go
+++ b/plugin/api.go
@@ -1168,6 +1168,24 @@ type API interface {
 	//
 	// Minimum server version: 7.6
 	RegisterCollectionAndTopic(collectionType, topicType string) error
+
+	// CreateUploadSession creates and returns a new (resumable) upload session.
+	//
+	// @tag Upload
+	// Minimum server version: 7.6
+	CreateUploadSession(us *model.UploadSession) (*model.UploadSession, error)
+
+	// UploadData uploads the data for a given upload session.
+	//
+	// @tag Upload
+	// Minimum server version: 7.6
+	UploadData(us *model.UploadSession, rd io.Reader) (*model.FileInfo, error)
+
+	// GetUploadSession returns the upload session for the provided id.
+	//
+	// @tag Upload
+	// Minimum server version: 7.6
+	GetUploadSession(uploadID string) (*model.UploadSession, error)
 }
 
 var handshake = plugin.HandshakeConfig{

--- a/plugin/api_timer_layer_generated.go
+++ b/plugin/api_timer_layer_generated.go
@@ -1246,3 +1246,24 @@ func (api *apiTimerLayer) RegisterCollectionAndTopic(collectionType, topicType s
 	api.recordTime(startTime, "RegisterCollectionAndTopic", _returnsA == nil)
 	return _returnsA
 }
+
+func (api *apiTimerLayer) CreateUploadSession(us *model.UploadSession) (*model.UploadSession, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.CreateUploadSession(us)
+	api.recordTime(startTime, "CreateUploadSession", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
+func (api *apiTimerLayer) UploadData(us *model.UploadSession, rd io.Reader) (*model.FileInfo, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.UploadData(us, rd)
+	api.recordTime(startTime, "UploadData", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
+func (api *apiTimerLayer) GetUploadSession(uploadID string) (*model.UploadSession, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.GetUploadSession(uploadID)
+	api.recordTime(startTime, "GetUploadSession", _returnsB == nil)
+	return _returnsA, _returnsB
+}

--- a/plugin/client_rpc_generated.go
+++ b/plugin/client_rpc_generated.go
@@ -5968,3 +5968,63 @@ func (s *apiRPCServer) RegisterCollectionAndTopic(args *Z_RegisterCollectionAndT
 	}
 	return nil
 }
+
+type Z_CreateUploadSessionArgs struct {
+	A *model.UploadSession
+}
+
+type Z_CreateUploadSessionReturns struct {
+	A *model.UploadSession
+	B error
+}
+
+func (g *apiRPCClient) CreateUploadSession(us *model.UploadSession) (*model.UploadSession, error) {
+	_args := &Z_CreateUploadSessionArgs{us}
+	_returns := &Z_CreateUploadSessionReturns{}
+	if err := g.client.Call("Plugin.CreateUploadSession", _args, _returns); err != nil {
+		log.Printf("RPC call to CreateUploadSession API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) CreateUploadSession(args *Z_CreateUploadSessionArgs, returns *Z_CreateUploadSessionReturns) error {
+	if hook, ok := s.impl.(interface {
+		CreateUploadSession(us *model.UploadSession) (*model.UploadSession, error)
+	}); ok {
+		returns.A, returns.B = hook.CreateUploadSession(args.A)
+		returns.B = encodableError(returns.B)
+	} else {
+		return encodableError(fmt.Errorf("API CreateUploadSession called but not implemented."))
+	}
+	return nil
+}
+
+type Z_GetUploadSessionArgs struct {
+	A string
+}
+
+type Z_GetUploadSessionReturns struct {
+	A *model.UploadSession
+	B error
+}
+
+func (g *apiRPCClient) GetUploadSession(uploadID string) (*model.UploadSession, error) {
+	_args := &Z_GetUploadSessionArgs{uploadID}
+	_returns := &Z_GetUploadSessionReturns{}
+	if err := g.client.Call("Plugin.GetUploadSession", _args, _returns); err != nil {
+		log.Printf("RPC call to GetUploadSession API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) GetUploadSession(args *Z_GetUploadSessionArgs, returns *Z_GetUploadSessionReturns) error {
+	if hook, ok := s.impl.(interface {
+		GetUploadSession(uploadID string) (*model.UploadSession, error)
+	}); ok {
+		returns.A, returns.B = hook.GetUploadSession(args.A)
+		returns.B = encodableError(returns.B)
+	} else {
+		return encodableError(fmt.Errorf("API GetUploadSession called but not implemented."))
+	}
+	return nil
+}

--- a/plugin/interface_generator/main.go
+++ b/plugin/interface_generator/main.go
@@ -35,6 +35,7 @@ var excludedPluginHooks = []string{
 	"OnActivate",
 	"PluginHTTP",
 	"ServeHTTP",
+	"UploadData",
 }
 
 var excludedProductHooks = []string{

--- a/plugin/plugintest/api.go
+++ b/plugin/plugintest/api.go
@@ -391,6 +391,29 @@ func (_m *API) CreateTeamMembersGracefully(teamID string, userIds []string, requ
 	return r0, r1
 }
 
+// CreateUploadSession provides a mock function with given fields: us
+func (_m *API) CreateUploadSession(us *model.UploadSession) (*model.UploadSession, error) {
+	ret := _m.Called(us)
+
+	var r0 *model.UploadSession
+	if rf, ok := ret.Get(0).(func(*model.UploadSession) *model.UploadSession); ok {
+		r0 = rf(us)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.UploadSession)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*model.UploadSession) error); ok {
+		r1 = rf(us)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // CreateUser provides a mock function with given fields: user
 func (_m *API) CreateUser(user *model.User) (*model.User, *model.AppError) {
 	ret := _m.Called(user)
@@ -2181,6 +2204,29 @@ func (_m *API) GetUnsanitizedConfig() *model.Config {
 	return r0
 }
 
+// GetUploadSession provides a mock function with given fields: uploadID
+func (_m *API) GetUploadSession(uploadID string) (*model.UploadSession, error) {
+	ret := _m.Called(uploadID)
+
+	var r0 *model.UploadSession
+	if rf, ok := ret.Get(0).(func(string) *model.UploadSession); ok {
+		r0 = rf(uploadID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.UploadSession)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(uploadID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetUser provides a mock function with given fields: userID
 func (_m *API) GetUser(userID string) (*model.User, *model.AppError) {
 	ret := _m.Called(userID)
@@ -3712,6 +3758,29 @@ func (_m *API) UpdateUserStatus(userID string, status string) (*model.Status, *m
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)
 		}
+	}
+
+	return r0, r1
+}
+
+// UploadData provides a mock function with given fields: us, rd
+func (_m *API) UploadData(us *model.UploadSession, rd io.Reader) (*model.FileInfo, error) {
+	ret := _m.Called(us, rd)
+
+	var r0 *model.FileInfo
+	if rf, ok := ret.Get(0).(func(*model.UploadSession, io.Reader) *model.FileInfo); ok {
+		r0 = rf(us, rd)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.FileInfo)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*model.UploadSession, io.Reader) error); ok {
+		r1 = rf(us, rd)
+	} else {
+		r1 = ret.Error(1)
 	}
 
 	return r0, r1


### PR DESCRIPTION
#### Summary

PR exposes the existing resumable uploads API to the plugins side. This change is currently required by Calls as we need some extra flexibility to deal with recording files, such as being able to upload into any channel (DMs included) and potentially bypassing the configured max file size (to be confirmed).

I am testing a bit locally that the uploaded data is properly buffered and no unexpected allocation happens due to having to go through the RPC layer. Everything is looking good so far.

@amyblais This PR is a requirement for the upcoming Calls release so looking to include it in 7.6

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48523

#### Release Note

```release-note
Exposed the resumable uploads API to plugins.
```

