### PR TITLE
[MM-36817] Fix "Missing plugin executable should fail with explicit error"

### DIFF
--- a/plugin/supervisor.go
+++ b/plugin/supervisor.go
@@ -59,9 +59,13 @@ func newSupervisor(pluginInfo *model.BundleInfo, apiImpl API, driver Driver, par
 		".",
 		pluginInfo.Manifest.GetExecutableForRuntime(runtime.GOOS, runtime.GOARCH),
 	))
+	if executable == "" {
+		return nil, fmt.Errorf("backend executable not found for plugin %s. GOOS - %s. GOARCH - %s", pluginInfo.Path, runtime.GOOS, runtime.GOARCH)
+	}
 	if strings.HasPrefix(executable, "..") {
 		return nil, fmt.Errorf("invalid backend executable")
 	}
+
 	executable = filepath.Join(pluginInfo.Path, executable)
 
 	cmd := exec.Command(executable)


### PR DESCRIPTION
#### Summary

At the moment, the error received when a plugin executable is missing is cryptic:

```
unable to start plugin: com.mattermost.custom-attributes: unable to generate a checksum for the plugin plugins/com.mattermost.custom-attributes: read plugins/com.mattermost.custom-attributes: is a directory
```


This PR makes it so we log a more specific error when the executable is missing:

```
unable to start plugin: com.mattermost.custom-attributes: backend executable not found for plugin %s. GOOS - darwin. GOARCH - arm64
```

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-36817


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
