### PR TITLE
[MM-51280] Fix JS error after ephemeral message

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -388,7 +388,7 @@ export function makeGetPostsForThread(): (state: GlobalState, rootId: string) =>
     );
 }
 
-// The selector below filters current user if it exists. Excluding currentUser is just for convinience
+// The selector below filters current user if it exists. Excluding currentUser is just for convenience
 export function makeGetProfilesForThread(): (state: GlobalState, rootId: string) => UserProfile[] {
     const getPostsForThread = makeGetPostsForThread();
     return createSelector(
@@ -398,7 +398,7 @@ export function makeGetProfilesForThread(): (state: GlobalState, rootId: string)
         getPostsForThread,
         getUserStatuses,
         (allUsers, currentUserId, posts, userStatuses) => {
-            const profileIds = posts.map((post) => post.user_id);
+            const profileIds = posts.map((post) => post.user_id).filter(Boolean);
             const uniqueIds = [...new Set(profileIds)];
             return uniqueIds.reduce((acc: UserProfile[], id: string) => {
                 const profile: UserProfile = userStatuses ? {...allUsers[id], status: userStatuses[id]} : {...allUsers[id]};


### PR DESCRIPTION
#### Summary
Because the ephemeral message does not have a `user_id`, it returns an empty string as `id` of a user.
Duplicate of https://github.com/mattermost/mattermost-webapp/pull/12350 because of "mono-repo".

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51280

#### Related Pull Requests
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```
