### PR TITLE
MM-48984: Add missing timeout while creating a connection

### DIFF
--- a/app/plugin_db_driver_test.go
+++ b/app/plugin_db_driver_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnCreateTimeout(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	*th.App.Config().SqlSettings.QueryTimeout = 0
+
+	d := NewDriverImpl(th.Server)
+	_, err := d.Conn(true)
+	require.Error(t, err)
+}
+

--- a/app/plugin_db_driver_test.go
+++ b/app/plugin_db_driver_test.go
@@ -19,4 +19,3 @@ func TestConnCreateTimeout(t *testing.T) {
 	_, err := d.Conn(true)
 	require.Error(t, err)
 }
-


### PR DESCRIPTION
If a timeout is missing, this goroutine waits indefinitely trying
to get a connection. Leading to a goroutine accumulation in a scenario
where the DB is somehow not release connections.

https://mattermost.atlassian.net/browse/MM-48984

```release-note
NONE
```
