### PR TITLE
MM-49658: Correctly disable plugin in product mode

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -130,23 +130,6 @@ func (ch *Channels) syncPluginsActiveState() {
 			}
 
 			if pluginEnabled {
-				// Disable focalboard in product mode.
-				if pluginID == model.PluginIdFocalboard && ch.cfgSvc.Config().FeatureFlags.BoardsProduct {
-					msg := "Plugin cannot run in product mode. Disabling."
-					mlog.Warn(msg, mlog.String("plugin_id", model.PluginIdFocalboard))
-
-					// This is a mini-version of ch.disablePlugin.
-					// We don't call that directly, because that will recursively call
-					// this method.
-					ch.cfgSvc.UpdateConfig(func(cfg *model.Config) {
-						cfg.PluginSettings.PluginStates[pluginID] = &model.PluginState{Enable: false}
-					})
-					pluginsEnvironment.SetPluginError(pluginID, msg)
-					ch.unregisterPluginCommands(pluginID)
-					disabledPlugins = append(disabledPlugins, plugin)
-					continue
-				}
-
 				enabledPlugins = append(enabledPlugins, plugin)
 			} else {
 				disabledPlugins = append(disabledPlugins, plugin)
@@ -322,6 +305,16 @@ func (ch *Channels) syncPlugins() *model.AppError {
 
 	var wg sync.WaitGroup
 	for _, plugin := range availablePlugins {
+		// Disable focalboard in product mode.
+		if plugin.Manifest.Id == model.PluginIdFocalboard && ch.cfgSvc.Config().FeatureFlags.BoardsProduct {
+			mlog.Info("Plugin cannot run in product mode, disabling.", mlog.String("plugin_id", model.PluginIdFocalboard))
+			appErr := ch.disablePlugin(model.PluginIdFocalboard)
+			if appErr != nil {
+				mlog.Error("Error disabling plugin", mlog.Err(err))
+			}
+			continue
+		}
+
 		wg.Add(1)
 		go func(pluginID string) {
 			defer wg.Done()


### PR DESCRIPTION
We disable the plugin now at a higher level
which goes through all the layers correctly.

Initially, it was trying to extract the plugin,
failing, and removing the local installation
as well, causing confusion.

https://mattermost.atlassian.net/browse/MM-49658

```release-note
NONE
```
