### PR TITLE
[MM-49959] Initialize the logger for CLI imports

### DIFF
--- a/cmd/mattermost/commands/import.go
+++ b/cmd/mattermost/commands/import.go
@@ -79,7 +79,7 @@ func slackImportCmdF(command *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("Running Slack Import. This may take a long time for large teams or teams with many messages.")
 
-	importErr, log := a.SlackImport(request.EmptyContext(nil), fileReader, fileInfo.Size(), team.Id)
+	importErr, log := a.SlackImport(request.EmptyContext(a.Log()), fileReader, fileInfo.Size(), team.Id)
 
 	if importErr != nil {
 		return err
@@ -152,7 +152,7 @@ func bulkImportCmdF(command *cobra.Command, args []string) error {
 
 	CommandPrettyPrintln("")
 
-	if err, lineNumber := a.BulkImportWithPath(request.EmptyContext(nil), fileReader, nil, !apply, workers, importPath); err != nil {
+	if err, lineNumber := a.BulkImportWithPath(request.EmptyContext(a.Log()), fileReader, nil, !apply, workers, importPath); err != nil {
 		CommandPrintErrorln(err.Error())
 		if lineNumber != 0 {
 			CommandPrintErrorln(fmt.Sprintf("Error occurred on data file line %v", lineNumber))


### PR DESCRIPTION
#### Summary
The logger was not properly initialized for bulk import from the mattermost CLI, We now initialize the logger.

#### Ticket Link
[MM-49959](https://mattermost.atlassian.net/browse/MM-49959) and https://github.com/mattermost/mattermost-server/issues/22142

#### Release Note
```release-note
NONE
```


[MM-49959]: https://mattermost.atlassian.net/browse/MM-49959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ