### PR TITLE
ESR Upgrade: One procedure per table in the v5.37 > v7.8 upgrade script

### DIFF
--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1113,9 +1113,6 @@ BEGIN
 
 	IF AddMattermostAppID THEN
 		SET AddMattermostAppIDQuery = 'ADD COLUMN MattermostAppID varchar(32) NOT NULL DEFAULT ""';
-	END IF;
-
-	IF AddMattermostAppID THEN
 		SET @query = CONCAT('ALTER TABLE OAuthApps ', CONCAT_WS(', ', AddMattermostAppIDQuery));
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1226,6 +1226,7 @@ CREATE TABLE IF NOT EXISTS PostAcknowledgements (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /* ==> mysql/000099_create_drafts.up.sql <== */
+/* ==> mysql/000100_add_draft_priority_column.up.sql <== */
 CREATE TABLE IF NOT EXISTS Drafts (
     CreateAt bigint(20) DEFAULT NULL,
     UpdateAt bigint(20) DEFAULT NULL,
@@ -1236,24 +1237,9 @@ CREATE TABLE IF NOT EXISTS Drafts (
     Message text,
     Props text,
     FileIds text,
+	Priority text,
     PRIMARY KEY (UserId, ChannelId, RootId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
-/* ==> mysql/000100_add_draft_priority_column.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE table_name = 'Drafts'
-        AND table_schema = DATABASE()
-        AND column_name = 'Priority'
-    ) > 0,
-    'SELECT 1',
-    'ALTER TABLE Drafts ADD COLUMN Priority text;'
-));
-
-PREPARE alterIfExists FROM @preparedStatement;
-EXECUTE alterIfExists;
-DEALLOCATE PREPARE alterIfExists;
 
 /* ==> mysql/000101_create_true_up_review_history.up.sql <== */
 CREATE TABLE IF NOT EXISTS TrueUpReviewHistory (

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -59,7 +59,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateUploadSessions procedure starting.') AS DEBUG;
-CALL MigrateUploadSessions ();
+CALL MigrateUploadSessions();
 SELECT CONCAT('-- ', NOW(), ' MigrateUploadSessions procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateUploadSessions;
 
@@ -92,7 +92,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateThreadMemberships procedure starting.') AS DEBUG;
-CALL MigrateThreadMemberships ();
+CALL MigrateThreadMemberships();
 SELECT CONCAT('-- ', NOW(), ' MigrateThreadMemberships procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateThreadMemberships;
 
@@ -229,7 +229,7 @@ END//
 DELIMITER ;
 
 SELECT CONCAT('-- ', NOW(), ' MigrateChannels procedure starting.') AS DEBUG;
-CALL MigrateChannels ();
+CALL MigrateChannels();
 SELECT CONCAT('-- ', NOW(), ' MigrateChannels procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateChannels;
 
@@ -253,7 +253,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateCommandWebhooks procedure starting.') AS DEBUG;
-CALL MigrateCommandWebhooks ();
+CALL MigrateCommandWebhooks();
 SELECT CONCAT('-- ', NOW(), ' MigrateCommandWebhooks procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateCommandWebhooks;
 
@@ -374,7 +374,7 @@ END//
 DELIMITER ;
 
 SELECT CONCAT('-- ', NOW(), ' MigrateChannelMembers procedure starting.') AS DEBUG;
-CALL MigrateChannelMembers ();
+CALL MigrateChannelMembers();
 SELECT CONCAT('-- ', NOW(), ' MigrateChannelMembers procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateChannelMembers;
 
@@ -510,7 +510,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateUsers procedure starting.') AS DEBUG;
-CALL MigrateUsers ();
+CALL MigrateUsers();
 SELECT CONCAT('-- ', NOW(), ' MigrateUsers procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateUsers;
 
@@ -557,7 +557,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateJobs procedure starting.') AS DEBUG;
-CALL MigrateJobs ();
+CALL MigrateJobs();
 SELECT CONCAT('-- ', NOW(), ' MigrateJobs procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateJobs;
 
@@ -581,7 +581,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateLinkMetadata procedure starting.') AS DEBUG;
-CALL MigrateLinkMetadata ();
+CALL MigrateLinkMetadata();
 SELECT CONCAT('-- ', NOW(), ' MigrateLinkMetadata procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateLinkMetadata;
 
@@ -631,7 +631,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateSessions procedure starting.') AS DEBUG;
-CALL MigrateSessions ();
+CALL MigrateSessions();
 SELECT CONCAT('-- ', NOW(), ' MigrateSessions procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateSessions;
 
@@ -759,7 +759,7 @@ BEGIN
 END//
 DELIMITER ;
 SELECT CONCAT('-- ', NOW(), ' MigrateThreads procedure starting.') AS DEBUG;
-CALL MigrateThreads ();
+CALL MigrateThreads();
 SELECT CONCAT('-- ', NOW(), ' MigrateThreads procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateThreads;
 

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1282,7 +1282,6 @@ BEGIN
 		AND column_name = 'ChannelId'
 		INTO AddChannelId;
 
-
 	SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.STATISTICS
 		WHERE table_name = 'Reactions'
 		AND table_schema = DATABASE()

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1099,20 +1099,25 @@ CALL MigrateOAuthApps ();
 DROP PROCEDURE IF EXISTS MigrateOAuthApps;
 
 /* ==> mysql/000079_usergroups_displayname_index.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-        WHERE table_name = 'UserGroups'
-        AND table_schema = DATABASE()
-        AND index_name = 'idx_usergroups_displayname'
-    ) > 0,
-    'SELECT 1',
-    'CREATE INDEX idx_usergroups_displayname ON UserGroups(DisplayName);'
-));
+DELIMITER //
+CREATE PROCEDURE MigrateUserGroups ()
+BEGIN
+	-- 'CREATE INDEX idx_usergroups_displayname ON UserGroups(DisplayName);'
+	DECLARE CreateIndex BOOLEAN;
 
-PREPARE createIndexIfNotExists FROM @preparedStatement;
-EXECUTE createIndexIfNotExists;
-DEALLOCATE PREPARE createIndexIfNotExists;
+	SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE table_name = 'UserGroups'
+		AND table_schema = DATABASE()
+		AND index_name = 'idx_usergroups_displayname'
+		INTO CreateIndex;
+
+	IF CreateIndex THEN
+		CREATE INDEX idx_usergroups_displayname ON UserGroups(DisplayName);
+	END IF;
+END//
+DELIMITER ;
+CALL MigrateUserGroups ();
+DROP PROCEDURE IF EXISTS MigrateUserGroups;
 
 /* ==> mysql/000081_threads_deleteat.up.sql <== */
 -- Replaced by 000083_threads_threaddeleteat.up.sql

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -52,7 +52,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', CreateIndexQuery, AlterIndexQuery, AlterColumnQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE UploadSessions ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE UploadSessions ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -197,7 +197,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', DropIndexQuery, CreateIndexTeamDisplayQuery, CreateIndexTeamTypeQuery, AddLastRootPostAtQuery, ModifyColumnQuery, SetDefaultQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Channels ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Channels ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -360,7 +360,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', ModifyNotifyPropsQuery, DropIndexQuery, CreateIndexLastViewedAtQuery, CreateIndexSchemeGuestQuery, ModifyRolesQuery, AddUrgentMentionCountQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE ChannelMembers ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE ChannelMembers ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -506,7 +506,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', ChangePropsQuery, ChangeNotifyPropsQuery, DropTimezoneDefaultQuery, ChangeTimezoneQuery, ChangeRolesQuery, DropTermsOfServiceQuery, DropServiceTermsQuery, DropThemePropsQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Users ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Users ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -554,7 +554,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', ModifyDataQuery, CreateIndexQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Jobs ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Jobs ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -628,7 +628,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', ModifyPropsQuery, ModifyRolesQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Sessions ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Sessions ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -748,7 +748,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', ChangeParticipantsQuery, DropDeleteAtQuery, CreateThreadDeleteAtQuery, DropTeamIdQuery, CreateThreadTeamIdQuery, CreateIndexQuery, DropIndexQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Threads ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Threads ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -804,7 +804,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', CreateIndexQuery, DropIndexQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Status ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Status ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -934,7 +934,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', DropParentIdQuery, ModifyFileIdsQuery, ModifyPropsQuery, CreateIndexRootIdQuery, DropIndexQuery, CreateIndexCreateAtQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Posts ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Posts ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -997,7 +997,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', ModifyRolesQuery, AddCreateAtQuery, CreateIndexQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE TeamMembers ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE TeamMembers ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -1071,7 +1071,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', AddDefaultPlaybookAdminRoleQuery, AddDefaultPlaybookMemberRoleQuery, AddDefaultRunAdminRoleQuery, AddDefaultRunMemberRoleQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Schemes ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Schemes ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -1234,7 +1234,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', AddCloudLimitsArchivedQuery, ModifyTypeQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Teams ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Teams ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -1307,7 +1307,7 @@ BEGIN
 
 	SET @alterQuery = CONCAT_WS(', ', AddChannelIdQuery, CreateIndexQuery);
 	IF @alterQuery <> '' THEN
-	    SET @query = CONCAT('ALTER TABLE Reactions ', alterQuery);
+	    SET @query = CONCAT('ALTER TABLE Reactions ', @alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1220,7 +1220,6 @@ DROP PROCEDURE IF EXISTS MigrateSidebarCategories;
 
 /* ==> mysql/000088_remaining_migrations.up.sql <== */
 DROP TABLE IF EXISTS JobStatuses;
-
 DROP TABLE IF EXISTS PasswordRecovery;
 
 /* ==> mysql/000089_add-channelid-to-reaction.up.sql <== */

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1248,23 +1248,9 @@ CREATE TABLE IF NOT EXISTS PostReminders (
     PostId varchar(26) NOT NULL,
     UserId varchar(26) NOT NULL,
     TargetTime bigint,
+	INDEX idx_postreminders_targettime (TargetTime),
     PRIMARY KEY (PostId, UserId)
 );
-
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-        WHERE table_name = 'PostReminders'
-        AND table_schema = DATABASE()
-        AND index_name = 'idx_postreminders_targettime'
-    ) > 0,
-    'SELECT 1',
-    'CREATE INDEX idx_postreminders_targettime ON PostReminders(TargetTime);'
-));
-
-PREPARE createIndexIfNotExists FROM @preparedStatement;
-EXECUTE createIndexIfNotExists;
-DEALLOCATE PREPARE createIndexIfNotExists;
 
 /* ==> mysql/000093_notify_admin.up.sql <== */
 CREATE TABLE IF NOT EXISTS NotifyAdmin (

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -58,7 +58,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateUploadSessions procedure starting.') AS DEBUG;
 CALL MigrateUploadSessions ();
+SELECT CONCAT('-- ', NOW(), ' MigrateUploadSessions procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateUploadSessions;
 
 /* ==> mysql/000055_create_crt_thread_count_and_unreads.up.sql <== */
@@ -89,7 +91,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateThreadMemberships procedure starting.') AS DEBUG;
 CALL MigrateThreadMemberships ();
+SELECT CONCAT('-- ', NOW(), ' MigrateThreadMemberships procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateThreadMemberships;
 
 /* ==> mysql/000056_upgrade_channels_v6.0.up.sql <== */
@@ -224,7 +228,9 @@ BEGIN
 END//
 DELIMITER ;
 
+SELECT CONCAT('-- ', NOW(), ' MigrateChannels procedure starting.') AS DEBUG;
 CALL MigrateChannels ();
+SELECT CONCAT('-- ', NOW(), ' MigrateChannels procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateChannels;
 
 /* ==> mysql/000057_upgrade_command_webhooks_v6.0.up.sql <== */
@@ -246,7 +252,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateCommandWebhooks procedure starting.') AS DEBUG;
 CALL MigrateCommandWebhooks ();
+SELECT CONCAT('-- ', NOW(), ' MigrateCommandWebhooks procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateCommandWebhooks;
 
 /* ==> mysql/000054_create_crt_channelmembership_count.up.sql <== */
@@ -365,7 +373,9 @@ BEGIN
 END//
 DELIMITER ;
 
+SELECT CONCAT('-- ', NOW(), ' MigrateChannelMembers procedure starting.') AS DEBUG;
 CALL MigrateChannelMembers ();
+SELECT CONCAT('-- ', NOW(), ' MigrateChannelMembers procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateChannelMembers;
 
 /* ==> mysql/000059_upgrade_users_v6.0.up.sql <== */
@@ -499,7 +509,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateUsers procedure starting.') AS DEBUG;
 CALL MigrateUsers ();
+SELECT CONCAT('-- ', NOW(), ' MigrateUsers procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateUsers;
 
 /* ==> mysql/000060_upgrade_jobs_v6.0.up.sql <== */
@@ -544,7 +556,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateJobs procedure starting.') AS DEBUG;
 CALL MigrateJobs ();
+SELECT CONCAT('-- ', NOW(), ' MigrateJobs procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateJobs;
 
 /* ==> mysql/000061_upgrade_link_metadata_v6.0.up.sql <== */
@@ -566,7 +580,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateLinkMetadata procedure starting.') AS DEBUG;
 CALL MigrateLinkMetadata ();
+SELECT CONCAT('-- ', NOW(), ' MigrateLinkMetadata procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateLinkMetadata;
 
 /* ==> mysql/000062_upgrade_sessions_v6.0.up.sql <== */
@@ -614,7 +630,9 @@ BEGIN
 
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateSessions procedure starting.') AS DEBUG;
 CALL MigrateSessions ();
+SELECT CONCAT('-- ', NOW(), ' MigrateSessions procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateSessions;
 
 /* ==> mysql/000063_upgrade_threads_v6.0.up.sql <== */
@@ -740,7 +758,9 @@ BEGIN
 		AND Threads.ThreadTeamId IS NULL;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateThreads procedure starting.') AS DEBUG;
 CALL MigrateThreads ();
+SELECT CONCAT('-- ', NOW(), ' MigrateThreads procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateThreads;
 
 /* ==> mysql/000064_upgrade_status_v6.0.up.sql <== */
@@ -783,7 +803,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateStatus procedure starting.') AS DEBUG;
 CALL MigrateStatus ();
+SELECT CONCAT('-- ', NOW(), ' MigrateStatus procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateStatus;
 
 /* ==> mysql/000065_upgrade_groupchannels_v6.0.up.sql <== */
@@ -804,7 +826,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateGroupChannels procedure starting.') AS DEBUG;
 CALL MigrateGroupChannels ();
+SELECT CONCAT('-- ', NOW(), ' MigrateGroupChannels procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateGroupChannels;
 
 /* ==> mysql/000066_upgrade_posts_v6.0.up.sql <== */
@@ -909,7 +933,9 @@ BEGIN
 
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigratePosts procedure starting.') AS DEBUG;
 CALL MigratePosts ();
+SELECT CONCAT('-- ', NOW(), ' MigratePosts procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigratePosts;
 
 /* ==> mysql/000068_upgrade_teammembers_v6.1.up.sql <== */
@@ -968,7 +994,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateTeamMembers procedure starting.') AS DEBUG;
 CALL MigrateTeamMembers ();
+SELECT CONCAT('-- ', NOW(), ' MigrateTeamMembers procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateTeamMembers;
 
 /* ==> mysql/000072_upgrade_schemes_v6.3.up.sql <== */
@@ -1039,7 +1067,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateSchemes procedure starting.') AS DEBUG;
 CALL MigrateSchemes ();
+SELECT CONCAT('-- ', NOW(), ' MigrateSchemes procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateSchemes;
 
 /* ==> mysql/000073_upgrade_plugin_key_value_store_v6.3.up.sql <== */
@@ -1061,7 +1091,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigratePluginKeyValueStore procedure starting.') AS DEBUG;
 CALL MigratePluginKeyValueStore ();
+SELECT CONCAT('-- ', NOW(), ' MigratePluginKeyValueStore procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigratePluginKeyValueStore;
 
 /* ==> mysql/000078_create_oauth_mattermost_app_id.up.sql <== */
@@ -1095,7 +1127,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateOAuthApps procedure starting.') AS DEBUG;
 CALL MigrateOAuthApps ();
+SELECT CONCAT('-- ', NOW(), ' MigrateOAuthApps procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateOAuthApps;
 
 /* ==> mysql/000079_usergroups_displayname_index.up.sql <== */
@@ -1116,7 +1150,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateUserGroups procedure starting.') AS DEBUG;
 CALL MigrateUserGroups ();
+SELECT CONCAT('-- ', NOW(), ' MigrateUserGroups procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateUserGroups;
 
 /* ==> mysql/000081_threads_deleteat.up.sql <== */
@@ -1149,7 +1185,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateFileInfo procedure starting.') AS DEBUG;
 CALL MigrateFileInfo ();
+SELECT CONCAT('-- ', NOW(), ' MigrateFileInfo procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateFileInfo;
 
 /* ==> mysql/000086_add_cloud_limits_archived.up.sql <== */
@@ -1194,7 +1232,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateTeams procedure starting.') AS DEBUG;
 CALL MigrateTeams ();
+SELECT CONCAT('-- ', NOW(), ' MigrateTeams procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateTeams;
 
 /* ==> mysql/000087_sidebar_categories_index.up.sql <== */
@@ -1215,7 +1255,9 @@ BEGIN
 	END IF;
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateSidebarCategories procedure starting.') AS DEBUG;
 CALL MigrateSidebarCategories ();
+SELECT CONCAT('-- ', NOW(), ' MigrateSidebarCategories procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateSidebarCategories;
 
 /* ==> mysql/000088_remaining_migrations.up.sql <== */
@@ -1265,7 +1307,9 @@ BEGIN
 	UPDATE Reactions SET ChannelId = COALESCE((select ChannelId from Posts where Posts.Id = Reactions.PostId), '') WHERE ChannelId="";
 END//
 DELIMITER ;
+SELECT CONCAT('-- ', NOW(), ' MigrateReactions procedure starting.') AS DEBUG;
 CALL MigrateReactions ();
+SELECT CONCAT('-- ', NOW(), ' MigrateReactions procedure finished.') AS DEBUG;
 DROP PROCEDURE IF EXISTS MigrateReactions;
 
 /* ==> mysql/000091_create_post_reminder.up.sql <== */

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -50,8 +50,9 @@ BEGIN
 		SET AlterColumnQuery = 'MODIFY COLUMN Type ENUM("attachment", "import")';
 	END IF;
 
-	IF CreateIndex OR AlterIndex OR AlterColumn THEN
-		SET @query = CONCAT('ALTER TABLE UploadSessions ', CONCAT_WS(', ', CreateIndexQuery, AlterIndexQuery, AlterColumnQuery));
+	SET @alterQuery = CONCAT_WS(', ', CreateIndexQuery, AlterIndexQuery, AlterColumnQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE UploadSessions ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -194,8 +195,9 @@ BEGIN
 		SET SetDefaultQuery = 'ALTER COLUMN LastRootPostAt SET DEFAULT 0';
 	END IF;
 
-	IF DropIndex OR CreateIndexTeamDisplay OR CreateIndexTeamType OR AddLastRootPostAt OR ModifyColumn OR SetDefault THEN
-		SET @query = CONCAT('ALTER TABLE Channels ', CONCAT_WS(', ', DropIndexQuery, CreateIndexTeamDisplayQuery, CreateIndexTeamTypeQuery, AddLastRootPostAtQuery, ModifyColumnQuery, SetDefaultQuery));
+	SET @alterQuery = CONCAT_WS(', ', DropIndexQuery, CreateIndexTeamDisplayQuery, CreateIndexTeamTypeQuery, AddLastRootPostAtQuery, ModifyColumnQuery, SetDefaultQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Channels ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -356,8 +358,9 @@ BEGIN
 		SET AddUrgentMentionCountQuery = 'ADD COLUMN UrgentMentionCount bigint(20)';
 	END IF;
 
-	IF ModifyNotifyProps OR DropIndex OR CreateIndexLastViewedAt OR CreateIndexSchemeGuest OR ModifyRoles THEN
-		SET @query = CONCAT('ALTER TABLE ChannelMembers ', CONCAT_WS(', ', ModifyNotifyPropsQuery, DropIndexQuery, CreateIndexLastViewedAtQuery, CreateIndexSchemeGuestQuery, ModifyRolesQuery, AddUrgentMentionCountQuery));
+	SET @alterQuery = CONCAT_WS(', ', ModifyNotifyPropsQuery, DropIndexQuery, CreateIndexLastViewedAtQuery, CreateIndexSchemeGuestQuery, ModifyRolesQuery, AddUrgentMentionCountQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE ChannelMembers ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -501,8 +504,9 @@ BEGIN
 		SET DropThemePropsQuery = 'DROP COLUMN ThemeProps';
 	END IF;
 
-	IF ChangeProps OR ChangeNotifyProps OR DropTimezoneDefault OR ChangeTimezone OR ChangeRoles OR DropTermsOfService OR DropServiceTerms OR DropThemeProps THEN
-		SET @query = CONCAT('ALTER TABLE Users ', CONCAT_WS(', ', ChangePropsQuery, ChangeNotifyPropsQuery, DropTimezoneDefaultQuery, ChangeTimezoneQuery, ChangeRolesQuery, DropTermsOfServiceQuery, DropServiceTermsQuery, DropThemePropsQuery));
+	SET @alterQuery = CONCAT_WS(', ', ChangePropsQuery, ChangeNotifyPropsQuery, DropTimezoneDefaultQuery, ChangeTimezoneQuery, ChangeRolesQuery, DropTermsOfServiceQuery, DropServiceTermsQuery, DropThemePropsQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Users ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -548,8 +552,9 @@ BEGIN
 		SET CreateIndexQuery = 'ADD INDEX idx_jobs_status_type (Status, Type)';
 	END IF;
 
-	IF ModifyData OR CreateIndex THEN
-		SET @query = CONCAT('ALTER TABLE Jobs ', CONCAT_WS(', ', ModifyDataQuery, CreateIndexQuery));
+	SET @alterQuery = CONCAT_WS(', ', ModifyDataQuery, CreateIndexQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Jobs ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -621,8 +626,9 @@ BEGIN
 		SET ModifyRolesQuery = 'MODIFY COLUMN Roles text';
 	END IF;
 
-	IF ModifyProps OR ModifyRoles THEN
-		SET @query = CONCAT('ALTER TABLE Sessions ', CONCAT_WS(', ', ModifyPropsQuery, ModifyRolesQuery));
+	SET @alterQuery = CONCAT_WS(', ', ModifyPropsQuery, ModifyRolesQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Sessions ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -740,8 +746,9 @@ BEGIN
 		SET DropIndexQuery = 'DROP INDEX idx_threads_channel_id';
 	END IF;
 
-	IF ChangeParticipants OR DropDeleteAt OR CreateThreadDeleteAt OR DropTeamId OR CreateThreadTeamId OR CreateIndex OR DropIndex THEN
-		SET @query = CONCAT('ALTER TABLE Threads ', CONCAT_WS(', ', ChangeParticipantsQuery, DropDeleteAtQuery, CreateThreadDeleteAtQuery, DropTeamIdQuery, CreateThreadTeamIdQuery, CreateIndexQuery, DropIndexQuery));
+	SET @alterQuery = CONCAT_WS(', ', ChangeParticipantsQuery, DropDeleteAtQuery, CreateThreadDeleteAtQuery, DropTeamIdQuery, CreateThreadTeamIdQuery, CreateIndexQuery, DropIndexQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Threads ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -795,8 +802,9 @@ BEGIN
 		SET DropIndexQuery = 'DROP INDEX idx_status_status';
 	END IF;
 
-	IF CreateIndex OR DropIndex THEN
-		SET @query = CONCAT('ALTER TABLE Status ', CONCAT_WS(', ', CreateIndexQuery, DropIndexQuery));
+	SET @alterQuery = CONCAT_WS(', ', CreateIndexQuery, DropIndexQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Status ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -924,8 +932,9 @@ BEGIN
 		SET CreateIndexCreateAtQuery = 'ADD INDEX idx_posts_create_at_id (CreateAt, Id)';
 	END IF;
 
-	IF DropParentId OR ModifyFileIds OR ModifyProps OR CreateIndexRootId OR DropIndex OR CreateIndexCreateAt THEN
-		SET @query = CONCAT('ALTER TABLE Posts ', CONCAT_WS(', ', DropParentIdQuery, ModifyFileIdsQuery, ModifyPropsQuery, CreateIndexRootIdQuery, DropIndexQuery, CreateIndexCreateAtQuery));
+	SET @alterQuery = CONCAT_WS(', ', DropParentIdQuery, ModifyFileIdsQuery, ModifyPropsQuery, CreateIndexRootIdQuery, DropIndexQuery, CreateIndexCreateAtQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Posts ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -986,8 +995,9 @@ BEGIN
 		SET CreateIndexQuery = 'ADD INDEX idx_teammembers_createat (CreateAt)';
 	END IF;
 
-	IF ModifyRoles OR AddCreateAt OR CreateIndex THEN
-		SET @query = CONCAT('ALTER TABLE TeamMembers ', CONCAT_WS(', ', ModifyRolesQuery, AddCreateAtQuery, CreateIndexQuery));
+	SET @alterQuery = CONCAT_WS(', ', ModifyRolesQuery, AddCreateAtQuery, CreateIndexQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE TeamMembers ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -1059,8 +1069,9 @@ BEGIN
 		SET AddDefaultRunMemberRoleQuery = 'ADD COLUMN DefaultRunMemberRole VARCHAR(64) DEFAULT ""';
 	END IF;
 
-	IF AddDefaultPlaybookAdminRole OR AddDefaultPlaybookMemberRole OR AddDefaultRunAdminRole OR AddDefaultRunMemberRole THEN
-		SET @query = CONCAT('ALTER TABLE Schemes ', CONCAT_WS(', ', AddDefaultPlaybookAdminRoleQuery, AddDefaultPlaybookMemberRoleQuery, AddDefaultRunAdminRoleQuery, AddDefaultRunMemberRoleQuery));
+	SET @alterQuery = CONCAT_WS(', ', AddDefaultPlaybookAdminRoleQuery, AddDefaultPlaybookMemberRoleQuery, AddDefaultRunAdminRoleQuery, AddDefaultRunMemberRoleQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Schemes ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -1221,8 +1232,9 @@ BEGIN
 		SET ModifyTypeQuery = 'MODIFY COLUMN Type ENUM("I", "O")';
 	END IF;
 
-	IF AddCloudLimitsArchived OR ModifyType THEN
-		SET @query = CONCAT('ALTER TABLE Teams ', CONCAT_WS(', ', AddCloudLimitsArchivedQuery, ModifyTypeQuery));
+	SET @alterQuery = CONCAT_WS(', ', AddCloudLimitsArchivedQuery, ModifyTypeQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Teams ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;
@@ -1293,8 +1305,9 @@ BEGIN
 		SET CreateIndexQuery = 'ADD INDEX idx_reactions_channel_id (ChannelId)';
 	END IF;
 
-	IF AddChannelId OR CreateIndex THEN
-		SET @query = CONCAT('ALTER TABLE Reactions ', CONCAT_WS(', ', AddChannelIdQuery, CreateIndexQuery));
+	SET @alterQuery = CONCAT_WS(', ', AddChannelIdQuery, CreateIndexQuery);
+	IF @alterQuery <> '' THEN
+	    SET @query = CONCAT('ALTER TABLE Reactions ', alterQuery);
 		PREPARE stmt FROM @query;
 		EXECUTE stmt;
 		DEALLOCATE PREPARE stmt;

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1124,11 +1124,11 @@ DROP PROCEDURE IF EXISTS MigrateUserGroups;
 
 /* ==> mysql/000084_recent_searches.up.sql <== */
 CREATE TABLE IF NOT EXISTS RecentSearches (
-    UserId CHAR(26),
-    SearchPointer int,
-    Query json,
-    CreateAt bigint NOT NULL,
-    PRIMARY KEY (UserId, SearchPointer)
+	UserId CHAR(26),
+	SearchPointer int,
+	Query json,
+	CreateAt bigint NOT NULL,
+	PRIMARY KEY (UserId, SearchPointer)
 );
 
 /* ==> mysql/000085_fileinfo_add_archived_column.up.sql <== */
@@ -1270,21 +1270,21 @@ DROP PROCEDURE IF EXISTS MigrateReactions;
 
 /* ==> mysql/000091_create_post_reminder.up.sql <== */
 CREATE TABLE IF NOT EXISTS PostReminders (
-    PostId varchar(26) NOT NULL,
-    UserId varchar(26) NOT NULL,
-    TargetTime bigint,
+	PostId varchar(26) NOT NULL,
+	UserId varchar(26) NOT NULL,
+	TargetTime bigint,
 	INDEX idx_postreminders_targettime (TargetTime),
-    PRIMARY KEY (PostId, UserId)
+	PRIMARY KEY (PostId, UserId)
 );
 
 /* ==> mysql/000093_notify_admin.up.sql <== */
 CREATE TABLE IF NOT EXISTS NotifyAdmin (
-    UserId varchar(26) NOT NULL,
-    CreateAt bigint(20) DEFAULT NULL,
-    RequiredPlan varchar(26) NOT NULL,
-    RequiredFeature varchar(100) NOT NULL,
-    Trial BOOLEAN NOT NULL,
-    PRIMARY KEY (UserId, RequiredFeature, RequiredPlan)
+	UserId varchar(26) NOT NULL,
+	CreateAt bigint(20) DEFAULT NULL,
+	RequiredPlan varchar(26) NOT NULL,
+	RequiredFeature varchar(100) NOT NULL,
+	Trial BOOLEAN NOT NULL,
+	PRIMARY KEY (UserId, RequiredFeature, RequiredPlan)
 );
 
 /* ==> mysql/000094_threads_teamid.up.sql <== */
@@ -1292,41 +1292,41 @@ CREATE TABLE IF NOT EXISTS NotifyAdmin (
 
 /* ==> mysql/000097_create_posts_priority.up.sql <== */
 CREATE TABLE IF NOT EXISTS PostsPriority (
-    PostId varchar(26) NOT NULL,
-    ChannelId varchar(26) NOT NULL,
-    Priority varchar(32) NOT NULL,
-    RequestedAck tinyint(1),
-    PersistentNotifications tinyint(1),
-    PRIMARY KEY (PostId)
+	PostId varchar(26) NOT NULL,
+	ChannelId varchar(26) NOT NULL,
+	Priority varchar(32) NOT NULL,
+	RequestedAck tinyint(1),
+	PersistentNotifications tinyint(1),
+	PRIMARY KEY (PostId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /* ==> mysql/000098_create_post_acknowledgements.up.sql <== */
 CREATE TABLE IF NOT EXISTS PostAcknowledgements (
-    PostId varchar(26) NOT NULL,
-    UserId varchar(26) NOT NULL,
-    AcknowledgedAt bigint(20) DEFAULT NULL,
-    PRIMARY KEY (PostId, UserId)
+	PostId varchar(26) NOT NULL,
+	UserId varchar(26) NOT NULL,
+	AcknowledgedAt bigint(20) DEFAULT NULL,
+	PRIMARY KEY (PostId, UserId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /* ==> mysql/000099_create_drafts.up.sql <== */
 /* ==> mysql/000100_add_draft_priority_column.up.sql <== */
 CREATE TABLE IF NOT EXISTS Drafts (
-    CreateAt bigint(20) DEFAULT NULL,
-    UpdateAt bigint(20) DEFAULT NULL,
-    DeleteAt bigint(20) DEFAULT NULL,
-    UserId varchar(26) NOT NULL,
-    ChannelId varchar(26) NOT NULL,
-    RootId varchar(26) DEFAULT '',
-    Message text,
-    Props text,
-    FileIds text,
+	CreateAt bigint(20) DEFAULT NULL,
+	UpdateAt bigint(20) DEFAULT NULL,
+	DeleteAt bigint(20) DEFAULT NULL,
+	UserId varchar(26) NOT NULL,
+	ChannelId varchar(26) NOT NULL,
+	RootId varchar(26) DEFAULT '',
+	Message text,
+	Props text,
+	FileIds text,
 	Priority text,
-    PRIMARY KEY (UserId, ChannelId, RootId)
+	PRIMARY KEY (UserId, ChannelId, RootId)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /* ==> mysql/000101_create_true_up_review_history.up.sql <== */
 CREATE TABLE IF NOT EXISTS TrueUpReviewHistory (
 	DueDate bigint(20),
 	Completed boolean,
-    PRIMARY KEY (DueDate)
+	PRIMARY KEY (DueDate)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -787,20 +787,25 @@ CALL MigrateStatus ();
 DROP PROCEDURE IF EXISTS MigrateStatus;
 
 /* ==> mysql/000065_upgrade_groupchannels_v6.0.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-        WHERE table_name = 'GroupChannels'
-        AND table_schema = DATABASE()
-        AND index_name = 'idx_groupchannels_schemeadmin'
-    ) > 0,
-    'SELECT 1',
-    'CREATE INDEX idx_groupchannels_schemeadmin ON GroupChannels(SchemeAdmin);'
-));
+DELIMITER //
+CREATE PROCEDURE MigrateGroupChannels ()
+BEGIN
+	-- 'CREATE INDEX idx_groupchannels_schemeadmin ON GroupChannels(SchemeAdmin);'
+	DECLARE CreateIndex BOOLEAN;
 
-PREPARE createIndexIfNotExists FROM @preparedStatement;
-EXECUTE createIndexIfNotExists;
-DEALLOCATE PREPARE createIndexIfNotExists;
+	SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE table_name = 'GroupChannels'
+		AND table_schema = DATABASE()
+		AND index_name = 'idx_groupchannels_schemeadmin'
+		INTO CreateIndex;
+
+	IF CreateIndex THEN
+		CREATE INDEX idx_groupchannels_schemeadmin ON GroupChannels(SchemeAdmin);
+	END IF;
+END//
+DELIMITER ;
+CALL MigrateGroupChannels ();
+DROP PROCEDURE IF EXISTS MigrateGroupChannels;
 
 /* ==> mysql/000066_upgrade_posts_v6.0.up.sql <== */
 /* ==> mysql/000080_posts_createat_id.up.sql <== */

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1198,20 +1198,25 @@ CALL MigrateTeams ();
 DROP PROCEDURE IF EXISTS MigrateTeams;
 
 /* ==> mysql/000087_sidebar_categories_index.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-        WHERE table_name = 'SidebarCategories'
-        AND table_schema = DATABASE()
-        AND index_name = 'idx_sidebarcategories_userid_teamid'
-    ) > 0,
-    'SELECT 1;',
-    'CREATE INDEX idx_sidebarcategories_userid_teamid on SidebarCategories(UserId, TeamId) LOCK=NONE;'
-));
+DELIMITER //
+CREATE PROCEDURE MigrateSidebarCategories ()
+BEGIN
+	-- 'CREATE INDEX idx_sidebarcategories_userid_teamid on SidebarCategories(UserId, TeamId) LOCK=NONE;'
+	DECLARE CreateIndex BOOLEAN;
 
-PREPARE createIndexIfNotExists FROM @preparedStatement;
-EXECUTE createIndexIfNotExists;
-DEALLOCATE PREPARE createIndexIfNotExists;
+	SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE table_name = 'SidebarCategories'
+		AND table_schema = DATABASE()
+		AND index_name = 'idx_sidebarcategories_userid_teamid'
+		INTO CreateIndex;
+
+	IF CreateIndex THEN
+		CREATE INDEX idx_sidebarcategories_userid_teamid on SidebarCategories(UserId, TeamId) LOCK=NONE;
+	END IF;
+END//
+DELIMITER ;
+CALL MigrateSidebarCategories ();
+DROP PROCEDURE IF EXISTS MigrateSidebarCategories;
 
 /* ==> mysql/000088_remaining_migrations.up.sql <== */
 DROP TABLE IF EXISTS JobStatuses;

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -1054,20 +1054,38 @@ EXECUTE alterTypeIfExists;
 DEALLOCATE PREPARE alterTypeIfExists;
 
 /* ==> mysql/000078_create_oauth_mattermost_app_id.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE table_name = 'OAuthApps'
-        AND table_schema = DATABASE()
-        AND column_name = 'MattermostAppID'
-    ) > 0,
-	'SELECT 1',
-    'ALTER TABLE OAuthApps ADD COLUMN MattermostAppID varchar(32);'
-));
+/* ==> mysql/000082_upgrade_oauth_mattermost_app_id.up.sql <== */
+DELIMITER //
+CREATE PROCEDURE MigrateOAuthApps ()
+BEGIN
+	-- 'ALTER TABLE OAuthApps ADD COLUMN MattermostAppID varchar(32);'
+	DECLARE AddMattermostAppID BOOLEAN;
+	DECLARE AddMattermostAppIDQuery TEXT DEFAULT NULL;
 
-PREPARE alterIfExists FROM @preparedStatement;
-EXECUTE alterIfExists;
-DEALLOCATE PREPARE alterIfExists;
+	SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE table_name = 'OAuthApps'
+		AND table_schema = DATABASE()
+		AND column_name = 'MattermostAppID'
+		INTO AddMattermostAppID;
+
+	IF AddMattermostAppID THEN
+		SET AddMattermostAppIDQuery = 'ADD COLUMN MattermostAppID varchar(32) NOT NULL DEFAULT ""';
+	END IF;
+
+	IF AddMattermostAppID THEN
+		SET @query = CONCAT('ALTER TABLE OAuthApps ', CONCAT_WS(', ', AddMattermostAppIDQuery));
+		PREPARE stmt FROM @query;
+		EXECUTE stmt;
+		DEALLOCATE PREPARE stmt;
+	END IF;
+
+	IF AddMattermostAppID THEN
+		UPDATE OAuthApps SET MattermostAppID = "" WHERE MattermostAppID IS NULL;
+	END IF;
+END//
+DELIMITER ;
+CALL MigrateOAuthApps ();
+DROP PROCEDURE IF EXISTS MigrateOAuthApps;
 
 /* ==> mysql/000079_usergroups_displayname_index.up.sql <== */
 SET @preparedStatement = (SELECT IF(
@@ -1087,37 +1105,6 @@ DEALLOCATE PREPARE createIndexIfNotExists;
 
 /* ==> mysql/000081_threads_deleteat.up.sql <== */
 -- Replaced by 000083_threads_threaddeleteat.up.sql
-
-/* ==> mysql/000082_upgrade_oauth_mattermost_app_id.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE table_name = 'OAuthApps'
-        AND table_schema = DATABASE()
-        AND column_name = 'MattermostAppID'
-    ) > 0,
-    'UPDATE OAuthApps SET MattermostAppID = "" WHERE MattermostAppID IS NULL;',
-    'SELECT 1'
-));
-
-PREPARE alterIfExists FROM @preparedStatement;
-EXECUTE alterIfExists;
-DEALLOCATE PREPARE alterIfExists;
-
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE table_name = 'OAuthApps'
-        AND table_schema = DATABASE()
-        AND column_name = 'MattermostAppID'
-    ) > 0,
-    'ALTER TABLE OAuthApps MODIFY MattermostAppID varchar(32) NOT NULL DEFAULT "";',
-    'SELECT 1'
-));
-
-PREPARE alterIfExists FROM @preparedStatement;
-EXECUTE alterIfExists;
-DEALLOCATE PREPARE alterIfExists;
 
 /* ==> mysql/000084_recent_searches.up.sql <== */
 CREATE TABLE IF NOT EXISTS RecentSearches (

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -753,35 +753,47 @@ CALL MigrateThreads ();
 DROP PROCEDURE IF EXISTS MigrateThreads;
 
 /* ==> mysql/000064_upgrade_status_v6.0.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-        WHERE table_name = 'Status'
-        AND table_schema = DATABASE()
-        AND index_name = 'idx_status_status_dndendtime'
-    ) > 0,
-    'SELECT 1',
-    'CREATE INDEX idx_status_status_dndendtime ON Status(Status, DNDEndTime);'
-));
+DELIMITER //
+CREATE PROCEDURE MigrateStatus ()
+BEGIN
+	-- 'CREATE INDEX idx_status_status_dndendtime ON Status(Status, DNDEndTime);'
+	DECLARE CreateIndex BOOLEAN;
+	DECLARE CreateIndexQuery TEXT DEFAULT NULL;
 
-PREPARE createIndexIfNotExists FROM @preparedStatement;
-EXECUTE createIndexIfNotExists;
-DEALLOCATE PREPARE createIndexIfNotExists;
+	-- 'DROP INDEX idx_status_status ON Status;',
+	DECLARE DropIndex BOOLEAN;
+	DECLARE DropIndexQuery TEXT DEFAULT NULL;
 
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-        WHERE table_name = 'Status'
-        AND table_schema = DATABASE()
-        AND index_name = 'idx_status_status'
-    ) > 0,
-    'DROP INDEX idx_status_status ON Status;',
-    'SELECT 1'
-));
+	SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE table_name = 'Status'
+		AND table_schema = DATABASE()
+		AND index_name = 'idx_status_status_dndendtime'
+		INTO CreateIndex;
 
-PREPARE removeIndexIfExists FROM @preparedStatement;
-EXECUTE removeIndexIfExists;
-DEALLOCATE PREPARE removeIndexIfExists;
+	SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+		WHERE table_name = 'Status'
+		AND table_schema = DATABASE()
+		AND index_name = 'idx_status_status'
+		INTO DropIndex;
+
+	IF CreateIndex THEN
+		SET CreateIndexQuery = 'ADD INDEX idx_status_status_dndendtime (Status, DNDEndTime)';
+	END IF;
+
+	IF DropIndex THEN
+		SET DropIndexQuery = 'DROP INDEX idx_status_status';
+	END IF;
+
+	IF CreateIndex OR DropIndex THEN
+		SET @query = CONCAT('ALTER TABLE Status ', CONCAT_WS(', ', CreateIndexQuery, DropIndexQuery));
+		PREPARE stmt FROM @query;
+		EXECUTE stmt;
+		DEALLOCATE PREPARE stmt;
+	END IF;
+END//
+DELIMITER ;
+CALL MigrateStatus ();
+DROP PROCEDURE IF EXISTS MigrateStatus;
 
 /* ==> mysql/000065_upgrade_groupchannels_v6.0.up.sql <== */
 SET @preparedStatement = (SELECT IF(

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -579,22 +579,52 @@ EXECUTE alterIfExists;
 DEALLOCATE PREPARE alterIfExists;
 
 /* ==> mysql/000062_upgrade_sessions_v6.0.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE table_name = 'Sessions'
-        AND table_schema = DATABASE()
-        AND column_name = 'Props'
-        AND column_type != 'JSON'
-    ) > 0,
-    'ALTER TABLE Sessions MODIFY COLUMN Props JSON;',
-    'SELECT 1'
-));
+/* ==> mysql/000071_upgrade_sessions_v6.1.up.sql <== */
+DELIMITER //
+CREATE PROCEDURE MigrateSessions ()
+BEGIN
+	-- 'ALTER TABLE Sessions MODIFY COLUMN Props JSON;',
+	DECLARE ModifyProps BOOLEAN;
+	DECLARE ModifyPropsQuery TEXT DEFAULT NULL;
 
-PREPARE alterIfExists FROM @preparedStatement;
-EXECUTE alterIfExists;
-DEALLOCATE PREPARE alterIfExists;
+	-- 'ALTER TABLE Sessions MODIFY COLUMN Roles text;',
+	DECLARE ModifyRoles BOOLEAN;
+	DECLARE ModifyRolesQuery TEXT DEFAULT NULL;
 
+	SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE table_name = 'Sessions'
+		AND table_schema = DATABASE()
+		AND column_name = 'Props'
+		AND LOWER(column_type) != 'json'
+		INTO ModifyProps;
+
+
+	SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE table_name = 'Sessions'
+		AND table_schema = DATABASE()
+		AND column_name = 'Roles'
+		AND LOWER(column_type) != 'text'
+		INTO ModifyRoles;
+
+	IF ModifyProps THEN
+		SET ModifyPropsQuery = 'MODIFY COLUMN Props JSON';
+	END IF;
+
+	IF ModifyRoles THEN
+		SET ModifyRolesQuery = 'MODIFY COLUMN Roles text';
+	END IF;
+
+	IF ModifyProps OR ModifyRoles THEN
+		SET @query = CONCAT('ALTER TABLE Sessions ', CONCAT_WS(', ', ModifyPropsQuery, ModifyRolesQuery));
+		PREPARE stmt FROM @query;
+		EXECUTE stmt;
+		DEALLOCATE PREPARE stmt;
+	END IF;
+
+END//
+DELIMITER ;
+CALL MigrateSessions ();
+DROP PROCEDURE IF EXISTS MigrateSessions;
 
 /* ==> mysql/000063_upgrade_threads_v6.0.up.sql <== */
 /* ==> mysql/000083_threads_threaddeleteat.up.sql <== */
@@ -843,23 +873,6 @@ SET @preparedStatement = (SELECT IF(
         AND column_type != 'text'
     ) > 0,
     'ALTER TABLE TeamMembers MODIFY COLUMN Roles text;',
-    'SELECT 1'
-));
-
-PREPARE alterIfExists FROM @preparedStatement;
-EXECUTE alterIfExists;
-DEALLOCATE PREPARE alterIfExists;
-
-/* ==> mysql/000071_upgrade_sessions_v6.1.up.sql <== */
-SET @preparedStatement = (SELECT IF(
-    (
-        SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE table_name = 'Sessions'
-        AND table_schema = DATABASE()
-        AND column_name = 'Roles'
-        AND column_type != 'text'
-    ) > 0,
-    'ALTER TABLE Sessions MODIFY COLUMN Roles text;',
     'SELECT 1'
 ));
 

--- a/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
+++ b/scripts/esrupgrades/esr.5.37-7.8.mysql.up.sql
@@ -67,34 +67,30 @@ reply time of the thread is earlier than the time the user viewed the channel.
 Marking a thread means setting the mention count to zero and setting the
 last viewed at time of the the thread as the last viewed at time
 of the channel */
-
 DELIMITER //
-CREATE PROCEDURE MigrateCRTThreadCountsAndUnreads ()
+CREATE PROCEDURE MigrateThreadMemberships ()
 BEGIN
-	IF(SELECT EXISTS(SELECT * FROM Systems WHERE Name = 'CRTThreadCountsAndUnreadsMigrationComplete') = 0) THEN
-		UPDATE
-			ThreadMemberships
-			INNER JOIN (
-				SELECT
-					PostId,
-					UserId,
-					ChannelMembers.LastViewedAt AS CM_LastViewedAt,
-					Threads.LastReplyAt
-				FROM
-					Threads
-					INNER JOIN ChannelMembers ON ChannelMembers.ChannelId = Threads.ChannelId
-				WHERE
-					Threads.LastReplyAt <= ChannelMembers.LastViewedAt) AS q ON ThreadMemberships.Postid = q.PostId
-				AND ThreadMemberships.UserId = q.UserId SET LastViewed = q.CM_LastViewedAt + 1, UnreadMentions = 0, LastUpdated = (
-				SELECT
-					(SELECT ROUND(UNIX_TIMESTAMP(NOW(3))*1000)));
-		INSERT INTO Systems
-			VALUES('CRTThreadCountsAndUnreadsMigrationComplete', 'true');
+	-- UPDATE ThreadMemberships SET LastViewed = ..., UnreadMentions = ..., LastUpdated = ...
+	DECLARE UpdateThreadMemberships BOOLEAN;
+	DECLARE UpdateThreadMembershipsQuery TEXT DEFAULT NULL;
+
+	SELECT COUNT(*) = 0 FROM Systems
+		WHERE Name = 'CRTThreadCountsAndUnreadsMigrationComplete'
+		INTO UpdateThreadMemberships;
+
+	IF UpdateThreadMemberships THEN
+		UPDATE ThreadMemberships INNER JOIN (
+				SELECT PostId, UserId, ChannelMembers.LastViewedAt AS CM_LastViewedAt, Threads.LastReplyAt
+					FROM Threads INNER JOIN ChannelMembers ON ChannelMembers.ChannelId = Threads.ChannelId
+					WHERE Threads.LastReplyAt <= ChannelMembers.LastViewedAt
+			) AS q ON ThreadMemberships.Postid = q.PostId AND ThreadMemberships.UserId = q.UserId
+			SET LastViewed = q.CM_LastViewedAt + 1, UnreadMentions = 0, LastUpdated = (SELECT (SELECT ROUND(UNIX_TIMESTAMP(NOW(3))*1000)));
+		INSERT INTO Systems VALUES('CRTThreadCountsAndUnreadsMigrationComplete', 'true');
 	END IF;
 END//
 DELIMITER ;
-CALL MigrateCRTThreadCountsAndUnreads ();
-DROP PROCEDURE IF EXISTS MigrateCRTThreadCountsAndUnreads;
+CALL MigrateThreadMemberships ();
+DROP PROCEDURE IF EXISTS MigrateThreadMemberships;
 
 /* ==> mysql/000056_upgrade_channels_v6.0.up.sql <== */
 /* ==> mysql/000070_upgrade_cte_v6.1.up.sql <== */


### PR DESCRIPTION
#### Summary
This PR modifies the script to upgrade from v5.37 to v7.8 by squashing together all migrations that affect the same table. For example Channels-related queries were present in migrations 56, 70, 76 and 90, with sometimes multiple queries per migration, while now they are grouped in a couple of queries inside the same MigrateChannels procedure. This happens for all tables affected by the migrations in this path. The goal of these procedures is two-fold:
1. Build and run a single query per table (sometimes not possible, since we need both an `ALTER TABLE` and an `UPDATE`).
2. Keep the idempotency of the individual migrations.

You can review by commit, but I think it's probably easier to just go through the whole file at once. However, the passing tests give me great confidence that the semantics are preserved, so feel free to focus on code-specific comments to improve readability or performance.

The script now only contains three types of modifications:
1. MigrateXYZ procedures.
2. Create table queries.
3. Drop table queries.

Modifications 2. and 3. are clear, but I wanted to describe the methodology used for the MigrateXYZ procedures. In general, they look like:

```sql
DELIMITER //
CREATE PROCEDURE MigrateXYZ ()
BEGIN
    -- One or more pairs of variable declarations for each individual modification. Each pair contains:
    DECLARE varName BOOLEAN;
    DECLARE varNameQuery TEXT DEFAULT NOT NULL;

    -- Initializations of each varName to know whether the specific modification needs to take place:
    SELECT ... INTO varName;

    --  Initializations of each varNameQuery in case varName is true:
    IF varName THEN
        SET varNameQuery = '...'; -- Specific modification that needs to take place, such as 'ADD COLUMN abc'
    END IF;
    
    -- Single IF block that constructs the query with all the previous subqueries
    IF varName1 OR varName2 OR ... THEN -- We can skip the query if all varNames are false
        -- If varNameXQuery was not initialized because varNameX was false, then its value is NULL and CONCAT_WS will just skip it
        SET @query = CONCAT('ALTER TABLE XYZ ', CONCAT_WS(', ', varName1Query, varName2Query, ...));
        PREPARE stmt FROM @query;
        EXECUTE stmt; -- Here's where the migration actually happen
        DEALLOCATE PREPARE stmt;
    END IF;
    
    -- In some cases, after the previous block, there are (sometimes conditional, sometimes unconditional)
    -- UPDATE queries that need to happen as well
    UPDATE XYZ SET ...;
END //
DELIMITER ;
CALL MigrateXYZ ();
DROP PROCEDURE IF EXISTS MigrateXYZ;
```

Note: this PR builds on top of #22573.

#### Ticket Link
--

#### Release Note
```release-note
NONE
```
