### PR TITLE
update dialog color for sidebar category

### DIFF
--- a/webapp/boards/src/components/sidebar/sidebarCategory.scss
+++ b/webapp/boards/src/components/sidebar/sidebarCategory.scss
@@ -6,6 +6,10 @@
         margin-top: 0;
     }
 
+    .dialog {
+        color: rgba(var(--center-channel-color-rgb));
+    }
+
     .octo-sidebar-item {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
Will rebase to master once mono-repo is merged.

#### Summary
Set the color for sidebar dialog box. Currently defaults to Sidebar Color `rgb(var(--sidebar-text-rgb))`, which cannot be seen in normal color scheme.

#### Ticket Link
  Fixes https://github.com/mattermost/focalboard/issues/4649

#### Release Note
```release-note
Fixes issue with Delete Category Dialog message not visible
```