### PR TITLE
Update haserver docker-compose to include boards as a product

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -108,6 +108,7 @@ services:
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
       - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
+      - "MM_FEATUREFLAGS_BoardsProduct=true"
     networks:
       - mm-test
     depends_on:
@@ -116,6 +117,7 @@ services:
       - './:/home/mattermost-server'
       - './../mattermost-webapp:/home/mattermost-webapp'
       - './../enterprise:/home/enterprise'
+      - './../focalboard:/home/focalboard'
     restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-f", "http://leader:8065/api/v4/system/ping"]
@@ -144,6 +146,7 @@ services:
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
       - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
+      - "MM_FEATUREFLAGS_BoardsProduct=true"
     networks:
       - mm-test
     depends_on:
@@ -152,6 +155,7 @@ services:
       - './:/home/mattermost-server'
       - './../mattermost-webapp:/home/mattermost-webapp'
       - './../enterprise:/home/enterprise'
+      - './../focalboard:/home/focalboard'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://follower:8065/api/v4/system/ping"]
       interval: 5s
@@ -180,6 +184,7 @@ services:
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
       - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
+      - "MM_FEATUREFLAGS_BoardsProduct=true"
     networks:
       - mm-test
     depends_on:
@@ -188,6 +193,7 @@ services:
       - './:/home/mattermost-server'
       - './../mattermost-webapp:/home/mattermost-webapp'
       - './../enterprise:/home/enterprise'
+      - './../focalboard:/home/focalboard'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://follower2:8065/api/v4/system/ping"]
       interval: 5s


### PR DESCRIPTION
#### Summary
This PR includes the `boards` product on the `haserver` targets.

#### Release Note
```release-note
NONE
```
