### PR TITLE
MM-49681 - Remove mentions of boards and integrations limits on delinquency emails, and replace remaining "Cloud Starter" text with "Cloud Free" text.

### DIFF
--- a/app/email/email.go
+++ b/app/email/email.go
@@ -1113,7 +1113,7 @@ func (es *Service) SendDelinquencyEmail30(email, locale, siteURL, planName strin
 	data.Props["SupportEmail"] = *es.config().SupportSettings.SupportEmail
 	data.Props["Button"] = T("api.templates.delinquency_30.button")
 	data.Props["EmailUs"] = T("api.templates.email_us_anytime_at")
-	data.Props["BulletListItems"] = []string{T("api.templates.delinquency_30.bullet.message_history"), T("api.templates.delinquency_30.bullet.files"), T("api.templates.delinquency_30.bullet.cards"), T("api.templates.delinquency_30.bullet.plugins")}
+	data.Props["BulletListItems"] = []string{T("api.templates.delinquency_30.bullet.message_history"), T("api.templates.delinquency_30.bullet.files")}
 	data.Props["LimitsDocs"] = T("api.templates.delinquency_30.limits_documentation")
 	data.Props["Footer"] = T("api.templates.copyright")
 
@@ -1178,7 +1178,7 @@ func (es *Service) SendDelinquencyEmail60(email, locale, siteURL string) error {
 	data.Props["Button"] = T("api.templates.delinquency_60.button")
 	data.Props["EmailUs"] = T("api.templates.email_us_anytime_at")
 	data.Props["IncludeSecondaryActionButton"] = true
-	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_60.downgrade_to_free")
+	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_60.downgrade_to_starter")
 	data.Props["Footer"] = T("api.templates.copyright")
 
 	// 45 day template is the same as the 60 day one so its reused
@@ -1211,7 +1211,7 @@ func (es *Service) SendDelinquencyEmail75(email, locale, siteURL, planName, deli
 	data.Props["Button"] = T("api.templates.delinquency_75.button")
 	data.Props["EmailUs"] = T("api.templates.email_us_anytime_at")
 	data.Props["IncludeSecondaryActionButton"] = true
-	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_75.downgrade_to_free")
+	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_75.downgrade_to_starter")
 	data.Props["Footer"] = T("api.templates.copyright")
 
 	// 45 day template is the same as the 75 day one so its reused

--- a/app/email/email.go
+++ b/app/email/email.go
@@ -1178,7 +1178,7 @@ func (es *Service) SendDelinquencyEmail60(email, locale, siteURL string) error {
 	data.Props["Button"] = T("api.templates.delinquency_60.button")
 	data.Props["EmailUs"] = T("api.templates.email_us_anytime_at")
 	data.Props["IncludeSecondaryActionButton"] = true
-	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_60.downgrade_to_starter")
+	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_60.downgrade_to_free")
 	data.Props["Footer"] = T("api.templates.copyright")
 
 	// 45 day template is the same as the 60 day one so its reused
@@ -1211,7 +1211,7 @@ func (es *Service) SendDelinquencyEmail75(email, locale, siteURL, planName, deli
 	data.Props["Button"] = T("api.templates.delinquency_75.button")
 	data.Props["EmailUs"] = T("api.templates.email_us_anytime_at")
 	data.Props["IncludeSecondaryActionButton"] = true
-	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_75.downgrade_to_starter")
+	data.Props["SecondaryActionButtonText"] = T("api.templates.delinquency_75.downgrade_to_free")
 	data.Props["Footer"] = T("api.templates.copyright")
 
 	// 45 day template is the same as the 75 day one so its reused

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -9280,7 +9280,7 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele zu Cloud Free."
+    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele zu Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
@@ -9452,7 +9452,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Außerdem kann es sein, dass deine Daten aufgrund der Beschränkungen von Cloud Free archiviert wurden."
+    "translation": "Außerdem kann es sein, dass deine Daten aufgrund der Beschränkungen von Cloud Starter archiviert wurden."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -9284,7 +9284,7 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Dein Arbeitsbereich wird auf Cloud Free herabgestuft. Deine {{.Plan}}-Funktionen werden gesperrt und einige deiner Arbeitsbereichsdaten können archiviert werden, bis dein ausstehender Betrag vollständig beglichen ist."
+    "translation": "Dein Arbeitsbereich wird auf Cloud Starter herabgestuft. Deine {{.Plan}}-Funktionen werden gesperrt und einige deiner Arbeitsbereichsdaten können archiviert werden, bis dein ausstehender Betrag vollständig beglichen ist."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9295,7 +9295,7 @@
     "translation": "Dein Mattermost {{.Plan}} wird in 15 Tagen herabgestuft"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
     "translation": "Herunterstufen zu Cloud Starter"
   },
   {
@@ -9324,7 +9324,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele unten zu Cloud Free."
+    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele unten zu Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9339,7 +9339,7 @@
     "translation": "Aktion notwendig: Arbeitsbereich wird in 30 Tagen herabgestuft"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
     "translation": "Herabstufen zu Cloud Starter"
   },
   {
@@ -9353,10 +9353,6 @@
   {
     "id": "api.templates.delinquency_45.subtitle3",
     "translation": "Aktualisiere jetzt deine Kreditkarteninformationen."
-  },
-  {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "Ein herabgestufter Arbeitsbereich kann sich negativ auf kritische Arbeitsabläufe, Integrationen und andere geschäftskritische Aktivitäten in deinem Arbeitsbereich auswirken."
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9395,20 +9391,12 @@
     "translation": "Bezahlart aktualisieren"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Aktive Plugins und Integrationen"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "Nachrichtenverlauf"
   },
   {
     "id": "api.templates.delinquency_30.bullet.files",
     "translation": "Dateien"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Karten von deinen Boards"
   },
   {
     "id": "api.templates.delinquency_14.title",
@@ -9420,7 +9408,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Wir konnten die hinterlegte Kreditkarte nicht belasten. Das bedeutet, dass ein Risiko besteht auf Cloud Free zurückgestuft zu werden."
+    "translation": "Wir konnten die hinterlegte Kreditkarte nicht belasten. Das bedeutet, dass ein Risiko besteht auf Cloud Starter zurückgestuft zu werden."
   },
   {
     "id": "api.templates.delinquency_14.subject",

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -9280,11 +9280,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele zu Cloud Starter."
+    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele zu Cloud Free."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Dein Arbeitsbereich wird auf Cloud Starter herabgestuft. Deine {{.Plan}}-Funktionen werden gesperrt und einige deiner Arbeitsbereichsdaten können archiviert werden, bis dein ausstehender Betrag vollständig beglichen ist."
+    "translation": "Dein Arbeitsbereich wird auf Cloud Free herabgestuft. Deine {{.Plan}}-Funktionen werden gesperrt und einige deiner Arbeitsbereichsdaten können archiviert werden, bis dein ausstehender Betrag vollständig beglichen ist."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9295,8 +9295,8 @@
     "translation": "Dein Mattermost {{.Plan}} wird in 15 Tagen herabgestuft"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Herunterstufen zu Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Herunterstufen zu Cloud Free"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9324,7 +9324,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele unten zu Cloud Starter."
+    "translation": "Aktualisiere jetzt deine Zahlungsinformationen oder wechsele unten zu Cloud Free."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9339,8 +9339,8 @@
     "translation": "Aktion notwendig: Arbeitsbereich wird in 30 Tagen herabgestuft"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Herabstufen zu Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Herabstufen zu Cloud Free"
   },
   {
     "id": "api.templates.delinquency_60.button",
@@ -9408,7 +9408,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Wir konnten die hinterlegte Kreditkarte nicht belasten. Das bedeutet, dass ein Risiko besteht auf Cloud Starter zurückgestuft zu werden."
+    "translation": "Wir konnten die hinterlegte Kreditkarte nicht belasten. Das bedeutet, dass ein Risiko besteht auf Cloud Free zurückgestuft zu werden."
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9452,7 +9452,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Außerdem kann es sein, dass deine Daten aufgrund der Beschränkungen von Cloud Starter archiviert wurden."
+    "translation": "Außerdem kann es sein, dass deine Daten aufgrund der Beschränkungen von Cloud Free archiviert wurden."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3281,7 +3281,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "We weren't able to charge the credit card we have on file. This means your workspace is at risk of being downgraded to Cloud Free."
+    "translation": "We weren't able to charge the credit card we have on file. This means your workspace is at risk of being downgraded to Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_14.subtitle2",
@@ -3292,20 +3292,12 @@
     "translation": "Payment not received"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Cards from your Boards"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.files",
     "translation": "Files"
   },
   {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "Message history"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Active plugins and integrations"
   },
   {
     "id": "api.templates.delinquency_30.button",
@@ -3345,7 +3337,7 @@
   },
   {
     "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "A downgraded workspace might negatively affect critical workflows, integrations and other business critical activities carried at your workspace."
+    "translation": "A downgraded workspace might negatively affect critical workflows and other business critical activities carried at your workspace."
   },
   {
     "id": "api.templates.delinquency_45.subtitle3",
@@ -3360,8 +3352,8 @@
     "translation": "Update payment"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
-    "translation": "Downgrade to Cloud Free"
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
+    "translation": "Downgrade to Cloud Starter"
   },
   {
     "id": "api.templates.delinquency_60.subject",
@@ -3377,7 +3369,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Update your payment information now or downgrade to Cloud Free below."
+    "translation": "Update your payment information now or downgrade to Cloud Starter below."
   },
   {
     "id": "api.templates.delinquency_60.title",
@@ -3404,8 +3396,8 @@
     "translation": "Update payment"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
-    "translation": "Downgrade to Cloud Free"
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
+    "translation": "Downgrade to Cloud Starter"
   },
   {
     "id": "api.templates.delinquency_75.subject",
@@ -3417,11 +3409,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Your workspace will be downgraded to Cloud Free. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
+    "translation": "Your workspace will be downgraded to Cloud Starter. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Update your payment information now, or downgrade to Cloud Free."
+    "translation": "Update your payment information now, or downgrade to Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_75.title",
@@ -3445,7 +3437,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "In addition, your data may have been archived due to Cloud Free limitations."
+    "translation": "In addition, your data may have been archived due to Cloud Starter limitations."
   },
   {
     "id": "api.templates.delinquency_90.subtitle3",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -3281,7 +3281,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "We weren't able to charge the credit card we have on file. This means your workspace is at risk of being downgraded to Cloud Starter."
+    "translation": "We weren't able to charge the credit card we have on file. This means your workspace is at risk of being downgraded to Cloud Free."
   },
   {
     "id": "api.templates.delinquency_14.subtitle2",
@@ -3352,8 +3352,8 @@
     "translation": "Update payment"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Downgrade to Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Downgrade to Cloud Free"
   },
   {
     "id": "api.templates.delinquency_60.subject",
@@ -3369,7 +3369,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Update your payment information now or downgrade to Cloud Starter below."
+    "translation": "Update your payment information now or downgrade to Cloud Free below."
   },
   {
     "id": "api.templates.delinquency_60.title",
@@ -3396,8 +3396,8 @@
     "translation": "Update payment"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Downgrade to Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Downgrade to Cloud Free"
   },
   {
     "id": "api.templates.delinquency_75.subject",
@@ -3409,11 +3409,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Your workspace will be downgraded to Cloud Starter. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
+    "translation": "Your workspace will be downgraded to Cloud Free. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Update your payment information now, or downgrade to Cloud Starter."
+    "translation": "Update your payment information now, or downgrade to Cloud Free."
   },
   {
     "id": "api.templates.delinquency_75.title",
@@ -3437,7 +3437,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "In addition, your data may have been archived due to Cloud Starter limitations."
+    "translation": "In addition, your data may have been archived due to Cloud Free limitations."
   },
   {
     "id": "api.templates.delinquency_90.subtitle3",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -9284,7 +9284,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "In addition, your data may have been archived due to Cloud Free limitations."
+    "translation": "In addition, your data may have been archived due to Cloud Starter limitations."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9308,11 +9308,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Update your payment information now, or downgrade to Cloud Free."
+    "translation": "Update your payment information now, or downgrade to Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Your workspace will be downgraded to Cloud Free. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
+    "translation": "Your workspace will be downgraded to Cloud Starter. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9323,7 +9323,7 @@
     "translation": "Your Mattermost {{.Plan}} will be downgraded in 15 days"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
     "translation": "Downgrade to Cloud Starter"
   },
   {
@@ -9348,7 +9348,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Update your payment information now or downgrade to Cloud Free below."
+    "translation": "Update your payment information now or downgrade to Cloud Starter below."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9363,7 +9363,7 @@
     "translation": "Action Required: Workspace will be downgraded in 30 days"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
     "translation": "Downgrade to Cloud Starter"
   },
   {
@@ -9380,7 +9380,7 @@
   },
   {
     "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "A downgraded workspace might negatively affect critical workflows, integrations and other business critical activities carried out in your workspace."
+    "translation": "A downgraded workspace might negatively affect critical workflows and other business critical activities carried out in your workspace."
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9419,10 +9419,6 @@
     "translation": "Update payment"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Active plugins and integrations"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "Message history"
   },
@@ -9431,16 +9427,12 @@
     "translation": "Files"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Cards from your Boards"
-  },
-  {
     "id": "api.templates.delinquency_14.title",
     "translation": "Payment not received"
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "The credit card on record wasn't able to be charged. This means your workspace is at risk of being downgraded to Cloud Free."
+    "translation": "The credit card on record wasn't able to be charged. This means your workspace is at risk of being downgraded to Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_14.subject",

--- a/i18n/en_AU.json
+++ b/i18n/en_AU.json
@@ -9284,7 +9284,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "In addition, your data may have been archived due to Cloud Starter limitations."
+    "translation": "In addition, your data may have been archived due to Cloud Free limitations."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9308,11 +9308,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Update your payment information now, or downgrade to Cloud Starter."
+    "translation": "Update your payment information now, or downgrade to Cloud Free."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Your workspace will be downgraded to Cloud Starter. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
+    "translation": "Your workspace will be downgraded to Cloud Free. Your {{.Plan}} features will be locked and some of your workspace data may be archived until your full outstanding balance is settled."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9323,8 +9323,8 @@
     "translation": "Your Mattermost {{.Plan}} will be downgraded in 15 days"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Downgrade to Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Downgrade to Cloud Free"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9348,7 +9348,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Update your payment information now or downgrade to Cloud Starter below."
+    "translation": "Update your payment information now or downgrade to Cloud Free below."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9363,8 +9363,8 @@
     "translation": "Action Required: Workspace will be downgraded in 30 days"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Downgrade to Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Downgrade to Cloud Free"
   },
   {
     "id": "api.templates.delinquency_60.button",
@@ -9432,7 +9432,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "The credit card on record wasn't able to be charged. This means your workspace is at risk of being downgraded to Cloud Starter."
+    "translation": "The credit card on record wasn't able to be charged. This means your workspace is at risk of being downgraded to Cloud Free."
   },
   {
     "id": "api.templates.delinquency_14.subject",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -9265,7 +9265,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Además, tus datos pueden haber sido archivados debido a las limitaciones de Cloud Free."
+    "translation": "Además, tus datos pueden haber sido archivados debido a las limitaciones de Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9289,11 +9289,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Actualiza ahora tu información de pago, o degrada a Cloud Free."
+    "translation": "Actualiza ahora tu información de pago, o degrada a Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Tu espacio de trabajo será degradado a Cloud Free. Las características de tu {{.Plan}} serán bloqueadas y algunos de los datos de tu espacio de trabajo podrían ser archivados hasta que liquides completamente tu saldo pendiente."
+    "translation": "Tu espacio de trabajo será degradado a Cloud Starter. Las características de tu {{.Plan}} serán bloqueadas y algunos de los datos de tu espacio de trabajo podrían ser archivados hasta que liquides completamente tu saldo pendiente."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9304,7 +9304,7 @@
     "translation": "Tu {{.Plan}} Mattermost será degradado en 15 días"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
     "translation": "Degradar a Cloud Starter"
   },
   {
@@ -9333,7 +9333,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Actualiza tu información de pago ahora o degrada a Cloud Free abajo."
+    "translation": "Actualiza tu información de pago ahora o degrada a Cloud Starter abajo."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9348,7 +9348,7 @@
     "translation": "Acción requerida: El workspace será degradado en 30 días"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
     "translation": "Degradar a Cloud Starter"
   },
   {
@@ -9362,10 +9362,6 @@
   {
     "id": "api.templates.delinquency_45.subtitle3",
     "translation": "Actualiza la información de tu tarjeta de crédito ahora."
-  },
-  {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "Un workspace degradado podría afectar negativamente los flujos de trabajo críticos, integraciones y otras actividades críticas de negocio realizadas en tu workspace."
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9404,20 +9400,12 @@
     "translation": "Actualizar pago"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Plugins e integraciones activas"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "Historial de mensajes"
   },
   {
     "id": "api.templates.delinquency_30.bullet.files",
     "translation": "Archivos"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Tarjetas de tus Boards"
   },
   {
     "id": "api.templates.delinquency_14.title",
@@ -9429,7 +9417,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "No pudimos realizar el cargo a la tarjeta de crédito que tenemos registrada. Por lo cual tu espacio de trabajo está en riesgo de ser degradado a Cloud Free."
+    "translation": "No pudimos realizar el cargo a la tarjeta de crédito que tenemos registrada. Por lo cual tu espacio de trabajo está en riesgo de ser degradado a Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_14.subject",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -9265,7 +9265,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Además, tus datos pueden haber sido archivados debido a las limitaciones de Cloud Starter."
+    "translation": "Además, tus datos pueden haber sido archivados debido a las limitaciones de Cloud Free."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9289,11 +9289,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Actualiza ahora tu información de pago, o degrada a Cloud Starter."
+    "translation": "Actualiza ahora tu información de pago, o degrada a Cloud Free."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Tu espacio de trabajo será degradado a Cloud Starter. Las características de tu {{.Plan}} serán bloqueadas y algunos de los datos de tu espacio de trabajo podrían ser archivados hasta que liquides completamente tu saldo pendiente."
+    "translation": "Tu espacio de trabajo será degradado a Cloud Free. Las características de tu {{.Plan}} serán bloqueadas y algunos de los datos de tu espacio de trabajo podrían ser archivados hasta que liquides completamente tu saldo pendiente."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9304,8 +9304,8 @@
     "translation": "Tu {{.Plan}} Mattermost será degradado en 15 días"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Degradar a Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Degradar a Cloud Free"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9333,7 +9333,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Actualiza tu información de pago ahora o degrada a Cloud Starter abajo."
+    "translation": "Actualiza tu información de pago ahora o degrada a Cloud Free abajo."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9348,8 +9348,8 @@
     "translation": "Acción requerida: El workspace será degradado en 30 días"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Degradar a Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Degradar a Cloud Free"
   },
   {
     "id": "api.templates.delinquency_60.button",
@@ -9417,7 +9417,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "No pudimos realizar el cargo a la tarjeta de crédito que tenemos registrada. Por lo cual tu espacio de trabajo está en riesgo de ser degradado a Cloud Starter."
+    "translation": "No pudimos realizar el cargo a la tarjeta de crédito que tenemos registrada. Por lo cual tu espacio de trabajo está en riesgo de ser degradado a Cloud Free."
   },
   {
     "id": "api.templates.delinquency_14.subject",

--- a/i18n/hu.json
+++ b/i18n/hu.json
@@ -9344,10 +9344,6 @@
     "translation": "Fizetés frissítése"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Aktív bővítmények és integrációk"
-  },
-  {
     "id": "api.cloud.delinquency_email.missing_email_to_trigger",
     "translation": "Hiányzó kötelező mezők a késedelmes e-mail küldéséhez."
   },

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -9269,7 +9269,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "加えて、Cloud Starterの制限により、あなたのデータがアーカイブされている可能性があります。"
+    "translation": "加えて、Cloud Freeの制限により、あなたのデータがアーカイブされている可能性があります。"
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9289,11 +9289,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "今すぐ支払い情報を更新するか、Cloud Starterにダウングレードしてください。"
+    "translation": "今すぐ支払い情報を更新するか、Cloud Freeにダウングレードしてください。"
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "ワークスペースは Cloud Starter にダウングレードされます。{{.Plan}}の機能はロックされ、ワークスペースのデータの一部は未払い金の全額が支払われるまでアーカイブされる場合があります。"
+    "translation": "ワークスペースは Cloud Free にダウングレードされます。{{.Plan}}の機能はロックされ、ワークスペースのデータの一部は未払い金の全額が支払われるまでアーカイブされる場合があります。"
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9304,8 +9304,8 @@
     "translation": "あなたのMattermostワークスペースは15日後にダウングレードされます"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Cloud Starterへダウングレード"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Cloud Freeへダウングレード"
   },
   {
     "id": "api.templates.delinquency_7.title",
@@ -9325,7 +9325,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "今すぐ支払い情報を更新するか、以下よりCloud Starterにダウングレードしてください。"
+    "translation": "今すぐ支払い情報を更新するか、以下よりCloud Freeにダウングレードしてください。"
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9340,8 +9340,8 @@
     "translation": "対応が必要です: ワークスペースは30日後にダウングレードされます"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Cloud Starterへのダウングレード"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Cloud Freeへのダウングレード"
   },
   {
     "id": "api.templates.delinquency_45.title",
@@ -9397,7 +9397,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "登録されているクレジットカードに課金することができませんでした。これは、お客様のワークスペースがCloud Starterにダウングレードされる危険性があることを意味します。"
+    "translation": "登録されているクレジットカードに課金することができませんでした。これは、お客様のワークスペースがCloud Freeにダウングレードされる危険性があることを意味します。"
   },
   {
     "id": "api.templates.delinquency_14.subject",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -9269,7 +9269,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "加えて、Cloud Freeの制限により、あなたのデータがアーカイブされている可能性があります。"
+    "translation": "加えて、Cloud Starterの制限により、あなたのデータがアーカイブされている可能性があります。"
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9289,11 +9289,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "今すぐ支払い情報を更新するか、Cloud Freeにダウングレードしてください。"
+    "translation": "今すぐ支払い情報を更新するか、Cloud Starterにダウングレードしてください。"
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "ワークスペースは Cloud Free にダウングレードされます。{{.Plan}}の機能はロックされ、ワークスペースのデータの一部は未払い金の全額が支払われるまでアーカイブされる場合があります。"
+    "translation": "ワークスペースは Cloud Starter にダウングレードされます。{{.Plan}}の機能はロックされ、ワークスペースのデータの一部は未払い金の全額が支払われるまでアーカイブされる場合があります。"
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9304,7 +9304,7 @@
     "translation": "あなたのMattermostワークスペースは15日後にダウングレードされます"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
     "translation": "Cloud Starterへダウングレード"
   },
   {
@@ -9325,7 +9325,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "今すぐ支払い情報を更新するか、以下よりCloud Freeにダウングレードしてください。"
+    "translation": "今すぐ支払い情報を更新するか、以下よりCloud Starterにダウングレードしてください。"
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9340,7 +9340,7 @@
     "translation": "対応が必要です: ワークスペースは30日後にダウングレードされます"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
     "translation": "Cloud Starterへのダウングレード"
   },
   {
@@ -9350,10 +9350,6 @@
   {
     "id": "api.templates.delinquency_45.subtitle3",
     "translation": "今すぐクレジットカード情報を更新してください。"
-  },
-  {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "ワークスペースがダウングレードされると、ワークスペースで実行されている重要なワークフロー、統合機能、その他のビジネス上の重要な活動に悪影響を与える可能性があります。"
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9384,10 +9380,6 @@
     "translation": "すべての制限事項に関する説明文書を確認する。"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "有効なプラグインと統合機能"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "メッセージ履歴"
   },
@@ -9405,7 +9397,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "登録されているクレジットカードに課金することができませんでした。これは、お客様のワークスペースがCloud Freeにダウングレードされる危険性があることを意味します。"
+    "translation": "登録されているクレジットカードに課金することができませんでした。これは、お客様のワークスペースがCloud Starterにダウングレードされる危険性があることを意味します。"
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9450,10 +9442,6 @@
   {
     "id": "api.templates.delinquency_30.button",
     "translation": "支払い情報を更新する"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Boardsのカード数"
   },
   {
     "id": "api.templates.delinquency_14.button",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -9304,7 +9304,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Werk nu jouw betalingsgegevens bij of downgrade naar Cloud Starter hieronder."
+    "translation": "Werk nu jouw betalingsgegevens bij of downgrade naar Cloud Free hieronder."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9319,8 +9319,8 @@
     "translation": "Actie vereist: Werkruimte zal binnen 30 dagen gedowngraded worden"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Downgraden naar Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Downgraden naar Cloud Free"
   },
   {
     "id": "api.templates.delinquency_60.button",
@@ -9388,7 +9388,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "We waren niet in staat om de kredietkaart die we in ons bestand hebben in rekening te brengen. Dit betekent dat jouw werkruimte het risico loopt te worden gedegradeerd naar Cloud Starter."
+    "translation": "We waren niet in staat om de kredietkaart die we in ons bestand hebben in rekening te brengen. Dit betekent dat jouw werkruimte het risico loopt te worden gedegradeerd naar Cloud Free."
   },
   {
     "id": "api.templates.delinquency_90.subject",
@@ -9408,11 +9408,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Werk nu jouw betalingsgegevens bij, of downgrade naar Cloud Starter."
+    "translation": "Werk nu jouw betalingsgegevens bij, of downgrade naar Cloud Free."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Jouw werkruimte zal worden gedowngrade naar Cloud Starter. Jouw {{.Plan}} functies zullen worden vergrendeld en sommige van jouw werkruimtegegevens kunnen worden gearchiveerd totdat je jouw volledige uitstaande saldo hebt voldaan."
+    "translation": "Jouw werkruimte zal worden gedowngrade naar Cloud Free. Jouw {{.Plan}} functies zullen worden vergrendeld en sommige van jouw werkruimtegegevens kunnen worden gearchiveerd totdat je jouw volledige uitstaande saldo hebt voldaan."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9423,8 +9423,8 @@
     "translation": "Jouw Mattermost {{.Plan}} zal over 15 dagen worden gedowngraded"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Downgraden naar Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Downgraden naar Cloud Free"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9436,7 +9436,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Bovendien kunnen jouw gegevens gearchiveerd worden als gevolg van de beperkingen bij Cloud Starter."
+    "translation": "Bovendien kunnen jouw gegevens gearchiveerd worden als gevolg van de beperkingen bij Cloud Free."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -9304,7 +9304,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Werk nu jouw betalingsgegevens bij of downgrade naar Cloud Free hieronder."
+    "translation": "Werk nu jouw betalingsgegevens bij of downgrade naar Cloud Starter hieronder."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9319,7 +9319,7 @@
     "translation": "Actie vereist: Werkruimte zal binnen 30 dagen gedowngraded worden"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
     "translation": "Downgraden naar Cloud Starter"
   },
   {
@@ -9333,10 +9333,6 @@
   {
     "id": "api.templates.delinquency_45.subtitle3",
     "translation": "Werk nu jouw creditcardgegevens bij."
-  },
-  {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "Een gedowngradede workspace kan een negatieve invloed hebben op kritische workflows, integraties en andere bedrijfskritische activiteiten die in jouw workspace worden uitgevoerd."
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9375,20 +9371,12 @@
     "translation": "Betalingsgegevens bijwerken"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Actieve plugins en integraties"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "Berichtengeschiedenis"
   },
   {
     "id": "api.templates.delinquency_30.bullet.files",
     "translation": "Bestanden"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Kaarten van jouw Boards"
   },
   {
     "id": "api.templates.delinquency_14.title",
@@ -9400,7 +9388,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "We waren niet in staat om de kredietkaart die we in ons bestand hebben in rekening te brengen. Dit betekent dat jouw werkruimte het risico loopt te worden gedegradeerd naar Cloud Free."
+    "translation": "We waren niet in staat om de kredietkaart die we in ons bestand hebben in rekening te brengen. Dit betekent dat jouw werkruimte het risico loopt te worden gedegradeerd naar Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_90.subject",
@@ -9420,11 +9408,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Werk nu jouw betalingsgegevens bij, of downgrade naar Cloud Free."
+    "translation": "Werk nu jouw betalingsgegevens bij, of downgrade naar Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Jouw werkruimte zal worden gedowngrade naar Cloud Free. Jouw {{.Plan}} functies zullen worden vergrendeld en sommige van jouw werkruimtegegevens kunnen worden gearchiveerd totdat je jouw volledige uitstaande saldo hebt voldaan."
+    "translation": "Jouw werkruimte zal worden gedowngrade naar Cloud Starter. Jouw {{.Plan}} functies zullen worden vergrendeld en sommige van jouw werkruimtegegevens kunnen worden gearchiveerd totdat je jouw volledige uitstaande saldo hebt voldaan."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9435,7 +9423,7 @@
     "translation": "Jouw Mattermost {{.Plan}} zal over 15 dagen worden gedowngraded"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
     "translation": "Downgraden naar Cloud Starter"
   },
   {
@@ -9448,7 +9436,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Bovendien kunnen jouw gegevens gearchiveerd worden als gevolg van de beperkingen bij Cloud Free."
+    "translation": "Bovendien kunnen jouw gegevens gearchiveerd worden als gevolg van de beperkingen bij Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -9289,7 +9289,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Nie byliśmy w stanie obciążyć karty kredytowej, którą mamy w pliku. Oznacza to, że Twój obszar roboczy może zostać zdegradowany do wersji Cloud Starter."
+    "translation": "Nie byliśmy w stanie obciążyć karty kredytowej, którą mamy w pliku. Oznacza to, że Twój obszar roboczy może zostać zdegradowany do wersji Cloud Free."
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9305,7 +9305,7 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Twój obszar roboczy zostanie zdegradowany do Cloud Starter. Funkcje Twojego {{.Plan}} zostaną zablokowane, a niektóre dane z Twojego obszaru roboczego mogą zostać zarchiwizowane do czasu uregulowania całego zaległego salda."
+    "translation": "Twój obszar roboczy zostanie zdegradowany do Cloud Free. Funkcje Twojego {{.Plan}} zostaną zablokowane, a niektóre dane z Twojego obszaru roboczego mogą zostać zarchiwizowane do czasu uregulowania całego zaległego salda."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9316,8 +9316,8 @@
     "translation": "Twój Mattermost {{.Plan}} zostanie zdegradowany za 15 dni"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Obniż na Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Obniż na Cloud Free"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9345,7 +9345,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Zaktualizuj swoje informacje o płatnościach teraz lub przejdź do wersji Cloud Starter poniżej."
+    "translation": "Zaktualizuj swoje informacje o płatnościach teraz lub przejdź do wersji Cloud Free poniżej."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9360,8 +9360,8 @@
     "translation": "Wymagane działanie: Obszar roboczy zostanie zdegradowany w ciągu 30 dni"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Obniż na Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Obniż na Cloud Free"
   },
   {
     "id": "api.templates.delinquency_60.button",
@@ -9413,7 +9413,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Ponadto Twoje dane mogły zostać zarchiwizowane z powodu ograniczeń Cloud Starter."
+    "translation": "Ponadto Twoje dane mogły zostać zarchiwizowane z powodu ograniczeń Cloud Free."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9437,7 +9437,7 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Zaktualizuj teraz swoje informacje o płatnościach lub przejdź do wersji Cloud Starter."
+    "translation": "Zaktualizuj teraz swoje informacje o płatnościach lub przejdź do wersji Cloud Free."
   },
   {
     "id": "api.templates.delinquency_30.limits_documentation",

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -9272,20 +9272,12 @@
     "translation": "Mattermost to platforma open source służąca do bezpiecznej komunikacji, współpracy i zgrania pracy między narzędziami i zespołami.\nMattermost zawiera trzy kluczowe narzędzia:\n\n**Kanały** - Pozostań w kontakcie ze swoim zespołem poprzez wiadomości 1:1 i wiadomości grupowe.\n**[Playbooki](/playbooki)** - tworzenie i konfigurowanie powtarzalnych procesów w celu osiągnięcia określonych i przewidywalnych wyników.\n**[Tablice](/boards)** - Zarządzaj projektami i zadaniami w strukturze tablicy Kanban, aby pomóc swojemu zespołowi w osiągnięciu kluczowych kamieni milowych.\n\n[Zobacz dokumentację i przewodniki]({{.HelpLink}})"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Aktywne wtyczki i integracje"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "Historia wiadomości"
   },
   {
     "id": "api.templates.delinquency_30.bullet.files",
     "translation": "Pliki"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Karty z twoich tablic"
   },
   {
     "id": "api.templates.delinquency_14.title",
@@ -9297,7 +9289,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Nie byliśmy w stanie obciążyć karty kredytowej, którą mamy w pliku. Oznacza to, że Twój obszar roboczy może zostać zdegradowany do wersji Cloud Free."
+    "translation": "Nie byliśmy w stanie obciążyć karty kredytowej, którą mamy w pliku. Oznacza to, że Twój obszar roboczy może zostać zdegradowany do wersji Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9313,7 +9305,7 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Twój obszar roboczy zostanie zdegradowany do Cloud Free. Funkcje Twojego {{.Plan}} zostaną zablokowane, a niektóre dane z Twojego obszaru roboczego mogą zostać zarchiwizowane do czasu uregulowania całego zaległego salda."
+    "translation": "Twój obszar roboczy zostanie zdegradowany do Cloud Starter. Funkcje Twojego {{.Plan}} zostaną zablokowane, a niektóre dane z Twojego obszaru roboczego mogą zostać zarchiwizowane do czasu uregulowania całego zaległego salda."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9324,7 +9316,7 @@
     "translation": "Twój Mattermost {{.Plan}} zostanie zdegradowany za 15 dni"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
     "translation": "Obniż na Cloud Starter"
   },
   {
@@ -9353,7 +9345,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Zaktualizuj swoje informacje o płatnościach teraz lub przejdź do wersji Cloud Free poniżej."
+    "translation": "Zaktualizuj swoje informacje o płatnościach teraz lub przejdź do wersji Cloud Starter poniżej."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9368,7 +9360,7 @@
     "translation": "Wymagane działanie: Obszar roboczy zostanie zdegradowany w ciągu 30 dni"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
     "translation": "Obniż na Cloud Starter"
   },
   {
@@ -9382,10 +9374,6 @@
   {
     "id": "api.templates.delinquency_45.subtitle3",
     "translation": "Zaktualizuj teraz informacje o swojej karcie kredytowej."
-  },
-  {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "Zmniejszona przestrzeń robocza może negatywnie wpłynąć na krytyczne przepływy pracy, integracje i inne krytyczne dla biznesu działania prowadzone w przestrzeni roboczej."
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9425,7 +9413,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Ponadto Twoje dane mogły zostać zarchiwizowane z powodu ograniczeń Cloud Free."
+    "translation": "Ponadto Twoje dane mogły zostać zarchiwizowane z powodu ograniczeń Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9449,7 +9437,7 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Zaktualizuj teraz swoje informacje o płatnościach lub przejdź do wersji Cloud Free."
+    "translation": "Zaktualizuj teraz swoje informacje o płatnościach lub przejdź do wersji Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_30.limits_documentation",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -9177,7 +9177,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Мы не смогли снять деньги с имеющейся у нас кредитной карты. Это означает, что ваше рабочее пространство может быть переведено в категорию Cloud Starter."
+    "translation": "Мы не смогли снять деньги с имеющейся у нас кредитной карты. Это означает, что ваше рабочее пространство может быть переведено в категорию Cloud Free."
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9385,7 +9385,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Кроме того, ваши данные могут быть заархивированы из-за ограничений Cloud Starter."
+    "translation": "Кроме того, ваши данные могут быть заархивированы из-за ограничений Cloud Free."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9409,11 +9409,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Starter."
+    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Free."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Ваше рабочее пространство будет понижено до уровня Cloud Starter. Ваши функции {{.Plan}} будут заблокированы, а некоторые данные рабочего пространства могут быть заархивированы до полного погашения задолженности."
+    "translation": "Ваше рабочее пространство будет понижено до уровня Cloud Free. Ваши функции {{.Plan}} будут заблокированы, а некоторые данные рабочего пространства могут быть заархивированы до полного погашения задолженности."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9449,7 +9449,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Starter ниже."
+    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Free ниже."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9528,12 +9528,12 @@
     "translation": "Тип коллекции уже существует."
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Понижение статуса до Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Понижение статуса до Cloud Free"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Понижение статуса до Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Понижение статуса до Cloud Free"
   },
   {
     "id": "api.user.add_user_to_group_syncables.not_ldap_user.app_error",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -9177,7 +9177,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Мы не смогли снять деньги с имеющейся у нас кредитной карты. Это означает, что ваше рабочее пространство может быть переведено в категорию Cloud Free."
+    "translation": "Мы не смогли снять деньги с имеющейся у нас кредитной карты. Это означает, что ваше рабочее пространство может быть переведено в категорию Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9385,7 +9385,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Кроме того, ваши данные могут быть заархивированы из-за ограничений Cloud Free."
+    "translation": "Кроме того, ваши данные могут быть заархивированы из-за ограничений Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9409,11 +9409,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Free."
+    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Ваше рабочее пространство будет понижено до уровня Cloud Free. Ваши функции {{.Plan}} будут заблокированы, а некоторые данные рабочего пространства могут быть заархивированы до полного погашения задолженности."
+    "translation": "Ваше рабочее пространство будет понижено до уровня Cloud Starter. Ваши функции {{.Plan}} будут заблокированы, а некоторые данные рабочего пространства могут быть заархивированы до полного погашения задолженности."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9449,7 +9449,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Free ниже."
+    "translation": "Обновите свою платёжную информацию сейчас или перейдите на Cloud Starter ниже."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9474,10 +9474,6 @@
   {
     "id": "api.templates.delinquency_45.subtitle3",
     "translation": "Обновите информацию о своей кредитной карте прямо сейчас."
-  },
-  {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "Пониженное рабочее пространство может негативно повлиять на критически важные рабочие процессы, интеграции и другие важные для бизнеса действия, выполняемые в вашем рабочем пространстве."
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9516,20 +9512,12 @@
     "translation": "Обновить платёж"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Активные плагины и интеграции"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "История сообщений"
   },
   {
     "id": "api.templates.delinquency_30.bullet.files",
     "translation": "Файлы"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Карточки с Ваших Boards"
   },
   {
     "id": "app.collection.add_topic.exists.app_error",
@@ -9540,12 +9528,12 @@
     "translation": "Тип коллекции уже существует."
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
-    "translation": "Понижение статуса до Cloud Free"
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
+    "translation": "Понижение статуса до Cloud Starter"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
-    "translation": "Понижение статуса до Cloud Free"
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
+    "translation": "Понижение статуса до Cloud Starter"
   },
   {
     "id": "api.user.add_user_to_group_syncables.not_ldap_user.app_error",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -9328,7 +9328,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Vi kunde inte debitera det kreditkort som vi har registrerat. Detta innebär att din arbetsyta riskerar att nedgraderas till Cloud Starter."
+    "translation": "Vi kunde inte debitera det kreditkort som vi har registrerat. Detta innebär att din arbetsyta riskerar att nedgraderas till Cloud Free."
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9392,7 +9392,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Dessutom kan dina data ha arkiverats på grund av begränsningar i Cloud Starter."
+    "translation": "Dessutom kan dina data ha arkiverats på grund av begränsningar i Cloud Free."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9416,11 +9416,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Uppdatera din betalningsinformation nu, eller nedgradera till Cloud Starter."
+    "translation": "Uppdatera din betalningsinformation nu, eller nedgradera till Cloud Free."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Din arbetsplats kommer att nedgraderas till Cloud Starter. Dina {{.Plan}}-funktioner kommer att spärras och delar av dina arbetsytedata kan komma att arkiveras tills hela ditt utestående belopp är betalt."
+    "translation": "Din arbetsplats kommer att nedgraderas till Cloud Free. Dina {{.Plan}}-funktioner kommer att spärras och delar av dina arbetsytedata kan komma att arkiveras tills hela ditt utestående belopp är betalt."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9431,8 +9431,8 @@
     "translation": "Din Mattermost {{.Plan}} kommer att nedgraderas om 15 dagar"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Nedgradera till Cloud Starter"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Nedgradera till Cloud Free"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9460,7 +9460,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Uppdatera din betalningsinformation nu eller nedgradera till Cloud Starter nedan."
+    "translation": "Uppdatera din betalningsinformation nu eller nedgradera till Cloud Free nedan."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9475,8 +9475,8 @@
     "translation": "Åtgärder krävs: Arbetsytan kommer att nedgraderas inom 30 dagar"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Nedgradera till Cloud Starter"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Nedgradera till Cloud Free"
   },
   {
     "id": "api.templates.delinquency_60.button",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -9287,10 +9287,6 @@
     "translation": "Uppdatera betalningsinformation"
   },
   {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "En nedgraderad arbetsyta kan få negativ påverkan på dina kritiska arbetsflöden, integrationer och andra affärskritiska aktiviteter som utförs på arbetsytan."
-  },
-  {
     "id": "api.templates.delinquency_45.subtitle1",
     "translation": "Vi har inte kunnat få betalt för utestående fakturor sedan {{.DelinquencyDate}}. Din arbetsyta riskerar att nedgraderas."
   },
@@ -9327,20 +9323,12 @@
     "translation": "Uppdatera betalningsinformation"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Aktiva plugins och integrationer"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "Meddelandehistorik"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Kort från dina Boards"
-  },
-  {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Vi kunde inte debitera det kreditkort som vi har registrerat. Detta innebär att din arbetsyta riskerar att nedgraderas till Cloud Free."
+    "translation": "Vi kunde inte debitera det kreditkort som vi har registrerat. Detta innebär att din arbetsyta riskerar att nedgraderas till Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_14.subject",
@@ -9404,7 +9392,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "Dessutom kan dina data ha arkiverats på grund av begränsningar i Cloud Free."
+    "translation": "Dessutom kan dina data ha arkiverats på grund av begränsningar i Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9428,11 +9416,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Uppdatera din betalningsinformation nu, eller nedgradera till Cloud Free."
+    "translation": "Uppdatera din betalningsinformation nu, eller nedgradera till Cloud Starter."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Din arbetsplats kommer att nedgraderas till Cloud Free. Dina {{.Plan}}-funktioner kommer att spärras och delar av dina arbetsytedata kan komma att arkiveras tills hela ditt utestående belopp är betalt."
+    "translation": "Din arbetsplats kommer att nedgraderas till Cloud Starter. Dina {{.Plan}}-funktioner kommer att spärras och delar av dina arbetsytedata kan komma att arkiveras tills hela ditt utestående belopp är betalt."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9443,7 +9431,7 @@
     "translation": "Din Mattermost {{.Plan}} kommer att nedgraderas om 15 dagar"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
     "translation": "Nedgradera till Cloud Starter"
   },
   {
@@ -9472,7 +9460,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Uppdatera din betalningsinformation nu eller nedgradera till Cloud Free nedan."
+    "translation": "Uppdatera din betalningsinformation nu eller nedgradera till Cloud Starter nedan."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9487,7 +9475,7 @@
     "translation": "Åtgärder krävs: Arbetsytan kommer att nedgraderas inom 30 dagar"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
     "translation": "Nedgradera till Cloud Starter"
   },
   {

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -9292,7 +9292,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "ek olarak, Cloud Starter tarifesinin sınırlamaları nedeniyle verileriniz arşive kaldırılabilir."
+    "translation": "ek olarak, Cloud Free tarifesinin sınırlamaları nedeniyle verileriniz arşive kaldırılabilir."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9316,11 +9316,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da Cloud Starter alt tarifesine geçebilirsiniz."
+    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da Cloud Free alt tarifesine geçebilirsiniz."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Çalışma alanınız Cloud Starter alt tarifesine geçirilecek. Ödemeyi yapana kadar {{.Plan}} tarifenizin özellikleri kilitlenecek. Ayrıca çalışma alanınızın bazı verileri arşive kaldırılabilir."
+    "translation": "Çalışma alanınız Cloud Free alt tarifesine geçirilecek. Ödemeyi yapana kadar {{.Plan}} tarifenizin özellikleri kilitlenecek. Ayrıca çalışma alanınızın bazı verileri arşive kaldırılabilir."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9335,8 +9335,8 @@
     "translation": "Mattermost {{.Plan}} tarifeniz 15 gün sonra alt tarifeye geçirilecek"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_starter",
-    "translation": "Cloud Starter alt tarifesine geç"
+    "id": "api.templates.delinquency_75.downgrade_to_free",
+    "translation": "Cloud Free alt tarifesine geç"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9360,7 +9360,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da aşağıdan Cloud Starter alt tarifesine geçebilirsiniz."
+    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da aşağıdan Cloud Free alt tarifesine geçebilirsiniz."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9388,7 +9388,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Bizde kayıtlı kredi kartı bilgilerinizi kullanarak ödeme alamadık. Çalışma alanınızın Cloud Starter alt tarifesine geçirilme riski var."
+    "translation": "Bizde kayıtlı kredi kartı bilgilerinizi kullanarak ödeme alamadık. Çalışma alanınızın Cloud Free alt tarifesine geçirilme riski var."
   },
   {
     "id": "api.templates.delinquency_60.subtitle1",
@@ -9399,8 +9399,8 @@
     "translation": "İşlem yapılması gerekli: Çalışma alanı 30 gün sonra alt tarifeye geçirilecek"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_starter",
-    "translation": "Cloud Starter alt tarifesine geç"
+    "id": "api.templates.delinquency_60.downgrade_to_free",
+    "translation": "Cloud Free alt tarifesine geç"
   },
   {
     "id": "api.templates.delinquency_60.button",

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -9292,7 +9292,7 @@
   },
   {
     "id": "api.templates.delinquency_90.subtitle2",
-    "translation": "ek olarak, Cloud Free tarifesinin sınırlamaları nedeniyle verileriniz arşive kaldırılabilir."
+    "translation": "ek olarak, Cloud Starter tarifesinin sınırlamaları nedeniyle verileriniz arşive kaldırılabilir."
   },
   {
     "id": "api.templates.delinquency_90.subtitle1",
@@ -9316,11 +9316,11 @@
   },
   {
     "id": "api.templates.delinquency_75.subtitle3",
-    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da Cloud Free alt tarifesine geçebilirsiniz."
+    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da Cloud Starter alt tarifesine geçebilirsiniz."
   },
   {
     "id": "api.templates.delinquency_75.subtitle2",
-    "translation": "Çalışma alanınız Cloud Free alt tarifesine geçirilecek. Ödemeyi yapana kadar {{.Plan}} tarifenizin özellikleri kilitlenecek. Ayrıca çalışma alanınızın bazı verileri arşive kaldırılabilir."
+    "translation": "Çalışma alanınız Cloud Starter alt tarifesine geçirilecek. Ödemeyi yapana kadar {{.Plan}} tarifenizin özellikleri kilitlenecek. Ayrıca çalışma alanınızın bazı verileri arşive kaldırılabilir."
   },
   {
     "id": "api.templates.delinquency_75.subtitle1",
@@ -9335,8 +9335,8 @@
     "translation": "Mattermost {{.Plan}} tarifeniz 15 gün sonra alt tarifeye geçirilecek"
   },
   {
-    "id": "api.templates.delinquency_75.downgrade_to_free",
-    "translation": "Cloud Free alt tarifesine geç"
+    "id": "api.templates.delinquency_75.downgrade_to_starter",
+    "translation": "Cloud Starter alt tarifesine geç"
   },
   {
     "id": "api.templates.delinquency_75.button",
@@ -9360,7 +9360,7 @@
   },
   {
     "id": "api.templates.delinquency_60.subtitle3",
-    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da aşağıdan Cloud Free alt tarifesine geçebilirsiniz."
+    "translation": "Hemen ödeme bilgilerinizi güncelleyebilir ya da aşağıdan Cloud Starter alt tarifesine geçebilirsiniz."
   },
   {
     "id": "api.templates.delinquency_60.subtitle2",
@@ -9369,10 +9369,6 @@
   {
     "id": "api.templates.delinquency_45.title",
     "translation": "Çalışma alanınız yakında alt tarifeye geçirilecek"
-  },
-  {
-    "id": "api.templates.delinquency_45.subtitle2",
-    "translation": "Alt tarifeye geçirilmiş bir çalışma alanında, yürütülen kritik iş akışları, bütünleştirmeler ve iş açısından önemli diğer işlemler olumsuz etkilenebilir."
   },
   {
     "id": "api.templates.delinquency_45.subtitle1",
@@ -9392,7 +9388,7 @@
   },
   {
     "id": "api.templates.delinquency_14.subtitle1",
-    "translation": "Bizde kayıtlı kredi kartı bilgilerinizi kullanarak ödeme alamadık. Çalışma alanınızın Cloud Free alt tarifesine geçirilme riski var."
+    "translation": "Bizde kayıtlı kredi kartı bilgilerinizi kullanarak ödeme alamadık. Çalışma alanınızın Cloud Starter alt tarifesine geçirilme riski var."
   },
   {
     "id": "api.templates.delinquency_60.subtitle1",
@@ -9403,8 +9399,8 @@
     "translation": "İşlem yapılması gerekli: Çalışma alanı 30 gün sonra alt tarifeye geçirilecek"
   },
   {
-    "id": "api.templates.delinquency_60.downgrade_to_free",
-    "translation": "Cloud Free alt tarifesine geç"
+    "id": "api.templates.delinquency_60.downgrade_to_starter",
+    "translation": "Cloud Starter alt tarifesine geç"
   },
   {
     "id": "api.templates.delinquency_60.button",
@@ -9439,20 +9435,12 @@
     "translation": "Ödeme bilgilerini güncelle"
   },
   {
-    "id": "api.templates.delinquency_30.bullet.plugins",
-    "translation": "Etkin uygulama eki ve bütünleştirmeler"
-  },
-  {
     "id": "api.templates.delinquency_30.bullet.message_history",
     "translation": "İleti geçmişi"
   },
   {
     "id": "api.templates.delinquency_30.bullet.files",
     "translation": "Dosyalar"
-  },
-  {
-    "id": "api.templates.delinquency_30.bullet.cards",
-    "translation": "Panolarınızdan kartlar"
   },
   {
     "id": "api.templates.delinquency_14.title",


### PR DESCRIPTION
#### Summary

As a part of the [Delinquency Automation Feature](https://mattermost.atlassian.net/browse/MM-43398), the mention of boards and integrations limits, as well as "Cloud Starter" on delinquency emails should be removed or replaced.

Text Changes:
- Board Limits: `Removed`
- Integration Limits: `Removed`
- Cloud Starter: `Replaced: "Cloud Free"`

#### Ticket Link

[MM-49681](https://mattermost.atlassian.net/browse/MM-49681)

#### Release Note

```release-note
NONE
```


[MM-49681]: https://mattermost.atlassian.net/browse/MM-49681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ