### PR TITLE
Support env var for playwright test directory

### DIFF
--- a/e2e/playwright/playwright.config.ts
+++ b/e2e/playwright/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     globalSetup: require.resolve('./global_setup'),
     forbidOnly: testConfig.isCI,
     outputDir: './test-results',
-    testDir: 'tests',
+    testDir: testConfig.testDir,
     timeout: duration.one_min,
     workers: testConfig.workers,
     expect: {

--- a/e2e/playwright/test.config.ts
+++ b/e2e/playwright/test.config.ts
@@ -22,12 +22,14 @@ export type TestConfig = {
     haClusterEnabled: boolean;
     haClusterNodeCount: number;
     haClusterName: string;
+    pluginMockOAuthToken?: string;
     // CI
     isCI: boolean;
     // Playwright
     headless: boolean;
     slowMo: number;
     workers: number;
+    testDir: string;
     // Visual tests
     snapshotEnabled: boolean;
     percyEnabled: boolean;
@@ -46,12 +48,14 @@ const config: TestConfig = {
     haClusterNodeCount: parseNumber(process.env.PW_HA_CLUSTER_NODE_COUNT, 2),
     haClusterName: process.env.PW_HA_CLUSTER_NAME || 'mm_dev_cluster',
     resetBeforeTest: parseBool(process.env.PW_RESET_BEFORE_TEST, false),
+    pluginMockOAuthToken: process.env.PLUGIN_E2E_MOCK_OAUTH_TOKEN,
     // CI
     isCI: !!process.env.CI,
     // Playwright
     headless: parseBool(process.env.PW_HEADLESS, false),
     slowMo: parseNumber(process.env.PW_SLOWMO, 0),
     workers: parseNumber(process.env.PW_WORKERS, 1),
+    testDir: process.env.PW_TEST_DIR || 'tests',
     // Visual tests
     snapshotEnabled: parseBool(process.env.PW_SNAPSHOT_ENABLE, false),
     percyEnabled: parseBool(process.env.PW_PERCY_ENABLE, false),


### PR DESCRIPTION
#### Summary

In order for other projects to use the Playwright testing environment implemented by the webapp repo, we can have the test runner support an arbitrary test directory via environment variable.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Related Pull Requests
<!--
List all PRs related to resolving a ticket. For instance, if you submitted a PR to `mattermost/mattermost-server`, please include it here.
-->
- https://github.com/mattermost/mattermost-plugin-github/pull/652

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
