### PR TITLE
docker-compose: include db driver type for the haserver env vars

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,6 +103,7 @@ services:
       dockerfile: ./build/Dockerfile.buildenv
     working_dir: '/home/mattermost-server'
     environment:
+      - "MM_SQLSETTINGS_DRIVERNAME=postgres"
       - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable\u0026connect_timeout=10"
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
@@ -141,6 +142,7 @@ services:
       dockerfile: ./build/Dockerfile.buildenv
     working_dir: '/home/mattermost-server'
     environment:
+      - "MM_SQLSETTINGS_DRIVERNAME=postgres"
       - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable\u0026connect_timeout=10"
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
@@ -179,6 +181,7 @@ services:
       dockerfile: ./build/Dockerfile.buildenv
     working_dir: '/home/mattermost-server'
     environment:
+      - "MM_SQLSETTINGS_DRIVERNAME=postgres"
       - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable\u0026connect_timeout=10"
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"


### PR DESCRIPTION


#### Summary
While running in HA server mode, we define the DSN from the `docker-compose.yml`, but we also use `config.json` as config source and if it has a different driver type, it fails to create the `DB` instance. This PR tries to emphasize that driver name should also need to be defined next to the DSN.

#### Release Note

```release-note
NONE
```
