### PR TITLE
[CLD-4570] Disable CodeQL Auto Build

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build
       run: |
         make setup-go-work
-        make build-linux
+        make build-linux-amd64
 
     # Perform Analysis
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,9 +34,9 @@ jobs:
         debug: false
         config-file: ./.github/codeql/codeql-config.yml              
     
-    # Autobuild attempts to build any compiled languages
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2    
+    - name: Build
+      run: |
+        make build
 
     # Perform Analysis
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,7 +36,8 @@ jobs:
     
     - name: Build
       run: |
-        make build
+        make setup-go-work
+        make build-linux
 
     # Perform Analysis
     - name: Perform CodeQL Analysis

--- a/build/release.mk
+++ b/build/release.mk
@@ -1,6 +1,8 @@
 dist: | check-style test package
 
-build-linux:
+build-linux: build-linux-amd64 build-linux-arm64
+
+build-linux-amd64:
 	@echo Build Linux amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
 	env GOOS=linux GOARCH=amd64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -ldflags '$(LDFLAGS)' ./...
@@ -8,6 +10,8 @@ else
 	mkdir -p $(GOBIN)/linux_amd64
 	env GOOS=linux GOARCH=amd64 $(GO) build -o $(GOBIN)/linux_amd64 $(GOFLAGS) -trimpath -ldflags '$(LDFLAGS)' ./...
 endif
+
+build-linux-arm64:
 	@echo Build Linux arm64
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_arm64")
 	env GOOS=linux GOARCH=arm64 $(GO) build -o $(GOBIN) $(GOFLAGS) -trimpath -ldflags '$(LDFLAGS)' ./...


### PR DESCRIPTION
#### Summary
We are using CodeQL Autobuild which is by default running `make` to create a build for Mattermost server. The challenge is that our default target for `make` is running `make run`, resulting CodeQL to be in an infinite loop as the process is running. We may want to consider changing that, as `make` default target is usually to create a build vs running it.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4570

#### Release Note
```release-note
NONE
```
