### PR TITLE
WIP: Add ability to restore archived groups from the user group modal

### DIFF
--- a/model/group.go
+++ b/model/group.go
@@ -118,6 +118,12 @@ type GroupSearchOpts struct {
 
 	IncludeChannelMemberCount string
 	IncludeTimezones          bool
+
+	// Include archived groups
+	IncludeArchived bool
+
+	// Only return archived groups
+	FilterArchived bool
 }
 
 type GetGroupOpts struct {

--- a/server/channels/api4/group.go
+++ b/server/channels/api4/group.go
@@ -989,8 +989,6 @@ func getGroups(c *Context, w http.ResponseWriter, r *http.Request) {
 	// Include archived groups
 	includeArchived := r.URL.Query().Get("include_archived") == "true"
 
-	// Only allow
-
 	opts := model.GroupSearchOpts{
 		Q:                         c.Params.Q,
 		IncludeMemberCount:        c.Params.IncludeMemberCount,

--- a/server/channels/api4/group.go
+++ b/server/channels/api4/group.go
@@ -986,14 +986,21 @@ func getGroups(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	includeTimezones := r.URL.Query().Get("include_timezones") == "true"
 
+	// Include archived groups
+	includeArchived := r.URL.Query().Get("include_archived") == "true"
+
+	// Only allow
+
 	opts := model.GroupSearchOpts{
 		Q:                         c.Params.Q,
 		IncludeMemberCount:        c.Params.IncludeMemberCount,
 		FilterAllowReference:      c.Params.FilterAllowReference,
+		FilterArchived:            c.Params.FilterArchived,
 		FilterParentTeamPermitted: c.Params.FilterParentTeamPermitted,
 		Source:                    source,
 		FilterHasMember:           c.Params.FilterHasMember,
 		IncludeTimezones:          includeTimezones,
+		IncludeArchived:           includeArchived,
 	}
 
 	if teamID != "" {
@@ -1145,15 +1152,19 @@ func deleteGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 	auditRec.AddEventParameter("group_id", c.Params.GroupId)
 
-	_, err = c.App.DeleteGroup(c.Params.GroupId)
+	group, err = c.App.DeleteGroup(c.Params.GroupId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
+	b, jsonErr := json.Marshal(group)
+	if jsonErr != nil {
+		c.Err = model.NewAppError("Api4.deleteGroup", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
+		return
+	}
 	auditRec.Success()
-
-	ReturnStatusOK(w)
+	w.Write(b)
 }
 
 func restoreGroup(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -1194,15 +1205,20 @@ func restoreGroup(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 	auditRec.AddMeta("group_id", c.Params.GroupId)
 
-	_, err = c.App.RestoreGroup(c.Params.GroupId)
+	restoredGroup, err := c.App.RestoreGroup(c.Params.GroupId)
 	if err != nil {
 		c.Err = err
 		return
 	}
 
-	auditRec.Success()
+	b, jsonErr := json.Marshal(restoredGroup)
+	if jsonErr != nil {
+		c.Err = model.NewAppError("Api4.restoreGroup", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
+		return
+	}
 
-	ReturnStatusOK(w)
+	auditRec.Success()
+	w.Write(b)
 }
 
 func addGroupMembers(c *Context, w http.ResponseWriter, r *http.Request) {
@@ -1223,13 +1239,13 @@ func addGroupMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if group.Source != model.GroupSourceCustom {
-		c.Err = model.NewAppError("Api4.deleteGroup", "app.group.crud_permission", nil, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("Api4.addGroupMembers", "app.group.crud_permission", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	appErr = licensedAndConfiguredForGroupBySource(c.App, model.GroupSourceCustom)
 	if appErr != nil {
-		appErr.Where = "Api4.deleteGroup"
+		appErr.Where = "Api4.addGroupMembers"
 		c.Err = appErr
 		return
 	}
@@ -1282,13 +1298,13 @@ func deleteGroupMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if group.Source != model.GroupSourceCustom {
-		c.Err = model.NewAppError("Api4.deleteGroup", "app.group.crud_permission", nil, "", http.StatusBadRequest)
+		c.Err = model.NewAppError("Api4.deleteGroupMembers", "app.group.crud_permission", nil, "", http.StatusBadRequest)
 		return
 	}
 
 	appErr = licensedAndConfiguredForGroupBySource(c.App, model.GroupSourceCustom)
 	if appErr != nil {
-		appErr.Where = "Api4.deleteGroup"
+		appErr.Where = "Api4.deleteGroupMembers"
 		c.Err = appErr
 		return
 	}

--- a/server/channels/app/group.go
+++ b/server/channels/app/group.go
@@ -213,6 +213,13 @@ func (a *App) DeleteGroup(groupID string) (*model.Group, *model.AppError) {
 		}
 	}
 
+	count, err := a.Srv().Store().Group().GetMemberCount(groupID)
+	if err != nil {
+		return nil, model.NewAppError("DeleteGroup", "app.group.id.app_error", nil, "", http.StatusBadRequest).Wrap(err)
+	}
+
+	deletedGroup.MemberCount = model.NewInt(int(count))
+
 	return deletedGroup, nil
 }
 
@@ -227,6 +234,22 @@ func (a *App) RestoreGroup(groupID string) (*model.Group, *model.AppError) {
 			return nil, model.NewAppError("RestoreGroup", "app.update_error", nil, err.Error(), http.StatusInternalServerError)
 		}
 	}
+
+	count, err := a.Srv().Store().Group().GetMemberCount(groupID)
+	if err != nil {
+		return nil, model.NewAppError("RestoreGroup", "app.group.id.app_error", nil, "", http.StatusBadRequest).Wrap(err)
+	}
+
+	restoredGroup.MemberCount = model.NewInt(int(count))
+
+	messageWs := model.NewWebSocketEvent(model.WebsocketEventReceivedGroup, "", "", "", nil, "")
+
+	groupJSON, err := json.Marshal(restoredGroup)
+	if err != nil {
+		return nil, model.NewAppError("RestoreGroup", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	messageWs.Add("group", string(groupJSON))
+	a.Publish(messageWs)
 
 	return restoredGroup, nil
 }

--- a/server/channels/store/sqlstore/group_store.go
+++ b/server/channels/store/sqlstore/group_store.go
@@ -351,9 +351,11 @@ func (s *SqlGroupStore) Delete(groupID string) (*model.Group, error) {
 	}
 
 	time := model.GetMillis()
+	group.DeleteAt = time
+	group.UpdateAt = time
 	if _, err := s.GetMasterX().Exec(`UPDATE UserGroups
 		SET DeleteAt=?, UpdateAt=?
-		WHERE Id=? AND DeleteAt=0`, time, time, groupID); err != nil {
+		WHERE Id=? AND DeleteAt=0`, group.DeleteAt, group.UpdateAt, groupID); err != nil {
 		return nil, errors.Wrapf(err, "failed to update Group with id=%s", groupID)
 	}
 
@@ -369,10 +371,11 @@ func (s *SqlGroupStore) Restore(groupID string) (*model.Group, error) {
 		return nil, errors.Wrapf(err, "failed to get Group with id=%s", groupID)
 	}
 
-	time := model.GetMillis()
+	group.UpdateAt = model.GetMillis()
+	group.DeleteAt = 0
 	if _, err := s.GetMasterX().Exec(`UPDATE UserGroups
 		SET DeleteAt=0, UpdateAt=?
-		WHERE Id=? AND DeleteAt!=0`, time, groupID); err != nil {
+		WHERE Id=? AND DeleteAt!=0`, group.UpdateAt, groupID); err != nil {
 		return nil, errors.Wrapf(err, "failed to update Group with id=%s", groupID)
 	}
 
@@ -1529,15 +1532,25 @@ func (s *SqlGroupStore) GetGroups(page, perPage int, opts model.GroupSearchOpts,
 	}
 
 	groupsQuery = groupsQuery.
-		From("UserGroups g").
-		OrderBy("g.DisplayName")
+		From("UserGroups g")
 
 	if opts.Since > 0 {
 		groupsQuery = groupsQuery.Where(sq.Gt{
 			"g.UpdateAt": opts.Since,
 		})
-	} else {
+	}
+
+	if opts.FilterArchived {
+		groupsQuery = groupsQuery.Where("g.DeleteAt > 0")
+	} else if !opts.IncludeArchived && opts.Since <= 0 {
+		// Mobile needs to return archived groups when the since parameter is set, will need to keep this for backwards compatibility
 		groupsQuery = groupsQuery.Where("g.DeleteAt = 0")
+	}
+
+	if opts.IncludeArchived {
+		groupsQuery = groupsQuery.OrderBy("CASE WHEN g.DeleteAt = 0 THEN g.DisplayName end, CASE WHEN g.DeleteAt != 0 THEN g.DisplayName END")
+	} else {
+		groupsQuery = groupsQuery.OrderBy("g.DisplayName")
 	}
 
 	if perPage != 0 {

--- a/server/channels/web/params.go
+++ b/server/channels/web/params.go
@@ -83,6 +83,7 @@ type Params struct {
 	IncludeTotalCount         bool
 	IncludeDeleted            bool
 	FilterAllowReference      bool
+	FilterArchived            bool
 	FilterParentTeamPermitted bool
 	CategoryId                string
 	WarnMetricId              string
@@ -208,6 +209,7 @@ func ParamsFromRequest(r *http.Request) *Params {
 	params.NotAssociatedToTeam = query.Get("not_associated_to_team")
 	params.NotAssociatedToChannel = query.Get("not_associated_to_channel")
 	params.FilterAllowReference, _ = strconv.ParseBool(query.Get("filter_allow_reference"))
+	params.FilterArchived, _ = strconv.ParseBool(query.Get("filter_archived"))
 	params.FilterParentTeamPermitted, _ = strconv.ParseBool(query.Get("filter_parent_team_permitted"))
 	params.IncludeChannelMemberCount = query.Get("include_channel_member_count")
 

--- a/webapp/channels/src/components/post_markdown/index.ts
+++ b/webapp/channels/src/components/post_markdown/index.ts
@@ -37,7 +37,7 @@ export function makeGetMentionKeysForPost(): (
         getCurrentUserMentionKeys,
         (state: GlobalState, post?: Post) => post,
         (state: GlobalState, post?: Post, channel?: Channel) =>
-            (channel ? getMyGroupMentionKeysForChannel(state, channel.team_id, channel.id) : getMyGroupMentionKeys(state)),
+        (channel ? getMyGroupMentionKeysForChannel(state, channel.team_id, channel.id) : getMyGroupMentionKeys(state, false)),
         (mentionKeysWithoutGroups, post, groupMentionKeys) => {
             let mentionKeys = mentionKeysWithoutGroups;
             if (!post?.props?.disable_group_highlight) {

--- a/webapp/channels/src/components/team_controller/actions/index.ts
+++ b/webapp/channels/src/components/team_controller/actions/index.ts
@@ -21,6 +21,7 @@ import LocalStorageStore from 'stores/local_storage_store';
 
 import {Team} from '@mattermost/types/teams';
 import {ServerError} from '@mattermost/types/errors';
+import {GetGroupsForUserParams, GetGroupsParams} from '@mattermost/types/groups';
 
 export function initializeTeam(team: Team): ActionFunc<Team, ServerError> {
     return async (dispatch, getState) => {
@@ -50,8 +51,20 @@ export function initializeTeam(team: Team): ActionFunc<Team, ServerError> {
         if (license &&
             license.IsLicensed === 'true' &&
             (license.LDAPGroups === 'true' || customGroupEnabled)) {
+            const groupsParams: GetGroupsParams = {
+                filter_allow_reference: false,
+                page: 0,
+                per_page: 60,
+                include_member_count: true,
+                include_archived: true,
+            };
+            const myGroupsParams: GetGroupsForUserParams = {
+                ...groupsParams,
+                filter_has_member: currentUser.id,
+            };
+
             if (currentUser) {
-                dispatch(getGroupsByUserIdPaginated(currentUser.id, false, 0, 60, true));
+                dispatch(getGroupsByUserIdPaginated(myGroupsParams));
             }
 
             if (license.LDAPGroups === 'true') {
@@ -61,7 +74,7 @@ export function initializeTeam(team: Team): ActionFunc<Team, ServerError> {
             if (team.group_constrained && license.LDAPGroups === 'true') {
                 dispatch(getAllGroupsAssociatedToTeam(team.id, true));
             } else {
-                dispatch(getGroups(false, 0, 60, true));
+                dispatch(getGroups(groupsParams));
             }
         }
 

--- a/webapp/channels/src/components/user_groups_modal/ad_ldap_upsell_banner.tsx
+++ b/webapp/channels/src/components/user_groups_modal/ad_ldap_upsell_banner.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect, useState} from 'react';
+import React, {memo, useEffect, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import moment from 'moment';
 import {useIntl} from 'react-intl';
@@ -154,4 +154,4 @@ function ADLDAPUpsellBanner() {
     );
 }
 
-export default ADLDAPUpsellBanner;
+export default memo(ADLDAPUpsellBanner);

--- a/webapp/channels/src/components/user_groups_modal/index.ts
+++ b/webapp/channels/src/components/user_groups_modal/index.ts
@@ -11,7 +11,7 @@ import {GlobalState} from 'types/store';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {getAllAssociatedGroupsForReference, getMyAllowReferencedGroups, searchAllowReferencedGroups, searchMyAllowReferencedGroups} from 'mattermost-redux/selectors/entities/groups';
 import {getGroups, getGroupsByUserIdPaginated, searchGroups} from 'mattermost-redux/actions/groups';
-import {Group, GroupSearachParams} from '@mattermost/types/groups';
+import {GetGroupsForUserParams, GetGroupsParams, Group, GroupSearachParams} from '@mattermost/types/groups';
 import {ModalIdentifiers} from 'utils/constants';
 import {isModalOpen} from 'selectors/views/modals';
 import {setModalSearchTerm} from 'actions/views/search';
@@ -20,18 +20,11 @@ import UserGroupsModal from './user_groups_modal';
 
 type Actions = {
     getGroups: (
-        filterAllowReference?: boolean,
-        page?: number,
-        perPage?: number,
-        includeMemberCount?: boolean
+        groupsParams: GetGroupsParams,
     ) => Promise<{data: Group[]}>;
     setModalSearchTerm: (term: string) => void;
     getGroupsByUserIdPaginated: (
-        userId: string,
-        filterAllowReference?: boolean,
-        page?: number,
-        perPage?: number,
-        includeMemberCount?: boolean
+        opts: GetGroupsForUserParams,
     ) => Promise<{data: Group[]}>;
     searchGroups: (
         params: GroupSearachParams,
@@ -44,11 +37,11 @@ function mapStateToProps(state: GlobalState) {
     let groups: Group[] = [];
     let myGroups: Group[] = [];
     if (searchTerm) {
-        groups = searchAllowReferencedGroups(state, searchTerm);
-        myGroups = searchMyAllowReferencedGroups(state, searchTerm);
+        groups = searchAllowReferencedGroups(state, searchTerm, true);
+        myGroups = searchMyAllowReferencedGroups(state, searchTerm, true);
     } else {
-        groups = getAllAssociatedGroupsForReference(state);
-        myGroups = getMyAllowReferencedGroups(state);
+        groups = getAllAssociatedGroupsForReference(state, true);
+        myGroups = getMyAllowReferencedGroups(state, true);
     }
 
     return {
@@ -71,4 +64,4 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(UserGroupsModal);
+export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(UserGroupsModal);

--- a/webapp/channels/src/components/user_groups_modal/user_groups_list/index.ts
+++ b/webapp/channels/src/components/user_groups_modal/user_groups_list/index.ts
@@ -8,7 +8,7 @@ import {ActionFunc, ActionResult, GenericAction} from 'mattermost-redux/types/ac
 
 import {GlobalState} from 'types/store';
 
-import {archiveGroup} from 'mattermost-redux/actions/groups';
+import {archiveGroup, restoreGroup} from 'mattermost-redux/actions/groups';
 import {ModalData} from 'types/actions';
 import {openModal} from 'actions/views/modals';
 import {getGroupListPermissions} from 'mattermost-redux/selectors/entities/roles';
@@ -18,6 +18,7 @@ import UserGroupsList from './user_groups_list';
 type Actions = {
     openModal: <P>(modalData: ModalData<P>) => void;
     archiveGroup: (groupId: string) => Promise<ActionResult>;
+    restoreGroup: (groupId: string) => Promise<ActionResult>;
 };
 
 function mapStateToProps(state: GlobalState) {
@@ -32,6 +33,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators<ActionCreatorsMapObject<ActionFunc | GenericAction>, Actions>({
             openModal,
             archiveGroup,
+            restoreGroup,
         }, dispatch),
     };
 }

--- a/webapp/channels/src/components/user_groups_modal/user_groups_list/user_groups_list.tsx
+++ b/webapp/channels/src/components/user_groups_modal/user_groups_list/user_groups_list.tsx
@@ -30,6 +30,7 @@ export type Props = {
     backButtonAction: () => void;
     actions: {
         archiveGroup: (groupId: string) => Promise<ActionResult>;
+        restoreGroup: (groupId: string) => Promise<ActionResult>;
         openModal: <P>(modalData: ModalData<P>) => void;
     };
 }
@@ -57,6 +58,10 @@ const UserGroupsList = React.forwardRef((props: Props, ref?: React.Ref<HTMLDivEl
     const archiveGroup = useCallback(async (groupId: string) => {
         await actions.archiveGroup(groupId);
     }, [actions.archiveGroup]);
+
+    const restoreGroup = useCallback(async (groupId: string) => {
+        await actions.restoreGroup(groupId);
+    }, [actions.restoreGroup]);
 
     const goToViewGroupModal = useCallback((group: Group) => {
         actions.openModal({
@@ -104,6 +109,10 @@ const UserGroupsList = React.forwardRef((props: Props, ref?: React.Ref<HTMLDivEl
                         }}
                     >
                         <span className='group-display-name'>
+                            {
+                                group.delete_at > 0 &&
+                                <i className='icon icon-archive-outline'/>
+                            }
                             {group.display_name}
                         </span>
                         <span className='group-name'>
@@ -153,6 +162,14 @@ const UserGroupsList = React.forwardRef((props: Props, ref?: React.Ref<HTMLDivEl
                                             text={Utils.localizeMessage('user_groups_modal.archiveGroup', 'Archive Group')}
                                             disabled={false}
                                             isDangerous={true}
+                                        />
+                                        <Menu.ItemAction
+                                            show={groupPermissionsMap[group.id].can_restore}
+                                            onClick={() => {
+                                                restoreGroup(group.id);
+                                            }}
+                                            text={Utils.localizeMessage('user_groups_modal.restoreGroup', 'Restore Group')}
+                                            disabled={false}
                                         />
                                     </Menu.Group>
                                 </Menu>

--- a/webapp/channels/src/components/user_groups_modal/user_groups_list/user_groups_list.tsx
+++ b/webapp/channels/src/components/user_groups_modal/user_groups_list/user_groups_list.tsx
@@ -1,9 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {FormattedMessage} from 'react-intl';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import {VariableSizeList, ListChildComponentProps} from 'react-window';
+import InfiniteLoader from 'react-window-infinite-loader';
 
 import NoResultsIndicator from 'components/no_results_indicator';
 import {NoResultsVariant} from 'components/no_results_indicator/types';
@@ -25,9 +28,10 @@ export type Props = {
     searchTerm: string;
     loading: boolean;
     groupPermissionsMap: Record<string, GroupPermissions>;
-    onScroll: () => void;
+    loadMoreGroups: () => void;
     onExited: () => void;
     backButtonAction: () => void;
+    hasNextPage: boolean;
     actions: {
         archiveGroup: (groupId: string) => Promise<ActionResult>;
         restoreGroup: (groupId: string) => Promise<ActionResult>;
@@ -41,12 +45,16 @@ const UserGroupsList = React.forwardRef((props: Props, ref?: React.Ref<HTMLDivEl
         searchTerm,
         loading,
         groupPermissionsMap,
-        onScroll,
+        hasNextPage,
+        loadMoreGroups,
         backButtonAction,
         onExited,
         actions,
     } = props;
 
+    const infiniteLoaderRef = useRef<InfiniteLoader | null>(null);
+    const variableSizeListRef = useRef<VariableSizeList | null>(null);
+    const [hasMounted, setHasMounted] = useState(false);
     const [overflowState, setOverflowState] = useState('overlay');
 
     useEffect(() => {
@@ -54,6 +62,26 @@ const UserGroupsList = React.forwardRef((props: Props, ref?: React.Ref<HTMLDivEl
             setOverflowState('visible');
         }
     }, [groups]);
+
+    useEffect(() => {
+        if (hasMounted) {
+            if (infiniteLoaderRef.current) {
+                infiniteLoaderRef.current.resetloadMoreItemsCache();
+            }
+            if (variableSizeListRef.current) {
+                variableSizeListRef.current.resetAfterIndex(0);
+            }
+        }
+        setHasMounted(true);
+    }, [searchTerm, groups.length, hasMounted]);
+
+    const itemCount = hasNextPage ? groups.length + 1 : groups.length;
+
+    const loadMoreItems = loading ? () => {} : loadMoreGroups;
+
+    const isItemLoaded = (index: number) => {
+        return !hasNextPage || index < groups.length;
+    };
 
     const archiveGroup = useCallback(async (groupId: string) => {
         await actions.archiveGroup(groupId);
@@ -86,102 +114,130 @@ const UserGroupsList = React.forwardRef((props: Props, ref?: React.Ref<HTMLDivEl
         return true;
     };
 
-    return (
-        <div
-            className='user-groups-modal__content user-groups-list'
-            onScroll={onScroll}
-            ref={ref}
-            style={{overflow: overflowState}}
-        >
-            {(groups.length === 0 && searchTerm) &&
+    const Item = ({index, style}: ListChildComponentProps) => {
+        if (groups.length === 0 && searchTerm) {
+            return (
                 <NoResultsIndicator
                     variant={NoResultsVariant.ChannelSearch}
                     titleValues={{channelName: `"${searchTerm}"`}}
                 />
+            );
+        }
+        if (isItemLoaded(index)) {
+            const group = groups[index] as Group;
+            if (!group) {
+                return null;
             }
-            {groups.map((group, i) => {
-                return (
-                    <div
-                        className='group-row'
-                        key={group.id}
-                        onClick={() => {
-                            goToViewGroupModal(group);
-                        }}
-                    >
-                        <span className='group-display-name'>
-                            {
-                                group.delete_at > 0 &&
-                                <i className='icon icon-archive-outline'/>
-                            }
-                            {group.display_name}
-                        </span>
-                        <span className='group-name'>
-                            {'@'}{group.name}
-                        </span>
-                        <div className='group-member-count'>
-                            <FormattedMessage
-                                id='user_groups_modal.memberCount'
-                                defaultMessage='{member_count} {member_count, plural, one {member} other {members}}'
-                                values={{
-                                    member_count: group.member_count,
-                                }}
-                            />
-                        </div>
-                        <div className='group-action'>
-                            <MenuWrapper
-                                isDisabled={false}
-                                stopPropagationOnToggle={true}
-                                id={`customWrapper-${group.id}`}
-                            >
-                                <button className='action-wrapper'>
-                                    <i className='icon icon-dots-vertical'/>
-                                </button>
-                                <Menu
-                                    openLeft={true}
-                                    openUp={groupListOpenUp(i)}
-                                    className={'group-actions-menu'}
-                                    ariaLabel={Utils.localizeMessage('admin.user_item.menuAriaLabel', 'User Actions Menu')}
-                                >
-                                    <Menu.Group>
-                                        <Menu.ItemAction
-                                            onClick={() => {
-                                                goToViewGroupModal(group);
-                                            }}
-                                            icon={<i className='icon-account-multiple-outline'/>}
-                                            text={Utils.localizeMessage('user_groups_modal.viewGroup', 'View Group')}
-                                            disabled={false}
-                                        />
-                                    </Menu.Group>
-                                    <Menu.Group>
-                                        <Menu.ItemAction
-                                            show={groupPermissionsMap[group.id].can_delete}
-                                            onClick={() => {
-                                                archiveGroup(group.id);
-                                            }}
-                                            icon={<i className='icon-archive-outline'/>}
-                                            text={Utils.localizeMessage('user_groups_modal.archiveGroup', 'Archive Group')}
-                                            disabled={false}
-                                            isDangerous={true}
-                                        />
-                                        <Menu.ItemAction
-                                            show={groupPermissionsMap[group.id].can_restore}
-                                            onClick={() => {
-                                                restoreGroup(group.id);
-                                            }}
-                                            text={Utils.localizeMessage('user_groups_modal.restoreGroup', 'Restore Group')}
-                                            disabled={false}
-                                        />
-                                    </Menu.Group>
-                                </Menu>
-                            </MenuWrapper>
-                        </div>
+
+            return (
+                <div
+                    className='group-row'
+                    style={style}
+                    key={group.id}
+                    onClick={() => {
+                        goToViewGroupModal(group);
+                    }}
+                >
+                    <span className='group-display-name'>
+                        {
+                            group.delete_at > 0 &&
+                            <i className='icon icon-archive-outline'/>
+                        }
+                        {group.display_name}
+                    </span>
+                    <span className='group-name'>
+                        {'@'}{group.name}
+                    </span>
+                    <div className='group-member-count'>
+                        <FormattedMessage
+                            id='user_groups_modal.memberCount'
+                            defaultMessage='{member_count} {member_count, plural, one {member} other {members}}'
+                            values={{
+                                member_count: group.member_count,
+                            }}
+                        />
                     </div>
-                );
-            })}
-            {
-                (loading) &&
-                <LoadingScreen/>
-            }
+                    <div className='group-action'>
+                        <MenuWrapper
+                            isDisabled={false}
+                            stopPropagationOnToggle={true}
+                            id={`customWrapper-${group.id}`}
+                        >
+                            <button className='action-wrapper'>
+                                <i className='icon icon-dots-vertical'/>
+                            </button>
+                            <Menu
+                                openLeft={true}
+                                openUp={groupListOpenUp(index)}
+                                className={'group-actions-menu'}
+                                ariaLabel={Utils.localizeMessage('admin.user_item.menuAriaLabel', 'User Actions Menu')}
+                            >
+                                <Menu.Group>
+                                    <Menu.ItemAction
+                                        onClick={() => {
+                                            goToViewGroupModal(group);
+                                        }}
+                                        icon={<i className='icon-account-multiple-outline'/>}
+                                        text={Utils.localizeMessage('user_groups_modal.viewGroup', 'View Group')}
+                                        disabled={false}
+                                    />
+                                </Menu.Group>
+                                <Menu.Group>
+                                    <Menu.ItemAction
+                                        show={groupPermissionsMap[group.id].can_delete}
+                                        onClick={() => {
+                                            archiveGroup(group.id);
+                                        }}
+                                        icon={<i className='icon-archive-outline'/>}
+                                        text={Utils.localizeMessage('user_groups_modal.archiveGroup', 'Archive Group')}
+                                        disabled={false}
+                                        isDangerous={true}
+                                    />
+                                    <Menu.ItemAction
+                                        show={groupPermissionsMap[group.id].can_restore}
+                                        onClick={() => {
+                                            restoreGroup(group.id);
+                                        }}
+                                        text={Utils.localizeMessage('user_groups_modal.restoreGroup', 'Restore Group')}
+                                        disabled={false}
+                                    />
+                                </Menu.Group>
+                            </Menu>
+                        </MenuWrapper>
+                    </div>
+                </div>
+            );
+        }
+        if (loading) {
+            return <LoadingScreen/>;
+        }
+        return null;
+    };
+
+    return (
+        <div
+            className='user-groups-modal__content user-groups-list'
+            style={{overflow: overflowState}}
+        >
+            <InfiniteLoader
+                ref={infiniteLoaderRef}
+                isItemLoaded={isItemLoaded}
+                itemCount={100000}
+                loadMoreItems={loadMoreItems}
+                threshold={5}
+            >
+                {({onItemsRendered, ref}) => (
+                    <VariableSizeList
+                        itemCount={itemCount}
+                        onItemsRendered={onItemsRendered}
+                        ref={ref}
+                        itemSize={() => 52}
+                        height={groups.length >= 8 ? 416 : groups.length * 52}
+                        width={'100%'}
+                    >
+                        {Item}
+                    </VariableSizeList>)}
+            </InfiniteLoader>
             <ADLDAPUpsellBanner/>
         </div>
     );

--- a/webapp/channels/src/components/user_groups_modal/user_groups_modal.scss
+++ b/webapp/channels/src/components/user_groups_modal/user_groups_modal.scss
@@ -284,6 +284,11 @@
                         max-width: 200px;
                         text-overflow: ellipsis;
                         white-space: nowrap;
+
+                        i {
+                            color: rgba(var(--center-channel-color-rgb), 0.56);
+                            font-size: 16px;
+                        }
                     }
 
                     .group-name {

--- a/webapp/channels/src/components/user_groups_modal/user_groups_modal.tsx
+++ b/webapp/channels/src/components/user_groups_modal/user_groups_modal.tsx
@@ -1,14 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {createRef, RefObject} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useDispatch} from 'react-redux';
 
 import {Modal} from 'react-bootstrap';
 
 import Constants from 'utils/constants';
 
 import * as Utils from 'utils/utils';
-import {Group, GroupSearachParams} from '@mattermost/types/groups';
+import {GetGroupsForUserParams, GetGroupsParams, Group, GroupSearachParams} from '@mattermost/types/groups';
 
 import './user_groups_modal.scss';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
@@ -33,18 +34,11 @@ export type Props = {
     backButtonAction: () => void;
     actions: {
         getGroups: (
-            filterAllowReference?: boolean,
-            page?: number,
-            perPage?: number,
-            includeMemberCount?: boolean
+            opts: GetGroupsParams,
         ) => Promise<{data: Group[]}>;
         setModalSearchTerm: (term: string) => void;
         getGroupsByUserIdPaginated: (
-            userId: string,
-            filterAllowReference?: boolean,
-            page?: number,
-            perPage?: number,
-            includeMemberCount?: boolean
+            opts: GetGroupsForUserParams,
         ) => Promise<{data: Group[]}>;
         searchGroups: (
             params: GroupSearachParams,
@@ -62,235 +56,274 @@ type State = {
     myGroupsFull: boolean;
 }
 
-export default class UserGroupsModal extends React.PureComponent<Props, State> {
-    divScrollRef: RefObject<HTMLDivElement>;
-    private searchTimeoutId: number
+const UserGroupsModal = (props: Props) => {
+    const divScrollRef = useRef<HTMLDivElement>(null);
+    const [searchTimeoutId, setSearchTimeoutId] = useState(0);
+    const [page, setPage] = useState(0);
+    const [myGroupsPage, setMyGroupsPage] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [show, setShow] = useState(true);
+    const [selectedFilter, setSelectedFilter] = useState('all');
+    const [allGroupsFull, setAllGroupsFull] = useState(false);
+    const [myGroupsFull, setMyGroupsFull] = useState(false);
 
-    constructor(props: Props) {
-        super(props);
-        this.divScrollRef = createRef();
-        this.searchTimeoutId = 0;
+    const [groups, setGroups] = useState(props.groups);
 
-        this.state = {
-            page: 0,
-            myGroupsPage: 0,
-            loading: true,
-            show: true,
-            selectedFilter: 'all',
-            allGroupsFull: false,
-            myGroupsFull: false,
-        };
-    }
-
-    doHide = () => {
-        this.setState({show: false});
-    }
-
-    async componentDidMount() {
-        const {
-            actions,
-        } = this.props;
-        await Promise.all([
-            actions.getGroups(false, this.state.page, GROUPS_PER_PAGE, true),
-            actions.getGroupsByUserIdPaginated(this.props.currentUserId, false, this.state.myGroupsPage, GROUPS_PER_PAGE, true),
-        ]);
-        this.loadComplete();
-    }
-
-    componentWillUnmount() {
-        this.props.actions.setModalSearchTerm('');
-    }
-
-    componentDidUpdate(prevProps: Props) {
-        if (prevProps.searchTerm !== this.props.searchTerm) {
-            clearTimeout(this.searchTimeoutId);
-            const searchTerm = this.props.searchTerm;
-
-            if (searchTerm === '') {
-                this.loadComplete();
-                this.searchTimeoutId = 0;
-                return;
-            }
-
-            const searchTimeoutId = window.setTimeout(
-                async () => {
-                    const params: GroupSearachParams = {
-                        q: searchTerm,
-                        filter_allow_reference: true,
-                        page: this.state.page,
-                        per_page: GROUPS_PER_PAGE,
-                        include_member_count: true,
-                    };
-                    if (this.state.selectedFilter === 'all') {
-                        await prevProps.actions.searchGroups(params);
-                    } else {
-                        params.user_id = this.props.currentUserId;
-                        await prevProps.actions.searchGroups(params);
-                    }
-                },
-                Constants.SEARCH_TIMEOUT_MILLISECONDS,
-            );
-
-            this.searchTimeoutId = searchTimeoutId;
+    useEffect(() => {
+        if (selectedFilter === 'all') {
+            setGroups(props.groups);
         }
+        if (selectedFilter === 'my') {
+            setGroups(props.myGroups);
+        }
+    }, [selectedFilter, props.groups, props.myGroups]);
+
+    const doHide = () => {
+        setShow(false);
     }
 
-    startLoad = () => {
-        this.setState({loading: true});
-    }
+    const loadComplete = useCallback(() => {
+        setLoading(false);
+    }, []);
 
-    loadComplete = () => {
-        this.setState({loading: false});
-    }
+    const getAllGroups = useCallback(async () => {
+        const groupsParams: GetGroupsParams = {
+            filter_allow_reference: false,
+            page: page,
+            per_page: GROUPS_PER_PAGE,
+            include_member_count: true,
+            include_archived: true,
+        };
 
-    handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const myGroupsParams: GetGroupsForUserParams = {
+            ...groupsParams,
+            filter_has_member: props.currentUserId,
+            page: myGroupsPage,
+        };
+
+        await Promise.all([
+            props.actions.getGroups(groupsParams),
+            props.actions.getGroupsByUserIdPaginated(myGroupsParams),
+        ]);
+        loadComplete();
+    }, [page, props.currentUserId, myGroupsPage, props.actions.getGroups, props.actions.getGroupsByUserIdPaginated]);
+
+    useEffect(() => {
+        getAllGroups();
+        return () => {
+            props.actions.setModalSearchTerm('');
+        };
+    }, [getAllGroups]);
+
+    useEffect(() => {
+
+        clearTimeout(searchTimeoutId);
+        const searchTerm = props.searchTerm;
+
+        if (searchTerm === '') {
+            loadComplete();
+            setSearchTimeoutId(0);
+            return;
+        }
+
+        const timeoutId = window.setTimeout(
+            async () => {
+                const params: GroupSearachParams = {
+                    q: searchTerm,
+                    filter_allow_reference: true,
+                    page: page,
+                    per_page: GROUPS_PER_PAGE,
+                    include_archived: true,
+                    include_member_count: true,
+                };
+                if (selectedFilter === 'all') {
+                    await props.actions.searchGroups(params);
+                } else {
+                    params.filter_has_member = props.currentUserId;
+                    await props.actions.searchGroups(params);
+                }
+            },
+            Constants.SEARCH_TIMEOUT_MILLISECONDS,
+        );
+
+        setSearchTimeoutId(timeoutId);
+    }, [props.searchTerm, setSearchTimeoutId]);
+
+    const getMyGroups = useCallback(async (page: number) => {
+        const {actions, currentUserId} = props;
+
+        setLoading(true);
+        const groupsParams: GetGroupsForUserParams = {
+            filter_allow_reference: false,
+            page: page,
+            per_page: GROUPS_PER_PAGE,
+            include_member_count: true,
+            filter_has_member: currentUserId,
+            include_archived: true,
+        };
+        const data = await actions.getGroupsByUserIdPaginated(groupsParams);
+        if (data.data.length === 0) {
+            setMyGroupsFull(true);
+        }
+        loadComplete();
+        setSelectedFilter('my');
+    }, [props.actions.getGroupsByUserIdPaginated, props.currentUserId, page]);
+
+    const getGroups = useCallback(async (page: number) => {
+        const {actions} = props;
+
+        setLoading(true);
+
+        const groupsParams: GetGroupsParams = {
+            filter_allow_reference: false,
+            page: page,
+            per_page: GROUPS_PER_PAGE,
+            include_member_count: true,
+            include_archived: true,
+        };
+        const data = await actions.getGroups(groupsParams);
+        if (data.data.length === 0) {
+            setAllGroupsFull(true);
+        }
+        loadComplete();
+        setSelectedFilter('all');
+    }, [props.actions.getGroups, page]);
+
+    const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         const term = e.target.value;
-        this.props.actions.setModalSearchTerm(term);
-    }
+        props.actions.setModalSearchTerm(term);
+    }, [props.actions.setModalSearchTerm]);
 
-    scrollGetGroups = debounce(
+    const scrollGetGroups = debounce(
         async () => {
-            const {page} = this.state;
             const newPage = page + 1;
-
-            this.setState({page: newPage});
-            this.getGroups(newPage);
+            setPage(newPage);
+            getGroups(newPage);
         },
         500,
         false,
         (): void => {},
     );
-    scrollGetMyGroups = debounce(
+    const scrollGetMyGroups = debounce(
         async () => {
-            const {myGroupsPage} = this.state;
             const newPage = myGroupsPage + 1;
-
-            this.setState({myGroupsPage: newPage});
-            this.getMyGroups(newPage);
+            setMyGroupsPage(newPage);
+            getMyGroups(newPage);
         },
         500,
         false,
         (): void => {},
     );
 
-    onScroll = () => {
-        const scrollHeight = this.divScrollRef.current?.scrollHeight || 0;
-        const scrollTop = this.divScrollRef.current?.scrollTop || 0;
-        const clientHeight = this.divScrollRef.current?.clientHeight || 0;
+    const onScroll = useCallback(() => {
+        const scrollHeight = divScrollRef.current?.scrollHeight || 0;
+        const scrollTop = divScrollRef.current?.scrollTop || 0;
+        const clientHeight = divScrollRef.current?.clientHeight || 0;
 
         if ((scrollTop + clientHeight + 30) >= scrollHeight) {
-            if (this.state.selectedFilter === 'all' && this.state.loading === false && !this.state.allGroupsFull) {
-                this.scrollGetGroups();
+            if (selectedFilter === 'all' && loading === false && !allGroupsFull) {
+                scrollGetGroups();
             }
-            if (this.state.selectedFilter !== 'all' && this.props.myGroups.length % GROUPS_PER_PAGE === 0 && this.state.loading === false) {
-                this.scrollGetMyGroups();
+            if (selectedFilter !== 'all' && loading === false && !myGroupsFull) {
+                scrollGetMyGroups();
             }
         }
-    }
+    }, [divScrollRef, selectedFilter, loading, allGroupsFull, scrollGetGroups, scrollGetMyGroups, props.myGroups]);
 
-    getMyGroups = async (page: number) => {
-        const {actions} = this.props;
+    const inputPrefix = useMemo(() => {
+        return <i className={'icon icon-magnify'}/>;
+    }, []);
 
-        this.startLoad();
-        const data = await actions.getGroupsByUserIdPaginated(this.props.currentUserId, false, page, GROUPS_PER_PAGE, true);
-        if (data.data.length === 0) {
-            this.setState({myGroupsFull: true});
-        }
-        this.loadComplete();
-        this.setState({selectedFilter: 'my'});
-    }
-
-    getGroups = async (page: number) => {
-        const {actions} = this.props;
-
-        this.startLoad();
-        const data = await actions.getGroups(false, page, GROUPS_PER_PAGE, true);
-        if (data.data.length === 0) {
-            this.setState({allGroupsFull: true});
-        }
-        this.loadComplete();
-        this.setState({selectedFilter: 'all'});
-    }
-
-    render() {
-        const groups = this.state.selectedFilter === 'all' ? this.props.groups : this.props.myGroups;
-
-        return (
-            <Modal
-                dialogClassName='a11y__modal user-groups-modal'
-                show={this.state.show}
-                onHide={this.doHide}
-                onExited={this.props.onExited}
-                role='dialog'
-                aria-labelledby='userGroupsModalLabel'
-                id='userGroupsModal'
-            >
-                <UserGroupsModalHeader
-                    onExited={this.props.onExited}
-                    backButtonAction={this.props.backButtonAction}
-                />
-                <Modal.Body>
-                    {(groups.length === 0 && !this.props.searchTerm) ? <>
-                        <NoResultsIndicator
-                            variant={NoResultsVariant.UserGroups}
+    return (
+        <Modal
+            dialogClassName='a11y__modal user-groups-modal'
+            show={show}
+            onHide={doHide}
+            onExited={props.onExited}
+            role='dialog'
+            aria-labelledby='userGroupsModalLabel'
+            id='userGroupsModal'
+        >
+            <UserGroupsModalHeader
+                onExited={props.onExited}
+                backButtonAction={props.backButtonAction}
+            />
+            <Modal.Body>
+                {(groups.length === 0 && !props.searchTerm) ? <>
+                    <NoResultsIndicator
+                        variant={NoResultsVariant.UserGroups}
+                    />
+                    <ADLDAPUpsellBanner/>
+                </> : <>
+                    <div className='user-groups-search'>
+                        <Input
+                            type='text'
+                            placeholder={Utils.localizeMessage('user_groups_modal.searchGroups', 'Search Groups')}
+                            onChange={handleSearch}
+                            value={props.searchTerm}
+                            data-testid='searchInput'
+                            className={'user-group-search-input'}
+                            inputPrefix={inputPrefix}
                         />
-                        <ADLDAPUpsellBanner/>
-                    </> : <>
-                        <div className='user-groups-search'>
-                            <Input
-                                type='text'
-                                placeholder={Utils.localizeMessage('user_groups_modal.searchGroups', 'Search Groups')}
-                                onChange={this.handleSearch}
-                                value={this.props.searchTerm}
-                                data-testid='searchInput'
-                                className={'user-group-search-input'}
-                                inputPrefix={<i className={'icon icon-magnify'}/>}
-                            />
-                        </div>
-                        <div className='more-modal__dropdown'>
-                            <MenuWrapper id='groupsFilterDropdown'>
-                                <a>
-                                    <span>{this.state.selectedFilter === 'all' ? Utils.localizeMessage('user_groups_modal.showAllGroups', 'Show: All Groups') : Utils.localizeMessage('user_groups_modal.showMyGroups', 'Show: My Groups')}</span>
-                                    <span className='icon icon-chevron-down'/>
-                                </a>
-                                <Menu
-                                    openLeft={false}
-                                    ariaLabel={Utils.localizeMessage('user_groups_modal.filterAriaLabel', 'Groups Filter Menu')}
-                                >
+                    </div>
+                    <div className='more-modal__dropdown'>
+                        <MenuWrapper id='groupsFilterDropdown'>
+                            <a>
+                                <span>{selectedFilter === 'all' ? Utils.localizeMessage('user_groups_modal.showAllGroups', 'Show: All Groups') : Utils.localizeMessage('user_groups_modal.showMyGroups', 'Show: My Groups')}</span>
+                                <span className='icon icon-chevron-down'/>
+                            </a>
+                            <Menu
+                                openLeft={false}
+                                ariaLabel={Utils.localizeMessage('user_groups_modal.filterAriaLabel', 'Groups Filter Menu')}
+                            >
+                                <Menu.Group>
                                     <Menu.ItemAction
                                         id='groupsDropdownAll'
                                         buttonClass='groups-filter-btn'
                                         onClick={() => {
-                                            this.getGroups(0);
+                                            getGroups(0);
                                         }}
                                         text={Utils.localizeMessage('user_groups_modal.allGroups', 'All Groups')}
-                                        rightDecorator={this.state.selectedFilter === 'all' && <i className='icon icon-check'/>}
+                                        rightDecorator={selectedFilter === 'all' && <i className='icon icon-check'/>}
                                     />
                                     <Menu.ItemAction
                                         id='groupsDropdownMy'
                                         buttonClass='groups-filter-btn'
                                         onClick={() => {
-                                            this.getMyGroups(0);
+                                            getMyGroups(0);
                                         }}
                                         text={Utils.localizeMessage('user_groups_modal.myGroups', 'My Groups')}
-                                        rightDecorator={this.state.selectedFilter !== 'all' && <i className='icon icon-check'/>}
+                                        rightDecorator={selectedFilter !== 'all' && <i className='icon icon-check'/>}
                                     />
-                                </Menu>
-                            </MenuWrapper>
-                        </div>
-                        <UserGroupsList
-                            groups={groups}
-                            searchTerm={this.props.searchTerm}
-                            loading={this.state.loading}
-                            onScroll={this.onScroll}
-                            ref={this.divScrollRef}
-                            onExited={this.props.onExited}
-                            backButtonAction={this.props.backButtonAction}
-                        />
-                    </>
-                    }
-                </Modal.Body>
-            </Modal>
-        );
-    }
+                                </Menu.Group>
+                                <Menu.Group>
+                                    <Menu.ItemAction
+                                        id='groupsDropdownArchived'
+                                        buttonClass='groups-filter-btn'
+                                        onClick={() => {
+                                            getMyGroups(0);
+                                        }}
+                                        text={Utils.localizeMessage('user_groups_modal.myGroups', 'My Groups')}
+                                        rightDecorator={selectedFilter !== 'all' && <i className='icon icon-check'/>}
+                                    />
+                                </Menu.Group>
+                            </Menu>
+                        </MenuWrapper>
+                    </div>
+                    <UserGroupsList
+                        groups={groups}
+                        searchTerm={props.searchTerm}
+                        loading={loading}
+                        onScroll={onScroll}
+                        ref={divScrollRef}
+                        onExited={props.onExited}
+                        backButtonAction={props.backButtonAction}
+                    />
+                </>
+                }
+            </Modal.Body>
+        </Modal>
+    );
 }
+
+export default React.memo(UserGroupsModal);

--- a/webapp/channels/src/components/view_user_group_modal/view_user_group_modal.tsx
+++ b/webapp/channels/src/components/view_user_group_modal/view_user_group_modal.tsx
@@ -174,7 +174,7 @@ export default class ViewUserGroupModal extends React.PureComponent<Props, State
         if (group) {
             return (
                 <div className='group-mention-name'>
-                    <span className='group-name'>{`@ ${group.name}`}</span>
+                    <span className='group-name'>{`@${group.name}`}</span>
                     {
                         group.source.toLowerCase() === GroupSource.Ldap &&
                         <span className='group-source'>

--- a/webapp/channels/src/packages/mattermost-redux/src/action_types/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/action_types/groups.ts
@@ -51,4 +51,6 @@ export default keyMirror({
     ARCHIVED_GROUP: null,
 
     CREATED_GROUP_TEAMS_AND_CHANNELS: null,
+
+    RESTORED_GROUP: null,
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/groups.ts
@@ -9,7 +9,7 @@ import {General} from 'mattermost-redux/constants';
 import {Client4} from 'mattermost-redux/client';
 
 import {ActionFunc, DispatchFunc, GetStateFunc} from 'mattermost-redux/types/actions';
-import {GroupPatch, SyncableType, SyncablePatch, GroupCreateWithUserIds, CustomGroupPatch, GroupSearachParams, GroupSource} from '@mattermost/types/groups';
+import {GroupPatch, SyncableType, SyncablePatch, GroupCreateWithUserIds, CustomGroupPatch, GroupSearachParams, GroupSource, GetGroupsParams, GetGroupsForUserParams} from '@mattermost/types/groups';
 
 import {logError} from './errors';
 import {bindClientFunc, forceLogoutIfNecessary} from './helpers';
@@ -156,18 +156,15 @@ export function getGroup(id: string, includeMemberCount = false): ActionFunc {
     });
 }
 
-export function getGroups(filterAllowReference = false, page = 0, perPage = 10, includeMemberCount = false): ActionFunc {
+export function getGroups(opts: GetGroupsParams): ActionFunc {
     return bindClientFunc({
-        clientFunc: async (param1, param2, param3, param4) => {
-            const result = await Client4.getGroups(param1, param2, param3, param4);
+        clientFunc: async (opts) => {
+            const result = await Client4.getGroups(opts);
             return result;
         },
         onSuccess: [GroupTypes.RECEIVED_GROUPS],
         params: [
-            filterAllowReference,
-            page,
-            perPage,
-            includeMemberCount,
+            opts,
         ],
     });
 }
@@ -302,19 +299,15 @@ export function getGroupsByUserId(userID: string): ActionFunc {
     });
 }
 
-export function getGroupsByUserIdPaginated(userId: string, filterAllowReference = false, page = 0, perPage: number = General.PAGE_SIZE_DEFAULT, includeMemberCount = false): ActionFunc {
+export function getGroupsByUserIdPaginated(opts: GetGroupsForUserParams): ActionFunc {
     return bindClientFunc({
-        clientFunc: async (param1, param2, param3, param4, param5) => {
-            const result = await Client4.getGroups(param1, param2, param3, param4, param5);
+        clientFunc: async (opts) => {
+            const result = await Client4.getGroups(opts);
             return result;
         },
         onSuccess: [GroupTypes.RECEIVED_MY_GROUPS, GroupTypes.RECEIVED_GROUPS],
         params: [
-            filterAllowReference,
-            page,
-            perPage,
-            includeMemberCount,
-            userId,
+            opts
         ],
     });
 }
@@ -404,7 +397,7 @@ export function searchGroups(params: GroupSearachParams): ActionFunc {
 
         const dispatches: AnyAction[] = [{type: GroupTypes.RECEIVED_GROUPS, data}];
 
-        if (params.user_id) {
+        if (params.filter_has_member) {
             dispatches.push({type: GroupTypes.RECEIVED_MY_GROUPS, data});
         }
         if (params.include_channel_member_count) {
@@ -430,6 +423,29 @@ export function archiveGroup(groupId: string): ActionFunc {
             {
                 type: GroupTypes.ARCHIVED_GROUP,
                 id: groupId,
+                data,
+            },
+        );
+
+        return {data};
+    };
+}
+
+export function restoreGroup(groupId: string): ActionFunc {
+    return async (dispatch: DispatchFunc, getState: GetStateFunc) => {
+        let data;
+        try {
+            data = await Client4.restoreGroup(groupId);
+        } catch (error) {
+            forceLogoutIfNecessary(error, dispatch, getState);
+            return {error};
+        }
+
+        dispatch(
+            {
+                type: GroupTypes.RESTORED_GROUP,
+                id: groupId,
+                data,
             },
         );
 

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/groups.ts
@@ -164,8 +164,7 @@ function myGroups(state: string[] = [], action: GenericAction) {
 
         return nextState;
     }
-    case GroupTypes.REMOVE_MY_GROUP:
-    case GroupTypes.ARCHIVED_GROUP: {
+    case GroupTypes.REMOVE_MY_GROUP: {
         const groupId = action.id;
         const index = state.indexOf(groupId);
 
@@ -203,6 +202,8 @@ function groups(state: Record<string, Group> = {}, action: GenericAction) {
     switch (action.type) {
     case GroupTypes.CREATE_GROUP_SUCCESS:
     case GroupTypes.PATCHED_GROUP:
+    case GroupTypes.RESTORED_GROUP:
+    case GroupTypes.ARCHIVED_GROUP:
     case GroupTypes.RECEIVED_GROUP: {
         return {
             ...state,
@@ -239,11 +240,6 @@ function groups(state: Record<string, Group> = {}, action: GenericAction) {
             nextState[group.id] = group;
         }
 
-        return nextState;
-    }
-    case GroupTypes.ARCHIVED_GROUP: {
-        const nextState = {...state};
-        Reflect.deleteProperty(nextState, action.id);
         return nextState;
     }
     default:

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.test.ts
@@ -214,7 +214,7 @@ describe('Selectors.Groups', () => {
             group4,
             group5,
         ];
-        expect(Selectors.getAllAssociatedGroupsForReference(testState)).toEqual(expected);
+        expect(Selectors.getAllAssociatedGroupsForReference(testState, false)).toEqual(expected);
     });
 
     it('getMyGroupMentionKeys', () => {
@@ -226,7 +226,7 @@ describe('Selectors.Groups', () => {
                 key: `@${group4.name}`,
             },
         ];
-        expect(Selectors.getMyGroupMentionKeys(testState)).toEqual(expected);
+        expect(Selectors.getMyGroupMentionKeys(testState, false)).toEqual(expected);
     });
 
     it('getMyGroupMentionKeysForChannel', () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.test.ts
@@ -208,13 +208,14 @@ describe('Selectors.Groups', () => {
         expect(Selectors.getGroupsAssociatedToChannelForReference(testState, channelID)).toEqual(expected);
     });
 
-    it('getAllAssociatedGroupsForReference', () => {
+    it('makeGetAllAssociatedGroupsForReference', () => {
         const expected = [
             group1,
             group4,
             group5,
         ];
-        expect(Selectors.getAllAssociatedGroupsForReference(testState, false)).toEqual(expected);
+        const getAllAssociatedGroupsForReference = Selectors.makeGetAllAssociatedGroupsForReference();
+        expect(getAllAssociatedGroupsForReference(testState, false)).toEqual(expected);
     });
 
     it('getMyGroupMentionKeys', () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
@@ -311,7 +311,6 @@ export const searchMyAllowReferencedGroups: (state: GlobalState, term: string, i
     (state: GlobalState, term: string) => term,
     (state: GlobalState, term: string, includeArchived: boolean) => searchGetMyAllowReferencedGroups(state, includeArchived),
     (term, groups) => {
-        console.log(groups);
         return filterGroupsMatchingTerm(groups, term);
     },
 );

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
@@ -114,7 +114,7 @@ export function getAssociatedGroupsForReference(state: GlobalState, teamId: stri
     } else if (channel && channel.group_constrained) {
         groupsForReference = getGroupsAssociatedToChannelForReference(state, channelId);
     } else {
-        groupsForReference = getAllAssociatedGroupsForReference(state);
+        groupsForReference = getAllAssociatedGroupsForReference(state, false);
     }
     return groupsForReference;
 }
@@ -205,20 +205,25 @@ export const getGroupsAssociatedToChannelForReference: (state: GlobalState, chan
     },
 );
 
-export const getAllAssociatedGroupsForReference: (state: GlobalState) => Group[] = createSelector(
+export const getAllAssociatedGroupsForReference: (state: GlobalState, includeArchived: boolean) => Group[] = createSelector(
     'getAllAssociatedGroupsForReference',
-    getAllGroups,
-    getCurrentUserLocale,
-    (allGroups, locale) => {
-        const groups = Object.entries(allGroups).filter((entry) => (entry[1].allow_reference && entry[1].delete_at === 0)).map((entry) => entry[1]);
-
+    (state: GlobalState) => getAllGroups(state),
+    (state: GlobalState) => getCurrentUserLocale(state),
+    (state: GlobalState, includeArchived: boolean) => includeArchived,
+    (allGroups, locale, includeArchived) => {
+        const groups = Object.entries(allGroups).filter((entry) => {
+            if (includeArchived) {
+                return entry[1].allow_reference
+            }
+            return entry[1].allow_reference && entry[1].delete_at === 0;
+        }).map((entry) => entry[1]);
         return sortGroups(groups, locale);
     },
 );
 
 export const getAllGroupsForReferenceByName: (state: GlobalState) => Record<string, Group> = createSelector(
     'getAllGroupsForReferenceByName',
-    getAllAssociatedGroupsForReference,
+    (state: GlobalState) => getAllAssociatedGroupsForReference(state, false),
     (groups) => {
         const groupsByName: Record<string, Group> = {};
 
@@ -233,12 +238,19 @@ export const getAllGroupsForReferenceByName: (state: GlobalState) => Record<stri
     },
 );
 
-export const getMyAllowReferencedGroups: (state: GlobalState) => Group[] = createSelector(
+export const getMyAllowReferencedGroups: (state: GlobalState, includeArchived: boolean) => Group[] = createSelector(
     'getMyAllowReferencedGroups',
-    getMyGroups,
-    getCurrentUserLocale,
-    (myGroups, locale) => {
-        const groups = myGroups.filter((group) => group.allow_reference && group.delete_at === 0);
+    (state: GlobalState) => getMyGroups(state),
+    (state: GlobalState) => getCurrentUserLocale(state),
+    (state: GlobalState, includeArchived: boolean) => includeArchived,
+    (myGroups, locale, includeArchived) => {
+        const groups = myGroups.filter((group) => {
+            if (includeArchived) {
+                return group.allow_reference;
+            }
+
+            return group.allow_reference && group.delete_at === 0;
+        });
 
         return sortGroups(groups, locale);
     },
@@ -253,9 +265,9 @@ export const getMyGroupsAssociatedToChannelForReference: (state: GlobalState, te
     },
 );
 
-export const getMyGroupMentionKeys: (state: GlobalState) => UserMentionKey[] = createSelector(
+export const getMyGroupMentionKeys: (state: GlobalState, includeArchived: boolean) => UserMentionKey[] = createSelector(
     'getMyGroupMentionKeys',
-    getMyAllowReferencedGroups,
+    (state: GlobalState, includeArchived: boolean) => getMyAllowReferencedGroups(state, includeArchived),
     (groups: Group[]) => {
         const keys: UserMentionKey[] = [];
         groups.forEach((group) => keys.push({key: `@${group.name}`}));
@@ -273,20 +285,21 @@ export const getMyGroupMentionKeysForChannel: (state: GlobalState, teamId: strin
     },
 );
 
-export const searchAllowReferencedGroups: (state: GlobalState, term: string) => Group[] = createSelector(
+export const searchAllowReferencedGroups: (state: GlobalState, term: string, includeArchived: boolean) => Group[] = createSelector(
     'searchAllowReferencedGroups',
-    getAllAssociatedGroupsForReference,
     (state: GlobalState, term: string) => term,
-    (groups, term) => {
+    (state: GlobalState, term: string, includeArchived: boolean) => getAllAssociatedGroupsForReference(state, includeArchived),
+    (term, groups) => {
         return filterGroupsMatchingTerm(groups, term);
     },
 );
 
-export const searchMyAllowReferencedGroups: (state: GlobalState, term: string) => Group[] = createSelector(
+export const searchMyAllowReferencedGroups: (state: GlobalState, term: string, includeArchived: boolean) => Group[] = createSelector(
     'searchMyAllowReferencedGroups',
-    getMyAllowReferencedGroups,
     (state: GlobalState, term: string) => term,
-    (groups, term) => {
+    (state: GlobalState, term: string, includeArchived: boolean) => getMyAllowReferencedGroups(state, includeArchived),
+    (term, groups) => {
+        console.log(groups);
         return filterGroupsMatchingTerm(groups, term);
     },
 );

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/groups.ts
@@ -205,21 +205,25 @@ export const getGroupsAssociatedToChannelForReference: (state: GlobalState, chan
     },
 );
 
-export const getAllAssociatedGroupsForReference: (state: GlobalState, includeArchived: boolean) => Group[] = createSelector(
-    'getAllAssociatedGroupsForReference',
-    (state: GlobalState) => getAllGroups(state),
-    (state: GlobalState) => getCurrentUserLocale(state),
-    (state: GlobalState, includeArchived: boolean) => includeArchived,
-    (allGroups, locale, includeArchived) => {
-        const groups = Object.entries(allGroups).filter((entry) => {
-            if (includeArchived) {
-                return entry[1].allow_reference
-            }
-            return entry[1].allow_reference && entry[1].delete_at === 0;
-        }).map((entry) => entry[1]);
-        return sortGroups(groups, locale);
-    },
-);
+export const makeGetAllAssociatedGroupsForReference = () => {
+    return createSelector(
+        'makeGetAllAssociatedGroupsForReference',
+        (state: GlobalState) => getAllGroups(state),
+        (state: GlobalState) => getCurrentUserLocale(state),
+        (_: GlobalState, includeArchived: boolean) => includeArchived,
+        (allGroups, locale, includeArchived) => {
+            const groups = Object.entries(allGroups).filter((entry) => {
+                if (includeArchived) {
+                    return entry[1].allow_reference
+                }
+                return entry[1].allow_reference && entry[1].delete_at === 0;
+            }).map((entry) => entry[1]);
+            return sortGroups(groups, locale);
+        },
+    );
+};
+
+const getAllAssociatedGroupsForReference = makeGetAllAssociatedGroupsForReference();
 
 export const getAllGroupsForReferenceByName: (state: GlobalState) => Record<string, Group> = createSelector(
     'getAllGroupsForReferenceByName',
@@ -238,23 +242,25 @@ export const getAllGroupsForReferenceByName: (state: GlobalState) => Record<stri
     },
 );
 
-export const getMyAllowReferencedGroups: (state: GlobalState, includeArchived: boolean) => Group[] = createSelector(
-    'getMyAllowReferencedGroups',
-    (state: GlobalState) => getMyGroups(state),
-    (state: GlobalState) => getCurrentUserLocale(state),
-    (state: GlobalState, includeArchived: boolean) => includeArchived,
-    (myGroups, locale, includeArchived) => {
-        const groups = myGroups.filter((group) => {
-            if (includeArchived) {
-                return group.allow_reference;
-            }
+export const makeGetMyAllowReferencedGroups = () => {
+    return createSelector(
+        'makeGetMyAllowReferencedGroups',
+        (state: GlobalState) => getMyGroups(state),
+        (state: GlobalState) => getCurrentUserLocale(state),
+        (_: GlobalState, includeArchived: boolean) => includeArchived,
+        (myGroups, locale, includeArchived) => {
+            const groups = myGroups.filter((group) => {
+                if (includeArchived) {
+                    return group.allow_reference;
+                }
 
-            return group.allow_reference && group.delete_at === 0;
-        });
+                return group.allow_reference && group.delete_at === 0;
+            });
 
-        return sortGroups(groups, locale);
-    },
-);
+            return sortGroups(groups, locale);
+        },
+    );
+}
 
 export const getMyGroupsAssociatedToChannelForReference: (state: GlobalState, teamId: string, channelId: string) => Group[] = createSelector(
     'getMyGroupsAssociatedToChannelForReference',
@@ -264,6 +270,8 @@ export const getMyGroupsAssociatedToChannelForReference: (state: GlobalState, te
         return myGroups.filter((group) => group.allow_reference && group.delete_at === 0 && groups[group.name]);
     },
 );
+
+const getMyAllowReferencedGroups = makeGetMyAllowReferencedGroups();
 
 export const getMyGroupMentionKeys: (state: GlobalState, includeArchived: boolean) => UserMentionKey[] = createSelector(
     'getMyGroupMentionKeys',
@@ -285,19 +293,23 @@ export const getMyGroupMentionKeysForChannel: (state: GlobalState, teamId: strin
     },
 );
 
+const searchGetAllAssociatedGroupsForReference = makeGetAllAssociatedGroupsForReference();
+
 export const searchAllowReferencedGroups: (state: GlobalState, term: string, includeArchived: boolean) => Group[] = createSelector(
     'searchAllowReferencedGroups',
     (state: GlobalState, term: string) => term,
-    (state: GlobalState, term: string, includeArchived: boolean) => getAllAssociatedGroupsForReference(state, includeArchived),
+    (state: GlobalState, term: string, includeArchived: boolean) => searchGetAllAssociatedGroupsForReference(state, includeArchived),
     (term, groups) => {
         return filterGroupsMatchingTerm(groups, term);
     },
 );
 
+const searchGetMyAllowReferencedGroups = makeGetMyAllowReferencedGroups();
+
 export const searchMyAllowReferencedGroups: (state: GlobalState, term: string, includeArchived: boolean) => Group[] = createSelector(
     'searchMyAllowReferencedGroups',
     (state: GlobalState, term: string) => term,
-    (state: GlobalState, term: string, includeArchived: boolean) => getMyAllowReferencedGroups(state, includeArchived),
+    (state: GlobalState, term: string, includeArchived: boolean) => searchGetMyAllowReferencedGroups(state, includeArchived),
     (term, groups) => {
         console.log(groups);
         return filterGroupsMatchingTerm(groups, term);

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/roles.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/roles.ts
@@ -61,7 +61,7 @@ export const getGroupListPermissions: (state: GlobalState) => Record<string, Gro
     getMySystemPermissions,
     (state) => state.entities.groups.groups,
     (myGroupRoles, roles, systemPermissions, allGroups) => {
-        const groups = Object.entries(allGroups).filter((entry) => (entry[1].allow_reference && entry[1].delete_at === 0)).map((entry) => entry[1]);
+        const groups = Object.entries(allGroups).filter((entry) => (entry[1].allow_reference)).map((entry) => entry[1]);
 
         const permissions = new Set<string>();
         groups.forEach((group) => {
@@ -84,8 +84,9 @@ export const getGroupListPermissions: (state: GlobalState) => Record<string, Gro
         const groupPermissionsMap: Record<string, GroupPermissions> = {};
         groups.forEach((g) => {
             groupPermissionsMap[g.id] = {
-                can_delete: permissions.has(Permissions.DELETE_CUSTOM_GROUP) && g.source.toLowerCase() !== 'ldap',
-                can_manage_members: permissions.has(Permissions.MANAGE_CUSTOM_GROUP_MEMBERS) && g.source.toLowerCase() !== 'ldap',
+                can_delete: permissions.has(Permissions.DELETE_CUSTOM_GROUP) && g.source.toLowerCase() !== 'ldap' && g.delete_at === 0,
+                can_manage_members: permissions.has(Permissions.MANAGE_CUSTOM_GROUP_MEMBERS) && g.source.toLowerCase() !== 'ldap' && g.delete_at === 0,
+                can_restore: permissions.has(Permissions.RESTORE_CUSTOM_GROUP) && g.source.toLowerCase() !== 'ldap' && g.delete_at !== 0,
             };
         });
         return groupPermissionsMap;

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/search.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/search.ts
@@ -21,7 +21,7 @@ export const getCurrentSearchForCurrentTeam: (state: GlobalState) => string = cr
 export const getAllUserMentionKeys: (state: GlobalState) => UserMentionKey[] = createSelector(
     'getAllUserMentionKeys',
     getCurrentUserMentionKeys,
-    getMyGroupMentionKeys,
+    (state: GlobalState) => getMyGroupMentionKeys(state, false),
     (userMentionKeys, groupMentionKeys) => {
         return userMentionKeys.concat(groupMentionKeys);
     },

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/group_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/group_utils.ts
@@ -34,6 +34,16 @@ export function filterGroupsMatchingTerm(groups: Group[], term: string): Group[]
 
 export function sortGroups(groups: Group[] = [], locale: string = General.DEFAULT_LOCALE): Group[] {
     return groups.sort((a, b) => {
-        return a.display_name.localeCompare(b.display_name, locale, {numeric: true});
+        if ((a.delete_at === 0 && b.delete_at === 0) || (a.delete_at > 0 && b.delete_at > 0)) {
+            return a.display_name.localeCompare(b.display_name, locale, {numeric: true});
+        }
+        if (a.delete_at < b.delete_at) {
+            return -1;
+        }
+        if (a.delete_at > b.delete_at) {
+            return 1;
+        }
+
+        return 0;
     });
 }

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -74,6 +74,8 @@ import {
     GroupCreateWithUserIds,
     GroupSearachParams,
     CustomGroupPatch,
+    GetGroupsParams,
+    GetGroupsForUserParams,
 } from '@mattermost/types/groups';
 import {PostActionResponse} from '@mattermost/types/integration_actions';
 import {
@@ -3585,19 +3587,9 @@ export default class Client4 {
         );
     };
 
-    getGroups = (filterAllowReference = false, page = 0, perPage = 10, includeMemberCount = false, hasFilterMember = false) => {
-        const qs: any = {
-            filter_allow_reference: filterAllowReference,
-            page,
-            per_page: perPage,
-            include_member_count: includeMemberCount,
-        };
-
-        if (hasFilterMember) {
-            qs.filter_has_member = hasFilterMember;
-        }
+    getGroups = (opts: GetGroupsForUserParams | GetGroupsParams) => {
         return this.doFetch<Group[]>(
-            `${this.getGroupsRoute()}${buildQueryString(qs)}`,
+            `${this.getGroupsRoute()}${buildQueryString(opts)}`,
             {method: 'get'},
         );
     };
@@ -3755,6 +3747,13 @@ export default class Client4 {
         return this.doFetch<Group>(
             `${this.getGroupRoute(groupId)}`,
             {method: 'delete'},
+        );
+    }
+
+    restoreGroup = (groupId: string) => {
+        return this.doFetch<Group>(
+            `${this.getGroupRoute(groupId)}/restore`,
+            {method: 'post'},
         );
     }
 

--- a/webapp/platform/types/src/groups.ts
+++ b/webapp/platform/types/src/groups.ts
@@ -150,13 +150,21 @@ export type GroupCreateWithUserIds = {
     description?: string;
 }
 
-export type GroupSearachParams = {
+export type GetGroupsParams = {
+    filter_allow_reference?: boolean;
+    page?: number;
+    per_page?: number;
+    include_member_count?: boolean;
+    include_archived?: boolean;
+}
+
+export type GetGroupsForUserParams = GetGroupsParams & {
+    filter_has_member: string;
+}
+
+export type GroupSearachParams = GetGroupsParams & {
     q: string;
-    filter_allow_reference: boolean;
-    page: number;
-    per_page: number;
-    include_member_count: boolean;
-    user_id?: string;
+    filter_has_member?: string;
     include_timezones?: string;
     include_channel_member_count?: string;
 }
@@ -169,4 +177,5 @@ export type GroupMembership = {
 export type GroupPermissions = {
     can_delete: boolean;
     can_manage_members: boolean;
+    can_restore: boolean;
 }


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
You can restore archived custom user groups from the user groups modal
```
