### PR TITLE
[MM-47760] Bugfix: Don't return threads with lastReplyAt of 0

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -2435,7 +2435,13 @@ func (a *App) GetThreadsForUser(userID, teamID string, options model.GetUserThre
 			if err != nil {
 				return errors.Wrapf(err, "failed to get threads for user id=%s", userID)
 			}
-			result.Threads = threads
+			var filteredThreads []*model.ThreadResponse
+			for _, thread := range threads {
+				if thread.LastReplyAt != 0 {
+					filteredThreads = append(filteredThreads, thread)
+				}
+			}
+			result.Threads = filteredThreads
 
 			return nil
 		})


### PR DESCRIPTION
#### Summary
Update GetThreadsForUser to filter out threads with a lastReplyAt value of 0, which is only applied to the thread when all replies have been deleted.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-47760

### Webapp changes

https://github.com/mattermost/mattermost-webapp/pull/11618

#### Release Note

```release-note
Fixed a bug where threads with no remaining replies are sent
```
