### PR TITLE
Update prepackage boards to v7.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.0
 PLUGIN_PACKAGES += mattermost-plugin-todo-v0.6.1
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.6.0
-PLUGIN_PACKAGES += focalboard-v7.5.2
+PLUGIN_PACKAGES += focalboard-v7.6.0
 PLUGIN_PACKAGES += mattermost-plugin-apps-v1.1.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target


### PR DESCRIPTION
#### Summary
Update pre-package boards to v7.6.0

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/4019

#### Release Note
```release-note
Update prepackaged boards version to v7.60
```
