### PR TITLE
Add blocklist for monorepo integrated plugins

### DIFF
--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -132,7 +132,7 @@ func (env *Environment) Available() ([]*model.BundleInfo, error) {
 	filteredList := make([]*model.BundleInfo, 0, len(rawList))
 	for _, bundleInfo := range rawList {
 		if PluginIDIsBlocked(bundleInfo.Manifest.Id) {
-			env.logger.Debug("Plugin ignored by blocklist", mlog.String("pluginid", bundleInfo.Manifest.Id))
+			env.logger.Debug("Plugin ignored by blocklist", mlog.String("plugin_id", bundleInfo.Manifest.Id))
 		} else {
 			filteredList = append(filteredList, bundleInfo)
 		}

--- a/plugin/environment.go
+++ b/plugin/environment.go
@@ -109,9 +109,36 @@ func scanSearchPath(path string) ([]*model.BundleInfo, error) {
 	return ret, nil
 }
 
+var pluginIDBlocklist = map[string]bool{
+	"playbooks": true,
+	"com.mattermost.plugin-incident-response":   true,
+	"com.mattermost.plugin-incident-management": true,
+	"focalboard": true,
+}
+
+func PluginIDIsBlocked(id string) bool {
+	_, ok := pluginIDBlocklist[id]
+	return ok
+}
+
 // Returns a list of all plugins within the environment.
 func (env *Environment) Available() ([]*model.BundleInfo, error) {
-	return scanSearchPath(env.pluginDir)
+	rawList, err := scanSearchPath(env.pluginDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter any plugins that match the blocklist
+	filteredList := make([]*model.BundleInfo, 0, len(rawList))
+	for _, bundleInfo := range rawList {
+		if PluginIDIsBlocked(bundleInfo.Manifest.Id) {
+			env.logger.Debug("Plugin ignored by blocklist", mlog.String("pluginid", bundleInfo.Manifest.Id))
+		} else {
+			filteredList = append(filteredList, bundleInfo)
+		}
+	}
+
+	return filteredList, nil
 }
 
 // Returns a list of prepackaged plugins available in the local prepackaged_plugins folder.

--- a/server/channels/app/channels.go
+++ b/server/channels/app/channels.go
@@ -287,11 +287,6 @@ func (ch *Channels) Start() error {
 
 	})
 
-	// This needs to be done after initPlugins has completed,
-	// because we want the full plugin processing to be complete before disabling it.
-	ch.disableBoardsIfNeeded()
-	ch.srv.AddClusterLeaderChangedListener(ch.disableBoardsIfNeeded)
-
 	// TODO: This should be moved to the platform service.
 	if err := ch.srv.platform.EnsureAsymmetricSigningKey(); err != nil {
 		return errors.Wrapf(err, "unable to ensure asymmetric signing key")
@@ -374,17 +369,4 @@ func (ch *Channels) HooksForPluginOrProduct(id string) (plugin.Hooks, error) {
 	}
 
 	return nil, fmt.Errorf("could not find hooks for id %s", id)
-}
-
-func (ch *Channels) disableBoardsIfNeeded() {
-	// Disable focalboard in product mode.
-	if ch.srv.Config().FeatureFlags.BoardsProduct {
-		// disablePlugin automatically checks if the plugin is running or not,
-		// and if it isn't, it returns an error. Therefore we ignore those errors.
-		// We don't want to check here again if the plugin is enabled or not.
-		appErr := ch.disablePlugin(model.PluginIdFocalboard)
-		if appErr != nil && appErr.Id != "app.plugin.not_installed.app_error" && appErr.Id != "app.plugin.disabled.app_error" {
-			ch.srv.Log().Error("Error disabling plugin in product mode", mlog.Err(appErr))
-		}
-	}
 }

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -161,11 +161,6 @@ func (ch *Channels) syncPluginsActiveState() {
 				defer wg.Done()
 
 				pluginID := plugin.Manifest.Id
-				// We skip it from activating here. It is disabled later, at a higher level
-				// from *Channels.Start.
-				if ch.srv.Config().FeatureFlags.BoardsProduct && pluginID == model.PluginIdFocalboard {
-					return
-				}
 				updatedManifest, activated, err := pluginsEnvironment.Activate(pluginID)
 				if err != nil {
 					plugin.WrapLogger(ch.srv.Log()).Error("Unable to activate plugin", mlog.Err(err))
@@ -439,10 +434,6 @@ func (ch *Channels) enablePlugin(id string) *model.AppError {
 
 	if manifest == nil {
 		return model.NewAppError("EnablePlugin", "app.plugin.not_installed.app_error", nil, "", http.StatusNotFound)
-	}
-
-	if id == model.PluginIdFocalboard && ch.cfgSvc.Config().FeatureFlags.BoardsProduct {
-		return model.NewAppError("EnablePlugin", "app.plugin.product_mode.app_error", map[string]any{"Name": model.PluginIdFocalboard}, "", http.StatusBadRequest)
 	}
 
 	ch.cfgSvc.UpdateConfig(func(cfg *model.Config) {

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -404,11 +404,6 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 			return manifest, nil
 		}
 
-		// We skip it from activating here. It is disabled later, at a higher level
-		// from *Channels.Start.
-		if ch.srv.Config().FeatureFlags.BoardsProduct && manifest.Id == model.PluginIdFocalboard {
-			return manifest, nil
-		}
 		updatedManifest, _, err := pluginsEnvironment.Activate(manifest.Id)
 		if err != nil {
 			return nil, model.NewAppError("installExtractedPlugin", "app.plugin.restart.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -46,6 +46,7 @@ import (
 	"github.com/blang/semver"
 
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/plugin"
 	"github.com/mattermost/mattermost-server/v6/server/channels/utils"
 	"github.com/mattermost/mattermost-server/v6/server/platform/shared/filestore"
 	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
@@ -139,6 +140,10 @@ func (ch *Channels) installPlugin(pluginFile, signature io.ReadSeeker, installat
 	manifest, appErr := ch.installPluginLocally(pluginFile, signature, installationStrategy)
 	if appErr != nil {
 		return nil, appErr
+	}
+
+	if manifest == nil {
+		return nil, nil
 	}
 
 	if signature != nil {
@@ -321,6 +326,12 @@ func (ch *Channels) installExtractedPlugin(manifest *model.Manifest, fromPluginD
 	bundles, err := pluginsEnvironment.Available()
 	if err != nil {
 		return nil, model.NewAppError("installExtractedPlugin", "app.plugin.install.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
+	// Check plugin id is not blocked
+	if plugin.PluginIDIsBlocked(manifest.Id) {
+		mlog.Debug("Skipping installation of plugin since plugin is on blocklist", mlog.String("plugin_id", manifest.Id))
+		return nil, nil
 	}
 
 	// Check for plugins installed with the same ID.

--- a/server/channels/app/plugin_install_test.go
+++ b/server/channels/app/plugin_install_test.go
@@ -167,6 +167,18 @@ func TestInstallPluginLocally(t *testing.T) {
 		assertBundleInfoManifests(t, th, []*model.Manifest{manifest})
 	})
 
+	t.Run("doesn't install if ID on block list", func(t *testing.T) {
+		th := Setup(t)
+		defer th.TearDown()
+		cleanExistingBundles(t, th)
+
+		manifest, appErr := installPlugin(t, th, "playbooks", "0.0.1", installPluginLocallyAlways)
+		require.Nil(t, appErr)
+		require.Nil(t, manifest)
+
+		assertBundleInfoManifests(t, th, []*model.Manifest{})
+	})
+
 	t.Run("different plugin already installed", func(t *testing.T) {
 		th := Setup(t)
 		defer th.TearDown()


### PR DESCRIPTION
#### Summary
Adds a blocklist for plugins that have been integrated into the monorepo. These plugins will not be installed or start.

Warnings are printed to the debug logs, otherwise no errors are raised. 

Removed boards blocking code from plugins. Left it everywhere else since it seemed to be used by the tests. Separate PR needed to remove the boards feature flag entirely. 

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-playbooks/issues/1832
Fixes https://github.com/mattermost/focalboard/issues/4628

#### Release Note
```release-note
NONE
```
