### PR TITLE
[MM-47600] Change channel type dropdown to a button instead of an anchor

### DIFF
--- a/webapp/channels/src/components/more_channels/searchable_channel_list.jsx
+++ b/webapp/channels/src/components/more_channels/searchable_channel_list.jsx
@@ -356,13 +356,16 @@ export default class SearchableChannelList extends React.PureComponent {
             );
             channelDropdown = (
                 <MenuWrapper id='channelsMoreDropdown'>
-                    <a id='menuWrapper'>
+                    <button
+                        id='menuWrapper'
+                        className='style--none'
+                    >
                         <span>{this.props.shouldShowArchivedChannels ? localizeMessage('more_channels.show_archived_channels', 'Channel Type: Archived') : localizeMessage('more_channels.show_public_channels', 'Channel Type: Public')}</span>
                         <ChevronDownIcon
                             color={'rgba(var(--center-channel-color-rgb), 0.64)'}
                             size={16}
                         />
-                    </a>
+                    </button>
                     <Menu
                         openLeft={false}
                         ariaLabel={localizeMessage('more_channels.title', 'Browse channels')}


### PR DESCRIPTION
#### Summary
Changes the existing `a`nchor tag for selecting channel type in "Browse Channels" to a `button`
    - This allows the element to be tabbed to, and controlled from a client leveraging a screen reader.

FYI: This change targets the webapp _after_ the `mono-repo` branch has been integrated

<details>

<summary>See the altered behaviour here</summary>

**Before**

https://user-images.githubusercontent.com/9254315/226441602-96d49b46-613e-4b95-9f07-eb9b536a54f2.mp4


**After**

https://user-images.githubusercontent.com/9254315/226441658-9c4e109f-ee2b-4785-a1bf-f85728cb85e3.mp4


</details>

#### Ticket Link
[GH-21417](https://github.com/mattermost/mattermost-server/issues/21417)
[MM-47600](https://mattermost.atlassian.net/browse/MM-47600)

#### Release Note

```release-note
Allows the "Channel Type" dropdown within the "Browse Channels" modal to be focused
```


[MM-47600]: https://mattermost.atlassian.net/browse/MM-47600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ