### PR TITLE
Optimize JSON marshalling in playbooks

### DIFF
--- a/server/playbooks/server/api/api.go
+++ b/server/playbooks/server/api/api.go
@@ -91,16 +91,10 @@ func HandleErrorWithCode(logger logrus.FieldLogger, w http.ResponseWriter, code 
 
 // ReturnJSON writes the given pointerToObject as json with the provided httpStatus
 func ReturnJSON(w http.ResponseWriter, pointerToObject interface{}, httpStatus int) {
-	jsonBytes, err := json.Marshal(pointerToObject)
-	if err != nil {
-		logrus.WithError(err).Error("Unable to marshal JSON")
-		return
-	}
-
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(httpStatus)
 
-	if _, err = w.Write(jsonBytes); err != nil {
+	if err := json.NewEncoder(w).Encode(pointerToObject); err != nil {
 		logrus.WithError(err).Warn("Unable to write to http.ResponseWriter")
 		return
 	}


### PR DESCRIPTION
While inspecting Pyroscope, the function api.ReturnJSON
was seen to take some chunk of the overall memory allocations.

Looking deeper, we can see that the entire object
is json marshalled into bytes, and then wrote to the network.

Instead, we can just do a streaming write to the network
which avoids pre-allocating the entire object.

A similar approach is taken in the server channels codebase
as well.

```release-note
NONE
```

![getPlaybookruns](https://user-images.githubusercontent.com/1774000/228731892-3cf96c97-5984-43a8-8637-89f94e0df6cf.png)

