### PR TITLE
[MM-50002] Fix infinite reconnect loop when reconnect handler fails

### DIFF
--- a/webapp/platform/client/src/websocket.ts
+++ b/webapp/platform/client/src/websocket.ts
@@ -189,9 +189,16 @@ export default class WebSocketClient {
                         console.log('long timeout, or server restart, or sequence number is not found.'); //eslint-disable-line no-console
 
                         this.missedEventCallback?.();
-                        this.missedMessageListeners.forEach((listener) => listener());
-
-                        this.serverSequence = 0;
+			
+			for (const listener of this.missedMessageListeners) {
+                            try {
+                                listener();
+                            } catch (e) {
+                                console.log(`missed message listener "${listener.name}" failed: ${e}`); // eslint-disable-line no-console
+                            }
+                        }
+                        
+			this.serverSequence = 0;
                     }
 
                     // If it's a fresh connection, we have to set the connectionId regardless.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

**NOTE** This is the same as https://github.com/mattermost/mattermost-webapp/pull/12302 created against the mono-repo. It has been code & QA reviewed, so it's ready to be merged.

When restarting (among other things) the server, there is a logic in `websocket.ts` that handles reconnecting after a certain amount of time (3 seconds currently). In case something goes wrong and an exception is thrown in any of the reconnect/missedMessages handlers (which e.g. can be handlers registered from plugins and this has happened in the past with the Todo plugin), the rest of the code in that branch of the file is not executed.

The most important part of the code not executed in that case is resetting the `serverSequence`, so after the `hello` message from the newly connected websocket, all subsequent messages fail as `serverSequence` is out of sync between the client and the server, causing and infinite loop of reconnects.

This PR wraps the calls to `missedMessageListeners` in a `try...finally` to make sure the reset code runs in any case.


#### How to reproduce

In order to reproduce the issue (using the current master branch that does not contain this fix):

1. Add a `throw` statement in the `reconnect` function of `actions/websocket_actions.jsx` (eg line 255)
2. Restart the server
3. Observe your console or network tab and see the periodic (every 3-5 seconds, due to a jitter that is applied in reconnect) requests that run forever.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-50002

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.


```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
