### PR TITLE
Handles an empty mysql.time_zone_name table.

### DIFF
--- a/store/sqlstore/channel_store.go
+++ b/store/sqlstore/channel_store.go
@@ -4661,19 +4661,27 @@ func (s SqlChannelStore) PostCountsByDuration(channelIDs []string, sinceUnixMill
 	if loc == "Local" {
 		loc = "UTC"
 	}
+	var format string
 	if s.DriverName() == model.DatabaseDriverMysql {
 		if duration == model.PostsByDay {
-			unixSelect = `DATE_FORMAT(CONVERT_TZ(FROM_UNIXTIME(Posts.CreateAt / 1000), 'GMT', '` + loc + `'),'%Y-%m-%d') AS duration`
+			format = `%Y-%m-%d`
 		} else {
-			unixSelect = `DATE_FORMAT(CONVERT_TZ(FROM_UNIXTIME(Posts.CreateAt / 1000), 'GMT', '` + loc + `'),'%Y-%m-%dT%H') AS duration`
+			format = `%Y-%m-%dT%H`
 		}
+		unixSelect = fmt.Sprintf(`DATE_FORMAT(
+			COALESCE(
+				CONVERT_TZ(FROM_UNIXTIME(Posts.CreateAt / 1000), 'GMT', '%s'),
+				FROM_UNIXTIME(Posts.CreateAt / 1000)
+			),
+		'%s') AS duration`, loc, format)
 		propsQuery = `(JSON_EXTRACT(Posts.Props, '$.from_bot') IS NULL OR JSON_EXTRACT(Posts.Props, '$.from_bot') = 'false') AND (JSON_EXTRACT(Posts.Props, '$.from_webhook') IS NULL OR JSON_EXTRACT(Posts.Props, '$.from_webhook') = 'false') AND (JSON_EXTRACT(Posts.Props, '$.from_plugin') IS NULL OR JSON_EXTRACT(Posts.Props, '$.from_plugin') = 'false') AND (JSON_EXTRACT(Posts.Props, '$.from_oauth_app') IS NULL OR JSON_EXTRACT(Posts.Props, '$.from_oauth_app') = 'false')`
 	} else if s.DriverName() == model.DatabaseDriverPostgres {
 		if duration == model.PostsByDay {
-			unixSelect = fmt.Sprintf(`TO_CHAR(TO_TIMESTAMP(Posts.CreateAt / 1000) AT TIME ZONE '%s', 'YYYY-MM-DD') AS duration`, loc)
+			format = "YYYY-MM-DD"
 		} else {
-			unixSelect = fmt.Sprintf(`TO_CHAR(TO_TIMESTAMP(Posts.CreateAt / 1000) AT TIME ZONE '%s', 'YYYY-MM-DD"T"HH24') AS duration`, loc)
+			format = `YYYY-MM-DD"T"HH24`
 		}
+		unixSelect = fmt.Sprintf(`TO_CHAR(TO_TIMESTAMP(Posts.CreateAt / 1000) AT TIME ZONE '%s', '%s') AS duration`, loc, format)
 		propsQuery = `(Posts.Props ->> 'from_bot' IS NULL OR Posts.Props ->> 'from_bot' = 'false') AND (Posts.Props ->> 'from_webhook' IS NULL OR Posts.Props ->> 'from_webhook' = 'false') AND (Posts.Props ->> 'from_oauth_app' IS NULL OR Posts.Props ->> 'from_oauth_app' = 'false') AND (Posts.Props ->> 'from_plugin' IS NULL OR Posts.Props ->> 'from_plugin' = 'false')`
 	}
 	query := sq.


### PR DESCRIPTION
#### Summary

In order to use timezone names, which we're using as a parameter to the `CONVERT_TZ` with MySQL, the database needs to have a matching value in the `mysql.time_zone_name` table. I didn't realize when I originally added the query that MySQL does not populate that table by default. It must be [populated on Linux](https://dev.mysql.com/doc/refman/8.0/en/time-zone-support.html#time-zone-installation) with something like `mysql_tzinfo_to_sql /usr/share/zoneinfo | mysql -u root -p mysql` or windows using another documented method.

If the current user's timezone is not present in the `time_zone_name` table then [they were seeing a blank Top Channels widget](https://community.mattermost.com/core/pl/c7ewitjkain6tci1qqd5z5gtuc).

This fixes that so that if the timezone name isn't present they'll at least see Top Channels based on posts using the GMT timezone.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49688

#### Release Note

```release-note
Fixed a bug where Top Channels didn't show results if the current user's configured timezone wasn't present in MySQL's mysql.time_zone_name table.
```
