### PR TITLE
[MM-51320] Rework Audit API being invoked incorrectly in API Handler

### DIFF
--- a/api4/bot.go
+++ b/api4/bot.go
@@ -296,7 +296,7 @@ func convertBotToUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec := c.MakeAuditRecord("convertBotToUser", audit.Fail)
 	defer c.LogAuditRec(auditRec)
 	auditRec.AddEventParameter("bot", bot)
-	auditRec.AddEventParameter("userPatch", userPatch)
+	auditRec.AddEventParameter("user_patch", &userPatch)
 	auditRec.AddEventParameter("set_system_admin", systemAdmin)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {

--- a/api4/channel_local.go
+++ b/api4/channel_local.go
@@ -87,7 +87,7 @@ func localUpdateChannelPrivacy(c *Context, w http.ResponseWriter, r *http.Reques
 
 	auditRec := c.MakeAuditRecord("localUpdateChannelPrivacy", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("privacy", privacy)
 
 	if channel.Name == model.DefaultChannelName && model.ChannelType(privacy) == model.ChannelTypePrivate {
 		c.Err = model.NewAppError("updateChannelPrivacy", "api.channel.update_channel_privacy.default_channel_error", nil, "", http.StatusBadRequest)
@@ -149,12 +149,18 @@ func localAddChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec := c.MakeAuditRecord("localAddChannelMember", audit.Fail)
+	auditRec.AddEventParameter("channel_id", c.Params.ChannelId)
+	defer c.LogAuditRec(auditRec)
+
 	props := model.StringInterfaceFromJSON(r.Body)
 	userId, ok := props["user_id"].(string)
 	if !ok || !model.IsValidId(userId) {
 		c.SetInvalidParam("user_id")
 		return
 	}
+
+	auditRec.AddEventParameter("user_id", userId)
 
 	member := &model.ChannelMember{
 		ChannelId: c.Params.ChannelId,
@@ -166,6 +172,8 @@ func localAddChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidParam("post_root_id")
 		return
 	}
+
+	auditRec.AddEventParameter("post_root_id", postRootId)
 
 	if ok && len(postRootId) == 26 {
 		rootPost, err := c.App.GetSinglePost(postRootId, false)
@@ -185,10 +193,7 @@ func localAddChannelMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec := c.MakeAuditRecord("localAddChannelMember", audit.Fail)
-	auditRec.AddEventParameter("props", props)
-	defer c.LogAuditRec(auditRec)
-	auditRec.AddMeta("channel", channel)
+	auditRec.AddEventParameter("channel", channel)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {
 		c.Err = model.NewAppError("localAddChannelMember", "api.channel.add_user_to_channel.type.app_error", nil, "", http.StatusBadRequest)
@@ -355,7 +360,8 @@ func localMoveChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("localMoveChannel", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("team_id", teamId)
+	auditRec.AddEventParameter("force", force)
 
 	// TODO do we need these?
 	auditRec.AddMeta("channel_id", channel.Id)
@@ -413,7 +419,7 @@ func localDeleteChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("localDeleteChannel", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddMeta("channeld", channel)
+	auditRec.AddEventPriorState(channel)
 	auditRec.AddEventParameter("channel_id", c.Params.ChannelId)
 
 	if channel.Type == model.ChannelTypeDirect || channel.Type == model.ChannelTypeGroup {

--- a/api4/command.go
+++ b/api4/command.go
@@ -37,7 +37,7 @@ func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("createCommand", audit.Fail)
-	auditRec.AddEventParameter("command", cmd)
+	auditRec.AddEventParameter("command", &cmd)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 
@@ -56,7 +56,6 @@ func createCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.Success()
 	c.LogAudit("success")
-	auditRec.AddMeta("command", rcmd)
 	auditRec.AddEventResultState(rcmd)
 	auditRec.AddEventObjectType("command")
 
@@ -79,17 +78,17 @@ func updateCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("updateCommand", audit.Fail)
-	auditRec.AddEventParameter("command", cmd)
+	auditRec.AddEventParameter("command", &cmd)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 
 	oldCmd, err := c.App.GetCommand(c.Params.CommandId)
 	if err != nil {
-		auditRec.AddMeta("command_id", c.Params.CommandId)
+		auditRec.AddEventParameter("command_id", c.Params.CommandId)
 		c.SetCommandNotFoundError()
 		return
 	}
-	auditRec.AddMeta("command", oldCmd)
+	auditRec.AddEventPriorState(oldCmd)
 
 	if cmd.TeamId != oldCmd.TeamId {
 		c.Err = model.NewAppError("updateCommand", "api.command.team_mismatch.app_error", nil, "user_id="+c.AppContext.Session().UserId, http.StatusBadRequest)
@@ -139,7 +138,7 @@ func moveCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("moveCommand", audit.Fail)
-	auditRec.AddEventParameter("command_move_request", cmr)
+	auditRec.AddEventParameter("command_move_request", &cmr)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 
@@ -148,7 +147,7 @@ func moveCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = appErr
 		return
 	}
-	auditRec.AddMeta("team", newTeam)
+	auditRec.AddEventParameter("team", newTeam)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), newTeam.Id, model.PermissionManageSlashCommands) {
 		c.LogAudit("fail - inappropriate permissions")
@@ -161,7 +160,7 @@ func moveCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetCommandNotFoundError()
 		return
 	}
-	auditRec.AddMeta("command", cmd)
+	auditRec.AddEventPriorState(cmd)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), cmd.TeamId, model.PermissionManageSlashCommands) {
 		c.LogAudit("fail - inappropriate permissions")
@@ -200,7 +199,7 @@ func deleteCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetCommandNotFoundError()
 		return
 	}
-	auditRec.AddMeta("command", cmd)
+	auditRec.AddEventPriorState(cmd)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), cmd.TeamId, model.PermissionManageSlashCommands) {
 		c.LogAudit("fail - inappropriate permissions")
@@ -222,7 +221,6 @@ func deleteCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddEventResultState(cmd)
 	auditRec.AddEventObjectType("command")
 	auditRec.Success()
 	c.LogAudit("success")
@@ -323,8 +321,7 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("executeCommand", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("command_args", commandArgs)
-	auditRec.AddMeta("commandargs", commandArgs)
+	auditRec.AddEventParameter("command_args", &commandArgs)
 
 	// checks that user is a member of the specified channel, and that they have permission to use slash commands in it
 	if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), commandArgs.ChannelId, model.PermissionUseSlashCommands) {
@@ -357,8 +354,6 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	commandArgs.T = c.AppContext.T
 	commandArgs.SiteURL = c.GetSiteURLHeader()
 	commandArgs.Session = *c.AppContext.Session()
-
-	auditRec.AddMeta("commandargs", commandArgs) // overwrite in case teamid changed. TODO do we need to log this too? is the original commandArgs not enough
 
 	response, err := c.App.ExecuteCommand(c.AppContext, &commandArgs)
 	if err != nil {
@@ -456,11 +451,11 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	cmd, err := c.App.GetCommand(c.Params.CommandId)
 	if err != nil {
-		auditRec.AddMeta("command_id", c.Params.CommandId)
+		auditRec.AddEventParameter("command_id", c.Params.CommandId)
 		c.SetCommandNotFoundError()
 		return
 	}
-	auditRec.AddMeta("command", cmd)
+	auditRec.AddEventPriorState(cmd)
 	auditRec.AddEventParameter("command_id", c.Params.CommandId)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), cmd.TeamId, model.PermissionManageSlashCommands) {
@@ -482,7 +477,7 @@ func regenCommandToken(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-
+	auditRec.AddEventResultState(rcmd)
 	auditRec.Success()
 	c.LogAudit("success")
 

--- a/api4/command_local.go
+++ b/api4/command_local.go
@@ -30,7 +30,7 @@ func localCreateCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("localCreateCommand", audit.Fail)
-	auditRec.AddEventParameter("command", cmd)
+	auditRec.AddEventParameter("command", &cmd)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 

--- a/api4/compliance.go
+++ b/api4/compliance.go
@@ -30,7 +30,7 @@ func createComplianceReport(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	auditRec := c.MakeAuditRecord("createComplianceReport", audit.Fail)
-	auditRec.AddEventParameter("compliance", job)
+	auditRec.AddEventParameter("compliance", &job)
 	defer c.LogAuditRec(auditRec)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionCreateComplianceExportJob) {

--- a/api4/data_retention.go
+++ b/api4/data_retention.go
@@ -122,7 +122,7 @@ func createPolicy(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 	auditRec := c.MakeAuditRecord("createPolicy", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("policy", policy)
+	auditRec.AddEventParameter("policy", &policy)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionSysconsoleWriteComplianceDataRetentionPolicy) {
 		c.SetPermissionError(model.PermissionSysconsoleWriteComplianceDataRetentionPolicy)
@@ -158,7 +158,7 @@ func patchPolicy(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("patchPolicy", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("patch", patch)
+	auditRec.AddEventParameter("patch", &patch)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionSysconsoleWriteComplianceDataRetentionPolicy) {
 		c.SetPermissionError(model.PermissionSysconsoleWriteComplianceDataRetentionPolicy)

--- a/api4/file.go
+++ b/api4/file.go
@@ -162,7 +162,7 @@ func uploadFileSimple(c *Context, r *http.Request, timestamp time.Time) *model.F
 		c.Err = appErr
 		return nil
 	}
-	auditRec.AddMeta("file", info)
+	auditRec.AddEventParameter("file", info)
 
 	fileUploadResponse := &model.FileUploadResponse{
 		FileInfos: []*model.FileInfo{info},
@@ -326,7 +326,7 @@ NextPart:
 			c.LogAuditRec(auditRec)
 			return nil
 		}
-		auditRec.AddMeta("file", info)
+		auditRec.AddEventParameter("file", info)
 
 		auditRec.Success()
 		c.LogAuditRec(auditRec)
@@ -430,7 +430,7 @@ func uploadFileMultipartLegacy(c *Context, mr *multipart.Reader,
 			c.LogAuditRec(auditRec)
 			return nil
 		}
-		auditRec.AddMeta("file", info)
+		auditRec.AddEventParameter("file", info)
 
 		auditRec.Success()
 		c.LogAuditRec(auditRec)
@@ -462,7 +462,7 @@ func getFile(c *Context, w http.ResponseWriter, r *http.Request) {
 		setInaccessibleFileHeader(w, err)
 		return
 	}
-	auditRec.AddMeta("file", info)
+	auditRec.AddEventParameter("file", &info)
 
 	if info.CreatorId != c.AppContext.Session().UserId && !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), info.PostId, model.PermissionReadChannel) {
 		c.SetPermissionError(model.PermissionReadChannel)
@@ -537,7 +537,7 @@ func getFileLink(c *Context, w http.ResponseWriter, r *http.Request) {
 		setInaccessibleFileHeader(w, err)
 		return
 	}
-	auditRec.AddMeta("file", info)
+	auditRec.AddEventParameter("file", info)
 
 	if info.CreatorId != c.AppContext.Session().UserId && !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), info.PostId, model.PermissionReadChannel) {
 		c.SetPermissionError(model.PermissionReadChannel)
@@ -554,7 +554,6 @@ func getFileLink(c *Context, w http.ResponseWriter, r *http.Request) {
 	resp["link"] = link
 
 	auditRec.Success()
-	auditRec.AddMeta("link", link)
 
 	w.Write([]byte(model.MapToJSON(resp)))
 }

--- a/api4/group.go
+++ b/api4/group.go
@@ -346,7 +346,7 @@ func linkGroupSyncable(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 	auditRec.AddEventParameter("group_id", c.Params.GroupId)
 	auditRec.AddEventParameter("syncable_id", syncableID)
-	auditRec.AddEventParameter("syncable_type", syncableType)
+	auditRec.AddEventParameter("syncable_type", &syncableType)
 
 	var patch *model.GroupSyncablePatch
 	err = json.Unmarshal(body, &patch)
@@ -1192,7 +1192,7 @@ func restoreGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("restoreGroup", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddMeta("group_id", c.Params.GroupId)
+	auditRec.AddEventParameter("group_id", c.Params.GroupId)
 
 	_, err = c.App.RestoreGroup(c.Params.GroupId)
 	if err != nil {

--- a/api4/job.go
+++ b/api4/job.go
@@ -113,7 +113,7 @@ func createJob(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("createJob", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("job", job)
+	auditRec.AddEventParameter("job", &job)
 
 	hasPermission, permissionRequired := c.App.SessionHasPermissionToCreateJob(*c.AppContext.Session(), &job)
 	if permissionRequired == nil {

--- a/api4/ldap.go
+++ b/api4/ldap.go
@@ -169,8 +169,6 @@ func linkLdapGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddMeta("ldap_group", ldapGroup)
-
 	if ldapGroup == nil {
 		c.Err = model.NewAppError("Api4.linkLdapGroup", "api.ldap_group.not_found", nil, "", http.StatusNotFound)
 		return
@@ -182,7 +180,7 @@ func linkLdapGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if group != nil {
-		auditRec.AddMeta("group", group)
+		auditRec.AddEventParameter("group", group)
 	}
 
 	var status int
@@ -295,7 +293,7 @@ func migrateIdLdap(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("idMigrateLdap", audit.Fail)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("to_attribute", toAttribute)
 	defer c.LogAuditRec(auditRec)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {

--- a/api4/oauth.go
+++ b/api4/oauth.go
@@ -32,7 +32,7 @@ func createOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("createOAuthApp", audit.Fail)
-	auditRec.AddEventParameter("oauth_app", oauthApp)
+	auditRec.AddEventParameter("oauth_app", &oauthApp)
 
 	defer c.LogAuditRec(auditRec)
 
@@ -85,7 +85,7 @@ func updateOAuthApp(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidParamWithErr("oauth_app", jsonErr)
 		return
 	}
-	auditRec.AddEventParameter("oauth_app", oauthApp)
+	auditRec.AddEventParameter("oauth_app", &oauthApp)
 
 	// The app being updated in the payload must be the same one as indicated in the URL.
 	if oauthApp.Id != c.Params.AppId {

--- a/api4/post.go
+++ b/api4/post.go
@@ -775,7 +775,7 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("updatePost", audit.Fail)
-	auditRec.AddEventParameter("post", post.Auditable())
+	auditRec.AddEventParameter("post", &post)
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)
 
 	// The post being updated in the payload must be the same one as indicated in the URL.
@@ -842,7 +842,7 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("patchPost", audit.Fail)
 	auditRec.AddEventParameter("id", c.Params.PostId)
-	auditRec.AddEventParameter("patch", post.Auditable())
+	auditRec.AddEventParameter("patch", &post)
 	defer c.LogAuditRecWithLevel(auditRec, app.LevelContent)
 
 	// Updating the file_ids of a post is not a supported operation and will be ignored

--- a/api4/remote_cluster.go
+++ b/api4/remote_cluster.go
@@ -92,7 +92,7 @@ func remoteClusterAcceptMessage(c *Context, w http.ResponseWriter, r *http.Reque
 	}
 
 	auditRec := c.MakeAuditRecord("remoteClusterAcceptMessage", audit.Fail)
-	auditRec.AddEventParameter("remote_cluster_frame", frame)
+	auditRec.AddEventParameter("remote_cluster_frame", &frame)
 	defer c.LogAuditRec(auditRec)
 
 	remoteId := c.GetRemoteID(r)
@@ -106,7 +106,7 @@ func remoteClusterAcceptMessage(c *Context, w http.ResponseWriter, r *http.Reque
 		c.SetInvalidRemoteIdError(frame.RemoteId)
 		return
 	}
-	auditRec.AddMeta("remoteCluster", rc)
+	auditRec.AddEventParameter("remote_cluster", rc)
 
 	// pass message to Remote Cluster Service and write response
 	resp := service.ReceiveIncomingMsg(rc, frame.Msg)
@@ -139,7 +139,7 @@ func remoteClusterConfirmInvite(c *Context, w http.ResponseWriter, r *http.Reque
 	}
 
 	auditRec := c.MakeAuditRecord("remoteClusterAcceptInvite", audit.Fail)
-	auditRec.AddEventParameter("remote_cluster_frame", frame)
+	auditRec.AddEventParameter("remote_cluster_frame", &frame)
 	defer c.LogAuditRec(auditRec)
 
 	remoteId := c.GetRemoteID(r)
@@ -153,7 +153,7 @@ func remoteClusterConfirmInvite(c *Context, w http.ResponseWriter, r *http.Reque
 		c.SetInvalidRemoteIdError(frame.RemoteId)
 		return
 	}
-	auditRec.AddMeta("remoteCluster", rc)
+	auditRec.AddEventParameter("remote_cluster", rc)
 
 	if time.Since(model.GetTimeForMillis(rc.CreateAt)) > remotecluster.InviteExpiresAfter {
 		c.Err = model.NewAppError("remoteClusterAcceptMessage", "api.context.invitation_expired.error", nil, "", http.StatusBadRequest)
@@ -272,7 +272,7 @@ func remoteSetProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidURLParam("user_id")
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventParameter("user", user)
 
 	imageData := imageArray[0]
 	if err := c.App.SetProfileImage(c.AppContext, c.Params.UserId, imageData); err != nil {

--- a/api4/role.go
+++ b/api4/role.go
@@ -123,7 +123,7 @@ func patchRole(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("patchRole", audit.Fail)
-	auditRec.AddEventParameter("role_patch", patch)
+	auditRec.AddEventParameter("role_patch", &patch)
 	defer c.LogAuditRec(auditRec)
 
 	oldRole, appErr := c.App.GetRole(c.Params.RoleId)

--- a/api4/scheme.go
+++ b/api4/scheme.go
@@ -31,7 +31,7 @@ func createScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("createScheme", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("scheme", scheme)
+	auditRec.AddEventParameter("scheme", &scheme)
 
 	if c.App.Channels().License() == nil || (!*c.App.Channels().License().Features.CustomPermissionsSchemes && c.App.Channels().License().SkuShortName != model.LicenseShortSkuProfessional) {
 		c.Err = model.NewAppError("Api4.CreateScheme", "api.scheme.create_scheme.license.error", nil, "", http.StatusNotImplemented)
@@ -191,7 +191,7 @@ func patchScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("patchScheme", audit.Fail)
-	auditRec.AddEventParameter("scheme_patch", patch)
+	auditRec.AddEventParameter("scheme_patch", &patch)
 	defer c.LogAuditRec(auditRec)
 
 	if c.App.Channels().License() == nil || (!*c.App.Channels().License().Features.CustomPermissionsSchemes && c.App.Channels().License().SkuShortName != model.LicenseShortSkuProfessional) {

--- a/api4/team.go
+++ b/api4/team.go
@@ -87,7 +87,7 @@ func createTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("createTeam", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("team", team)
+	auditRec.AddEventParameter("team", &team)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionCreateTeam) {
 		c.Err = model.NewAppError("createTeam", "api.team.is_team_creation_allowed.disabled.app_error", nil, "", http.StatusForbidden)
@@ -203,7 +203,7 @@ func updateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("updateTeam", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("team", team)
+	auditRec.AddEventParameter("team", &team)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionManageTeam) {
 		c.SetPermissionError(model.PermissionManageTeam)
@@ -239,7 +239,7 @@ func patchTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("patchTeam", audit.Fail)
-	auditRec.AddEventParameter("team_patch", team)
+	auditRec.AddEventParameter("team_patch", &team)
 	defer c.LogAuditRec(auditRec)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionManageTeam) {
@@ -354,7 +354,7 @@ func updateTeamPrivacy(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("updateTeamPrivacy", audit.Fail)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("privacy", privacy)
 	defer c.LogAuditRec(auditRec)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionManageTeam) {
@@ -715,7 +715,7 @@ func addTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("addTeamMember", audit.Fail)
-	auditRec.AddEventParameter("member", member)
+	auditRec.AddEventParameter("member", &member)
 	defer c.LogAuditRec(auditRec)
 
 	if member.UserId == c.AppContext.Session().UserId {
@@ -746,7 +746,7 @@ func addTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	auditRec.AddMeta("team", team)
+	auditRec.AddEventParameter("team", team)
 
 	if team.IsGroupConstrained() {
 		nonMembers, err := c.App.FilterNonGroupTeamMembers([]string{member.UserId}, team)
@@ -862,7 +862,7 @@ func addTeamMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = appErr
 		return
 	}
-	auditRec.AddMeta("team", team)
+	auditRec.AddEventParameter("team", team)
 
 	if team.IsGroupConstrained() {
 		nonMembers, err := c.App.FilterNonGroupTeamMembers(memberIDs, team)
@@ -961,14 +961,14 @@ func removeTeamMember(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	auditRec.AddMeta("team", team)
+	auditRec.AddEventParameter("team", team)
 
 	user, err := c.App.GetUser(c.Params.UserId)
 	if err != nil {
 		c.Err = err
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventParameter("user", user)
 
 	if team.IsGroupConstrained() && (c.Params.UserId != c.AppContext.Session().UserId) && !user.IsBot {
 		c.Err = model.NewAppError("removeTeamMember", "api.team.remove_member.group_constrained.app_error", nil, "", http.StatusBadRequest)
@@ -1055,7 +1055,7 @@ func updateTeamMemberRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("updateTeamMemberRoles", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("roles", newRoles)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionManageTeamRoles) {
 		c.SetPermissionError(model.PermissionManageTeamRoles)
@@ -1089,7 +1089,7 @@ func updateTeamMemberSchemeRoles(c *Context, w http.ResponseWriter, r *http.Requ
 
 	auditRec := c.MakeAuditRecord("updateTeamMemberSchemeRoles", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("scheme_roles", schemeRoles)
+	auditRec.AddEventParameter("scheme_roles", &schemeRoles)
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionManageTeamRoles) {
 		c.SetPermissionError(model.PermissionManageTeamRoles)
@@ -1510,7 +1510,7 @@ func inviteGuestsToChannels(c *Context, w http.ResponseWriter, r *http.Request) 
 		c.Err = model.NewAppError("Api4.inviteGuestsToChannels", "api.team.invite_guests_to_channels.invalid_body.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 		return
 	}
-	auditRec.AddEventParameter("guests_invite", guestsInvite)
+	auditRec.AddEventParameter("guests_invite", &guestsInvite)
 
 	for i, email := range guestsInvite.Emails {
 		guestsInvite.Emails[i] = strings.ToLower(email)
@@ -1770,7 +1770,7 @@ func updateTeamScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = err
 			return
 		}
-		auditRec.AddMeta("scheme", scheme)
+		auditRec.AddEventParameter("scheme", scheme)
 
 		if scheme.Scope != model.SchemeScopeTeam {
 			c.Err = model.NewAppError("Api4.UpdateTeamScheme", "api.team.update_team_scheme.scheme_scope.error", nil, "", http.StatusBadRequest)
@@ -1783,7 +1783,7 @@ func updateTeamScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	auditRec.AddMeta("team", team)
+	auditRec.AddEventParameter("team", team)
 
 	team.SchemeId = schemeID
 

--- a/api4/team_local.go
+++ b/api4/team_local.go
@@ -254,7 +254,7 @@ func localCreateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("localCreateTeam", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("team", team)
+	auditRec.AddEventParameter("team", &team)
 
 	rteam, err := c.App.CreateTeam(c.AppContext, &team)
 	if err != nil {
@@ -266,7 +266,6 @@ func localCreateTeam(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddEventResultState(rteam)
 	auditRec.AddEventObjectType("type")
 	auditRec.Success()
-	auditRec.AddMeta("team", team) // overwrite meta
 
 	w.WriteHeader(http.StatusCreated)
 	if err := json.NewEncoder(w).Encode(rteam); err != nil {

--- a/api4/upload.go
+++ b/api4/upload.go
@@ -42,7 +42,7 @@ func createUpload(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("createUpload", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("upload", us)
+	auditRec.AddEventParameter("upload", &us)
 
 	if us.Type == model.UploadTypeImport {
 		if !c.IsSystemAdmin() {

--- a/api4/user.go
+++ b/api4/user.go
@@ -123,9 +123,9 @@ func createUser(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("createUser", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("iid", inviteId)
-	auditRec.AddEventParameter("r", redirect)
-	auditRec.AddEventParameter("user", user)
+	auditRec.AddEventParameter("invite_id", inviteId)
+	auditRec.AddEventParameter("redirect", redirect)
+	auditRec.AddEventParameter("user", &user)
 
 	// No permission check required
 
@@ -471,7 +471,7 @@ func setProfileImage(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidURLParam("user_id")
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventResultState(user)
 
 	if (user.IsLDAPUser() || (user.IsSAMLUser() && *c.App.Config().SamlSettings.EnableSyncWithLdap)) &&
 		*c.App.Config().LdapSettings.PictureAttribute != "" {
@@ -518,7 +518,7 @@ func setDefaultProfileImage(c *Context, w http.ResponseWriter, r *http.Request) 
 		c.Err = err
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventParameter("user", user)
 
 	if err := c.App.SetDefaultProfileImage(c.AppContext, user); err != nil {
 		c.Err = err
@@ -1233,20 +1233,21 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	auditRec := c.MakeAuditRecord("updateUser", audit.Fail)
+	defer c.LogAuditRec(auditRec)
+
 	var user model.User
 	if jsonErr := json.NewDecoder(r.Body).Decode(&user); jsonErr != nil {
 		c.SetInvalidParamWithErr("user", jsonErr)
 		return
 	}
 
+	auditRec.AddEventParameter("user", &user)
 	// The user being updated in the payload must be the same one as indicated in the URL.
 	if user.Id != c.Params.UserId {
 		c.SetInvalidParam("user_id")
 		return
 	}
-
-	auditRec := c.MakeAuditRecord("updateUser", audit.Fail)
-	defer c.LogAuditRec(auditRec)
 
 	// Cannot update a system admin unless user making request is a systemadmin also.
 	if user.IsSystemAdmin() && !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
@@ -1264,7 +1265,6 @@ func updateUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	auditRec.AddEventParameter("user", user)
 	auditRec.AddEventPriorState(ouser)
 	auditRec.AddEventObjectType("user")
 
@@ -1322,7 +1322,7 @@ func patchUser(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("patchUser", audit.Fail)
-	auditRec.AddEventParameter("user_patch", patch.Auditable())
+	auditRec.AddEventParameter("user_patch", &patch)
 	defer c.LogAuditRec(auditRec)
 
 	if !c.App.SessionHasPermissionToUser(*c.AppContext.Session(), c.Params.UserId) {
@@ -1472,7 +1472,7 @@ func updateUserRoles(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("updateUserRoles", audit.Fail)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("roles", newRoles)
 	defer c.LogAuditRec(auditRec)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageRoles) {
@@ -1510,7 +1510,6 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("updateUserActive", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
 	auditRec.AddEventParameter("active", active)
 
 	// true when you're trying to de-activate yourself
@@ -1586,7 +1585,7 @@ func updateUserAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddEventParameter("user_auth", userAuth.Auditable())
+	auditRec.AddEventParameter("user_auth", &userAuth)
 
 	if userAuth.AuthData == nil || *userAuth.AuthData == "" || userAuth.AuthService == "" {
 		c.Err = model.NewAppError("updateUserAuth", "api.user.update_user_auth.invalid_request", nil, "", http.StatusBadRequest)
@@ -1634,7 +1633,7 @@ func updateUserMfa(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if user, err := c.App.GetUser(c.Params.UserId); err == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 	}
 
 	props := model.StringInterfaceFromJSON(r.Body)
@@ -1713,7 +1712,7 @@ func updatePassword(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var canUpdatePassword bool
 	if user, err := c.App.GetUser(c.Params.UserId); err == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 
 		if user.IsSystemAdmin() {
 			canUpdatePassword = c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem)
@@ -1775,7 +1774,6 @@ func resetPassword(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("resetPassword", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddMeta("token", token)
 	c.LogAudit("attempt - token=" + token)
 
 	if err := c.App.ResetPasswordFromToken(c.AppContext, token, newPassword); err != nil {
@@ -1802,7 +1800,7 @@ func sendPasswordReset(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("sendPasswordReset", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("email", email)
 
 	sent, err := c.App.SendPasswordReset(email, c.App.GetSiteURL())
 	if err != nil {
@@ -1920,7 +1918,7 @@ func login(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventResultState(user)
 
 	if user.IsGuest() {
 		if c.App.Channels().License() == nil {
@@ -2003,7 +2001,7 @@ func loginCWS(c *Context, w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, *c.App.Config().ServiceSettings.SiteURL, http.StatusFound)
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventParameter("user", user)
 	c.LogAuditWithUserId(user.Id, "authenticated")
 	err = c.App.DoLogin(c.AppContext, w, r, user, "", false, false, false)
 	if err != nil {
@@ -2100,6 +2098,7 @@ func revokeSession(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetInvalidParam("session_id")
 		return
 	}
+	auditRec.AddEventParameter("session_id", sessionId)
 
 	session, err := c.App.GetSessionById(sessionId)
 	if err != nil {
@@ -2107,7 +2106,6 @@ func revokeSession(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddEventParameter("props", props)
 	auditRec.AddEventPriorState(session)
 	auditRec.AddEventObjectType("session")
 
@@ -2184,7 +2182,7 @@ func attachDeviceId(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("attachDeviceId", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("device_id", deviceId)
 
 	// A special case where we logout of all other sessions with the same device id
 	if err := c.App.RevokeSessionsForDeviceId(c.AppContext.Session().UserId, deviceId, c.AppContext.Session().Id); err != nil {
@@ -2240,7 +2238,7 @@ func getUserAudits(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 
 	if user, err := c.App.GetUser(c.Params.UserId); err == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 	}
 
 	if !c.App.SessionHasPermissionToUser(*c.AppContext.Session(), c.Params.UserId) {
@@ -2299,8 +2297,8 @@ func sendVerificationEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("sendVerificationEmail", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
-	auditRec.AddEventParameter("r", redirect)
+	auditRec.AddEventParameter("email", email)
+	auditRec.AddEventParameter("redirect", redirect)
 
 	user, err := c.App.GetUserForLogin("", email)
 	if err != nil {
@@ -2308,7 +2306,7 @@ func sendVerificationEmail(c *Context, w http.ResponseWriter, r *http.Request) {
 		ReturnStatusOK(w)
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventResultState(user)
 
 	if err = c.App.SendEmailVerification(user, user.Email, redirect); err != nil {
 		// Don't want to leak whether the email is valid or not
@@ -2330,7 +2328,7 @@ func switchAccountType(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("switchAccountType", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("switch_request", switchRequest)
+	auditRec.AddEventParameter("switch_request", &switchRequest)
 
 	link := ""
 	var err *model.AppError
@@ -2375,7 +2373,7 @@ func createUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 
 	if user, err := c.App.GetUser(c.Params.UserId); err == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 	}
 
 	if c.AppContext.Session().IsOAuth {
@@ -2546,7 +2544,7 @@ func revokeUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("revokeUserAccessToken", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("token_id", tokenId)
 	c.LogAudit("")
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionRevokeUserAccessToken) {
@@ -2561,7 +2559,7 @@ func revokeUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if user, errGet := c.App.GetUser(accessToken.UserId); errGet == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 	}
 
 	if !c.App.SessionHasPermissionToUserOrBot(*c.AppContext.Session(), accessToken.UserId) {
@@ -2589,7 +2587,7 @@ func disableUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	auditRec := c.MakeAuditRecord("disableUserAccessToken", audit.Fail)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("token_id", tokenId)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("")
 
@@ -2606,7 +2604,7 @@ func disableUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) 
 	}
 
 	if user, errGet := c.App.GetUser(accessToken.UserId); errGet == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 	}
 
 	if !c.App.SessionHasPermissionToUserOrBot(*c.AppContext.Session(), accessToken.UserId) {
@@ -2635,7 +2633,7 @@ func enableUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("enableUserAccessToken", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("token_id", tokenId)
 	c.LogAudit("")
 
 	// No separate permission for this action for now
@@ -2651,7 +2649,7 @@ func enableUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if user, errGet := c.App.GetUser(accessToken.UserId); errGet == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 	}
 
 	if !c.App.SessionHasPermissionToUserOrBot(*c.AppContext.Session(), accessToken.UserId) {
@@ -2673,24 +2671,25 @@ func enableUserAccessToken(c *Context, w http.ResponseWriter, r *http.Request) {
 func saveUserTermsOfService(c *Context, w http.ResponseWriter, r *http.Request) {
 	props := model.StringInterfaceFromJSON(r.Body)
 
+	auditRec := c.MakeAuditRecord("saveUserTermsOfService", audit.Fail)
+	defer c.LogAuditRec(auditRec)
+
 	userId := c.AppContext.Session().UserId
 	termsOfServiceId, ok := props["termsOfServiceId"].(string)
 	if !ok {
 		c.SetInvalidParam("termsOfServiceId")
 		return
 	}
+	auditRec.AddEventParameter("terms_of_service_id", termsOfServiceId)
 	accepted, ok := props["accepted"].(bool)
 	if !ok {
 		c.SetInvalidParam("accepted")
 		return
 	}
-
-	auditRec := c.MakeAuditRecord("saveUserTermsOfService", audit.Fail)
-	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("accepted", accepted)
 
 	if user, err := c.App.GetUser(userId); err == nil {
-		auditRec.AddMeta("user", user)
+		auditRec.AddEventParameter("user", user)
 	}
 
 	if _, err := c.App.GetTermsOfService(termsOfServiceId); err != nil {
@@ -2741,7 +2740,7 @@ func promoteGuestToUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = err
 		return
 	}
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventResultState(user)
 
 	if !user.IsGuest() {
 		c.Err = model.NewAppError("Api4.promoteGuestToUser", "api.user.promote_guest_to_user.no_guest.app_error", nil, "", http.StatusNotImplemented)
@@ -2800,7 +2799,7 @@ func demoteUserToGuest(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventResultState(user)
 
 	if user.IsGuest() {
 		c.Err = model.NewAppError("Api4.demoteUserToGuest", "api.user.demote_user_to_guest.already_guest.app_error", nil, "", http.StatusNotImplemented)
@@ -2896,7 +2895,7 @@ func convertUserToBot(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec := c.MakeAuditRecord("convertUserToBot", audit.Fail)
 	auditRec.AddEventParameter("user_id", c.Params.UserId)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddMeta("user", user)
+	auditRec.AddEventParameter("user", user)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
 		c.SetPermissionError(model.PermissionManageSystem)
@@ -2997,7 +2996,9 @@ func migrateAuthToLDAP(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("migrateAuthToLdap", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("from", from)
+	auditRec.AddEventParameter("force", force)
+	auditRec.AddEventParameter("match_field", matchField)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
 		c.SetPermissionError(model.PermissionManageSystem)
@@ -3054,7 +3055,9 @@ func migrateAuthToSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("migrateAuthToSaml", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("props", props)
+	auditRec.AddEventParameter("from", from)
+	auditRec.AddEventParameter("auto", auto)
+	auditRec.AddEventParameter("matches", matches)
 
 	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
 		c.SetPermissionError(model.PermissionManageSystem)

--- a/api4/webhook.go
+++ b/api4/webhook.go
@@ -42,8 +42,8 @@ func createIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("createIncomingHook", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("incoming_webhook", hook)
-	auditRec.AddMeta("channel", channel)
+	auditRec.AddEventParameter("incoming_webhook", &hook)
+	auditRec.AddEventParameter("channel", channel)
 	c.LogAudit("attempt")
 
 	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), channel.TeamId, model.PermissionManageIncomingWebhooks) {
@@ -110,7 +110,7 @@ func updateIncomingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("updateIncomingHook", audit.Fail)
 	auditRec.AddEventParameter("hook_id", c.Params.HookId)
-	auditRec.AddEventParameter("updated_hook", updatedHook)
+	auditRec.AddEventParameter("updated_hook", &updatedHook)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 
@@ -357,7 +357,7 @@ func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec := c.MakeAuditRecord("updateOutgoingHook", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("updated_hook", updatedHook)
+	auditRec.AddEventParameter("updated_hook", &updatedHook)
 	c.LogAudit("attempt")
 
 	oldHook, err := c.App.GetOutgoingWebhook(c.Params.HookId)
@@ -410,7 +410,7 @@ func createOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec := c.MakeAuditRecord("createOutgoingHook", audit.Fail)
-	auditRec.AddEventParameter("hook", hook)
+	auditRec.AddEventParameter("hook", &hook)
 	defer c.LogAuditRec(auditRec)
 	c.LogAudit("attempt")
 

--- a/api4/webhook_local.go
+++ b/api4/webhook_local.go
@@ -51,8 +51,8 @@ func localCreateIncomingHook(c *Context, w http.ResponseWriter, r *http.Request)
 
 	auditRec := c.MakeAuditRecord("localCreateIncomingHook", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("hook", hook)
-	auditRec.AddMeta("channel", channel)
+	auditRec.AddEventParameter("hook", &hook)
+	auditRec.AddEventParameter("channel", channel)
 	c.LogAudit("attempt")
 
 	incomingHook, err := c.App.CreateIncomingWebhookForChannel(hook.UserId, channel, &hook)
@@ -81,7 +81,7 @@ func localCreateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request)
 
 	auditRec := c.MakeAuditRecord("createOutgoingHook", audit.Fail)
 	defer c.LogAuditRec(auditRec)
-	auditRec.AddEventParameter("hook", hook)
+	auditRec.AddEventParameter("hook", &hook)
 	c.LogAudit("attempt")
 
 	if hook.CreatorId == "" {

--- a/app/session.go
+++ b/app/session.go
@@ -267,7 +267,7 @@ func (a *App) ExtendSessionExpiryIfNeeded(session *model.Session) bool {
 
 	auditRec := a.MakeAuditRecord("extendSessionExpiry", audit.Fail)
 	defer a.LogAuditRec(auditRec, nil)
-	auditRec.AddMeta("session", session)
+	auditRec.AddEventPriorState(session)
 
 	newExpiry := now + sessionLength
 	if err := a.ch.srv.platform.ExtendSessionExpiry(session, newExpiry); err != nil {
@@ -280,7 +280,7 @@ func (a *App) ExtendSessionExpiryIfNeeded(session *model.Session) bool {
 		mlog.Int64("newExpiry", newExpiry), mlog.Int64("session_length", sessionLength))
 
 	auditRec.Success()
-	auditRec.AddMeta("extended_session", session)
+	auditRec.AddEventResultState(session)
 	return true
 }
 

--- a/model/bot.go
+++ b/model/bot.go
@@ -54,6 +54,14 @@ type BotPatch struct {
 	Description *string `json:"description"`
 }
 
+func (b *BotPatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"username":     b.Username,
+		"display_name": b.DisplayName,
+		"description":  b.Description,
+	}
+}
+
 // BotGetOptions acts as a filter on bulk bot fetching queries.
 type BotGetOptions struct {
 	OwnerId        string

--- a/model/channel.go
+++ b/model/channel.go
@@ -142,6 +142,13 @@ type ChannelModerationPatch struct {
 	Roles *ChannelModeratedRolesPatch `json:"roles"`
 }
 
+func (c *ChannelModerationPatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"name":  c.Name,
+		"roles": c.Roles,
+	}
+}
+
 type ChannelModeratedRolesPatch struct {
 	Guests  *bool `json:"guests"`
 	Members *bool `json:"members"`

--- a/model/file_info.go
+++ b/model/file_info.go
@@ -59,6 +59,21 @@ type FileInfo struct {
 	Archived        bool    `json:"archived"`
 }
 
+func (fi *FileInfo) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"id":         fi.Id,
+		"creator_id": fi.CreatorId,
+		"post_id":    fi.PostId,
+		"channel_id": fi.ChannelId,
+		"create_at":  fi.CreateAt,
+		"update_at":  fi.UpdateAt,
+		"delete_at":  fi.DeleteAt,
+		"name":       fi.Name,
+		"extension":  fi.Extension,
+		"size":       fi.Size,
+	}
+}
+
 func (fi *FileInfo) PreSave() {
 	if fi.Id == "" {
 		fi.Id = NewId()

--- a/model/group.go
+++ b/model/group.go
@@ -66,6 +66,21 @@ type GroupWithUserIds struct {
 	UserIds []string `json:"user_ids"`
 }
 
+func (group *GroupWithUserIds) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"id":              group.Id,
+		"source":          group.Source,
+		"remote_id":       group.RemoteId,
+		"create_at":       group.CreateAt,
+		"update_at":       group.UpdateAt,
+		"delete_at":       group.DeleteAt,
+		"has_syncables":   group.HasSyncables,
+		"member_count":    group.MemberCount,
+		"allow_reference": group.AllowReference,
+		"user_ids":        group.UserIds,
+	}
+}
+
 type GroupWithSchemeAdmin struct {
 	Group
 	SchemeAdmin *bool `db:"SyncableSchemeAdmin" json:"scheme_admin,omitempty"`
@@ -136,6 +151,12 @@ type GroupStats struct {
 
 type GroupModifyMembers struct {
 	UserIds []string `json:"user_ids"`
+}
+
+func (group *GroupModifyMembers) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"user_ids": group.UserIds,
+	}
 }
 
 func (group *Group) Patch(patch *GroupPatch) {

--- a/model/group_syncable.go
+++ b/model/group_syncable.go
@@ -153,6 +153,13 @@ type GroupSyncablePatch struct {
 	SchemeAdmin *bool `json:"scheme_admin"`
 }
 
+func (syncable *GroupSyncablePatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"auto_add":     syncable.AutoAdd,
+		"scheme_admin": syncable.SchemeAdmin,
+	}
+}
+
 func (syncable *GroupSyncable) Patch(patch *GroupSyncablePatch) {
 	if patch.AutoAdd != nil {
 		syncable.AutoAdd = *patch.AutoAdd

--- a/model/guest_invite.go
+++ b/model/guest_invite.go
@@ -13,6 +13,13 @@ type GuestsInvite struct {
 	Message  string   `json:"message"`
 }
 
+func (i *GuestsInvite) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"emails":   i.Emails,
+		"channels": i.Channels,
+	}
+}
+
 // IsValid validates the user and returns an error if it isn't configured
 // correctly.
 func (i *GuestsInvite) IsValid() *AppError {

--- a/model/member_invite.go
+++ b/model/member_invite.go
@@ -14,6 +14,13 @@ type MemberInvite struct {
 	Message    string   `json:"message"`
 }
 
+func (i *MemberInvite) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"emails":      i.Emails,
+		"channel_ids": i.ChannelIds,
+	}
+}
+
 // IsValid validates that the invitation info is loaded correctly and with the correct structure
 func (i *MemberInvite) IsValid() *AppError {
 	if len(i.Emails) == 0 {

--- a/model/onboarding.go
+++ b/model/onboarding.go
@@ -13,6 +13,12 @@ type CompleteOnboardingRequest struct {
 	InstallPlugins []string `json:"install_plugins"` // InstallPlugins is a list of plugins to be installed
 }
 
+func (r *CompleteOnboardingRequest) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"install_plugins": r.InstallPlugins,
+	}
+}
+
 // CompleteOnboardingRequest decodes a json-encoded request from the given io.Reader.
 func CompleteOnboardingRequestFromReader(reader io.Reader) (*CompleteOnboardingRequest, error) {
 	var r *CompleteOnboardingRequest

--- a/model/remote_cluster.go
+++ b/model/remote_cluster.go
@@ -41,6 +41,19 @@ type RemoteCluster struct {
 	CreatorId    string `json:"creator_id"`
 }
 
+func (rc *RemoteCluster) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"remote_id":      rc.RemoteId,
+		"remote_team_id": rc.RemoteTeamId,
+		"name":           rc.Name,
+		"display_name":   rc.DisplayName,
+		"site_url":       rc.SiteURL,
+		"create_at":      rc.CreateAt,
+		"last_ping_at":   rc.LastPingAt,
+		"creator_id":     rc.CreatorId,
+	}
+}
+
 func (rc *RemoteCluster) PreSave() {
 	if rc.RemoteId == "" {
 		rc.RemoteId = NewId()
@@ -152,6 +165,13 @@ type RemoteClusterInfo struct {
 type RemoteClusterFrame struct {
 	RemoteId string           `json:"remote_id"`
 	Msg      RemoteClusterMsg `json:"msg"`
+}
+
+func (f *RemoteClusterFrame) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"remote_id": f.RemoteId,
+		"msg":       f.Msg,
+	}
 }
 
 func (f *RemoteClusterFrame) IsValid() *AppError {

--- a/model/role.go
+++ b/model/role.go
@@ -437,6 +437,12 @@ type RolePatch struct {
 	Permissions *[]string `json:"permissions"`
 }
 
+func (r *RolePatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"permissions": r.Permissions,
+	}
+}
+
 type RolePermissions struct {
 	RoleID      string
 	Permissions []string

--- a/model/scheme.go
+++ b/model/scheme.go
@@ -68,8 +68,22 @@ type SchemePatch struct {
 	Description *string `json:"description"`
 }
 
+func (scheme *SchemePatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"name":         scheme.Name,
+		"display_name": scheme.DisplayName,
+		"description":  scheme.Description,
+	}
+}
+
 type SchemeIDPatch struct {
 	SchemeID *string `json:"scheme_id"`
+}
+
+func (p *SchemeIDPatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"scheme_id": p.SchemeID,
+	}
 }
 
 // SchemeConveyor is used for importing and exporting a Scheme and its associated Roles.

--- a/model/session.go
+++ b/model/session.go
@@ -70,7 +70,6 @@ func (s *Session) Auditable() map[string]interface{} {
 		"is_oauth":         s.IsOAuth,
 		"expired_notify":   s.ExpiredNotify,
 		"local":            s.Local,
-		// TODO: props and members?
 	}
 }
 

--- a/model/switch_request.go
+++ b/model/switch_request.go
@@ -13,6 +13,15 @@ type SwitchRequest struct {
 	LdapLoginId    string `json:"ldap_id"`
 }
 
+func (o *SwitchRequest) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"current_service": o.CurrentService,
+		"new_service":     o.NewService,
+		"email":           o.Email,
+		"ldap_login_id":   o.LdapLoginId,
+	}
+}
+
 func (o *SwitchRequest) EmailToOAuth() bool {
 	return o.CurrentService == UserAuthServiceEmail &&
 		(o.NewService == UserAuthServiceSaml ||

--- a/model/team.go
+++ b/model/team.go
@@ -70,6 +70,14 @@ type TeamPatch struct {
 	CloudLimitsArchived *bool   `json:"cloud_limits_archived"`
 }
 
+func (o *TeamPatch) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"allow_open_invite":     o.AllowOpenInvite,
+		"group_constrained":     o.GroupConstrained,
+		"cloud_limits_archived": o.CloudLimitsArchived,
+	}
+}
+
 type TeamForExport struct {
 	Team
 	SchemeName *string

--- a/model/upload_session.go
+++ b/model/upload_session.go
@@ -47,6 +47,19 @@ type UploadSession struct {
 	ReqFileId string `json:"req_file_id"`
 }
 
+func (us *UploadSession) Auditable() map[string]interface{} {
+	return map[string]interface{}{
+		"id":         us.Id,
+		"type":       us.Type,
+		"user_id":    us.UserId,
+		"channel_id": us.ChannelId,
+		"filename":   us.Filename,
+		"file_size":  us.FileSize,
+		"remote_id":  us.RemoteId,
+		"ReqFileId":  us.ReqFileId,
+	}
+}
+
 // PreSave is a utility function used to fill required information.
 func (us *UploadSession) PreSave() {
 	if us.Id == "" {


### PR DESCRIPTION
#### Summary
This patch implements additional auditable interface implements from @crspeller's original PR and changes the API invocation to use pointers instead of values. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51320

#### Release Note
```release-note
NONE
```
