### PR TITLE
MM-49048: do not omit needed wsbroadcast vars

### DIFF
--- a/app/platform/web_hub_test.go
+++ b/app/platform/web_hub_test.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"encoding/json"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -550,4 +551,32 @@ func BenchmarkGetHubForUserId(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		hubSink = th.Service.GetHubForUserId(th.BasicUser.Id)
 	}
+}
+
+func TestClusterBroadcast(t *testing.T) {
+	testCluster := &testlib.FakeClusterInterface{}
+
+	th := SetupWithCluster(t, testCluster)
+	defer th.TearDown()
+
+	ev := model.NewWebSocketEvent("test_event", "", "", "", nil, "")
+	broadcast := &model.WebsocketBroadcast{
+		ContainsSanitizedData: true,
+		ContainsSensitiveData: true,
+	}
+	ev = ev.SetBroadcast(broadcast)
+	th.Service.Publish(ev)
+
+	messages := testCluster.GetMessages()
+
+	var clusterEvent struct {
+		Event     string                    `json:"event"`
+		Data      map[string]any            `json:"data"`
+		Broadcast *model.WebsocketBroadcast `json:"broadcast"`
+		Sequence  int64                     `json:"seq"`
+	}
+
+	err := json.Unmarshal(messages[0].Data, &clusterEvent)
+	require.NoError(t, err)
+	require.Equal(t, clusterEvent.Broadcast, broadcast)
 }

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -97,8 +97,8 @@ type WebsocketBroadcast struct {
 	TeamId                string          `json:"team_id"`            // broadcast only occurs for users in this team
 	ConnectionId          string          `json:"connection_id"`      // broadcast only occurs for this connection
 	OmitConnectionId      string          `json:"omit_connection_id"` // broadcast is omitted for this connection
-	ContainsSanitizedData bool            `json:"-"`
-	ContainsSensitiveData bool            `json:"-"`
+	ContainsSanitizedData bool            `json:"contains_sanitized_data,omitempty"`
+	ContainsSensitiveData bool            `json:"contains_sensitive_data,omitempty"`
 	// ReliableClusterSend indicates whether or not the message should
 	// be sent through the cluster using the reliable, TCP backed channel.
 	ReliableClusterSend bool `json:"-"`

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -91,14 +91,14 @@ type WebSocketMessage interface {
 }
 
 type WebsocketBroadcast struct {
-	OmitUsers             map[string]bool `json:"omit_users"`         // broadcast is omitted for users listed here
-	UserId                string          `json:"user_id"`            // broadcast only occurs for this user
-	ChannelId             string          `json:"channel_id"`         // broadcast only occurs for users in this channel
-	TeamId                string          `json:"team_id"`            // broadcast only occurs for users in this team
-	ConnectionId          string          `json:"connection_id"`      // broadcast only occurs for this connection
-	OmitConnectionId      string          `json:"omit_connection_id"` // broadcast is omitted for this connection
-	ContainsSanitizedData bool            `json:"contains_sanitized_data,omitempty"`
-	ContainsSensitiveData bool            `json:"contains_sensitive_data,omitempty"`
+	OmitUsers             map[string]bool `json:"omit_users"`                        // broadcast is omitted for users listed here
+	UserId                string          `json:"user_id"`                           // broadcast only occurs for this user
+	ChannelId             string          `json:"channel_id"`                        // broadcast only occurs for users in this channel
+	TeamId                string          `json:"team_id"`                           // broadcast only occurs for users in this team
+	ConnectionId          string          `json:"connection_id"`                     // broadcast only occurs for this connection
+	OmitConnectionId      string          `json:"omit_connection_id"`                // broadcast is omitted for this connection
+	ContainsSanitizedData bool            `json:"contains_sanitized_data,omitempty"` // broadcast only occurs for non-sysadmins
+	ContainsSensitiveData bool            `json:"contains_sensitive_data,omitempty"` // broadcase only occurs for sysadmins
 	// ReliableClusterSend indicates whether or not the message should
 	// be sent through the cluster using the reliable, TCP backed channel.
 	ReliableClusterSend bool `json:"-"`

--- a/model/websocket_message.go
+++ b/model/websocket_message.go
@@ -98,7 +98,7 @@ type WebsocketBroadcast struct {
 	ConnectionId          string          `json:"connection_id"`                     // broadcast only occurs for this connection
 	OmitConnectionId      string          `json:"omit_connection_id"`                // broadcast is omitted for this connection
 	ContainsSanitizedData bool            `json:"contains_sanitized_data,omitempty"` // broadcast only occurs for non-sysadmins
-	ContainsSensitiveData bool            `json:"contains_sensitive_data,omitempty"` // broadcase only occurs for sysadmins
+	ContainsSensitiveData bool            `json:"contains_sensitive_data,omitempty"` // broadcast only occurs for sysadmins
 	// ReliableClusterSend indicates whether or not the message should
 	// be sent through the cluster using the reliable, TCP backed channel.
 	ReliableClusterSend bool `json:"-"`


### PR DESCRIPTION
#### Summary

It seems that are omitting ContainsSanitizedData, and ContainsSensitiveData variables in WebsocketBroadcast. This created a bug in cluster mode, where we where sending duplicate events to users when normally they would have access to only one of those.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49048

#### Release Note

```release-note
Fixed an issue where duplicate `post_deleted`, and `user_updated` events would get sent to users when in cluster
```
