### PR TITLE
Skip flaky test GetUptoNSizeFileTime

### DIFF
--- a/store/storetest/file_info_store.go
+++ b/store/storetest/file_info_store.go
@@ -810,6 +810,7 @@ func testFileInfoGetStorageUsage(t *testing.T, ss store.Store) {
 }
 
 func testGetUptoNSizeFileTime(t *testing.T, ss store.Store) {
+	t.Skip("MM-48627")
 	_, err := ss.FileInfo().GetUptoNSizeFileTime(0)
 	assert.Error(t, err)
 	_, err = ss.FileInfo().GetUptoNSizeFileTime(-1)


### PR DESCRIPTION
#### Summary
A test, added [in this PR](https://github.com/mattermost/mattermost-server/pull/20703), was found to be flaky in [this commit](https://github.com/mattermost/mattermost-server/commit/a05dd722edd0e5eaad6c5a3a90b92cfa113a3dc4) to the master branch. The relevant error is:

```
=== RUN   TestFileInfoStore/PostgreSQL/GetUptoNSizeFileTime
    file_info_store.go:870: 
        	Error Trace:	/mattermost/mattermost-server/store/sqlstore/file_info_store.go:870
        	            				/mattermost/mattermost-server/store/sqlstore/file_info_store.go:35
        	Error:      	Not equal: 
        	            	expected: 1669294161253
        	            	actual  : 1669294151252
        	Test:       	TestFileInfoStore/PostgreSQL/GetUptoNSizeFileTime
```

This PR skips it until https://mattermost.atlassian.net/browse/MM-48627, assigned to the Channels team, is fixed.

#### Ticket Link
--

#### Release Note
```release-note
NONE
```
