### PR TITLE
MM-48412 - backdrop issue when rhs expanded; ramdom fixes to channels tour

### DIFF
--- a/webapp/channels/src/components/tours/channels_tour_tip.tsx
+++ b/webapp/channels/src/components/tours/channels_tour_tip.tsx
@@ -33,6 +33,7 @@ export type ChannelsTourTipProps = {
     hideBackdrop?: boolean;
     tippyBlueStyle?: boolean;
     showOptOut?: boolean;
+    interactivePunchOut?: boolean;
 }
 
 export const ChannelsTourTip = ({
@@ -50,6 +51,7 @@ export const ChannelsTourTip = ({
     hideBackdrop = false,
     tippyBlueStyle = false,
     showOptOut = true,
+    interactivePunchOut = false,
 }: ChannelsTourTipProps) => {
     const {
         show,
@@ -131,6 +133,7 @@ export const ChannelsTourTip = ({
             hideBackdrop={hideBackdrop}
             tippyBlueStyle={tippyBlueStyle}
             showOptOut={showOptOut}
+            interactivePunchOut={interactivePunchOut}
         />
     );
 };

--- a/webapp/channels/src/components/tours/crt_tour/crt_threads_pane_tutorial_tip.tsx
+++ b/webapp/channels/src/components/tours/crt_tour/crt_threads_pane_tutorial_tip.tsx
@@ -9,7 +9,7 @@ import {Constants, Preferences} from 'utils/constants';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 
-import {TourTip, useMeasurePunchouts} from '@mattermost/components';
+import {TourTip, useFollowElementDimensions, useMeasurePunchouts} from '@mattermost/components';
 
 const translate = {x: 2, y: 25};
 
@@ -17,6 +17,9 @@ const CRTThreadsPaneTutorialTip = () => {
     const dispatch = useDispatch();
     const {formatMessage} = useIntl();
     const currentUserId = useSelector(getCurrentUserId);
+
+    const dimensions = useFollowElementDimensions('sidebar-right');
+
     const title = (
         <FormattedMessage
             id='tutorial_threads.threads_pane.title'
@@ -60,7 +63,7 @@ const CRTThreadsPaneTutorialTip = () => {
         dispatch(savePreferences(currentUserId, preferences));
     };
 
-    const overlayPunchOut = useMeasurePunchouts(['rhsContainer'], []);
+    const overlayPunchOut = useMeasurePunchouts(['rhsContainer'], [dimensions?.width]);
 
     return (
         <TourTip

--- a/webapp/channels/src/components/tours/onboarding_tour/create_and_join_channels_tour_tip.tsx
+++ b/webapp/channels/src/components/tours/onboarding_tour/create_and_join_channels_tour_tip.tsx
@@ -8,7 +8,7 @@ import {useMeasurePunchouts} from '@mattermost/components';
 
 import OnboardingTourTip from './onboarding_tour_tip';
 
-const translate = {x: 0, y: 18};
+const translate = {x: 0, y: 70};
 
 export const CreateAndJoinChannelsTour = () => {
     const title = (
@@ -26,7 +26,7 @@ export const CreateAndJoinChannelsTour = () => {
         </p>
     );
 
-    const overlayPunchOut = useMeasurePunchouts(['showMoreChannels', 'invitePeople'], [], {y: -8, height: 16, x: 0, width: 0});
+    const overlayPunchOut = useMeasurePunchouts(['showMoreChannels', 'showNewChannel'], [], {y: -8, height: 16, x: 0, width: 0});
 
     return (
         <OnboardingTourTip

--- a/webapp/channels/src/components/tours/onboarding_tour/invite_people_tour_tip.tsx
+++ b/webapp/channels/src/components/tours/onboarding_tour/invite_people_tour_tip.tsx
@@ -26,7 +26,7 @@ export const InvitePeopleTour = () => {
         </p>
     );
 
-    const overlayPunchOut = useMeasurePunchouts(['showMoreChannels', 'invitePeople'], [], {y: -8, height: 16, x: 0, width: 0});
+    const overlayPunchOut = useMeasurePunchouts(['invitePeople'], [], {y: -8, height: 16, x: 0, width: 0});
 
     return (
         <OnboardingTourTip

--- a/webapp/channels/src/components/tours/worktemplate_explore_tour/boards_tour_tip.tsx
+++ b/webapp/channels/src/components/tours/worktemplate_explore_tour/boards_tour_tip.tsx
@@ -4,6 +4,8 @@
 import React from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
+import {useFollowElementDimensions, useMeasurePunchouts} from '@mattermost/components';
+
 import OnboardingWorkTemplateTourTip from './worktemplate_explore_tour_tip';
 import {useShowTourTip} from './useShowTourTip';
 
@@ -11,7 +13,8 @@ export const BoardsTourTip = (): JSX.Element | null => {
     const {formatMessage} = useIntl();
 
     const {playbooksCount, boardsCount, showBoardsTour} = useShowTourTip();
-
+    const dimensions = useFollowElementDimensions('sidebar-right');
+    const overlayPunchOut = useMeasurePunchouts(['sidebar-right'], [dimensions?.width]);
     if (!showBoardsTour) {
         return null;
     }
@@ -50,13 +53,14 @@ export const BoardsTourTip = (): JSX.Element | null => {
     return (
         <OnboardingWorkTemplateTourTip
             pulsatingDotPlacement={'left'}
-            pulsatingDotTranslate={{x: 10, y: -140}}
+            pulsatingDotTranslate={{x: 10, y: -350}}
             title={title}
             screen={screen}
+            overlayPunchOut={overlayPunchOut}
             singleTip={playbooksCount === 0}
-            overlayPunchOut={null}
             placement='left-start'
             showOptOut={false}
+            interactivePunchOut={true}
         />
     );
 };

--- a/webapp/channels/src/components/tours/worktemplate_explore_tour/playbooks_tour_tip.tsx
+++ b/webapp/channels/src/components/tours/worktemplate_explore_tour/playbooks_tour_tip.tsx
@@ -4,12 +4,16 @@
 import React from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
+import {useFollowElementDimensions, useMeasurePunchouts} from '@mattermost/components';
+
 import {useShowTourTip} from './useShowTourTip';
 import OnboardingWorkTemplateTourTip from './worktemplate_explore_tour_tip';
 
 export const PlaybooksTourTip = (): JSX.Element | null => {
     const {formatMessage} = useIntl();
     const {playbooksCount, boardsCount, showPlaybooksTour} = useShowTourTip();
+    const dimensions = useFollowElementDimensions('sidebar-right');
+    const overlayPunchOut = useMeasurePunchouts(['sidebar-right'], [dimensions?.width]);
 
     if (!showPlaybooksTour) {
         return null;
@@ -53,9 +57,10 @@ export const PlaybooksTourTip = (): JSX.Element | null => {
             title={title}
             screen={screen}
             singleTip={boardsCount === 0}
-            overlayPunchOut={null}
+            overlayPunchOut={overlayPunchOut}
             placement='left-start'
             showOptOut={false}
+            interactivePunchOut={true}
         />
     );
 };

--- a/webapp/platform/components/src/common/hooks/useFollowElementDimensions.ts
+++ b/webapp/platform/components/src/common/hooks/useFollowElementDimensions.ts
@@ -1,0 +1,27 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useEffect, useState} from 'react';
+
+export const useFollowElementDimensions = (elementId: string): DOMRectReadOnly => {
+    const [dimensions, setDimensions] = useState(new DOMRect());
+
+    useEffect(() => {
+        const element = document.getElementById(elementId);
+        if (!element) {
+            return undefined;
+        }
+        const observer = new ResizeObserver((entries) => {
+            if (entries.length > 0) {
+                setDimensions(entries[0].contentRect);
+            }
+        });
+        observer.observe(element);
+
+        return () => {
+            observer.unobserve(element);
+        };
+    }, [elementId]);
+
+    return dimensions;
+};

--- a/webapp/platform/components/src/index.tsx
+++ b/webapp/platform/components/src/index.tsx
@@ -16,3 +16,4 @@ export {FocusTrap} from './focus_trap';
 // hooks
 export * from './common/hooks/useMeasurePunchouts';
 export {useElementAvailable} from './common/hooks/useElementAvailable';
+export {useFollowElementDimensions} from './common/hooks/useFollowElementDimensions';

--- a/webapp/platform/components/src/tour_tip/tour_tip.scss
+++ b/webapp/platform/components/src/tour_tip/tour_tip.scss
@@ -363,7 +363,7 @@
 
     &__backdrop {
         position: absolute;
-        z-index: 999;
+        z-index: 100;
         top: 0;
         left: 0;
         width: 100%;

--- a/webapp/platform/components/src/tour_tip/tour_tip_backdrop.tsx
+++ b/webapp/platform/components/src/tour_tip/tour_tip_backdrop.tsx
@@ -81,4 +81,3 @@ export const TourTipBackdrop = ({
         </TourTipRootPortal>
     );
 };
-


### PR DESCRIPTION
#### Summary
During the PR https://github.com/mattermost/mattermost-webapp/pull/12301 an issue was identified related to tourtip backdrop when the RHS bar was expanded-collapsed making the punchout to don't update along with a weird behavior caused by the rb-tooltip interaction (The found issues were already open issues https://mattermost.atlassian.net/browse/MM-48412 https://mattermost.atlassian.net/browse/MM-48647 ). This PR fixes those two issues and also fixes a couple of issues related with the explore channels tour.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48412
https://mattermost.atlassian.net/browse/MM-48647

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/12301

Migrated from: https://github.com/mattermost/mattermost-webapp/pull/12354


#### Screenshots
Before:

https://user-images.githubusercontent.com/10082627/224367231-ca696026-3d4b-4133-ba4c-a6453bda13ae.mov

After:


https://user-images.githubusercontent.com/10082627/224367297-6d1e8478-73c1-4f75-99f0-e695223f064e.mov


https://user-images.githubusercontent.com/10082627/224367306-9f2762b7-0a1d-4db4-b7b4-3047c6a242b5.mov


Channels Tour Fix:
Before:
<img width="977" alt="Screenshot 2023-03-10 at 17 16 49" src="https://user-images.githubusercontent.com/10082627/224367812-b9dc4e59-c40c-4d6a-940a-5a910ce9e4f2.png">
<img width="795" alt="Screenshot 2023-03-10 at 17 17 11" src="https://user-images.githubusercontent.com/10082627/224367819-3615c921-edd2-48dd-a823-50d99e921b0a.png">


After:
<img width="841" alt="Screenshot 2023-03-10 at 17 17 45" src="https://user-images.githubusercontent.com/10082627/224367784-1b1dea93-7e20-4877-87b6-d0f38eb9cbf6.png">
<img width="900" alt="Screenshot 2023-03-10 at 17 17 51" src="https://user-images.githubusercontent.com/10082627/224367790-b1b243dc-ca2a-4929-9146-089d9ba9a706.png">



#### Release Note
```release-note
NONE
```
