### PR TITLE
[MM-49929] Work templates: allow simple users to list marketplace plugins

### DIFF
--- a/app/plugin.go
+++ b/app/plugin.go
@@ -571,22 +571,24 @@ func (a *App) GetMarketplacePlugins(filter *model.MarketplacePluginFilter) ([]*m
 		plugins = p
 	}
 
-	// Some plugin don't work on cloud. The remote Marketplace is aware of this fact,
-	// but prepackaged plugins are not. Hence, on a cloud installation prepackaged plugins
-	// shouldn't be shown in the Marketplace modal.
-	// This is a short term fix. The long term solution is to have a separate set of
-	// prepacked plugins for cloud: https://mattermost.atlassian.net/browse/MM-31331.
-	license := a.Srv().License()
-	if license == nil || !license.IsCloud() {
-		appErr := a.mergePrepackagedPlugins(plugins)
+	if !filter.RemoteOnly {
+		// Some plugin don't work on cloud. The remote Marketplace is aware of this fact,
+		// but prepackaged plugins are not. Hence, on a cloud installation prepackaged plugins
+		// shouldn't be shown in the Marketplace modal.
+		// This is a short term fix. The long term solution is to have a separate set of
+		// prepacked plugins for cloud: https://mattermost.atlassian.net/browse/MM-31331.
+		license := a.Srv().License()
+		if license == nil || !license.IsCloud() {
+			appErr := a.mergePrepackagedPlugins(plugins)
+			if appErr != nil {
+				return nil, appErr
+			}
+		}
+
+		appErr := a.mergeLocalPlugins(plugins)
 		if appErr != nil {
 			return nil, appErr
 		}
-	}
-
-	appErr := a.mergeLocalPlugins(plugins)
-	if appErr != nil {
-		return nil, appErr
 	}
 
 	// Filter plugins.

--- a/model/marketplace_plugin.go
+++ b/model/marketplace_plugin.go
@@ -89,6 +89,7 @@ type MarketplacePluginFilter struct {
 	Platform             string
 	PluginId             string
 	ReturnAllVersions    bool
+	RemoteOnly           bool
 }
 
 // ApplyToURL modifies the given url to include query string parameters for the request.
@@ -104,6 +105,7 @@ func (filter *MarketplacePluginFilter) ApplyToURL(u *url.URL) {
 	q.Add("enterprise_plugins", strconv.FormatBool(filter.EnterprisePlugins))
 	q.Add("cloud", strconv.FormatBool(filter.Cloud))
 	q.Add("local_only", strconv.FormatBool(filter.LocalOnly))
+	q.Add("remote_only", strconv.FormatBool(filter.RemoteOnly))
 	q.Add("platform", filter.Platform)
 	q.Add("plugin_id", filter.PluginId)
 	q.Add("return_all_versions", strconv.FormatBool(filter.ReturnAllVersions))


### PR DESCRIPTION
#### Summary

This PR introduces a new `remote_only=true` query string to only parse public information from the remote marketplace. Used in work templates to retrieve plugin info (picture and name).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49929

#### Release Note
```release-note
NONE
```
