### PR TITLE
fix mem leak in hubConnectionIndex

### DIFF
--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -599,6 +599,8 @@ func (i *hubConnectionIndex) Remove(wc *WebConn) {
 	last := userConnections[len(userConnections)-1]
 	// set the slot that we are trying to remove to be the last connection.
 	userConnections[userConnIndex] = last
+	// remove the last connection pointer from slice.
+	userConnections[len(userConnections)-1] = nil
 	// remove the last connection from the slice.
 	i.byUserId[wc.UserId] = userConnections[:len(userConnections)-1]
 	// set the index of the connection that was moved to the new index.

--- a/server/channels/app/platform/web_hub_test.go
+++ b/server/channels/app/platform/web_hub_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 	"time"
 
@@ -537,6 +538,42 @@ func BenchmarkHubConnIndex(b *testing.B) {
 			connIndex.Remove(wc2)
 		}
 	})
+}
+
+func TestHubConnIndexRemoveMemLeak(t *testing.T) {
+	th := Setup(t)
+	defer th.TearDown()
+
+	connIndex := newHubConnectionIndex(1 * time.Second)
+
+	wc := &WebConn{
+		Platform: th.Service,
+		Suite:    th.Suite,
+	}
+	wc.SetConnectionID(model.NewId())
+	wc.SetSession(&model.Session{})
+
+	ch := make(chan struct{})
+
+	runtime.SetFinalizer(wc, func(*WebConn) {
+		close(ch)
+	})
+
+	connIndex.Add(wc)
+	connIndex.Remove(wc)
+
+	runtime.GC()
+
+	timer := time.NewTimer(3 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-ch:
+	case <-timer.C:
+		t.Fatal("timeout waiting for collection of wc")
+	}
+
+	assert.Len(t, connIndex.byConnection, 0)
 }
 
 var hubSink *Hub

--- a/server/channels/app/platform/web_hub_test.go
+++ b/server/channels/app/platform/web_hub_test.go
@@ -570,7 +570,7 @@ func TestHubConnIndexRemoveMemLeak(t *testing.T) {
 	select {
 	case <-ch:
 	case <-timer.C:
-		t.Fatal("timeout waiting for collection of wc")
+		require.Fail(t, "timeout waiting for collection of wc")
 	}
 
 	assert.Len(t, connIndex.byConnection, 0)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
We still hold pointer of the last element when WebConn is removed. https://go101.org/article/container.html#slice-manipulations:~:text=Delete%20one%20slice%20element


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixed https://github.com/mattermost/mattermost-server/issues/22351

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
