### PR TITLE
MM-49080 - Fix for: channel links causing the webapp to refresh

### DIFF
--- a/webapp/channels/src/utils/text_formatting.test.ts
+++ b/webapp/channels/src/utils/text_formatting.test.ts
@@ -7,7 +7,13 @@ import EmojiMap from 'utils/emoji_map';
 import {getEmojiMap} from 'selectors/emojis';
 import store from 'stores/redux_store.jsx';
 
-import {formatText, autolinkAtMentions, highlightSearchTerms, handleUnicodeEmoji, parseSearchTerms} from 'utils/text_formatting';
+import {
+    formatText,
+    autolinkAtMentions,
+    highlightSearchTerms,
+    handleUnicodeEmoji,
+    parseSearchTerms, autolinkChannelMentions, ChannelNamesMap,
+} from 'utils/text_formatting';
 import LinkOnlyRenderer from 'utils/markdown/link_only_renderer';
 
 const emptyEmojiMap = new EmojiMap(new Map());
@@ -173,6 +179,26 @@ describe('highlightSearchTerms', () => {
         const output = highlightSearchTerms(text, tokens, searchPatterns);
         expect(output).toBe('$MM_SEARCHTERM1$');
         expect(tokens.get('$MM_SEARCHTERM1$')!.value).toBe('<span class="search-highlight">$MM_HASHTAG0$</span>');
+    });
+});
+
+describe('autolink channel mentions', () => {
+    test('link a channel mention', () => {
+        const mention = '~test-channel';
+        const leadingText = 'pre blah blah ';
+        const trailingText = ' post blah blah';
+        const text = `${leadingText}${mention}${trailingText}`;
+        const tokens = new Map();
+        const channelNamesMap: ChannelNamesMap = {
+            'test-channel': {
+                team_name: 'ad-1',
+                display_name: 'Test Channel',
+            },
+        };
+
+        const output = autolinkChannelMentions(text, tokens, channelNamesMap);
+        expect(output).toBe(`${leadingText}$MM_CHANNELMENTION0$${trailingText}`);
+        expect(tokens.get('$MM_CHANNELMENTION0$').value).toBe('<a class="mention-link" href="/ad-1/channels/test-channel" data-channel-mention-team="ad-1" data-channel-mention="test-channel">~Test Channel</a>');
     });
 });
 

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -498,7 +498,7 @@ function autolinkChannelMentions(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             href = ((window as any).basename || '') + '/' + teamName + '/channels/' + channelName;
             tokens.set(alias, {
-                value: `<a class="mention-link" href="${href}" data-channel-mention-team="${teamName}" "data-channel-mention="${channelName}">~${displayName}</a>`,
+                value: `<a class="mention-link" href="${href}" data-channel-mention-team="${teamName}" data-channel-mention="${channelName}">~${displayName}</a>`,
                 originalText: mention,
             });
         } else if (team) {

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -481,7 +481,7 @@ export function allAtMentions(text: string): RegExpMatchArray {
     return text.match(Constants.SPECIAL_MENTIONS_REGEX && AT_MENTION_PATTERN) || [];
 }
 
-function autolinkChannelMentions(
+export function autolinkChannelMentions(
     text: string,
     tokens: Tokens,
     channelNamesMap: ChannelNamesMap,


### PR DESCRIPTION
#### Summary
- If a user clicked on a channel link for a channels the user was not a part of, the webapp would refresh. This caused the current call to drop. The problem was an accidental quotation mark. (Hat-tip to Harrison for spotting the typo!)
- I've added a test so this particular issue won't regress

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-49080

#### Release Note
```release-note
Fixed a problem where clicking on a channel link (for a channel the user was not a part of) would cause the webapp to refresh, dropping the user's current call.
```
