### PR TITLE
The GH token is not required for accesing PR metadata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     parameters:
       target-branch:
         type: string
-        default: '$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" $(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//") | jq ".base.ref" | tr -d "\042" )'
+        default: '$(curl -s $(echo https://api.github.com/repos/${CIRCLE_PULL_REQUEST:19} | sed "s/\/pull\//\/pulls\//") | jq ".base.ref" | tr -d "\042" )'
     working_directory: /mnt/ramdisk/mattermost-server
     docker:
       - image: cimg/go:1.18


### PR DESCRIPTION

#### Summary
It appears that we don't need to use the token, this would solve the context issue in the automated cherry-picks

#### Release Note

```release-note
NONE
```
