### PR TITLE
MM-51683 Re-add CODEOWNERS for Web Platform files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,9 @@
 /plugin/ @mattermost/toolkit
+
+/.github/workflows/channels-ci.yml @mattermost/web-platform
+/webapp/package.json @mattermost/web-platform
+/webapp/channels/package.json @mattermost/web-platform
+/webapp/Makefile @mattermost/web-platform
+/webapp/package-lock.json @mattermost/web-platform
+/webapp/platform/*/package.json @mattermost/web-platform
+/webapp/scripts @mattermost/web-platform

--- a/webapp/channels/CODEOWNERS
+++ b/webapp/channels/CODEOWNERS
@@ -1,4 +1,0 @@
-# Web Platform should be assigned to review all PRs that involve changing dependencies in the app, either intentional or accidental.
-package.json @mattermost/web-platform
-*/package.json @mattermost/web-platform
-package-lock.json @mattermost/web-platform


### PR DESCRIPTION
The web app repo was previously set up so that our review was needed on the package.json files so that we'd see when dependencies changed. I also added it to the web app CI config, Makefile, and build scripts just since I want to be aware of when those change

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51683

#### Release Note
```release-note
NONE
```
