### PR TITLE
Restore admin notify cooloff and remove debug logs

### DIFF
--- a/api4/notify_admin.go
+++ b/api4/notify_admin.go
@@ -7,13 +7,10 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/mattermost/mattermost-server/v6/shared/mlog"
-
 	"github.com/mattermost/mattermost-server/v6/model"
 )
 
 func handleNotifyAdmin(c *Context, w http.ResponseWriter, r *http.Request) {
-	mlog.Info("enter handleNotifyAdmin")
 	var notifyAdminRequest *model.NotifyAdminToUpgradeRequest
 	err := json.NewDecoder(r.Body).Decode(&notifyAdminRequest)
 	if err != nil {
@@ -27,14 +24,11 @@ func handleNotifyAdmin(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = appErr
 		return
 	}
-	mlog.Info("exit handleNotifyAdmin")
 
 	ReturnStatusOK(w)
 }
 
 func handleTriggerNotifyAdminPosts(c *Context, w http.ResponseWriter, r *http.Request) {
-	mlog.Info("enter handleTriggerNotifyAdminPosts")
-
 	if !*c.App.Config().ServiceSettings.EnableAPITriggerAdminNotifications {
 		c.Err = model.NewAppError("Api4.handleTriggerNotifyAdminPosts", "api.cloud.app_error", nil, "Manual triggering of notifications not allowed", http.StatusForbidden)
 		return
@@ -58,8 +52,6 @@ func handleTriggerNotifyAdminPosts(c *Context, w http.ResponseWriter, r *http.Re
 		c.Err = appErr
 		return
 	}
-
-	mlog.Info("exit handleTriggerNotifyAdminPosts")
 
 	ReturnStatusOK(w)
 }

--- a/app/notify_admin.go
+++ b/app/notify_admin.go
@@ -20,7 +20,7 @@ import (
 
 const lastTrialNotificationTimeStamp = "LAST_TRIAL_NOTIFICATION_TIMESTAMP"
 const lastUpgradeNotificationTimeStamp = "LAST_UPGRADE_NOTIFICATION_TIMESTAMP"
-const defaultNotifyAdminCoolOffDays = 0.0104166667 // this is a temp change
+const defaultNotifyAdminCoolOffDays = 14
 
 func (a *App) SaveAdminNotification(userId string, notifyData *model.NotifyAdminToUpgradeRequest) *model.AppError {
 	requiredFeature := notifyData.RequiredFeature
@@ -28,7 +28,6 @@ func (a *App) SaveAdminNotification(userId string, notifyData *model.NotifyAdmin
 	trial := notifyData.TrialNotification
 
 	isUserAlreadyNotified := a.UserAlreadyNotifiedOnRequiredFeature(userId, requiredFeature)
-	mlog.Info("SaveAdminNotification")
 	if isUserAlreadyNotified {
 		return model.NewAppError("app.SaveAdminNotification", "api.cloud.notify_admin_to_upgrade_error.already_notified", nil, "", http.StatusForbidden)
 	}
@@ -61,9 +60,7 @@ func (a *App) DoCheckForAdminNotifications(trial bool) *model.AppError {
 }
 
 func (a *App) SaveAdminNotifyData(data *model.NotifyAdminData) (*model.NotifyAdminData, *model.AppError) {
-	mlog.Info("Trying to save NotifyAdmin data")
 	d, err := a.Srv().Store().NotifyAdmin().Save(data)
-	mlog.Info("NotifyAdmin data saved")
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -73,7 +70,6 @@ func (a *App) SaveAdminNotifyData(data *model.NotifyAdminData) (*model.NotifyAdm
 			return nil, model.NewAppError("SaveAdminNotifyData", "app.notify_admin.save.app_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
-	mlog.Info("return from SaveAdminNotifyData")
 
 	return d, nil
 }
@@ -88,8 +84,6 @@ func filterNotificationData(data []*model.NotifyAdminData, test func(*model.Noti
 }
 
 func (a *App) SendNotifyAdminPosts(c *request.Context, workspaceName string, currentSKU string, trial bool) *model.AppError {
-	mlog.Info("enter SendNotifyAdminPosts")
-
 	if !a.CanNotifyAdmin(trial) {
 		return model.NewAppError("SendNotifyAdminPosts", "app.notify_admin.send_notification_post.app_error", nil, "Cannot notify yet", http.StatusForbidden)
 	}
@@ -112,8 +106,6 @@ func (a *App) SendNotifyAdminPosts(c *request.Context, workspaceName string, cur
 	now := model.GetMillis()
 
 	data, err := a.Srv().Store().NotifyAdmin().Get(trial)
-	mlog.Info("SendNotifyAdminPosts")
-
 	if err != nil {
 		return model.NewAppError("SendNotifyAdminPosts", "app.notify_admin.send_notification_post.app_error", nil, err.Error(), http.StatusInternalServerError)
 	}
@@ -135,8 +127,6 @@ func (a *App) SendNotifyAdminPosts(c *request.Context, workspaceName string, cur
 		}
 
 		if len(userBasedPluginData) > 0 {
-			mlog.Info("SendNotifyAdminPosts", mlog.String("length of user based plugin data", fmt.Sprint(len(userBasedPluginData))))
-
 			a.pluginInstallAdminNotifyPost(c, userBasedPluginData, pluginBasedData, systemBot, admin)
 		}
 	}
@@ -163,11 +153,8 @@ func (a *App) pluginInstallAdminNotifyPost(c *request.Context, userBasedData map
 	props["requested_plugins_by_plugin_ids"] = pluginBasedPluginData
 	props["requested_plugins_by_user_ids"] = userBasedData
 	post.SetProps(props)
-	mlog.Info("pluginInstallAdminNotifyPost: send props")
 
 	_, appErr = a.CreatePost(c, post, channel, false, true)
-	mlog.Info("pluginInstallAdminNotifyPost: post created")
-
 	if appErr != nil {
 		a.Log().Warn("Error creating post", mlog.Err(appErr))
 	}
@@ -258,8 +245,6 @@ func (a *App) CanNotifyAdmin(trial bool) bool {
 }
 
 func (a *App) FinishSendAdminNotifyPost(trial bool, now int64, pluginBasedData map[string][]*model.NotifyAdminData) {
-	mlog.Info("FinishSendAdminNotifyPost")
-
 	systemVarName := lastUpgradeNotificationTimeStamp
 	if trial {
 		systemVarName = lastTrialNotificationTimeStamp
@@ -289,8 +274,6 @@ func (a *App) FinishSendAdminNotifyPost(trial bool, now int64, pluginBasedData m
 	if err := a.Srv().Store().NotifyAdmin().DeleteBefore(trial, now); err != nil {
 		a.Log().Error("Unable to finish send admin notify post job", mlog.Err(err))
 	}
-	mlog.Info("exit FinishSendAdminNotifyPost")
-
 }
 
 func (a *App) groupNotifyAdminByUser(data []*model.NotifyAdminData) (map[string][]*model.NotifyAdminData, map[string][]*model.NotifyAdminData) {


### PR DESCRIPTION
#### Summary
Commit done after the review of the notify admin for plugin installation have changed the value of the cooldown + introduced some debug logs. This PR fixes those changes.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
