### PR TITLE
MM-51792 Replace Boards feature flag with env var

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -51,9 +51,6 @@ type FeatureFlags struct {
 
 	CommandPalette bool
 
-	// Enable Boards as a product (multi-product architecture)
-	BoardsProduct bool
-
 	// A/B Test on posting a welcome message
 	SendWelcomePost bool
 
@@ -95,7 +92,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.InsightsEnabled = true
 	f.CommandPalette = false
 	f.CallsEnabled = true
-	f.BoardsProduct = false
 	f.SendWelcomePost = true
 	f.PostPriority = true
 	f.PeopleProduct = false

--- a/server/Makefile
+++ b/server/Makefile
@@ -89,7 +89,6 @@ endif
 # Boards
 BUILD_BOARDS = true
 BUILD_HASH_BOARDS = $(BUILD_HASH)
-export MM_FEATUREFLAGS_BoardsProduct=true
 
 # Playbooks
 BUILD_PLAYBOOKS ?= true
@@ -462,9 +461,9 @@ else
 endif
 
 test-server-race: test-server-pre
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=false ./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(TE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=true ./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(BOARDS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
-	MM_DISABLE_PLAYBOOKS=false MM_FEATUREFLAGS_BoardsProduct=false ./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(PLAYBOOKS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=true ./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(TE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=false ./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(BOARDS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
+	MM_DISABLE_PLAYBOOKS=false MM_DISABLE_BOARDS=true ./scripts/test.sh "$(GO)" "-race $(GOFLAGS)" "$(PLAYBOOKS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "90m" "atomic"
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)
     ifneq ($(TEMP_DOCKER_SERVICES),)
@@ -475,9 +474,9 @@ ifneq ($(IS_CI),true)
 endif
 
 test-server: test-server-pre
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=false ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(TE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "45m" "count"
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=true ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(BOARDS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "45m" "count"
-	MM_DISABLE_PLAYBOOKS=false MM_FEATUREFLAGS_BoardsProduct=false ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(PLAYBOOKS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "45m" "count"
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=true ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(TE_PACKAGES) $(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "45m" "count"
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=false ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(BOARDS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "45m" "count"
+	MM_DISABLE_PLAYBOOKS=false MM_DISABLE_BOARDS=true ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(PLAYBOOKS_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "45m" "count"
 ifneq ($(IS_CI),true)
   ifneq ($(MM_NO_DOCKER),true)
     ifneq ($(TEMP_DOCKER_SERVICES),)
@@ -489,19 +488,19 @@ endif
 
 test-server-ee: check-prereqs-enterprise start-docker go-junit-report do-cover-file ## Runs EE tests.
 	@echo Running only EE tests
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=false ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "20m" "count"
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=true ./scripts/test.sh "$(GO)" "$(GOFLAGS)" "$(EE_PACKAGES)" "$(TESTS)" "$(TESTFLAGS)" "$(GOBIN)" "20m" "count"
 
 test-server-quick: check-prereqs-enterprise ## Runs only quick tests.
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Running all tests
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=false $(GO) test $(GOFLAGS) -short $(TE_PACKAGES) $(EE_PACKAGES)
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=true $(GO) test $(GOFLAGS) -short $(BOARDS_PACKAGES)
-	MM_DISABLE_PLAYBOOKS=false MM_FEATUREFLAGS_BoardsProduct=false $(GO) test $(GOFLAGS) -short $(PLAYBOOKS_PACKAGES)
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=true $(GO) test $(GOFLAGS) -short $(TE_PACKAGES) $(EE_PACKAGES)
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=false $(GO) test $(GOFLAGS) -short $(BOARDS_PACKAGES)
+	MM_DISABLE_PLAYBOOKS=false MM_DISABLE_BOARDS=true $(GO) test $(GOFLAGS) -short $(PLAYBOOKS_PACKAGES)
 else
 	@echo Running only TE tests
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=false $(GO) test $(GOFLAGS) -short $(TE_PACKAGES)
-	MM_DISABLE_PLAYBOOKS=true MM_FEATUREFLAGS_BoardsProduct=true $(GO) test $(GOFLAGS) -short $(BOARDS_PACKAGES)
-	MM_DISABLE_PLAYBOOKS=false MM_FEATUREFLAGS_BoardsProduct=false $(GO) test $(GOFLAGS) -short $(PLAYBOOKS_PACKAGES)
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=true $(GO) test $(GOFLAGS) -short $(TE_PACKAGES)
+	MM_DISABLE_PLAYBOOKS=true MM_DISABLE_BOARDS=false $(GO) test $(GOFLAGS) -short $(BOARDS_PACKAGES)
+	MM_DISABLE_PLAYBOOKS=false MM_DISABLE_BOARDS=true $(GO) test $(GOFLAGS) -short $(PLAYBOOKS_PACKAGES)
 endif
 
 internal-test-web-client: ## Runs web client tests.

--- a/server/boards/product/boards_product.go
+++ b/server/boards/product/boards_product.go
@@ -222,11 +222,6 @@ func populateServices(boardsProd *boardsProduct, services map[product.ServiceKey
 }
 
 func (bp *boardsProduct) Start() error {
-	if !bp.configService.Config().FeatureFlags.BoardsProduct {
-		bp.logger.Info("Boards product disabled via feature flag")
-		return nil
-	}
-
 	bp.logger.Info("Starting boards service")
 
 	adapter := newServiceAPIAdapter(bp)

--- a/server/boards/server/boards_service_util.go
+++ b/server/boards/server/boards_service_util.go
@@ -81,7 +81,7 @@ func CreateBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 	}
 
 	return &config.Configuration{
-		ServerRoot:               "/boards",
+		ServerRoot:               baseURL + "/boards",
 		Port:                     -1,
 		DBType:                   *mmconfig.SqlSettings.DriverName,
 		DBConfigString:           *mmconfig.SqlSettings.DataSource,

--- a/server/boards/server/boards_service_util.go
+++ b/server/boards/server/boards_service_util.go
@@ -80,12 +80,8 @@ func CreateBoardsConfig(mmconfig mm_model.Config, baseURL string, serverID strin
 		showFullName = *mmconfig.PrivacySettings.ShowFullName
 	}
 
-	serverRoot := baseURL + "/plugins/focalboard"
-	if mmconfig.FeatureFlags.BoardsProduct {
-		serverRoot = baseURL + "/boards"
-	}
 	return &config.Configuration{
-		ServerRoot:               serverRoot,
+		ServerRoot:               "/boards",
 		Port:                     -1,
 		DBType:                   *mmconfig.SqlSettings.DriverName,
 		DBConfigString:           *mmconfig.SqlSettings.DataSource,

--- a/server/channels/app/product.go
+++ b/server/channels/app/product.go
@@ -72,14 +72,14 @@ func (s *Server) initializeProducts(
 
 func (s *Server) shouldStart(product string) bool {
 	if product == "boards" {
-		if !s.Config().FeatureFlags.BoardsProduct {
-			s.Log().Warn("Skipping boards start: not enabled via feature flag")
+		if os.Getenv("MM_DISABLE_BOARDS") == "true" {
+			s.Log().Warn("Skipping Boards start: disabled via env var")
 			return false
 		}
 	}
 	if product == "playbooks" {
 		if os.Getenv("MM_DISABLE_PLAYBOOKS") == "true" {
-			s.Log().Warn("Skipping playbooks start: disabled via env var")
+			s.Log().Warn("Skipping Playbooks start: disabled via env var")
 			return false
 		}
 	}

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -109,7 +109,6 @@ services:
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
       - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
-      - "MM_FEATUREFLAGS_BoardsProduct=true"
     networks:
       - mm-test
     depends_on:
@@ -147,7 +146,6 @@ services:
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
       - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
-      - "MM_FEATUREFLAGS_BoardsProduct=true"
     networks:
       - mm-test
     depends_on:
@@ -185,7 +183,6 @@ services:
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
       - "MM_CLUSTERSETTINGS_CLUSTERNAME=mm_dev_cluster"
-      - "MM_FEATUREFLAGS_BoardsProduct=true"
     networks:
       - mm-test
     depends_on:


### PR DESCRIPTION
#### Summary
This PR replaces the Boards feature flag with an env var on the back-end.  A PR to remove from front-end is pending.

Currently Boards can be disabled via a feature flag that defaults to disabled. Multiple production incidents have happened on community due to not having the feature flag set.  The FF will be replaced with a env var that defaults to enabled.  

This is temporary until mm-server unit tests can run without disabling Boards.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51792

#### Release Note
```release-note
NONE
```
