### PR TITLE
use post.Auditable() to pass as event parameter

### DIFF
--- a/api4/post.go
+++ b/api4/post.go
@@ -59,7 +59,7 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("createPost", audit.Fail)
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)
-	auditRec.AddEventParameter("post", &post)
+	auditRec.AddEventParameter("post", post.Auditable())
 
 	hasPermission := false
 	if c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), post.ChannelId, model.PermissionCreatePost) {


### PR DESCRIPTION


#### Summary
Since we are eventually going to call `post.Auditable()` we can use this instead of the pointer. It copies the values so it's safe to pass around. Another thing is that, prior to this change, it wasn't an issue as these are sequential operations.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50525

#### Release Note

```release-note
NONE
```
