### PR TITLE
[MM-49198] Fix user agent containing Mattermost from mobile v2 being …

### DIFF
--- a/app/user_agent.go
+++ b/app/user_agent.go
@@ -84,9 +84,11 @@ func getOSName(ua *uasurfer.UserAgent) string {
 }
 
 func getBrowserVersion(ua *uasurfer.UserAgent, userAgentString string) string {
-	if index := strings.Index(userAgentString, "Mattermost/"); index != -1 {
-		afterVersion := userAgentString[index+len("Mattermost/"):]
-		return strings.Fields(afterVersion)[0]
+	for _, v := range []string{"Mattermost/", "Mattermost Desktop/"} {
+		if index := strings.Index(userAgentString, v); index != -1 {
+			afterVersion := userAgentString[index+len(v):]
+			return strings.Fields(afterVersion)[0]
+		}
 	}
 
 	if index := strings.Index(userAgentString, "mmctl/"); index != -1 {
@@ -123,7 +125,7 @@ var browserNames = map[uasurfer.BrowserName]string{
 func getBrowserName(ua *uasurfer.UserAgent, userAgentString string) string {
 	browser := ua.Browser.Name
 
-	if strings.Contains(userAgentString, "Mattermost") {
+	if strings.Contains(userAgentString, "Mattermost/") || strings.Contains(userAgentString, "Mattermost Desktop/") {
 		return "Desktop App"
 	}
 

--- a/app/user_agent_test.go
+++ b/app/user_agent_test.go
@@ -33,6 +33,8 @@ var testUserAgents = []testUserAgent{
 	{"Safari 9", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Safari/604.1.38"},
 	{"Safari 8", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12"},
 	{"Safari Mobile", "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B137 Safari/601.1"},
+	{"Mattermost Mobile v2", "Mattermost Mobile/2.0.0+ae3faea (Android; 11.0.0; Samsung S8)"},
+	{"MM App 5.3.0", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost Desktop/5.3.0 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36"},
 }
 
 func TestGetPlatformName(t *testing.T) {
@@ -113,6 +115,8 @@ func TestGetBrowserName(t *testing.T) {
 		"Safari",
 		"Safari",
 		"Safari",
+		"Unknown",
+		"Desktop App",
 	}
 
 	for i, userAgent := range testUserAgents {
@@ -143,6 +147,8 @@ func TestGetBrowserVersion(t *testing.T) {
 		"11.0",
 		"8.0.7",
 		"9.0",
+		"0.0",
+		"5.3.0",
 	}
 
 	for i, userAgent := range testUserAgents {


### PR DESCRIPTION
…reported as desktop app

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
With Mobile v2 changing the format of its user agent (relevant code: https://github.com/mattermost/mattermost-mobile/commit/b28e21a27273b89b8d5528febacb480c5be3c34f , which in the user agent uses "Mattermost Mobile"), the server identifies its browser name for the current session as "Desktop App", because the server code checks for the existence of the word "Mattermost" in the user agent string.

This PR fixes the issue by checking for "Mattermost/" instead of "Mattermost" (which matches both mobile and desktop). A separate ticket has been created for the desktop app to actually change the user agent it uses from Mattermost/{version} to Mattermost Desktop/{version} to be clearer and this PR takes that into account to avoid breaking things in the future.

A separate PR will be needed (or input on this PR) from the mobile team if mobile v2 depending on the expectations for browser name and browser version which with the new mobile user agent will be "Unknown" and "0.0".

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-49198

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
