### PR TITLE
[MM-49170] Implement Auditable Interface for Patch Post Struct

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -802,6 +802,7 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("patchPost", audit.Fail)
+	auditRec.AddEventParameter("id", c.Params.PostId)
 	auditRec.AddEventParameter("patch", post)
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)
 

--- a/api4/post.go
+++ b/api4/post.go
@@ -803,7 +803,7 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("patchPost", audit.Fail)
 	auditRec.AddEventParameter("id", c.Params.PostId)
-	auditRec.AddEventParameter("patch", post)
+	auditRec.AddEventParameter("patch", post.Auditable())
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)
 
 	// Updating the file_ids of a post is not a supported operation and will be ignored

--- a/model/post.go
+++ b/model/post.go
@@ -197,9 +197,10 @@ func (o *PostPatch) WithRewrittenImageURLs(f func(string) string) *PostPatch {
 
 func (o *PostPatch) Auditable() map[string]interface{} {
 	return map[string]interface{}{
-		"is_pinned": o.IsPinned,
-		"props":     o.Props,
-		"file_ids":  o.FileIds,
+		"is_pinned":     o.IsPinned,
+		"props":         o.Props,
+		"file_ids":      o.FileIds,
+		"has_reactions": o.HasReactions,
 	}
 }
 

--- a/model/post.go
+++ b/model/post.go
@@ -119,7 +119,7 @@ type Post struct {
 }
 
 func (o *Post) Auditable() map[string]interface{} {
-	return map[string]interface{}{ // TODO check this
+	return map[string]interface{}{
 		"id":              o.Id,
 		"create_at":       o.CreateAt,
 		"update_at":       o.UpdateAt,
@@ -193,6 +193,14 @@ func (o *PostPatch) WithRewrittenImageURLs(f func(string) string) *PostPatch {
 		*copy.Message = RewriteImageURLs(*o.Message, f)
 	}
 	return &copy
+}
+
+func (o *PostPatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"is_pinned": o.IsPinned,
+		"props":     o.Props,
+		"file_ids":  o.FileIds,
+	}
 }
 
 type PostForExport struct {


### PR DESCRIPTION
#### Summary
Add implementation of the auditable interface for `PostPatch`. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49170

#### Release Note
```release-note
NONE
```
