### PR TITLE
Remove unnecessary debug log

### DIFF
--- a/api4/drafts.go
+++ b/api4/drafts.go
@@ -124,7 +124,6 @@ func deleteDraft(c *Context, w http.ResponseWriter, r *http.Request) {
 		switch {
 		case err.StatusCode == http.StatusNotFound:
 			// If the draft doesn't exist in the server, we don't need to delete.
-			mlog.Debug("Unable to find the draft", mlog.Err(err))
 			ReturnStatusOK(w)
 		default:
 			c.Err = err


### PR DESCRIPTION
This log is continuously spamming our community server
and I see it all the time in my dev environment.

Let's remove this to keep the logs clean.

```release-note
NONE
```
