### PR TITLE
Automated cherry pick of #22018

### DIFF
--- a/app/post_test.go
+++ b/app/post_test.go
@@ -2409,7 +2409,14 @@ func TestFollowThreadSkipsParticipants(t *testing.T) {
 		require.True(t, p.Id == sysadmin.Id || p.Id == user.Id)
 	}
 
+	oldID := threadMembership.PostId
 	threadMembership.PostId = "notfound"
+	_, err = th.App.GetThreadForUser(threadMembership, false)
+	require.NotNil(t, err)
+	assert.Equal(t, http.StatusNotFound, err.StatusCode)
+
+	threadMembership.Following = false
+	threadMembership.PostId = oldID
 	_, err = th.App.GetThreadForUser(threadMembership, false)
 	require.NotNil(t, err)
 	assert.Equal(t, http.StatusNotFound, err.StatusCode)

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -503,7 +503,7 @@ func (s *SqlThreadStore) GetThreadFollowers(threadID string, fetchOnlyActive boo
 
 func (s *SqlThreadStore) GetThreadForUser(threadMembership *model.ThreadMembership, extended, postPriorityEnabled bool) (*model.ThreadResponse, error) {
 	if !threadMembership.Following {
-		return nil, nil // in case the thread is not followed anymore - return nil error to be interpreted as 404
+		return nil, store.NewErrNotFound("ThreadMembership", "<following>")
 	}
 
 	unreadRepliesQuery := sq.


### PR DESCRIPTION
Cherry pick of #22018 on cloud.

/cc  @agnivade

```release-note
NONE
```