### PR TITLE
MM-51735 Remove references to mattermost-redux from Boards

### DIFF
--- a/webapp/boards/package.json
+++ b/webapp/boards/package.json
@@ -45,7 +45,6 @@
 		"glob-parent": "6.0.2",
 		"lodash": "^4.17.21",
 		"marked": "^4.0.12",
-		"mattermost-redux": "5.33.1",
 		"mini-create-react-context": "^0.4.1",
 		"moment": "^2.29.1",
 		"nanoevents": "^5.1.13",

--- a/webapp/boards/src/components/cloudUpgradeNudge/cloudUpgradeNudge.tsx
+++ b/webapp/boards/src/components/cloudUpgradeNudge/cloudUpgradeNudge.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react'
-import {Post} from 'mattermost-redux/types/posts'
+import {Post} from '@mattermost/types/posts'
 
 const PostTypeCloudUpgradeNudge = (props: {post: Post}): JSX.Element => {
     const ctaHandler = (e: React.MouseEvent) => {

--- a/webapp/boards/src/index.tsx
+++ b/webapp/boards/src/index.tsx
@@ -6,11 +6,9 @@ import {Store, Action} from 'redux'
 import {Provider as ReduxProvider} from 'react-redux'
 import {createBrowserHistory, History} from 'history'
 
-import {rudderAnalytics, RudderTelemetryHandler} from 'mattermost-redux/client/rudder'
+import {rudderAnalytics, RudderTelemetryHandler} from 'src/rudder'
 
-import {GlobalState} from 'mattermost-redux/types/store'
-
-import {selectTeam} from 'mattermost-redux/actions/teams'
+import {GlobalState} from '@mattermost/types/store'
 
 import {SuiteWindow} from 'src/types/index'
 
@@ -185,6 +183,8 @@ const HeaderComponent = () => {
     )
 }
 
+(window as any).setTeam = setTeam;
+
 export default class Plugin {
     channelHeaderButtonId?: string
     rhsId?: string
@@ -293,10 +293,15 @@ export default class Plugin {
             const currentTeamID: string = store.getState().teams.currentId
             const currentUserId = mmStore.getState().entities.users.currentUserId
             if (currentTeamID !== fbPrevTeamID) {
+                console.log('HARRISON boards team changed to', currentTeamID);
                 fbPrevTeamID = currentTeamID
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                mmStore.dispatch(selectTeam(currentTeamID))
+
+                mmStore.dispatch({
+                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                    // @ts-ignore
+                    type: 'SELECT_TEAM',
+                    data: currentTeamID,
+                })
                 localStorage.setItem(`user_prev_team:${currentUserId}`, currentTeamID)
             }
         })

--- a/webapp/boards/src/index.tsx
+++ b/webapp/boards/src/index.tsx
@@ -6,13 +6,13 @@ import {Store, Action} from 'redux'
 import {Provider as ReduxProvider} from 'react-redux'
 import {createBrowserHistory, History} from 'history'
 
-import {rudderAnalytics, RudderTelemetryHandler} from 'src/rudder'
-
 import {GlobalState} from '@mattermost/types/store'
 
 import {SuiteWindow} from 'src/types/index'
 
 import {PluginRegistry} from 'src/types/mattermost-webapp'
+
+import {rudderAnalytics, RudderTelemetryHandler} from 'src/rudder'
 
 import appBarIcon from 'static/app-bar-icon.png'
 
@@ -183,8 +183,6 @@ const HeaderComponent = () => {
     )
 }
 
-(window as any).setTeam = setTeam;
-
 export default class Plugin {
     channelHeaderButtonId?: string
     rhsId?: string
@@ -293,7 +291,6 @@ export default class Plugin {
             const currentTeamID: string = store.getState().teams.currentId
             const currentUserId = mmStore.getState().entities.users.currentUserId
             if (currentTeamID !== fbPrevTeamID) {
-                console.log('HARRISON boards team changed to', currentTeamID);
                 fbPrevTeamID = currentTeamID
 
                 mmStore.dispatch({

--- a/webapp/boards/src/rudder.ts
+++ b/webapp/boards/src/rudder.ts
@@ -1,0 +1,65 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// This file is duplicated from mattermost-redux in the web app with some slight modifications to make it standalone
+
+// As per rudder-sdk-js documentation, import this only once and use like a singleton.
+// See https://github.com/rudderlabs/rudder-sdk-js#step-1-install-rudderstack-using-the-code-snippet
+import * as rudderAnalytics from 'rudder-sdk-js'
+export {rudderAnalytics}
+
+import {TelemetryHandler} from '@mattermost/client'
+
+import {Utils} from 'src/utils'
+
+export class RudderTelemetryHandler implements TelemetryHandler {
+    trackEvent(userId: string, userRoles: string, category: string, event: string, props?: any) {
+        const properties = Object.assign({
+            category,
+            type: event,
+            user_actual_role: getActualRoles(userRoles),
+            user_actual_id: userId,
+        }, props)
+        const options = {
+            context: {
+                ip: '0.0.0.0',
+            },
+            page: {
+                path: '',
+                referrer: '',
+                search: '',
+                title: '',
+                url: '',
+            },
+            anonymousId: '00000000000000000000000000',
+        }
+
+        rudderAnalytics.track('event', properties, options)
+    }
+
+    pageVisited(userId: string, userRoles: string, category: string, name: string) {
+        rudderAnalytics.page(
+            category,
+            name,
+            {
+                path: '',
+                referrer: '',
+                search: '',
+                title: '',
+                url: '',
+                user_actual_role: getActualRoles(userRoles),
+                user_actual_id: userId,
+            },
+            {
+                context: {
+                    ip: '0.0.0.0',
+                },
+                anonymousId: '00000000000000000000000000',
+            },
+        )
+    }
+}
+
+function getActualRoles(userRoles: string) {
+    return userRoles && Utils.isSystemAdmin(userRoles) ? 'system_admin, system_user' : 'system_user'
+}

--- a/webapp/boards/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/boards/src/types/mattermost-webapp/index.d.ts
@@ -3,7 +3,7 @@
 
 import type React from 'react'
 
-import type {Channel, ChannelMembership} from 'mattermost-redux/types/channels'
+import type {Channel, ChannelMembership} from '@mattermost/types/channels'
 
 type ReactResolvable = React.ReactNode | React.ElementType
 

--- a/webapp/boards/webpack.config.js
+++ b/webapp/boards/webpack.config.js
@@ -53,8 +53,6 @@ const config = {
     resolve: {
         alias: {
             src: path.resolve(__dirname, './src/'),
-            // 'mattermost-redux': path.resolve(__dirname, '../channels/src/packages/mattermost-redux/src/'),
-            // reselect: path.resolve(__dirname, '../channels/src/packages/reselect/src/index'),
             '@mattermost/client': path.resolve(__dirname, '../platform/client/src/'),
             '@mattermost/components': path.resolve(__dirname, '../platform/components/src/'),
         },

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -44,7 +44,6 @@
         "glob-parent": "6.0.2",
         "lodash": "^4.17.21",
         "marked": "^4.0.12",
-        "mattermost-redux": "5.33.1",
         "mini-create-react-context": "^0.4.1",
         "moment": "^2.29.1",
         "nanoevents": "^5.1.13",
@@ -8322,14 +8321,6 @@
       "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
-    "node_modules/@react-native-community/netinfo": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.7.0.tgz",
-      "integrity": "sha512-a/sDB+AsLEUNmhAUlAaTYeXKyQdFGBUfatqKkX5jluBo2CB3OAuTHfm7rSjcaLB9EmG5iSq3fOTpync2E7EYTA==",
-      "peerDependencies": {
-        "react-native": ">=0.59"
-      }
-    },
     "node_modules/@redux-devtools/extension": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.2.3.tgz",
@@ -13206,11 +13197,6 @@
         "typescript": ">=3.x || >= 4.x"
       }
     },
-    "node_modules/component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA=="
-    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -17652,11 +17638,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/get-params": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/get-params/-/get-params-0.1.2.tgz",
-      "integrity": "sha512-41eOxtlGgHQRbFyA8KTH+w+32Em3cRdfBud7j67ulzmIfmaHX9doq47s0fa4P5o9H64BZX9nrYI6sJvk46Op+Q=="
-    },
     "node_modules/get-proxy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
@@ -19292,6 +19273,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -21363,11 +21345,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsan": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.14.tgz",
-      "integrity": "sha512-wStfgOJqMv4QKktuH273f5fyi3D3vy2pHOiSDGPvpcS/q+wb/M7AK3vkCcaHbkZxDOlDU/lDJgccygKSG2OhtA=="
-    },
     "node_modules/jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -21501,7 +21478,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "node_modules/json-to-pretty-yaml": {
       "version": "1.2.2",
@@ -21719,11 +21697,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/linked-list": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
-      "integrity": "sha512-Zr4ovrd0ODzF3ut2TWZMdHIxb8iFdJc/P3QM4iCJdlxxGHXo69c9hGIHzLo8/FtuR9E6WUZc5irKhtPUgOKMAg=="
     },
     "node_modules/listr2": {
       "version": "4.0.5",
@@ -22207,131 +22180,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/mattermost-redux": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/mattermost-redux/-/mattermost-redux-5.33.1.tgz",
-      "integrity": "sha512-fHTW5PeB0xAE5u6uMds+hlWaJsUeWgE1034vekUah1X4bZCzBcMK4fM+ycGaIQ7c5Ylj9ML6Ni10XJYiQpMo5w==",
-      "dependencies": {
-        "core-js": "3.8.3",
-        "form-data": "3.0.0",
-        "gfycat-sdk": "1.4.18",
-        "moment-timezone": "0.5.32",
-        "redux": "4.0.5",
-        "redux-action-buffer": "1.2.0",
-        "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
-        "redux-persist": "4.9.1",
-        "redux-persist-node-storage": "2.0.0",
-        "redux-thunk": "2.3.0",
-        "remote-redux-devtools": "0.5.16",
-        "reselect": "4.0.0",
-        "rudder-sdk-js": "1.0.14",
-        "serialize-error": "6.0.0",
-        "shallow-equals": "1.0.0"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/core-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/form-data": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-      "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/moment-timezone": {
-      "version": "0.5.32",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
-      "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
-      "dependencies": {
-        "moment": ">= 2.9.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/redux": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "symbol-observable": "^1.2.0"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/redux-persist": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.9.1.tgz",
-      "integrity": "sha512-XoOmfPyo9GEU/WLH9FgB47dNIN9l5ArjHes4o7vUWx9nxZoPxnVodhuHdyc4Ot+fMkdj3L2LTqSHhwrkr0QFUg==",
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.4",
-        "lodash-es": "^4.17.4"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/redux-thunk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
-    },
-    "node_modules/mattermost-redux/node_modules/reselect": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
-    },
-    "node_modules/mattermost-redux/node_modules/rudder-sdk-js": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-1.0.14.tgz",
-      "integrity": "sha512-q86qmF6VUXjTUCv1YRFc2V1pt408D641nD2ymKFaLtGZTLjkZCzotQ7cW8c48vPKlSWwekkBlA3kghy/NKGwOw==",
-      "deprecated": "1.x.x versions of the SDK are deprecated. Please upgrade to the latest (2.x.x) version"
-    },
-    "node_modules/mattermost-redux/node_modules/serialize-error": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-6.0.0.tgz",
-      "integrity": "sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==",
-      "dependencies": {
-        "type-fest": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/mattermost-redux/node_modules/type-fest": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
-      "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mattermost-webapp": {
@@ -23313,6 +23161,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
       "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "dev": true,
       "dependencies": {
         "write-file-atomic": "^1.1.4"
       },
@@ -23324,6 +23173,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
       "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -25425,6 +25275,7 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
       "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
       "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
       "engines": {
         "node": ">=0.4.x"
       }
@@ -26406,56 +26257,12 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "node_modules/redux-action-buffer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
-      "integrity": "sha512-SvXSJQrn1Nsmza+xVMlvqZf0eiHIPV3I796jVC2DCC8X8+JXpAaSFuNxlxV0Cn+TAilat7KZ3srTwG5+HHL8tw=="
-    },
     "node_modules/redux-batched-actions": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.5.0.tgz",
       "integrity": "sha512-6orZWyCnIQXMGY4DUGM0oj0L7oYnwTACsfsru/J7r94RM3P9eS7SORGpr3LCeRCMoIMQcpfKZ7X4NdyFHBS8Eg==",
       "peerDependencies": {
         "redux": ">=1.0.0"
-      }
-    },
-    "node_modules/redux-devtools-core": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/redux-devtools-core/-/redux-devtools-core-0.2.1.tgz",
-      "integrity": "sha512-RAGOxtUFdr/1USAvxrWd+Gq/Euzgw7quCZlO5TgFpDfG7rB5tMhZUrNyBjpzgzL2yMk0eHnPYIGm7NkIfRzHxQ==",
-      "deprecated": "Package moved to @redux-devtools/app.",
-      "dependencies": {
-        "get-params": "^0.1.2",
-        "jsan": "^3.1.13",
-        "lodash": "^4.17.11",
-        "nanoid": "^2.0.0",
-        "remotedev-serialize": "^0.1.8"
-      }
-    },
-    "node_modules/redux-devtools-core/node_modules/nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
-    },
-    "node_modules/redux-devtools-instrument": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.10.0.tgz",
-      "integrity": "sha512-X8JRBCzX2ADSMp+iiV7YQ8uoTNyEm0VPFPd4T854coz6lvRiBrFSqAr9YAS2n8Kzxx8CJQotR0QF9wsMM+3DvA==",
-      "deprecated": "Package moved to @redux-devtools/instrument.",
-      "dependencies": {
-        "lodash": "^4.17.19",
-        "symbol-observable": "^1.2.0"
-      },
-      "peerDependencies": {
-        "redux": "^3.4.0 || ^4.0.0"
-      }
-    },
-    "node_modules/redux-devtools-instrument/node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/redux-mock-store": {
@@ -26465,29 +26272,6 @@
       "dev": true,
       "dependencies": {
         "lodash.isplainobject": "^4.0.6"
-      }
-    },
-    "node_modules/redux-offline": {
-      "version": "1.1.5",
-      "resolved": "git+ssh://git@github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
-      "integrity": "sha512-srmJ1vWm8ZQTYflZCf7oUs3WBX83GyCIzsFUpwxUg2wcDHngSHjjShRTCgmkciPkVmM4aJ33i9baYS9jRC+zLA==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-native-community/netinfo": "^4.1.3",
-        "redux-persist": "^4.5.0"
-      },
-      "peerDependencies": {
-        "redux": ">=3"
-      }
-    },
-    "node_modules/redux-offline/node_modules/redux-persist": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.10.2.tgz",
-      "integrity": "sha512-U+e0ieMGC69Zr72929iJW40dEld7Mflh6mu0eJtVMLGfMq/aJqjxUM1hzyUWMR1VUyAEEdPHuQmeq5ti9krIgg==",
-      "dependencies": {
-        "json-stringify-safe": "^5.0.1",
-        "lodash": "^4.17.4",
-        "lodash-es": "^4.17.4"
       }
     },
     "node_modules/redux-persist": {
@@ -26502,6 +26286,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redux-persist-node-storage/-/redux-persist-node-storage-2.0.0.tgz",
       "integrity": "sha512-nytPz/iNTrAO4o8A17UaipPl8tVcrnm84r6v0tgHJ+q0ysEzyS/rBlPGXrKNIPplXi/W4riUTQlCIhajodIfJg==",
+      "dev": true,
       "dependencies": {
         "node-localstorage": "^1.3.0"
       }
@@ -26693,28 +26478,6 @@
       "dev": true,
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/remote-redux-devtools": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
-      "integrity": "sha512-xZ2D1VRIWzat5nsvcraT6fKEX9Cfi+HbQBCwzNnUAM8Uicm/anOc60XGalcaDPrVmLug7nhDl2nimEa3bL3K9w==",
-      "dependencies": {
-        "jsan": "^3.1.13",
-        "querystring": "^0.2.0",
-        "redux-devtools-core": "^0.2.1",
-        "redux-devtools-instrument": "^1.9.4",
-        "rn-host-detect": "^1.1.5",
-        "socketcluster-client": "^14.2.1"
-      }
-    },
-    "node_modules/remotedev-serialize": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.9.tgz",
-      "integrity": "sha512-5tFdZg9mSaAWTv6xmQ7HtHjKMLSFQFExEZOtJe10PLsv1wb7cy7kYHtBvTYRro27/3fRGEcQBRNKSaixOpb69w==",
-      "deprecated": "Package moved to @redux-devtools/serialize.",
-      "dependencies": {
-        "jsan": "^3.1.13"
       }
     },
     "node_modules/remove-trailing-separator": {
@@ -27039,11 +26802,6 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
-    },
-    "node_modules/rn-host-detect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.2.0.tgz",
-      "integrity": "sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A=="
     },
     "node_modules/rollup": {
       "version": "2.79.1",
@@ -27389,24 +27147,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/sc-channel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
-      "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
-      "dependencies": {
-        "component-emitter": "1.2.1"
-      }
-    },
-    "node_modules/sc-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-2.0.1.tgz",
-      "integrity": "sha512-JoVhq3Ud+3Ujv2SIG7W0XtjRHsrNgl6iXuHHsh0s+Kdt5NwI6N2EGAZD4iteitdDv68ENBkpjtSvN597/wxPSQ=="
-    },
-    "node_modules/sc-formatter": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.3.tgz",
-      "integrity": "sha512-lYI/lTs1u1c0geKElcj+bmEUfcP/HuKg2iDeTijPSjiTNFzN3Cf8Qh6tVd65oi7Qn+2/oD7LP4s6GC13v/9NiQ=="
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
@@ -27901,6 +27641,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -27921,72 +27662,6 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/socketcluster-client": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.3.2.tgz",
-      "integrity": "sha512-xDtgW7Ss0ARlfhx53bJ5GY5THDdEOeJnT+/C9Rmrj/vnZr54xeiQfrCZJbcglwe732nK3V+uZq87IvrRl7Hn4g==",
-      "dependencies": {
-        "buffer": "^5.2.1",
-        "clone": "2.1.1",
-        "component-emitter": "1.2.1",
-        "linked-list": "0.1.0",
-        "querystring": "0.2.0",
-        "sc-channel": "^1.2.0",
-        "sc-errors": "^2.0.1",
-        "sc-formatter": "^3.0.1",
-        "uuid": "3.2.1",
-        "ws": "^7.5.0"
-      }
-    },
-    "node_modules/socketcluster-client/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/socketcluster-client/node_modules/clone": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-      "integrity": "sha512-h5FLmEMFHeuzqmpVRcDayNlVZ+k4uK1niyKQN6oUMe7ieJihv44Vc3dY/kDnnWX4PDQSwes48s965PG/D4GntQ==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/socketcluster-client/node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
-    "node_modules/socketcluster-client/node_modules/uuid": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/sockjs": {
@@ -31585,6 +31260,7 @@
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
       "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -39138,11 +38814,6 @@
       "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
       "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg=="
     },
-    "@react-native-community/netinfo": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.7.0.tgz",
-      "integrity": "sha512-a/sDB+AsLEUNmhAUlAaTYeXKyQdFGBUfatqKkX5jluBo2CB3OAuTHfm7rSjcaLB9EmG5iSq3fOTpync2E7EYTA=="
-    },
     "@redux-devtools/extension": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.2.3.tgz",
@@ -42299,7 +41970,6 @@
         "jest-mock": "27.5.1",
         "lodash": "^4.17.21",
         "marked": "^4.0.12",
-        "mattermost-redux": "5.33.1",
         "mini-create-react-context": "^0.4.1",
         "moment": "^2.29.1",
         "nanoevents": "^5.1.13",
@@ -44790,11 +44460,6 @@
       "requires": {
         "helpertypes": "^0.0.18"
       }
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha512-jPatnhd33viNplKjqXKRkGU345p263OIWzDL2wH3LGIGp5Kojo+uXizHmOADRvhGFFTnJqX3jBAKP6vvmSDKcA=="
     },
     "compressible": {
       "version": "2.0.18",
@@ -48291,11 +47956,6 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
-    "get-params": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/get-params/-/get-params-0.1.2.tgz",
-      "integrity": "sha512-41eOxtlGgHQRbFyA8KTH+w+32Em3cRdfBud7j67ulzmIfmaHX9doq47s0fa4P5o9H64BZX9nrYI6sJvk46Op+Q=="
-    },
     "get-proxy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
@@ -49518,7 +49178,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -51084,11 +50745,6 @@
         "esprima": "^4.0.0"
       }
     },
-    "jsan": {
-      "version": "3.1.14",
-      "resolved": "https://registry.npmjs.org/jsan/-/jsan-3.1.14.tgz",
-      "integrity": "sha512-wStfgOJqMv4QKktuH273f5fyi3D3vy2pHOiSDGPvpcS/q+wb/M7AK3vkCcaHbkZxDOlDU/lDJgccygKSG2OhtA=="
-    },
     "jsdom": {
       "version": "16.7.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
@@ -51195,7 +50851,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "json-to-pretty-yaml": {
       "version": "1.2.2",
@@ -51366,11 +51023,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "linked-list": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/linked-list/-/linked-list-0.1.0.tgz",
-      "integrity": "sha512-Zr4ovrd0ODzF3ut2TWZMdHIxb8iFdJc/P3QM4iCJdlxxGHXo69c9hGIHzLo8/FtuR9E6WUZc5irKhtPUgOKMAg=="
     },
     "listr2": {
       "version": "4.0.5",
@@ -51770,105 +51422,6 @@
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
-    },
-    "mattermost-redux": {
-      "version": "5.33.1",
-      "resolved": "https://registry.npmjs.org/mattermost-redux/-/mattermost-redux-5.33.1.tgz",
-      "integrity": "sha512-fHTW5PeB0xAE5u6uMds+hlWaJsUeWgE1034vekUah1X4bZCzBcMK4fM+ycGaIQ7c5Ylj9ML6Ni10XJYiQpMo5w==",
-      "requires": {
-        "core-js": "3.8.3",
-        "form-data": "3.0.0",
-        "gfycat-sdk": "1.4.18",
-        "moment-timezone": "0.5.32",
-        "redux": "4.0.5",
-        "redux-action-buffer": "1.2.0",
-        "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
-        "redux-persist": "4.9.1",
-        "redux-persist-node-storage": "2.0.0",
-        "redux-thunk": "2.3.0",
-        "remote-redux-devtools": "0.5.16",
-        "reselect": "4.0.0",
-        "rudder-sdk-js": "1.0.14",
-        "serialize-error": "6.0.0",
-        "shallow-equals": "1.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-          "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
-        },
-        "form-data": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
-          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "moment-timezone": {
-          "version": "0.5.32",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.32.tgz",
-          "integrity": "sha512-Z8QNyuQHQAmWucp8Knmgei8YNo28aLjJq6Ma+jy1ZSpSk5nyfRT8xgUbSQvD2+2UajISfenndwvFuH3NGS+nvA==",
-          "requires": {
-            "moment": ">= 2.9.0"
-          }
-        },
-        "redux": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
-          "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "symbol-observable": "^1.2.0"
-          }
-        },
-        "redux-persist": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.9.1.tgz",
-          "integrity": "sha512-XoOmfPyo9GEU/WLH9FgB47dNIN9l5ArjHes4o7vUWx9nxZoPxnVodhuHdyc4Ot+fMkdj3L2LTqSHhwrkr0QFUg==",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "lodash": "^4.17.4",
-            "lodash-es": "^4.17.4"
-          }
-        },
-        "redux-thunk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
-          "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
-        },
-        "reselect": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
-          "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
-        },
-        "rudder-sdk-js": {
-          "version": "1.0.14",
-          "resolved": "https://registry.npmjs.org/rudder-sdk-js/-/rudder-sdk-js-1.0.14.tgz",
-          "integrity": "sha512-q86qmF6VUXjTUCv1YRFc2V1pt408D641nD2ymKFaLtGZTLjkZCzotQ7cW8c48vPKlSWwekkBlA3kghy/NKGwOw=="
-        },
-        "serialize-error": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-6.0.0.tgz",
-          "integrity": "sha512-3vmBkMZLQO+BR4RPHcyRGdE09XCF6cvxzk2N2qn8Er3F91cy8Qt7VvEbZBOpaL53qsBbe2cFOefU6tRY6WDelA==",
-          "requires": {
-            "type-fest": "^0.12.0"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        },
-        "type-fest": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
-          "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg=="
-        }
-      }
     },
     "mattermost-webapp": {
       "version": "file:channels",
@@ -52791,6 +52344,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
       "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "dev": true,
       "requires": {
         "write-file-atomic": "^1.1.4"
       },
@@ -52799,6 +52353,7 @@
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -56013,7 +55568,8 @@
     "querystring": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
-      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true
     },
     "querystringify": {
       "version": "2.2.0",
@@ -56755,50 +56311,10 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "redux-action-buffer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
-      "integrity": "sha512-SvXSJQrn1Nsmza+xVMlvqZf0eiHIPV3I796jVC2DCC8X8+JXpAaSFuNxlxV0Cn+TAilat7KZ3srTwG5+HHL8tw=="
-    },
     "redux-batched-actions": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.5.0.tgz",
       "integrity": "sha512-6orZWyCnIQXMGY4DUGM0oj0L7oYnwTACsfsru/J7r94RM3P9eS7SORGpr3LCeRCMoIMQcpfKZ7X4NdyFHBS8Eg=="
-    },
-    "redux-devtools-core": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/redux-devtools-core/-/redux-devtools-core-0.2.1.tgz",
-      "integrity": "sha512-RAGOxtUFdr/1USAvxrWd+Gq/Euzgw7quCZlO5TgFpDfG7rB5tMhZUrNyBjpzgzL2yMk0eHnPYIGm7NkIfRzHxQ==",
-      "requires": {
-        "get-params": "^0.1.2",
-        "jsan": "^3.1.13",
-        "lodash": "^4.17.11",
-        "nanoid": "^2.0.0",
-        "remotedev-serialize": "^0.1.8"
-      },
-      "dependencies": {
-        "nanoid": {
-          "version": "2.1.11",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-          "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
-        }
-      }
-    },
-    "redux-devtools-instrument": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.10.0.tgz",
-      "integrity": "sha512-X8JRBCzX2ADSMp+iiV7YQ8uoTNyEm0VPFPd4T854coz6lvRiBrFSqAr9YAS2n8Kzxx8CJQotR0QF9wsMM+3DvA==",
-      "requires": {
-        "lodash": "^4.17.19",
-        "symbol-observable": "^1.2.0"
-      },
-      "dependencies": {
-        "symbol-observable": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-          "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
-        }
-      }
     },
     "redux-mock-store": {
       "version": "1.5.4",
@@ -56807,27 +56323,6 @@
       "dev": true,
       "requires": {
         "lodash.isplainobject": "^4.0.6"
-      }
-    },
-    "redux-offline": {
-      "version": "git+ssh://git@github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
-      "integrity": "sha512-srmJ1vWm8ZQTYflZCf7oUs3WBX83GyCIzsFUpwxUg2wcDHngSHjjShRTCgmkciPkVmM4aJ33i9baYS9jRC+zLA==",
-      "from": "redux-offline@git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
-      "requires": {
-        "@react-native-community/netinfo": "^4.1.3",
-        "redux-persist": "^4.5.0"
-      },
-      "dependencies": {
-        "redux-persist": {
-          "version": "4.10.2",
-          "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.10.2.tgz",
-          "integrity": "sha512-U+e0ieMGC69Zr72929iJW40dEld7Mflh6mu0eJtVMLGfMq/aJqjxUM1hzyUWMR1VUyAEEdPHuQmeq5ti9krIgg==",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "lodash": "^4.17.4",
-            "lodash-es": "^4.17.4"
-          }
-        }
       }
     },
     "redux-persist": {
@@ -56839,6 +56334,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redux-persist-node-storage/-/redux-persist-node-storage-2.0.0.tgz",
       "integrity": "sha512-nytPz/iNTrAO4o8A17UaipPl8tVcrnm84r6v0tgHJ+q0ysEzyS/rBlPGXrKNIPplXi/W4riUTQlCIhajodIfJg==",
+      "dev": true,
       "requires": {
         "node-localstorage": "^1.3.0"
       }
@@ -56988,27 +56484,6 @@
       "resolved": "https://registry.npmjs.org/remedial/-/remedial-1.0.8.tgz",
       "integrity": "sha512-/62tYiOe6DzS5BqVsNpH/nkGlX45C/Sp6V+NtiN6JQNS1Viay7cWkazmRkrQrdFj2eshDe96SIQNIoMxqhzBOg==",
       "dev": true
-    },
-    "remote-redux-devtools": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.16.tgz",
-      "integrity": "sha512-xZ2D1VRIWzat5nsvcraT6fKEX9Cfi+HbQBCwzNnUAM8Uicm/anOc60XGalcaDPrVmLug7nhDl2nimEa3bL3K9w==",
-      "requires": {
-        "jsan": "^3.1.13",
-        "querystring": "^0.2.0",
-        "redux-devtools-core": "^0.2.1",
-        "redux-devtools-instrument": "^1.9.4",
-        "rn-host-detect": "^1.1.5",
-        "socketcluster-client": "^14.2.1"
-      }
-    },
-    "remotedev-serialize": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/remotedev-serialize/-/remotedev-serialize-0.1.9.tgz",
-      "integrity": "sha512-5tFdZg9mSaAWTv6xmQ7HtHjKMLSFQFExEZOtJe10PLsv1wb7cy7kYHtBvTYRro27/3fRGEcQBRNKSaixOpb69w==",
-      "requires": {
-        "jsan": "^3.1.13"
-      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -57260,11 +56735,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "rn-host-detect": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.2.0.tgz",
-      "integrity": "sha512-btNg5kzHcjZZ7t7mvvV/4wNJ9e3MPgrWivkRgWURzXL0JJ0pwWlU4zrbmdlz3HHzHOxhBhHB4D+/dbMFfu4/4A=="
-    },
     "rollup": {
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
@@ -57479,24 +56949,6 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
-    },
-    "sc-channel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
-      "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
-      "requires": {
-        "component-emitter": "1.2.1"
-      }
-    },
-    "sc-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-2.0.1.tgz",
-      "integrity": "sha512-JoVhq3Ud+3Ujv2SIG7W0XtjRHsrNgl6iXuHHsh0s+Kdt5NwI6N2EGAZD4iteitdDv68ENBkpjtSvN597/wxPSQ=="
-    },
-    "sc-formatter": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.3.tgz",
-      "integrity": "sha512-lYI/lTs1u1c0geKElcj+bmEUfcP/HuKg2iDeTijPSjiTNFzN3Cf8Qh6tVd65oi7Qn+2/oD7LP4s6GC13v/9NiQ=="
     },
     "scheduler": {
       "version": "0.20.2",
@@ -57906,7 +57358,8 @@
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw=="
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true
     },
     "smooth-scroll-into-view-if-needed": {
       "version": "1.1.33",
@@ -57924,49 +57377,6 @@
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "socketcluster-client": {
-      "version": "14.3.2",
-      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.3.2.tgz",
-      "integrity": "sha512-xDtgW7Ss0ARlfhx53bJ5GY5THDdEOeJnT+/C9Rmrj/vnZr54xeiQfrCZJbcglwe732nK3V+uZq87IvrRl7Hn4g==",
-      "requires": {
-        "buffer": "^5.2.1",
-        "clone": "2.1.1",
-        "component-emitter": "1.2.1",
-        "linked-list": "0.1.0",
-        "querystring": "0.2.0",
-        "sc-channel": "^1.2.0",
-        "sc-errors": "^2.0.1",
-        "sc-formatter": "^3.0.1",
-        "uuid": "3.2.1",
-        "ws": "^7.5.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.1.13"
-          }
-        },
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha512-h5FLmEMFHeuzqmpVRcDayNlVZ+k4uK1niyKQN6oUMe7ieJihv44Vc3dY/kDnnWX4PDQSwes48s965PG/D4GntQ=="
-        },
-        "querystring": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-          "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        }
       }
     },
     "sockjs": {
@@ -60705,7 +60115,8 @@
     "ws": {
       "version": "7.5.9",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "dev": true
     },
     "xhr": {
       "version": "2.6.0",

--- a/webapp/playbooks/jest.config.js
+++ b/webapp/playbooks/jest.config.js
@@ -9,6 +9,7 @@ const config = {
         '^@mattermost/(components)$': '<rootDir>/../platform/$1/src',
         '^@mattermost/(client)$': '<rootDir>/../platform/$1/src',
         '^@mattermost/(types)/(.*)$': '<rootDir>/../platform/$1/src/$2',
+        '^mattermost-redux/(.*)$': '<rootDir>/../channels/src/packages/mattermost-redux/src/$1',
         '^reselect$': '<rootDir>/../channels/src/packages/reselect/src',
         '^src/(.*)$': '<rootDir>/src/$1',
     },


### PR DESCRIPTION
I was hoping to have Boards just use the latest version of mattermost-redux from the web app like Playbooks does, but I ran into some other issues that would've taken too much time to sort out right now. For example, Boards uses the proper `createSelector` which has a different interface than our custom `createSelector` that we use in the rest of the web app, and I couldn't figure out how to make that work nicely without changing the import paths of one or the other.

Since the only parts of mattermost-redux used directly by Boards are:
1. Some types exposed in `@mattermost/types` already
2. The selectTeam action creator
3. Some telemetry stuff

It was easier to just copy over the code for 2 and 3 instead of fix those properly.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51735

#### Release Note
```release-note
NONE
```
