### PR TITLE
prepackage boards v7.9.0 (#22423)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ PLUGIN_PACKAGES += mattermost-plugin-nps-v1.3.1
 PLUGIN_PACKAGES += mattermost-plugin-todo-v0.6.1
 PLUGIN_PACKAGES += mattermost-plugin-welcomebot-v1.2.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.6.0
-PLUGIN_PACKAGES += focalboard-v7.8.2
+PLUGIN_PACKAGES += focalboard-v7.9.0
 PLUGIN_PACKAGES += mattermost-plugin-apps-v1.2.0
 
 # Prepares the enterprise build if exists. The IGNORE stuff is a hack to get the Makefile to execute the commands outside a target


### PR DESCRIPTION
Co-authored-by: Mattermost Build <build@mattermost.com>
(cherry picked from commit c300c4600c95bf24210069b258ea1a69bf8b1b79)

#### Summary
Prepackage boards v7.9.0

#### Ticket Link

  Fixes https://github.com/mattermost/focalboard/issues/4585

#### Release Note
```release-note
Prepackage boards to v7.9.0
```