### PR TITLE
Revert "[MM-42652] Re-enable test"

### DIFF
--- a/api4/channel_category_test.go
+++ b/api4/channel_category_test.go
@@ -103,6 +103,7 @@ func TestCreateCategoryForTeamForUser(t *testing.T) {
 	})
 
 	t.Run("should publish expected WS payload", func(t *testing.T) {
+		t.Skip("MM-42652")
 		userWSClient, err := th.CreateWebSocketClient()
 		require.NoError(t, err)
 		defer userWSClient.Close()


### PR DESCRIPTION
Reverts mattermost/mattermost-server#21986

We are seeing the failure again in our CI.

```release-note
NONE
```