### PR TITLE
Re-add dist target for web app

### DIFF
--- a/.github/workflows/channels-ci.yml
+++ b/.github/workflows/channels-ci.yml
@@ -190,15 +190,7 @@ jobs:
       - name: ci/build
         working-directory: webapp/channels
         run: |
-          node --version
-          npm version
-          make dist
-      - name: ci/persist-artifact
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          name: webapp-artifact
-          path: webapp/channels/mattermost-webapp.tar.gz
-          retention-days: 14
+          npm run build
   # run-performance-bechmarks:
   #   uses: ./.github/workflows/performance-benchmarks.yml
   #   needs: build

--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -93,7 +93,7 @@ build-cmd: setup-go-work build-cmd-linux build-cmd-windows build-cmd-osx
 build-client:
 	@echo Building mattermost web app
 
-	cd $(BUILD_WEBAPP_DIR) && $(MAKE) build
+	cd $(BUILD_WEBAPP_DIR) && $(MAKE) dist
 
 package-prep:
 	@ echo Packaging mattermost
@@ -121,9 +121,9 @@ package-prep:
 	sed -i'' -e 's|"SMTPPort": "2500",|"SMTPPort": "",|g' $(DIST_PATH)/config/config.json
 	chmod 600 $(DIST_PATH)/config/config.json
 
-	@# Package webapp
+	@# Package web app
 	mkdir -p $(DIST_PATH)/client
-	cp -RL $(BUILD_WEBAPP_DIR)/dist/* $(DIST_PATH)/client
+	cp -RL $(BUILD_WEBAPP_DIR)/channels/dist/* $(DIST_PATH)/client
 
 	@# Help files
 ifeq ($(BUILD_ENTERPRISE_READY),true)
@@ -193,26 +193,6 @@ else
 		fi; \
 	done
 endif
-
-	@# Products
-
-	@if [ -d $(BUILD_BOARDS_DIR) ] ; then \
-		echo "Copying web app files for Boards product"; \
-		mkdir -p $(DIST_PATH_GENERIC)/client/products/boards; \
-		cp -R $(BUILD_BOARDS_DIR)/mattermost-plugin/webapp/dist/* $(DIST_PATH_GENERIC)/client/products/boards/; \
-	else \
-		echo "Unable to find files for Boards product. Please ensure that the Focalboard repository is checked out alongside the server and run 'make build-product' in it."; \
-		exit 1; \
-	fi
-
-	@if [ -d $(BUILD_PLAYBOOKS_DIR) ] ; then \
-		echo "Copying web app files for Playbooks product"; \
-		mkdir -p $(DIST_PATH_GENERIC)/client/products/playbooks; \
-		cp -R $(BUILD_PLAYBOOKS_DIR)/webapp/dist/* $(DIST_PATH_GENERIC)/client/products/playbooks/; \
-	else \
-		echo "Unable to find files for Playbooks product. Please ensure that the Playbooks repository is checked out alongside the server and run 'make build-product' in it."; \
-		exit 1; \
-	fi
 
 package-osx-amd64: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_OSX_AMD64) CURRENT_PACKAGE_ARCH=darwin_amd64 PLUGIN_ARCH=osx-amd64 MMCTL_PLATFORM="Darwin-x86_64" MM_BIN_NAME=mattermost $(MAKE) package-general

--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -51,6 +51,21 @@ check-types: node_modules ## Checks TS file for TypeScript confirmity
 
 	npm run check-types
 
+.PHONY: build
+build: node_modules ## Builds all web app packages
+	@echo Building Web App and related packages
+
+	npm run build
+
+.PHONY: dist
+dist: build ## Builds all web app packages and copies Boards/Playbooks files into Channels dist folder
+	@echo Packaging Mattermost Web App
+
+	mkdir -p channels/dist/products/boards
+	cp -R boards/dist/* channels/dist/products/boards
+	mkdir -p channels/dist/products/playbooks
+	cp -R playbooks/dist/* channels/dist/products/playbooks
+
 node_modules: package.json $(wildcard package-lock.json)
 	@echo Getting dependencies using npm
 

--- a/webapp/channels/Makefile
+++ b/webapp/channels/Makefile
@@ -1,5 +1,3 @@
-.PHONY: dist emojis help update-dependencies
-
 BUILD_SERVER_DIR = ../mattermost-server
 
 export NODE_OPTIONS=--max-old-space-size=4096
@@ -11,20 +9,6 @@ i18n-extract: ## Extract strings for translation from the source code
 e2e/playwright/node_modules:
 	@echo Install Playwright and its dependencies
 	cd e2e/playwright && npm install
-
-.PHONY: dist
-dist: ## Builds and packages app
-	@echo Building Mattermost Web App
-
-	npm run build
-
-	@echo Packaging Mattermost Web App
-
-	mkdir tmp
-	mv dist tmp/client
-	tar -C tmp -czf mattermost-webapp.tar.gz client
-	mv tmp/client dist
-	rmdir tmp
 
 .PHONY: e2e-test
 e2e-test:


### PR DESCRIPTION
Instead of having the web app generate a tarball with its `make dist`, it now builds all parts of the web app and then copies the Playbooks/Boards files into the web app's dist folder in `webapp/channels/dist`. As far as I can tell, that tarball isn't needed any more.

I also updated the server's `release.mk` to look for the web app files in the above location

#### Release Note
```release-note
NONE
```
