### PR TITLE
[MM-48010] Fetch Threads since parameter should return threads with new replies.

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -6182,6 +6182,41 @@ func TestGetThreadsForUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uss.TotalUnreadThreads, int64(0))
 	})
+
+	t.Run("Since should return threads with new replies and updated memberships", func(t *testing.T) {
+		client := th.Client
+
+		// Create "thread 1"
+		rootPost1, _ := postAndCheck(t, client, &model.Post{ChannelId: th.BasicChannel.Id, Message: "Thread 1"})
+		postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel.Id, Message: "Thread 1, reply 1", RootId: rootPost1.Id})
+		uss, _, err := th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
+			Since: 0,
+		})
+		require.NoError(t, err)
+		require.Len(t, uss.Threads, 1)
+
+		// Should not fetch any threads since there are no new replies/new threads since the membership is updated
+		threadMembership, _ := th.App.GetThreadMembershipForUser(th.BasicUser.Id, rootPost1.Id)
+		uss, _, err = th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
+			Since: uint64(threadMembership.LastUpdated),
+		})
+		require.NoError(t, err)
+		require.Len(t, uss.Threads, 0)
+
+		// Create "thread 2"
+		rootPost2, _ := postAndCheck(t, client, &model.Post{ChannelId: th.BasicChannel.Id, Message: "Thread 2"})
+		postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel.Id, Message: "Thread 2, reply 1", RootId: rootPost2.Id})
+
+		// Add a reply to "thread 1"
+		postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel.Id, Message: "Thread 1, Reply 2", RootId: rootPost1.Id})
+
+		// Should fetch "thread 1" & "thread 2"
+		uss, _, err = th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
+			Since: uint64(threadMembership.LastUpdated),
+		})
+		require.NoError(t, err)
+		require.Equal(t, uss.TotalUnreadThreads, int64(2))
+	})
 }
 
 func TestThreadSocketEvents(t *testing.T) {

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -6190,7 +6190,7 @@ func TestGetThreadsForUser(t *testing.T) {
 		rootPost1, _ := postAndCheck(t, client, &model.Post{ChannelId: th.BasicChannel.Id, Message: "Thread 1"})
 		postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel.Id, Message: "Thread 1, reply 1", RootId: rootPost1.Id})
 		uss, _, err := th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
-			Since: 0,
+			Since: uint64(rootPost1.CreateAt),
 		})
 		require.NoError(t, err)
 		require.Len(t, uss.Threads, 1)
@@ -6198,7 +6198,7 @@ func TestGetThreadsForUser(t *testing.T) {
 		// Should not fetch any threads since there are no new replies/new threads since the membership is updated
 		threadMembership, _ := th.App.GetThreadMembershipForUser(th.BasicUser.Id, rootPost1.Id)
 		uss, _, err = th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
-			Since: uint64(threadMembership.LastUpdated),
+			Since: uint64(threadMembership.LastUpdated) + 1,
 		})
 		require.NoError(t, err)
 		require.Len(t, uss.Threads, 0)
@@ -6212,7 +6212,7 @@ func TestGetThreadsForUser(t *testing.T) {
 
 		// Should fetch "thread 1" & "thread 2"
 		uss, _, err = th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{
-			Since: uint64(threadMembership.LastUpdated),
+			Since: uint64(threadMembership.LastUpdated) + 1,
 		})
 		require.NoError(t, err)
 		require.Equal(t, uss.TotalUnreadThreads, int64(2))

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -316,8 +316,8 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 	if opts.Since > 0 {
 		query = query.
 			Where(sq.Or{
-				sq.Gt{"ThreadMemberships.LastUpdated": opts.Since},
-				sq.Gt{"Threads.LastReplyAt": opts.Since},
+				sq.GtOrEq{"ThreadMemberships.LastUpdated": opts.Since},
+				sq.GtOrEq{"Threads.LastReplyAt": opts.Since},
 			})
 	}
 

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -314,7 +314,11 @@ func (s *SqlThreadStore) GetThreadsForUser(userId, teamId string, opts model.Get
 	}
 
 	if opts.Since > 0 {
-		query = query.Where(sq.GtOrEq{"ThreadMemberships.LastUpdated": opts.Since})
+		query = query.
+			Where(sq.Or{
+				sq.Gt{"ThreadMemberships.LastUpdated": opts.Since},
+				sq.Gt{"Threads.LastReplyAt": opts.Since},
+			})
 	}
 
 	if opts.Unread {


### PR DESCRIPTION
#### Summary
When the `since` param is used, API only returns new threads with `since` greater than `ThreadMembership.LastUpdatedAt`. Due to this threads with new replies are not synced on the mobile client. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48010

#### Release Note
```
behavioral change
```