### PR TITLE
Fix slow query on Posts

### DIFF
--- a/db/migrations/mysql/000102_add_index_channel_id_create_at_to_posts.down.sql
+++ b/db/migrations/mysql/000102_add_index_channel_id_create_at_to_posts.down.sql
@@ -1,0 +1,1 @@
+drop index idx_posts_channel_id_create_at on Posts;

--- a/db/migrations/mysql/000102_add_index_channel_id_create_at_to_posts.up.sql
+++ b/db/migrations/mysql/000102_add_index_channel_id_create_at_to_posts.up.sql
@@ -1,0 +1,2 @@
+create index idx_posts_channel_id_create_at
+    on Posts (ChannelId asc, CreateAt desc);

--- a/db/migrations/postgres/000102_add_index_channel_id_create_at_to_posts.down.sql
+++ b/db/migrations/postgres/000102_add_index_channel_id_create_at_to_posts.down.sql
@@ -1,0 +1,1 @@
+drop index idx_posts_channel_id_create_at;

--- a/db/migrations/postgres/000102_add_index_channel_id_create_at_to_posts.up.sql
+++ b/db/migrations/postgres/000102_add_index_channel_id_create_at_to_posts.up.sql
@@ -1,0 +1,2 @@
+create index idx_posts_channel_id_create_at
+    on Posts (ChannelId asc, CreateAt desc);


### PR DESCRIPTION
#### Summary
We recently faced a couple of database latency spikes and did some investigation to find the root cause. We found that this query: 
```sql
select *
from Posts
where ChannelId = '<channel_id>'
ORDER BY CreateAt DESC
LIMIT 60 OFFSET 0;
```
takes seconds (sometimes minutes, depending on the channel) to complete. Which led us to verify the indexes on `Posts`. 
We found that a composite index for `ChannelId` and `CreateAt` was missing. After adding it all queries where as fast as expected (200ms-400ms) 
This pull requests adds the needed index to the mysql and postgres migrations. 
I'm a bit surprised that this issue came up to us (first?), since our installation might not be the biggest on earth, so there might be another related issues as well.



#### Release Note
I don't have access to the `Schema Migration Template` doc and cannot request it as well. 

```release-note
Adds composite index to the Posts table for `ChannelId` and `CreateAt`
```

