### PR TITLE
[MM-49641] - System console setting to disable channel autocomplete

### DIFF
--- a/config/client.go
+++ b/config/client.go
@@ -270,6 +270,8 @@ func GenerateLimitedClientConfig(c *model.Config, telemetryID string, license *m
 
 	props["DefaultClientLocale"] = *c.LocalizationSettings.DefaultClientLocale
 
+	props["EnableChannelAutocomplete"] = strconv.FormatBool(*c.ChannelSettings.EnableChannelAutocomplete)
+
 	props["EnableCustomEmoji"] = strconv.FormatBool(*c.ServiceSettings.EnableCustomEmoji)
 	props["AppDownloadLink"] = *c.NativeAppSettings.AppDownloadLink
 	props["AndroidAppDownloadLink"] = *c.NativeAppSettings.AndroidAppDownloadLink

--- a/model/config.go
+++ b/model/config.go
@@ -2329,6 +2329,16 @@ func (s *LocalizationSettings) SetDefaults() {
 	}
 }
 
+type ChannelSettings struct {
+	EnableChannelAutocomplete *bool `access:"site_posts"`
+}
+
+func (s *ChannelSettings) SetDefaults() {
+	if s.EnableChannelAutocomplete == nil {
+		s.EnableChannelAutocomplete = NewBool(true)
+	}
+}
+
 type SamlSettings struct {
 	// Basic
 	Enable                        *bool `access:"authentication_saml"`
@@ -3174,6 +3184,7 @@ type Config struct {
 	LdapSettings              LdapSettings
 	ComplianceSettings        ComplianceSettings
 	LocalizationSettings      LocalizationSettings
+	ChannelSettings           ChannelSettings
 	SamlSettings              SamlSettings
 	NativeAppSettings         NativeAppSettings
 	ClusterSettings           ClusterSettings
@@ -3289,6 +3300,7 @@ func (o *Config) SetDefaults() {
 	o.AnalyticsSettings.SetDefaults()
 	o.ComplianceSettings.SetDefaults()
 	o.LocalizationSettings.SetDefaults()
+	o.ChannelSettings.SetDefaults()
 	o.ElasticsearchSettings.SetDefaults()
 	o.BleveSettings.SetDefaults()
 	o.NativeAppSettings.SetDefaults()

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -49,6 +49,7 @@ const (
 	TrackConfigLDAP              = "config_ldap"
 	TrackConfigCompliance        = "config_compliance"
 	TrackConfigLocalization      = "config_localization"
+	TrackConfigChannel           = "config_channel"
 	TrackConfigSAML              = "config_saml"
 	TrackConfigPassword          = "config_password"
 	TrackConfigCluster           = "config_cluster"
@@ -679,6 +680,10 @@ func (ts *TelemetryService) trackConfig() {
 		"default_server_locale": *cfg.LocalizationSettings.DefaultServerLocale,
 		"default_client_locale": *cfg.LocalizationSettings.DefaultClientLocale,
 		"available_locales":     *cfg.LocalizationSettings.AvailableLocales,
+	})
+
+	ts.SendTelemetry(TrackConfigChannel, map[string]any{
+		"enable_channel_autocomplete": *cfg.ChannelSettings.EnableChannelAutocomplete,
 	})
 
 	ts.SendTelemetry(TrackConfigSAML, map[string]any{


### PR DESCRIPTION

#### Summary
System console setting to disable channel autocomplete.
It is a follow up on the this frontend task https://github.com/mattermost/mattermost-webapp/pull/12199


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-server/issues/22068

#### Demo video
https://www.loom.com/share/5b23a1494f234cc6a538c4af1aec873b

#### Release note
```release-note
Adds system console setting to enable/disable channel autocomplete
```
