### PR TITLE
MM-49865 - add telemetry to account creation screen

### DIFF
--- a/webapp/channels/src/components/signup/__snapshots__/signup.test.tsx.snap
+++ b/webapp/channels/src/components/signup/__snapshots__/signup.test.tsx.snap
@@ -58,6 +58,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="email"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Email address"
               type="text"
@@ -75,6 +76,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="name"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Choose a Username"
               type="text"
@@ -87,6 +89,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               error=""
               info="Must be 5-64 characters long."
               inputSize="large"
+              onBlur={[Function]}
               onChange={[Function]}
               value=""
             />
@@ -206,6 +209,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="email"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Email address"
               type="text"
@@ -223,6 +227,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               disabled={false}
               inputSize="large"
               name="name"
+              onBlur={[Function]}
               onChange={[Function]}
               placeholder="Choose a Username"
               type="text"
@@ -235,6 +240,7 @@ exports[`components/signup/Signup should match snapshot for all signup options e
               error=""
               info="Must be 5-64 characters long."
               inputSize="large"
+              onBlur={[Function]}
               onChange={[Function]}
               value=""
             />

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -1366,11 +1366,13 @@ export function getPasswordConfig(config: Partial<ClientConfig>) {
 
 export function isValidPassword(password: string, passwordConfig: ReturnType<typeof getPasswordConfig>, intl?: IntlShape) {
     let errorId = t('user.settings.security.passwordError');
+    const telemetryErrorIds = [];
     let valid = true;
     const minimumLength = passwordConfig.minimumLength || Constants.MIN_PASSWORD_LENGTH;
 
     if (password.length < minimumLength || password.length > Constants.MAX_PASSWORD_LENGTH) {
         valid = false;
+        telemetryErrorIds.push({field: 'password', rule: 'error_length'});
     }
 
     if (passwordConfig.requireLowercase) {
@@ -1379,6 +1381,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Lowercase';
+        telemetryErrorIds.push({field: 'password', rule: 'lowercase'});
     }
 
     if (passwordConfig.requireUppercase) {
@@ -1387,6 +1390,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Uppercase';
+        telemetryErrorIds.push({field: 'password', rule: 'uppercase'});
     }
 
     if (passwordConfig.requireNumber) {
@@ -1395,6 +1399,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Number';
+        telemetryErrorIds.push({field: 'password', rule: 'number'});
     }
 
     if (passwordConfig.requireSymbol) {
@@ -1403,6 +1408,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         }
 
         errorId += 'Symbol';
+        telemetryErrorIds.push({field: 'password', rule: 'symbol'});
     }
 
     let error;
@@ -1430,7 +1436,7 @@ export function isValidPassword(password: string, passwordConfig: ReturnType<typ
         );
     }
 
-    return {valid, error};
+    return {valid, error, telemetryErrorIds};
 }
 
 function isChannelOrPermalink(link: string) {
@@ -1828,9 +1834,14 @@ export function getRoleForTrackFlow() {
     return {started_by_role: startedByRole};
 }
 
-export function getRoleFromTrackFlow() {
+export function getSbr() {
     const params = new URLSearchParams(window.location.search);
     const sbr = params.get('sbr') ?? '';
+    return sbr;
+}
+
+export function getRoleFromTrackFlow() {
+    const sbr = getSbr();
     const startedByRole = TrackFlowRoles[sbr] ?? '';
 
     return {started_by_role: startedByRole};


### PR DESCRIPTION
#### Summary
This PR adds telemetry events for first admins when they initially land to the account creation page . The intention is to capture some of the interactions and events the first users have with the account creation page in order to be able to measure and take actions aiming to improve the product usage and adoption.

Captured Events:

The category used for these telemetry values is: `signup` and the extra data that will contain each one of these values is the serverId value.

* Then there are events captured if the user has typed anything in the email, username or password inputs

- `typed_input_email`
- `typed_input_username`
- `typed_input_password`

we listen for the blur event on the email, username and password inputs, then we check if there is a value in the input meaning the user entered some text.

* When the user clicks "Create Account Button"
the event `click_create_account` will be send under the `signup` category

* After the user clicks create account button, the subsequent validations are performed and in the case of validation errors, the following events are aggregated and send. The possible error events are:

Email
- No email provided: `[{field: 'email', rule: 'not_provided'}]`
- Entered an email but is an invalid email: [{field: 'email', rule: 'invalid_email'}]

Username
- Not entered a username: `[{field: 'username', rule: 'username_required'}]`
- Entered a username that does not match the min or max length criteria: `[{field: 'username', rule: 'invalid_length'}]`
- Entered a username with invalid characters: `[{field: 'username', rule: 'invalid_characters'}]`
- Entered a username with invalid first character: `[{field: 'username', rule: 'invalid_first_character'}]`
- Entered a username with a reserved username: `[{field: 'username', rule: 'reserved_name'}]`

Password
The password error telemetry id value will vary depending on the entered password not matching one or several of the password validation requirements, so it will contain a first part indicating the password error and the last part of the id will indicate the error or errors not matching the criteria:

- Not entered a password: `[{field: 'password', rule: 'password_required'}]`
- Entered a password that does not match the min or max length criteria: `[{field: 'password', rule: 'error_length'}]`
- Entered a password that does not contain lowercase: `[{field: 'password', rule: 'lowercase'}]`
- Entered a password that does not contain an uppercase character: `[{field: 'password', rule: 'uppercase'}]`
- Entered a password that does not contain a number: `[{field: 'password', rule: 'number'}]`
- Entered a password that does not contain a symbol: `[{field: 'password', rule: 'symbol'}]`

if there are errors those will be aggregated and send like:

`{success: false, errors: [<<Array of all possible errors mentioned above>>]}
`

![Screenshot 2023-03-07 at 18 45 13](https://user-images.githubusercontent.com/10082627/224062380-9f5fb149-2cb6-4030-a3a6-9474b15d7a42.png)

On the opposite side, if there were no errors, the format will be:
`{success: true, errors: []}
`

![Screenshot 2023-03-07 at 18 46 00](https://user-images.githubusercontent.com/10082627/224062466-33138708-ee59-41fb-b24b-3d1b1e368dbe.png)


```

```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49865

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/12260

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
