### PR TITLE
MM-49551: Check if RemoteId is nil for participant

### DIFF
--- a/app/platform/shared_channel_notifier.go
+++ b/app/platform/shared_channel_notifier.go
@@ -111,7 +111,7 @@ func handleInvitation(ps *PlatformService, syncService SharedChannelServiceIFace
 		return err
 	}
 
-	if participant == nil {
+	if participant == nil || participant.RemoteId == nil {
 		return nil
 	}
 


### PR DESCRIPTION
We were trying to dereference without a nil check first.

https://mattermost.atlassian.net/browse/MM-49551

```release-note
NONE
```
