### PR TITLE
[MM-50382] Shows an error if post edit history fails to load

### DIFF
--- a/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
+++ b/webapp/channels/src/components/post_edit_history/__snapshots__/post_edit_history.test.tsx.snap
@@ -1,5 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/post_edit_history should display error screen if errors are present 1`] = `
+<div
+  className="sidebar-right__body"
+  id="rhsContainer"
+>
+  <Scrollbars
+    autoHeight={false}
+    autoHeightMax={200}
+    autoHeightMin={0}
+    autoHide={true}
+    autoHideDuration={500}
+    autoHideTimeout={500}
+    hideTracksWhenNotNeeded={false}
+    renderThumbHorizontal={[Function]}
+    renderThumbVertical={[Function]}
+    renderTrackHorizontal={[Function]}
+    renderTrackVertical={[Function]}
+    renderView={[Function]}
+    tagName="div"
+    thumbMinSize={30}
+    universal={false}
+  >
+    <Connect(SearchResultsHeader)>
+      Edit History
+      <div
+        className="sidebar--right__title__channel"
+      >
+        channel_display_name
+      </div>
+    </Connect(SearchResultsHeader)>
+    <div
+      className="edit-post-history__error_container"
+    >
+      <div
+        className="edit-post-history__error_item"
+      >
+        <AlertOutlineIcon
+          size={67}
+        />
+        <p
+          className="edit-post-history__error_heading"
+        >
+          Unable to load edit history
+        </p>
+        <p
+          className="edit-post-history__error_subheading"
+        >
+          There was an error loading the history for this message. Check your network connection or try again later.
+        </p>
+      </div>
+    </div>
+  </Scrollbars>
+</div>
+`;
+
+exports[`components/post_edit_history should display loading screen while postEditHistory is empty and no errors are present 1`] = `
+<div
+  className="sidebar-right__body"
+  id="rhsContainer"
+>
+  <LoadingScreen
+    style={
+      Object {
+        "display": "grid",
+        "flex": "1",
+        "placeContent": "center",
+      }
+    }
+  />
+</div>
+`;
+
 exports[`components/post_edit_history should match snapshot 1`] = `
 <div
   className="sidebar-right__body"
@@ -32,6 +104,7 @@ exports[`components/post_edit_history should match snapshot 1`] = `
     </Connect(SearchResultsHeader)>
     <Connect(Component)
       isCurrent={true}
+      key="post_id"
       post={
         Object {
           "channel_id": "",

--- a/webapp/channels/src/components/post_edit_history/index.ts
+++ b/webapp/channels/src/components/post_edit_history/index.ts
@@ -8,7 +8,7 @@ import {getChannel, getCurrentChannel} from 'mattermost-redux/selectors/entities
 import {GlobalState} from 'types/store';
 
 import {getSelectedPostId} from 'selectors/rhs';
-import {getPostEditHistory} from 'selectors/posts';
+import {getPostEditHistory, getPostErrors} from 'selectors/posts';
 
 import PostEditHistory from './post_edit_history';
 
@@ -16,10 +16,12 @@ function mapStateToProps(state: GlobalState) {
     const selectedPostId = getSelectedPostId(state) || '';
     const originalPost = getPost(state, selectedPostId);
     const channelDisplayName = getCurrentChannel(state) ? getCurrentChannel(state).display_name : getChannel(state, originalPost.channel_id).display_name;
+    const errors = getPostErrors(state).postEditHistory || false;
 
     return {
         channelDisplayName,
         originalPost,
+        errors,
         postEditHistory: getPostEditHistory(state),
     };
 }

--- a/webapp/channels/src/components/post_edit_history/post_edit_history.test.tsx
+++ b/webapp/channels/src/components/post_edit_history/post_edit_history.test.tsx
@@ -25,12 +25,25 @@ describe('components/post_edit_history', () => {
                 message: 'post message version 2',
             }),
         ],
+        errors: false,
         dispatch: jest.fn(),
     };
 
     test('should match snapshot', () => {
         const wrapper = shallow(<PostEditHistory {...baseProps}/>);
 
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should display error screen if errors are present', () => {
+        const propsWithError = {...baseProps, errors: true};
+        const wrapper = shallow(<PostEditHistory {...propsWithError}/>);
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should display loading screen while postEditHistory is empty and no errors are present', () => {
+        const propsWhileLoading = {...baseProps, postEditHistory: []};
+        const wrapper = shallow(<PostEditHistory {...propsWhileLoading}/>);
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/webapp/channels/src/components/post_edit_history/post_edit_history.tsx
+++ b/webapp/channels/src/components/post_edit_history/post_edit_history.tsx
@@ -12,6 +12,7 @@ import LoadingScreen from 'components/loading_screen';
 import EditedPostItem from './edited_post_item';
 
 import {PropsFromRedux} from '.';
+import {AlertOutlineIcon} from '@mattermost/compass-icons/components';
 
 const renderView = (props: Record<string, unknown>): JSX.Element => (
     <div
@@ -38,6 +39,7 @@ const PostEditHistory = ({
     channelDisplayName,
     originalPost,
     postEditHistory,
+    errors,
 }: PropsFromRedux) => {
     const scrollbars = useRef<Scrollbars | null>(null);
     const {formatMessage} = useIntl();
@@ -51,11 +53,21 @@ const PostEditHistory = ({
         defaultMessage: 'Edit History',
     });
 
-    if (!postEditHistory) {
-        return null;
-    }
+    const errorContainer: JSX.Element = (
+        <div className='edit-post-history__error_container'>
+            <div className='edit-post-history__error_item'>
+                <AlertOutlineIcon size={67}/>
+                <p className='edit-post-history__error_heading'>
+                    {formatMessage({id: 'post_info.edit.history.retrieveError', defaultMessage: 'Unable to load edit history'})}
+                </p>
+                <p className='edit-post-history__error_subheading'>
+                    {formatMessage({id: 'post_info.edit.history.retrieveErrorVerbose', defaultMessage: 'There was an error loading the history for this message. Check your network connection or try again later.'})}
+                </p>
+            </div>
+        </div>
+    );
 
-    if (postEditHistory.length === 0) {
+    if (postEditHistory.length === 0 && !errors) {
         return (
             <div
                 id='rhsContainer'
@@ -72,12 +84,20 @@ const PostEditHistory = ({
         );
     }
 
-    const postEditItems = postEditHistory.map((postEdited) => (
+    const currentItem = (
+        <EditedPostItem
+            post={originalPost}
+            key={originalPost.id}
+            isCurrent={true}
+        />
+    );
+
+    const postEditItems = [currentItem, ...postEditHistory.map((postEdited) => (
         <EditedPostItem
             key={postEdited.id}
             post={postEdited}
         />
-    ));
+    ))];
 
     return (
         <div
@@ -97,11 +117,7 @@ const PostEditHistory = ({
                     {title}
                     <div className='sidebar--right__title__channel'>{channelDisplayName}</div>
                 </SearchResultsHeader>
-                <EditedPostItem
-                    post={originalPost}
-                    isCurrent={true}
-                />
-                {postEditItems}
+                {errors ? errorContainer : postEditItems}
             </Scrollbars>
         </div>
     );

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4432,6 +4432,8 @@
   "post_info.edit": "Edit",
   "post_info.edit.aria_label": "Select to restore an old message.",
   "post_info.edit.current_version": "Current Version",
+  "post_info.edit.history.retrieveError": "Unable to load edit history",
+  "post_info.edit.history.retrieveErrorVerbose": "There was an error loading the history for this message. Check your network connection or try again later.",
   "post_info.edit.restore": "Restore this version",
   "post_info.edit.restore_question": "Restore this version?",
   "post_info.edit.undo": "Undo",

--- a/webapp/channels/src/packages/mattermost-redux/src/action_types/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/action_types/posts.ts
@@ -30,6 +30,7 @@ export default keyMirror({
     RECEIVED_POST: null,
     RECEIVED_NEW_POST: null,
     RECEIVED_POST_HISTORY: null,
+    RECEIVE_POST_HISTORY_FAILURE: null,
 
     RECEIVED_POSTS: null,
     RECEIVED_POSTS_AFTER: null,

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/posts.ts
@@ -1140,6 +1140,7 @@ export function getPostEditHistory(postId: string) {
         clientFunc: Client4.getPostEditHistory,
         onSuccess: PostTypes.RECEIVED_POST_HISTORY,
         params: [postId],
+        onFailure: PostTypes.RECEIVE_POST_HISTORY_FAILURE,
     });
 }
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/posts.ts
@@ -1575,6 +1575,20 @@ export function limitedViews(
     }
 }
 
+export interface ErrorsReducer {
+    postEditHistory?: true;
+}
+const emptyErrors = {};
+export function errors(state: ErrorsReducer = emptyErrors, action: GenericAction) {
+    switch (action.type) {
+    case PostTypes.RECEIVE_POST_HISTORY_FAILURE: {
+        return {...state, postEditHistory: true};
+    }
+    default:
+        return state;
+    }
+}
+
 export default function reducer(state: Partial<PostsState> = {}, action: GenericAction) {
     const nextPosts = handlePosts(state.posts, action);
     const nextPostsInChannel = postsInChannel(state.postsInChannel, action, state.posts!, nextPosts);
@@ -1623,6 +1637,9 @@ export default function reducer(state: Partial<PostsState> = {}, action: Generic
         // whether this particular view has messages that are hidden
         // because of the cloud workspace limit.
         limitedViews: limitedViews(state.limitedViews, action),
+
+        // Object mapping state keys to booleans indicating errors are present
+        errors: errors(state.errors, action),
     };
 
     if (state.posts === nextState.posts && state.postsInChannel === nextState.postsInChannel &&
@@ -1636,7 +1653,8 @@ export default function reducer(state: Partial<PostsState> = {}, action: Generic
         state.openGraph === nextState.openGraph &&
         state.messagesHistory === nextState.messagesHistory &&
         state.expandedURLs === nextState.expandedURLs &&
-        state.limitedViews === nextState.limitedViews) {
+        state.limitedViews === nextState.limitedViews &&
+        state.errors === nextState.errors) {
         // None of the children have changed so don't even let the parent object change
         return state;
     }

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -2356,6 +2356,35 @@
     font-weight: 600;
 }
 
+.edit-post-history__error_container {
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+
+    .edit-post-history__error_item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 56px;
+        text-align: center;
+
+        .edit-post-history__error_heading {
+            padding-top: 20px;
+            color: var(--center-channel-color);
+            font-size: 20px;
+            font-weight: 600;
+            line-height: 28px;
+        }
+
+        .edit-post-history__error_subheading {
+            color: rgba(var(--center-channel-color-rgb), 0.72);
+            font-weight: 400;
+        }
+    }
+}
+
 .post-list__dynamic {
     scrollbar-color: var(--center-channel-color-32) #fff0;
     scrollbar-width: thin;

--- a/webapp/channels/src/sass/components/_scrollbar.scss
+++ b/webapp/channels/src/sass/components/_scrollbar.scss
@@ -61,6 +61,9 @@ body {
 }
 
 .scrollbar--view {
+    display: flex;
+    flex-direction: column;
+
     .browser--ie & {
         margin: 0 !important;
         -ms-overflow-style: none;

--- a/webapp/channels/src/selectors/posts.ts
+++ b/webapp/channels/src/selectors/posts.ts
@@ -3,7 +3,7 @@
 
 import {createSelector} from 'reselect';
 
-import {Post} from '@mattermost/types/posts';
+import {Post, PostsState} from '@mattermost/types/posts';
 
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
@@ -51,4 +51,8 @@ export function isInlineImageVisible(state: GlobalState, postId: string, imageKe
     const imageCollapsed = arePreviewsCollapsed(state);
 
     return getGlobalItem(state, StoragePrefixes.INLINE_IMAGE_VISIBLE + currentUserId + '_' + postId + '_' + imageKey, !imageCollapsed);
+}
+
+export function getPostErrors(state: GlobalState): PostsState['errors'] {
+    return state.entities.posts.errors;
 }

--- a/webapp/platform/types/src/posts.ts
+++ b/webapp/platform/types/src/posts.ts
@@ -154,6 +154,7 @@ export type PostsState = {
         threads: Record<Post['root_id'], number>;
     };
     acknowledgements: RelationOneToOne<Post, Record<UserProfile['id'], number>>;
+    errors: Record<string, boolean>;
 };
 
 export declare type OpenGraphMetadataImage = {


### PR DESCRIPTION
#### Summary
This PR aims to add an error display when message history fails to load instead of the current behavior of the loading screen seemingly looping forever. The first cut of this solution is leveraging a separate `errors` reducer within the `posts` entity which currently only holds the `postEditHistory` boolean error indicator. 

<details>

<summary>Before/After video examples</summary>

(The below examples were simulated with a 5 second delay before making a request that will 404)

**Before**

https://user-images.githubusercontent.com/9254315/225959346-7f01dad9-f486-4a67-951b-7319d5209fc4.mp4


**After**

https://user-images.githubusercontent.com/9254315/225956643-956234eb-9261-4365-b4bb-8ce18f96b679.mp4

</details>


A number of small changes and assumptions were required to make this possible (inspired by the `HostedCustomerState.errors` handling) :
- Binds the `onFailure` action for `getPostEditHistory` to a **new** `RECEIVE_POST_HISTORY_FAILURE` action type
- Adds a `errors` reducer to `posts` entity 
    - Currently only defines `postEditHistory` as a potential key
- Adds `getPostErrors` selector for the `errors` reducer

Along with changes to the `PostEditHistory` component and syling:
- Adds an `errors` prop to `PostEditHistory` by leveraging the `getPostErrors` selector in `mapStateToProps`
- Adjusts `PostEditHistory` component to display an error container if errors are present 
    - Includes relevant styling adjustments to match Figma spec 
    - Includes test additions to ensure various states (loading, success, failure) all work as expected

**Note the alert icon currently does not match Figma designs, it is a placeholder while I source the correct icon**

#### Ticket Link
[MM-50382](https://mattermost.atlassian.net/browse/MM-50382)
[GH-22265](https://github.com/mattermost/mattermost-server/issues/22265)

#### Release Note
```release-note
Displays an error if post edit history fails to load
```


[MM-50382]: https://mattermost.atlassian.net/browse/MM-50382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ