### PR TITLE
[MM-49172] Close pipes on file writer error

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -824,6 +824,7 @@ func (t *UploadFileTask) postprocessImage(file io.Reader) {
 		_, aerr := t.writeFile(r, path)
 		if aerr != nil {
 			mlog.Error("Unable to upload", mlog.String("path", path), mlog.Err(aerr))
+			r.CloseWithError(aerr) // always returns nil
 			return
 		}
 	}

--- a/app/upload.go
+++ b/app/upload.go
@@ -93,6 +93,7 @@ func (a *App) runPluginsHook(c request.CTX, info *model.FileInfo, file io.Reader
 		if fileErr := a.RemoveFile(tmpPath); fileErr != nil {
 			mlog.Warn("Failed to remove file", mlog.Err(fileErr))
 		}
+		r.CloseWithError(err) // always returns nil
 		return err
 	}
 


### PR DESCRIPTION
#### Summary
This is a sibling PR to https://github.com/mattermost/mattermost-server/pull/21854. I discovered two more instances of go-routines potentially getting stuck when the `FileWriter` experiences an error.

#### Ticket Link
[MM-49172](https://mattermost.atlassian.net/browse/MM-49172)

#### Release Note
```release-note
NONE
```
