### PR TITLE
MM-48924 Don't cache remote_entry.js files

### DIFF
--- a/web/static.go
+++ b/web/static.go
@@ -81,7 +81,11 @@ func staticFilesHandler(handler http.Handler) http.Handler {
 		//wrap our ResponseWriter with our no-cache 404-handler
 		w = &notFoundNoCacheResponseWriter{ResponseWriter: w}
 
-		w.Header().Set("Cache-Control", "max-age=31556926, public")
+		if path.Base(r.URL.Path) == "remote_entry.js" {
+			w.Header().Set("Cache-Control", "no-cache, max-age=0")
+		} else {
+			w.Header().Set("Cache-Control", "max-age=31556926, public")
+		}
 
 		if strings.HasSuffix(r.URL.Path, "/") {
 			http.NotFound(w, r)

--- a/web/static.go
+++ b/web/static.go
@@ -82,7 +82,7 @@ func staticFilesHandler(handler http.Handler) http.Handler {
 		w = &notFoundNoCacheResponseWriter{ResponseWriter: w}
 
 		if path.Base(r.URL.Path) == "remote_entry.js" {
-			w.Header().Set("Cache-Control", "no-cache, max-age=0")
+			w.Header().Set("Cache-Control", "no-cache, max-age=31556926, public")
 		} else {
 			w.Header().Set("Cache-Control", "max-age=31556926, public")
 		}

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -410,14 +410,14 @@ func TestStaticFilesCaching(t *testing.T) {
 	th.Web.MainRouter.ServeHTTP(res, req)
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, fakeRemoteEntry, res.Body.String())
-	require.Equal(t, []string{"no-cache, max-age=0"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+	require.Equal(t, []string{"no-cache, max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
 
 	req, _ = http.NewRequest("GET", "/static/products/boards/remote_entry.js", nil)
 	res = httptest.NewRecorder()
 	th.Web.MainRouter.ServeHTTP(res, req)
 	require.Equal(t, http.StatusOK, res.Code)
 	require.Equal(t, fakeRemoteEntry, res.Body.String())
-	require.Equal(t, []string{"no-cache, max-age=0"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+	require.Equal(t, []string{"no-cache, max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
 }
 
 func TestCheckClientCompatability(t *testing.T) {

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"testing"
 	"time"
@@ -358,6 +360,65 @@ func TestStatic(t *testing.T) {
 	assert.Equalf(t, resp.StatusCode, http.StatusOK, "couldn't get static files %v", resp.StatusCode)
 }
 */
+
+func TestStaticFilesCaching(t *testing.T) {
+	th := Setup(t).InitPlugins()
+	defer th.TearDown()
+
+	wd, _ := os.Getwd()
+	cmd := exec.Command("ls", path.Join(wd, "client", "plugins"))
+	cmd.Stdout = os.Stdout
+	cmd.Run()
+
+	fakeMainBundleName := "main.1234ab.js"
+	fakeRootHTML := `<html>
+<head>
+	<title>Mattermost</title>
+</head>
+</html>`
+	fakeMainBundle := `module.exports = 'main';`
+	fakeRemoteEntry := `module.exports = 'remote';`
+
+	err := os.WriteFile("./client/root.html", []byte(fakeRootHTML), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile("./client/"+fakeMainBundleName, []byte(fakeMainBundle), 0600)
+	require.NoError(t, err)
+	err = os.WriteFile("./client/remote_entry.js", []byte(fakeRemoteEntry), 0600)
+	require.NoError(t, err)
+
+	err = os.MkdirAll("./client/products/boards", 0777)
+	require.NoError(t, err)
+	err = os.WriteFile("./client/products/boards/remote_entry.js", []byte(fakeRemoteEntry), 0600)
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	res := httptest.NewRecorder()
+	th.Web.MainRouter.ServeHTTP(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, fakeRootHTML, res.Body.String())
+	require.Equal(t, []string{"no-cache, max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+
+	req, _ = http.NewRequest("GET", "/static/"+fakeMainBundleName, nil)
+	res = httptest.NewRecorder()
+	th.Web.MainRouter.ServeHTTP(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, fakeMainBundle, res.Body.String())
+	require.Equal(t, []string{"max-age=31556926, public"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+
+	req, _ = http.NewRequest("GET", "/static/remote_entry.js", nil)
+	res = httptest.NewRecorder()
+	th.Web.MainRouter.ServeHTTP(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, fakeRemoteEntry, res.Body.String())
+	require.Equal(t, []string{"no-cache, max-age=0"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+
+	req, _ = http.NewRequest("GET", "/static/products/boards/remote_entry.js", nil)
+	res = httptest.NewRecorder()
+	th.Web.MainRouter.ServeHTTP(res, req)
+	require.Equal(t, http.StatusOK, res.Code)
+	require.Equal(t, fakeRemoteEntry, res.Body.String())
+	require.Equal(t, []string{"no-cache, max-age=0"}, res.Result().Header[http.CanonicalHeaderKey("Cache-Control")])
+}
 
 func TestCheckClientCompatability(t *testing.T) {
 	//Browser Name, UA String, expected result (if the browser should fail the test false and if it should pass the true)


### PR DESCRIPTION
As discussed in the threads linked in the accompanying Jira ticket, module federation introduces `remote_entry.js` files for each federated container (currently the web app and the Boards product) that contain the locations of each chunk of the JS bundle and where to find them. Each version of those files has a unique name which means they can be cached, but the names of the `remote_entry.js` files are non-unique, so we can't cache them.

I looked at possibly giving them unique names, but given that the different entry points need help finding each other, it doesn't seem like we can do that right now. Best I can tell, it's intended that we don't cache these files since they're very small anyway (~8kb).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48924

#### Release Note
```release-note
Prevented browsers and CDNs from caching remote entrypoint files
```
