### PR TITLE
MM-45009: fixes threads after leaving channel

### DIFF
--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -486,7 +486,7 @@ func (s *SqlThreadStore) GetThreadFollowers(threadID string, fetchOnlyActive boo
 	users := []string{}
 
 	fetchConditions := sq.And{
-		sq.Eq{"PostId": threadID},
+		sq.Eq{"ThreadMemberships.PostId": threadID},
 	}
 
 	if fetchOnlyActive {

--- a/store/storetest/thread_store.go
+++ b/store/storetest/thread_store.go
@@ -1848,7 +1848,7 @@ func testMarkAllAsReadByTeam(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	for _, userId := range userIds {
-		_, err := ss.Channel().SaveMember(&model.ChannelMember{
+		_, err = ss.Channel().SaveMember(&model.ChannelMember{
 			ChannelId:   team2channel2.Id,
 			UserId:      userId,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
@@ -1924,7 +1924,7 @@ func testMarkAllAsReadByTeam(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	for _, userId := range userIds {
-		_, err := ss.Channel().SaveMember(&model.ChannelMember{
+		_, err = ss.Channel().SaveMember(&model.ChannelMember{
 			ChannelId:   gm1.Id,
 			UserId:      userId,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),
@@ -1955,7 +1955,7 @@ func testMarkAllAsReadByTeam(t *testing.T, ss store.Store) {
 	require.NoError(t, err)
 
 	for _, userId := range userIds {
-		_, err := ss.Channel().SaveMember(&model.ChannelMember{
+		_, err = ss.Channel().SaveMember(&model.ChannelMember{
 			ChannelId:   gm2.Id,
 			UserId:      userId,
 			NotifyProps: model.GetDefaultChannelNotifyProps(),


### PR DESCRIPTION
#### Summary

Currently we don't filter out threads from channel a user is no longer a member of.
This commit excludes threads from those channels.

The store methods affected:

- GetThreadForUser
- GetThreadsForUser
- GetThreadFollowers
- GetTotalUnreadMentions
- GetTotalUnreadUrgentMentions
- GetTeamsUnreadForUser


#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45009

#### Release Note

```release-note
Fixed a bug where a user would still see threads, in threads view, of channels they have left.
```
