### PR TITLE
MM-49083 Disable write timeouts for exports

### DIFF
--- a/app/file.go
+++ b/app/file.go
@@ -178,22 +178,8 @@ func (s *Server) writeFile(fr io.Reader, path string) (int64, *model.AppError) {
 }
 
 func (s *Server) writeFileContext(ctx context.Context, fr io.Reader, path string) (int64, *model.AppError) {
-	type ContextWriter interface {
-		WriteFileContext(context.Context, io.Reader, string) (int64, error)
-	}
-
-	var (
-		fileBackend = s.FileBackend()
-		written     int64
-		err         error
-	)
-
 	// Check if we can provide a custom context, otherwise just use the default method.
-	if cw, ok := fileBackend.(ContextWriter); ok {
-		written, err = cw.WriteFileContext(ctx, fr, path)
-	} else {
-		written, err = fileBackend.WriteFile(fr, path)
-	}
+	written, err := filestore.TryWriteFileContext(s.FileBackend(), ctx, fr, path)
 	if err != nil {
 		return written, model.NewAppError("WriteFile", "api.file.write_file.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}

--- a/shared/filestore/filesstore.go
+++ b/shared/filestore/filesstore.go
@@ -96,7 +96,7 @@ func TryWriteFileContext(fb FileBackend, ctx context.Context, fr io.Reader, path
 
 	if cw, ok := fb.(ContextWriter); ok {
 		return cw.WriteFileContext(ctx, fr, path)
-	} else {
-		return fb.WriteFile(fr, path)
 	}
+
+	return fb.WriteFile(fr, path)
 }


### PR DESCRIPTION
#### Summary
This PR introduces a new convenience function to disable filestore write timeouts without having to manually define and assert the interface. Instead we can use `filestore.TryWriteFileContext` which does the assertion for us.

#### Ticket Link
[MM-49083](https://mattermost.atlassian.net/browse/MM-49083)

#### Release Note
```release-note
NONE
```


[MM-49083]: https://mattermost.atlassian.net/browse/MM-49083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ