### PR TITLE
Automated cherry pick of #21882

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -595,7 +595,7 @@ func (s *Server) startInterClusterServices(license *model.License) error {
 	// Shared Channels service
 
 	// License check
-	if !*license.Features.SharedChannels {
+	if !license.HasSharedChannels() {
 		mlog.Debug("License does not have shared channels enabled")
 		return nil
 	}

--- a/config/client.go
+++ b/config/client.go
@@ -196,7 +196,7 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 			props["DataRetentionBoardsRetentionDays"] = strconv.FormatInt(int64(*c.DataRetentionSettings.BoardsRetentionDays), 10)
 		}
 
-		if *license.Features.SharedChannels {
+		if license.HasSharedChannels() {
 			props["ExperimentalSharedChannels"] = strconv.FormatBool(*c.ExperimentalSettings.EnableSharedChannels)
 			props["ExperimentalRemoteClusterService"] = strconv.FormatBool(c.FeatureFlags.EnableRemoteClusterService && *c.ExperimentalSettings.EnableRemoteClusterService)
 		}

--- a/config/client_test.go
+++ b/config/client_test.go
@@ -254,6 +254,78 @@ func TestGetClientConfig(t *testing.T) {
 				"EnableCustomGroups": "false",
 			},
 		},
+		{
+			"Shared channels other license",
+			&model.Config{
+				ExperimentalSettings: model.ExperimentalSettings{
+					EnableSharedChannels: model.NewBool(true),
+				},
+			},
+			"",
+			&model.License{
+				Features: &model.Features{
+					SharedChannels: model.NewBool(false),
+				},
+				SkuShortName: "other",
+			},
+			map[string]string{
+				"ExperimentalSharedChannels": "false",
+			},
+		},
+		{
+			"licensed for shared channels",
+			&model.Config{
+				ExperimentalSettings: model.ExperimentalSettings{
+					EnableSharedChannels: model.NewBool(true),
+				},
+			},
+			"",
+			&model.License{
+				Features: &model.Features{
+					SharedChannels: model.NewBool(true),
+				},
+				SkuShortName: "other",
+			},
+			map[string]string{
+				"ExperimentalSharedChannels": "true",
+			},
+		},
+		{
+			"Shared channels professional license",
+			&model.Config{
+				ExperimentalSettings: model.ExperimentalSettings{
+					EnableSharedChannels: model.NewBool(true),
+				},
+			},
+			"",
+			&model.License{
+				Features: &model.Features{
+					SharedChannels: model.NewBool(false),
+				},
+				SkuShortName: model.LicenseShortSkuProfessional,
+			},
+			map[string]string{
+				"ExperimentalSharedChannels": "true",
+			},
+		},
+		{
+			"Shared channels enterprise license",
+			&model.Config{
+				ExperimentalSettings: model.ExperimentalSettings{
+					EnableSharedChannels: model.NewBool(true),
+				},
+			},
+			"",
+			&model.License{
+				Features: &model.Features{
+					SharedChannels: model.NewBool(false),
+				},
+				SkuShortName: model.LicenseShortSkuEnterprise,
+			},
+			map[string]string{
+				"ExperimentalSharedChannels": "true",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/model/license.go
+++ b/model/license.go
@@ -312,6 +312,16 @@ func (l *License) HasEnterpriseMarketplacePlugins() bool {
 		l.SkuShortName == LicenseShortSkuEnterprise
 }
 
+func (l *License) HasSharedChannels() bool {
+	if l == nil {
+		return false
+	}
+
+	return (l.Features != nil && l.Features.SharedChannels != nil && *l.Features.SharedChannels) ||
+		l.SkuShortName == LicenseShortSkuProfessional ||
+		l.SkuShortName == LicenseShortSkuEnterprise
+}
+
 // NewTestLicense returns a license that expires in the future and has the given features.
 func NewTestLicense(features ...string) *License {
 	ret := &License{

--- a/model/license_test.go
+++ b/model/license_test.go
@@ -343,3 +343,53 @@ func TestLicense_IsSanctionedTrial(t *testing.T) {
 		assert.True(t, license.IsSanctionedTrial())
 	})
 }
+
+func TestLicenseHasSharedChannels(t *testing.T) {
+
+	testCases := []struct {
+		description   string
+		license       License
+		expectedValue bool
+	}{
+		{
+			"licensed for shared channels",
+			License{
+				Features: &Features{
+					SharedChannels: NewBool(true),
+				},
+				SkuShortName: "other",
+			},
+			true,
+		},
+		{
+			"not licensed for shared channels",
+			License{
+				Features:     &Features{},
+				SkuShortName: "other",
+			},
+			false,
+		},
+		{
+			"professional license for shared channels",
+			License{
+				Features:     &Features{},
+				SkuShortName: LicenseShortSkuProfessional,
+			},
+			true,
+		},
+		{
+			"enterprise license for shared channels",
+			License{
+				Features:     &Features{},
+				SkuShortName: LicenseShortSkuEnterprise,
+			},
+			true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			assert.Equal(t, testCase.expectedValue, testCase.license.HasSharedChannels())
+		})
+	}
+}


### PR DESCRIPTION
Cherry pick of #21882 on release-7.7.

/cc  @mylonsuren

```release-note
NONE
```