### PR TITLE
MM-49374: Update job metadata for bulk export

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -435,7 +435,7 @@ type AppIface interface {
 	BuildPostReactions(ctx request.CTX, postID string) (*[]ReactionImportData, *model.AppError)
 	BuildPushNotificationMessage(c request.CTX, contentsConfig string, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string, explicitMention bool, channelWideMention bool, replyToThreadType string) (*model.PushNotification, *model.AppError)
 	BuildSamlMetadataObject(idpMetadata []byte) (*model.SamlMetadataResponse, *model.AppError)
-	BulkExport(ctx request.CTX, writer io.Writer, outPath string, opts model.BulkExportOpts) *model.AppError
+	BulkExport(ctx request.CTX, writer io.Writer, outPath string, job *model.Job, opts model.BulkExportOpts) *model.AppError
 	BulkImport(c *request.Context, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun bool, workers int) (*model.AppError, int)
 	BulkImportWithPath(c *request.Context, jsonlReader io.Reader, attachmentsReader *zip.Reader, dryRun bool, workers int, importPath string) (*model.AppError, int)
 	CanNotifyAdmin(trial bool) bool

--- a/app/export_test.go
+++ b/app/export_test.go
@@ -164,7 +164,7 @@ func TestExportCustomEmoji(t *testing.T) {
 	outPath, err := filepath.Abs(filePath)
 	require.NoError(t, err)
 
-	_, appErr := th.App.exportCustomEmoji(th.Context, fileWriter, outPath, dirNameToExportEmoji, false)
+	_, appErr := th.App.exportCustomEmoji(th.Context, nil, fileWriter, outPath, dirNameToExportEmoji, false)
 	require.Nil(t, appErr, "should not have failed")
 }
 
@@ -178,7 +178,7 @@ func TestExportAllUsers(t *testing.T) {
 	require.Nil(t, err)
 
 	var b bytes.Buffer
-	err = th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	err = th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, err)
 
 	th2 := Setup(t)
@@ -235,7 +235,7 @@ func TestExportDMChannel(t *testing.T) {
 		})
 
 		var b bytes.Buffer
-		err := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+		err := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 		require.Nil(t, err)
 
 		channels, nErr := th1.App.Srv().Store().Channel().GetAllDirectChannelsForExportAfter(1000, "00000000")
@@ -282,7 +282,7 @@ func TestExportDMChannel(t *testing.T) {
 		th1.App.PermanentDeleteUser(th1.Context, th1.BasicUser)
 
 		var b bytes.Buffer
-		err := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+		err := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 		require.Nil(t, err)
 
 		th2 := Setup(t).InitBasic()
@@ -306,7 +306,7 @@ func TestExportDMChannelToSelf(t *testing.T) {
 	th1.CreateDmChannel(th1.BasicUser)
 
 	var b bytes.Buffer
-	err := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	err := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, err)
 
 	channels, nErr := th1.App.Srv().Store().Channel().GetAllDirectChannelsForExportAfter(1000, "00000000")
@@ -344,7 +344,7 @@ func TestExportGMChannel(t *testing.T) {
 	th1.CreateGroupChannel(th1.Context, user1, user2)
 
 	var b bytes.Buffer
-	err := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	err := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, err)
 
 	channels, nErr := th1.App.Srv().Store().Channel().GetAllDirectChannelsForExportAfter(1000, "00000000")
@@ -376,7 +376,7 @@ func TestExportGMandDMChannels(t *testing.T) {
 	th1.CreateGroupChannel(th1.Context, user1, user2)
 
 	var b bytes.Buffer
-	err := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	err := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, err)
 
 	channels, nErr := th1.App.Srv().Store().Channel().GetAllDirectChannelsForExportAfter(1000, "00000000")
@@ -459,7 +459,7 @@ func TestExportDMandGMPost(t *testing.T) {
 	assert.Equal(t, 4, len(posts))
 
 	var b bytes.Buffer
-	appErr := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	appErr := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, appErr)
 
 	th1.TearDown()
@@ -534,7 +534,7 @@ func TestExportPostWithProps(t *testing.T) {
 	require.NotEmpty(t, posts[1].Props)
 
 	var b bytes.Buffer
-	appErr := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	appErr := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, appErr)
 
 	th1.TearDown()
@@ -572,7 +572,7 @@ func TestExportDMPostWithSelf(t *testing.T) {
 	th1.CreatePost(dmChannel)
 
 	var b bytes.Buffer
-	err := th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	err := th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, err)
 
 	posts, nErr := th1.App.Srv().Store().Post().GetDirectPostParentsForExportAfter(1000, "0000000")
@@ -640,7 +640,7 @@ func TestBulkExport(t *testing.T) {
 		IncludeAttachments: true,
 		CreateArchive:      true,
 	}
-	appErr = th.App.BulkExport(th.Context, exportFile, dir, opts)
+	appErr = th.App.BulkExport(th.Context, exportFile, dir, nil, opts)
 	require.Nil(t, appErr)
 
 	th.TearDown()
@@ -731,7 +731,7 @@ func TestExportDeletedTeams(t *testing.T) {
 	require.Nil(t, err)
 
 	var b bytes.Buffer
-	err = th1.App.BulkExport(th1.Context, &b, "somePath", model.BulkExportOpts{})
+	err = th1.App.BulkExport(th1.Context, &b, "somePath", nil, model.BulkExportOpts{})
 	require.Nil(t, err)
 
 	th2 := Setup(t)

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -974,7 +974,7 @@ func (a *OpenTracingAppLayer) BuildSamlMetadataObject(idpMetadata []byte) (*mode
 	return resultVar0, resultVar1
 }
 
-func (a *OpenTracingAppLayer) BulkExport(ctx request.CTX, writer io.Writer, outPath string, opts model.BulkExportOpts) *model.AppError {
+func (a *OpenTracingAppLayer) BulkExport(ctx request.CTX, writer io.Writer, outPath string, job *model.Job, opts model.BulkExportOpts) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.BulkExport")
 
@@ -986,7 +986,7 @@ func (a *OpenTracingAppLayer) BulkExport(ctx request.CTX, writer io.Writer, outP
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.BulkExport(ctx, writer, outPath, opts)
+	resultVar0 := a.app.BulkExport(ctx, writer, outPath, job, opts)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))

--- a/cmd/mattermost/commands/export.go
+++ b/cmd/mattermost/commands/export.go
@@ -240,7 +240,7 @@ func bulkExportCmdF(command *cobra.Command, args []string) error {
 	var opts model.BulkExportOpts
 	opts.IncludeAttachments = attachments
 	opts.CreateArchive = archive
-	if err := a.BulkExport(request.EmptyContext(a.Log()), fileWriter, filepath.Dir(outPath), opts); err != nil {
+	if err := a.BulkExport(request.EmptyContext(a.Log()), fileWriter, filepath.Dir(outPath), nil /* nil job since it's spawned from CLI */, opts); err != nil {
 		CommandPrintErrorln(err.Error())
 		return err
 	}

--- a/jobs/base_workers.go
+++ b/jobs/base_workers.go
@@ -78,6 +78,14 @@ func (worker *SimpleWorker) DoJob(job *model.Job) {
 		return
 	}
 
+	var appErr *model.AppError
+	// We get the job again because ClaimJob changes the job status.
+	job, appErr = worker.jobServer.GetJob(job.Id)
+	if appErr != nil {
+		mlog.Error("SimpleWorker: job execution error", mlog.String("worker", worker.name), mlog.String("job_id", job.Id), mlog.Err(appErr))
+		worker.setJobError(job, appErr)
+	}
+
 	err := worker.execute(job)
 	if err != nil {
 		mlog.Error("SimpleWorker: job execution error", mlog.String("worker", worker.name), mlog.String("job_id", job.Id), mlog.Err(err))
@@ -90,8 +98,13 @@ func (worker *SimpleWorker) DoJob(job *model.Job) {
 }
 
 func (worker *SimpleWorker) setJobSuccess(job *model.Job) {
+	if err := worker.jobServer.SetJobProgress(job, 100); err != nil {
+		mlog.Error("Worker: Failed to update progress for job", mlog.String("worker", worker.name), mlog.String("job_id", job.Id), mlog.Err(err))
+		worker.setJobError(job, err)
+	}
+
 	if err := worker.jobServer.SetJobSuccess(job); err != nil {
-		mlog.Error("SimpleWorker: Failed to set success for job", mlog.String("worker", worker.name), mlog.String("job_id", job.Id), mlog.String("error", err.Error()))
+		mlog.Error("SimpleWorker: Failed to set success for job", mlog.String("worker", worker.name), mlog.String("job_id", job.Id), mlog.Err(err))
 		worker.setJobError(job, err)
 	}
 }

--- a/jobs/export_process/worker.go
+++ b/jobs/export_process/worker.go
@@ -21,7 +21,7 @@ type AppIface interface {
 	configservice.ConfigService
 	WriteFile(fr io.Reader, path string) (int64, *model.AppError)
 	WriteFileContext(ctx context.Context, fr io.Reader, path string) (int64, *model.AppError)
-	BulkExport(ctx request.CTX, writer io.Writer, outPath string, opts model.BulkExportOpts) *model.AppError
+	BulkExport(ctx request.CTX, writer io.Writer, outPath string, job *model.Job, opts model.BulkExportOpts) *model.AppError
 	Log() *mlog.Logger
 }
 
@@ -56,7 +56,7 @@ func MakeWorker(jobServer *jobs.JobServer, app AppIface) model.Worker {
 		}()
 
 		logger := app.Log().With(mlog.String("job_id", job.Id))
-		appErr := app.BulkExport(request.EmptyContext(logger), wr, outPath, opts)
+		appErr := app.BulkExport(request.EmptyContext(logger), wr, outPath, job, opts)
 		wr.Close() // Close never returns an error
 
 		if appErr != nil {


### PR DESCRIPTION
If a bulk export is triggered via a job, then
we update the metadata field of the job as it
progresses through the records.

https://mattermost.atlassian.net/browse/MM-49374

```release-note
Now you can monitor the progress of the bulk export job
via its metadata field. It is available at
`mmctl export job show <jobID>`.
```


[MM-49374]: https://mattermost.atlassian.net/browse/MM-49374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ