### PR TITLE
MM-48553: Fix panic in json.MarshalerError

### DIFF
--- a/model/group_syncable.go
+++ b/model/group_syncable.go
@@ -144,9 +144,7 @@ func (syncable *GroupSyncable) MarshalJSON() ([]byte, error) {
 			Alias: (*Alias)(syncable),
 		})
 	default:
-		return nil, &json.MarshalerError{
-			Err: fmt.Errorf("unknown syncable type: %s", syncable.Type),
-		}
+		return nil, fmt.Errorf("unknown syncable type: %s", syncable.Type)
 	}
 }
 

--- a/model/group_syncable_test.go
+++ b/model/group_syncable_test.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupSyncableMarshal(t *testing.T) {
+	require.NotPanics(t, func() {
+		var syncable GroupSyncable
+		_, err := json.Marshal(&syncable)
+		require.Error(t, err)
+		t.Log(err.Error())
+	}, "marshaling groupsyncable should not panic")
+}


### PR DESCRIPTION
Although this isn't the root cause for the panic in the sentry crash,
this is indeed a bug and will cause a crash in the exact same way.

I have looked at other possibilities and I don't see any other
way for model.ChannelMembers to panic during json marshaling.

Other sentry crashes are there for ths customer and they point
to data corruption which indicates there is something funky going on.

Nevertheless, this is a valid bug and should be fixed.

https://mattermost.atlassian.net/browse/MM-48553

```release-note
NONE
```
