### PR TITLE
[MM-51089] Fix sorting value of category in CreateSidebarCategoryForTeamForUser

### DIFF
--- a/store/sqlstore/channel_store_categories.go
+++ b/store/sqlstore/channel_store_categories.go
@@ -335,7 +335,7 @@ func (s SqlChannelStore) CreateSidebarCategory(userId, teamId string, newCategor
 		Id:          newCategoryId,
 		UserId:      userId,
 		TeamId:      teamId,
-		Sorting:     model.SidebarCategorySortDefault,
+		Sorting:     newCategory.Sorting,
 		SortOrder:   int64(model.MinimalSidebarSortDistance * len(newOrder)), // first we place it at the end of the list
 		Type:        model.SidebarCategoryCustom,
 		Muted:       newCategory.Muted,

--- a/store/storetest/channel_store_categories.go
+++ b/store/storetest/channel_store_categories.go
@@ -672,6 +672,38 @@ func testCreateSidebarCategory(t *testing.T, ss store.Store) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{}, res2.Channels)
 	})
+
+	t.Run("should store the correct sorting value", func(t *testing.T) {
+		userId := model.NewId()
+
+		team := setupTeam(t, ss, userId)
+
+		opts := &store.SidebarCategorySearchOpts{
+			TeamID:      team.Id,
+			ExcludeTeam: false,
+		}
+		res, nErr := ss.Channel().CreateInitialSidebarCategories(userId, opts)
+		require.NoError(t, nErr)
+		require.NotEmpty(t, res)
+		// Create the category
+		created, err := ss.Channel().CreateSidebarCategory(userId, team.Id, &model.SidebarCategoryWithChannels{
+			SidebarCategory: model.SidebarCategory{
+				DisplayName: model.NewId(),
+				Sorting:     model.SidebarCategorySortManual,
+			},
+		})
+		require.NoError(t, err)
+
+		// Confirm that sorting value is correct
+		res, err = ss.Channel().GetSidebarCategoriesForTeamForUser(userId, team.Id)
+		require.NoError(t, err)
+		require.Len(t, res.Categories, 4)
+		// first category will be favorites and second will be newly created
+		assert.Equal(t, model.SidebarCategoryCustom, res.Categories[1].Type)
+		assert.Equal(t, created.Id, res.Categories[1].Id)
+		assert.Equal(t, model.SidebarCategorySortManual, res.Categories[1].Sorting)
+		assert.Equal(t, model.SidebarCategorySortManual, created.Sorting)
+	})
 }
 
 func testGetSidebarCategory(t *testing.T, ss store.Store, s SqlStore) {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR is for https://github.com/mattermost/mattermost-server/issues/22445
Sorting attribute was being ignored while creating category.
This PR makes a change to start using that attribute.
Updated the unit test and added screen recording of testing API with postman

https://user-images.githubusercontent.com/5559347/223619971-8244bccf-3ed0-42b5-93f9-86c159e9a045.mov


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
JIRA: https://mattermost.atlassian.net/browse/MM-51089
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fix sorting value of category in CreateSidebarCategoryForTeamForUser
```
