### PR TITLE
[MM-49009] Allow an end time for compliance exports

### DIFF
--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -181,6 +181,10 @@ func buildExportCmdF(format string) func(command *cobra.Command, args []string) 
 			return errors.New("limit flag error")
 		}
 
+		if endTime > 0 && limit > 0 {
+			CommandPrettyPrintln("WARNING: Using both the --exportTo and --limit flags may lead to inconsistent exports.")
+		}
+
 		if a.MessageExport() == nil || license == nil || !*license.Features.MessageExport {
 			return errors.New("message export feature not available")
 		}

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -75,7 +75,7 @@ func init() {
 	CsvExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
 	ActianceExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
-	CsvExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
+	ActianceExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
 	ActianceExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
 	GlobalRelayZipExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -71,9 +71,11 @@ func init() {
 	ScheduleExportCmd.Flags().Int("timeoutSeconds", -1, "The maximum number of seconds to wait for the job to complete before timing out.")
 
 	CsvExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
+	CsvExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
 	CsvExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
 	ActianceExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
+	CsvExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
 	ActianceExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
 	GlobalRelayZipExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
@@ -168,6 +170,11 @@ func buildExportCmdF(format string) func(command *cobra.Command, args []string) 
 			return errors.New("exportFrom must be a positive integer")
 		}
 
+		endTime, err := command.Flags().GetInt64("exportTo")
+		if err != nil {
+			return errors.New("exportFrom flag error")
+		}
+
 		limit, err := command.Flags().GetInt("limit")
 		if err != nil {
 			return errors.New("limit flag error")
@@ -177,7 +184,7 @@ func buildExportCmdF(format string) func(command *cobra.Command, args []string) 
 			return errors.New("message export feature not available")
 		}
 
-		warningsCount, appErr := a.MessageExport().RunExport(format, startTime, limit)
+		warningsCount, appErr := a.MessageExport().RunExport(format, startTime, endTime, limit)
 		if appErr != nil {
 			return appErr
 		}

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -79,6 +79,7 @@ func init() {
 	ActianceExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
 	GlobalRelayZipExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
+	GlobalRelayZipExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
 	GlobalRelayZipExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
 	BulkExportCmd.Flags().Bool("all-teams", true, "Export all teams from the server.")

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -70,16 +70,16 @@ func init() {
 	ScheduleExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
 	ScheduleExportCmd.Flags().Int("timeoutSeconds", -1, "The maximum number of seconds to wait for the job to complete before timing out.")
 
-	CsvExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
-	CsvExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
+	CsvExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in milliseconds since the unix epoch.")
+	CsvExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in milliseconds since the unix epoch.")
 	CsvExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
-	ActianceExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
-	ActianceExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
+	ActianceExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in milliseconds since the unix epoch.")
+	ActianceExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in milliseconds since the unix epoch.")
 	ActianceExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
-	GlobalRelayZipExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in seconds since the unix epoch.")
-	GlobalRelayZipExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in seconds since the unix epoch.")
+	GlobalRelayZipExportCmd.Flags().Int64("exportFrom", -1, "The timestamp of the earliest post to export, expressed in milliseconds since the unix epoch.")
+	GlobalRelayZipExportCmd.Flags().Int64("exportTo", -1, "The timestamp until which posts are exported (excluding), expressed in milliseconds since the unix epoch.")
 	GlobalRelayZipExportCmd.Flags().Int("limit", -1, "The number of posts to export. The default of -1 means no limit.")
 
 	BulkExportCmd.Flags().Bool("all-teams", true, "Export all teams from the server.")

--- a/einterfaces/message_export.go
+++ b/einterfaces/message_export.go
@@ -11,5 +11,5 @@ import (
 
 type MessageExportInterface interface {
 	StartSynchronizeJob(ctx context.Context, exportFromTimestamp int64) (*model.Job, *model.AppError)
-	RunExport(format string, since int64, limit int) (int64, *model.AppError)
+	RunExport(format string, since, until int64, limit int) (int64, *model.AppError)
 }

--- a/einterfaces/mocks/MessageExportInterface.go
+++ b/einterfaces/mocks/MessageExportInterface.go
@@ -17,20 +17,20 @@ type MessageExportInterface struct {
 	mock.Mock
 }
 
-// RunExport provides a mock function with given fields: format, since, limit
-func (_m *MessageExportInterface) RunExport(format string, since int64, limit int) (int64, *model.AppError) {
-	ret := _m.Called(format, since, limit)
+// RunExport provides a mock function with given fields: format, since, until, limit
+func (_m *MessageExportInterface) RunExport(format string, since int64, until int64, limit int) (int64, *model.AppError) {
+	ret := _m.Called(format, since, until, limit)
 
 	var r0 int64
-	if rf, ok := ret.Get(0).(func(string, int64, int) int64); ok {
-		r0 = rf(format, since, limit)
+	if rf, ok := ret.Get(0).(func(string, int64, int64, int) int64); ok {
+		r0 = rf(format, since, until, limit)
 	} else {
 		r0 = ret.Get(0).(int64)
 	}
 
 	var r1 *model.AppError
-	if rf, ok := ret.Get(1).(func(string, int64, int) *model.AppError); ok {
-		r1 = rf(format, since, limit)
+	if rf, ok := ret.Get(1).(func(string, int64, int64, int) *model.AppError); ok {
+		r1 = rf(format, since, until, limit)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7568,6 +7568,10 @@
     "translation": "Your license does not support ID Loaded Push Notifications."
   },
   {
+    "id": "ent.jobs.do_job.batch_end_timestamp.parse_error",
+    "translation": "Could not parse message export job end timestamp."
+  },
+  {
     "id": "ent.jobs.do_job.batch_size.parse_error",
     "translation": "Could not parse message export job BatchSize."
   },

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -3197,7 +3197,7 @@ func (s *OpenTracingLayerComplianceStore) GetAll(offset int, limit int) (model.C
 	return result, err
 }
 
-func (s *OpenTracingLayerComplianceStore) MessageExport(cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+func (s *OpenTracingLayerComplianceStore) MessageExport(cursor model.MessageExportCursor, endAt int64, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ComplianceStore.MessageExport")
 	s.Root.Store.SetContext(newCtx)
@@ -3206,7 +3206,7 @@ func (s *OpenTracingLayerComplianceStore) MessageExport(cursor model.MessageExpo
 	}()
 
 	defer span.Finish()
-	result, resultVar1, err := s.ComplianceStore.MessageExport(cursor, limit)
+	result, resultVar1, err := s.ComplianceStore.MessageExport(cursor, endAt, limit)
 	if err != nil {
 		span.LogFields(spanlog.Error(err))
 		ext.Error.Set(span, true)

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -3567,11 +3567,11 @@ func (s *RetryLayerComplianceStore) GetAll(offset int, limit int) (model.Complia
 
 }
 
-func (s *RetryLayerComplianceStore) MessageExport(cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+func (s *RetryLayerComplianceStore) MessageExport(cursor model.MessageExportCursor, endAt int64, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
 
 	tries := 0
 	for {
-		result, resultVar1, err := s.ComplianceStore.MessageExport(cursor, limit)
+		result, resultVar1, err := s.ComplianceStore.MessageExport(cursor, endAt, limit)
 		if err == nil {
 			return result, resultVar1, nil
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -549,7 +549,7 @@ type ComplianceStore interface {
 	Get(id string) (*model.Compliance, error)
 	GetAll(offset, limit int) (model.Compliances, error)
 	ComplianceExport(compliance *model.Compliance, cursor model.ComplianceExportCursor, limit int) ([]*model.CompliancePost, model.ComplianceExportCursor, error)
-	MessageExport(cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error)
+	MessageExport(cursor model.MessageExportCursor, endAt int64, limit int) ([]*model.MessageExport, model.MessageExportCursor, error)
 }
 
 type OAuthStore interface {

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -399,7 +399,7 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -469,7 +469,7 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 
 	// fetch the message exports for both posts that user1 sent
 	messageExportMap := map[string]model.MessageExport{}
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(messages))
 
@@ -503,7 +503,7 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -573,7 +573,7 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 
 	// fetch the message exports for both posts that user1 sent
 	messageExportMap := map[string]model.MessageExport{}
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(messages))
 
@@ -609,7 +609,7 @@ func testMessageExportDirectMessageChannel(t *testing.T, ss store.Store) {
 
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -664,7 +664,7 @@ func testMessageExportDirectMessageChannel(t *testing.T, ss store.Store) {
 
 	// fetch the message export for the post that user1 sent
 	messageExportMap := map[string]model.MessageExport{}
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, len(messages))
@@ -690,7 +690,7 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -762,7 +762,7 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 
 	// fetch the message export for the post that user1 sent
 	messageExportMap := map[string]model.MessageExport{}
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(messages))
 
@@ -787,7 +787,7 @@ func testEditExportMessage(t *testing.T, ss store.Store) {
 	defer cleanupStoreState(t, ss)
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -842,7 +842,7 @@ func testEditExportMessage(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	// fetch the message exports from the start
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(messages))
 
@@ -879,7 +879,7 @@ func testEditAfterExportMessage(t *testing.T, ss store.Store) {
 	defer cleanupStoreState(t, ss)
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -927,7 +927,7 @@ func testEditAfterExportMessage(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	// fetch the message exports from the start
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(messages))
 
@@ -953,7 +953,7 @@ func testEditAfterExportMessage(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	// fetch the message exports after edit
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: postEditTime - 1}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: postEditTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(messages))
 
@@ -990,7 +990,7 @@ func testDeleteExportMessage(t *testing.T, ss store.Store) {
 	defer cleanupStoreState(t, ss)
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -1043,7 +1043,7 @@ func testDeleteExportMessage(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	// fetch the message exports from the start
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(messages))
 
@@ -1075,7 +1075,7 @@ func testDeleteAfterExportMessage(t *testing.T, ss store.Store) {
 	defer cleanupStoreState(t, ss)
 	// get the starting number of message export entries
 	startTime := model.GetMillis()
-	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err := ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(messages))
 
@@ -1123,7 +1123,7 @@ func testDeleteAfterExportMessage(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	// fetch the message exports from the start
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(messages))
 
@@ -1146,7 +1146,7 @@ func testDeleteAfterExportMessage(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	// fetch the message exports after delete
-	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: postDeleteTime - 1}, 10)
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: postDeleteTime - 1}, model.GetMillis()+1000, 10)
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(messages))
 

--- a/store/storetest/compliance_store.go
+++ b/store/storetest/compliance_store.go
@@ -477,6 +477,11 @@ func testMessageExportPublicChannel(t *testing.T, ss store.Store) {
 		messageExportMap[*v.PostId] = *v
 	}
 
+	// fetch time message export for one of the posts that user1 sent
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, startTime+5, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(messages))
+
 	// post1 was made by user1 in channel1 and team1
 	assert.Equal(t, post1.Id, *messageExportMap[post1.Id].PostId)
 	assert.Equal(t, post1.CreateAt, *messageExportMap[post1.Id].PostCreateAt)
@@ -580,6 +585,11 @@ func testMessageExportPrivateChannel(t *testing.T, ss store.Store) {
 	for _, v := range messages {
 		messageExportMap[*v.PostId] = *v
 	}
+
+	// fetch the message exports for one of the posts that user1 sent
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, startTime+5, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(messages))
 
 	// post1 was made by user1 in channel1 and team1
 	assert.Equal(t, post1.Id, *messageExportMap[post1.Id].PostId)
@@ -769,6 +779,10 @@ func testMessageExportGroupMessageChannel(t *testing.T, ss store.Store) {
 	for _, v := range messages {
 		messageExportMap[*v.PostId] = *v
 	}
+
+	messages, _, err = ss.Compliance().MessageExport(model.MessageExportCursor{LastPostUpdateAt: startTime - 10}, model.GetMillis()+10, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(messages))
 
 	// post is a DM between user1 and user2
 	// there is no channel display name for direct messages, so we sub in the string "Direct Message" instead

--- a/store/storetest/mocks/ComplianceStore.go
+++ b/store/storetest/mocks/ComplianceStore.go
@@ -90,13 +90,13 @@ func (_m *ComplianceStore) GetAll(offset int, limit int) (model.Compliances, err
 	return r0, r1
 }
 
-// MessageExport provides a mock function with given fields: cursor, limit
-func (_m *ComplianceStore) MessageExport(cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
-	ret := _m.Called(cursor, limit)
+// MessageExport provides a mock function with given fields: cursor, endAt, limit
+func (_m *ComplianceStore) MessageExport(cursor model.MessageExportCursor, endAt int64, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+	ret := _m.Called(cursor, endAt, limit)
 
 	var r0 []*model.MessageExport
-	if rf, ok := ret.Get(0).(func(model.MessageExportCursor, int) []*model.MessageExport); ok {
-		r0 = rf(cursor, limit)
+	if rf, ok := ret.Get(0).(func(model.MessageExportCursor, int64, int) []*model.MessageExport); ok {
+		r0 = rf(cursor, endAt, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*model.MessageExport)
@@ -104,15 +104,15 @@ func (_m *ComplianceStore) MessageExport(cursor model.MessageExportCursor, limit
 	}
 
 	var r1 model.MessageExportCursor
-	if rf, ok := ret.Get(1).(func(model.MessageExportCursor, int) model.MessageExportCursor); ok {
-		r1 = rf(cursor, limit)
+	if rf, ok := ret.Get(1).(func(model.MessageExportCursor, int64, int) model.MessageExportCursor); ok {
+		r1 = rf(cursor, endAt, limit)
 	} else {
 		r1 = ret.Get(1).(model.MessageExportCursor)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(model.MessageExportCursor, int) error); ok {
-		r2 = rf(cursor, limit)
+	if rf, ok := ret.Get(2).(func(model.MessageExportCursor, int64, int) error); ok {
+		r2 = rf(cursor, endAt, limit)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -2932,10 +2932,10 @@ func (s *TimerLayerComplianceStore) GetAll(offset int, limit int) (model.Complia
 	return result, err
 }
 
-func (s *TimerLayerComplianceStore) MessageExport(cursor model.MessageExportCursor, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
+func (s *TimerLayerComplianceStore) MessageExport(cursor model.MessageExportCursor, endAt int64, limit int) ([]*model.MessageExport, model.MessageExportCursor, error) {
 	start := time.Now()
 
-	result, resultVar1, err := s.ComplianceStore.MessageExport(cursor, limit)
+	result, resultVar1, err := s.ComplianceStore.MessageExport(cursor, endAt, limit)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {


### PR DESCRIPTION
#### Summary
This is the server part of the new compliance export end time functionality. Compliance exports now allow the user to define a `--exportTo` flag with a Unix timestamp to limit the number of exports. The messages will be exported *excluding* the timestamp, so you can combine it with `--exportFrom` without an overlap.

It also logs the post IDs and timestamps for the first and last post in the export. Making it easier to do chunked exports.
```
{"timestamp":"2022-12-13 11:43:41.042 +01:00","level":"debug","msg":"Found posts to export","caller":"message_export/message_export.go:101","number_of_posts":199}
{"timestamp":"2022-12-13 11:43:41.042 +01:00","level":"info","msg":"Export scope","caller":"message_export/message_export.go:109","first_post_id":"oc7r4sdkm3gyzr98tg4qfphmqc","first_post_timestamp":1554596394957,"last_post_id":"aor98cf8mpyddckm4bo7cj8h6e","last_post_timestamp":1554597627720}
```

Despite what the CLI help text claimed, the timestamps are in unix milliseconds, not seconds. This has been corrected for the message exports.

#### Ticket Link
[MM-49009](https://mattermost.atlassian.net/browse/MM-49009)

#### Release Note
```release-note
Compliance exports may now be started with an end timestamp until which messages will be exported using the CLI: `--exportTo 123`
```
