### PR TITLE
[MM-49991] Enable EnableOAuthServiceProvider by default

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -482,7 +482,7 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 	}
 
 	if s.EnableOAuthServiceProvider == nil {
-		s.EnableOAuthServiceProvider = NewBool(false)
+		s.EnableOAuthServiceProvider = NewBool(true)
 	}
 
 	if s.EnableIncomingWebhooks == nil {


### PR DESCRIPTION
#### Summary
On a freshly installed MM server, the Apps Plugin does not correctly work because OAuth 2.0 in the MM server need to be enabled.

To ease the first UX with apps, the setting should be enabled by default.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49991

#### Release Note
```release-note
Enable EnableOAuthServiceProvider by default
```
