### PR TITLE
Remove configuration auto enable.

### DIFF
--- a/model/config.go
+++ b/model/config.go
@@ -2872,19 +2872,9 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 		s.PluginStates[PluginIdNPS] = &PluginState{Enable: ls.EnableDiagnostics == nil || *ls.EnableDiagnostics}
 	}
 
-	if s.PluginStates[PluginIdPlaybooks] == nil {
-		// Enable the playbooks plugin by default
-		s.PluginStates[PluginIdPlaybooks] = &PluginState{Enable: true}
-	}
-
 	if s.PluginStates[PluginIdChannelExport] == nil && BuildEnterpriseReady == "true" {
 		// Enable the channel export plugin by default
 		s.PluginStates[PluginIdChannelExport] = &PluginState{Enable: true}
-	}
-
-	if s.PluginStates[PluginIdFocalboard] == nil {
-		// Enable the focalboard plugin by default
-		s.PluginStates[PluginIdFocalboard] = &PluginState{Enable: true}
 	}
 
 	if s.PluginStates[PluginIdApps] == nil {

--- a/server/channels/api4/config.go
+++ b/server/channels/api4/config.go
@@ -157,11 +157,6 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		*cfg.PluginSettings.MarketplaceURL = *appCfg.PluginSettings.MarketplaceURL
 	}
 
-	if cfg.PluginSettings.PluginStates[model.PluginIdFocalboard].Enable && cfg.FeatureFlags.BoardsProduct {
-		c.Err = model.NewAppError("EnablePlugin", "app.plugin.product_mode.app_error", map[string]any{"Name": model.PluginIdFocalboard}, "", http.StatusInternalServerError)
-		return
-	}
-
 	// There are some settings that cannot be changed in a cloud env
 	if c.App.Channels().License().IsCloud() {
 		// Both of them cannot be nil since cfg.SetDefaults is called earlier for cfg,

--- a/server/config/diff_test.go
+++ b/server/config/diff_test.go
@@ -807,12 +807,6 @@ func TestDiff(t *testing.T) {
 						"com.mattermost.nps": {
 							Enable: !defaultConfigGen().PluginSettings.PluginStates["com.mattermost.nps"].Enable,
 						},
-						"focalboard": {
-							Enable: true,
-						},
-						"playbooks": {
-							Enable: true,
-						},
 						"com.mattermost.apps": {
 							Enable: true,
 						},
@@ -845,12 +839,6 @@ func TestDiff(t *testing.T) {
 						"com.mattermost.newplugin": {
 							Enable: true,
 						},
-						"focalboard": {
-							Enable: true,
-						},
-						"playbooks": {
-							Enable: true,
-						},
 						"com.mattermost.apps": {
 							Enable: true,
 						},
@@ -875,12 +863,6 @@ func TestDiff(t *testing.T) {
 					Path:    "PluginSettings.PluginStates",
 					BaseVal: defaultConfigGen().PluginSettings.PluginStates,
 					ActualVal: map[string]*model.PluginState{
-						"focalboard": {
-							Enable: true,
-						},
-						"playbooks": {
-							Enable: true,
-						},
 						"com.mattermost.apps": {
 							Enable: true,
 						},

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -6092,10 +6092,6 @@
     "translation": "Plugin is not installed."
   },
   {
-    "id": "app.plugin.product_mode.app_error",
-    "translation": "Plugin {{.Name}} cannot be enabled in product mode."
-  },
-  {
     "id": "app.plugin.remove.app_error",
     "translation": "Unable to delete plugin."
   },


### PR DESCRIPTION
#### Summary
Removes the automatic enabling of Playbooks and Boards on new configurations that are created.


#### Release Note
```release-note
NONE
```
