### PR TITLE
[MM-51054] Allow enabling/disabling plugins through env override

### DIFF
--- a/config/common_test.go
+++ b/config/common_test.go
@@ -188,9 +188,9 @@ func TestConfigEnvironmentOverridesPluginStates(t *testing.T) {
 	require.NoError(t, err)
 	originalConfig := &model.Config{}
 	originalConfig.PluginSettings.PluginStates = map[string]*model.PluginState{
-		"focalboard":           &model.PluginState{Enable: true},
-		"playbooks":            &model.PluginState{Enable: false},
-		"com.mattermost.calls": &model.PluginState{Enable: true},
+		"focalboard":           {Enable: true},
+		"playbooks":            {Enable: false},
+		"com.mattermost.calls": {Enable: true},
 	}
 
 	os.Setenv("MM_PLUGINSETTINGS_PLUGINSTATES_PLAYBOOKS", "true")


### PR DESCRIPTION
#### Summary

PR implements some logic to enable overriding the plugins state through env variables more granularly (at plugin level). Before it was only possible to set the whole JSON object (e.g. `MM_PLUGINSETTINGS_PLUGINSTATES="{\"com.mattermost.calls\":{\"Enable\":true}"`) which isn't very convenient.

To be noted, this won't behave exactly like other environment overrides as the implementation is lacking a way to detect the applied override and remove it from config so it's more of a permanent override meaning the value gets actually persisted in the config. I think this is fine for the current need (permanently disable certain plugins) and can be improved at a later time.

@amyblais This is needed to unblock https://community.mattermost.com/private-core/channels/edwwn1bfafgzxxsufk8znst7ye

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51054

#### Release Notes

```release-note
Added support to override plugins state (enable/disable) through environment variables (e.g. `MM_PLUGINSETTINGS_PLUGINSTATES_PLAYBOOKS=true`). Note: the state will be persisted in the configuration so it should not be used for temporary overrides.
```
