### PR TITLE
[MM-48412] Webapp: UI discrepancy on tooltip shaded overlay when RHS is expanded

### DIFF
--- a/webapp/platform/components/src/tour_tip/tour_tip.tsx
+++ b/webapp/platform/components/src/tour_tip/tour_tip.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useRef} from 'react';
+import React, {useRef, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import Tippy from '@tippyjs/react';
 import {Placement} from 'tippy.js';
 import classNames from 'classnames';
 
 import {PunchOutCoordsHeightAndWidth} from '../common/hooks/useMeasurePunchouts';
+import {useClickOutsideRef} from '../common/hooks/useClickOutsideRef';
 
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/themes/light-border.css';
@@ -89,11 +90,14 @@ export const TourTip = ({
 }: Props) => {
     const FIRST_STEP_INDEX = 0;
     const triggerRef = useRef(null);
+    const [useBackdrop, setUseBackdrop] = useState(!hideBackdrop);
     const onJump = (event: React.MouseEvent, jumpToStep: number) => {
-        if (handleJump) {
-            handleJump(event, jumpToStep);
-        }
+        handleJump?.(event, jumpToStep);
     };
+
+    useClickOutsideRef(triggerRef, () => {
+        setUseBackdrop(false);
+    });
 
     // This needs to be changed if root-portal node isn't available to maybe body
     const rootPortal = document.getElementById('root-portal');
@@ -210,7 +214,7 @@ export const TourTip = ({
             >
                 <PulsatingDot/>
             </div>
-            <TourTipBackdrop
+            {useBackdrop && <TourTipBackdrop
                 show={show}
                 onDismiss={handleDismiss}
                 onPunchOut={handlePunchOut}
@@ -218,7 +222,7 @@ export const TourTip = ({
                 overlayPunchOut={overlayPunchOut}
                 appendTo={rootPortal!}
                 transparent={hideBackdrop}
-            />
+            />}
             {show && (
                 <Tippy
                     showOnCreate={show}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This is a migration of a PR that was opened before the monorepo - https://github.com/mattermost/mattermost-webapp/pull/11649

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

[MM-48647](https://mattermost.atlassian.net/browse/MM-48647)

#### Release Note
```
NONE
```