### PR TITLE
Cherry-pick: MM-49485: Set BoardsProduct FF to on by default (#22006)

### DIFF
--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -808,7 +808,7 @@ func TestDiff(t *testing.T) {
 							Enable: !defaultConfigGen().PluginSettings.PluginStates["com.mattermost.nps"].Enable,
 						},
 						"focalboard": {
-							Enable: true,
+							Enable: false,
 						},
 						"playbooks": {
 							Enable: true,
@@ -846,7 +846,7 @@ func TestDiff(t *testing.T) {
 							Enable: true,
 						},
 						"focalboard": {
-							Enable: true,
+							Enable: false,
 						},
 						"playbooks": {
 							Enable: true,
@@ -876,7 +876,7 @@ func TestDiff(t *testing.T) {
 					BaseVal: defaultConfigGen().PluginSettings.PluginStates,
 					ActualVal: map[string]*model.PluginState{
 						"focalboard": {
-							Enable: true,
+							Enable: false,
 						},
 						"playbooks": {
 							Enable: true,

--- a/model/config.go
+++ b/model/config.go
@@ -2852,8 +2852,8 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 	}
 
 	if s.PluginStates[PluginIdFocalboard] == nil {
-		// Enable the focalboard plugin by default
-		s.PluginStates[PluginIdFocalboard] = &PluginState{Enable: true}
+		// Disable the focalboard plugin by default
+		s.PluginStates[PluginIdFocalboard] = &PluginState{Enable: false}
 	}
 
 	if s.PluginStates[PluginIdApps] == nil {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -387,11 +387,11 @@ func TestConfigDefaultChannelExportPluginState(t *testing.T) {
 }
 
 func TestConfigDefaultFocalboardPluginState(t *testing.T) {
-	t.Run("should enable Focalboard plugin by default", func(t *testing.T) {
+	t.Run("should not enable Focalboard plugin by default", func(t *testing.T) {
 		c1 := Config{}
 		c1.SetDefaults()
 
-		assert.True(t, c1.PluginSettings.PluginStates["focalboard"].Enable)
+		assert.False(t, c1.PluginSettings.PluginStates["focalboard"].Enable)
 	})
 
 	t.Run("should not re-enable focalboard plugin after it has been disabled", func(t *testing.T) {

--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -92,7 +92,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.InsightsEnabled = true
 	f.CommandPalette = false
 	f.CallsEnabled = true
-	f.BoardsProduct = false
+	f.BoardsProduct = true
 	f.SendWelcomePost = true
 	f.PostPriority = true
 	f.PeopleProduct = false

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,6 +14,7 @@ COVERMODE=$8
 
 PACKAGES_COMMA=$(echo $PACKAGES | tr ' ' ',')
 export MM_SERVER_PATH=$PWD
+export MM_FEATUREFLAGS_BoardsProduct=false
 
 echo "Packages to test: $PACKAGES"
 echo "GOFLAGS: $GOFLAGS"


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-49485

```release-note
Boards will be served as an in-built product from
within Mattermost server instead of a plugin.

If you want to disable this, please set the
MM_FEATUREFLAGS_BoardsProduct env var to "false" (without
                                                  the quotes).

In this mode, the boards plugin will remain disabled.
```
