### PR TITLE
[MM-50007] WorkTemplate: disallow creating private playbook without an enterprise license

### DIFF
--- a/api4/work_templates.go
+++ b/api4/work_templates.go
@@ -116,6 +116,7 @@ func executeWorkTemplate(c *Context, w http.ResponseWriter, r *http.Request) {
 	canCreatePublicPlaybook := c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), wtcr.TeamID, model.PermissionPublicPlaybookCreate)
 	canCreatePrivatePlaybook := c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), wtcr.TeamID, model.PermissionPrivatePlaybookCreate)
 	appErr = wtcr.CanBeExecuted(worktemplates.PermissionSet{
+		License:                  c.App.License(),
 		CanCreatePublicChannel:   canCreatePublicChannel,
 		CanCreatePrivateChannel:  canCreatePrivateChannel,
 		CanCreatePublicBoard:     canCreatePublicBoard,

--- a/app/worktemplates/model.go
+++ b/app/worktemplates/model.go
@@ -21,6 +21,8 @@ type ExecutionRequest struct {
 }
 
 type PermissionSet struct {
+	License *model.License
+
 	// channels
 	CanCreatePublicChannel  bool
 	CanCreatePrivateChannel bool
@@ -61,6 +63,9 @@ func (r *ExecutionRequest) CanBeExecuted(p PermissionSet) *model.AppError {
 			}
 			if !public && !p.CanCreatePrivatePlaybook {
 				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.cannot_create_private_playbook", nil, "", http.StatusForbidden)
+			}
+			if !public && (p.License == nil || p.License.SkuShortName != model.LicenseShortSkuEnterprise) {
+				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.server_cannot_create_private_playbook", nil, "", http.StatusForbidden)
 			}
 
 			// we need to check what's the template default run execution mode

--- a/app/worktemplates/model.go
+++ b/app/worktemplates/model.go
@@ -64,9 +64,7 @@ func (r *ExecutionRequest) CanBeExecuted(p PermissionSet) *model.AppError {
 			if !public && !p.CanCreatePrivatePlaybook {
 				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.cannot_create_private_playbook", nil, "", http.StatusForbidden)
 			}
-			// if the playbook is private, we need to error if:
-			// - there is no license
-			// - OR the license is not E20 && is not enterprise
+			// private playbook is an E20/Enterprise feature
 			if !public && (p.License == nil || (p.License.SkuShortName != model.LicenseShortSkuE20 && p.License.SkuShortName != model.LicenseShortSkuEnterprise)) {
 				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.license_cannot_create_private_playbook", nil, "", http.StatusForbidden)
 			}

--- a/app/worktemplates/model.go
+++ b/app/worktemplates/model.go
@@ -64,8 +64,11 @@ func (r *ExecutionRequest) CanBeExecuted(p PermissionSet) *model.AppError {
 			if !public && !p.CanCreatePrivatePlaybook {
 				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.cannot_create_private_playbook", nil, "", http.StatusForbidden)
 			}
-			if !public && (p.License == nil || p.License.SkuShortName != model.LicenseShortSkuEnterprise) {
-				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.server_cannot_create_private_playbook", nil, "", http.StatusForbidden)
+			// if the playbook is private, we need to error if:
+			// - there is no license
+			// - OR the license is not E20 && is not enterprise
+			if !public && (p.License == nil || (p.License.SkuShortName != model.LicenseShortSkuE20 && p.License.SkuShortName != model.LicenseShortSkuEnterprise)) {
+				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.license_cannot_create_private_playbook", nil, "", http.StatusForbidden)
 			}
 
 			// we need to check what's the template default run execution mode

--- a/app/worktemplates/model_test.go
+++ b/app/worktemplates/model_test.go
@@ -79,8 +79,17 @@ func TestCanBeExecuted(t *testing.T) {
 		})
 		require.NotNil(t, appErr)
 
+		// enterprise and E20 ok
 		appErr = wtcrMod.CanBeExecuted(PermissionSet{
 			License:                  model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise, ""),
+			CanCreatePrivateChannel:  true,
+			CanCreatePrivateBoard:    true,
+			CanCreatePrivatePlaybook: true,
+			CanCreatePublicChannel:   true,
+		})
+		require.Nil(t, appErr)
+		appErr = wtcrMod.CanBeExecuted(PermissionSet{
+			License:                  model.NewTestLicenseSKU(model.LicenseShortSkuE20, ""),
 			CanCreatePrivateChannel:  true,
 			CanCreatePrivateBoard:    true,
 			CanCreatePrivatePlaybook: true,

--- a/app/worktemplates/model_test.go
+++ b/app/worktemplates/model_test.go
@@ -58,6 +58,37 @@ func TestCanBeExecuted(t *testing.T) {
 		assert.Nil(t, appErr)
 	})
 
+	t.Run("cannot create private playbook if the license is not enterprise", func(t *testing.T) {
+		wtcrMod := *wtcr
+		wtcrMod.Visibility = model.WorkTemplateVisibilityPrivate
+		appErr := wtcrMod.CanBeExecuted(PermissionSet{
+			License:                  model.NewTestLicenseSKU(model.LicenseShortSkuProfessional, ""),
+			CanCreatePrivateChannel:  true,
+			CanCreatePrivateBoard:    true,
+			CanCreatePrivatePlaybook: true,
+			CanCreatePublicChannel:   true, // needed for the channel run
+		})
+		require.NotNil(t, appErr)
+
+		appErr = wtcrMod.CanBeExecuted(PermissionSet{
+			License:                  nil,
+			CanCreatePrivateChannel:  true,
+			CanCreatePrivateBoard:    true,
+			CanCreatePrivatePlaybook: true,
+			CanCreatePublicChannel:   true,
+		})
+		require.NotNil(t, appErr)
+
+		appErr = wtcrMod.CanBeExecuted(PermissionSet{
+			License:                  model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise, ""),
+			CanCreatePrivateChannel:  true,
+			CanCreatePrivateBoard:    true,
+			CanCreatePrivatePlaybook: true,
+			CanCreatePublicChannel:   true,
+		})
+		require.Nil(t, appErr)
+	})
+
 	t.Run("fails when something is not allowed", func(t *testing.T) {
 		appErr := wtcr.CanBeExecuted(PermissionSet{
 			CanCreatePublicChannel:  true,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7076,7 +7076,7 @@
     "translation": "Unable to find playbook template associated with this work template."
   },
   {
-    "id": "app.worktemplate.execution_request.server_cannot_create_private_playbook",
+    "id": "app.worktemplate.execution_request.license_cannot_create_private_playbook",
     "translation": "Your license does not support private playbooks."
   },
   {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7076,6 +7076,10 @@
     "translation": "Unable to find playbook template associated with this work template."
   },
   {
+    "id": "app.worktemplate.execution_request.server_cannot_create_private_playbook",
+    "translation": "Your license does not support private playbooks."
+  },
+  {
     "id": "app.worktemplates.execute_work_template.app_error",
     "translation": "Error while executing a work template."
   },


### PR DESCRIPTION
#### Summary
This PR ensures that we do not let users create private playbooks if the server's license is not enterprise or E20.

A PR will come later in the webapp to disable the "private" option if the server does not hold an E20 license.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50007

#### Release Note
```release-note
NONE
```
