### PR TITLE
MM-47489 Fix all occurrences of checking for RemoteClusterServiceLicense

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -580,7 +580,7 @@ func (s *Server) startInterClusterServices(license *model.License) error {
 	// Remote Cluster service
 
 	// License check (assume enabled if shared channels enabled)
-	if !*license.Features.RemoteClusterService && !license.HasSharedChannels() {
+	if !license.HasRemoteClusterService() && !license.HasSharedChannels() {
 		mlog.Debug("License does not have Remote Cluster services enabled")
 		return nil
 	}

--- a/model/license.go
+++ b/model/license.go
@@ -321,6 +321,21 @@ func (l *License) HasEnterpriseMarketplacePlugins() bool {
 		l.SkuShortName == LicenseShortSkuEnterprise
 }
 
+func (l *License) HasRemoteClusterService() bool {
+	if l == nil {
+		return false
+	}
+
+	// If SharedChannels is enabled then RemoteClusterService must be enabled.
+	if l.HasSharedChannels() {
+		return true
+	}
+
+	return (l.Features != nil && l.Features.RemoteClusterService != nil && *l.Features.RemoteClusterService) ||
+		l.SkuShortName == LicenseShortSkuProfessional ||
+		l.SkuShortName == LicenseShortSkuEnterprise
+}
+
 func (l *License) HasSharedChannels() bool {
 	if l == nil {
 		return false

--- a/web/context.go
+++ b/web/context.go
@@ -145,7 +145,7 @@ func (c *Context) CloudKeyRequired() {
 }
 
 func (c *Context) RemoteClusterTokenRequired() {
-	if license := c.App.Channels().License(); license == nil || !*license.Features.RemoteClusterService || c.AppContext.Session().Props[model.SessionPropType] != model.SessionTypeRemoteclusterToken {
+	if license := c.App.Channels().License(); license == nil || !license.HasRemoteClusterService() || c.AppContext.Session().Props[model.SessionPropType] != model.SessionTypeRemoteclusterToken {
 		c.Err = model.NewAppError("", "api.context.session_expired.app_error", nil, "TokenRequired", http.StatusUnauthorized)
 		return
 	}

--- a/web/handlers.go
+++ b/web/handlers.go
@@ -302,7 +302,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		} else {
 			c.AppContext.SetSession(session)
 		}
-	} else if token != "" && c.App.Channels().License() != nil && *c.App.Channels().License().Features.RemoteClusterService && tokenLocation == app.TokenLocationRemoteClusterHeader {
+	} else if token != "" && c.App.Channels().License() != nil && c.App.Channels().License().HasRemoteClusterService() && tokenLocation == app.TokenLocationRemoteClusterHeader {
 		// Get the remote cluster
 		if remoteId := c.GetRemoteID(r); remoteId == "" {
 			c.Logger.Warn("Missing remote cluster id") //


### PR DESCRIPTION
#### Summary
The ticket linked below intended to enable Shared Channels for Professional licenses.  This is the third (and final) PR to implement the intended logic.  This PR ensures the licence check in the web handler also respects the rule that if SharedChannels is enabled then RemoteClusterService is enabled.

Without this fix, the services were started, but invitations to connect remote servers fail on the license check with Pro licenses. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47489

#### Release Note
```release-note
Fixes issue with Shared Channels under Professional license.
```
