### PR TITLE
Skip "block user by domain but allow bot" test

### DIFF
--- a/app/team_test.go
+++ b/app/team_test.go
@@ -102,6 +102,7 @@ func TestAddUserToTeam(t *testing.T) {
 	})
 
 	t.Run("block user by domain but allow bot", func(t *testing.T) {
+		t.Skip("MM-48973")
 		th.BasicTeam.AllowedDomains = "example.com"
 		_, err := th.App.UpdateTeam(th.BasicTeam)
 		require.Nil(t, err, "Should update the team")


### PR DESCRIPTION
#### Summary

There is a recent flaky test [failing with a data race](https://app.circleci.com/pipelines/github/mattermost/mattermost-server/39336/workflows/13f67056-9a30-409f-8a4e-ce8066e4c3b4/jobs/356399), possibly introduced by #21836. This PR skips the test until https://mattermost.atlassian.net/browse/MM-48973 is fixed.

#### Ticket Link
--

#### Release Note
```release-note
NONE
```
