### PR TITLE
Invoice not found is a 404 instead of a 500 error

### DIFF
--- a/server/channels/api4/hosted_customer.go
+++ b/server/channels/api4/hosted_customer.go
@@ -13,6 +13,8 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/server/channels/utils"
 	"github.com/mattermost/mattermost-server/v6/server/platform/shared/mlog"
@@ -250,6 +252,10 @@ func selfHostedInvoices(c *Context, w http.ResponseWriter, r *http.Request) {
 	invoices, err := c.App.Cloud().GetSelfHostedInvoices()
 
 	if err != nil {
+		if err.Error() == "404" {
+			c.Err = model.NewAppError(where, "api.cloud.app_error", nil, "", http.StatusNotFound).Wrap(errors.New("invoices for license not found"))
+			return
+		}
 		c.Err = model.NewAppError(where, "api.cloud.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		return
 	}


### PR DESCRIPTION
#### Summary
Return 404 if the enterprise library error returned is 404

![invoices-404](https://user-images.githubusercontent.com/13738432/227332223-4473352f-2a67-43bc-bdc5-451bcdf66393.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51294

#### Release Note
```release-note
Invoice not found is a 404 instead of a 500 error.
```
