### PR TITLE
MM-50355 - add senderId so the channel validations function can validate sender permissions when inviting guests

### DIFF
--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -420,6 +420,44 @@ func TestCreateUserWithToken(t *testing.T) {
 		// one channel from the two he was invited (plus the two default channels)
 		require.Len(t, channelList, 3)
 	})
+
+	t.Run("Validate inviterUser permissions on channels he is inviting, when inviting guests", func(t *testing.T) {
+		user := model.User{Email: th.GenerateTestEmail(), Nickname: "Guest User", Password: "hello1", Username: GenerateTestUsername(), Roles: model.SystemUserRoleId}
+		channelIdWithoutPermissions := th.BasicPrivateChannel2.Id
+		channelIds := th.BasicChannel.Id + " " + channelIdWithoutPermissions
+		token := model.NewToken(
+			app.TokenTypeTeamInvitation,
+			model.MapToJSON(map[string]string{"guest": "true", "teamId": th.BasicTeam.Id, "email": user.Email, "senderId": th.BasicUser.Id, "channels": channelIds}),
+		)
+		require.NoError(t, th.App.Srv().Store().Token().Save(token))
+
+		ruser, resp, err := th.Client.CreateUserWithToken(&user, token.Token)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+
+		th.Client.Login(user.Email, user.Password)
+		require.Equal(t, user.Nickname, ruser.Nickname)
+		require.Equal(t, model.SystemUserRoleId, ruser.Roles, "should clear roles")
+		CheckUserSanitization(t, ruser)
+		_, err = th.App.Srv().Store().Token().GetByToken(token.Token)
+		require.Error(t, err, "The token must be deleted after being used")
+
+		teams, appErr := th.App.GetTeamsForUser(ruser.Id)
+		require.Nil(t, appErr)
+		require.NotEmpty(t, teams, "The guest must have teams")
+		require.Equal(t, th.BasicTeam.Id, teams[0].Id, "The guest joined team must be the team provided.")
+
+		// Now we get all the channels for the just created guest
+		channelList, cErr := th.App.GetChannelsForTeamForUser(th.Context, th.BasicTeam.Id, ruser.Id, &model.ChannelSearchOpts{
+			IncludeDeleted: false,
+			LastDeleteAt:   0,
+		})
+		require.Nil(t, cErr)
+
+		// basicUser has no permissions on BasicPrivateChannel2 so the new invited guest should be able to only access
+		// one channel from the two he was invited (plus the two default channels)
+		require.Len(t, channelList, 3)
+	})
 }
 
 func TestCreateUserWebSocketEvent(t *testing.T) {

--- a/app/email/email.go
+++ b/app/email/email.go
@@ -567,6 +567,7 @@ func (es *Service) SendGuestInviteEmails(
 					"channels": strings.Join(channelIDs, " "),
 					"email":    invite,
 					"guest":    "true",
+					"senderId": senderUserId,
 				}),
 			)
 


### PR DESCRIPTION
#### Summary
As part of https://github.com/mattermost/mattermost-server/pull/22119 a new validation was added when signing up a new user created from an invitation via email token. There was a regression because in the function that sends the invitation for the Guest users, the senderId (inviter) data was not added, causing that the function running the validation has no user to check permissions against and returning false (no permission) for each of the channels.

This PR makes sure to add the senderId to the invitation token for Guests so the validation can be performed successfully.


https://user-images.githubusercontent.com/10082627/217282222-3b1a788b-b23a-4685-a8e0-2c98440863d6.mov



#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50355

#### Release Note
```release-note
NONE
```
