### PR TITLE
Add `GetDirectChannelOrCreate` to product API

### DIFF
--- a/app/channel.go
+++ b/app/channel.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mattermost/logr/v2"
+
 	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/plugin"
@@ -27,6 +28,7 @@ import (
 // channelsWrapper provides an implementation of `product.ChannelService` to be used by products.
 type channelsWrapper struct {
 	srv *Server
+	app *App
 }
 
 func (s *channelsWrapper) GetDirectChannel(userID1, userID2 string) (*model.Channel, *model.AppError) {
@@ -45,6 +47,10 @@ func (s *channelsWrapper) GetChannelMember(channelID string, userID string) (*mo
 
 func (s *channelsWrapper) GetChannelsForTeamForUser(teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
 	return s.srv.getChannelsForTeamForUser(request.EmptyContext(s.srv.Log()), teamID, userID, opts)
+}
+
+func (s *channelsWrapper) GetDirectChannelOrCreate(userID1, userID2 string) (*model.Channel, *model.AppError) {
+	return s.app.GetOrCreateDirectChannel(request.EmptyContext(s.srv.Log()), userID1, userID2)
 }
 
 // Ensure the wrapper implements the product service.

--- a/app/channels.go
+++ b/app/channels.go
@@ -213,6 +213,11 @@ func NewChannels(services map[product.ServiceKey]any) (*Channels, error) {
 	pluginsRoute.HandleFunc("/public/{public_file:.*}", ch.ServePluginPublicRequest)
 	pluginsRoute.HandleFunc("/{anything:.*}", ch.ServePluginRequest)
 
+	services[product.ChannelKey] = &channelsWrapper{
+		srv: s,
+		app: &App{ch: ch},
+	}
+
 	services[product.PostKey] = &postServiceWrapper{
 		app: &App{ch: ch},
 	}

--- a/app/server.go
+++ b/app/server.go
@@ -238,15 +238,16 @@ func NewServer(options ...Option) (*Server, error) {
 	// ensure app implements `product.UserService`
 	var _ product.UserService = (*App)(nil)
 
+	app := New(ServerConnector(s.Channels()))
 	serviceMap := map[product.ServiceKey]any{
 		ServerKey:                s,
-		product.ChannelKey:       &channelsWrapper{srv: s},
+		product.ChannelKey:       &channelsWrapper{srv: s, app: app},
 		product.ConfigKey:        s.platform,
 		product.LicenseKey:       s.licenseWrapper,
 		product.FilestoreKey:     s.platform.FileBackend(),
 		product.FileInfoStoreKey: &fileInfoWrapper{srv: s},
 		product.ClusterKey:       s.platform,
-		product.UserKey:          New(ServerConnector(s.Channels())),
+		product.UserKey:          app,
 		product.LogKey:           s.platform.Log(),
 		product.CloudKey:         &cloudWrapper{cloud: s.Cloud},
 		product.KVStoreKey:       s.platform,

--- a/product/api.go
+++ b/product/api.go
@@ -62,6 +62,7 @@ type ClusterService interface {
 // The service shall be registered via app.ChannelKey service key.
 type ChannelService interface {
 	GetDirectChannel(userID1, userID2 string) (*model.Channel, *model.AppError)
+	GetDirectChannelOrCreate(userID1, userID2 string) (*model.Channel, *model.AppError)
 	GetChannelByID(channelID string) (*model.Channel, *model.AppError)
 	GetChannelMember(channelID string, userID string) (*model.ChannelMember, *model.AppError)
 	GetChannelsForTeamForUser(teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError)


### PR DESCRIPTION
#### Summary
This PR adds `GetDirectChannelOrCreate` to the product API for Channels.  This is needed to fix a bug in Boards.  See https://github.com/mattermost/focalboard/pull/4496

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49752

#### Release Note
```release-note
NONE
```
