### PR TITLE
Add additional metadata to post reminder

### DIFF
--- a/app/post.go
+++ b/app/post.go
@@ -2170,10 +2170,12 @@ func (a *App) CheckPostReminders() {
 					"PostId":   postID,
 					"Username": metadata.Username,
 				}),
-				Type:   model.PostTypeDefault,
+				Type:   model.PostTypeReminder,
 				UserId: systemBot.UserId,
 				Props: model.StringInterface{
-					"username": systemBot.Username,
+					"team_name": metadata.TeamName,
+					"post_id":   postID,
+					"username":  systemBot.Username,
 				},
 			}
 

--- a/app/post.go
+++ b/app/post.go
@@ -2175,7 +2175,7 @@ func (a *App) CheckPostReminders() {
 				Props: model.StringInterface{
 					"team_name": metadata.TeamName,
 					"post_id":   postID,
-					"username":  systemBot.Username,
+					"username":  metadata.Username,
 				},
 			}
 

--- a/model/post.go
+++ b/model/post.go
@@ -415,6 +415,7 @@ func (o *Post) IsValid(maxPostSize int) *AppError {
 		PostTypeAddBotTeamsChannels,
 		PostTypeSystemWarnMetricStatus,
 		PostTypeWelcomePost,
+		PostTypeReminder,
 		PostTypeMe:
 	default:
 		if !strings.HasPrefix(o.Type, PostCustomTypePrefix) {


### PR DESCRIPTION
The webapp needs to construct the full message because
the team_name needs to be inserted into the permalink.

So we need to send everything in the metadata for the
client to construct the message.

Also, we set a custom post type for the client to easily
add a custom condition.

```release-note
NONE
```
