### PR TITLE
Return 404 when thread membership not found

### DIFF
--- a/app/post_test.go
+++ b/app/post_test.go
@@ -2410,6 +2410,11 @@ func TestFollowThreadSkipsParticipants(t *testing.T) {
 	for _, p := range thread.Participants {
 		require.True(t, p.Id == sysadmin.Id || p.Id == user.Id)
 	}
+
+	threadMembership.PostId = "notfound"
+	_, err = th.App.GetThreadForUser(threadMembership, false)
+	require.NotNil(t, err)
+	assert.Equal(t, http.StatusNotFound, err.StatusCode)
 }
 
 func TestAutofollowBasedOnRootPost(t *testing.T) {

--- a/app/user.go
+++ b/app/user.go
@@ -2484,12 +2484,15 @@ func (a *App) GetThreadsForUser(userID, teamID string, options model.GetUserThre
 }
 
 func (a *App) GetThreadMembershipForUser(userId, threadId string) (*model.ThreadMembership, *model.AppError) {
-	threadMembership, err := a.Srv().Store().Thread().GetMembershipForUser(userId, threadId)
-	if err != nil {
-		return nil, model.NewAppError("GetThreadMembershipForUser", "app.user.get_thread_membership_for_user.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
-	}
-	if threadMembership == nil {
-		return nil, model.NewAppError("GetThreadMembershipForUser", "app.user.get_thread_membership_for_user.not_found", nil, "thread membership not found/followed", http.StatusNotFound)
+	threadMembership, nErr := a.Srv().Store().Thread().GetMembershipForUser(userId, threadId)
+	if nErr != nil {
+		var nfErr *store.ErrNotFound
+		switch {
+		case errors.As(nErr, &nfErr):
+			return nil, model.NewAppError("GetThreadMembershipForUser", "app.user.get_thread_membership_for_user.not_found", nil, "", http.StatusNotFound).Wrap(nErr)
+		default:
+			return nil, model.NewAppError("GetThreadMembershipForUser", "app.user.get_thread_membership_for_user.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
+		}
 	}
 	return threadMembership, nil
 }

--- a/app/user_test.go
+++ b/app/user_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1703,6 +1704,10 @@ func TestUpdateThreadReadForUser(t *testing.T) {
 		require.Nil(t, appErr)
 		require.NotNil(t, threadMembership)
 		assert.True(t, threadMembership.Following)
+
+		_, appErr = th.App.GetThreadMembershipForUser(th.BasicUser.Id, "notfound")
+		require.NotNil(t, appErr)
+		assert.Equal(t, http.StatusNotFound, appErr.StatusCode)
 	})
 
 	t.Run("Ensure no panic on error", func(t *testing.T) {


### PR DESCRIPTION
We were incorrectly returning by checking
for `err != nil` when a 404 error was included
in that condition.

```release-note
NONE
```
