### PR TITLE
sqlstore/store: make SetupConnection public to be used by products (#…

### DIFF
--- a/store/sqlstore/store.go
+++ b/store/sqlstore/store.go
@@ -226,7 +226,9 @@ func New(settings model.SqlSettings, metrics einterfaces.MetricsInterface) *SqlS
 	return store
 }
 
-func setupConnection(connType string, dataSource string, settings *model.SqlSettings) *dbsql.DB {
+// SetupConnection sets up the connection to the database and pings it to make sure it's alive.
+// It also applies any database configuration settings that are required.
+func SetupConnection(connType string, dataSource string, settings *model.SqlSettings) *dbsql.DB {
 	db, err := dbsql.Open(*settings.DriverName, dataSource)
 	if err != nil {
 		mlog.Fatal("Failed to open SQL connection to err.", mlog.Err(err))
@@ -292,7 +294,7 @@ func (ss *SqlStore) initConnection() {
 		}
 	}
 
-	handle := setupConnection("master", dataSource, ss.settings)
+	handle := SetupConnection("master", dataSource, ss.settings)
 	ss.masterX = newSqlxDBWrapper(sqlx.NewDb(handle, ss.DriverName()),
 		time.Duration(*ss.settings.QueryTimeout)*time.Second,
 		*ss.settings.Trace)
@@ -303,7 +305,7 @@ func (ss *SqlStore) initConnection() {
 	if len(ss.settings.DataSourceReplicas) > 0 {
 		ss.ReplicaXs = make([]*sqlxDBWrapper, len(ss.settings.DataSourceReplicas))
 		for i, replica := range ss.settings.DataSourceReplicas {
-			handle := setupConnection(fmt.Sprintf("replica-%v", i), replica, ss.settings)
+			handle := SetupConnection(fmt.Sprintf("replica-%v", i), replica, ss.settings)
 			ss.ReplicaXs[i] = newSqlxDBWrapper(sqlx.NewDb(handle, ss.DriverName()),
 				time.Duration(*ss.settings.QueryTimeout)*time.Second,
 				*ss.settings.Trace)
@@ -316,7 +318,7 @@ func (ss *SqlStore) initConnection() {
 	if len(ss.settings.DataSourceSearchReplicas) > 0 {
 		ss.searchReplicaXs = make([]*sqlxDBWrapper, len(ss.settings.DataSourceSearchReplicas))
 		for i, replica := range ss.settings.DataSourceSearchReplicas {
-			handle := setupConnection(fmt.Sprintf("search-replica-%v", i), replica, ss.settings)
+			handle := SetupConnection(fmt.Sprintf("search-replica-%v", i), replica, ss.settings)
 			ss.searchReplicaXs[i] = newSqlxDBWrapper(sqlx.NewDb(handle, ss.DriverName()),
 				time.Duration(*ss.settings.QueryTimeout)*time.Second,
 				*ss.settings.Trace)
@@ -332,7 +334,7 @@ func (ss *SqlStore) initConnection() {
 			if src.DataSource == nil {
 				continue
 			}
-			ss.replicaLagHandles[i] = setupConnection(fmt.Sprintf(replicaLagPrefix+"-%d", i), *src.DataSource, ss.settings)
+			ss.replicaLagHandles[i] = SetupConnection(fmt.Sprintf(replicaLagPrefix+"-%d", i), *src.DataSource, ss.settings)
 		}
 	}
 }
@@ -1073,7 +1075,7 @@ func (ss *SqlStore) migrate(direction migrationDirection) error {
 		if err != nil {
 			return err
 		}
-		db := setupConnection("master", dataSource, ss.settings)
+		db := SetupConnection("master", dataSource, ss.settings)
 		driver, err = ms.WithInstance(db)
 		defer db.Close()
 	case model.DatabaseDriverPostgres:


### PR DESCRIPTION

#### Summary
Yet another fix for CI to have a successful build. Since https://github.com/mattermost/focalboard/pull/4429 merged into the release branch of focalboard, the corresponding PR for https://github.com/mattermost/focalboard/pull/4395 should be cherry-picked to release branch of mattermost-server. Hence the PR.


#### Release Note

```release-note
NONE
```
