### PR TITLE
[MM-48649]: Call the SendSubscriptionHistoryEvent function in a GO routine

### DIFF
--- a/app/user.go
+++ b/app/user.go
@@ -316,10 +316,13 @@ func (a *App) createUserOrGuest(c request.CTX, user *model.User, guest bool) (*m
 		}, plugin.UserHasBeenCreatedID)
 	})
 
-	_, cwsErr := a.SendSubscriptionHistoryEvent(ruser.Id)
-	if cwsErr != nil {
-		c.Logger().Error("Failed to create/update the SubscriptionHistoryEvent", mlog.Err(cwsErr))
-	}
+	// Create/Update the subscriptionHistoryEvent
+	go func() {
+		_, err := a.SendSubscriptionHistoryEvent(ruser.Id)
+		if err != nil {
+			c.Logger().Error("Failed to create/update the SubscriptionHistoryEvent", mlog.Err(err))
+		}
+	}()
 
 	return ruser, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

The `SendSubscriptionHistoryEvent` function will now be called in a Go routine, so that it does not stall the UI when a new user is created.

Also related to this PR: https://github.com/mattermost/enterprise/pull/1317
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48649
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
