### PR TITLE
MM-49845: fixes acknowledgements in getpostsince

### DIFF
--- a/app/post_acknowledgements.go
+++ b/app/post_acknowledgements.go
@@ -42,6 +42,9 @@ func (a *App) SaveAcknowledgementForPost(c *request.Context, postID, userID stri
 		}
 	}
 
+	// The post is always modified since the UpdateAt always changes
+	a.invalidateCacheForChannelPosts(channel.Id)
+
 	a.Srv().Go(func() {
 		a.sendAcknowledgementEvent(model.WebsocketEventAcknowledgementAdded, acknowledgement, post)
 	})
@@ -84,6 +87,9 @@ func (a *App) DeleteAcknowledgementForPost(c *request.Context, postID, userID st
 	if nErr != nil {
 		return model.NewAppError("DeleteAcknowledgementForPost", "app.acknowledgement.delete.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}
+
+	// The post is always modified since the UpdateAt always changes
+	a.invalidateCacheForChannelPosts(channel.Id)
 
 	a.Srv().Go(func() {
 		a.sendAcknowledgementEvent(model.WebsocketEventAcknowledgementRemoved, oldAck, post)

--- a/app/post_acknowledgements_test.go
+++ b/app/post_acknowledgements_test.go
@@ -36,6 +36,26 @@ func testSaveAcknowledgementForPost(t *testing.T) {
 		require.Equal(t, post.Id, acknowledgment.PostId)
 		require.Equal(t, th.BasicUser.Id, acknowledgment.UserId)
 	})
+
+	t.Run("saving acknowledgment should update the post's update_at", func(t *testing.T) {
+		post, err := th.App.CreatePostAsUser(th.Context, &model.Post{
+			UserId:    th.BasicUser.Id,
+			ChannelId: th.BasicChannel.Id,
+			Message:   "message",
+		}, "", true)
+
+		require.Nil(t, err)
+
+		oldUpdateAt := post.UpdateAt
+
+		_, err = th.App.SaveAcknowledgementForPost(th.Context, post.Id, th.BasicUser.Id)
+		require.Nil(t, err)
+
+		post, err = th.App.GetSinglePost(post.Id, false)
+		require.Nil(t, err)
+
+		require.Greater(t, post.UpdateAt, oldUpdateAt)
+	})
 }
 
 func testDeleteAcknowledgementForPost(t *testing.T) {
@@ -64,6 +84,24 @@ func testDeleteAcknowledgementForPost(t *testing.T) {
 		acknowledgments, err = th.App.GetAcknowledgementsForPost(post.Id)
 		require.Nil(t, err)
 		require.Empty(t, acknowledgments)
+	})
+
+	t.Run("deleting acknowledgment should update the post's update_at", func(t *testing.T) {
+		_, err = th.App.SaveAcknowledgementForPost(th.Context, post.Id, th.BasicUser.Id)
+		require.Nil(t, err)
+
+		post, err = th.App.GetSinglePost(post.Id, false)
+		require.Nil(t, err)
+
+		oldUpdateAt := post.UpdateAt
+
+		err = th.App.DeleteAcknowledgementForPost(th.Context, post.Id, th.BasicUser.Id)
+		require.Nil(t, err)
+
+		post, err = th.App.GetSinglePost(post.Id, false)
+		require.Nil(t, err)
+
+		require.Greater(t, post.UpdateAt, oldUpdateAt)
 	})
 
 	t.Run("delete acknowledgment for post after 5 min after acknowledged should not delete", func(t *testing.T) {

--- a/app/post_acknowledgements_test.go
+++ b/app/post_acknowledgements_test.go
@@ -61,16 +61,16 @@ func testSaveAcknowledgementForPost(t *testing.T) {
 func testDeleteAcknowledgementForPost(t *testing.T) {
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
-	post, err := th.App.CreatePostAsUser(th.Context, &model.Post{
+	post, err1 := th.App.CreatePostAsUser(th.Context, &model.Post{
 		UserId:    th.BasicUser.Id,
 		ChannelId: th.BasicChannel.Id,
 		CreateAt:  model.GetMillis(),
 		Message:   "message",
 	}, "", true)
-	require.Nil(t, err)
+	require.Nil(t, err1)
 
 	t.Run("delete acknowledgment for post should delete acknowledgement", func(t *testing.T) {
-		_, err = th.App.SaveAcknowledgementForPost(th.Context, post.Id, th.BasicUser.Id)
+		_, err := th.App.SaveAcknowledgementForPost(th.Context, post.Id, th.BasicUser.Id)
 		require.Nil(t, err)
 
 		acknowledgments, err := th.App.GetAcknowledgementsForPost(post.Id)
@@ -87,7 +87,7 @@ func testDeleteAcknowledgementForPost(t *testing.T) {
 	})
 
 	t.Run("deleting acknowledgment should update the post's update_at", func(t *testing.T) {
-		_, err = th.App.SaveAcknowledgementForPost(th.Context, post.Id, th.BasicUser.Id)
+		_, err := th.App.SaveAcknowledgementForPost(th.Context, post.Id, th.BasicUser.Id)
 		require.Nil(t, err)
 
 		post, err = th.App.GetSinglePost(post.Id, false)

--- a/store/sqlstore/post_acknowledgements_store.go
+++ b/store/sqlstore/post_acknowledgements_store.go
@@ -81,12 +81,12 @@ func (s *SqlPostAcknowledgementStore) Save(postID, userID string, acknowledgedAt
 	}
 
 	err = updatePost(transaction, acknowledgement.PostId)
-
 	if err != nil {
 		return nil, err
 	}
 
-	if err := transaction.Commit(); err != nil {
+	err = transaction.Commit()
+	if err != nil {
 		return nil, errors.Wrap(err, "commit_transaction")
 	}
 
@@ -98,8 +98,8 @@ func (s *SqlPostAcknowledgementStore) Delete(ack *model.PostAcknowledgement) err
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
-
 	defer finalizeTransactionX(transaction, &err)
+	
 	query := s.getQueryBuilder().
 		Update("PostAcknowledgements").
 		Set("AcknowledgedAt", 0).
@@ -114,12 +114,12 @@ func (s *SqlPostAcknowledgementStore) Delete(ack *model.PostAcknowledgement) err
 	}
 
 	err = updatePost(transaction, ack.PostId)
-
 	if err != nil {
 		return err
 	}
 
-	if err := transaction.Commit(); err != nil {
+	err = transaction.Commit()
+	if err != nil {
 		return errors.Wrap(err, "commit_transaction")
 	}
 

--- a/store/sqlstore/post_acknowledgements_store.go
+++ b/store/sqlstore/post_acknowledgements_store.go
@@ -93,19 +93,19 @@ func (s *SqlPostAcknowledgementStore) Save(postID, userID string, acknowledgedAt
 	return acknowledgement, nil
 }
 
-func (s *SqlPostAcknowledgementStore) Delete(ack *model.PostAcknowledgement) error {
+func (s *SqlPostAcknowledgementStore) Delete(acknowledgement *model.PostAcknowledgement) error {
 	transaction, err := s.GetMasterX().Beginx()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
 	defer finalizeTransactionX(transaction, &err)
-	
+
 	query := s.getQueryBuilder().
 		Update("PostAcknowledgements").
 		Set("AcknowledgedAt", 0).
 		Where(sq.And{
-			sq.Eq{"PostId": ack.PostId},
-			sq.Eq{"UserId": ack.UserId},
+			sq.Eq{"PostId": acknowledgement.PostId},
+			sq.Eq{"UserId": acknowledgement.UserId},
 		})
 
 	_, err = transaction.ExecBuilder(query)
@@ -113,7 +113,7 @@ func (s *SqlPostAcknowledgementStore) Delete(ack *model.PostAcknowledgement) err
 		return err
 	}
 
-	err = updatePost(transaction, ack.PostId)
+	err = updatePost(transaction, acknowledgement.PostId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Summary

GetPostsSince returns posts updated after a user requested date. If a user acknowledges a post the post's update at won't change thus not getting that post returned from GetPostsSince. This is troublesome particularly for the mobile client since it relies a lot to GetPostsSince for keeping the data up to date.

This commit updates the post's update_at when a user acknowledges/un-acknowledges a post fixing this way the issue above.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49845

#### Release Note

```release-note
NONE
```
