### PR TITLE
Mm 50735

### DIFF
--- a/model/hosted_customer.go
+++ b/model/hosted_customer.go
@@ -21,10 +21,11 @@ type BootstrapSelfHostedSignupResponseInternal struct {
 
 // email contained in token, so not in the request body.
 type SelfHostedCustomerForm struct {
-	FirstName      string   `json:"first_name"`
-	LastName       string   `json:"last_name"`
-	BillingAddress *Address `json:"billing_address"`
-	Organization   string   `json:"organization"`
+	FirstName       string   `json:"first_name"`
+	LastName        string   `json:"last_name"`
+	BillingAddress  *Address `json:"billing_address"`
+	ShippingAddress *Address `json:"shipping_address"`
+	Organization    string   `json:"organization"`
 }
 
 type SelfHostedConfirmPaymentMethodRequest struct {

--- a/webapp/channels/src/components/choose_different_shipping/choose_different_shipping.scss
+++ b/webapp/channels/src/components/choose_different_shipping/choose_different_shipping.scss
@@ -1,0 +1,39 @@
+.shipping-address-section {
+    display: flex;
+    align-content: flex-start;
+    // padding: 0 96px;
+    padding-bottom: 24px;
+    font-weight: normal;
+
+    button.no-style {
+        padding-left: 0;
+        background: transparent;
+        outline: unset;
+        border: none;
+        text-align: left;
+
+        &:focus {
+            outline: unset;
+        }
+    }
+
+    #address-same-than-billing-address {
+        width: 17px;
+        height: 17px;
+        flex-shrink: 0;
+    }
+
+    .Form-checkbox-label {
+        padding-left: 12px;
+        cursor: default;
+        font-family: 'Open Sans', sans-serif;
+        vertical-align: middle;
+    }
+
+    .billing_address_btn_text {
+        color: var(--center-channel-color);
+        font-family: 'Open Sans', sans-serif;
+        font-weight: bold;
+    }
+}
+

--- a/webapp/channels/src/components/choose_different_shipping/choose_different_shipping.scss
+++ b/webapp/channels/src/components/choose_different_shipping/choose_different_shipping.scss
@@ -1,7 +1,6 @@
 .shipping-address-section {
     display: flex;
     align-content: flex-start;
-    // padding: 0 96px;
     padding-bottom: 24px;
     font-weight: normal;
 

--- a/webapp/channels/src/components/choose_different_shipping/choose_different_shipping.scss
+++ b/webapp/channels/src/components/choose_different_shipping/choose_different_shipping.scss
@@ -7,9 +7,9 @@
 
     button.no-style {
         padding-left: 0;
+        border: none;
         background: transparent;
         outline: unset;
-        border: none;
         text-align: left;
 
         &:focus {
@@ -36,4 +36,3 @@
         font-weight: bold;
     }
 }
-

--- a/webapp/channels/src/components/choose_different_shipping/index.tsx
+++ b/webapp/channels/src/components/choose_different_shipping/index.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {useIntl} from 'react-intl';
+
+interface Props {
+    shippingIsSame: boolean;
+    setShippingIsSame: (different: boolean) => void;
+}
+export default function ChooseDifferentShipping(props: Props) {
+    const intl = useIntl();
+    const toggle = () => props.setShippingIsSame(!props.shippingIsSame);
+
+    return (
+        <div className='shipping-address-section'>
+            <input
+                id='address-same-than-billing-address'
+                className='Form-checkbox-input'
+                name='terms'
+                type='checkbox'
+                checked={props.shippingIsSame}
+                onChange={toggle}
+            />
+            <span className='Form-checkbox-label'>
+                <button
+                    onClick={toggle}
+                    type='button'
+                    className='no-style'
+                >
+                    <span className='billing_address_btn_text'>
+                        {intl.formatMessage({
+                            id: 'admin.billing.subscription.complianceScreenShippingSameAsBilling',
+                            defaultMessage:
+                                'My shipping address is the same as my billing address',
+                        })}
+                    </span>
+                </button>
+            </span>
+        </div>
+    );
+}

--- a/webapp/channels/src/components/choose_different_shipping/index.tsx
+++ b/webapp/channels/src/components/choose_different_shipping/index.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 
 import {useIntl} from 'react-intl';
 
+import './choose_different_shipping.scss'
+
 interface Props {
     shippingIsSame: boolean;
     setShippingIsSame: (different: boolean) => void;

--- a/webapp/channels/src/components/choose_different_shipping/index.tsx
+++ b/webapp/channels/src/components/choose_different_shipping/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import {useIntl} from 'react-intl';
 
-import './choose_different_shipping.scss'
+import './choose_different_shipping.scss';
 
 interface Props {
     shippingIsSame: boolean;

--- a/webapp/channels/src/components/dropdown_input.scss
+++ b/webapp/channels/src/components/dropdown_input.scss
@@ -1,5 +1,7 @@
+$dropdown_input_index: 999999;
+
 .DropdownInput {
-    z-index: 999999;
+    z-index: $dropdown_input_index;
 
     &.Input_container {
         margin-top: 20px;
@@ -37,7 +39,7 @@
 }
 
 .DropdownInput__option > div {
-    z-index: 999999;
+    z-index: $dropdown_input_index;
     padding: 10px 24px;
     cursor: pointer;
     line-height: 16px;
@@ -50,4 +52,34 @@
 
 .DropdownInput__option.focused > div {
     background-color: rgba(var(--center-channel-color-rgb), 0.08);
+}
+
+.second-dropdown-sibling-wrapper {
+    .DropdownInput {
+        z-index: $dropdown_input_index - 1;
+    }
+
+    .DropdownInput__option > div {
+        z-index: $dropdown_input_index - 1;
+    }
+}
+
+.third-dropdown-sibling-wrapper {
+    .DropdownInput {
+        z-index: $dropdown_input_index - 2;
+    }
+
+    .DropdownInput__option > div {
+        z-index: $dropdown_input_index - 2;
+    }
+}
+
+.fourth-dropdown-sibling-wrapper {
+    .DropdownInput {
+        z-index: $dropdown_input_index - 3;
+    }
+
+    .DropdownInput__option > div {
+        z-index: $dropdown_input_index - 3;
+    }
 }

--- a/webapp/channels/src/components/dropdown_input.tsx
+++ b/webapp/channels/src/components/dropdown_input.tsx
@@ -18,6 +18,7 @@ type Props<T> = Omit<SelectProps<T>, 'onChange'> & {
     value?: T;
     legend?: string;
     error?: string;
+    wrapperClassName?: string;
     onChange: (value: T, action: ActionMeta<T>) => void;
     testId?: string;
 };
@@ -113,7 +114,7 @@ const DropdownInput = <T extends ValueType>(props: Props<T>) => {
 
     return (
         <div
-            className='DropdownInput Input_container'
+            className={classNames({'DropdownInput Input_container': true, [props.wrapperClassName!]: Boolean(props.wrapperClassName)})}
             data-testid={testId || ''}
         >
             <fieldset

--- a/webapp/channels/src/components/dropdown_input.tsx
+++ b/webapp/channels/src/components/dropdown_input.tsx
@@ -18,7 +18,6 @@ type Props<T> = Omit<SelectProps<T>, 'onChange'> & {
     value?: T;
     legend?: string;
     error?: string;
-    wrapperClassName?: string;
     onChange: (value: T, action: ActionMeta<T>) => void;
     testId?: string;
 };
@@ -114,7 +113,7 @@ const DropdownInput = <T extends ValueType>(props: Props<T>) => {
 
     return (
         <div
-            className={classNames({'DropdownInput Input_container': true, [props.wrapperClassName!]: Boolean(props.wrapperClassName)})}
+            className='DropdownInput Input_container'
             data-testid={testId || ''}
         >
             <fieldset

--- a/webapp/channels/src/components/payment_form/address_form.tsx
+++ b/webapp/channels/src/components/payment_form/address_form.tsx
@@ -61,25 +61,27 @@ const AddressForm = (props: AddressFormProps) => {
                     {...props.title}
                 />
             </div>
-            <DropdownInput
-                onChange={handleCountryChange}
-                value={
-                    props.address.country ? {value: props.address.country, label: props.address.country} : undefined
-                }
-                options={COUNTRIES.map((country) => ({
-                    value: country.name,
-                    label: country.name,
-                }))}
-                legend={formatMessage({
-                    id: 'payment_form.country',
-                    defaultMessage: 'Country',
-                })}
-                placeholder={formatMessage({
-                    id: 'payment_form.country',
-                    defaultMessage: 'Country',
-                })}
-                name={'billing_dropdown'}
-            />
+            <div className='third-dropdown-sibling-wrapper'>
+                <DropdownInput
+                    onChange={handleCountryChange}
+                    value={
+                        props.address.country ? {value: props.address.country, label: props.address.country} : undefined
+                    }
+                    options={COUNTRIES.map((country) => ({
+                        value: country.name,
+                        label: country.name,
+                    }))}
+                    legend={formatMessage({
+                        id: 'payment_form.country',
+                        defaultMessage: 'Country',
+                    })}
+                    placeholder={formatMessage({
+                        id: 'payment_form.country',
+                        defaultMessage: 'Country',
+                    })}
+                    name={'billing_dropdown'}
+                />
+            </div>
             <div className='form-row'>
                 <Input
                     name='address'
@@ -122,7 +124,7 @@ const AddressForm = (props: AddressFormProps) => {
                 />
             </div>
             <div className='form-row'>
-                <div className='form-row-third-1 selector'>
+                <div className='form-row-third-1 selector fourth-dropdown-sibling-wrapper'>
                     <StateSelector
                         country={props.address.country}
                         state={props.address.state}

--- a/webapp/channels/src/components/payment_form/payment_form.scss
+++ b/webapp/channels/src/components/payment_form/payment_form.scss
@@ -12,7 +12,6 @@
 
     .form-row-third-1 {
         .DropdownInput {
-            z-index: 99999;
             margin-top: 0;
         }
 
@@ -37,7 +36,6 @@
 
     .DropdownInput {
         position: relative;
-        z-index: 999999;
         height: 36px;
         margin-bottom: 24px;
         font-weight: normal;

--- a/webapp/channels/src/components/payment_form/payment_form.tsx
+++ b/webapp/channels/src/components/payment_form/payment_form.tsx
@@ -251,7 +251,7 @@ export default class PaymentForm extends React.PureComponent<Props, State> {
                         />
                     </div>
                     <div className='form-row'>
-                        <div className='form-row-third-1 selector'>
+                        <div className='form-row-third-1 selector second-dropdown-sibling-wrapper'>
                             <StateSelector
                                 country={this.state.country}
                                 state={this.state.state}

--- a/webapp/channels/src/components/purchase_modal/purchase.scss
+++ b/webapp/channels/src/components/purchase_modal/purchase.scss
@@ -2,44 +2,6 @@
     overflow: hidden;
     height: 100%;
 
-    .shipping-address-section {
-        display: flex;
-        align-content: center;
-        padding: 0 96px;
-        padding-bottom: 28px;
-        font-weight: normal;
-
-        button.no-style {
-            padding-left: 0;
-            background: transparent;
-            outline: unset;
-
-            &:focus {
-                outline: unset;
-            }
-        }
-
-        #address-same-than-billing-address {
-            width: 20px;
-            height: 20px;
-            margin-top: auto;
-            margin-bottom: auto;
-        }
-
-        .Form-checkbox-label {
-            padding-left: 12px;
-            cursor: default;
-            font-family: 'Open Sans', sans-serif;
-            vertical-align: middle;
-        }
-
-        .billing_address_btn_text {
-            color: var(--center-channel-color);
-            font-family: 'Open Sans', sans-serif;
-            font-weight: normal;
-        }
-    }
-
     &__purchase-body {
         overflow-y: auto;
     }

--- a/webapp/channels/src/components/purchase_modal/purchase.scss
+++ b/webapp/channels/src/components/purchase_modal/purchase.scss
@@ -40,6 +40,10 @@
         }
     }
 
+    &__purchase-body {
+        overflow-y: auto;
+    }
+
     >div {
         &.processing {
             display: none;

--- a/webapp/channels/src/components/purchase_modal/purchase.scss
+++ b/webapp/channels/src/components/purchase_modal/purchase.scss
@@ -2,7 +2,7 @@
     overflow: hidden;
     height: 100%;
 
-    &__purchase-body {
+    & &__purchase-body {
         overflow-y: auto;
     }
 

--- a/webapp/channels/src/components/purchase_modal/purchase_modal.tsx
+++ b/webapp/channels/src/components/purchase_modal/purchase_modal.tsx
@@ -6,6 +6,7 @@
 import React, {ReactNode} from 'react';
 import {FormattedMessage, injectIntl, IntlShape} from 'react-intl';
 
+import classnames from 'classnames';
 import {Stripe, StripeCardElementChangeEvent} from '@stripe/stripe-js';
 import {loadStripe} from '@stripe/stripe-js/pure'; // https://github.com/stripe/stripe-js#importing-loadstripe-without-side-effects
 import {Elements} from '@stripe/react-stripe-js';
@@ -812,7 +813,7 @@ class PurchaseModal extends React.PureComponent<Props, State> {
         }
 
         return (
-            <div className={this.state.processing ? 'processing' : ''}>
+            <div className={classnames('PurchaseModal__purchase-body', {processing: this.state.processing})}>
                 <div className='LHS'>
                     <h2 className='title'>{title}</h2>
                     <UpgradeSvg

--- a/webapp/channels/src/components/self_hosted_purchase_modal/address.tsx
+++ b/webapp/channels/src/components/self_hosted_purchase_modal/address.tsx
@@ -62,6 +62,7 @@ export default function Address(props: Props) {
                     id: 'payment_form.country',
                     defaultMessage: 'Country',
                 })}
+                wrapperClassName={props.type === 'shipping' ? 'DropdownInput Input_container DropdownInput--has-younger-sibling' : ''}
                 name={'billing_dropdown'}
             />
             <div className='form-row'>

--- a/webapp/channels/src/components/self_hosted_purchase_modal/address.tsx
+++ b/webapp/channels/src/components/self_hosted_purchase_modal/address.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {useIntl} from 'react-intl';
+
+import StateSelector from 'components/payment_form/state_selector';
+
+import {COUNTRIES} from 'utils/countries';
+
+import DropdownInput from 'components/dropdown_input';
+import Input from 'components/widgets/inputs/input/input';
+
+interface Props {
+    type: 'shipping' | 'billing';
+    testPrefix?: string;
+
+    country: string;
+    changeCountry: (option: {value: string}) => void;
+
+    address: string;
+    changeAddress: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+    address2: string;
+    changeAddress2: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+    city: string;
+    changeCity: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+    state: string;
+    changeState: (postalCode: string) => void;
+
+    postalCode: string;
+    changePostalCode: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+export default function Address(props: Props) {
+    const testPrefix = props.testPrefix || 'selfHostedPurchase';
+    const intl = useIntl();
+    let countrySelectorId = `${testPrefix}CountrySelector`;
+    let stateSelectorId = `${testPrefix}StateSelector`;
+    if (props.type === 'shipping') {
+        countrySelectorId += '_Shipping';
+        stateSelectorId += '_Shipping';
+    }
+    return (
+        <>
+            <DropdownInput
+                testId={countrySelectorId}
+                onChange={props.changeCountry}
+                value={
+                    props.country ? {value: props.country, label: props.country} : undefined
+                }
+                options={COUNTRIES.map((country) => ({
+                    value: country.name,
+                    label: country.name,
+                }))}
+                legend={intl.formatMessage({
+                    id: 'payment_form.country',
+                    defaultMessage: 'Country',
+                })}
+                placeholder={intl.formatMessage({
+                    id: 'payment_form.country',
+                    defaultMessage: 'Country',
+                })}
+                name={'billing_dropdown'}
+            />
+            <div className='form-row'>
+                <Input
+                    name='address'
+                    type='text'
+                    value={props.address}
+                    onChange={props.changeAddress}
+                    placeholder={intl.formatMessage({
+                        id: 'payment_form.address',
+                        defaultMessage: 'Address',
+                    })}
+                    required={true}
+                />
+            </div>
+            <div className='form-row'>
+                <Input
+                    name='address2'
+                    type='text'
+                    value={props.address2}
+                    onChange={props.changeAddress2}
+                    placeholder={intl.formatMessage({
+                        id: 'payment_form.address_2',
+                        defaultMessage: 'Address 2',
+                    })}
+                />
+            </div>
+            <div className='form-row'>
+                <Input
+                    name='city'
+                    type='text'
+                    value={props.city}
+                    onChange={props.changeCity}
+                    placeholder={intl.formatMessage({
+                        id: 'payment_form.city',
+                        defaultMessage: 'City',
+                    })}
+                    required={true}
+                />
+            </div>
+            <div className='form-row'>
+                <div className='form-row-third-1'>
+                    <StateSelector
+                        testId={stateSelectorId}
+                        country={props.country}
+                        state={props.state}
+                        onChange={props.changeState}
+                    />
+                </div>
+                <div className='form-row-third-2'>
+                    <Input
+                        name='postalCode'
+                        type='text'
+                        value={props.postalCode}
+                        onChange={props.changePostalCode}
+                        placeholder={intl.formatMessage({
+                            id: 'payment_form.zipcode',
+                            defaultMessage: 'Zip/Postal Code',
+                        })}
+                        required={true}
+                    />
+                </div>
+            </div>
+        </>
+    );
+}

--- a/webapp/channels/src/components/self_hosted_purchase_modal/address.tsx
+++ b/webapp/channels/src/components/self_hosted_purchase_modal/address.tsx
@@ -3,13 +3,13 @@
 
 import React from 'react';
 import {useIntl} from 'react-intl';
-
-import StateSelector from 'components/payment_form/state_selector';
+import classNames from 'classnames';
 
 import {COUNTRIES} from 'utils/countries';
 
 import DropdownInput from 'components/dropdown_input';
 import Input from 'components/widgets/inputs/input/input';
+import StateSelector from 'components/payment_form/state_selector';
 
 interface Props {
     type: 'shipping' | 'billing';
@@ -44,27 +44,28 @@ export default function Address(props: Props) {
     }
     return (
         <>
-            <DropdownInput
-                testId={countrySelectorId}
-                onChange={props.changeCountry}
-                value={
-                    props.country ? {value: props.country, label: props.country} : undefined
-                }
-                options={COUNTRIES.map((country) => ({
-                    value: country.name,
-                    label: country.name,
-                }))}
-                legend={intl.formatMessage({
-                    id: 'payment_form.country',
-                    defaultMessage: 'Country',
-                })}
-                placeholder={intl.formatMessage({
-                    id: 'payment_form.country',
-                    defaultMessage: 'Country',
-                })}
-                wrapperClassName={props.type === 'shipping' ? 'DropdownInput Input_container DropdownInput--has-younger-sibling' : ''}
-                name={'billing_dropdown'}
-            />
+            <div className={classNames({'third-dropdown-sibling-wrapper': props.type === 'shipping'})}>
+                <DropdownInput
+                    testId={countrySelectorId}
+                    onChange={props.changeCountry}
+                    value={
+                        props.country ? {value: props.country, label: props.country} : undefined
+                    }
+                    options={COUNTRIES.map((country) => ({
+                        value: country.name,
+                        label: country.name,
+                    }))}
+                    legend={intl.formatMessage({
+                        id: 'payment_form.country',
+                        defaultMessage: 'Country',
+                    })}
+                    placeholder={intl.formatMessage({
+                        id: 'payment_form.country',
+                        defaultMessage: 'Country',
+                    })}
+                    name={'billing_dropdown'}
+                />
+            </div>
             <div className='form-row'>
                 <Input
                     name='address'
@@ -104,7 +105,7 @@ export default function Address(props: Props) {
                 />
             </div>
             <div className='form-row'>
-                <div className='form-row-third-1'>
+                <div className={classNames('form-row-third-1', {'second-dropdown-sibling-wrapper': props.type === 'billing', 'fourth-dropdown-sibling-wrapper': props.type === 'shipping'})}>
                     <StateSelector
                         testId={stateSelectorId}
                         country={props.country}

--- a/webapp/channels/src/components/self_hosted_purchase_modal/index.test.tsx
+++ b/webapp/channels/src/components/self_hosted_purchase_modal/index.test.tsx
@@ -310,6 +310,15 @@ describe('SelfHostedPurchaseModal :: canSubmit', () => {
             state: 'string',
             country: 'string',
             postalCode: '12345',
+
+            shippingSame: true,
+            shippingAddress: '',
+            shippingAddress2: '',
+            shippingCity: '',
+            shippingState: '',
+            shippingCountry: '',
+            shippingPostalCode: '',
+
             cardName: 'string',
             organization: 'string',
             agreedTerms: true,
@@ -361,6 +370,21 @@ describe('SelfHostedPurchaseModal :: canSubmit', () => {
         expect(canSubmit(state, SelfHostedSignupProgress.CREATED_CUSTOMER)).toBe(false);
         expect(canSubmit(state, SelfHostedSignupProgress.CREATED_INTENT)).toBe(false);
     });
+
+    it('if shipping address different and is not filled, can not submit', () => {
+        const state = makeHappyPathState();
+        state.shippingSame = false;
+        expect(canSubmit(state, SelfHostedSignupProgress.START)).toBe(false);
+
+        state.shippingAddress = 'more shipping info';
+        state.shippingAddress2 = 'more shipping info';
+        state.shippingCity = 'more shipping info';
+        state.shippingState = 'more shipping info';
+        state.shippingCountry = 'more shipping info';
+        state.shippingPostalCode = 'more shipping info';
+        expect(canSubmit(state, SelfHostedSignupProgress.START)).toBe(true);
+    });
+
     it('if card number missing and card has not been confirmed, can not submit', () => {
         const state = makeHappyPathState();
         state.cardFilled = false;

--- a/webapp/channels/src/components/self_hosted_purchase_modal/self_hosted_purchase_modal.scss
+++ b/webapp/channels/src/components/self_hosted_purchase_modal/self_hosted_purchase_modal.scss
@@ -48,6 +48,9 @@
             .DropdownInput {
                 position: relative;
                 z-index: 999999;
+                &--has-younger-sibling {
+                    z-index: 9999;
+                }
                 height: 36px;
                 margin-bottom: 24px;
 
@@ -518,6 +521,9 @@
         }
 
         input[type=checkbox] {
+            width: 17px;
+            height: 17px;
+            flex-shrink: 0;
             margin-right: 12px;
         }
 

--- a/webapp/channels/src/components/self_hosted_purchase_modal/self_hosted_purchase_modal.scss
+++ b/webapp/channels/src/components/self_hosted_purchase_modal/self_hosted_purchase_modal.scss
@@ -4,19 +4,20 @@
 
     .form-view {
         display: flex;
-        overflow: hidden;
         width: 100%;
         height: 100%;
         flex-direction: row;
         flex-grow: 1;
         flex-wrap: wrap;
-        align-content: top;
+        align-items: flex-start;
         justify-content: center;
         padding: 77px 107px;
         color: var(--center-channel-color);
         font-family: "Open Sans";
         font-size: 16px;
         font-weight: 600;
+        overflow-x: hidden;
+        overflow-y: auto;
 
         .title {
             font-size: 22px;

--- a/webapp/channels/src/components/self_hosted_purchase_modal/self_hosted_purchase_modal.scss
+++ b/webapp/channels/src/components/self_hosted_purchase_modal/self_hosted_purchase_modal.scss
@@ -40,17 +40,12 @@
                 margin-right: 16px;
 
                 .DropdownInput {
-                    z-index: 99999;
                     margin-top: 0;
                 }
             }
 
             .DropdownInput {
                 position: relative;
-                z-index: 999999;
-                &--has-younger-sibling {
-                    z-index: 9999;
-                }
                 height: 36px;
                 margin-bottom: 24px;
 

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4378,6 +4378,7 @@
   "payment_form.no_billing_address": "No billing address added",
   "payment_form.no_credit_card": "No credit card added",
   "payment_form.saved_payment_method": "Saved Payment Method",
+  "payment_form.shipping_address": "Shipping Address",
   "payment_form.zipcode": "Zip/Postal Code",
   "payment.card_number": "Card Number",
   "payment.field_required": "This field is required",

--- a/webapp/platform/types/src/hosted_customer.ts
+++ b/webapp/platform/types/src/hosted_customer.ts
@@ -18,6 +18,7 @@ export interface SelfHostedSignupForm {
     first_name: string;
     last_name: string;
     billing_address: Address;
+    shipping_address: Address;
     organization: string;
 }
 


### PR DESCRIPTION
#### Summary
Self-hosted admins can now choose a separate shipping address. An issue with the cloud and self-hosted purchase fullscreen modal not being scrollable is fixed. Also made some z-indexing rules around the purchase modals' 4 different dropdowns more consistent.

Cloud modal scrollable:

https://user-images.githubusercontent.com/13738432/227312960-d494e76b-a72a-4070-aafb-c6eb676c9e35.mp4

Self-hosted modal scrollable:

https://user-images.githubusercontent.com/13738432/227313120-6911cc02-840d-41e4-a4b6-b752b955cf51.mp4

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50735

#### Release Note

```release-note
* Self-hosted admins can now choose a separate shipping address.
* Fix scrolling issue in cloud and self-hosted purchase modals.
```