### PR TITLE
[MM-46463] Return last_picture_update for new team members

### DIFF
--- a/model/insights.go
+++ b/model/insights.go
@@ -118,13 +118,14 @@ type NewTeamMembersList struct {
 }
 
 type NewTeamMember struct {
-	Id        string `json:"id"`
-	Username  string `json:"username"`
-	FirstName string `json:"first_name"`
-	LastName  string `json:"last_name"`
-	Position  string `json:"position"`
-	Nickname  string `json:"nickname"`
-	CreateAt  int64  `json:"create_at"`
+	Id                string `json:"id"`
+	Username          string `json:"username"`
+	FirstName         string `json:"first_name"`
+	LastName          string `json:"last_name"`
+	Position          string `json:"position"`
+	Nickname          string `json:"nickname"`
+	LastPictureUpdate int64  `json:"last_picture_update,omitempty"`
+	CreateAt          int64  `json:"create_at"`
 }
 
 type DurationPostCount struct {

--- a/store/sqlstore/team_store.go
+++ b/store/sqlstore/team_store.go
@@ -1675,7 +1675,7 @@ func (s SqlTeamStore) GetNewTeamMembersSince(teamID string, since int64, offset 
 		return nil, 0, errors.Wrap(err, "failed to count team members since")
 	}
 
-	newTeamMembersBuilder := builderF("Users.Id, Users.Username, Users.FirstName, Users.LastName, Users.Position, TeamMembers.CreateAt, Users.Nickname").
+	newTeamMembersBuilder := builderF("Users.Id, Users.Username, Users.FirstName, Users.LastName, Users.Position, Users.LastPictureUpdate, TeamMembers.CreateAt, Users.Nickname").
 		Limit(uint64(limit + 1)).
 		Offset(uint64(offset))
 	query, args, err = newTeamMembersBuilder.ToSql()


### PR DESCRIPTION
#### Summary
Return the last profile update timestamp to be used in webapp for getting the latest picture.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-46463

#### Release Note
```release-note
Fixes fetching the latest user's picture in insights.
```