### PR TITLE
Avoid divide by zero when hubs not created before first websocket msg

### DIFF
--- a/app/platform/web_hub.go
+++ b/app/platform/web_hub.go
@@ -121,6 +121,10 @@ func (ps *PlatformService) HubStop() {
 
 // GetHubForUserId returns the hub for a given user id.
 func (ps *PlatformService) GetHubForUserId(userID string) *Hub {
+	if len(ps.hubs) == 0 {
+		return nil
+	}
+
 	// TODO: check if caching the userID -> hub mapping
 	// is worth the memory tradeoff.
 	// https://mattermost.atlassian.net/browse/MM-26629.


### PR DESCRIPTION
#### Summary
This PR avoids a divide-by-zero panic on server start-up due to websocket messages being sent during plugin start-up, before web_hubs are created.  `GetHubForUserId` assumes the hubs are created but can get called before they are.  All callers of `GetHubForUserId` check for a nil return, so this PR simply returns a nil in this case. 

This is a simpler fix than trying to refactor the server init sequence (again).

```
error [2023-02-10 10:31:26.450 -05:00] CallbackQueue callback panic                  caller="utils/callbackqueue.go:124" product=boards name=blockChangeNotifier panic="runtime error: integer divide by zero" stack="goroutine 5374 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x65
github.com/mattermost/focalboard/server/utils.(*CallbackQueue).exec.func1()
	/home/dlauder/Development/mattermost/focalboard/server/utils/callbackqueue.go:123 +0x58
panic({0x29f6ba0, 0x5324820})
	/usr/local/go/src/runtime/panic.go:884 +0x212
github.com/mattermost/mattermost-server/v6/app/platform.(*PlatformService).GetHubForUserId(0xc00109ea00, {0x2d8c500?, 0xc00515eb40?})
	/home/dlauder/Development/mattermost/mattermost-server/app/platform/web_hub.go:130 +0xd4
github.com/mattermost/mattermost-server/v6/app/platform.(*PlatformService).PublishSkipClusterSend(0xc00109ea00, 0xc00515eb10)
	/home/dlauder/Development/mattermost/mattermost-server/app/platform/cluster.go:215 +0x59
github.com/mattermost/mattermost-server/v6/app/platform.(*PlatformService).Publish(0xc00109ea00, 0xc00515eb10)
	/home/dlauder/Development/mattermost/mattermost-server/app/platform/cluster.go:187 +0x74
github.com/mattermost/mattermost-server/v6/app/platform.(*PlatformService).PublishWebSocketEvent(0x0?, {0x2d8a83e?, 0xc0000dfa00?}, {0x2da699a, 0xc}, 0xc005227d10, 0xc004558de0)
	/home/dlauder/Development/mattermost/mattermost-server/app/platform/cluster.go:81 +0x2b5
github.com/mattermost/focalboard/mattermost-plugin/product.(*serviceAPIAdapter).PublishWebSocketEvent(0xc000266140?, {0x2da699a?, 0x1?}, 0xc00509af80?, 0x1b?)
	/home/dlauder/Development/mattermost/focalboard/mattermost-plugin/product/api_adapter.go:173 +0x42
github.com/mattermost/focalboard/server/ws.(*PluginAdapter).sendUserMessageSkipCluster(...)
	/home/dlauder/Development/mattermost/focalboard/server/ws/plugin_adapter.go:404
github.com/mattermost/focalboard/server/ws.(*PluginAdapter).sendBoardMessageSkipCluster(0xc000266140, {0x4b8a740?, 0x0?}, {0xc00509af80?, 0xc0000dfad8?}, 0x40f7a7?, {0xc0052375c0?, 0x28fb4a0?, 0xc002b1d101?})
	/home/dlauder/Development/mattermost/focalboard/server/ws/plugin_adapter.go:435 +0xf2
github.com/mattermost/focalboard/server/ws.(*PluginAdapter).sendBoardMessage(0xc000266140, {0x4b8a740, 0x1}, {0xc00509af80, 0x1b}, 0xc005227d10, {0xc0052375c0, 0x1, 0x1})
	/home/dlauder/Development/mattermost/focalboard/server/ws/plugin_adapter.go:453 +0x176
github.com/mattermost/focalboard/server/ws.(*PluginAdapter).BroadcastMemberChange(0xc000266140, {0x4b8a740, 0x1}, {0xc00509af80, 0x1b}, 0xc0050f32c0)
	/home/dlauder/Development/mattermost/focalboard/server/ws/plugin_adapter.go:627 +0x52d
github.com/mattermost/focalboard/server/app.(*App).AddMemberToBoard.func1()
	/home/dlauder/Development/mattermost/focalboard/server/app/boards.go:546 +0x3d
github.com/mattermost/focalboard/server/utils.(*CallbackQueue).exec(0xc000e60eb0, 0xc0000dff60?)
	/home/dlauder/Development/mattermost/focalboard/server/utils/callbackqueue.go:132 +0x76
github.com/mattermost/focalboard/server/utils.(*CallbackQueue).loop(0xc000e60eb0, 0xc0028d21b0?)
	/home/dlauder/Development/mattermost/focalboard/server/utils/callbackqueue.go:112 +0x8d
created by github.com/mattermost/focalboard/server/utils.NewCallbackQueue
	/home/dlauder/Development/mattermost/focalboard/server/utils/callbackqueue.go:44 +0x147
```

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```
