### PR TITLE
[MM-49993] Return error if there is no telemetry ID

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -360,7 +360,11 @@ func NewServer(options ...Option) (*Server, error) {
 	})
 	s.htmlTemplateWatcher = htmlTemplateWatcher
 
-	s.telemetryService = telemetry.New(New(ServerConnector(s.Channels())), s.Store(), s.platform.SearchEngine, s.Log(), *s.Config().LogSettings.VerboseDiagnostics)
+	s.telemetryService, err = telemetry.New(New(ServerConnector(s.Channels())), s.Store(), s.platform.SearchEngine, s.Log(), *s.Config().LogSettings.VerboseDiagnostics)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to initialize telemetry service")
+	}
+
 	s.platform.SetTelemetryId(s.TelemetryId()) // TODO: move this into platform once telemetry service moved to platform.
 
 	emailService, err := email.NewService(email.ServiceConfig{

--- a/services/telemetry/telemetry.go
+++ b/services/telemetry/telemetry.go
@@ -142,12 +142,14 @@ func (ts *TelemetryService) ensureTelemetryID() error {
 		ts.log.Info("Ensuring the telemetry ID", mlog.String("id", id))
 		systemID := &model.System{Name: model.SystemTelemetryId, Value: id}
 		systemID, err = ts.dbStore.System().InsertIfExists(systemID)
-		if err == nil {
-			ts.TelemetryID = systemID.Value
-			return nil
+		if err != nil {
+			ts.log.Info("Unable to get/set the telemetry ID", mlog.Err(err))
+			time.Sleep(DBAccessTimeoutSecs * time.Second)
+			continue
 		}
 
-		time.Sleep(DBAccessTimeoutSecs * time.Second)
+		ts.TelemetryID = systemID.Value
+		return nil
 	}
 
 	return fmt.Errorf("unable to get the telemetry ID: %w", err)

--- a/services/telemetry/telemetry_test.go
+++ b/services/telemetry/telemetry_test.go
@@ -346,7 +346,7 @@ func TestEnsureTelemetryID(t *testing.T) {
 		systemStore := storeMocks.SystemStore{}
 
 		insertError := errors.New("insert error")
-		systemStore.On("InsertIfExists", mock.AnythingOfType("*model.System")).Return(nil, insertError).Once()
+		systemStore.On("InsertIfExists", mock.AnythingOfType("*model.System")).Return(nil, insertError).Times(DBAccessAttempts)
 
 		storeMock.On("System").Return(&systemStore)
 

--- a/services/telemetry/telemetry_test.go
+++ b/services/telemetry/telemetry_test.go
@@ -119,7 +119,9 @@ func makeTelemetryServiceAndReceiver(t *testing.T, cloudLicense bool) (*Telemetr
 		pchan <- p
 	}))
 
-	service := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
+	service, err := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
+	require.NoError(t, err)
+
 	service.TelemetryID = testTelemetryID
 	service.rudderClient = nil
 	service.initRudder(receiver.URL, RudderKey)
@@ -297,7 +299,9 @@ func TestEnsureTelemetryID(t *testing.T) {
 
 		testLogger, _ := mlog.NewLogger()
 
-		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
+		telemetryService, err := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
+		require.NoError(t, err)
+
 		assert.Equal(t, "test", telemetryService.TelemetryID)
 
 		telemetryService.ensureTelemetryID()
@@ -330,7 +334,9 @@ func TestEnsureTelemetryID(t *testing.T) {
 
 		testLogger, _ := mlog.NewLogger()
 
-		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
+		telemetryService, err := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
+		require.NoError(t, err)
+
 		assert.Equal(t, generatedID, telemetryService.TelemetryID)
 	})
 
@@ -350,8 +356,8 @@ func TestEnsureTelemetryID(t *testing.T) {
 
 		testLogger, _ := mlog.NewLogger()
 
-		telemetryService := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
-		assert.Equal(t, "", telemetryService.TelemetryID)
+		_, err := New(serverIfaceMock, storeMock, searchengine.NewBroker(cfg), testLogger, false)
+		require.Error(t, err)
 	})
 }
 


### PR DESCRIPTION

#### Summary
We are making sure that the telemetry ID is written or being read from the systems table. If not, we are returning the error upwards.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49993

#### Release Note

```release-note
The app server won't start if the telemetry ID in the systems table doesn't exist. Although there is no action required by the administrators, it may be good to be aware of this change.
```
