### PR TITLE
Adds support for clustered websocket messages for products

### DIFF
--- a/app/cluster_handlers.go
+++ b/app/cluster_handlers.go
@@ -37,7 +37,7 @@ func (s *Server) clusterPluginEventHandler(msg *model.ClusterMessage) {
 		return
 	}
 	pluginID := msg.Props["PluginID"]
-	// if plugin is empty, the message cloud come from a product
+	// if the plugin key is empty, the message might be coming from a product.
 	if pluginID == "" {
 		pluginID = msg.Props["ProductID"]
 	}

--- a/app/cluster_handlers.go
+++ b/app/cluster_handlers.go
@@ -37,6 +37,10 @@ func (s *Server) clusterPluginEventHandler(msg *model.ClusterMessage) {
 		return
 	}
 	pluginID := msg.Props["PluginID"]
+	// if plugin is empty, the message cloud come from a product
+	if pluginID == "" {
+		pluginID = msg.Props["ProductID"]
+	}
 	eventID := msg.Props["EventID"]
 	if pluginID == "" || eventID == "" {
 		mlog.Warn("Invalid ClusterMessage.Props values for plugin event",

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -499,6 +499,12 @@ func (env *Environment) HooksForPlugin(id string) (Hooks, error) {
 		}
 	}
 
+	if p, ok := env.registeredProducts.Load(id); ok {
+		rp := p.(*registeredProduct)
+
+		return rp.adapter, nil
+	}
+
 	return nil, fmt.Errorf("plugin not found: %v", id)
 }
 


### PR DESCRIPTION
#### Summary
This PR updates the `HooksForPlugin` function to return product registered hooks as well, and allows for clustered websocket messages to be processed.

#### Release Note
```release-note
* Adds support for product websocket messages on high availability instances.
```
