### PR TITLE
MM-49604: Fix race condition in test

### DIFF
--- a/store/sqlstore/store_test.go
+++ b/store/sqlstore/store_test.go
@@ -703,7 +703,6 @@ func TestVersionString(t *testing.T) {
 }
 
 func TestReplicaLagQuery(t *testing.T) {
-	t.Skip("MM-49604")
 	testDrivers := []string{
 		model.DatabaseDriverPostgres,
 		model.DatabaseDriverMysql,
@@ -730,7 +729,6 @@ func TestReplicaLagQuery(t *testing.T) {
 		}}
 
 		mockMetrics := &mocks.MetricsInterface{}
-		defer mockMetrics.AssertExpectations(t)
 		mockMetrics.On("SetReplicaLagAbsolute", tableName, float64(1))
 		mockMetrics.On("SetReplicaLagTime", tableName, float64(1))
 		mockMetrics.On("RegisterDBCollector", mock.AnythingOfType("*sql.DB"), "master")
@@ -753,6 +751,7 @@ func TestReplicaLagQuery(t *testing.T) {
 		require.NoError(t, err)
 		err = store.ReplicaLagTime()
 		require.NoError(t, err)
+		mockMetrics.AssertExpectations(t)
 	}
 }
 


### PR DESCRIPTION
The AssertExpectations was being called after the store
was closed. To fix it we move it to the last line.

https://mattermost.atlassian.net/browse/MM-49604

```release-note
NONE
```
