### PR TITLE
[MM-49932] Remove experimental warning about plugins

### DIFF
--- a/api4/plugin.go
+++ b/api4/plugin.go
@@ -1,8 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// EXPERIMENTAL - SUBJECT TO CHANGE
-
 package api4
 
 import (
@@ -25,8 +23,6 @@ const (
 )
 
 func (api *API) InitPlugin() {
-	mlog.Debug("EXPERIMENTAL: Initializing plugin api")
-
 	api.BaseRoutes.Plugins.Handle("", api.APISessionRequired(uploadPlugin)).Methods("POST")
 	api.BaseRoutes.Plugins.Handle("", api.APISessionRequired(getPlugins)).Methods("GET")
 	api.BaseRoutes.Plugin.Handle("", api.APISessionRequired(removePlugin)).Methods("DELETE")


### PR DESCRIPTION
#### Summary
Plugins are no longer in beta or marked as experimental. The codebase should reflect that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49932

#### Release Note
```release-note
NONE
```
