### PR TITLE
[MM-49265] Update translations when config is changed

### DIFF
--- a/api4/config.go
+++ b/api4/config.go
@@ -194,6 +194,7 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventPriorState(&diffs)
 
 	if err = updateTranslations(c.App, diffs); err != nil {
+		c.Err = model.NewAppError("updateConfig", "api.config.update_config.translations.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		return
 	}
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1535,6 +1535,10 @@
     "translation": "Failed to merge given config."
   },
   {
+    "id": "api.config.update_config.translations.app_error",
+    "translation": "Failed to update server translations."
+  },
+  {
     "id": "api.context.404.app_error",
     "translation": "Sorry, we could not find the page."
   },


### PR DESCRIPTION
#### Summary
When a config like the default server translation was changed, there was no action taken to update the server until it was reinitialized after a full server restart, which is rare for most systems.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49265

#### Related Pull Requests
- Has webapp changes: https://github.com/mattermost/mattermost-webapp/pull/12044

#### Release Note
```release-note
Fixed new teams to use the updated translation for default channels after config change.
```


[MM-49265]: https://mattermost.atlassian.net/browse/MM-49265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ