### PR TITLE
MM-49920: Respect query parameters with AuthURLs - OAuth

### DIFF
--- a/app/oauth.go
+++ b/app/oauth.go
@@ -765,17 +765,27 @@ func (a *App) GetAuthorizationCode(w http.ResponseWriter, r *http.Request, servi
 
 	redirectURI := siteURL + "/signup/" + service + "/complete"
 
-	authURL := endpoint + "?response_type=code&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirectURI) + "&state=" + url.QueryEscape(state)
+	authURL, sErr := url.Parse(endpoint)
+	if sErr != nil {
+		return "", model.NewAppError("GetAuthorizationCode.ParseEndpoint", "api.user.get_authorization_code.endpoint_parse.app_error", nil, "failed to parse authentication endpoint URL", http.StatusBadRequest).Wrap(sErr)
+	}
+	queryParams := authURL.Query()
+	queryParams.Set("response_type", "code")
+	queryParams.Set("client_id", clientId)
+	queryParams.Set("redirect_uri", url.QueryEscape(redirectURI))
+	queryParams.Set("state", url.QueryEscape(state))
 
 	if scope != "" {
-		authURL += "&scope=" + utils.URLEncode(scope)
+		queryParams.Set("scope", utils.URLEncode(scope))
 	}
 
 	if loginHint != "" {
-		authURL += "&login_hint=" + utils.URLEncode(loginHint)
+		queryParams.Set("login_hint", utils.URLEncode(loginHint))
 	}
 
-	return authURL, nil
+	authURL.RawQuery = queryParams.Encode()
+
+	return authURL.String(), nil
 }
 
 func (a *App) AuthorizeOAuthUser(w http.ResponseWriter, r *http.Request, service, code, state, redirectURI string) (io.ReadCloser, string, map[string]string, *model.User, *model.AppError) {

--- a/app/oauth_test.go
+++ b/app/oauth_test.go
@@ -620,11 +620,11 @@ func TestGetAuthorizationCode(t *testing.T) {
 
 		})
 
-		t.Run("auth URL without query parameters", func(t *testing.T) {
+		t.Run("auth URL with query parameters", func(t *testing.T) {
 			th.App.UpdateConfig(func(cfg *model.Config) {
 				*cfg.GitLabSettings.Enable = true
-				*cfg.GitLabSettings.AuthEndpoint = "https://sample.gitlab.com"
-				*cfg.ServiceSettings.SiteURL = "https://mattermost.example.com?simply=lovely"
+				*cfg.GitLabSettings.AuthEndpoint = "https://sample.gitlab.com?simply=lovely"
+				*cfg.ServiceSettings.SiteURL = "https://mattermost.example.com"
 			})
 
 			request, _ := http.NewRequest(http.MethodGet, "https://mattermost.example.com", nil)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

In `app.GetAuthorizationCode` function, the following line of code generates malformed URL if provided an authorization URL with query parameters. Using `net/url` to concatenate query parameters fixes that.

```go
authURL := endpoint + "?response_type=code&client_id=" + clientId + "&redirect_uri=" + url.QueryEscape(redirectURI) + "&state=" + url.QueryEscape(state)
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-49920
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixed a bug in OAuth flow where query parameters in authentication endpoint resulted in malformed URL.
```
