### PR TITLE
[OSF] Allows opening the work template modal from a slash command

### DIFF
--- a/app/slashcommands/command_templates.go
+++ b/app/slashcommands/command_templates.go
@@ -10,22 +10,22 @@ import (
 	"github.com/mattermost/mattermost-server/v6/shared/i18n"
 )
 
-type WorkTemplateProvider struct {
+type TemplatesProvider struct {
 }
 
 const (
-	CmdWorkTemplate = "worktemplate"
+	CmdTemplates = "templates"
 )
 
 func init() {
-	app.RegisterCommandProvider(&WorkTemplateProvider{})
+	app.RegisterCommandProvider(&TemplatesProvider{})
 }
 
-func (h *WorkTemplateProvider) GetTrigger() string {
-	return CmdWorkTemplate
+func (h *TemplatesProvider) GetTrigger() string {
+	return CmdTemplates
 }
 
-func (h *WorkTemplateProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command {
+func (h *TemplatesProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command {
 	workTemplateEnabled := a.Config().FeatureFlags.WorkTemplate
 	pbActive, err := a.IsPluginActive(model.PluginIdPlaybooks)
 	if err != nil {
@@ -37,17 +37,17 @@ func (h *WorkTemplateProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *mod
 	}
 
 	return &model.Command{
-		Trigger:          CmdWorkTemplate,
+		Trigger:          CmdTemplates,
 		AutoComplete:     hasBoard && pbActive && workTemplateEnabled,
-		AutoCompleteDesc: T("api.command_work_template.desc"),
-		DisplayName:      T("api.command_work_template.name"),
+		AutoCompleteDesc: T("api.command_templates.desc"),
+		DisplayName:      T("api.command_templates.name"),
 	}
 }
 
-func (h *WorkTemplateProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+func (h *TemplatesProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
 	// This command is handled client-side and shouldn't hit the server.
 	return &model.CommandResponse{
-		Text:         args.T("api.command_work_template.unsupported.app_error"),
+		Text:         args.T("api.command_templates.unsupported.app_error"),
 		ResponseType: model.CommandResponseTypeEphemeral,
 	}
 }

--- a/app/slashcommands/command_work_template.go
+++ b/app/slashcommands/command_work_template.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package slashcommands
+
+import (
+	"github.com/mattermost/mattermost-server/v6/app"
+	"github.com/mattermost/mattermost-server/v6/app/request"
+	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/shared/i18n"
+)
+
+type WorkTemplateProvider struct {
+}
+
+const (
+	CmdWorkTemplate = "worktemplate"
+)
+
+func init() {
+	app.RegisterCommandProvider(&WorkTemplateProvider{})
+}
+
+func (h *WorkTemplateProvider) GetTrigger() string {
+	return CmdWorkTemplate
+}
+
+func (h *WorkTemplateProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Command {
+	workTemplateEnabled := a.Config().FeatureFlags.WorkTemplate
+	pbActive, err := a.IsPluginActive(model.PluginIdPlaybooks)
+	if err != nil {
+		pbActive = false
+	}
+	hasBoard, err := a.HasBoardProduct()
+	if err != nil {
+		hasBoard = false
+	}
+
+	return &model.Command{
+		Trigger:          CmdWorkTemplate,
+		AutoComplete:     hasBoard && pbActive && workTemplateEnabled,
+		AutoCompleteDesc: T("api.command_work_template.desc"),
+		DisplayName:      T("api.command_work_template.name"),
+	}
+}
+
+func (h *WorkTemplateProvider) DoCommand(a *app.App, c request.CTX, args *model.CommandArgs, message string) *model.CommandResponse {
+	// This command is handled client-side and shouldn't hit the server.
+	return &model.CommandResponse{
+		Text:         args.T("api.command_work_template.unsupported.app_error"),
+		ResponseType: model.CommandResponseTypeEphemeral,
+	}
+}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1495,16 +1495,16 @@
     "translation": "shrug"
   },
   {
-    "id": "api.command_work_template.desc",
+    "id": "api.command_templates.desc",
     "translation": "Open the create from template window"
   },
   {
-    "id": "api.command_work_template.name",
-    "translation": "worktemplate"
+    "id": "api.command_templates.name",
+    "translation": "templates"
   },
   {
-    "id": "api.command_work_template.unsupported.app_error",
-    "translation": "The worktemplate command is not supported on your device."
+    "id": "api.command_templates.unsupported.app_error",
+    "translation": "The templates command is not supported on your device."
   },
   {
     "id": "api.config.client.old_format.app_error",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1495,6 +1495,18 @@
     "translation": "shrug"
   },
   {
+    "id": "api.command_work_template.desc",
+    "translation": "Open the create from template window"
+  },
+  {
+    "id": "api.command_work_template.name",
+    "translation": "worktemplate"
+  },
+  {
+    "id": "api.command_work_template.unsupported.app_error",
+    "translation": "The worktemplate command is not supported on your device."
+  },
+  {
     "id": "api.config.client.old_format.app_error",
     "translation": "New format for the client configuration is not supported yet. Please specify format=old in the query string."
   },


### PR DESCRIPTION
#### Summary
Adds a `/templates` command to open the modal.

#### Ticket Link
N/A: OSF 

#### Related Pull Requests
- Has webapp changes https://github.com/mattermost/mattermost-webapp/pull/12145

#### Release Note
```release-note
NONE
```
