### PR TITLE
Allowed substring search in admin console for user

### DIFF
--- a/store/searchtest/user_layer.go
+++ b/store/searchtest/user_layer.go
@@ -876,28 +876,65 @@ func testSearchUserBySubstringInAnyName(t *testing.T, th *SearchTestHelper) {
 		require.NoError(t, err)
 		defer th.deleteUser(userAlternate)
 
+		// searching user without specifying team
 		options := createDefaultOptions(true, false, false)
-		users, err := th.Store.User().Search(th.Team.Id, "hello", options)
+		users, err := th.Store.User().Search("", "hello", options)
+		require.NoError(t, err)
+		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
+
+		// adding user to team to search by team
+		err = th.addUserToTeams(userAlternate, []string{th.Team.Id})
+		require.NoError(t, err)
+
+		err = th.addUserToChannels(userAlternate, []string{th.ChannelBasic.Id})
+		require.NoError(t, err)
+
+		options = createDefaultOptions(true, false, false)
+		users, err = th.Store.User().Search(th.Team.Id, "hello", options)
 		require.NoError(t, err)
 		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
 	})
-	t.Run("Should search users by substring in first name", func(t *testing.T) {
+	t.Run("Should search users by substring in last name name", func(t *testing.T) {
 		userAlternate, err := th.createUser("user-alternate", "user-alternate", "alternate", "alternate helloooo last name")
 		require.NoError(t, err)
 		defer th.deleteUser(userAlternate)
 
 		options := createDefaultOptions(true, false, false)
-		users, err := th.Store.User().Search(th.Team.Id, "hello", options)
+		users, err := th.Store.User().Search("", "hello", options)
+		require.NoError(t, err)
+		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
+
+		// adding user to team to search by team
+		err = th.addUserToTeams(userAlternate, []string{th.Team.Id})
+		require.NoError(t, err)
+
+		err = th.addUserToChannels(userAlternate, []string{th.ChannelBasic.Id})
+		require.NoError(t, err)
+
+		options = createDefaultOptions(true, false, false)
+		users, err = th.Store.User().Search(th.Team.Id, "hello", options)
 		require.NoError(t, err)
 		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
 	})
-	t.Run("Should search users by substring in first name", func(t *testing.T) {
+	t.Run("Should search users by substring in nickname name", func(t *testing.T) {
 		userAlternate, err := th.createUser("user-alternate", "alternate helloooo nickname", "alternate hello first name", "alternate")
 		require.NoError(t, err)
 		defer th.deleteUser(userAlternate)
 
 		options := createDefaultOptions(true, false, false)
-		users, err := th.Store.User().Search(th.Team.Id, "hello", options)
+		users, err := th.Store.User().Search("", "hello", options)
+		require.NoError(t, err)
+		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
+
+		// adding user to team to search by team
+		err = th.addUserToTeams(userAlternate, []string{th.Team.Id})
+		require.NoError(t, err)
+
+		err = th.addUserToChannels(userAlternate, []string{th.ChannelBasic.Id})
+		require.NoError(t, err)
+
+		options = createDefaultOptions(true, false, false)
+		users, err = th.Store.User().Search(th.Team.Id, "hello", options)
 		require.NoError(t, err)
 		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
 	})

--- a/store/searchtest/user_layer.go
+++ b/store/searchtest/user_layer.go
@@ -152,6 +152,11 @@ var searchUserStoreTests = []searchTest{
 		Fn:   testSearchUsersInTeamUsernameWithUnderscore,
 		Tags: []string{EngineAll},
 	},
+	{
+		Name: "Should support search all users containing a substring in any name",
+		Fn:   testSearchUserBySubstringInAnyName,
+		Tags: []string{EngineAll},
+	},
 }
 
 func TestSearchUserStore(t *testing.T, s store.Store, testEngine *SearchTestEngine) {
@@ -862,6 +867,39 @@ func testSearchUsersByFullName(t *testing.T, th *SearchTestHelper) {
 		users, err := th.Store.User().Search(th.Team.Id, "basicfirstname1", options)
 		require.NoError(t, err)
 		th.assertUsersMatchInAnyOrder(t, []*model.User{}, users)
+	})
+}
+
+func testSearchUserBySubstringInAnyName(t *testing.T, th *SearchTestHelper) {
+	t.Run("Should search users by substring in first name", func(t *testing.T) {
+		userAlternate, err := th.createUser("user-alternate", "user-alternate", "alternate helloooo first name", "alternate")
+		require.NoError(t, err)
+		defer th.deleteUser(userAlternate)
+
+		options := createDefaultOptions(true, false, false)
+		users, err := th.Store.User().Search(th.Team.Id, "hello", options)
+		require.NoError(t, err)
+		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
+	})
+	t.Run("Should search users by substring in first name", func(t *testing.T) {
+		userAlternate, err := th.createUser("user-alternate", "user-alternate", "alternate", "alternate helloooo last name")
+		require.NoError(t, err)
+		defer th.deleteUser(userAlternate)
+
+		options := createDefaultOptions(true, false, false)
+		users, err := th.Store.User().Search(th.Team.Id, "hello", options)
+		require.NoError(t, err)
+		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
+	})
+	t.Run("Should search users by substring in first name", func(t *testing.T) {
+		userAlternate, err := th.createUser("user-alternate", "alternate helloooo nickname", "alternate hello first name", "alternate")
+		require.NoError(t, err)
+		defer th.deleteUser(userAlternate)
+
+		options := createDefaultOptions(true, false, false)
+		users, err := th.Store.User().Search(th.Team.Id, "hello", options)
+		require.NoError(t, err)
+		th.assertUsersMatchInAnyOrder(t, []*model.User{userAlternate}, users)
 	})
 }
 

--- a/store/sqlstore/user_store.go
+++ b/store/sqlstore/user_store.go
@@ -1540,7 +1540,7 @@ func generateSearchQuery(query sq.SelectBuilder, terms []string, fields []string
 			} else {
 				searchFields = append(searchFields, fmt.Sprintf("%s LIKE ? escape '*' ", field))
 			}
-			termArgs = append(termArgs, fmt.Sprintf("%s%%", strings.TrimLeft(term, "@")))
+			termArgs = append(termArgs, fmt.Sprintf("%%%s%%", strings.TrimLeft(term, "@")))
 		}
 		query = query.Where(fmt.Sprintf("(%s)", strings.Join(searchFields, " OR ")), termArgs...)
 	}


### PR DESCRIPTION
#### Summary
Allows to search by part of the first name, last name, nickname or username in admin console users section.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-51197
Fixes https://mattermost.atlassian.net/browse/MM-30399

#### Related Pull Requests
* Has webapp changes - https://github.com/mattermost/mattermost-webapp/pull/12341

#### Release Note
```release-note
none
```
