### PR TITLE
Add Boards build information to client config

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -223,6 +223,8 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 	props["BuildHash"] = model.BuildHash
 	props["BuildHashEnterprise"] = model.BuildHashEnterprise
 	props["BuildEnterpriseReady"] = model.BuildEnterpriseReady
+	props["BuildHashBoards"] = model.BuildHashBoards
+	props["BuildBoards"] = model.BuildBoards
 
 	props["EnableBotAccountCreation"] = strconv.FormatBool(*c.ServiceSettings.EnableBotAccountCreation)
 	props["EnableFile"] = strconv.FormatBool(*c.LogSettings.EnableFile)


### PR DESCRIPTION
We're already writing that information as part of the Makefile, but this will expose it to the frontend like it does for the build hashes of the server and enterprise repos

#### Release Note
```release-note
Added Boards build information to client config
```
