### PR TITLE
product/hooks: hooks service no longer requires channels service start

### DIFF
--- a/app/channels.go
+++ b/app/channels.go
@@ -318,10 +318,6 @@ type hooksService struct {
 }
 
 func (s *hooksService) RegisterHooks(productID string, hooks any) error {
-	if s.ch.pluginsEnvironment == nil {
-		return errors.New("could not find plugins environment")
-	}
-
 	return s.ch.srv.hooksManager.AddProduct(productID, hooks)
 }
 

--- a/product/api.go
+++ b/product/api.go
@@ -112,7 +112,7 @@ type ConfigService interface {
 }
 
 // HooksService is the API for adding exiting plugin hooks to the server so that they can be called as
-// they were. This Service is required to be used after the products start. Otherwise it will return an error.
+// they were. This Service is required to be accessed after the channels product start.
 //
 // The service shall be registered via app.HooksKey service key.
 type HooksService interface {

--- a/product/api.go
+++ b/product/api.go
@@ -112,7 +112,7 @@ type ConfigService interface {
 }
 
 // HooksService is the API for adding exiting plugin hooks to the server so that they can be called as
-// they were. This Service is required to be accessed after the channels product start.
+// they were. This Service is required to be accessed after the channels product initialized.
 //
 // The service shall be registered via app.HooksKey service key.
 type HooksService interface {


### PR DESCRIPTION

#### Summary
We don't need to wait plugins environment to exist to register hooks. It's also guaranteed to Channels product initialized first. So, other product can safely call hooks service in their initialized


#### Release Note

```release-note
NONE
```
