### PR TITLE
[MM-49486]: Option to exclude file count in channel stats

### DIFF
--- a/api4/channel.go
+++ b/api4/channel.go
@@ -627,6 +627,9 @@ func getChannelUnread(c *Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func getChannelStats(c *Context, w http.ResponseWriter, r *http.Request) {
+	excludeFilesCount := r.URL.Query().Get("exclude_files_count")
+	excludeFilesCountBool, _ := strconv.ParseBool(excludeFilesCount)
+
 	c.RequireChannelId()
 	if c.Err != nil {
 		return
@@ -655,10 +658,13 @@ func getChannelStats(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filesCount, err := c.App.GetChannelFileCount(c.AppContext, c.Params.ChannelId)
-	if err != nil {
-		c.Err = err
-		return
+	filesCount := int64(-1)
+	if !excludeFilesCountBool {
+		filesCount, err = c.App.GetChannelFileCount(c.AppContext, c.Params.ChannelId)
+		if err != nil {
+			c.Err = err
+			return
+		}
 	}
 
 	stats := model.ChannelStats{

--- a/api4/channel_test.go
+++ b/api4/channel_test.go
@@ -2543,7 +2543,7 @@ func TestGetChannelStats(t *testing.T) {
 	client := th.Client
 	channel := th.CreatePrivateChannel()
 
-	stats, _, err := client.GetChannelStats(channel.Id, "")
+	stats, _, err := client.GetChannelStats(channel.Id, "", false)
 	require.NoError(t, err)
 
 	require.Equal(t, channel.Id, stats.ChannelId, "couldn't get extra info")
@@ -2552,7 +2552,7 @@ func TestGetChannelStats(t *testing.T) {
 	require.Equal(t, int64(0), stats.FilesCount, "got incorrect file count")
 
 	th.CreatePinnedPostWithClient(th.Client, channel)
-	stats, _, err = client.GetChannelStats(channel.Id, "")
+	stats, _, err = client.GetChannelStats(channel.Id, "", false)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), stats.PinnedPostCount, "should have returned 1 pinned post count")
 
@@ -2563,30 +2563,35 @@ func TestGetChannelStats(t *testing.T) {
 	require.NoError(t, err)
 	th.CreatePostInChannelWithFiles(channel, fileResp.FileInfos...)
 	// make sure the file count channel stats is updated
-	stats, _, err = client.GetChannelStats(channel.Id, "")
+	stats, _, err = client.GetChannelStats(channel.Id, "", false)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), stats.FilesCount, "should have returned 1 file count")
 
-	_, resp, err := client.GetChannelStats("junk", "")
+	// exclude file counts
+	stats, _, err = client.GetChannelStats(channel.Id, "", true)
+	require.NoError(t, err)
+	require.Equal(t, int64(-1), stats.FilesCount, "should have returned -1 file count for exclude_files_count=true")
+
+	_, resp, err := client.GetChannelStats("junk", "", false)
 	require.Error(t, err)
 	CheckBadRequestStatus(t, resp)
 
-	_, resp, err = client.GetChannelStats(model.NewId(), "")
+	_, resp, err = client.GetChannelStats(model.NewId(), "", false)
 	require.Error(t, err)
 	CheckForbiddenStatus(t, resp)
 
 	client.Logout()
-	_, resp, err = client.GetChannelStats(channel.Id, "")
+	_, resp, err = client.GetChannelStats(channel.Id, "", false)
 	require.Error(t, err)
 	CheckUnauthorizedStatus(t, resp)
 
 	th.LoginBasic2()
 
-	_, resp, err = client.GetChannelStats(channel.Id, "")
+	_, resp, err = client.GetChannelStats(channel.Id, "", false)
 	require.Error(t, err)
 	CheckForbiddenStatus(t, resp)
 
-	_, _, err = th.SystemAdminClient.GetChannelStats(channel.Id, "")
+	_, _, err = th.SystemAdminClient.GetChannelStats(channel.Id, "", false)
 	require.NoError(t, err)
 }
 

--- a/model/client4.go
+++ b/model/client4.go
@@ -3032,8 +3032,9 @@ func (c *Client4) GetChannel(channelId, etag string) (*Channel, *Response, error
 }
 
 // GetChannelStats returns statistics for a channel.
-func (c *Client4) GetChannelStats(channelId string, etag string) (*ChannelStats, *Response, error) {
-	r, err := c.DoAPIGet(c.channelRoute(channelId)+"/stats", etag)
+func (c *Client4) GetChannelStats(channelId string, etag string, excludeFilesCount bool) (*ChannelStats, *Response, error) {
+	route := c.channelRoute(channelId) + fmt.Sprintf("/stats?exclude_files_count=%v", excludeFilesCount)
+	r, err := c.DoAPIGet(route, etag)
 	if err != nil {
 		return nil, BuildResponse(r), err
 	}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
- Added a `exclude_files_count` param to exclude file counts from channel stats API. Returns -1 if file counts have been excluded. This is to differentiate between a zero files count, and excluded files count.
- cherry-pick https://github.com/mattermost/mattermost-server/pull/22096 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
- https://mattermost.atlassian.net/browse/MM-49486

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Added a `exclude_files_count` parameter to exclude file counts from channel stats API
```
