### PR TITLE
Mm 47853 telemetry off remove fields

### DIFF
--- a/app/true_up.go
+++ b/app/true_up.go
@@ -137,11 +137,17 @@ func (a *App) GetTrueUpProfile() (map[string]any, error) {
 	delete(telemetryProperties, "plugins")
 	plugins := profile.Plugins.ToMap()
 	for pluginName, pluginValue := range plugins {
-		telemetryProperties["plugin_"+pluginName] = pluginValue
+		telemetryProperties[pluginName] = pluginValue
 	}
 
 	delete(telemetryProperties, "authentication_features")
 	telemetryProperties["authentication_features"] = strings.Join(profile.AuthenticationFeatures, ",")
+
+	if !a.Srv().telemetryService.TelemetryEnabled() {
+		for _, property := range model.DisallowedPropertyWhenTelemetryIsDisabled {
+			delete(telemetryProperties, property)
+		}
+	}
 
 	return telemetryProperties, nil
 }

--- a/model/true_up_review_profile.go
+++ b/model/true_up_review_profile.go
@@ -5,6 +5,17 @@ package model
 
 import "strings"
 
+var DisallowedPropertyWhenTelemetryIsDisabled = []string{
+	"server_id",
+	"server_installation_type",
+	"incoming_webhooks_count",
+	"outgoing_webhooks_count",
+	"plugins",
+	"total_plugins",
+	"plugin_names",
+	"authentication_features",
+}
+
 type TrueUpReviewProfile struct {
 	ServerId               string              `json:"server_id"`
 	ServerVersion          string              `json:"server_version"`


### PR DESCRIPTION
Adds functionality to remove telemetry-related fields from true-up review in the case that the customer has disabled telemetry.