### PR TITLE
MM-51744: Ignore http.ErrServerClosed from Playbooks metricsServer

### DIFF
--- a/server/playbooks/product/playbooks_product.go
+++ b/server/playbooks/product/playbooks_product.go
@@ -582,7 +582,7 @@ func (pp *playbooksProduct) runMetricsServer() {
 	// Run server to expose metrics
 	go func() {
 		err := pp.metricsServer.Run()
-		if err != nil {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logrus.WithError(err).Error("Metrics server could not be started")
 		}
 	}()


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-51744

```release-note
NONE
```
