### PR TITLE
MM-49851: forces PostPriority config to true

### DIFF
--- a/app/migrations.go
+++ b/app/migrations.go
@@ -20,7 +20,7 @@ const ContentExtractionConfigDefaultTrueMigrationKey = "ContentExtractionConfigD
 const PlaybookRolesCreationMigrationKey = "PlaybookRolesCreationMigrationComplete"
 const FirstAdminSetupCompleteKey = model.SystemFirstAdminSetupComplete
 const remainingSchemaMigrationsKey = "RemainingSchemaMigrations"
-const PostPriorityConfigDefaultTrueMigrationKey = "PostPriorityConfigDefaultTrueMigrationComplete"
+const postPriorityConfigDefaultTrueMigrationKey = "PostPriorityConfigDefaultTrueMigrationComplete"
 
 // This function migrates the default built in roles from code/config to the database.
 func (a *App) DoAdvancedPermissionsMigration() {
@@ -541,7 +541,7 @@ func (s *Server) doRemainingSchemaMigrations() {
 
 func (s *Server) doPostPriorityConfigDefaultTrueMigration() {
 	// If the migration is already marked as completed, don't do it again.
-	if _, err := s.Store().System().GetByName(PostPriorityConfigDefaultTrueMigrationKey); err == nil {
+	if _, err := s.Store().System().GetByName(postPriorityConfigDefaultTrueMigrationKey); err == nil {
 		return
 	}
 
@@ -550,7 +550,7 @@ func (s *Server) doPostPriorityConfigDefaultTrueMigration() {
 	})
 
 	system := model.System{
-		Name:  PostPriorityConfigDefaultTrueMigrationKey,
+		Name:  postPriorityConfigDefaultTrueMigrationKey,
 		Value: "true",
 	}
 

--- a/app/migrations.go
+++ b/app/migrations.go
@@ -554,7 +554,7 @@ func (s *Server) doPostPriorityConfigDefaultTrueMigration() {
 		Value: "true",
 	}
 
-	if err := s.Store().System().Save(&system); err != nil {
+	if err := s.Store().System().SaveOrUpdate(&system); err != nil {
 		mlog.Fatal("Failed to mark post priority config migration as completed.", mlog.Err(err))
 	}
 }

--- a/testlib/store.go
+++ b/testlib/store.go
@@ -38,6 +38,7 @@ func GetMockStoreForSetupFunctions() *mocks.Store {
 	systemStore.On("GetByName", "GuestRolesCreationMigrationComplete").Return(&model.System{Name: "GuestRolesCreationMigrationComplete", Value: "true"}, nil)
 	systemStore.On("GetByName", "SystemConsoleRolesCreationMigrationComplete").Return(&model.System{Name: "SystemConsoleRolesCreationMigrationComplete", Value: "true"}, nil)
 	systemStore.On("GetByName", "PlaybookRolesCreationMigrationComplete").Return(&model.System{Name: "PlaybookRolesCreationMigrationComplete", Value: "true"}, nil)
+	systemStore.On("GetByName", "PostPriorityConfigDefaultTrueMigrationComplete").Return(&model.System{Name: "PostPriorityConfigDefaultTrueMigrationComplete", Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyEmojiPermissionsSplit).Return(&model.System{Name: model.MigrationKeyEmojiPermissionsSplit, Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyWebhookPermissionsSplit).Return(&model.System{Name: model.MigrationKeyWebhookPermissionsSplit, Value: "true"}, nil)
 	systemStore.On("GetByName", model.MigrationKeyListJoinPublicPrivateTeams).Return(&model.System{Name: model.MigrationKeyListJoinPublicPrivateTeams, Value: "true"}, nil)


### PR DESCRIPTION
#### Summary
We want to enable `PostPriority` by default since 7.7 onward. Unfortunately while the feature was still behind a feature flag we had the config as default false thus some servers have it as false even when we updated the config to default to true.

This commit inserts an one-time migration to change the config from false to true.


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49851

#### Release Note

```release-note
[Message Priority & Acknowledgement](https://docs.mattermost.com/configure/site-configuration-settings.html#message-priority) is now enabled by default for all instances. You may disable this feature in the System Console by going to **Posts > Message Priority** or via the config ``PostPriority`` setting.
```
