### PR TITLE
Moving file response functionality to shared folder

### DIFF
--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 )
 
 func (api *API) InitCloud() {

--- a/api4/cloud.go
+++ b/api4/cloud.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
@@ -641,7 +642,7 @@ func getSubscriptionInvoicePDF(c *Context, w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	writeFileResponse(
+	web.WriteFileResponse(
 		filename,
 		"application/pdf",
 		int64(binary.Size(pdfData)),

--- a/api4/file.go
+++ b/api4/file.go
@@ -29,28 +29,6 @@ const (
 	ThumbnailImageType = "image/jpeg"
 )
 
-var UnsafeContentTypes = [...]string{
-	"application/javascript",
-	"application/ecmascript",
-	"text/javascript",
-	"text/ecmascript",
-	"application/x-javascript",
-	"text/html",
-}
-
-var MediaContentTypes = [...]string{
-	"image/jpeg",
-	"image/png",
-	"image/bmp",
-	"image/gif",
-	"image/tiff",
-	"video/avi",
-	"video/mpeg",
-	"video/mp4",
-	"audio/mpeg",
-	"audio/wav",
-}
-
 const maxMultipartFormDataBytes = 10 * 1024 // 10Kb
 
 func (api *API) InitFile() {

--- a/api4/file.go
+++ b/api4/file.go
@@ -17,8 +17,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/app"
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/utils"
 )
 

--- a/api4/file.go
+++ b/api4/file.go
@@ -11,14 +11,13 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/app"
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/utils"
 )
@@ -502,7 +501,7 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 
-	writeFileResponse(info.Name, info.MimeType, info.Size, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, forceDownload, w, r)
+	web.WriteFileResponse(info.Name, info.MimeType, info.Size, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, forceDownload, w, r)
 }
 
 func getFileThumbnail(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -537,7 +536,7 @@ func getFileThumbnail(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	defer fileReader.Close()
 
-	writeFileResponse(info.Name, ThumbnailImageType, 0, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, forceDownload, w, r)
+	web.WriteFileResponse(info.Name, ThumbnailImageType, 0, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, forceDownload, w, r)
 }
 
 func getFileLink(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -614,7 +613,7 @@ func getFilePreview(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	defer fileReader.Close()
 
-	writeFileResponse(info.Name, PreviewImageType, 0, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, forceDownload, w, r)
+	web.WriteFileResponse(info.Name, PreviewImageType, 0, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, forceDownload, w, r)
 }
 
 func getFileInfo(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -681,64 +680,7 @@ func getPublicFile(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	defer fileReader.Close()
 
-	writeFileResponse(info.Name, info.MimeType, info.Size, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, false, w, r)
-}
-
-func writeFileResponse(filename string, contentType string, contentSize int64, lastModification time.Time, webserverMode string, fileReader io.ReadSeeker, forceDownload bool, w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Cache-Control", "private, no-cache")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
-
-	if contentSize > 0 {
-		contentSizeStr := strconv.Itoa(int(contentSize))
-		if webserverMode == "gzip" {
-			w.Header().Set("X-Uncompressed-Content-Length", contentSizeStr)
-		} else {
-			w.Header().Set("Content-Length", contentSizeStr)
-		}
-	}
-
-	if contentType == "" {
-		contentType = "application/octet-stream"
-	} else {
-		for _, unsafeContentType := range UnsafeContentTypes {
-			if strings.HasPrefix(contentType, unsafeContentType) {
-				contentType = "text/plain"
-				break
-			}
-		}
-	}
-
-	w.Header().Set("Content-Type", contentType)
-
-	var toDownload bool
-	if forceDownload {
-		toDownload = true
-	} else {
-		isMediaType := false
-
-		for _, mediaContentType := range MediaContentTypes {
-			if strings.HasPrefix(contentType, mediaContentType) {
-				isMediaType = true
-				break
-			}
-		}
-
-		toDownload = !isMediaType
-	}
-
-	filename = url.PathEscape(filename)
-
-	if toDownload {
-		w.Header().Set("Content-Disposition", "attachment;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
-	} else {
-		w.Header().Set("Content-Disposition", "inline;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
-	}
-
-	// prevent file links from being embedded in iframes
-	w.Header().Set("X-Frame-Options", "DENY")
-	w.Header().Set("Content-Security-Policy", "Frame-ancestors 'none'")
-
-	http.ServeContent(w, r, filename, lastModification, fileReader)
+	web.WriteFileResponse(info.Name, info.MimeType, info.Size, time.Unix(0, info.UpdateAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, false, w, r)
 }
 
 func searchFilesInTeam(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/hosted_customer.go
+++ b/api4/hosted_customer.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/mattermost/mattermost-server/v6/utils"
 )
@@ -264,7 +265,7 @@ func selfHostedInvoicePDF(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeFileResponse(
+	web.WriteFileResponse(
 		filename,
 		"application/pdf",
 		int64(binary.Size(pdfData)),

--- a/api4/hosted_customer.go
+++ b/api4/hosted_customer.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/utils"
 )
 

--- a/api4/job.go
+++ b/api4/job.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
@@ -100,7 +101,7 @@ func downloadJob(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	// We are able to pass 0 for content size due to the fact that Golang's serveContent (https://golang.org/src/net/http/fs.go)
 	// already sets that for us
-	writeFileResponse(fileName, FileMime, 0, time.Unix(0, job.LastActivityAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, true, w, r)
+	web.WriteFileResponse(fileName, FileMime, 0, time.Unix(0, job.LastActivityAt*int64(1000*1000)), *c.App.Config().ServiceSettings.WebserverMode, fileReader, true, w, r)
 }
 
 func createJob(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/job.go
+++ b/api4/job.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/mattermost/mattermost-server/v6/audit"
 	"github.com/mattermost/mattermost-server/v6/model"
-	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 )
 
 func (api *API) InitJob() {

--- a/api4/system.go
+++ b/api4/system.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/services/cache"
 	"github.com/mattermost/mattermost-server/v6/services/upgrader"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
@@ -122,7 +123,7 @@ func generateSupportPacket(c *Context, w http.ResponseWriter, r *http.Request) {
 	// Send the zip file back to client
 	// We are able to pass 0 for content size due to the fact that Golang's serveContent (https://golang.org/src/net/http/fs.go)
 	// already sets that for us
-	writeFileResponse(outputZipFilename, FileMime, 0, now, *c.App.Config().ServiceSettings.WebserverMode, fileBytesReader, true, w, r)
+	web.WriteFileResponse(outputZipFilename, FileMime, 0, now, *c.App.Config().ServiceSettings.WebserverMode, fileBytesReader, true, w, r)
 }
 
 func getSystemPing(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/api4/system.go
+++ b/api4/system.go
@@ -21,8 +21,8 @@ import (
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/services/cache"
 	"github.com/mattermost/mattermost-server/v6/services/upgrader"
-	"github.com/mattermost/mattermost-server/v6/shared/web"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+	"github.com/mattermost/mattermost-server/v6/shared/web"
 )
 
 const (

--- a/shared/web/files.go
+++ b/shared/web/files.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"

--- a/shared/web/files.go
+++ b/shared/web/files.go
@@ -36,7 +36,6 @@ func WriteFileResponse(filename string, contentType string, contentSize int64, l
 	w.Header().Set("Cache-Control", "private, no-cache")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
-	fmt.Println("+++++++++++++ Running successfully +++++++++++")
 	if contentSize > 0 {
 		contentSizeStr := strconv.Itoa(int(contentSize))
 		if webserverMode == "gzip" {

--- a/shared/web/files.go
+++ b/shared/web/files.go
@@ -1,0 +1,91 @@
+package web
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var UnsafeContentTypes = [...]string{
+	"application/javascript",
+	"application/ecmascript",
+	"text/javascript",
+	"text/ecmascript",
+	"application/x-javascript",
+	"text/html",
+}
+
+var MediaContentTypes = [...]string{
+	"image/jpeg",
+	"image/png",
+	"image/bmp",
+	"image/gif",
+	"image/tiff",
+	"video/avi",
+	"video/mpeg",
+	"video/mp4",
+	"audio/mpeg",
+	"audio/wav",
+}
+
+func WriteFileResponse(filename string, contentType string, contentSize int64, lastModification time.Time, webserverMode string, fileReader io.ReadSeeker, forceDownload bool, w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "private, no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	fmt.Println("+++++++++++++ Running successfully +++++++++++")
+	if contentSize > 0 {
+		contentSizeStr := strconv.Itoa(int(contentSize))
+		if webserverMode == "gzip" {
+			w.Header().Set("X-Uncompressed-Content-Length", contentSizeStr)
+		} else {
+			w.Header().Set("Content-Length", contentSizeStr)
+		}
+	}
+
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	} else {
+		for _, unsafeContentType := range UnsafeContentTypes {
+			if strings.HasPrefix(contentType, unsafeContentType) {
+				contentType = "text/plain"
+				break
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", contentType)
+
+	var toDownload bool
+	if forceDownload {
+		toDownload = true
+	} else {
+		isMediaType := false
+
+		for _, mediaContentType := range MediaContentTypes {
+			if strings.HasPrefix(contentType, mediaContentType) {
+				isMediaType = true
+				break
+			}
+		}
+
+		toDownload = !isMediaType
+	}
+
+	filename = url.PathEscape(filename)
+
+	if toDownload {
+		w.Header().Set("Content-Disposition", "attachment;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
+	} else {
+		w.Header().Set("Content-Disposition", "inline;filename=\""+filename+"\"; filename*=UTF-8''"+filename)
+	}
+
+	// prevent file links from being embedded in iframes
+	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("Content-Security-Policy", "Frame-ancestors 'none'")
+
+	http.ServeContent(w, r, filename, lastModification, fileReader)
+}

--- a/shared/web/files.go
+++ b/shared/web/files.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package web
 
 import (


### PR DESCRIPTION
#### Summary
Moved the attachment serve response functionality method to the shared folder so that all other Mattermost products can use them which achieves to use of only a single attachment serve response throughout the Mattermost ecosystem. 

```release-note
Moved the attachment serve functionality to a shared folder making it universal throughout the mm ecosystem
```