### PR TITLE
Clean untranslated logs

### DIFF
--- a/model/utils.go
+++ b/model/utils.go
@@ -256,11 +256,15 @@ func (er *AppError) Error() string {
 	// render the error information
 	sb.WriteString(er.Where)
 	sb.WriteString(": ")
-	sb.WriteString(er.Message)
+	if er.Message != NoTranslation {
+		sb.WriteString(er.Message)
+	}
 
 	// only render the detailed error when it's present
 	if er.DetailedError != "" {
-		sb.WriteString(", ")
+		if er.Message != NoTranslation {
+			sb.WriteString(", ")
+		}
 		sb.WriteString(er.DetailedError)
 	}
 

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -81,6 +81,11 @@ func TestAppError(t *testing.T) {
 	t.Log(appErr.Error())
 }
 
+func TestAppErrorNoTranslation(t *testing.T) {
+	appErr := NewAppError("TestAppError", NoTranslation, nil, "test error", http.StatusBadRequest)
+	require.Equal(t, "TestAppError: test error", appErr.Error())
+}
+
 func TestAppErrorJunk(t *testing.T) {
 	rerr := AppErrorFromJSON(strings.NewReader("<html><body>This is a broken test</body></html>"))
 	require.Equal(t, "body: <html><body>This is a broken test</body></html>", rerr.DetailedError)


### PR DESCRIPTION
Remove the word "`<untranslated>`" from appearing
in the logs.

```release-note
NONE
```
