### PR TITLE
app/plugin: fix a possible panic while accessing plugins env for telemetry

### DIFF
--- a/api4/websocket.go
+++ b/api4/websocket.go
@@ -61,7 +61,7 @@ func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	wc := c.App.Srv().Platform().NewWebConn(cfg, c.App, c.App.PluginService().GetPluginsEnvironment)
+	wc := c.App.Srv().Platform().NewWebConn(cfg, c.App, c.App.GetPluginsEnvironment)
 	if c.AppContext.Session().UserId != "" {
 		c.App.Srv().Platform().HubRegister(wc)
 	}

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -177,6 +177,12 @@ func (s *PluginService) GetPluginsEnvironment() *plugin.Environment {
 // To get the plugins environment when the plugins are disabled, manually acquire the plugins
 // lock instead.
 func (a *App) GetPluginsEnvironment() *plugin.Environment {
+	// TODO: Telemetry service starts before products start, so we need to check if the plugin service is initialized.
+	// Move the telemetry service to start after products start.
+	if a.ch.srv.pluginService == nil {
+		return nil
+	}
+
 	return a.ch.srv.pluginService.GetPluginsEnvironment()
 }
 

--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -16,5 +16,5 @@ func (a *App) PopulateWebConnConfig(s *model.Session, cfg *platform.WebConnConfi
 
 // NewWebConn returns a new WebConn instance.
 func (a *App) NewWebConn(cfg *platform.WebConnConfig) *platform.WebConn {
-	return a.Srv().Platform().NewWebConn(cfg, a, a.Srv().pluginService.GetPluginsEnvironment)
+	return a.Srv().Platform().NewWebConn(cfg, a, a.GetPluginsEnvironment)
 }


### PR DESCRIPTION

#### Summary

We are trying to access plugins environment from `app.PluginService`, which is initialized after the Channels product. But we start the telemetries before starting products. And the telemetry service is trying to access plugins environment from PluginService after recent MPA refactor. Hence, we need to add a `nil` check to pluginService instead of environment. The behavior will remain the same, but in any case this needs to be reviewed therefore added a comment.

#### Release Note

```release-note
NONE
```
