### PR TITLE
[MM-41758] Fixes fetching first/last name for GitLab user using OpenID

### DIFF
--- a/model/oauthproviders/openid/openid.go
+++ b/model/oauthproviders/openid/openid.go
@@ -56,18 +56,33 @@ func (o *OpenIdProvider) userFromOpenIdUser(u *OpenIdUser) *model.User {
 
 	user.Email = u.Email
 	user.Username = model.CleanUsername(strings.Split(user.Email, "@")[0])
-	if o.CacheData.Service == model.ServiceGitlab && u.Nickname != "" {
-		user.Username = u.Nickname
-	}
 
 	user.FirstName = u.FirstName
 	user.LastName = u.LastName
 	user.Nickname = u.Nickname
 
+	if o.CacheData.Service == model.ServiceGitlab {
+		o.handleGitLabUser(user, u)
+	}
+
 	user.AuthData = new(string)
 	*user.AuthData = o.getAuthData(u)
 
 	return user
+}
+
+func (o *OpenIdProvider) handleGitLabUser(user *model.User, u *OpenIdUser) {
+	if u.Nickname != "" {
+		user.Username = u.Nickname
+	}
+
+	splitName := strings.SplitN(strings.TrimSpace(u.Name), " ", 2)
+	if len(splitName) == 2 {
+		user.FirstName = splitName[0]
+		user.LastName = splitName[1]
+	} else {
+		user.FirstName = u.Name
+	}
 }
 
 func (o *OpenIdProvider) getAuthData(u *OpenIdUser) string {

--- a/model/oauthproviders/openid/openid_test.go
+++ b/model/oauthproviders/openid/openid_test.go
@@ -74,6 +74,29 @@ func TestOpenIdUserFromJSON(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("valid GitLab user", func(t *testing.T) {
+		glu := OpenIdUser{
+			Id:       ou.Id,
+			Email:    ou.Email,
+			Nickname: ou.Nickname,
+			Name:     ou.FirstName + " " + ou.LastName + " another-lastname",
+		}
+
+		b, err := json.Marshal(glu)
+		require.NoError(t, err)
+
+		gitLabProvider := &OpenIdProvider{
+			CacheData: &CacheData{
+				Service: model.ServiceGitlab,
+			},
+		}
+		userData, err := gitLabProvider.GetUserFromJSON(bytes.NewReader(b), nil)
+		require.NoError(t, err)
+		require.Equal(t, ou.Nickname, userData.Username)
+		require.Equal(t, ou.FirstName, userData.FirstName)
+		require.Equal(t, ou.LastName+" another-lastname", userData.LastName)
+	})
+
 	t.Run("empty body should fail without panic", func(t *testing.T) {
 		_, err := provider.GetUserFromJSON(strings.NewReader("{}"), nil)
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary
Looks like this was handled at the [GitLab integration](https://github.com/mattermost/mattermost-server/blob/master/model/oauthproviders/gitlab/gitlab.go#L40-L49) but not for the OpenID version of it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-41758

#### Release Note
```release-note
Fixed fetching first/last name for GitLab user using OpenID
```
