### PR TITLE
[MM-48521] Fix for batch notification email not rendering properly

### DIFF
--- a/app/email/email_batching.go
+++ b/app/email/email_batching.go
@@ -315,7 +315,7 @@ func (es *Service) sendBatchedEmailNotification(userID string, notifications []*
 				MessageURL:               MessageURL,
 				ShowChannelIcon:          showChannelIcon,
 				OtherChannelMembersCount: otherChannelMembersCount,
-				MessageAttachments:       es.processMessageAttachments(notification.post),
+				MessageAttachments:       ProcessMessageAttachments(notification.post),
 			})
 		}
 	}

--- a/app/email/email_batching.go
+++ b/app/email/email_batching.go
@@ -33,6 +33,7 @@ type postData struct {
 	Time                     string
 	ShowChannelIcon          bool
 	OtherChannelMembersCount int
+	MessageAttachments       []*EmailMessageAttachment
 }
 
 func (es *Service) InitEmailBatching() {
@@ -314,6 +315,7 @@ func (es *Service) sendBatchedEmailNotification(userID string, notifications []*
 				MessageURL:               MessageURL,
 				ShowChannelIcon:          showChannelIcon,
 				OtherChannelMembersCount: otherChannelMembersCount,
+				MessageAttachments:       es.processMessageAttachments(notification.post),
 			})
 		}
 	}

--- a/app/email/notification_email.go
+++ b/app/email/notification_email.go
@@ -60,6 +60,12 @@ func (es *Service) GetMessageForNotification(post *model.Post, translateFunc i18
 	return translateFunc("api.post.get_message_for_notification.files_sent", len(filenames), props)
 }
 
+/*
+MM-48521: following functions along with FieldRow, EmailMessageAttachment are duplicate of code in app/notification_email.go
+
+A subsequent ticket MM-48635 will help clean the same.
+*/
+
 func (es *Service) processMessageAttachments(post *model.Post) []*EmailMessageAttachment {
 	emailMessageAttachments := []*EmailMessageAttachment{}
 

--- a/app/email/notification_email.go
+++ b/app/email/notification_email.go
@@ -4,6 +4,8 @@
 package email
 
 import (
+	"html"
+	"html/template"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -11,7 +13,20 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/utils"
 )
+
+type FieldRow struct {
+	Cells []*model.SlackAttachmentField
+}
+
+type EmailMessageAttachment struct {
+	model.SlackAttachment
+
+	Pretext   template.HTML
+	Text      template.HTML
+	FieldRows []FieldRow
+}
 
 func (es *Service) GetMessageForNotification(post *model.Post, translateFunc i18n.TranslateFunc) string {
 	if strings.TrimSpace(post.Message) != "" || len(post.FileIds) == 0 {
@@ -43,4 +58,79 @@ func (es *Service) GetMessageForNotification(post *model.Post, translateFunc i18
 		return translateFunc("api.post.get_message_for_notification.images_sent", len(filenames), props)
 	}
 	return translateFunc("api.post.get_message_for_notification.files_sent", len(filenames), props)
+}
+
+func (es *Service) processMessageAttachments(post *model.Post) []*EmailMessageAttachment {
+	emailMessageAttachments := []*EmailMessageAttachment{}
+
+	for _, messageAttachment := range post.Attachments() {
+		emailMessageAttachment := &EmailMessageAttachment{
+			SlackAttachment: *messageAttachment,
+			Pretext:         es.prepareTextForEmail(messageAttachment.Pretext),
+			Text:            es.prepareTextForEmail(messageAttachment.Text),
+		}
+
+		stripedTitle, err := utils.StripMarkdown(emailMessageAttachment.Title)
+		if err != nil {
+			mlog.Warn("Failed parse to markdown from messageatatchment title", mlog.String("post_id", post.Id), mlog.Err(err))
+			stripedTitle = ""
+		}
+
+		emailMessageAttachment.Title = stripedTitle
+
+		shortFieldRow := FieldRow{}
+
+		for i := range messageAttachment.Fields {
+			// Create a new instance to avoid altering the original pointer reference
+			// We update field value to parse markdown.
+			// If we do that on the original pointer, the rendered text in mattermost
+			// becomes invalid as its no longer a markdown string, but rather an HTML string.
+			field := &model.SlackAttachmentField{
+				Title: messageAttachment.Fields[i].Title,
+				Value: messageAttachment.Fields[i].Value,
+				Short: messageAttachment.Fields[i].Short,
+			}
+
+			if stringValue, ok := field.Value.(string); ok {
+				field.Value = es.prepareTextForEmail(stringValue)
+			}
+
+			if !field.Short {
+				if len(shortFieldRow.Cells) > 0 {
+					emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, shortFieldRow)
+					shortFieldRow = FieldRow{}
+				}
+
+				emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, FieldRow{[]*model.SlackAttachmentField{field}})
+			} else {
+				shortFieldRow.Cells = append(shortFieldRow.Cells, field)
+
+				if len(shortFieldRow.Cells) == 2 {
+					emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, shortFieldRow)
+					shortFieldRow = FieldRow{}
+				}
+			}
+		}
+
+		// collect any leftover short fields
+		if len(shortFieldRow.Cells) > 0 {
+			emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, shortFieldRow)
+			shortFieldRow = FieldRow{}
+		}
+
+		emailMessageAttachments = append(emailMessageAttachments, emailMessageAttachment)
+	}
+
+	return emailMessageAttachments
+}
+
+func (es *Service) prepareTextForEmail(text string) template.HTML {
+	escapedText := html.EscapeString(text)
+	markdownText, err := utils.MarkdownToHTML(escapedText)
+	if err != nil {
+		mlog.Warn("Encountered error while converting markdown to HTML", mlog.Err(err))
+		return template.HTML(text)
+	}
+
+	return template.HTML(markdownText)
 }

--- a/app/email/notification_email.go
+++ b/app/email/notification_email.go
@@ -60,20 +60,14 @@ func (es *Service) GetMessageForNotification(post *model.Post, translateFunc i18
 	return translateFunc("api.post.get_message_for_notification.files_sent", len(filenames), props)
 }
 
-/*
-MM-48521: following functions along with FieldRow, EmailMessageAttachment are duplicate of code in app/notification_email.go
-
-A subsequent ticket MM-48635 will help clean the same.
-*/
-
-func (es *Service) processMessageAttachments(post *model.Post) []*EmailMessageAttachment {
+func ProcessMessageAttachments(post *model.Post) []*EmailMessageAttachment {
 	emailMessageAttachments := []*EmailMessageAttachment{}
 
 	for _, messageAttachment := range post.Attachments() {
 		emailMessageAttachment := &EmailMessageAttachment{
 			SlackAttachment: *messageAttachment,
-			Pretext:         es.prepareTextForEmail(messageAttachment.Pretext),
-			Text:            es.prepareTextForEmail(messageAttachment.Text),
+			Pretext:         prepareTextForEmail(messageAttachment.Pretext),
+			Text:            prepareTextForEmail(messageAttachment.Text),
 		}
 
 		stripedTitle, err := utils.StripMarkdown(emailMessageAttachment.Title)
@@ -98,7 +92,7 @@ func (es *Service) processMessageAttachments(post *model.Post) []*EmailMessageAt
 			}
 
 			if stringValue, ok := field.Value.(string); ok {
-				field.Value = es.prepareTextForEmail(stringValue)
+				field.Value = prepareTextForEmail(stringValue)
 			}
 
 			if !field.Short {
@@ -130,7 +124,7 @@ func (es *Service) processMessageAttachments(post *model.Post) []*EmailMessageAt
 	return emailMessageAttachments
 }
 
-func (es *Service) prepareTextForEmail(text string) template.HTML {
+func prepareTextForEmail(text string) template.HTML {
 	escapedText := html.EscapeString(text)
 	markdownText, err := utils.MarkdownToHTML(escapedText)
 	if err != nil {

--- a/app/email/notification_email_test.go
+++ b/app/email/notification_email_test.go
@@ -1,0 +1,70 @@
+package email
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessMessageAttachments(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	post := &model.Post{
+		Message: "This is the message",
+	}
+	job := NewEmailBatchingJob(th.service, 128)
+
+	messageAttachments := []*model.SlackAttachment{
+		{
+			Color:      "#FF0000",
+			Pretext:    "message attachment 1 pretext",
+			AuthorName: "author name",
+			AuthorLink: "https://example.com/slack_attachment_1/author_link",
+			AuthorIcon: "https://example.com/slack_attachment_1/author_icon",
+			Title:      "message attachment 1 title",
+			TitleLink:  "https://example.com/slack_attachment_1/title_link",
+			Text:       "message attachment 1 text",
+			ImageURL:   "https://example.com/slack_attachment_1/image",
+			ThumbURL:   "https://example.com/slack_attachment_1/thumb",
+			Fields: []*model.SlackAttachmentField{
+				{
+					Short: true,
+					Title: "message attachment 1 field 1 title",
+					Value: "message attachment 1 field 1 value",
+				},
+				{
+					Short: false,
+					Title: "message attachment 1 field 2 title",
+					Value: "message attachment 1 field 2 value",
+				},
+				{
+					Short: true,
+					Title: "message attachment 1 field 3 title",
+					Value: "message attachment 1 field 3 value",
+				},
+				{
+					Short: true,
+					Title: "message attachment 1 field 4 title",
+					Value: "message attachment 1 field 4 value",
+				},
+			},
+		},
+		{
+			Color:      "#FF0000",
+			Pretext:    "message attachment 2 pretext",
+			AuthorName: "author name 2",
+			Text:       "message attachment 2 text",
+		},
+	}
+
+	model.ParseSlackAttachment(post, messageAttachments)
+
+	processedAttachcmentsPost := job.service.processMessageAttachments(post)
+	require.NotNil(t, processedAttachcmentsPost)
+	require.Len(t, processedAttachcmentsPost, 2)
+	require.Equal(t, processedAttachcmentsPost[0].Color, "#FF0000")
+	require.Equal(t, processedAttachcmentsPost[0].FieldRows[0].Cells[0].Title, "message attachment 1 field 1 title")
+	require.Equal(t, processedAttachcmentsPost[1].Color, "#FF0000")
+}

--- a/app/email/notification_email_test.go
+++ b/app/email/notification_email_test.go
@@ -17,7 +17,6 @@ func TestProcessMessageAttachments(t *testing.T) {
 	post := &model.Post{
 		Message: "This is the message",
 	}
-	job := NewEmailBatchingJob(th.service, 128)
 
 	messageAttachments := []*model.SlackAttachment{
 		{
@@ -64,7 +63,7 @@ func TestProcessMessageAttachments(t *testing.T) {
 
 	model.ParseSlackAttachment(post, messageAttachments)
 
-	processedAttachcmentsPost := job.service.processMessageAttachments(post)
+	processedAttachcmentsPost := ProcessMessageAttachments(post)
 	require.NotNil(t, processedAttachcmentsPost)
 	require.Len(t, processedAttachcmentsPost, 2)
 	require.Equal(t, processedAttachcmentsPost[0].Color, "#FF0000")

--- a/app/email/notification_email_test.go
+++ b/app/email/notification_email_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package email
 
 import (

--- a/app/notification_email.go
+++ b/app/notification_email.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	email "github.com/mattermost/mattermost-server/v6/app/email"
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
@@ -201,18 +202,6 @@ func truncateUserNames(name string, i int) string {
 	return name
 }
 
-type FieldRow struct {
-	Cells []*model.SlackAttachmentField
-}
-
-type EmailMessageAttachment struct {
-	model.SlackAttachment
-
-	Pretext   template.HTML
-	Text      template.HTML
-	FieldRows []FieldRow
-}
-
 type postData struct {
 	SenderName               string
 	ChannelName              string
@@ -223,7 +212,7 @@ type postData struct {
 	Time                     string
 	ShowChannelIcon          bool
 	OtherChannelMembersCount int
-	MessageAttachments       []*EmailMessageAttachment
+	MessageAttachments       []*email.EmailMessageAttachment
 }
 
 /**
@@ -258,7 +247,7 @@ func (a *App) getNotificationEmailBody(c request.CTX, recipient *model.User, pos
 		}
 		pData.Message = template.HTML(normalizedPostMessage)
 		pData.Time = translateFunc("app.notification.body.dm.time", messageTime)
-		pData.MessageAttachments = a.processMessageAttachments(post)
+		pData.MessageAttachments = email.ProcessMessageAttachments(post)
 	}
 
 	data := a.Srv().EmailService.NewEmailTemplateData(recipient.Locale)
@@ -318,81 +307,6 @@ func (a *App) getNotificationEmailBody(c request.CTX, recipient *model.User, pos
 	}
 
 	return a.Srv().TemplatesContainer().RenderToString("messages_notification", data)
-}
-
-func (a *App) processMessageAttachments(post *model.Post) []*EmailMessageAttachment {
-	emailMessageAttachments := []*EmailMessageAttachment{}
-
-	for _, messageAttachment := range post.Attachments() {
-		emailMessageAttachment := &EmailMessageAttachment{
-			SlackAttachment: *messageAttachment,
-			Pretext:         a.prepareTextForEmail(messageAttachment.Pretext),
-			Text:            a.prepareTextForEmail(messageAttachment.Text),
-		}
-
-		stripedTitle, err := utils.StripMarkdown(emailMessageAttachment.Title)
-		if err != nil {
-			mlog.Warn("Failed parse to markdown from messageatatchment title", mlog.String("post_id", post.Id), mlog.Err(err))
-			stripedTitle = ""
-		}
-
-		emailMessageAttachment.Title = stripedTitle
-
-		shortFieldRow := FieldRow{}
-
-		for i := range messageAttachment.Fields {
-			// Create a new instance to avoid altering the original pointer reference
-			// We update field value to parse markdown.
-			// If we do that on the original pointer, the rendered text in mattermost
-			// becomes invalid as its no longer a markdown string, but rather an HTML string.
-			field := &model.SlackAttachmentField{
-				Title: messageAttachment.Fields[i].Title,
-				Value: messageAttachment.Fields[i].Value,
-				Short: messageAttachment.Fields[i].Short,
-			}
-
-			if stringValue, ok := field.Value.(string); ok {
-				field.Value = a.prepareTextForEmail(stringValue)
-			}
-
-			if !field.Short {
-				if len(shortFieldRow.Cells) > 0 {
-					emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, shortFieldRow)
-					shortFieldRow = FieldRow{}
-				}
-
-				emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, FieldRow{[]*model.SlackAttachmentField{field}})
-			} else {
-				shortFieldRow.Cells = append(shortFieldRow.Cells, field)
-
-				if len(shortFieldRow.Cells) == 2 {
-					emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, shortFieldRow)
-					shortFieldRow = FieldRow{}
-				}
-			}
-		}
-
-		// collect any leftover short fields
-		if len(shortFieldRow.Cells) > 0 {
-			emailMessageAttachment.FieldRows = append(emailMessageAttachment.FieldRows, shortFieldRow)
-			shortFieldRow = FieldRow{}
-		}
-
-		emailMessageAttachments = append(emailMessageAttachments, emailMessageAttachment)
-	}
-
-	return emailMessageAttachments
-}
-
-func (a *App) prepareTextForEmail(text string) template.HTML {
-	escapedText := html.EscapeString(text)
-	markdownText, err := utils.MarkdownToHTML(escapedText)
-	if err != nil {
-		mlog.Warn("Encountered error while converting markdown to HTML", mlog.Err(err))
-		return template.HTML(text)
-	}
-
-	return template.HTML(markdownText)
 }
 
 type formattedPostTime struct {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Some recent additions to single notification email renders weren't applied to batch email, causing them to fail. This PR patches batch notification events with `MessageAttachments`.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48521
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed bug where batch notifications failed while rendering.
```
