### PR TITLE
dry up some code. Move other code to app layer

### DIFF
--- a/api4/license.go
+++ b/api4/license.go
@@ -344,6 +344,11 @@ func requestTrueUpReview(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	profileMap, err := c.App.GetTrueUpProfile()
+	if err != nil {
+		c.Err = model.NewAppError("requestTrueUpReview", "api.license.true_up_review.get_status_error", nil, "", http.StatusInternalServerError)
+		return
+	}
+
 	profileMapJson, err := json.Marshal(profileMap)
 	if err != nil {
 		c.SetJSONEncodingError(err)

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -811,6 +811,7 @@ type AppIface interface {
 	GetTopReactionsForUserSince(userID string, teamID string, opts *model.InsightsOpts) (*model.TopReactionList, *model.AppError)
 	GetTopThreadsForTeamSince(c request.CTX, teamID, userID string, opts *model.InsightsOpts) (*model.TopThreadList, *model.AppError)
 	GetTopThreadsForUserSince(c request.CTX, teamID, userID string, opts *model.InsightsOpts) (*model.TopThreadList, *model.AppError)
+	GetTrueUpProfile() (map[string]any, error)
 	GetUploadSession(c request.CTX, uploadId string) (*model.UploadSession, *model.AppError)
 	GetUploadSessionsForUser(userID string) ([]*model.UploadSession, *model.AppError)
 	GetUser(userID string) (*model.User, *model.AppError)

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -10328,6 +10328,28 @@ func (a *OpenTracingAppLayer) GetTotalUsersStats(viewRestrictions *model.ViewUse
 	return resultVar0, resultVar1
 }
 
+func (a *OpenTracingAppLayer) GetTrueUpProfile() (map[string]any, error) {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetTrueUpProfile")
+
+	a.ctx = newCtx
+	a.app.Srv().Store().SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store().SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0, resultVar1 := a.app.GetTrueUpProfile()
+
+	if resultVar1 != nil {
+		span.LogFields(spanlog.Error(resultVar1))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0, resultVar1
+}
+
 func (a *OpenTracingAppLayer) GetUploadSession(c request.CTX, uploadId string) (*model.UploadSession, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.GetUploadSession")

--- a/app/true_up.go
+++ b/app/true_up.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/services/telemetry"
+)
+
+func (a *App) getTrueUpProfile() (*model.TrueUpReviewProfile, error) {
+
+	license := a.Channels().License()
+	// Customer Info & Usage Analytics
+	activeUserCount, err := a.Srv().Store().Status().GetTotalActiveUsersCount()
+	if err != nil {
+		return nil, model.NewAppError("requestTrueUpReview", "api.license.true_up_review.user_count_fail", nil, "Could not get the total active users count", http.StatusInternalServerError)
+	}
+
+	// Webhook, calls, boards, and playbook counts
+	incomingWebhookCount, err := a.Srv().Store().Webhook().AnalyticsIncomingCount("")
+	if err != nil {
+		return nil, model.NewAppError("requestTrueUpReview", "api.license.true_up_review.webhook_in_count_fail", nil, "Could not get the total incoming webhook count", http.StatusInternalServerError)
+	}
+	outgoingWebhookCount, err := a.Srv().Store().Webhook().AnalyticsOutgoingCount("")
+	if err != nil {
+		return nil, model.NewAppError("requestTrueUpReview", "api.license.true_up_review.webhook_out_count_fail", nil, "Could not get the total outgoing webhook count", http.StatusInternalServerError)
+	}
+
+	// Plugin Data
+	trueUpReviewPlugins := model.TrueUpReviewPlugins{
+		ActivePluginNames:   []string{},
+		InactivePluginNames: []string{},
+	}
+
+	if pluginResponse, err := a.GetPlugins(); err == nil {
+		for _, plugin := range pluginResponse.Active {
+			trueUpReviewPlugins.ActivePluginNames = append(trueUpReviewPlugins.ActivePluginNames, plugin.Name)
+		}
+		trueUpReviewPlugins.TotalActivePlugins = len(trueUpReviewPlugins.ActivePluginNames)
+
+		for _, plugin := range pluginResponse.Inactive {
+			trueUpReviewPlugins.InactivePluginNames = append(trueUpReviewPlugins.InactivePluginNames, plugin.Name)
+		}
+		trueUpReviewPlugins.TotalInactivePlugins = len(trueUpReviewPlugins.InactivePluginNames)
+	}
+
+	// Authentication Features
+	config := a.Config()
+	mfaUsed := config.ServiceSettings.EnforceMultifactorAuthentication
+	ldapUsed := config.LdapSettings.Enable
+	samlUsed := config.SamlSettings.Enable
+	openIdUsed := config.OpenIdSettings.Enable
+	guestAccessAllowed := config.GuestAccountsSettings.Enable
+
+	authFeatures := map[string]*bool{
+		model.TrueUpReviewAuthFeaturesMfa:        mfaUsed,
+		model.TrueUpReviewAuthFeaturesADLdap:     ldapUsed,
+		model.TrueUpReviewAuthFeaturesSaml:       samlUsed,
+		model.TrueUpReviewAuthFeatureOpenId:      openIdUsed,
+		model.TrueUpReviewAuthFeatureGuestAccess: guestAccessAllowed,
+	}
+
+	authFeatureList := []string{}
+	for feature, used := range authFeatures {
+		if used != nil && *used {
+			authFeatureList = append(authFeatureList, feature)
+		}
+	}
+
+	reviewProfile := model.TrueUpReviewProfile{
+		ServerId:               a.TelemetryId(),
+		ServerVersion:          model.CurrentVersion,
+		ServerInstallationType: os.Getenv(telemetry.EnvVarInstallType),
+		LicenseId:              license.Id,
+		LicensedSeats:          *license.Features.Users,
+		LicensePlan:            license.SkuName,
+		CustomerName:           license.Customer.Name,
+		ActiveUsers:            activeUserCount,
+		TotalIncomingWebhooks:  incomingWebhookCount,
+		TotalOutgoingWebhooks:  outgoingWebhookCount,
+		Plugins:                trueUpReviewPlugins,
+		AuthenticationFeatures: authFeatureList,
+	}
+
+	return &reviewProfile, nil
+
+}
+
+func (a *App) GetTrueUpProfile() (map[string]any, error) {
+	profile, err := a.getTrueUpProfile()
+
+	if err != nil {
+		return nil, err
+	}
+
+	profileJson, err := json.Marshal(profile)
+	if err != nil {
+		return nil, err
+	}
+	telemetryProperties := map[string]any{}
+
+	json.Unmarshal(profileJson, &telemetryProperties)
+	delete(telemetryProperties, "plugins")
+	plugins := profile.Plugins.ToMap()
+	for pluginName, pluginValue := range plugins {
+		telemetryProperties["plugin_"+pluginName] = pluginValue
+	}
+
+	delete(telemetryProperties, "authentication_features")
+	telemetryProperties["authentication_features"] = strings.Join(profile.AuthenticationFeatures, ",")
+
+	return telemetryProperties, nil
+}


### PR DESCRIPTION
#### Summary
Noticed a few additional things we might want:
* share the get-or-create review status code between endpoints
* The API handler code is getting pretty long. It's standard to keep business logic out of the API layer. Since you need to access multiple data sources, we can't cleanly put it in a single store method, so I think the typical way to do this is to add an app method.
* Noticed that the payload sent by telemetry was the flattened object, but the profile written to the client for the case of download was a json version of the structured profile. I'm thinking we should send the same format to the client so that its easier to ingest into CWS once we get there.
#### Release Note
```release-note
NONE
```
