### PR TITLE
[MM-42652] Re-enable test

### DIFF
--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -103,7 +103,6 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 	})
 
 	t.Run("should publish expected WS payload", func(t *testing.T) {
-		t.Skip("MM-42652")
 		userWSClient, err := th.CreateWebSocketClient()
 		require.NoError(t, err)
 		defer userWSClient.Close()


### PR DESCRIPTION
#### Summary
At that time, it was reported that this test was failing. However, it still passes even by checking both the server and enterprise to commits before skipping the test. Any code related to that functionality didn't have any change that could affect it. It was probably a plugin or a setup issue at that time that affected it, and it looks ok now to re-enable it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-42652

#### Release Note
```release-note
NONE
```


[MM-42652]: https://mattermost.atlassian.net/browse/MM-42652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ