### PR TITLE
[MM-48920] Fix updating channel moderation with WS

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -1121,6 +1121,15 @@ func (a *App) PatchChannelModerationsForChannel(c request.CTX, channel *model.Ch
 
 	cErr := a.forEachChannelMember(c, channel.Id, func(channelMember model.ChannelMember) error {
 		a.Srv().Store().Channel().InvalidateAllChannelMembersForUser(channelMember.UserId)
+
+		evt := model.NewWebSocketEvent(model.WebsocketEventChannelMemberUpdated, "", "", channelMember.UserId, nil, "")
+		memberJSON, jsonErr := json.Marshal(channelMember)
+		if jsonErr != nil {
+			return jsonErr
+		}
+		evt.Add("channelMember", string(memberJSON))
+		a.Publish(evt)
+
 		return nil
 	})
 	if cErr != nil {


### PR DESCRIPTION
#### Summary
Even though there were WS events for the channel and role changes, it was missing the one connecting all of them, so the flow `custom_role -> channel_member -> custom_role` would have a new role id associated with the channel and wouldn't get any updates until a reload.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48920

#### Release Note
```release-note
NONE
```
