### PR TITLE
[MM-36289] App badge count fix for the direct messages

### DIFF
--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1401,17 +1401,13 @@ func (us SqlUserStore) AnalyticsActiveCountForPeriod(startTime int64, endTime in
 }
 
 func (us SqlUserStore) GetUnreadCount(userId string, isCRTEnabled bool) (int64, error) {
-	var totalMsgCountColumn = "c.TotalMsgCount"
-	var msgCountColumn = "cm.MsgCount"
 	var mentionCountColumn = "cm.MentionCount"
 	if isCRTEnabled {
-		totalMsgCountColumn = "c.TotalMsgCountRoot"
-		msgCountColumn = "cm.MsgCountRoot"
 		mentionCountColumn = "cm.MentionCountRoot"
 	}
 
 	query := `
-		SELECT SUM(CASE WHEN c.Type = ? THEN (` + totalMsgCountColumn + ` - ` + msgCountColumn + `) ELSE ` + mentionCountColumn + ` END)
+		SELECT SUM(` + mentionCountColumn + `)
 		FROM Channels c
 		INNER JOIN ChannelMembers cm
 			ON cm.ChannelId = c.Id
@@ -1420,7 +1416,7 @@ func (us SqlUserStore) GetUnreadCount(userId string, isCRTEnabled bool) (int64, 
 	`
 
 	var count int64
-	err := us.GetReplicaX().Get(&count, query, model.ChannelTypeDirect, userId)
+	err := us.GetReplicaX().Get(&count, query, userId)
 	if err != nil {
 		return count, errors.Wrapf(err, "failed to count unread Channels for userId=%s", userId)
 	}


### PR DESCRIPTION
#### Summary
When a post is marked as unread, we are sending a push notification with the updated badge count.

Currently in the query, for the direct messages, we are doing `totalMessages - messagesCount` which is leading to the wrong count of the messages as it includes all the messages by both users. We are doing this to count all DM `unreads` as `mentions`. 

https://github.com/mattermost/mattermost-server/blob/91ee9ed2ebf1a9cd3ecf365dff1c4261452a576f/app/post.go#L1756-L1778

For the direct messages, we are already including all the `unreads` as `mentions`, and the same query used for the rest of the channels will also work for the direct messages.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36289

#### Release Note
```
NONE
```
