### PR TITLE
MM-50976_Fix error on non-cloud initial start

### DIFF
--- a/webapp/channels/src/components/common/hooks/useOpenSalesLink.ts
+++ b/webapp/channels/src/components/common/hooks/useOpenSalesLink.ts
@@ -26,7 +26,7 @@ export default function useOpenSalesLink(): [() => void, string] {
         companyName = customer.name || '';
         utmMedium = 'in-product-cloud';
     } else {
-        customerEmail = currentUser.email || '';
+        customerEmail = currentUser?.email || '';
     }
 
     const contactSalesLink = buildMMURL(LicenseLinks.CONTACT_SALES, firstName, lastName, companyName, customerEmail, utmSource, utmMedium);


### PR DESCRIPTION
#### Summary
Fixing error introduced in https://github.com/mattermost/mattermost-server/pull/22640/
causing the webapp to not start in non-cloud envs.
<img width="705" alt="Screen Shot 2023-03-27 at 12 06 33 PM" src="https://user-images.githubusercontent.com/79058848/228019073-8264c0af-2d0e-4788-95e3-cf9c4a56c9ac.png">


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50976

#### Release Note
```release-note
NONE
```
