### PR TITLE
MM-47489 Assume Remote Cluster Service enabled if Shared Channels enabled.

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -579,7 +579,7 @@ func (s *Server) startInterClusterServices(license *model.License) error {
 
 	// Remote Cluster service
 
-	// License check  (assumed enabled if shared channels enabled)
+	// License check (assume enabled if shared channels enabled)
 	if !*license.Features.RemoteClusterService && !license.HasSharedChannels() {
 		mlog.Debug("License does not have Remote Cluster services enabled")
 		return nil

--- a/app/server.go
+++ b/app/server.go
@@ -579,8 +579,8 @@ func (s *Server) startInterClusterServices(license *model.License) error {
 
 	// Remote Cluster service
 
-	// License check
-	if !*license.Features.RemoteClusterService {
+	// License check  (assumed enabled if shared channels enabled)
+	if !*license.Features.RemoteClusterService && !license.HasSharedChannels() {
 		mlog.Debug("License does not have Remote Cluster services enabled")
 		return nil
 	}
@@ -606,7 +606,7 @@ func (s *Server) startInterClusterServices(license *model.License) error {
 	s.remoteClusterService = rcs
 	s.serviceMux.Unlock()
 
-	// Shared Channels service
+	// Shared Channels service (depends on remote cluster service)
 
 	// License check
 	if !license.HasSharedChannels() {

--- a/app/server.go
+++ b/app/server.go
@@ -586,7 +586,7 @@ func (s *Server) startInterClusterServices(license *model.License) error {
 	}
 
 	// Config check
-	if !*s.platform.Config().ExperimentalSettings.EnableRemoteClusterService {
+	if !*s.platform.Config().ExperimentalSettings.EnableRemoteClusterService && !*s.platform.Config().ExperimentalSettings.EnableSharedChannels {
 		mlog.Debug("Remote Cluster Service disabled via config")
 		return nil
 	}


### PR DESCRIPTION
#### Summary
The ticket linked below intended to enable Shared Channels for Professional licenses.  The PRs missed adding the dependency Remote Cluster Service to the professional license.  This PR corrects that by assuming Remote Cluster Service is enabled if Shared Channels is enabled.  It also simplifies configuration by allowing users to simply set the Shared Channels config item.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47489

#### Release Note
```release-note
Shared Channels feature included in Professional license.
```
