### PR TITLE
[GH-21901]: Add Interactive Dialog Trigger Timeout Env Option

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -176,6 +176,8 @@ const (
 
 	ExperimentalSettingsDefaultLinkMetadataTimeoutMilliseconds = 5000
 
+	ExperimentalSettingsDefaultInteractiveDialogTriggerTimeoutMilliseconds = 5000
+
 	AnalyticsSettingsDefaultMaxUsersForStatistics = 2500
 
 	AnnouncementSettingsDefaultBannerColor                  = "#f2a93b"
@@ -960,15 +962,16 @@ func (s *MetricsSettings) SetDefaults() {
 }
 
 type ExperimentalSettings struct {
-	ClientSideCertEnable            *bool   `access:"experimental_features,cloud_restrictable"`
-	ClientSideCertCheck             *string `access:"experimental_features,cloud_restrictable"`
-	LinkMetadataTimeoutMilliseconds *int64  `access:"experimental_features,write_restrictable,cloud_restrictable"`
-	RestrictSystemAdmin             *bool   `access:"experimental_features,write_restrictable"`
-	UseNewSAMLLibrary               *bool   `access:"experimental_features,cloud_restrictable"`
-	EnableSharedChannels            *bool   `access:"experimental_features"`
-	EnableRemoteClusterService      *bool   `access:"experimental_features"`
-	EnableAppBar                    *bool   `access:"experimental_features"`
-	PatchPluginsReactDOM            *bool   `access:"experimental_features"`
+	ClientSideCertEnable                        *bool   `access:"experimental_features,cloud_restrictable"`
+	ClientSideCertCheck                         *string `access:"experimental_features,cloud_restrictable"`
+	LinkMetadataTimeoutMilliseconds             *int64  `access:"experimental_features,write_restrictable,cloud_restrictable"`
+	RestrictSystemAdmin                         *bool   `access:"experimental_features,write_restrictable"`
+	UseNewSAMLLibrary                           *bool   `access:"experimental_features,cloud_restrictable"`
+	EnableSharedChannels                        *bool   `access:"experimental_features"`
+	EnableRemoteClusterService                  *bool   `access:"experimental_features"`
+	EnableAppBar                                *bool   `access:"experimental_features"`
+	PatchPluginsReactDOM                        *bool   `access:"experimental_features"`
+	InteractiveDialogTriggerTimeoutMilliseconds *int64  `access:"experimental_features,write_restrictable,cloud_restrictable"`
 }
 
 func (s *ExperimentalSettings) SetDefaults() {
@@ -1006,6 +1009,10 @@ func (s *ExperimentalSettings) SetDefaults() {
 
 	if s.PatchPluginsReactDOM == nil {
 		s.PatchPluginsReactDOM = NewBool(false)
+	}
+
+	if s.InteractiveDialogTriggerTimeoutMilliseconds == nil {
+		s.InteractiveDialogTriggerTimeoutMilliseconds = NewInt64(ExperimentalSettingsDefaultInteractiveDialogTriggerTimeoutMilliseconds)
 	}
 }
 

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -734,15 +734,16 @@ func (ts *TelemetryService) trackConfig() {
 	})
 
 	ts.SendTelemetry(TrackConfigExperimental, map[string]any{
-		"client_side_cert_enable":            *cfg.ExperimentalSettings.ClientSideCertEnable,
-		"isdefault_client_side_cert_check":   isDefault(*cfg.ExperimentalSettings.ClientSideCertCheck, model.ClientSideCertCheckPrimaryAuth),
-		"link_metadata_timeout_milliseconds": *cfg.ExperimentalSettings.LinkMetadataTimeoutMilliseconds,
-		"restrict_system_admin":              *cfg.ExperimentalSettings.RestrictSystemAdmin,
-		"use_new_saml_library":               *cfg.ExperimentalSettings.UseNewSAMLLibrary,
-		"enable_shared_channels":             *cfg.ExperimentalSettings.EnableSharedChannels,
-		"enable_remote_cluster_service":      *cfg.ExperimentalSettings.EnableRemoteClusterService && cfg.FeatureFlags.EnableRemoteClusterService,
-		"enable_app_bar":                     *cfg.ExperimentalSettings.EnableAppBar,
-		"patch_plugins_react_dom":            *cfg.ExperimentalSettings.PatchPluginsReactDOM,
+		"client_side_cert_enable":                         *cfg.ExperimentalSettings.ClientSideCertEnable,
+		"isdefault_client_side_cert_check":                isDefault(*cfg.ExperimentalSettings.ClientSideCertCheck, model.ClientSideCertCheckPrimaryAuth),
+		"link_metadata_timeout_milliseconds":              *cfg.ExperimentalSettings.LinkMetadataTimeoutMilliseconds,
+		"restrict_system_admin":                           *cfg.ExperimentalSettings.RestrictSystemAdmin,
+		"use_new_saml_library":                            *cfg.ExperimentalSettings.UseNewSAMLLibrary,
+		"enable_shared_channels":                          *cfg.ExperimentalSettings.EnableSharedChannels,
+		"enable_remote_cluster_service":                   *cfg.ExperimentalSettings.EnableRemoteClusterService && cfg.FeatureFlags.EnableRemoteClusterService,
+		"enable_app_bar":                                  *cfg.ExperimentalSettings.EnableAppBar,
+		"patch_plugins_react_dom":                         *cfg.ExperimentalSettings.PatchPluginsReactDOM,
+		"interactive_dialog_trigger_timeout_milliseconds": *cfg.ExperimentalSettings.InteractiveDialogTriggerTimeoutMilliseconds,
 	})
 
 	ts.SendTelemetry(TrackConfigAnalytics, map[string]any{


### PR DESCRIPTION
#### Summary
Added environment variable support to set interactive dialog trigger timeout

#### Ticket Link
  Fixes https://github.com/mattermost/mattermost-server/issues/21901

#### Related Pull Requests
- Has web app changes (https://github.com/mattermost/mattermost-webapp/pull/11968)

#### Release Note
```
None
```