### PR TITLE
Support product-registered commands

### DIFF
--- a/app/app_iface.go
+++ b/app/app_iface.go
@@ -75,6 +75,8 @@ type AppIface interface {
 	// overriding attributes set by the user's login provider; otherwise, the name of the offending
 	// field is returned.
 	CheckProviderAttributes(user *model.User, patch *model.UserPatch) string
+	// CommandsForTeam returns all the plugin and product commands for the given team.
+	CommandsForTeam(teamID string) []*model.Command
 	// ComputeLastAccessibleFileTime updates cache with CreateAt time of the last accessible file as per the cloud plan's limit.
 	// Use GetLastAccessibleFileTime() to access the result.
 	ComputeLastAccessibleFileTime() error
@@ -944,7 +946,6 @@ type AppIface interface {
 	PermanentDeleteTeam(c request.CTX, team *model.Team) *model.AppError
 	PermanentDeleteTeamId(c request.CTX, teamID string) *model.AppError
 	PermanentDeleteUser(c *request.Context, user *model.User) *model.AppError
-	PluginCommandsForTeam(teamID string) []*model.Command
 	PostActionCookieSecret() []byte
 	PostAddToChannelMessage(c request.CTX, user *model.User, addedUser *model.User, channel *model.Channel, postRootId string) *model.AppError
 	PostPatchWithProxyRemovedFromImageURLs(patch *model.PostPatch) *model.PostPatch
@@ -970,6 +971,7 @@ type AppIface interface {
 	RegenerateTeamInviteId(teamID string) (*model.Team, *model.AppError)
 	RegisterCollectionAndTopic(pluginID, collectionType, topicType string) error
 	RegisterPluginCommand(pluginID string, command *model.Command) error
+	RegisterProductCommand(ProductID string, command *model.Command) error
 	ReloadConfig() error
 	RemoveAllDeactivatedMembersFromChannel(c request.CTX, channel *model.Channel) *model.AppError
 	RemoveChannelsFromRetentionPolicy(policyID string, channelIDs []string) *model.AppError

--- a/app/channels.go
+++ b/app/channels.go
@@ -48,6 +48,9 @@ type Channels struct {
 	pluginsEnvironment     *plugin.Environment
 	pluginConfigListenerID string
 
+	productCommandsLock sync.RWMutex
+	productCommands     []*ProductCommand
+
 	imageProxy *imageproxy.ImageProxy
 
 	// cached counts that are used during notice condition validation
@@ -331,7 +334,7 @@ func (ch *Channels) RequestTrialLicense(requesterID string, users int, termsAcce
 }
 
 func (a *App) HooksManager() *product.HooksManager {
-	return a.Srv().hooksManager
+	return a.ch.srv.hooksManager
 }
 
 // Ensure hooksService implements `product.HooksService`

--- a/app/opentracing/opentracing_layer.go
+++ b/app/opentracing/opentracing_layer.go
@@ -1592,6 +1592,23 @@ func (a *OpenTracingAppLayer) Cloud() einterfaces.CloudInterface {
 	return resultVar0
 }
 
+func (a *OpenTracingAppLayer) CommandsForTeam(teamID string) []*model.Command {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CommandsForTeam")
+
+	a.ctx = newCtx
+	a.app.Srv().Store().SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store().SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.CommandsForTeam(teamID)
+
+	return resultVar0
+}
+
 func (a *OpenTracingAppLayer) CompareAndDeletePluginKey(pluginID string, key string, oldValue []byte) (bool, *model.AppError) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.CompareAndDeletePluginKey")
@@ -13241,23 +13258,6 @@ func (a *OpenTracingAppLayer) PermanentDeleteUser(c *request.Context, user *mode
 	return resultVar0
 }
 
-func (a *OpenTracingAppLayer) PluginCommandsForTeam(teamID string) []*model.Command {
-	origCtx := a.ctx
-	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.PluginCommandsForTeam")
-
-	a.ctx = newCtx
-	a.app.Srv().Store().SetContext(newCtx)
-	defer func() {
-		a.app.Srv().Store().SetContext(origCtx)
-		a.ctx = origCtx
-	}()
-
-	defer span.Finish()
-	resultVar0 := a.app.PluginCommandsForTeam(teamID)
-
-	return resultVar0
-}
-
 func (a *OpenTracingAppLayer) PopulateWebConnConfig(s *model.Session, cfg *platform.WebConnConfig, seqVal string) (*platform.WebConnConfig, error) {
 	origCtx := a.ctx
 	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.PopulateWebConnConfig")
@@ -13828,6 +13828,28 @@ func (a *OpenTracingAppLayer) RegisterPluginCommand(pluginID string, command *mo
 
 	defer span.Finish()
 	resultVar0 := a.app.RegisterPluginCommand(pluginID, command)
+
+	if resultVar0 != nil {
+		span.LogFields(spanlog.Error(resultVar0))
+		ext.Error.Set(span, true)
+	}
+
+	return resultVar0
+}
+
+func (a *OpenTracingAppLayer) RegisterProductCommand(ProductID string, command *model.Command) error {
+	origCtx := a.ctx
+	span, newCtx := tracing.StartSpanWithParentByContext(a.ctx, "app.RegisterProductCommand")
+
+	a.ctx = newCtx
+	a.app.Srv().Store().SetContext(newCtx)
+	defer func() {
+		a.app.Srv().Store().SetContext(origCtx)
+		a.ctx = origCtx
+	}()
+
+	defer span.Finish()
+	resultVar0 := a.app.RegisterProductCommand(ProductID, command)
 
 	if resultVar0 != nil {
 		span.LogFields(spanlog.Error(resultVar0))

--- a/app/plugin_api.go
+++ b/app/plugin_api.go
@@ -1101,7 +1101,7 @@ func (api *PluginAPI) ListPluginCommands(teamID string) ([]*model.Command, error
 	commands := make([]*model.Command, 0)
 	seen := make(map[string]bool)
 
-	for _, cmd := range api.app.PluginCommandsForTeam(teamID) {
+	for _, cmd := range api.app.CommandsForTeam(teamID) {
 		if !seen[cmd.Trigger] {
 			seen[cmd.Trigger] = true
 			commands = append(commands, cmd)

--- a/app/plugin_commands.go
+++ b/app/plugin_commands.go
@@ -107,20 +107,20 @@ func (a *App) CommandsForTeam(teamID string) []*model.Command {
 	var commands []*model.Command
 
 	a.ch.pluginCommandsLock.RLock()
-	defer a.ch.pluginCommandsLock.RUnlock()
 	for _, pc := range a.ch.pluginCommands {
 		if pc.Command.TeamId == "" || pc.Command.TeamId == teamID {
 			commands = append(commands, pc.Command)
 		}
 	}
+	a.ch.pluginCommandsLock.RUnlock()
 
 	a.ch.productCommandsLock.RLock()
-	defer a.ch.productCommandsLock.RUnlock()
 	for _, pc := range a.ch.productCommands {
 		if pc.Command.TeamId == "" || pc.Command.TeamId == teamID {
 			commands = append(commands, pc.Command)
 		}
 	}
+	a.ch.productCommandsLock.RUnlock()
 	return commands
 }
 

--- a/app/plugin_commands.go
+++ b/app/plugin_commands.go
@@ -102,12 +102,21 @@ func (ch *Channels) unregisterPluginCommands(pluginID string) {
 	ch.pluginCommands = remaining
 }
 
-func (a *App) PluginCommandsForTeam(teamID string) []*model.Command {
+// CommandsForTeam returns all the plugin and product commands for the given team.
+func (a *App) CommandsForTeam(teamID string) []*model.Command {
+	var commands []*model.Command
+
 	a.ch.pluginCommandsLock.RLock()
 	defer a.ch.pluginCommandsLock.RUnlock()
-
-	var commands []*model.Command
 	for _, pc := range a.ch.pluginCommands {
+		if pc.Command.TeamId == "" || pc.Command.TeamId == teamID {
+			commands = append(commands, pc.Command)
+		}
+	}
+
+	a.ch.productCommandsLock.RLock()
+	defer a.ch.productCommandsLock.RUnlock()
+	for _, pc := range a.ch.productCommands {
 		if pc.Command.TeamId == "" || pc.Command.TeamId == teamID {
 			commands = append(commands, pc.Command)
 		}
@@ -169,6 +178,118 @@ func (a *App) tryExecutePluginCommand(c request.CTX, args *model.CommandArgs) (*
 	// e.g setting a status code of 0 will crash the server. So we always bucket everything under 500.
 	if appErr != nil && (appErr.StatusCode < 100 || appErr.StatusCode > 999) {
 		mlog.Warn("Invalid status code returned from plugin. Converting to internal server error.", mlog.String("plugin_id", matched.PluginId), mlog.Int("status_code", appErr.StatusCode))
+		appErr.StatusCode = http.StatusInternalServerError
+	}
+
+	return matched.Command, response, appErr
+}
+
+// Support for slash commands to MPA
+//
+// Key differences/points with plugin commands:
+// - There's no need of health checks or unregisterProductCommands on products, they are compiled and assumed as active server side
+// - HooksForProduct still returns a plugin.Hooks struct, it might make sense to improve the name/package
+// - Plugin code had a check for a plugin crash after a command was executed, that has been omitted for products
+
+type ProductCommand struct {
+	Command   *model.Command
+	ProductID string
+}
+
+func (a *App) RegisterProductCommand(ProductID string, command *model.Command) error {
+	if command.Trigger == "" {
+		return errors.New("invalid command")
+	}
+	if command.AutocompleteData != nil {
+		if err := command.AutocompleteData.IsValid(); err != nil {
+			return errors.Wrap(err, "invalid autocomplete data in command")
+		}
+	}
+
+	if command.AutocompleteData == nil {
+		command.AutocompleteData = model.NewAutocompleteData(command.Trigger, command.AutoCompleteHint, command.AutoCompleteDesc)
+	} else {
+		baseURL, err := url.Parse("/plugins/" + ProductID)
+		if err != nil {
+			return errors.Wrapf(err, "Can't parse url %s", "/plugins/"+ProductID)
+		}
+		err = command.AutocompleteData.UpdateRelativeURLsForPluginCommands(baseURL)
+		if err != nil {
+			return errors.Wrap(err, "Can't update relative urls for plugin commands")
+		}
+	}
+
+	command = &model.Command{
+		Trigger:              strings.ToLower(command.Trigger),
+		TeamId:               command.TeamId,
+		AutoComplete:         command.AutoComplete,
+		AutoCompleteDesc:     command.AutoCompleteDesc,
+		AutoCompleteHint:     command.AutoCompleteHint,
+		DisplayName:          command.DisplayName,
+		AutocompleteData:     command.AutocompleteData,
+		AutocompleteIconData: command.AutocompleteIconData,
+	}
+
+	a.ch.productCommandsLock.Lock()
+	defer a.ch.productCommandsLock.Unlock()
+
+	for _, pc := range a.ch.productCommands {
+		if pc.Command.Trigger == command.Trigger && pc.Command.TeamId == command.TeamId {
+			if pc.ProductID == ProductID {
+				pc.Command = command
+				return nil
+			}
+		}
+	}
+
+	a.ch.productCommands = append(a.ch.productCommands, &ProductCommand{
+		Command:   command,
+		ProductID: ProductID,
+	})
+	return nil
+}
+
+// tryExecuteProductCommand attempts to run a command provided by a product based on the given arguments. If no such
+// command can be found, returns nil for all arguments.
+func (a *App) tryExecuteProductCommand(c request.CTX, args *model.CommandArgs) (*model.Command, *model.CommandResponse, *model.AppError) {
+	parts := strings.Split(args.Command, " ")
+	trigger := parts[0][1:]
+	trigger = strings.ToLower(trigger)
+
+	var matched *ProductCommand
+	a.ch.productCommandsLock.RLock()
+	for _, pc := range a.ch.productCommands {
+		if (pc.Command.TeamId == "" || pc.Command.TeamId == args.TeamId) && pc.Command.Trigger == trigger {
+			matched = pc
+			break
+		}
+	}
+	a.ch.productCommandsLock.RUnlock()
+	if matched == nil {
+		return nil, nil, nil
+	}
+
+	// The type returned is still plugin.Hooks, could make sense in the future to move Hooks
+	// to another package or change  the abstraction
+	productHooks := a.HooksManager().HooksForProduct(matched.ProductID)
+	if productHooks == nil {
+		return matched.Command, nil, model.NewAppError("ExecutePropductCommand", "model.plugin_command.error.app_error", nil, "", http.StatusInternalServerError)
+	}
+
+	for username, userID := range a.MentionsToTeamMembers(c, args.Command, args.TeamId) {
+		args.AddUserMention(username, userID)
+	}
+
+	for channelName, channelID := range a.MentionsToPublicChannels(c, args.Command, args.TeamId) {
+		args.AddChannelMention(channelName, channelID)
+	}
+
+	response, appErr := productHooks.ExecuteCommand(pluginContext(c), args)
+
+	// This is a response from the product, which may set an incorrect status code;
+	// e.g setting a status code of 0 will crash the server. So we always bucket everything under 500.
+	if appErr != nil && (appErr.StatusCode < 100 || appErr.StatusCode > 999) {
+		mlog.Warn("Invalid status code returned from plugin. Converting to internal server error.", mlog.String("plugin_id", matched.ProductID), mlog.Int("status_code", appErr.StatusCode))
 		appErr.StatusCode = http.StatusInternalServerError
 	}
 

--- a/app/plugin_commands_test.go
+++ b/app/plugin_commands_test.go
@@ -477,7 +477,7 @@ func TestProductCommands(t *testing.T) {
 		th := Setup(t).InitBasic()
 		defer th.TearDown()
 		// Server hijack.
-		// This must be done in a cleaner way.
+		// Follow-up task to improve this https://mattermost.atlassian.net/browse/MM-51190
 		th.Server.initializeProducts(products, th.Server.services)
 		th.Server.products["productT"].Start()
 		require.Len(t, th.Server.products, 2) // 1 product + channels
@@ -508,7 +508,7 @@ func TestProductCommands(t *testing.T) {
 		defer th.TearDown()
 
 		// Server hijack.
-		// This must be done in a cleaner way.
+		// Follow-up task to improve this https://mattermost.atlassian.net/browse/MM-51190
 		th.Server.initializeProducts(products, th.Server.services)
 		th.Server.products["productT"].Start()
 		require.Len(t, th.Server.products, 2) // 1 product + channels
@@ -601,7 +601,7 @@ func TestProductCommands(t *testing.T) {
 		require.Nil(t, nil, activationErrors[0])
 
 		// Server hijack.
-		// This must be done in a cleaner way.
+		// Follow-up task to improve this https://mattermost.atlassian.net/browse/MM-51190
 		th.Server.initializeProducts(products, th.Server.services)
 		th.Server.products["productT"].Start()
 		require.Len(t, th.Server.products, 2) // 1 product + channels

--- a/app/server.go
+++ b/app/server.go
@@ -257,6 +257,7 @@ func NewServer(options ...Option) (*Server, error) {
 		product.SystemKey:        &systemServiceAdapter{server: s},
 		product.SessionKey:       app,
 		product.FrontendKey:      app,
+		product.CommandKey:       app,
 	}
 
 	// Step 4: Initialize products.

--- a/product/api.go
+++ b/product/api.go
@@ -253,7 +253,7 @@ type FrontendService interface {
 // The service shall be registered via app.CommandKey service key.
 type CommandService interface {
 	ExecuteCommand(c request.CTX, args *model.CommandArgs) (*model.CommandResponse, *model.AppError)
-	RegisterPluginCommand(pluginID string, command *model.Command) error
+	RegisterProductCommand(productID string, command *model.Command) error
 }
 
 // ThreadsService is the API for interacting with threads anywhere.


### PR DESCRIPTION
#### Summary
Support for slash commands in the context of Multi Product Architecture.

This PR has been extracted from the PR done to add [MPA support for playbooks](https://github.com/mattermost/mattermost-server/pull/22371) to have a cleaner merge path with the monorepo changes in mind.

The command will be executed in this order (higher ones can override lower ones):
1. plugins commands 
2. products commands 
3. custom commands 
4. builtin commands

The tests are a bit hacky when preparing the server, @isacikgoz kindly agreed to improve that approach 🥇.


#### Ticket Link
Nope


#### Release Note
```release-note
Added slash command support for products.
```
