### PR TITLE
MM-49720 Remove the check for active sessions in IsFirstUserAccount

### DIFF
--- a/app/platform/config.go
+++ b/app/platform/config.go
@@ -320,18 +320,12 @@ func (ps *PlatformService) LimitedClientConfig() map[string]string {
 }
 
 func (ps *PlatformService) IsFirstUserAccount() bool {
-	cachedSessions, err := ps.sessionCache.Len()
+	count, err := ps.Store.User().Count(model.UserCountOptions{IncludeDeleted: true})
 	if err != nil {
 		return false
 	}
-	if cachedSessions == 0 {
-		count, err := ps.Store.User().Count(model.UserCountOptions{IncludeDeleted: true})
-		if err != nil {
-			return false
-		}
-		if count <= 0 {
-			return true
-		}
+	if count <= 0 {
+		return true
 	}
 
 	return false

--- a/app/platform/config.go
+++ b/app/platform/config.go
@@ -324,11 +324,8 @@ func (ps *PlatformService) IsFirstUserAccount() bool {
 	if err != nil {
 		return false
 	}
-	if count <= 0 {
-		return true
-	}
 
-	return false
+	return count <= 0
 }
 
 func (ps *PlatformService) MaxPostSize() int {


### PR DESCRIPTION
#### Summary
Bots may maintain sessions during the initial setup of the server. This throws off `IsFirstUserAccount` and prevents the creation of the initial admin account.

#### Ticket Link
[MM-49720](https://mattermost.atlassian.net/browse/MM-49720)

#### Release Note
```release-note
Fixed an issue that prevented the creation of the initial admin user for new servers
```


[MM-49720]: https://mattermost.atlassian.net/browse/MM-49720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ