### PR TITLE
[MM-47285] - Migrate /autocomplete/database e2e tests to TypeScript 

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/autocomplete/common_test.ts
+++ b/e2e-tests/cypress/tests/integration/channels/autocomplete/common_test.ts
@@ -16,13 +16,13 @@ import {
     verifySuggestionAtPostTextbox,
 } from './helpers';
 
-export function doTestPostextbox(mention: string, ...suggestion: Cypress.UserProfile[]) {
+export function doTestPostextbox(mention: string, ...suggestion: SimpleUser[]) {
     getPostTextboxInput();
     startAtMention(mention);
     verifySuggestionAtPostTextbox(...suggestion);
 }
 
-export function doTestQuickChannelSwitcher(mention: string, ...suggestion: Cypress.UserProfile[]) {
+export function doTestQuickChannelSwitcher(mention: string, ...suggestion: SimpleUser[]) {
     getQuickChannelSwitcherInput();
     startAtMention(mention);
     verifySuggestionAtChannelSwitcher(...suggestion);

--- a/e2e-tests/cypress/tests/integration/channels/autocomplete/database/users_in_channel_switcher_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/autocomplete/database/users_in_channel_switcher_spec.ts
@@ -12,11 +12,11 @@
 
 import {getRandomLetter} from '../../../../utils';
 import {doTestQuickChannelSwitcher} from '../common_test';
-import {createSearchData} from '../helpers';
+import {createSearchData, SimpleUser} from '../helpers';
 
 describe('Autocomplete with Database - Users', () => {
-    const prefix = getRandomLetter(3);
-    let testUsers;
+    const prefix: string = getRandomLetter(3);
+    let testUsers: Record<string, SimpleUser>;
 
     before(() => {
         cy.apiGetClientLicense().then(({isCloudLicensed}) => {

--- a/e2e-tests/cypress/tests/integration/channels/autocomplete/database/users_in_message_input_box_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/autocomplete/database/users_in_message_input_box_spec.ts
@@ -12,11 +12,11 @@
 
 import {getRandomLetter} from '../../../../utils';
 import {doTestPostextbox} from '../common_test';
-import {createSearchData} from '../helpers';
+import {createSearchData, SimpleUser} from '../helpers';
 
 describe('Autocomplete with Database - Users', () => {
     const prefix = getRandomLetter(3);
-    let testUsers;
+    let testUsers: Record<string, SimpleUser>;
 
     before(() => {
         cy.apiGetClientLicense().then(({isCloudLicensed}) => {

--- a/e2e-tests/cypress/tests/integration/channels/autocomplete/database/users_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/autocomplete/database/users_spec.ts
@@ -12,12 +12,12 @@
 
 import {getRandomLetter} from '../../../../utils';
 import {doTestDMChannelSidebar, doTestUserChannelSection} from '../common_test';
-import {createSearchData} from '../helpers';
+import {createSearchData, SimpleUser} from '../helpers';
 
 describe('Autocomplete with Database - Users', () => {
     const prefix = getRandomLetter(3);
-    let testUsers;
-    let testTeam;
+    let testUsers: Record<string, SimpleUser>;
+    let testTeam: Cypress.Team;
 
     before(() => {
         cy.apiGetClientLicense().then(({isCloudLicensed}) => {

--- a/e2e-tests/cypress/tests/integration/channels/autocomplete/helpers.ts
+++ b/e2e-tests/cypress/tests/integration/channels/autocomplete/helpers.ts
@@ -211,14 +211,14 @@ function startAtMention(string: string) {
     cy.get('#suggestionList').should('be.visible');
 }
 
-function verifySuggestionAtPostTextbox(...expectedUsers: Cypress.UserProfile[]) {
+function verifySuggestionAtPostTextbox(...expectedUsers: SimpleUser[]) {
     expectedUsers.forEach((user) => {
         cy.wait(TIMEOUTS.HALF_SEC);
-        cy.uiVerifyAtMentionSuggestion(user);
+        cy.uiVerifyAtMentionSuggestion(user as Cypress.UserProfile);
     });
 }
 
-function verifySuggestionAtChannelSwitcher(...expectedUsers: Cypress.UserProfile[]) {
+function verifySuggestionAtChannelSwitcher(...expectedUsers: SimpleUser[]) {
     expectedUsers.forEach((user) => {
         cy.findByTestId(user.username).
             should('be.visible').

--- a/e2e-tests/cypress/tests/support/api/system.d.ts
+++ b/e2e-tests/cypress/tests/support/api/system.d.ts
@@ -199,5 +199,13 @@ declare namespace Cypress {
          *   cy.shouldHaveEmailEnabled();
          */
         shouldHaveEmailEnabled(): Chainable;
+
+        /**
+         * Allow test for server with Elastic search disabled.
+         * Otherwise, fail fast.
+         * @example
+         *   cy.shouldHaveElasticsearchDisabled();
+         */
+        shouldHaveElasticsearchDisabled(): Chainable;
     }
 }


### PR DESCRIPTION
Summary
cypress e2e: Migrate /autocomplete/database e2e tests to TypeScript

#### Fixes https://github.com/mattermost/mattermost-server/issues/21301


#### Demo snapshot
<img width="431" alt="Screen Shot 2023-03-03 at 16 36 17" src="https://user-images.githubusercontent.com/68722497/223914890-85136c58-607e-4b74-a939-2327eea0bfd0.png">

<img width="432" alt="Screen Shot 2023-03-03 at 16 35 50" src="https://user-images.githubusercontent.com/68722497/223914912-2163ad43-3323-4c12-bc0b-b6ba87fec109.png">

<img width="449" alt="Screen Shot 2023-03-03 at 16 34 41" src="https://user-images.githubusercontent.com/68722497/223914974-04395bad-2db4-4da3-abf0-4cecac4afa81.png">

#### Release note
```release-note
Migrate /autocomplete/database e2e tests to TypeScript 
```

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.