### PR TITLE
always set CWSURL in client config

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -92,6 +92,8 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 
 	props["EnableEmailInvitations"] = strconv.FormatBool(*c.ServiceSettings.EnableEmailInvitations)
 
+	props["CWSURL"] = *c.CloudSettings.CWSURL
+
 	// Set default values for all options that require a license.
 	props["ExperimentalEnableAuthenticationTransfer"] = "true"
 	props["LdapNicknameAttributeSet"] = "false"
@@ -123,7 +125,6 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["DataRetentionFileRetentionDays"] = "0"
 	props["DataRetentionEnableBoardsDeletion"] = "false"
 	props["DataRetentionBoardsRetentionDays"] = "0"
-	props["CWSURL"] = ""
 
 	props["CustomUrlSchemes"] = strings.Join(c.DisplaySettings.CustomURLSchemes, ",")
 	props["IsDefaultMarketplace"] = strconv.FormatBool(*c.PluginSettings.MarketplaceURL == model.PluginSettingsDefaultMarketplaceURL)
@@ -193,10 +194,6 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 			props["DataRetentionFileRetentionDays"] = strconv.FormatInt(int64(*c.DataRetentionSettings.FileRetentionDays), 10)
 			props["DataRetentionEnableBoardsDeletion"] = strconv.FormatBool(*c.DataRetentionSettings.EnableBoardsDeletion)
 			props["DataRetentionBoardsRetentionDays"] = strconv.FormatInt(int64(*c.DataRetentionSettings.BoardsRetentionDays), 10)
-		}
-
-		if license.IsCloud() {
-			props["CWSURL"] = *c.CloudSettings.CWSURL
 		}
 
 		if *license.Features.SharedChannels {


### PR DESCRIPTION
#### Summary
We want to set CWSURL for all installations now, not just cloud ones. Self-hosted ones will need this info in the client for things like contact us links.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49258 / https://docs.google.com/document/d/1TDpO4woW3rlUxGGwSSWE0j4F0nNKeO0LpzmQs9eNZ4Y/edit#

#### Release Note

-->
```release-note
NONE
```
