### PR TITLE
error instead of panic if cloud endpoints are hit

### DIFF
--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -755,7 +755,12 @@ func handleCWSWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func handleCheckCWSConnection(c *Context, w http.ResponseWriter, r *http.Request) {
-	if err := c.App.Cloud().CheckCWSConnection(c.AppContext.Session().UserId); err != nil {
+	cloud := c.App.Cloud()
+	if cloud == nil {
+		c.Err = model.NewAppError("Api4.handleCWSHealthCheck", "api.server.cws.needs_enterprise_edition", nil, "", http.StatusBadRequest)
+		return
+	}
+	if err := cloud.CheckCWSConnection(c.AppContext.Session().UserId); err != nil {
 		c.Err = model.NewAppError("Api4.handleCWSHealthCheck", "api.server.cws.health_check.app_error", nil, "CWS Server is not available.", http.StatusInternalServerError)
 		return
 	}

--- a/api4/hosted_customer.go
+++ b/api4/hosted_customer.go
@@ -36,6 +36,12 @@ func (api *API) InitHostedCustomer() {
 }
 
 func ensureSelfHostedAdmin(c *Context, where string) {
+	cloud := c.App.Cloud()
+	if cloud == nil {
+		c.Err = model.NewAppError(where, "api.server.cws.needs_enterprise_edition", nil, "", http.StatusBadRequest)
+		return
+	}
+
 	license := c.App.Channels().License()
 
 	if license.IsCloud() {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2580,6 +2580,10 @@
     "translation": "CWS Server is not available."
   },
   {
+    "id": "api.server.cws.needs_enterprise_edition",
+    "translation": "Service only available in Mattermost Enterprise edition"
+  },
+  {
     "id": "api.server.hosted_signup_unavailable.error",
     "translation": "Portal unavailable for self-hosted signup."
   },


### PR DESCRIPTION
#### Summary
If not an enterprise build (e.g. there is no cloud interface), attempts to check CWS connectivity result in 400 Bad request instead of panics. Not strictly needed because [the webapp PR](https://github.com/mattermost/mattermost-webapp/pull/12117) should prevent requests from being made in the first place, but it would be better to not go through the http handler panic/recover cycle if someone crafts a request to these endpoints manually.

#### Ticket Link
* https://mattermost.atlassian.net/browse/MM-50049
* https://mattermost.atlassian.net/browse/MM-50050

#### Release Note

```release-note
* Team edition returns 400 Bad request for attempts to check CWS availability
```
