### PR TITLE
Expose Boards APIs for MPA

### DIFF
--- a/app/product.go
+++ b/app/product.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/mattermost/mattermost-server/v6/product"
 )
@@ -23,48 +22,17 @@ func (s *Server) initializeProducts(
 		pmap[name] = struct{}{}
 	}
 
-	// We figure out the initialization order by trial and error fashion hence maxTry
-	// is the maximum possible trials of initialization attempts. The order is not
-	// determined elsewhere therefore we do a on the fly sorting here. Which means the
-	// initialization order will be resolved during the loop.
-	maxTry := len(pmap) * len(pmap)
+	// Initialize each product. Products will populate the serviceMap with services they provide.
+	for product := range pmap {
+		manifest := productMap[product]
 
-	for len(pmap) > 0 && maxTry != 0 {
-	initLoop:
-		for product := range pmap {
-			manifest := productMap[product]
-			// we have dependencies defined. Here we check if the serviceMap
-			// has all the dependencies registered. If not, we continue to the
-			// loop to let other products initialize and register their services
-			// if they have any.
-			for key := range manifest.Dependencies {
-				if _, ok := serviceMap[key]; !ok {
-					maxTry--
-					continue initLoop
-				}
-			}
-
-			// some products can register themselves/their services
-			initializer := manifest.Initializer
-			prod, err := initializer(serviceMap)
-			if err != nil {
-				return fmt.Errorf("error initializing product %q: %w", product, err)
-			}
-			s.products[product] = prod
-
-			// we remove this product from the map to not try to initialize it again
-			delete(pmap, product)
+		initializer := manifest.Initializer
+		prod, err := initializer(serviceMap)
+		if err != nil {
+			return fmt.Errorf("error initializing product %q: %w", product, err)
 		}
+		s.products[product] = prod
 	}
-
-	if maxTry == 0 && len(pmap) != 0 {
-		var products string
-		for p := range pmap {
-			products = strings.Join([]string{products, fmt.Sprintf("%q", p)}, " ")
-		}
-		return fmt.Errorf("could not initialize product(s) due to circular dependency: %s", products)
-	}
-
 	return nil
 }
 

--- a/app/product_test.go
+++ b/app/product_test.go
@@ -6,10 +6,11 @@ package app
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/mattermost/mattermost-server/v6/app/platform"
 	"github.com/mattermost/mattermost-server/v6/config"
 	"github.com/mattermost/mattermost-server/v6/product"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -24,8 +25,8 @@ func newProductA(m map[product.ServiceKey]any) (product.Product, error) {
 	return &productA{}, nil
 }
 
-func (p *productA) Start() error { return nil }
-func (p *productA) Stop() error  { return nil }
+func (p *productA) Start(map[product.ServiceKey]any) error { return nil }
+func (p *productA) Stop() error                            { return nil }
 
 type productB struct{}
 
@@ -34,8 +35,8 @@ func newProductB(m map[product.ServiceKey]any) (product.Product, error) {
 	return &productB{}, nil
 }
 
-func (p *productB) Start() error { return nil }
-func (p *productB) Stop() error  { return nil }
+func (p *productB) Start(map[product.ServiceKey]any) error { return nil }
+func (p *productB) Stop() error                            { return nil }
 
 func TestInitializeProducts(t *testing.T) {
 	ps, err := platform.New(platform.ServiceConfig{ConfigStore: config.NewTestMemoryStore()})

--- a/app/product_test.go
+++ b/app/product_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +17,10 @@ import (
 const (
 	testSrvKey1 = "test_1"
 	testSrvKey2 = "test_2"
+	testSrvKey3 = "test_3"
 )
+
+var errMissingDependency = errors.New("missing dependency")
 
 type productA struct{}
 
@@ -25,8 +29,17 @@ func newProductA(m map[product.ServiceKey]any) (product.Product, error) {
 	return &productA{}, nil
 }
 
-func (p *productA) Start(map[product.ServiceKey]any) error { return nil }
-func (p *productA) Stop() error                            { return nil }
+func (p *productA) Start(services map[product.ServiceKey]any) error {
+	dependencies := []product.ServiceKey{
+		product.ConfigKey,
+		product.LicenseKey,
+		product.FilestoreKey,
+		product.ClusterKey,
+		testSrvKey2,
+	}
+	return checkDependencies(dependencies, services)
+}
+func (p *productA) Stop() error { return nil }
 
 type productB struct{}
 
@@ -35,14 +48,45 @@ func newProductB(m map[product.ServiceKey]any) (product.Product, error) {
 	return &productB{}, nil
 }
 
-func (p *productB) Start(map[product.ServiceKey]any) error { return nil }
-func (p *productB) Stop() error                            { return nil }
+func (p *productB) Start(services map[product.ServiceKey]any) error {
+	dependencies := []product.ServiceKey{
+		product.ConfigKey,
+		product.LicenseKey,
+		product.FilestoreKey,
+		product.ClusterKey,
+		testSrvKey1,
+	}
+	return checkDependencies(dependencies, services)
+}
+func (p *productB) Stop() error { return nil }
+
+type productC struct{}
+
+func newProductC(m map[product.ServiceKey]any) (product.Product, error) {
+	m[testSrvKey3] = nil
+	return &productC{}, nil
+}
+
+func (p *productC) Start(services map[product.ServiceKey]any) error {
+	dependencies := []product.ServiceKey{}
+	return checkDependencies(dependencies, services)
+}
+func (p *productC) Stop() error { return nil }
+
+func checkDependencies(deps []product.ServiceKey, services map[product.ServiceKey]any) error {
+	for _, key := range deps {
+		if _, ok := services[key]; !ok {
+			return errMissingDependency
+		}
+	}
+	return nil
+}
 
 func TestInitializeProducts(t *testing.T) {
 	ps, err := platform.New(platform.ServiceConfig{ConfigStore: config.NewTestMemoryStore()})
 	require.NoError(t, err)
 
-	t.Run("2 products and no circular dependency", func(t *testing.T) {
+	t.Run("2 products and circular dependency", func(t *testing.T) {
 		serviceMap := map[product.ServiceKey]any{
 			product.ConfigKey:    nil,
 			product.LicenseKey:   nil,
@@ -53,21 +97,9 @@ func TestInitializeProducts(t *testing.T) {
 		products := map[string]product.Manifest{
 			"productA": {
 				Initializer: newProductA,
-				Dependencies: map[product.ServiceKey]struct{}{
-					product.ConfigKey:    {},
-					product.LicenseKey:   {},
-					product.FilestoreKey: {},
-					product.ClusterKey:   {},
-				},
 			},
 			"productB": {
 				Initializer: newProductB,
-				Dependencies: map[product.ServiceKey]struct{}{
-					product.ConfigKey:    {},
-					testSrvKey1:          {},
-					product.FilestoreKey: {},
-					product.ClusterKey:   {},
-				},
 			},
 		}
 
@@ -81,44 +113,6 @@ func TestInitializeProducts(t *testing.T) {
 		require.Len(t, server.products, 2)
 	})
 
-	t.Run("2 products and circular dependency", func(t *testing.T) {
-		serviceMap := map[product.ServiceKey]any{
-			product.ConfigKey:    nil,
-			product.LicenseKey:   nil,
-			product.FilestoreKey: nil,
-			product.ClusterKey:   nil,
-		}
-
-		products := map[string]product.Manifest{
-			"productA": {
-				Initializer: newProductA,
-				Dependencies: map[product.ServiceKey]struct{}{
-					product.ConfigKey:    {},
-					product.LicenseKey:   {},
-					product.FilestoreKey: {},
-					product.ClusterKey:   {},
-					testSrvKey2:          {},
-				},
-			},
-			"productB": {
-				Initializer: newProductB,
-				Dependencies: map[product.ServiceKey]struct{}{
-					product.ConfigKey:    {},
-					testSrvKey1:          {},
-					product.FilestoreKey: {},
-					product.ClusterKey:   {},
-				},
-			},
-		}
-		server := &Server{
-			products: make(map[string]product.Product),
-			platform: ps,
-		}
-
-		err := server.initializeProducts(products, serviceMap)
-		require.Error(t, err)
-	})
-
 	t.Run("2 products and one w/o any dependency", func(t *testing.T) {
 		serviceMap := map[product.ServiceKey]any{
 			product.ConfigKey:    nil,
@@ -130,13 +124,9 @@ func TestInitializeProducts(t *testing.T) {
 		products := map[string]product.Manifest{
 			"productA": {
 				Initializer: newProductA,
-				Dependencies: map[product.ServiceKey]struct{}{
-					product.ConfigKey:  {},
-					product.LicenseKey: {},
-				},
 			},
-			"productB": {
-				Initializer: newProductB,
+			"productC": {
+				Initializer: newProductC,
 			},
 		}
 		server := &Server{

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80
 	github.com/lib/pq v1.10.7
+	github.com/mattermost/focalboard/server v0.0.0-20221220054841-a43228c4d207
 	github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404
 	github.com/mattermost/gziphandler v0.0.1
 	github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d
@@ -85,6 +86,7 @@ require (
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bits-and-blooms/bitset v1.3.3 // indirect
 	github.com/bits-and-blooms/bloom/v3 v3.3.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/blevesearch/bleve_index_api v1.0.5 // indirect
 	github.com/blevesearch/geo v0.1.15 // indirect
 	github.com/blevesearch/go-porterstemmer v1.0.3 // indirect
@@ -131,10 +133,10 @@ require (
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/levigross/exp-html v0.0.0-20120902181939-8df60c69a8f5 // indirect
+	github.com/mattermost/mattermost-plugin-api v0.0.29-0.20220801143717-73008cfda2fb // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
@@ -179,7 +181,7 @@ require (
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
-	lukechampine.com/uint128 v1.1.1 // indirect
+	lukechampine.com/uint128 v1.2.0 // indirect
 	modernc.org/cc/v3 v3.36.0 // indirect
 	modernc.org/ccgo/v3 v3.16.6 // indirect
 	modernc.org/libc v1.16.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,8 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/blevesearch/bleve/v2 v2.3.6-0.20221111171245-56dc9b25507e h1:r/cWPLUPgAM3SWWniQ6j0Hzb++h+uEycDD9UOUuC1Vk=
 github.com/blevesearch/bleve/v2 v2.3.6-0.20221111171245-56dc9b25507e/go.mod h1:mfCWvuwg/XnPVZHEejATm5TyFqyeLmm8p9Y3xDvwz4k=
 github.com/blevesearch/bleve_index_api v1.0.3/go.mod h1:fiwKS0xLEm+gBRgv5mumf0dhgFr2mDgZah1pqv1c1M4=
@@ -979,6 +981,8 @@ github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsI
 github.com/markbates/pkger v0.15.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/mattermost/focalboard/server v0.0.0-20221220054841-a43228c4d207 h1:/hTdWZPqj6r8IOAo871ZyKP3JCNlJz2Irk7gsaUa72k=
+github.com/mattermost/focalboard/server v0.0.0-20221220054841-a43228c4d207/go.mod h1:h1HQ8UVoNMyDHzjPD7UtYbTPMWjP6d1qJZuLdT6ElNg=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 h1:Khvh6waxG1cHc4Cz5ef9n3XVCxRWpAKUtqg9PJl5+y8=
 github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404/go.mod h1:RyS7FDNQlzF1PsjbJWHRI35exqaKGSO9qD4iv8QjE34=
 github.com/mattermost/gziphandler v0.0.1 h1:uXHcXF5agnQ6bXabvpiwwwZOlCYoa7mKHH0lxns/o8w=
@@ -987,6 +991,8 @@ github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d h1:/RJ/UV7M5c7L2TQ
 github.com/mattermost/ldap v0.0.0-20201202150706-ee0e6284187d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
 github.com/mattermost/logr/v2 v2.0.15 h1:+WNbGcsc3dBao65eXlceB6dTILNJRIrvubnsTl3zBew=
 github.com/mattermost/logr/v2 v2.0.15/go.mod h1:mpPp935r5dIkFDo2y9Q87cQWhFR/4xXpNh0k/y8Hmwg=
+github.com/mattermost/mattermost-plugin-api v0.0.29-0.20220801143717-73008cfda2fb h1:q1qXKVv59rA2gcQ7lVLc5OlWBmfsR3i8mdGD5EZesyk=
+github.com/mattermost/mattermost-plugin-api v0.0.29-0.20220801143717-73008cfda2fb/go.mod h1:PIeo40t9VTA4Wu1FwjzH7QmcgC3SRyk/ohCwJw4/oSo=
 github.com/mattermost/morph v1.0.5-0.20221115094356-4c18a75b1f5e h1:VfNz+fvJ3DxOlALM22Eea8ONp5jHrybKBCcCtDPVlss=
 github.com/mattermost/morph v1.0.5-0.20221115094356-4c18a75b1f5e/go.mod h1:xo0ljDknTpPxEdhhrUdwhLCexIsYyDKS6b41HqG8wGU=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
@@ -1028,7 +1034,6 @@ github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A
 github.com/mattn/go-sqlite3 v1.14.10/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.12/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
@@ -2282,8 +2287,9 @@ k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-lukechampine.com/uint128 v1.1.1 h1:pnxCASz787iMf+02ssImqk6OLt+Z5QHMoZyUXR4z6JU=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
+lukechampine.com/uint128 v1.2.0 h1:mBi/5l91vocEN8otkC5bDLhi2KdCticRiwbdB0O+rjI=
+lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/b v1.0.0/go.mod h1:uZWcZfRj1BpYzfN9JTerzlNUnnPsV9O2ZA8JsRcubNg=
 modernc.org/cc/v3 v3.32.4/go.mod h1:0R6jl1aZlIl2avnYfbfHBS1QB6/f+16mihBObaBC878=
 modernc.org/cc/v3 v3.36.0 h1:0kmRkTmqNidmu3c7BNDSdVHCxXCkWLmWmCIVX4LUboo=

--- a/product/api.go
+++ b/product/api.go
@@ -196,15 +196,16 @@ type PreferencesService interface {
 //
 // The service shall be registered via app.BoardsKey service key.
 type BoardsService interface {
-	GetTemplates(teamID string) ([]*fb_model.Board, error)
+	GetTemplates(teamID string, userID string) ([]*fb_model.Board, error)
 	GetBoard(boardID string) (*fb_model.Board, error)
-	CreateBoard(board *fb_model.Board) (*fb_model.Board, error)
-	PatchBoard(boardID string, boardPatch *fb_model.BoardPatch) (*fb_model.Board, error)
-	DeleteBoard(boardID string) error
-	SearchBoards(teamID string, searchField fb_model.BoardSearchField, searchTerm string) ([]*fb_model.Board, error)
-	LinkBoardToChannel(boardID string, channelID string) (*fb_model.Board, error)
-	GetCards(boardID string, userID string) ([]*fb_model.Card, error)
+	CreateBoard(board *fb_model.Board, userID string, addmember bool) (*fb_model.Board, error)
+	PatchBoard(boardPatch *fb_model.BoardPatch, boardID string, userID string) (*fb_model.Board, error)
+	DeleteBoard(boardID string, userID string) error
+	SearchBoards(searchTerm string, searchField fb_model.BoardSearchField, userID string, includePublicBoards bool) ([]*fb_model.Board, error)
+	LinkBoardToChannel(boardID string, channelID string, userID string) (*fb_model.Board, error)
+	GetCards(boardID string) ([]*fb_model.Card, error)
 	GetCard(cardID string) (*fb_model.Card, error)
-	CreateCard(boardID string, userID string, card *fb_model.Card, disableNotify bool) (*fb_model.Card, error)
-	PatchCard(cardID string, cardPatch *fb_model.CardPatch) (*fb_model.Card, error)
+	CreateCard(card *fb_model.Card, boardID string, userID string) (*fb_model.Card, error)
+	PatchCard(cardPatch *fb_model.CardPatch, cardID string, userID string) (*fb_model.Card, error)
+	DeleteCard(cardID string, userID string) error
 }

--- a/product/api.go
+++ b/product/api.go
@@ -12,6 +12,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/filestore"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+
+	fb_model "github.com/mattermost/focalboard/server/model"
 )
 
 // RouterService enables registering the product router to the server. After registering the
@@ -188,4 +190,21 @@ type PreferencesService interface {
 	GetPreferencesForUser(userID string) (model.Preferences, *model.AppError)
 	UpdatePreferencesForUser(userID string, preferences model.Preferences) *model.AppError
 	DeletePreferencesForUser(userID string, preferences model.Preferences) *model.AppError
+}
+
+// BoardsService is the API for accessing Boards service APIs.
+//
+// The service shall be registered via app.BoardsKey service key.
+type BoardsService interface {
+	GetTemplates(teamID string) ([]*fb_model.Board, error)
+	GetBoard(boardID string) (*fb_model.Board, error)
+	CreateBoard(board *fb_model.Board) (*fb_model.Board, error)
+	PatchBoard(boardID string, boardPatch *fb_model.BoardPatch) (*fb_model.Board, error)
+	DeleteBoard(boardID string) error
+	SearchBoards(teamID string, searchField fb_model.BoardSearchField, searchTerm string) ([]*fb_model.Board, error)
+	LinkBoardToChannel(boardID string, channelID string) (*fb_model.Board, error)
+	GetCards(boardID string, userID string) ([]*fb_model.Card, error)
+	GetCard(cardID string) (*fb_model.Card, error)
+	CreateCard(boardID string, userID string, card *fb_model.Card, disableNotify bool) (*fb_model.Card, error)
+	PatchCard(cardID string, cardPatch *fb_model.CardPatch) (*fb_model.Card, error)
 }

--- a/product/product.go
+++ b/product/product.go
@@ -4,13 +4,12 @@
 package product
 
 type Product interface {
-	Start() error
+	Start(map[ServiceKey]any) error
 	Stop() error
 }
 
 type Manifest struct {
-	Initializer  func(map[ServiceKey]any) (Product, error)
-	Dependencies map[ServiceKey]struct{}
+	Initializer func(map[ServiceKey]any) (Product, error)
 }
 
 var products = make(map[string]Manifest)

--- a/product/service.go
+++ b/product/service.go
@@ -25,4 +25,5 @@ const (
 	StoreKey         ServiceKey = "storekey"
 	SystemKey        ServiceKey = "systemkey"
 	PreferencesKey   ServiceKey = "preferenceskey"
+	BoardsKey        ServiceKey = "boards"
 )


### PR DESCRIPTION
#### Summary
This PR exposes the Boards product APIs to other products.  Includes a refactor of product initialization:
- Initializer is where a product adds its own APIs to the services map and remembers the built-in suite APIs
- `Start` is called with a fully populated services map; product API dependencies are remembered here and is any are missing the method errors.

This PR includes Boards as a Channels dependency.  This can be removed as its not strictly needed yet.

Corresponding Boards PR:  https://github.com/mattermost/focalboard/pull/4371

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
