### PR TITLE
Mm 49258 - Inform admins trying to self-hosted purchase who the email listed on the JWT claim is

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -92,6 +92,8 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 
 	props["EnableEmailInvitations"] = strconv.FormatBool(*c.ServiceSettings.EnableEmailInvitations)
 
+	props["CWSURL"] = *c.CloudSettings.CWSURL
+
 	// Set default values for all options that require a license.
 	props["ExperimentalEnableAuthenticationTransfer"] = "true"
 	props["LdapNicknameAttributeSet"] = "false"
@@ -123,7 +125,6 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["DataRetentionFileRetentionDays"] = "0"
 	props["DataRetentionEnableBoardsDeletion"] = "false"
 	props["DataRetentionBoardsRetentionDays"] = "0"
-	props["CWSURL"] = ""
 
 	props["CustomUrlSchemes"] = strings.Join(c.DisplaySettings.CustomURLSchemes, ",")
 	props["IsDefaultMarketplace"] = strconv.FormatBool(*c.PluginSettings.MarketplaceURL == model.PluginSettingsDefaultMarketplaceURL)
@@ -193,10 +194,6 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 			props["DataRetentionFileRetentionDays"] = strconv.FormatInt(int64(*c.DataRetentionSettings.FileRetentionDays), 10)
 			props["DataRetentionEnableBoardsDeletion"] = strconv.FormatBool(*c.DataRetentionSettings.EnableBoardsDeletion)
 			props["DataRetentionBoardsRetentionDays"] = strconv.FormatInt(int64(*c.DataRetentionSettings.BoardsRetentionDays), 10)
-		}
-
-		if license.IsCloud() {
-			props["CWSURL"] = *c.CloudSettings.CWSURL
 		}
 
 		if *license.Features.SharedChannels {

--- a/model/hosted_customer.go
+++ b/model/hosted_customer.go
@@ -10,6 +10,8 @@ type BootstrapSelfHostedSignupRequest struct {
 
 type BootstrapSelfHostedSignupResponse struct {
 	Progress string `json:"progress"`
+	// email listed on the JWT claim
+	Email string `json:"email"`
 }
 
 type BootstrapSelfHostedSignupResponseInternal struct {


### PR DESCRIPTION
#### Summary
Add email to response so that other admins can know if someone else is already trying to do a self-hosted purchase, and if so, don't interfere with it.

See also:
* https://github.com/mattermost/enterprise/pull/1350
* https://github.com/mattermost/mattermost-webapp/pull/11879

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49258

#### Release Note
```release-note
NONE
```
