### PR TITLE
if cloud interface reports upstream is off, notify the web client

### DIFF
--- a/api4/hosted_customer.go
+++ b/api4/hosted_customer.go
@@ -217,7 +217,11 @@ func handleSignupAvailable(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := c.App.Cloud().SelfHostedSignupAvailable(); err != nil {
-		c.Err = model.NewAppError(where, "api.server.hosted_signup_unavailable.error", nil, "", http.StatusNotImplemented)
+		if err.Error() == "upstream_off" {
+			c.Err = model.NewAppError(where, "api.server.hosted_signup_unavailable.error", nil, "", http.StatusServiceUnavailable)
+		} else {
+			c.Err = model.NewAppError(where, "api.server.hosted_signup_unavailable.error", nil, "", http.StatusNotImplemented)
+		}
 		return
 	}
 


### PR DESCRIPTION
#### Summary
If cloud interface reports upstream is off, notify the web client of the same so that it can open a new tab instead of showing airgapped modal.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49772

Supports https://github.com/mattermost/mattermost-webapp/pull/12046

#### Release Note
```release-note
NONE
```
