### PR TITLE
[MM-50082] Work templates: copy + other tweaks

### DIFF
--- a/app/work_template_executor.go
+++ b/app/work_template_executor.go
@@ -51,6 +51,7 @@ func (e *appWorkTemplateExecutor) CreatePlaybook(
 	pbTemplate.TeamID = wtcr.TeamID
 	pbTemplate.Title = name
 	pbTemplate.Public = wtcr.Visibility == model.WorkTemplateVisibilityPublic
+	pbTemplate.CreatePublicPlaybookRun = wtcr.Visibility == model.WorkTemplateVisibilityPublic
 	data, err := json.Marshal(pbTemplate)
 	if err != nil {
 		return "", fmt.Errorf("unable to marshal playbook template: %w", err)

--- a/app/work_template_executor.go
+++ b/app/work_template_executor.go
@@ -39,7 +39,7 @@ func (e *appWorkTemplateExecutor) CreatePlaybook(
 	// determine playbook name
 	name := playbook.Name
 	if wtcr.Name != "" {
-		name = fmt.Sprintf("%s: %s", wtcr.Name, playbook.Name)
+		name += " " + wtcr.Name
 	}
 
 	// get the correct playbook pbTemplate
@@ -70,7 +70,7 @@ func (e *appWorkTemplateExecutor) CreatePlaybook(
 
 	runName := channel.Name
 	if wtcr.Name != "" {
-		runName = fmt.Sprintf("%s: %s", wtcr.Name, channel.Name)
+		runName = wtcr.Name
 	}
 	data, err = json.Marshal(pbclient.PlaybookRunCreateOptions{
 		Name:        runName,
@@ -117,7 +117,7 @@ func (e *appWorkTemplateExecutor) CreateChannel(
 	channelID := ""
 	channelDisplayName := cChannel.Name
 	if wtcr.Name != "" {
-		channelDisplayName = fmt.Sprintf("%s: %s", wtcr.Name, cChannel.Name)
+		channelDisplayName = wtcr.Name
 	}
 
 	var channelCreationAppErr *model.AppError = &model.AppError{}
@@ -188,7 +188,7 @@ func (e *appWorkTemplateExecutor) CreateBoard(
 
 	title := cBoard.Name
 	if wtcr.Name != "" {
-		title = fmt.Sprintf("%s: %s", wtcr.Name, cBoard.Name)
+		title += " " + wtcr.Name
 	}
 
 	// Duplicate board From template

--- a/app/worktemplates/model.go
+++ b/app/worktemplates/model.go
@@ -68,19 +68,6 @@ func (r *ExecutionRequest) CanBeExecuted(p PermissionSet) *model.AppError {
 			if !public && (p.License == nil || (p.License.SkuShortName != model.LicenseShortSkuE20 && p.License.SkuShortName != model.LicenseShortSkuEnterprise)) {
 				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.license_cannot_create_private_playbook", nil, "", http.StatusForbidden)
 			}
-
-			// we need to check what's the template default run execution mode
-			// to determine how the channel is created
-			tmpl, err := r.FindPlaybookTemplate(c.Playbook.Template)
-			if err != nil {
-				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.cannot_find_playbook_template", nil, err.Error(), http.StatusInternalServerError)
-			}
-			if tmpl.CreatePublicPlaybookRun && !p.CanCreatePublicChannel {
-				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.cannot_create_public_run", nil, "", http.StatusForbidden)
-			}
-			if !tmpl.CreatePublicPlaybookRun && !p.CanCreatePrivateChannel {
-				return model.NewAppError("WorkTemplateExecutionRequest.CanBeExecuted", "app.worktemplate.execution_request.cannot_create_private_run", nil, "", http.StatusForbidden)
-			}
 			continue
 		}
 

--- a/app/worktemplates/model_test.go
+++ b/app/worktemplates/model_test.go
@@ -106,16 +106,4 @@ func TestCanBeExecuted(t *testing.T) {
 		})
 		require.NotNil(t, appErr)
 	})
-
-	t.Run("returns an error and no res when playbook template is not found", func(t *testing.T) {
-		wtcrMod := *wtcr
-		wtcrMod.foundPlaybookTemplates = map[string]*pbclient.PlaybookCreateOptions{}
-		wtcrMod.PlaybookTemplates = []*PlaybookTemplate{}
-		appErr := wtcrMod.CanBeExecuted(PermissionSet{
-			CanCreatePublicChannel:  true,
-			CanCreatePublicPlaybook: true,
-			CanCreatePublicBoard:    true,
-		})
-		require.NotNil(t, appErr)
-	})
 }

--- a/app/worktemplates/templates.yaml
+++ b/app/worktemplates/templates.yaml
@@ -3,7 +3,7 @@
 ######################
 id: "product_teams/feature_release:v1"
 category: product_teams
-useCase: Feature Release
+useCase: Manage feature release
 illustration: /static/worktemplates/product_teams/feature_release/feature_release.svg
 visibility: public
 description:
@@ -50,7 +50,7 @@ content:
 ---
 id: 'product_teams/goals_and_okrs:v1'
 category: product_teams
-useCase: Goals and OKR's
+useCase: Set goals and OKR's
 illustration: /static/worktemplates/product_teams/goals_and_okrs/goals_and_okrs.svg
 visibility: public
 description:
@@ -96,7 +96,7 @@ content:
 ---
 id: 'product_teams/bug_bash:v1'
 category: product_teams
-useCase: Bug Bash
+useCase: Run a bug bash
 illustration: /static/worktemplates/product_teams/bug_bash/bug_bash.svg
 visibility: public
 description:
@@ -137,7 +137,7 @@ content:
 ---
 id: 'product_teams/sprint_planning:v1'
 category: product_teams
-useCase: Sprint Planning
+useCase: Plan sprints
 illustration: /static/worktemplates/product_teams/sprint_planning/sprint_planning.svg
 visibility: public
 description:
@@ -179,7 +179,7 @@ content:
 ---
 id: 'product_teams/product_roadmap:v1'
 category: product_teams
-useCase: Product Roadmap
+useCase: Create a product roadmap
 illustration: /static/worktemplates/product_teams/product_roadmap/product_roadmap.svg
 visibility: public
 description:
@@ -206,7 +206,7 @@ content:
 ######################
 id: 'devops/incident_resolution:v1'
 category: devops
-useCase: Incident Resolution
+useCase: Resolve incidents
 illustration: /static/worktemplates/devops/incident_resolution/incident_resolution.png
 visibility: public
 description:
@@ -239,7 +239,7 @@ content:
 ---
 id: 'devops/product_release:v1'
 category: devops
-useCase: Product Release
+useCase: Prepare a product release
 illustration: /static/worktemplates/devops/product_release/product_release.svg
 visibility: public
 description:
@@ -275,7 +275,7 @@ content:
 ######################
 id: 'companywide/goals_and_okrs:v1'
 category: companywide
-useCase: Goals and OKR's
+useCase: Set goals and OKR's
 illustration: /static/worktemplates/companywide/goals_and_okrs/goals_and_okrs.svg
 visibility: public
 description:
@@ -314,7 +314,7 @@ content:
 ---
 id: 'companywide/create_project:v1'
 category: companywide
-useCase: Create Project
+useCase: Create a project
 illustration: /static/worktemplates/companywide/create_project/create_project.svg
 visibility: public
 description:
@@ -358,7 +358,7 @@ content:
 ######################
 id: 'leadership/goals_and_okrs:v1'
 category: leadership
-useCase: Goals and OKR's
+useCase: Set goals and OKR's
 illustration: /static/worktemplates/leadership/goals_and_okrs/goals_and_okrs.svg
 visibility: public
 description:

--- a/app/worktemplates/worktemplate_generated.go
+++ b/app/worktemplates/worktemplate_generated.go
@@ -85,7 +85,7 @@ var wtce9b74766edff1096ba7c67999ca259b6 = &WorkTemplateCategory{
 var wt00a1b44a5831c0a3acb14787b3fdd352 = &WorkTemplate{
 	ID:           "product_teams/feature_release:v1",
 	Category:     "product_teams",
-	UseCase:      "Feature Release",
+	UseCase:      "Manage feature release",
 	Illustration: "/static/worktemplates/product_teams/feature_release/feature_release.svg",
 	Visibility:   "public",
 
@@ -163,7 +163,7 @@ var wt00a1b44a5831c0a3acb14787b3fdd352 = &WorkTemplate{
 var wt5baa68055bf9ea423273662e01ccc575 = &WorkTemplate{
 	ID:           "product_teams/goals_and_okrs:v1",
 	Category:     "product_teams",
-	UseCase:      "Goals and OKR's",
+	UseCase:      "Set goals and OKR's",
 	Illustration: "/static/worktemplates/product_teams/goals_and_okrs/goals_and_okrs.svg",
 	Visibility:   "public",
 
@@ -224,7 +224,7 @@ var wt5baa68055bf9ea423273662e01ccc575 = &WorkTemplate{
 var wtfeb56bc6a8f277c47b503bd1c92d830e = &WorkTemplate{
 	ID:           "product_teams/bug_bash:v1",
 	Category:     "product_teams",
-	UseCase:      "Bug Bash",
+	UseCase:      "Run a bug bash",
 	Illustration: "/static/worktemplates/product_teams/bug_bash/bug_bash.svg",
 	Visibility:   "public",
 
@@ -279,7 +279,7 @@ var wtfeb56bc6a8f277c47b503bd1c92d830e = &WorkTemplate{
 var wt8d2ef53deac5517eb349dc5de6150196 = &WorkTemplate{
 	ID:           "product_teams/sprint_planning:v1",
 	Category:     "product_teams",
-	UseCase:      "Sprint Planning",
+	UseCase:      "Plan sprints",
 	Illustration: "/static/worktemplates/product_teams/sprint_planning/sprint_planning.svg",
 	Visibility:   "public",
 
@@ -331,7 +331,7 @@ var wt8d2ef53deac5517eb349dc5de6150196 = &WorkTemplate{
 var wt00ab91a945627f4a624957dd80490bb2 = &WorkTemplate{
 	ID:           "product_teams/product_roadmap:v1",
 	Category:     "product_teams",
-	UseCase:      "Product Roadmap",
+	UseCase:      "Create a product roadmap",
 	Illustration: "/static/worktemplates/product_teams/product_roadmap/product_roadmap.svg",
 	Visibility:   "public",
 
@@ -372,7 +372,7 @@ var wt00ab91a945627f4a624957dd80490bb2 = &WorkTemplate{
 var wtce19b9352a59d6a5d26f292d83e84377 = &WorkTemplate{
 	ID:           "devops/incident_resolution:v1",
 	Category:     "devops",
-	UseCase:      "Incident Resolution",
+	UseCase:      "Resolve incidents",
 	Illustration: "/static/worktemplates/devops/incident_resolution/incident_resolution.png",
 	Visibility:   "public",
 
@@ -426,7 +426,7 @@ var wtce19b9352a59d6a5d26f292d83e84377 = &WorkTemplate{
 var wt37406285a41c18bcdeb881189f7acde0 = &WorkTemplate{
 	ID:           "devops/product_release:v1",
 	Category:     "devops",
-	UseCase:      "Product Release",
+	UseCase:      "Prepare a product release",
 	Illustration: "/static/worktemplates/devops/product_release/product_release.svg",
 	Visibility:   "public",
 
@@ -480,7 +480,7 @@ var wt37406285a41c18bcdeb881189f7acde0 = &WorkTemplate{
 var wtf7b846d35810f8272eeb9a1a562025b5 = &WorkTemplate{
 	ID:           "companywide/goals_and_okrs:v1",
 	Category:     "companywide",
-	UseCase:      "Goals and OKR's",
+	UseCase:      "Set goals and OKR's",
 	Illustration: "/static/worktemplates/companywide/goals_and_okrs/goals_and_okrs.svg",
 	Visibility:   "public",
 
@@ -532,7 +532,7 @@ var wtf7b846d35810f8272eeb9a1a562025b5 = &WorkTemplate{
 var wtb9ab412890c2410c7b49eec8f12e7edc = &WorkTemplate{
 	ID:           "companywide/create_project:v1",
 	Category:     "companywide",
-	UseCase:      "Create Project",
+	UseCase:      "Create a project",
 	Illustration: "/static/worktemplates/companywide/create_project/create_project.svg",
 	Visibility:   "public",
 
@@ -594,7 +594,7 @@ var wtb9ab412890c2410c7b49eec8f12e7edc = &WorkTemplate{
 var wt32ab773bfe021e3d4913931041552559 = &WorkTemplate{
 	ID:           "leadership/goals_and_okrs:v1",
 	Category:     "leadership",
-	UseCase:      "Goals and OKR's",
+	UseCase:      "Set goals and OKR's",
 	Illustration: "/static/worktemplates/leadership/goals_and_okrs/goals_and_okrs.svg",
 	Visibility:   "public",
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7060,10 +7060,6 @@
     "translation": "You don't have permissions to create a private playbook."
   },
   {
-    "id": "app.worktemplate.execution_request.cannot_create_private_run",
-    "translation": "You don't have permissions to create a private channel for the playbook run."
-  },
-  {
     "id": "app.worktemplate.execution_request.cannot_create_public_board",
     "translation": "You don't have permissions to create a public board."
   },
@@ -7074,14 +7070,6 @@
   {
     "id": "app.worktemplate.execution_request.cannot_create_public_playbook",
     "translation": "You don't have permissions to create a public playbook."
-  },
-  {
-    "id": "app.worktemplate.execution_request.cannot_create_public_run",
-    "translation": "You don't have permissions to create a public channel for the playbook run."
-  },
-  {
-    "id": "app.worktemplate.execution_request.cannot_find_playbook_template",
-    "translation": "Unable to find playbook template associated with this work template."
   },
   {
     "id": "app.worktemplate.execution_request.license_cannot_create_private_playbook",


### PR DESCRIPTION
#### Summary

- Changes names of work templates
- If the user input a name, this name will be used as the channel name. Also works on playbook run's generated channels.
- Boards and playbook will now be suffixed  with the user input (`Mobile: Projet Tasks` becomes `Project Tasks Mobile`)
- Playbook run channel visibility is forced to match the user selection. It also allows us to simplify the permission check.

Make sure to also take a look at the frontend PR to have more details on all changes: https://github.com/mattermost/mattermost-webapp/pull/12114

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50082

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
