### PR TITLE
Use `rolling-stable` branch when fetching focalboard repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           cd ..
           git clone --depth=1 --no-single-branch https://github.com/mattermost/focalboard.git
           cd focalboard
-          git checkout $CIRCLE_BRANCH || git checkout main
+          git checkout $CIRCLE_BRANCH || git checkout rolling-stable
           echo $(git rev-parse HEAD)
           cd ../mattermost-server
           make setup-go-work


### PR DESCRIPTION
#### Summary
Boards team would like CI fetches of boards repo to use the `rolling-stable` branch.  This branch will be updated every few days from main, once the latest batch of PR's are tested.  

Similar PRs are being issued for enterprise, and the gitlab CI repos.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4604

#### Release Note
```release-note
NONE
```
