### PR TITLE
Actually build the web app when the server builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,32 +175,6 @@ jobs:
     steps:
       - name: Checkout mattermost-server
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: Checkout mattermost-webapp
-        run: |
-          cd ../..
-          git clone --depth=1 --no-single-branch https://github.com/mattermost/mattermost-webapp.git
-          cd mattermost-webapp
-          git checkout $GITHUB_HEAD_REF || git checkout master
-          export WEBAPP_GIT_COMMIT=$(git rev-parse HEAD)
-          echo "$WEBAPP_GIT_COMMIT"
-          FILE_DIST=dist.tar.gz
-          runtime="2 minute"
-          endtime=$(date -ud "$runtime" +%s)
-          while [[ $(date -u +%s) -le $endtime ]]; do
-            if curl -s --max-time 30 -f -o $FILE_DIST https://pr-builds.mattermost.com/mattermost-webapp/commit/$WEBAPP_GIT_COMMIT/mattermost-webapp.tar.gz; then
-              break
-            fi
-            echo "Waiting for webapp git commit $WEBAPP_GIT_COMMIT with sleep 5: `date +%H:%M:%S`"
-            sleep 5
-          done
-          if [[ -f "$FILE_DIST" ]]; then
-            echo "Precompiled version of web app found"
-            mkdir dist && tar -xf $FILE_DIST -C dist --strip-components=1
-          else
-          echo "Building web app from source"
-          make dist
-          fi
-          cd ../mattermost-server/server
       - name: Build
         run: |
           make config-reset

--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -86,9 +86,9 @@ else
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN)/windows_amd64 $(GOFLAGS) -trimpath -tags '$(GOTAGS)' -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
-build: setup-go-work build-linux build-windows build-osx
+build: setup-go-work build-client build-linux build-windows build-osx
 
-build-cmd: setup-go-work build-cmd-linux build-cmd-windows build-cmd-osx
+build-cmd: setup-go-work build-client build-cmd-linux build-cmd-windows build-cmd-osx
 
 build-client:
 	@echo Building mattermost web app


### PR DESCRIPTION
Apparently I was wrong for assuming the `build-client` target is actually called by `make build` or `make build-cmd`

#### Release Note
```release-note
NONE
```
