### PR TITLE
MM-48048 Update HTML lang attribute based on user locale

### DIFF
--- a/web/static.go
+++ b/web/static.go
@@ -90,6 +90,14 @@ func root(c *Context, w http.ResponseWriter, r *http.Request) {
 		contents = bytes.ReplaceAll(contents, []byte(originalHTML), []byte(modifiedHTML))
 	}
 
+	htmlTemplate := "<html lang=\"%s\">"
+	originalHtmlLocale := fmt.Sprintf(htmlTemplate, html.EscapeString(model.DefaultLocale))
+	modifiedHtmlLocale := getCurrentHtmlTag(c)
+
+	if originalHtmlLocale != modifiedHtmlLocale {
+		contents = bytes.ReplaceAll(contents, []byte(originalHtmlLocale), []byte(modifiedHtmlLocale))
+	}
+
 	w.Header().Set("Content-Type", "text/html")
 	w.Write(contents)
 }
@@ -171,4 +179,16 @@ func getOpenGraphMetaTags(c *Context) string {
 	}
 
 	return titleHTML + descriptionHTML
+}
+
+func getCurrentHtmlTag(c *Context) string {
+	userLocale := model.DefaultLocale
+	htmlTemplate := "<html lang=\"%s\">"
+	user, _ := c.App.GetUser(c.AppContext.Session().UserId)
+	if user != nil {
+		userLocale = user.Locale
+	}
+
+	modifiedHtml := fmt.Sprintf(htmlTemplate, html.EscapeString(userLocale))
+	return modifiedHtml
 }


### PR DESCRIPTION
### Summary
This PR follows up on this task. https://github.com/mattermost/mattermost-webapp/pull/12159
The HTML tag always has lang="en" even if the language in settings is set to a different language

#### Fixes https://github.com/mattermost/mattermost-server/issues/21552

#### Demo video
Client demo video.
https://www.loom.com/share/19060c7452614ae984e31bc3fb757223

#### Release note
```release-note
Updates HTML lang attribute when a user updates locale
```
