### PR TITLE
MM-50443 - LdapSettings.SyncEnabled error message

### DIFF
--- a/app/ldap.go
+++ b/app/ldap.go
@@ -24,8 +24,8 @@ func (a *App) SyncLdap(includeRemovedMembers bool) {
 				mlog.Error("LdapSettings.EnableSync is set to false. Skipping LDAP sync.")
 				return
 			}
-			ldapI := a.Ldap()
 
+			ldapI := a.Ldap()
 			if ldapI == nil {
 				mlog.Error("Not executing ldap sync because ldap is not available")
 				return

--- a/app/ldap.go
+++ b/app/ldap.go
@@ -20,15 +20,17 @@ func (a *App) SyncLdap(includeRemovedMembers bool) {
 	a.Srv().Go(func() {
 
 		if license := a.Srv().License(); license != nil && *license.Features.LDAP {
-			if *a.Config().LdapSettings.EnableSync {
-				if ldapI := a.Ldap(); ldapI != nil {
-					ldapI.StartSynchronizeJob(false, includeRemovedMembers)
-				} else {
-					mlog.Error("Not executing ldap sync because ldap is not available")
-				}
-			} else {
+			if !*a.Config().LdapSettings.EnableSync {
 				mlog.Error("LdapSettings.EnableSync is set to false. Skipping LDAP sync.")
+				return
 			}
+			ldapI := a.Ldap()
+
+			if ldapI == nil {
+				mlog.Error("Not executing ldap sync because ldap is not available")
+				return
+			}
+			ldapI.StartSynchronizeJob(false, includeRemovedMembers)
 		}
 	})
 }

--- a/app/ldap.go
+++ b/app/ldap.go
@@ -19,11 +19,15 @@ import (
 func (a *App) SyncLdap(includeRemovedMembers bool) {
 	a.Srv().Go(func() {
 
-		if license := a.Srv().License(); license != nil && *license.Features.LDAP && *a.Config().LdapSettings.EnableSync {
-			if ldapI := a.Ldap(); ldapI != nil {
-				ldapI.StartSynchronizeJob(false, includeRemovedMembers)
+		if license := a.Srv().License(); license != nil && *license.Features.LDAP {
+			if *a.Config().LdapSettings.EnableSync {
+				if ldapI := a.Ldap(); ldapI != nil {
+					ldapI.StartSynchronizeJob(false, includeRemovedMembers)
+				} else {
+					mlog.Error("Not executing ldap sync because ldap is not available")
+				}
 			} else {
-				mlog.Error("Not executing ldap sync because ldap is not available")
+				mlog.Error("LdapSettings.EnableSync is set to false. Skipping LDAP sync.")
 			}
 		}
 	})


### PR DESCRIPTION
#### Summary
This adds a simple error that occurs when you run an LDAP sync via mmctl or the api.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50443

#### Release Note
```release-note
Added an error message when you run LDAP sync with `SyncEnabled` set to false.
```

