### PR TITLE
[MM-46941] Fix: PDF preview doesn't render some Japanese characters (clone)

### DIFF
--- a/webapp/channels/src/components/pdf_preview.jsx
+++ b/webapp/channels/src/components/pdf_preview.jsx
@@ -10,6 +10,8 @@ import {getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
 import LoadingSpinner from 'components/widgets/loading/loading_spinner';
 import FileInfoPreview from 'components/file_info_preview';
 
+import {getSiteURL} from 'utils/url';
+
 const INITIAL_RENDERED_PAGES = 3;
 
 export default class PDFPreview extends React.PureComponent {
@@ -149,7 +151,11 @@ export default class PDFPreview extends React.PureComponent {
             const worker = await import('pdfjs-dist/build/pdf.worker.entry.js');
             PDFJS.GlobalWorkerOptions.workerSrc = worker;
 
-            const pdf = await PDFJS.getDocument(this.props.fileUrl).promise;
+            const pdf = await PDFJS.getDocument({
+                url: this.props.fileUrl,
+                cMapUrl: getSiteURL() + '/static/cmaps/',
+                cMapPacked: true,
+            }).promise;
             this.onDocumentLoad(pdf);
         } catch (err) {
             this.onDocumentLoadError(err);

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -220,6 +220,7 @@ var config = {
                 {from: 'src/images/cloud-laptop-error.png', to: 'images'},
                 {from: 'src/images/cloud-laptop-warning.png', to: 'images'},
                 {from: 'src/images/cloud-upgrade-person-hand-to-face.png', to: 'images'},
+                {from: '../node_modules/pdfjs-dist/cmaps', to: 'cmaps'},
             ],
         }),
 


### PR DESCRIPTION
This is merely a copy of the branch from the https://github.com/mattermost/mattermost-server/pull/22599 PR so that we can run a Spinwick to test the code.