### PR TITLE
Revert "[MM-50996] Set WorkTemplate FF to true by default"

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -102,7 +102,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.SendWelcomePost = true
 	f.PostPriority = true
 	f.PeopleProduct = false
-	f.WorkTemplate = true
+	f.WorkTemplate = false
 	f.ReduceOnBoardingTaskList = false
 	f.ThreadsEverywhere = false
 	f.GlobalDrafts = true


### PR DESCRIPTION
Reverts mattermost/mattermost-server#22427
Boards is being reverted back to plugin mode due to an incident in the latest Cloud release.