### PR TITLE
add sentry org to the env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       env:
         DOCKER_CLI_EXPERIMENTAL: enabled
       run: |
-        export TAG=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+        export TAG=$(echo "${{ github.event.pull_request.head.sha || github.sha }}" | cut -c1-7)
         cd build
         export DOCKER_CLI_EXPERIMENTAL=enabled
         export MM_PACKAGE=https://pr-builds.mattermost.com/mattermost-server/commit/${GITHUB_SHA}/mattermost-team-linux-amd64.tar.gz
@@ -277,9 +277,10 @@ jobs:
       - test-postgres-binary
       - test-postgres-normal
       - test-mysql
-    if:  ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' }}
     env:
       SENTRY_CLI_VERSION: 1.64.1
+      SENTRY_ORG: mattermost-mr
     steps:
       - name: Checkout mattermost-server
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0


### PR DESCRIPTION

#### Summary
The sentry organization is required for the sentry-cli. Since it was being set from the env vars before, I missed to include that.


#### Release Note

```release-note
NONE
```
