### PR TITLE
propogate context for running plugins

### DIFF
--- a/api4/plugin.go
+++ b/api4/plugin.go
@@ -7,6 +7,7 @@ package api4
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -155,7 +156,8 @@ func installMarketplacePlugin(c *Context, w http.ResponseWriter, r *http.Request
 	// https://mattermost.atlassian.net/browse/MM-41981
 	pluginRequest.Version = ""
 
-	manifest, appErr := c.App.Channels().InstallMarketplacePlugin(pluginRequest)
+	// TODO: We need to create a new context from the master context
+	manifest, appErr := c.App.Channels().InstallMarketplacePlugin(context.TODO(), pluginRequest)
 	if appErr != nil {
 		c.Err = appErr
 		return
@@ -396,7 +398,8 @@ func parseMarketplacePluginFilter(u *url.URL) (*model.MarketplacePluginFilter, e
 }
 
 func installPlugin(c *Context, w http.ResponseWriter, plugin io.ReadSeeker, force bool) {
-	manifest, appErr := c.App.InstallPlugin(plugin, force)
+	// TODO: We need to create a new context from the master context
+	manifest, appErr := c.App.InstallPlugin(context.TODO(), plugin, force)
 	if appErr != nil {
 		c.Err = appErr
 		return

--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -243,7 +243,7 @@ type AppIface interface {
 	// HubUnregister unregisters a connection from a hub.
 	HubUnregister(webConn *platform.WebConn)
 	// InstallPlugin unpacks and installs a plugin but does not enable or activate it.
-	InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError)
+	InstallPlugin(ctx context.Context, pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError)
 	// LogAuditRec logs an audit record using default LvlAuditCLI.
 	LogAuditRec(rec *audit.Record, err error)
 	// LogAuditRecWithLevel logs an audit record using specified Level.
@@ -334,7 +334,7 @@ type AppIface interface {
 	SyncLdap(includeRemovedMembers bool)
 	// SyncPlugins synchronizes the plugins installed locally
 	// with the plugin bundles available in the file store.
-	SyncPlugins() *model.AppError
+	SyncPlugins(ctx context.Context) *model.AppError
 	// SyncRolesAndMembership updates the SchemeAdmin status and membership of all of the members of the given
 	// syncable.
 	SyncRolesAndMembership(c request.CTX, syncableID string, syncableType model.GroupSyncableType, includeRemovedMembers bool)

--- a/app/cluster_handlers.go
+++ b/app/cluster_handlers.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -16,7 +17,8 @@ func (s *Server) clusterInstallPluginHandler(msg *model.ClusterMessage) {
 	if jsonErr := json.Unmarshal(msg.Data, &data); jsonErr != nil {
 		mlog.Warn("Failed to decode from JSON", mlog.Err(jsonErr))
 	}
-	s.Channels().installPluginFromData(data)
+	// TODO: we need to create a nex context from the master context
+	s.Channels().installPluginFromData(context.TODO(), data)
 }
 
 func (s *Server) clusterRemovePluginHandler(msg *model.ClusterMessage) {

--- a/app/onboarding.go
+++ b/app/onboarding.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -41,7 +42,8 @@ func (a *App) CompleteOnboarding(c *request.Context, request *model.CompleteOnbo
 			installRequest := &model.InstallMarketplacePluginRequest{
 				Id: id,
 			}
-			_, appErr := a.Channels().InstallMarketplacePlugin(installRequest)
+			// TODO: we need to create a nex context from the master context
+			_, appErr := a.Channels().InstallMarketplacePlugin(context.TODO(), installRequest)
 			if appErr != nil {
 				mlog.Error("Failed to install plugin for onboarding", mlog.String("id", id), mlog.Err(appErr))
 				return

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -11700,7 +11700,7 @@ func (a *OpenTracingAppLayer) InitPlugins(c *request.Context, pluginDir string, 
 	a.app.InitPlugins(c, pluginDir, webappPluginDir)
 }
 
-func (a *OpenTracingAppLayer) InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError) {
+func (a *OpenTracingAppLayer) InstallPlugin(ctx context.Context, pluginFile io.ReadSeeker, replace bool) (*model.Manifest, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.InstallPlugin")
 
@@ -11712,7 +11712,7 @@ func (a *OpenTracingAppLayer) InstallPlugin(pluginFile io.ReadSeeker, replace bo
 	}()
 
 	defer span.Finish()
-	resultVar0, resultVar1 := a.app.InstallPlugin(pluginFile, replace)
+	resultVar0, resultVar1 := a.app.InstallPlugin(ctx, pluginFile, replace)
 
 	if resultVar1 != nil {
 		span.LogFields(spanlog.Error(resultVar1))
@@ -16589,7 +16589,7 @@ func (a *OpenTracingAppLayer) SyncLdap(includeRemovedMembers bool) {
 	a.app.SyncLdap(includeRemovedMembers)
 }
 
-func (a *OpenTracingAppLayer) SyncPlugins() *model.AppError {
+func (a *OpenTracingAppLayer) SyncPlugins(ctx context.Context) *model.AppError {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.SyncPlugins")
 
@@ -16601,7 +16601,7 @@ func (a *OpenTracingAppLayer) SyncPlugins() *model.AppError {
 	}()
 
 	defer span.Finish()
-	resultVar0 := a.app.SyncPlugins()
+	resultVar0 := a.app.SyncPlugins(ctx)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -903,7 +904,7 @@ func (api *PluginAPI) InstallPlugin(file io.Reader, replace bool) (*model.Manife
 		return nil, model.NewAppError("InstallPlugin", "api.plugin.upload.file.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	return api.app.InstallPlugin(bytes.NewReader(fileBuffer), replace)
+	return api.app.InstallPlugin(context.Background(), bytes.NewReader(fileBuffer), replace)
 }
 
 // KV Store Section

--- a/app/plugin_api_test.go
+++ b/app/plugin_api_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -107,7 +108,7 @@ func setupMultiPluginAPITest(t *testing.T, pluginCodes []string, pluginManifests
 		}
 
 		os.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(pluginManifests[i]), 0600)
-		manifest, activated, reterr := env.Activate(pluginID)
+		manifest, activated, reterr := env.Activate(context.Background(), pluginID)
 		require.NoError(t, reterr)
 		require.NotNil(t, manifest)
 		require.True(t, activated)
@@ -859,7 +860,7 @@ func TestPluginAPIGetPlugins(t *testing.T) {
 		utils.CompileGo(t, pluginCode, backend)
 
 		os.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(fmt.Sprintf(`{"id": "%s", "server": {"executable": "backend.exe"}}`, pluginID)), 0600)
-		manifest, activated, reterr := env.Activate(pluginID)
+		manifest, activated, reterr := env.Activate(context.Background(), pluginID)
 
 		require.NoError(t, reterr)
 		require.NotNil(t, manifest)
@@ -946,7 +947,7 @@ func TestInstallPlugin(t *testing.T) {
 		utils.CompileGo(t, pluginCode, backend)
 
 		os.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(pluginManifest), 0600)
-		manifest, activated, reterr := env.Activate(pluginID)
+		manifest, activated, reterr := env.Activate(context.Background(), pluginID)
 		require.NoError(t, reterr)
 		require.NotNil(t, manifest)
 		require.True(t, activated)
@@ -1672,7 +1673,7 @@ func TestAPIMetrics(t *testing.T) {
 		// Setup mocks
 		metricsMock.On("ObservePluginAPIDuration", pluginID, "UpdateUser", true, mock.Anything).Return()
 
-		_, _, activationErr := env.Activate(pluginID)
+		_, _, activationErr := env.Activate(context.Background(), pluginID)
 		require.NoError(t, activationErr)
 
 		require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
@@ -2090,7 +2091,7 @@ func TestRegisterCollectionAndTopic(t *testing.T) {
 	utils.CompileGo(t, pluginCode, backend)
 
 	os.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(pluginManifest), 0600)
-	manifest, activated, reterr := env.Activate(pluginID)
+	manifest, activated, reterr := env.Activate(context.Background(), pluginID)
 	require.NoError(t, reterr)
 	require.NotNil(t, manifest)
 	require.True(t, activated)
@@ -2190,7 +2191,7 @@ func TestPluginUploadsAPI(t *testing.T) {
 	utils.CompileGo(t, pluginCode, backend)
 
 	os.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(pluginManifest), 0600)
-	manifest, activated, reterr := env.Activate(pluginID)
+	manifest, activated, reterr := env.Activate(context.Background(), pluginID)
 	require.NoError(t, reterr)
 	require.NotNil(t, manifest)
 	require.True(t, activated)

--- a/app/plugin_health_check_test.go
+++ b/app/plugin_health_check_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,7 +53,7 @@ func TestHealthCheckJob(t *testing.T) {
 	hooks, err := env.HooksForPlugin(id)
 	require.NoError(t, err)
 	hooks.MessageWillBePosted(&plugin.Context{}, &model.Post{})
-	job.CheckPlugin(id)
+	job.CheckPlugin(context.Background(), id)
 	bundles = env.Active()
 	require.Equal(t, 1, len(bundles))
 	require.Equal(t, id, bundles[0].Manifest.Id)
@@ -62,7 +63,7 @@ func TestHealthCheckJob(t *testing.T) {
 	hooks, err = env.HooksForPlugin(id)
 	require.NoError(t, err)
 	hooks.MessageWillBePosted(&plugin.Context{}, &model.Post{})
-	job.CheckPlugin(id)
+	job.CheckPlugin(context.Background(), id)
 	bundles = env.Active()
 	require.Equal(t, 1, len(bundles))
 	require.Equal(t, id, bundles[0].Manifest.Id)
@@ -72,14 +73,14 @@ func TestHealthCheckJob(t *testing.T) {
 	hooks, err = env.HooksForPlugin(id)
 	require.NoError(t, err)
 	hooks.MessageWillBePosted(&plugin.Context{}, &model.Post{})
-	job.CheckPlugin(id)
+	job.CheckPlugin(context.Background(), id)
 	bundles = env.Active()
 	require.Equal(t, 0, len(bundles))
 	require.Equal(t, model.PluginStateFailedToStayRunning, env.GetPluginState(id))
 
 	// Activated manually, plugin should stay active
-	env.Activate(id)
-	job.CheckPlugin(id)
+	env.Activate(context.Background(), id)
+	job.CheckPlugin(context.Background(), id)
 	bundles = env.Active()
 	require.Equal(t, 1, len(bundles))
 	require.Equal(t, model.PluginStateRunning, env.GetPluginState(id))

--- a/app/plugin_hooks_test.go
+++ b/app/plugin_hooks_test.go
@@ -45,7 +45,7 @@ func SetAppEnvironmentWithPlugins(t *testing.T, pluginCode []string, app *App, a
 		utils.CompileGo(t, code, backend)
 
 		os.WriteFile(filepath.Join(pluginDir, pluginID, "plugin.json"), []byte(`{"id": "`+pluginID+`", "server": {"executable": "backend.exe"}}`), 0600)
-		_, _, activationErr := env.Activate(pluginID)
+		_, _, activationErr := env.Activate(context.Background(), pluginID)
 		pluginIDs = append(pluginIDs, pluginID)
 		activationErrors = append(activationErrors, activationErr)
 
@@ -1082,7 +1082,7 @@ func TestHookMetrics(t *testing.T) {
 		metricsMock.On("ObservePluginMultiHookIterationDuration", mock.Anything, mock.Anything, mock.Anything).Return()
 		metricsMock.On("ObservePluginMultiHookDuration", mock.Anything).Return()
 
-		_, _, activationErr := env.Activate(pluginID)
+		_, _, activationErr := env.Activate(context.Background(), pluginID)
 		require.NoError(t, activationErr)
 
 		th.App.UpdateConfig(func(cfg *model.Config) {

--- a/app/plugin_install_test.go
+++ b/app/plugin_install_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -73,7 +74,7 @@ func TestInstallPluginLocally(t *testing.T) {
 		th := Setup(t)
 		defer th.TearDown()
 
-		actualManifest, appErr := th.App.ch.installPluginLocally(&nilReadSeeker{}, nil, installPluginLocallyOnlyIfNew)
+		actualManifest, appErr := th.App.ch.installPluginLocally(context.Background(), &nilReadSeeker{}, nil, installPluginLocallyOnlyIfNew)
 		require.NotNil(t, appErr)
 		assert.Equal(t, "app.plugin.extract.app_error", appErr.Id, appErr.Error())
 		require.Nil(t, actualManifest)
@@ -87,7 +88,7 @@ func TestInstallPluginLocally(t *testing.T) {
 			{"test", "test file"},
 		})
 
-		actualManifest, appErr := th.App.ch.installPluginLocally(reader, nil, installPluginLocallyOnlyIfNew)
+		actualManifest, appErr := th.App.ch.installPluginLocally(context.Background(), reader, nil, installPluginLocallyOnlyIfNew)
 		require.NotNil(t, appErr)
 		assert.Equal(t, "app.plugin.manifest.app_error", appErr.Id, appErr.Error())
 		require.Nil(t, actualManifest)
@@ -106,7 +107,7 @@ func TestInstallPluginLocally(t *testing.T) {
 			{"plugin.json", string(manifestJSON)},
 		})
 
-		actualManifest, appError := th.App.ch.installPluginLocally(reader, nil, installationStrategy)
+		actualManifest, appError := th.App.ch.installPluginLocally(context.Background(), reader, nil, installationStrategy)
 		if actualManifest != nil {
 			require.Equal(t, manifest, actualManifest)
 		}
@@ -275,7 +276,7 @@ func TestInstallPluginAlreadyActive(t *testing.T) {
 	reader, err := os.Open(filepath.Join(path, "testplugin.tar.gz"))
 	require.NoError(t, err)
 
-	actualManifest, appError := th.App.InstallPlugin(reader, true)
+	actualManifest, appError := th.App.InstallPlugin(context.Background(), reader, true)
 	require.NotNil(t, actualManifest)
 	require.Nil(t, appError)
 	appError = th.App.EnablePlugin(actualManifest.Id)
@@ -293,7 +294,7 @@ func TestInstallPluginAlreadyActive(t *testing.T) {
 		}
 	}
 
-	actualManifest, appError = th.App.InstallPlugin(reader, true)
+	actualManifest, appError = th.App.InstallPlugin(context.Background(), reader, true)
 	require.NotNil(t, appError)
 	require.Nil(t, actualManifest)
 	require.Equal(t, "app.plugin.restart.app_error", appError.Id)

--- a/app/plugin_shutdown_test.go
+++ b/app/plugin_shutdown_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -63,7 +64,7 @@ func TestPluginShutdownTest(t *testing.T) {
 	done := make(chan bool)
 	go func() {
 		defer close(done)
-		th.App.ch.ShutDownPlugins()
+		th.App.ch.ShutDownPlugins(context.Background())
 	}()
 
 	select {

--- a/plugin/health_check_test.go
+++ b/plugin/health_check_test.go
@@ -4,6 +4,7 @@
 package plugin
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -54,7 +55,7 @@ func testPluginHealthCheckSuccess(t *testing.T) {
 	log := mlog.CreateConsoleTestLogger(true, mlog.LvlError)
 	defer log.Shutdown()
 
-	supervisor, err := newSupervisor(bundle, nil, nil, log, nil)
+	supervisor, err := newSupervisor(context.Background(), bundle, nil, nil, log, nil)
 	require.NoError(t, err)
 	require.NotNil(t, supervisor)
 	defer supervisor.Shutdown()
@@ -97,7 +98,7 @@ func testPluginHealthCheckPanic(t *testing.T) {
 	log := mlog.CreateConsoleTestLogger(true, mlog.LvlError)
 	defer log.Shutdown()
 
-	supervisor, err := newSupervisor(bundle, nil, nil, log, nil)
+	supervisor, err := newSupervisor(context.Background(), bundle, nil, nil, log, nil)
 	require.NoError(t, err)
 	require.NotNil(t, supervisor)
 	defer supervisor.Shutdown()

--- a/plugin/supervisor.go
+++ b/plugin/supervisor.go
@@ -4,6 +4,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -28,7 +29,7 @@ type supervisor struct {
 	hooksClient *hooksRPCClient
 }
 
-func newSupervisor(pluginInfo *model.BundleInfo, apiImpl API, driver Driver, parentLogger *mlog.Logger, metrics einterfaces.MetricsInterface) (retSupervisor *supervisor, retErr error) {
+func newSupervisor(ctx context.Context, pluginInfo *model.BundleInfo, apiImpl API, driver Driver, parentLogger *mlog.Logger, metrics einterfaces.MetricsInterface) (retSupervisor *supervisor, retErr error) {
 	sup := supervisor{}
 	defer func() {
 		if retErr != nil {
@@ -60,7 +61,7 @@ func newSupervisor(pluginInfo *model.BundleInfo, apiImpl API, driver Driver, par
 	}
 	executable = filepath.Join(pluginInfo.Path, executable)
 
-	cmd := exec.Command(executable)
+	cmd := exec.CommandContext(ctx, executable)
 
 	sup.client = plugin.NewClient(&plugin.ClientConfig{
 		HandshakeConfig: handshake,

--- a/plugin/supervisor_test.go
+++ b/plugin/supervisor_test.go
@@ -4,6 +4,7 @@
 package plugin
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,7 +37,7 @@ func testSupervisorInvalidExecutablePath(t *testing.T) {
 	bundle := model.BundleInfoForPath(dir)
 	log := mlog.CreateConsoleTestLogger(true, mlog.LvlError)
 	defer log.Shutdown()
-	supervisor, err := newSupervisor(bundle, nil, nil, log, nil)
+	supervisor, err := newSupervisor(context.Background(), bundle, nil, nil, log, nil)
 	assert.Nil(t, supervisor)
 	assert.Error(t, err)
 }
@@ -51,7 +52,7 @@ func testSupervisorNonExistentExecutablePath(t *testing.T) {
 	bundle := model.BundleInfoForPath(dir)
 	log := mlog.CreateConsoleTestLogger(true, mlog.LvlError)
 	defer log.Shutdown()
-	supervisor, err := newSupervisor(bundle, nil, nil, log, nil)
+	supervisor, err := newSupervisor(context.Background(), bundle, nil, nil, log, nil)
 	require.Error(t, err)
 	require.Nil(t, supervisor)
 }
@@ -77,7 +78,7 @@ func testSupervisorStartTimeout(t *testing.T) {
 	bundle := model.BundleInfoForPath(dir)
 	log := mlog.CreateConsoleTestLogger(true, mlog.LvlError)
 	defer log.Shutdown()
-	supervisor, err := newSupervisor(bundle, nil, nil, log, nil)
+	supervisor, err := newSupervisor(context.Background(), bundle, nil, nil, log, nil)
 	require.Error(t, err)
 	require.Nil(t, supervisor)
 }

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -4,6 +4,7 @@
 package web
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -229,7 +230,7 @@ func TestStaticFilesRequest(t *testing.T) {
 	os.WriteFile(filepath.Join(pluginDir, "plugin.json"), []byte(pluginManifest), 0600)
 
 	// Activate the plugin
-	manifest, activated, reterr := th.App.GetPluginsEnvironment().Activate(pluginID)
+	manifest, activated, reterr := th.App.GetPluginsEnvironment().Activate(context.Background(), pluginID)
 	require.NoError(t, reterr)
 	require.NotNil(t, manifest)
 	require.True(t, activated)
@@ -324,7 +325,7 @@ func TestPublicFilesRequest(t *testing.T) {
 	htmlFileErr = os.WriteFile(filepath.Join(pluginDir, pluginID, "nefarious-file-access.html"), []byte(nefariousHTML), 0600)
 	assert.NoError(t, htmlFileErr)
 
-	manifest, activated, reterr := env.Activate(pluginID)
+	manifest, activated, reterr := env.Activate(context.Background(), pluginID)
 	require.NoError(t, reterr)
 	require.NotNil(t, manifest)
 	require.True(t, activated)


### PR DESCRIPTION

#### Summary
Make plugin commands run with context. And also propagate these context from the highest possible call. As there are several `TODO`s in the PR, it appears that we have almost no control how to run plugins and there are many ways of running a plugin. The PR is not a solution to the zombie plugin issue but its rather a discussion starting point of how we should handle this. Feel free to drop some ideas and we will get to a better solution eventually.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49353

#### Release Note

```release-note
NONE
```
