### PR TITLE
MM47860 - Add CWS health check endpoint.

### DIFF
--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -51,6 +51,9 @@ func (api *API) InitCloud() {
 
 	// POST /api/v4/cloud/webhook
 	api.BaseRoutes.Cloud.Handle("/webhook", api.CloudAPIKeyRequired(handleCWSWebhook)).Methods("POST")
+
+	// GET /api/v4/cloud/cws-health-check
+	api.BaseRoutes.HostedCustomer.Handle("/cws-health-check", api.APIHandler(handleCWSHealthCheck)).Methods("GET")
 }
 
 func getSubscription(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -680,6 +683,15 @@ func handleCWSWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	default:
 		c.Err = model.NewAppError("Api4.handleCWSWebhook", "api.cloud.cws_webhook_event_missing_error", nil, "", http.StatusNotFound)
+		return
+	}
+
+	ReturnStatusOK(w)
+}
+
+func handleCWSHealthCheck(c *Context, w http.ResponseWriter, r *http.Request) {
+	if err := c.App.Cloud().CWSHealthCheck(c.AppContext.Session().UserId); err != nil {
+		c.Err = model.NewAppError("Api4.handleCWSHealthCheck", "api.server.cws.health_check.app_error", nil, "", http.StatusInternalServerError)
 		return
 	}
 

--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -53,7 +53,7 @@ func (api *API) InitCloud() {
 	api.BaseRoutes.Cloud.Handle("/webhook", api.CloudAPIKeyRequired(handleCWSWebhook)).Methods("POST")
 
 	// GET /api/v4/cloud/cws-health-check
-	api.BaseRoutes.HostedCustomer.Handle("/cws-health-check", api.APIHandler(handleCWSHealthCheck)).Methods("GET")
+	api.BaseRoutes.Cloud.Handle("/cws-health-check", api.APIHandler(handleCWSHealthCheck)).Methods("GET")
 }
 
 func getSubscription(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/hosted_customer.go
+++ b/api4/hosted_customer.go
@@ -16,6 +16,9 @@ func (api *API) InitHostedCustomer() {
 
 	// POST /api/v4/hosted_customer/bootstrap
 	api.BaseRoutes.HostedCustomer.Handle("/bootstrap", api.APISessionRequired(selfHostedBootstrap)).Methods("POST")
+
+	// GET /api/v4/cloud/cws-health-check
+	api.BaseRoutes.HostedCustomer.Handle("/cws-health-check", api.APIHandler(handleCWSHealthCheck)).Methods("GET")
 }
 
 func ensureSelfHostedAdmin(c *Context, where string) {
@@ -70,4 +73,13 @@ func selfHostedBootstrap(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(json)
+}
+
+func handleCWSHealthCheck(c *Context, w http.ResponseWriter, r *http.Request) {
+	if err := c.App.Cloud().CWSHealthCheck(c.AppContext.Session().UserId); err != nil {
+		c.Err = model.NewAppError("Api4.handleCWSHealthCheck", "api.server.cws.health_check.app_error", nil, "", http.StatusInternalServerError)
+		return
+	}
+
+	ReturnStatusOK(w)
 }

--- a/api4/hosted_customer.go
+++ b/api4/hosted_customer.go
@@ -16,9 +16,6 @@ func (api *API) InitHostedCustomer() {
 
 	// POST /api/v4/hosted_customer/bootstrap
 	api.BaseRoutes.HostedCustomer.Handle("/bootstrap", api.APISessionRequired(selfHostedBootstrap)).Methods("POST")
-
-	// GET /api/v4/cloud/cws-health-check
-	api.BaseRoutes.HostedCustomer.Handle("/cws-health-check", api.APIHandler(handleCWSHealthCheck)).Methods("GET")
 }
 
 func ensureSelfHostedAdmin(c *Context, where string) {
@@ -73,13 +70,4 @@ func selfHostedBootstrap(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(json)
-}
-
-func handleCWSHealthCheck(c *Context, w http.ResponseWriter, r *http.Request) {
-	if err := c.App.Cloud().CWSHealthCheck(c.AppContext.Session().UserId); err != nil {
-		c.Err = model.NewAppError("Api4.handleCWSHealthCheck", "api.server.cws.health_check.app_error", nil, "", http.StatusInternalServerError)
-		return
-	}
-
-	ReturnStatusOK(w)
 }

--- a/einterfaces/cloud.go
+++ b/einterfaces/cloud.go
@@ -36,4 +36,6 @@ type CloudInterface interface {
 	BootstrapSelfHostedSignup(req model.BootstrapSelfHostedSignupRequest) (*model.BootstrapSelfHostedSignupResponse, error)
 	CreateOrUpdateSubscriptionHistoryEvent(userID string, userCount int) (*model.SubscriptionHistory, error)
 	HandleLicenseChange() error
+
+	CWSHealthCheck(userId string) error
 }

--- a/einterfaces/mocks/CloudInterface.go
+++ b/einterfaces/mocks/CloudInterface.go
@@ -37,6 +37,20 @@ func (_m *CloudInterface) BootstrapSelfHostedSignup(req model.BootstrapSelfHoste
 	return r0, r1
 }
 
+// CWSHealthCheck provides a mock function with given fields: userId
+func (_m *CloudInterface) CWSHealthCheck(userId string) error {
+	ret := _m.Called(userId)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(userId)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ChangeSubscription provides a mock function with given fields: userID, subscriptionID, subscriptionChange
 func (_m *CloudInterface) ChangeSubscription(userID string, subscriptionID string, subscriptionChange *model.SubscriptionChange) (*model.Subscription, error) {
 	ret := _m.Called(userID, subscriptionID, subscriptionChange)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2544,6 +2544,10 @@
     "translation": "Your license does not support update permissions schemes"
   },
   {
+    "id": "api.server.cws.health_check.app_error",
+    "translation": "CWS Server is not available."
+  },
+  {
     "id": "api.server.license_up_for_renewal.error_generating_link",
     "translation": "Failed to generate the license renewal link"
   },

--- a/model/client4.go
+++ b/model/client4.go
@@ -8603,7 +8603,7 @@ func (c *Client4) GetWorkTemplatesByCategory(category string) ([]*WorkTemplate, 
 }
 
 func (c *Client4) CWSHealthCheck(userId string) (*Response, error) {
-	r, err := c.DoAPIGet(c.cloudRoute()+"/healthz", "")
+	r, err := c.DoAPIGet(c.cloudRoute()+"/cws-health-check", "")
 
 	if err != nil {
 		return BuildResponse(r), err

--- a/model/client4.go
+++ b/model/client4.go
@@ -8601,3 +8601,14 @@ func (c *Client4) GetWorkTemplatesByCategory(category string) ([]*WorkTemplate, 
 	err = json.NewDecoder(r.Body).Decode(&templates)
 	return templates, BuildResponse(r), err
 }
+
+func (c *Client4) CWSHealthCheck(userId string) (*Response, error) {
+	r, err := c.DoAPIGet(c.cloudRoute()+"/healthz", "")
+
+	if err != nil {
+		return BuildResponse(r), err
+	}
+	defer closeBody(r)
+
+	return BuildResponse(r), nil
+}


### PR DESCRIPTION
#### Summary
Adds an endpoint to use the health check in the internal customer web server.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47860

#### Related Pull Requests

Air Gapped Purchase Modal:
https://github.com/mattermost/mattermost-webapp/pull/11683

Adding CWS Health checks:
https://github.com/mattermost/enterprise/pull/1311

#### Release Note

```release-note
NONE
```
