### PR TITLE
MM-49077: fixes errors in migration job

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3850,7 +3850,31 @@ func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId 
 	defer finalizeTransactionX(transaction, &err)
 
 	channelMembers := []channelMember{}
-	if err := transaction.Select(&channelMembers, "SELECT * from ChannelMembers WHERE (ChannelId, UserId) > (?, ?) ORDER BY ChannelId, UserId LIMIT 100", fromChannelId, fromUserId); err != nil {
+	query := `
+		SELECT
+			ChannelId,
+			UserId,
+			Roles,
+			LastViewedAt,
+			MsgCount,
+			MentionCount,
+			MentionCountRoot,
+			COALESCE(UrgentMentionCount, 0) AS UrgentMentionCount,
+			MsgCountRoot,
+			NotifyProps,
+			LastUpdateAt,
+			SchemeUser,
+			SchemeAdmin,
+			SchemeGuest,
+		FROM
+			ChannelMembers
+		WHERE
+			(ChannelId, UserId) > (?, ?)
+		ORDER BY ChannelId, UserId
+		LIMIT 100
+	`
+
+	if err := transaction.Select(&channelMembers, query, fromChannelId, fromUserId); err != nil {
 		return nil, errors.Wrap(err, "failed to find ChannelMembers")
 	}
 
@@ -3954,7 +3978,31 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() (err error) {
 		}
 
 		channelMembers := []*channelMember{}
-		if err = transaction.Select(&channelMembers, "SELECT * from ChannelMembers WHERE (ChannelId, UserId) > (?, ?) ORDER BY ChannelId, UserId LIMIT 1000", lastChannelId, lastUserId); err != nil {
+		query := `
+			SELECT
+				ChannelId,
+				UserId,
+				Roles,
+				LastViewedAt,
+				MsgCount,
+				MentionCount,
+				MentionCountRoot,
+				COALESCE(UrgentMentionCount, 0) AS UrgentMentionCount,
+				MsgCountRoot,
+				NotifyProps,
+				LastUpdateAt,
+				SchemeUser,
+				SchemeAdmin,
+				SchemeGuest,
+			FROM
+				ChannelMembers
+			WHERE
+				(ChannelId, UserId) > (?, ?)
+			ORDER BY ChannelId, UserId
+			LIMIT 1000
+		`
+
+		if err = transaction.Select(&channelMembers, query, lastChannelId, lastUserId); err != nil {
 			finalizeTransactionX(transaction, &err)
 			return errors.Wrap(err, "failed to find ChannelMembers")
 		}

--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -3865,7 +3865,7 @@ func (s SqlChannelStore) MigrateChannelMembers(fromChannelId string, fromUserId 
 			LastUpdateAt,
 			SchemeUser,
 			SchemeAdmin,
-			SchemeGuest,
+			SchemeGuest
 		FROM
 			ChannelMembers
 		WHERE
@@ -3993,7 +3993,7 @@ func (s SqlChannelStore) ClearAllCustomRoleAssignments() (err error) {
 				LastUpdateAt,
 				SchemeUser,
 				SchemeAdmin,
-				SchemeGuest,
+				SchemeGuest
 			FROM
 				ChannelMembers
 			WHERE


### PR DESCRIPTION
#### Summary

`UrgentMentionCount` does not have a default values, so `COALESCE` has to be used.
`SELECT * FROM ChannelMembers` fails for the above reason. This commit `SELECT`s each and every column from `ChannelMembers` instead.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49077

#### Release Note

```release-note
NONE
```
