### PR TITLE
[MM 48403]: Allow Wrangler to work for DMs/ Group messages

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -2356,7 +2356,7 @@ func (a *App) CopyWranglerPostlist(c *request.Context, wpl *model.WranglerPostLi
 }
 
 func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, channelID string, user *model.User) *model.AppError {
-	var appErr *model.AppError
+
 	postListResponse, appErr := a.GetPostThread(postID, model.GetPostsOptions{}, user.Id)
 	if appErr != nil {
 		return model.NewAppError("getPostThread", "app.post.move_thread_command.error", nil, "postID="+postID+", "+"UserId="+user.Id+"", http.StatusBadRequest)
@@ -2417,9 +2417,9 @@ func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, cha
 	}
 
 	if targetChannel.TeamId != "" {
-		targetTeam, appErr := a.GetTeam(targetChannel.TeamId)
-		if appErr != nil {
-			return appErr
+		targetTeam, teamErr := a.GetTeam(targetChannel.TeamId)
+		if teamErr != nil {
+			return teamErr
 		}
 		targetName := targetTeam.Name
 		newPostLink := makePostLink(*a.Config().ServiceSettings.SiteURL, targetName, newRootPost.Id)

--- a/app/post.go
+++ b/app/post.go
@@ -2411,9 +2411,11 @@ func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, cha
 
 	c.Logger().Info("Wrangler thread move complete", mlog.String("user_id", user.Id), mlog.String("new_post_id", newRootPost.Id), mlog.String("channel_id", channelID))
 
-	msg := fmt.Sprintf("A thread with %d messages has been moved to a Direct/Group Message\n", wpl.NumPosts())
+	T := i18n.GetUserTranslations(user.Locale)
+
+	msg := T("app.post.move_thread_command.direct_or_group.multiple_messages", model.StringInterface{"NumMessages": wpl.NumPosts()})
 	if wpl.NumPosts() == 1 {
-		msg = "A message has been moved to a Direct/Group Message\n"
+		msg = T("app.post.move_thread_command.direct_or_group.one_message")
 	}
 
 	if targetChannel.TeamId != "" {
@@ -2423,9 +2425,9 @@ func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, cha
 		}
 		targetName := targetTeam.Name
 		newPostLink := makePostLink(*a.Config().ServiceSettings.SiteURL, targetName, newRootPost.Id)
-		msg = fmt.Sprintf("A thread with %d messages has been moved: %s\n", wpl.NumPosts(), newPostLink)
+		msg = T("app.post.move_thread_command.channel.multiple_messages", model.StringInterface{"NumMessages": wpl.NumPosts(), "Link": newPostLink})
 		if wpl.NumPosts() == 1 {
-			msg = fmt.Sprintf("A message has been moved: %s\n", newPostLink)
+			msg = T("app.post.move_thread_command.channel.one_message", model.StringInterface{"Link": newPostLink})
 		}
 	}
 

--- a/app/post.go
+++ b/app/post.go
@@ -2356,7 +2356,7 @@ func (a *App) CopyWranglerPostlist(c *request.Context, wpl *model.WranglerPostLi
 }
 
 func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, channelID string, user *model.User) *model.AppError {
-
+	var appErr *model.AppError
 	postListResponse, appErr := a.GetPostThread(postID, model.GetPostsOptions{}, user.Id)
 	if appErr != nil {
 		return model.NewAppError("getPostThread", "app.post.move_thread_command.error", nil, "postID="+postID+", "+"UserId="+user.Id+"", http.StatusBadRequest)

--- a/app/post.go
+++ b/app/post.go
@@ -2381,11 +2381,6 @@ func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, cha
 		return model.NewAppError("validateMoveOrCopy", "app.post.move_thread_command.error", nil, err.Error(), http.StatusBadRequest)
 	}
 
-	targetTeam, appErr := a.GetTeam(targetChannel.TeamId)
-	if appErr != nil {
-		return appErr
-	}
-
 	// Begin creating the new thread.
 	c.Logger().Info("Wrangler is moving a thread", mlog.String("user_id", user.Id), mlog.String("original_post_id", wpl.RootPost().Id), mlog.String("original_channel_id", originalChannel.Id))
 
@@ -2416,7 +2411,23 @@ func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, cha
 
 	c.Logger().Info("Wrangler thread move complete", mlog.String("user_id", user.Id), mlog.String("new_post_id", newRootPost.Id), mlog.String("channel_id", channelID))
 
-	newPostLink := makePostLink(*a.Config().ServiceSettings.SiteURL, targetTeam.Name, newRootPost.Id)
+	msg := fmt.Sprintf("A thread with %d messages has been moved to a Direct/Group Message\n", wpl.NumPosts())
+	if wpl.NumPosts() == 1 {
+		msg = "A message has been moved to a Direct/Group Message\n"
+	}
+
+	if targetChannel.TeamId != "" {
+		targetTeam, appErr := a.GetTeam(targetChannel.TeamId)
+		if appErr != nil {
+			return appErr
+		}
+		targetName := targetTeam.Name
+		newPostLink := makePostLink(*a.Config().ServiceSettings.SiteURL, targetName, newRootPost.Id)
+		msg = fmt.Sprintf("A thread with %d messages has been moved: %s\n", wpl.NumPosts(), newPostLink)
+		if wpl.NumPosts() == 1 {
+			msg = fmt.Sprintf("A message has been moved: %s\n", newPostLink)
+		}
+	}
 
 	// executor, execError := a.GetUser(user.Id)
 	// if execError != nil {
@@ -2436,11 +2447,6 @@ func (a *App) MoveThread(c *request.Context, postID string, sourceChannelID, cha
 	// 	)
 	// }
 	// }
-
-	msg := fmt.Sprintf("A thread with %d messages has been moved: %s\n", wpl.NumPosts(), newPostLink)
-	if wpl.NumPosts() == 1 {
-		msg = fmt.Sprintf("A message has been moved: %s\n", newPostLink)
-	}
 
 	_, appErr = a.CreatePost(c, &model.Post{
 		UserId:    user.Id,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -6176,6 +6176,22 @@
     "translation": "Failed to marshal post."
   },
   {
+    "id": "app.post.move_thread_command.channel.multiple_messages",
+    "translation": "A thread with {{.NumMessages}} messages has been moved: {{.Link}}\n"
+  },
+  {
+    "id": "app.post.move_thread_command.channel.one_message",
+    "translation": "A message has been moved: {{.Link}}\n"
+  },
+  {
+    "id": "app.post.move_thread_command.direct_or_group.multiple_messages",
+    "translation": "A thread with {{.NumMessages}} messages has been moved to a Direct/Group Message\n"
+  },
+  {
+    "id": "app.post.move_thread_command.direct_or_group.one_message",
+    "translation": "A message has been moved to a Direct/Group Message\n"
+  },
+  {
     "id": "app.post.move_thread_command.error",
     "translation": "Unable to remove thread"
   },


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Previously, when trying to move a thread to a group message or direct message, it results in an error. This is because the target channel (DM/ group message) didn't have a teamID and the `GetTeam` function fails. 

I've moved the call to `GetTeam` into an if statement that only executes when the target channel has a teamID. This means that any attempts to move a thread to a direct/group message can skip the `GetTeam` function and the thread can be moved.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-48403
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
