### PR TITLE
Improve error handling when plugin checksum fails

### DIFF
--- a/plugin/supervisor.go
+++ b/plugin/supervisor.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	plugin "github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-server/v6/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -70,7 +71,7 @@ func newSupervisor(pluginInfo *model.BundleInfo, apiImpl API, driver Driver, par
 	// https://mattermost.atlassian.net/browse/MM-49167
 	pluginChecksum, err := getPluginExecutableChecksum(executable)
 	if err != nil {
-		return nil, fmt.Errorf("unable to generate a checksum for the plugin %s", pluginInfo.Path)
+		return nil, errors.Wrapf(err, "unable to generate a checksum for the plugin %s", pluginInfo.Path)
 	}
 
 	sup.client = plugin.NewClient(&plugin.ClientConfig{


### PR DESCRIPTION
#### Summary

This PR makes sure we include the specific error that occurred in the log message, when we fail to generate a checksum for a plugin. In my case, the linux binary was missing from my plugin bundle because I built with `MM_SERVICESETTINGS_ENABLEDEVELOPER=true`, but I didn't know this was the case until I made the change in this PR.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
