### PR TITLE
app: avoid plugin env check for RunMultiHook and use pluginslock while accessing plugin env

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -343,15 +343,13 @@ func (a *App) CreateChannel(c request.CTX, channel *model.Channel, addMember boo
 		a.InvalidateCacheForUser(channel.CreatorId)
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.ChannelHasBeenCreated(pluginContext, sc)
-				return true
-			}, plugin.ChannelHasBeenCreatedID)
-		})
-	}
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.ChannelHasBeenCreated(pluginContext, sc)
+			return true
+		}, plugin.ChannelHasBeenCreatedID)
+	})
 
 	return sc, nil
 }
@@ -429,15 +427,13 @@ func (a *App) handleCreationEvent(c request.CTX, userID, otherUserID string, cha
 	a.InvalidateCacheForUser(userID)
 	a.InvalidateCacheForUser(otherUserID)
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.ChannelHasBeenCreated(pluginContext, channel)
-				return true
-			}, plugin.ChannelHasBeenCreatedID)
-		})
-	}
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.ChannelHasBeenCreated(pluginContext, channel)
+			return true
+		}, plugin.ChannelHasBeenCreatedID)
+	})
 
 	message := model.NewWebSocketEvent(model.WebsocketEventDirectAdded, "", channel.Id, "", nil, "")
 	message.Add("creator_id", userID)
@@ -1599,15 +1595,13 @@ func (a *App) AddChannelMember(c request.CTX, userID string, channel *model.Chan
 		return nil, err
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.UserHasJoinedChannel(pluginContext, cm, userRequestor)
-				return true
-			}, plugin.UserHasJoinedChannelID)
-		})
-	}
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.UserHasJoinedChannel(pluginContext, cm, userRequestor)
+			return true
+		}, plugin.UserHasJoinedChannelID)
+	})
 
 	if opts.UserRequestorID == "" || userID == opts.UserRequestorID {
 		if err := a.postJoinChannelMessage(c, user, channel); err != nil {
@@ -2177,15 +2171,13 @@ func (a *App) JoinChannel(c request.CTX, channel *model.Channel, userID string) 
 		return err
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.UserHasJoinedChannel(pluginContext, cm, nil)
-				return true
-			}, plugin.UserHasJoinedChannelID)
-		})
-	}
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.UserHasJoinedChannel(pluginContext, cm, nil)
+			return true
+		}, plugin.UserHasJoinedChannelID)
+	})
 
 	if err := a.postJoinChannelMessage(c, user, channel); err != nil {
 		return err
@@ -2484,20 +2476,18 @@ func (a *App) removeUserFromChannel(c request.CTX, userIDToRemove string, remove
 	a.InvalidateCacheForUser(userIDToRemove)
 	a.invalidateCacheForChannelMembers(channel.Id)
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		var actorUser *model.User
-		if removerUserId != "" {
-			actorUser, _ = a.GetUser(removerUserId)
-		}
-
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.UserHasLeftChannel(pluginContext, cm, actorUser)
-				return true
-			}, plugin.UserHasLeftChannelID)
-		})
+	var actorUser *model.User
+	if removerUserId != "" {
+		actorUser, _ = a.GetUser(removerUserId)
 	}
+
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.UserHasLeftChannel(pluginContext, cm, actorUser)
+			return true
+		}, plugin.UserHasLeftChannelID)
+	})
 
 	message := model.NewWebSocketEvent(model.WebsocketEventUserRemoved, "", channel.Id, "", nil, "")
 	message.Add("user_id", userIDToRemove)

--- a/app/channels.go
+++ b/app/channels.go
@@ -326,9 +326,11 @@ func (s *hooksService) RegisterHooks(productID string, hooks any) error {
 }
 
 func (ch *Channels) RunMultiHook(hookRunnerFunc func(hooks plugin.Hooks) bool, hookId int) {
+	ch.pluginsLock.RLock()
 	if env := ch.pluginsEnvironment; env != nil {
 		env.RunMultiPluginHook(hookRunnerFunc, hookId)
 	}
+	ch.pluginsLock.RUnlock()
 
 	// run hook for the products
 	ch.srv.hooksManager.RunMultiHook(hookRunnerFunc, hookId)

--- a/app/channels.go
+++ b/app/channels.go
@@ -326,11 +326,9 @@ func (s *hooksService) RegisterHooks(productID string, hooks any) error {
 }
 
 func (ch *Channels) RunMultiHook(hookRunnerFunc func(hooks plugin.Hooks) bool, hookId int) {
-	ch.pluginsLock.RLock()
-	if env := ch.pluginsEnvironment; env != nil {
+	if env := ch.GetPluginsEnvironment(); env != nil {
 		env.RunMultiPluginHook(hookRunnerFunc, hookId)
 	}
-	ch.pluginsLock.RUnlock()
 
 	// run hook for the products
 	ch.srv.hooksManager.RunMultiHook(hookRunnerFunc, hookId)
@@ -338,7 +336,7 @@ func (ch *Channels) RunMultiHook(hookRunnerFunc func(hooks plugin.Hooks) bool, h
 
 func (ch *Channels) HooksForPluginOrProduct(id string) (plugin.Hooks, error) {
 	var hooks plugin.Hooks
-	if env := ch.pluginsEnvironment; env != nil {
+	if env := ch.GetPluginsEnvironment(); env != nil {
 		// we intentionally ignore the error here, because the id can be a product id
 		// we are going to check if we have the hooks or not
 		hooks, _ = env.HooksForPlugin(id)

--- a/app/file.go
+++ b/app/file.go
@@ -895,29 +895,27 @@ func (a *App) DoUploadFileExpectModification(c request.CTX, now time.Time, rawTe
 		info.ThumbnailPath = pathPrefix + nameWithoutExtension + "_thumb." + getFileExtFromMimeType(info.MimeType)
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		var rejectionError *model.AppError
-		pluginContext := pluginContext(c)
-		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-			var newBytes bytes.Buffer
-			replacementInfo, rejectionReason := hooks.FileWillBeUploaded(pluginContext, info, bytes.NewReader(data), &newBytes)
-			if rejectionReason != "" {
-				rejectionError = model.NewAppError("DoUploadFile", "File rejected by plugin. "+rejectionReason, nil, "", http.StatusBadRequest)
-				return false
-			}
-			if replacementInfo != nil {
-				info = replacementInfo
-			}
-			if newBytes.Len() != 0 {
-				data = newBytes.Bytes()
-				info.Size = int64(len(data))
-			}
-
-			return true
-		}, plugin.FileWillBeUploadedID)
-		if rejectionError != nil {
-			return nil, data, rejectionError
+	var rejectionError *model.AppError
+	pluginContext := pluginContext(c)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+		var newBytes bytes.Buffer
+		replacementInfo, rejectionReason := hooks.FileWillBeUploaded(pluginContext, info, bytes.NewReader(data), &newBytes)
+		if rejectionReason != "" {
+			rejectionError = model.NewAppError("DoUploadFile", "File rejected by plugin. "+rejectionReason, nil, "", http.StatusBadRequest)
+			return false
 		}
+		if replacementInfo != nil {
+			info = replacementInfo
+		}
+		if newBytes.Len() != 0 {
+			data = newBytes.Bytes()
+			info.Size = int64(len(data))
+		}
+
+		return true
+	}, plugin.FileWillBeUploadedID)
+	if rejectionError != nil {
+		return nil, data, rejectionError
 	}
 
 	if _, err := a.WriteFile(bytes.NewReader(data), info.Path); err != nil {

--- a/app/plugin.go
+++ b/app/plugin.go
@@ -278,14 +278,13 @@ func (ch *Channels) initPlugins(c *request.Context, pluginDir, webappPluginDir s
 			ch.installFeatureFlagPlugins()
 			ch.syncPluginsActiveState()
 		}
-		if pluginsEnvironment := ch.GetPluginsEnvironment(); pluginsEnvironment != nil {
-			ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				if err := hooks.OnConfigurationChange(); err != nil {
-					ch.srv.Log().Error("Plugin OnConfigurationChange hook failed", mlog.Err(err))
-				}
-				return true
-			}, plugin.OnConfigurationChangeID)
-		}
+
+		ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			if err := hooks.OnConfigurationChange(); err != nil {
+				ch.srv.Log().Error("Plugin OnConfigurationChange hook failed", mlog.Err(err))
+			}
+			return true
+		}, plugin.OnConfigurationChangeID)
 	})
 	ch.pluginsLock.Unlock()
 

--- a/app/post.go
+++ b/app/post.go
@@ -263,38 +263,36 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 		post.Metadata.Priority = nil
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		var metadata *model.PostMetadata
-		if post.Metadata != nil {
-			metadata = post.Metadata.Copy()
-		}
-		var rejectionError *model.AppError
-		pluginContext := pluginContext(c)
-		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-			replacementPost, rejectionReason := hooks.MessageWillBePosted(pluginContext, post.ForPlugin())
-			if rejectionReason != "" {
-				id := "Post rejected by plugin. " + rejectionReason
-				if rejectionReason == plugin.DismissPostError {
-					id = plugin.DismissPostError
-				}
-				rejectionError = model.NewAppError("createPost", id, nil, "", http.StatusBadRequest)
-				return false
+	var metadata *model.PostMetadata
+	if post.Metadata != nil {
+		metadata = post.Metadata.Copy()
+	}
+	var rejectionError *model.AppError
+	pluginContext := pluginContext(c)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+		replacementPost, rejectionReason := hooks.MessageWillBePosted(pluginContext, post.ForPlugin())
+		if rejectionReason != "" {
+			id := "Post rejected by plugin. " + rejectionReason
+			if rejectionReason == plugin.DismissPostError {
+				id = plugin.DismissPostError
 			}
-			if replacementPost != nil {
-				post = replacementPost
-				if post.Metadata != nil && metadata != nil {
-					post.Metadata.Priority = metadata.Priority
-				} else {
-					post.Metadata = metadata
-				}
-			}
-
-			return true
-		}, plugin.MessageWillBePostedID)
-
-		if rejectionError != nil {
-			return nil, rejectionError
+			rejectionError = model.NewAppError("createPost", id, nil, "", http.StatusBadRequest)
+			return false
 		}
+		if replacementPost != nil {
+			post = replacementPost
+			if post.Metadata != nil && metadata != nil {
+				post.Metadata.Priority = metadata.Priority
+			} else {
+				post.Metadata = metadata
+			}
+		}
+
+		return true
+	}, plugin.MessageWillBePostedID)
+
+	if rejectionError != nil {
+		return nil, rejectionError
 	}
 
 	// Pre-fill the CreateAt field for link previews to get the correct timestamp.
@@ -328,16 +326,13 @@ func (a *App) CreatePost(c request.CTX, post *model.Post, channel *model.Channel
 
 	// We make a copy of the post for the plugin hook to avoid a race condition,
 	// and to remove the non-GOB-encodable Metadata from it.
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		pluginPost := rpost.ForPlugin()
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.MessageHasBeenPosted(pluginContext, pluginPost)
-				return true
-			}, plugin.MessageHasBeenPostedID)
-		})
-	}
+	pluginPost := rpost.ForPlugin()
+	a.Srv().Go(func() {
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.MessageHasBeenPosted(pluginContext, pluginPost)
+			return true
+		}, plugin.MessageHasBeenPostedID)
+	})
 
 	if a.Metrics() != nil {
 		a.Metrics().IncrementPostCreate()
@@ -658,20 +653,18 @@ func (a *App) UpdatePost(c *request.Context, post *model.Post, safeUpdate bool) 
 		oldPost.RemoteId = model.NewString(*post.RemoteId)
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		var rejectionReason string
-		pluginContext := pluginContext(c)
-		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-			newPost, rejectionReason = hooks.MessageWillBeUpdated(pluginContext, newPost.ForPlugin(), oldPost.ForPlugin())
-			return post != nil
-		}, plugin.MessageWillBeUpdatedID)
-		if newPost == nil {
-			return nil, model.NewAppError("UpdatePost", "Post rejected by plugin. "+rejectionReason, nil, "", http.StatusBadRequest)
-		}
-		// Restore the post metadata that was stripped by the plugin. Set it to
-		// the last known good.
-		newPost.Metadata = oldPost.Metadata
+	var rejectionReason string
+	pluginContext := pluginContext(c)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+		newPost, rejectionReason = hooks.MessageWillBeUpdated(pluginContext, newPost.ForPlugin(), oldPost.ForPlugin())
+		return post != nil
+	}, plugin.MessageWillBeUpdatedID)
+	if newPost == nil {
+		return nil, model.NewAppError("UpdatePost", "Post rejected by plugin. "+rejectionReason, nil, "", http.StatusBadRequest)
 	}
+	// Restore the post metadata that was stripped by the plugin. Set it to
+	// the last known good.
+	newPost.Metadata = oldPost.Metadata
 
 	rpost, nErr := a.Srv().Store().Post().Update(newPost, oldPost)
 	if nErr != nil {
@@ -684,17 +677,14 @@ func (a *App) UpdatePost(c *request.Context, post *model.Post, safeUpdate bool) 
 		}
 	}
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		pluginOldPost := oldPost.ForPlugin()
-		pluginNewPost := newPost.ForPlugin()
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.MessageHasBeenUpdated(pluginContext, pluginNewPost, pluginOldPost)
-				return true
-			}, plugin.MessageHasBeenUpdatedID)
-		})
-	}
+	pluginOldPost := oldPost.ForPlugin()
+	pluginNewPost := newPost.ForPlugin()
+	a.Srv().Go(func() {
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.MessageHasBeenUpdated(pluginContext, pluginNewPost, pluginOldPost)
+			return true
+		}, plugin.MessageHasBeenUpdatedID)
+	})
 
 	rpost = a.PreparePostForClientWithEmbedsAndImages(c, rpost, false, true, true)
 

--- a/app/reaction.go
+++ b/app/reaction.go
@@ -43,15 +43,13 @@ func (a *App) SaveReactionForPost(c *request.Context, reaction *model.Reaction) 
 	// The post is always modified since the UpdateAt always changes
 	a.invalidateCacheForChannelPosts(post.ChannelId)
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.ReactionHasBeenAdded(pluginContext, reaction)
-				return true
-			}, plugin.ReactionHasBeenAddedID)
-		})
-	}
+	pluginContext := pluginContext(c)
+	a.Srv().Go(func() {
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.ReactionHasBeenAdded(pluginContext, reaction)
+			return true
+		}, plugin.ReactionHasBeenAddedID)
+	})
 
 	a.Srv().Go(func() {
 		a.sendReactionEvent(model.WebsocketEventReactionAdded, reaction, post)
@@ -142,15 +140,13 @@ func (a *App) DeleteReactionForPost(c *request.Context, reaction *model.Reaction
 	// The post is always modified since the UpdateAt always changes
 	a.invalidateCacheForChannelPosts(post.ChannelId)
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.ReactionHasBeenRemoved(pluginContext, reaction)
-				return true
-			}, plugin.ReactionHasBeenRemovedID)
-		})
-	}
+	pluginContext := pluginContext(c)
+	a.Srv().Go(func() {
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.ReactionHasBeenRemoved(pluginContext, reaction)
+			return true
+		}, plugin.ReactionHasBeenRemovedID)
+	})
 
 	a.Srv().Go(func() {
 		a.sendReactionEvent(model.WebsocketEventReactionRemoved, reaction, post)

--- a/app/team.go
+++ b/app/team.go
@@ -846,20 +846,18 @@ func (a *App) JoinUserToTeam(c request.CTX, team *model.Team, user *model.User, 
 	a.InvalidateCacheForUser(user.Id)
 	a.invalidateCacheForUserTeams(user.Id)
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		var actor *model.User
-		if userRequestorId != "" {
-			actor, _ = a.GetUser(userRequestorId)
-		}
-
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.UserHasJoinedTeam(pluginContext, teamMember, actor)
-				return true
-			}, plugin.UserHasJoinedTeamID)
-		})
+	var actor *model.User
+	if userRequestorId != "" {
+		actor, _ = a.GetUser(userRequestorId)
 	}
+
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.UserHasJoinedTeam(pluginContext, teamMember, actor)
+			return true
+		}, plugin.UserHasJoinedTeamID)
+	})
 
 	message := model.NewWebSocketEvent(model.WebsocketEventAddedToTeam, "", "", user.Id, nil, "")
 	message.Add("team_id", team.Id)
@@ -1220,20 +1218,18 @@ func (a *App) RemoveUserFromTeam(c request.CTX, teamID string, userID string, re
 }
 
 func (a *App) postProcessTeamMemberLeave(c request.CTX, teamMember *model.TeamMember, requestorId string) *model.AppError {
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		var actor *model.User
-		if requestorId != "" {
-			actor, _ = a.GetUser(requestorId)
-		}
-
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.UserHasLeftTeam(pluginContext, teamMember, actor)
-				return true
-			}, plugin.UserHasLeftTeamID)
-		})
+	var actor *model.User
+	if requestorId != "" {
+		actor, _ = a.GetUser(requestorId)
 	}
+
+	a.Srv().Go(func() {
+		pluginContext := pluginContext(c)
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.UserHasLeftTeam(pluginContext, teamMember, actor)
+			return true
+		}, plugin.UserHasLeftTeamID)
+	})
 
 	user, nErr := a.Srv().Store().User().Get(context.Background(), teamMember.UserId)
 	if nErr != nil {

--- a/app/upload.go
+++ b/app/upload.go
@@ -49,11 +49,6 @@ func (a *App) genFileInfoFromReader(name string, file io.ReadSeeker, size int64)
 }
 
 func (a *App) runPluginsHook(c *request.Context, info *model.FileInfo, file io.Reader) *model.AppError {
-	pluginsEnvironment := a.GetPluginsEnvironment()
-	if pluginsEnvironment == nil {
-		return nil
-	}
-
 	filePath := info.Path
 	// using a pipe to avoid loading the whole file content in memory.
 	r, w := io.Pipe()

--- a/app/user.go
+++ b/app/user.go
@@ -308,15 +308,13 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 	message.Add("user_id", ruser.Id)
 	a.Publish(message)
 
-	if pluginsEnvironment := a.GetPluginsEnvironment(); pluginsEnvironment != nil {
-		a.Srv().Go(func() {
-			pluginContext := pluginContext(c)
-			a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
-				hooks.UserHasBeenCreated(pluginContext, ruser)
-				return true
-			}, plugin.UserHasBeenCreatedID)
-		})
-	}
+	pluginContext := pluginContext(c)
+	a.Srv().Go(func() {
+		a.ch.RunMultiHook(func(hooks plugin.Hooks) bool {
+			hooks.UserHasBeenCreated(pluginContext, ruser)
+			return true
+		}, plugin.UserHasBeenCreatedID)
+	})
 
 	_, cwsErr := a.SendSubscriptionHistoryEvent(ruser.Id)
 	if cwsErr != nil {


### PR DESCRIPTION

#### Summary
It seems like on of the recent MPA refactor PR (#21772) caused a data race in a test as following test log. 

Also while checking on this I realized that I missed a huge point, if you disable the plugins, product hooks wouldn't work. I also added that bit as the second commit.

```
==================
WARNING: DATA RACE
Write at 0x00c009b22260 by goroutine 571:
  github.com/mattermost/mattermost-server/v6/app.(*Channels).ShutDownPlugins()
      /mattermost/mattermost-server/app/plugin.go:395 +0x1f9
  github.com/mattermost/mattermost-server/v6/app.(*Channels).Stop()
      /mattermost/mattermost-server/app/channels.go:285 +0x44
  github.com/mattermost/mattermost-server/v6/app.(*Server).Shutdown()
      /mattermost/mattermost-server/app/server.go:748 +0x14c8
  github.com/mattermost/mattermost-server/v6/api4.(*TestHelper).ShutdownApp.func1()
      /mattermost/mattermost-server/api4/apitestlib.go:360 +0x64

Previous read at 0x00c009b22260 by goroutine 488:
  github.com/mattermost/mattermost-server/v6/app.(*Channels).RunMultiHook()
      /mattermost/mattermost-server/app/channels.go:329 +0x57
  github.com/mattermost/mattermost-server/v6/app/platform.(*WebConn).pluginPostedConsumer()
      /mattermost/mattermost-server/app/platform/web_conn.go:239 +0x145
  github.com/mattermost/mattermost-server/v6/app/platform.(*WebConn).Pump.func3()
      /mattermost/mattermost-server/app/platform/web_conn.go:318 +0x47

Goroutine 571 (running) created at:
  github.com/mattermost/mattermost-server/v6/api4.(*TestHelper).ShutdownApp()
      /mattermost/mattermost-server/api4/apitestlib.go:359 +0x10e
  github.com/mattermost/mattermost-server/v6/api4.(*TestHelper).TearDown()
      /mattermost/mattermost-server/api4/apitestlib.go:378 +0xd9
  github.com/mattermost/mattermost-server/v6/api4.TestUpdatePreferencesWebsocket.func1()
      /mattermost/mattermost-server/api4/preference_test.go:262 +0x39
  runtime.deferreturn()
      /usr/local/go/src/runtime/panic.go:436 +0x32
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1486 +0x47

Goroutine 488 (running) created at:
  github.com/mattermost/mattermost-server/v6/app/platform.(*WebConn).Pump()
      /mattermost/mattermost-server/app/platform/web_conn.go:318 +0x1da
  github.com/mattermost/mattermost-server/v6/api4.connectWebSocket()
      /mattermost/mattermost-server/api4/websocket.go:69 +0xae7
  github.com/mattermost/mattermost-server/v6/web.Handler.ServeHTTP()
      /mattermost/mattermost-server/web/handlers.go:358 +0x4302
  github.com/mattermost/mattermost-server/v6/web.(*Handler).ServeHTTP()
      <autogenerated>:1 +0xe9
  github.com/mattermost/gziphandler.GzipHandlerWithOpts.func1.1()
      /go/pkg/mod/github.com/mattermost/gziphandler@v0.0.1/gzip.go:343 +0x4a8
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2084 +0x4d
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x361
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2916 +0x896
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1966 +0xbaa
  net/http.(*Server).Serve.func3()
      /usr/local/go/src/net/http/server.go:3071 +0x58
==================
```

#### Release Note

```release-note
NONE
```
