### PR TITLE
[MM-48560] LastAccessiblePostTime not removed on upgrade to Professional

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -1392,7 +1392,6 @@ func (a *App) ComputeLastAccessibleFileTime() error {
 			default:
 				return model.NewAppError("ComputeLastAccessibleFileTime", "app.system.get_by_name.app_error", nil, err.Error(), http.StatusInternalServerError)
 			}
-
 		}
 		if systemValue != nil {
 			// Previous value was set, so we must clear it

--- a/app/file.go
+++ b/app/file.go
@@ -1380,6 +1380,29 @@ func (a *App) ComputeLastAccessibleFileTime() error {
 		return appErr
 	}
 
+	if limit == 0 {
+		// All files are accessible - we must check if a previous value was set so we can clear it
+		systemValue, err := a.Srv().Store().System().GetByName(model.SystemLastAccessibleFileTime)
+		if err != nil {
+			var nfErr *store.ErrNotFound
+			switch {
+			case errors.As(err, &nfErr):
+				// All files are already accessible
+				return nil
+			default:
+				return model.NewAppError("ComputeLastAccessibleFileTime", "app.system.get_by_name.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
+
+		}
+		if systemValue != nil {
+			// Previous value was set, so we must clear it
+			if _, err := a.Srv().Store().System().PermanentDeleteByName(model.SystemLastAccessibleFileTime); err != nil {
+				return model.NewAppError("ComputeLastAccessibleFileTime", "app.system.permanent_delete_by_name.app_error", nil, err.Error(), http.StatusInternalServerError)
+			}
+		}
+		return nil
+	}
+
 	createdAt, err := a.Srv().GetStore().FileInfo().GetUptoNSizeFileTime(limit)
 	if err != nil {
 		var nfErr *store.ErrNotFound

--- a/app/post_test.go
+++ b/app/post_test.go
@@ -2887,7 +2887,7 @@ func TestComputeLastAccessiblePostTime(t *testing.T) {
 		mockSystemStore.AssertCalled(t, "SaveOrUpdate", mock.Anything)
 	})
 
-	t.Run("Do NOT update the time, if cloud limit is NOT applicable", func(t *testing.T) {
+	t.Run("Remove the time if cloud limit is NOT applicable", func(t *testing.T) {
 		th := SetupWithStoreMock(t)
 		defer th.TearDown()
 
@@ -2901,13 +2901,15 @@ func TestComputeLastAccessiblePostTime(t *testing.T) {
 
 		mockStore := th.App.Srv().Store().(*storemocks.Store)
 		mockSystemStore := storemocks.SystemStore{}
-		mockSystemStore.On("SaveOrUpdate", mock.Anything).Return(nil)
+		mockSystemStore.On("GetByName", mock.Anything).Return(&model.System{Name: model.SystemLastAccessiblePostTime, Value: "10"}, nil)
+		mockSystemStore.On("PermanentDeleteByName", mock.Anything).Return(nil, nil)
 		mockStore.On("System").Return(&mockSystemStore)
 
 		err := th.App.ComputeLastAccessiblePostTime()
 		assert.NoError(t, err)
 
 		mockSystemStore.AssertNotCalled(t, "SaveOrUpdate", mock.Anything)
+		mockSystemStore.AssertCalled(t, "PermanentDeleteByName", mock.Anything)
 	})
 }
 


### PR DESCRIPTION
#### Summary
The logic for ComputeLastAccessiblePostTime was not clearing the System store value in the event the limits were 0 - this causes the value to not be cleared after an upgrade from Starter to Professional, keeping the history limit. 

This PR will remove both the LastAccessiblePostTime and LastAccessibleFileTime if the limits for each are nil/0  (with the way LastAccessibleFileTime was implemented it's technically not a problem as it will store CreateAt `0` - but added the delete so both implementations are similar) 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48560

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
None
```
