### PR TITLE
set the Dialog color for sidebar.

### DIFF
--- a/webapp/boards/src/components/sidebar/sidebarCategory.scss
+++ b/webapp/boards/src/components/sidebar/sidebarCategory.scss
@@ -3,7 +3,7 @@
     width: calc(100% - 4px);
 
     .Dialog {
-        color:rgba(var(--center-channel-color-rgb))
+        color: rgba(var(--center-channel-color-rgb))
     }
     &:first-child {
         margin-top: 0;

--- a/webapp/boards/src/components/sidebar/sidebarCategory.scss
+++ b/webapp/boards/src/components/sidebar/sidebarCategory.scss
@@ -2,6 +2,9 @@
     margin-top: 12px;
     width: calc(100% - 4px);
 
+    .Dialog {
+        color:rgba(var(--center-channel-color-rgb))
+    }
     &:first-child {
         margin-top: 0;
     }


### PR DESCRIPTION
Will rebase to master once mono-repo is merged.

#### Summary
Set the color for sidebar dialog box. Currently defaults to Sidebar Color `rgb(var(--sidebar-text-rgb))`, which cannot be seen in normal color scheme.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/4649

#### Release Note
```release-note
Fixes issue with Delete Category Dialog message not visible
```

