### PR TITLE
MM-51804 - add channels lhs not working

### DIFF
--- a/webapp/channels/src/components/sidebar/__snapshots__/add_channels_cta_button.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/__snapshots__/add_channels_cta_button.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`components/new_channel_modal should match snapshot 1`] = `
     aria-label="Add Channels Dropdown"
     className="SidebarChannelNavigator__addChannelsCtaLhsButton SidebarChannelNavigator__addChannelsCtaLhsButton--untouched"
     id="addChannelsCta"
+    onClick={[Function]}
   >
     <li
       aria-label="Add channels"
@@ -43,4 +44,24 @@ exports[`components/new_channel_modal should match snapshot 1`] = `
     </MenuGroup>
   </Menu>
 </MenuWrapper>
+`;
+
+exports[`components/new_channel_modal should match snapshot when user has only join channel permissions 1`] = `
+<button
+  aria-label="Add Channels Dropdown"
+  className="SidebarChannelNavigator__addChannelsCtaLhsButton SidebarChannelNavigator__addChannelsCtaLhsButton--untouched"
+  id="addChannelsCta"
+  onClick={[Function]}
+>
+  <li
+    aria-label="Add channels"
+  >
+    <i
+      className="icon-plus-box"
+    />
+    <span>
+      Add Channels
+    </span>
+  </li>
+</button>
 `;

--- a/webapp/channels/src/components/sidebar/add_channels_cta_button.tsx
+++ b/webapp/channels/src/components/sidebar/add_channels_cta_button.tsx
@@ -106,8 +106,28 @@ const AddChannelsCtaButton = (): JSX.Element | null => {
         );
     };
 
-    const trackOpen = (opened: boolean) => {
-        openAddChannelsCtaOpen(opened);
+    const addChannelsButton = (btnCallback?: () => void) => {
+        const handleClick = () => btnCallback?.();
+        return (
+            <button
+                className={buttonClass}
+                id={'addChannelsCta'}
+                aria-label={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.dropdownAriaLabel', defaultMessage: 'Add Channels Dropdown'})}
+                onClick={handleClick}
+            >
+                <li
+                    aria-label={intl.formatMessage({id: 'sidebar_left.sidebar_channel_navigator.addChannelsCta', defaultMessage: 'Add channels'})}
+                >
+                    <i className='icon-plus-box'/>
+                    <span>
+                        {intl.formatMessage({id: 'sidebar_left.addChannelsCta', defaultMessage: 'Add Channels'})}
+                    </span>
+                </li>
+            </button>
+        );
+    };
+
+    const storePreferencesAndTrackEvent = () => {
         trackEvent('ui', 'add_channels_cta_button_clicked');
         if (!touchedAddChannelsCtaButton) {
             dispatch(savePreferences(
@@ -122,26 +142,26 @@ const AddChannelsCtaButton = (): JSX.Element | null => {
         }
     };
 
+    const trackOpen = (opened: boolean) => {
+        openAddChannelsCtaOpen(opened);
+        storePreferencesAndTrackEvent();
+    };
+
+    if (!canCreateChannel) {
+        const browseChannelsAction = () => {
+            showMoreChannelsModal();
+            storePreferencesAndTrackEvent();
+        };
+        return addChannelsButton(browseChannelsAction);
+    }
+
     return (
         <MenuWrapper
             className='AddChannelsCtaDropdown'
             onToggle={trackOpen}
             open={isAddChannelCtaOpen}
         >
-            <button
-                className={buttonClass}
-                id={'addChannelsCta'}
-                aria-label={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.dropdownAriaLabel', defaultMessage: 'Add Channels Dropdown'})}
-            >
-                <li
-                    aria-label={intl.formatMessage({id: 'sidebar_left.sidebar_channel_navigator.addChannelsCta', defaultMessage: 'Add channels'})}
-                >
-                    <i className='icon-plus-box'/>
-                    <span>
-                        {intl.formatMessage({id: 'sidebar_left.addChannelsCta', defaultMessage: 'Add Channels'})}
-                    </span>
-                </li>
-            </button>
+            {addChannelsButton()}
             <Menu
                 id='AddChannelCtaDropdown'
                 ariaLabel={intl.formatMessage({id: 'sidebar_left.add_channel_cta_dropdown.dropdownAriaLabel', defaultMessage: 'Add Channels Dropdown'})}

--- a/webapp/channels/src/components/sidebar/sidebar_list/__snapshots__/sidebar_list.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_list/__snapshots__/sidebar_list.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`SidebarList should match snapshot 1`] = `
       renderView={[Function]}
       style={
         Object {
+          "overflow": "initial",
           "position": "absolute",
         }
       }

--- a/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
@@ -69,7 +69,7 @@ export function renderThumbVertical(props: any) {
     );
 }
 
-const scrollbarStyles: CSSProperties = {position: 'absolute'};
+const scrollbarStyles: CSSProperties = {position: 'absolute', overflow: 'initial'};
 
 type Props = {
     currentTeam: Team;

--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_cloud_trial.test.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_cloud_trial.test.tsx
@@ -205,7 +205,6 @@ describe('components/widgets/menu/menu_items/menu_cloud_trial', () => {
         };
         const store = mockStore(state);
         const wrapper = mountWithIntl(<Provider store={store}><MenuCloudTrial id='menuCloudTrial'/></Provider>);
-        console.log(wrapper.debug());
         expect(wrapper.find('.open-learn-more-trial-modal').exists()).toEqual(true);
     });
 

--- a/webapp/channels/src/sass/base/_structure.scss
+++ b/webapp/channels/src/sass/base/_structure.scss
@@ -160,7 +160,6 @@ body.app__body #root {
             }
             #SidebarContainer.move--right {
                 position: relative;
-                left: 65px;
             }
         }
     }

--- a/webapp/channels/src/sass/layout/_sidebar-left.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-left.scss
@@ -575,6 +575,19 @@ $sidebarOpacityAnimationDuration: 0.15s;
         }
     }
 
+    @media screen and (min-width: 768px) {
+        .SidebarNavContainer {
+            .scrollbar--view {
+                overflow: initial !important;
+                max-width: 240px;
+            }
+        }
+
+        #SidebarContainer .SidebarChannelGroup .SidebarChannelGroupHeader {
+            max-width: 240px;
+        }
+    }
+
     .SidebarCategory_newLabel {
         display: flex;
         width: 32px;
@@ -741,6 +754,7 @@ $sidebarOpacityAnimationDuration: 0.15s;
     }
 
     .AddChannelsCtaDropdown .dropdown-menu {
+        min-width: 232px !important;
         margin-left: 20px;
     }
 
@@ -748,17 +762,10 @@ $sidebarOpacityAnimationDuration: 0.15s;
     #addChannelsCta {
         display: flex;
         width: 100%;
+        margin-top: -6px;
 
         &:hover {
             background-color: var(--sidebar-text-hover-bg);
-        }
-    }
-
-    #AddChannelCtaDropdown {
-        position: fixed;
-
-        ul {
-            min-width: 232px !important;
         }
     }
 
@@ -1021,7 +1028,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
     /* Channels */
     .SidebarChannel {
         display: flex;
-        overflow: hidden;
         height: 32px;
 
         /* height required for transition animation */


### PR DESCRIPTION
#### Summary
This PR fixes a couple of issues related to the add channels cta button located at the lhs. The following points describes what was fixed:

- By clicking the button the button was being show outside of the viewport so it was giving the impression it was not working. This was caused to a css naming clash with a Menu class coming from boards after the monorepo changes.
- The above space between the lhs cta add channels and invite members was bigger than other list elements, this was also fixed in this PR.
- The lhs menu in mobile view was being shown separated from the lhs edge of the screen.

#### Ticket Link
Button not working: https://mattermost.atlassian.net/browse/MM-51804
Top space in buttons: https://mattermost.atlassian.net/browse/MM-51803
LHS not working in mobile view: I need to find the ticket

#### Screenshots
Before:
<img width="307" alt="Screenshot 2023-03-30 at 16 08 59" src="https://user-images.githubusercontent.com/10082627/228895501-ac49d73f-f045-4953-a2ad-fb6614371fd8.png">
<img width="625" alt="Screenshot 2023-03-30 at 17 41 04" src="https://user-images.githubusercontent.com/10082627/228895727-7c2d27e8-1819-4976-8e7f-e319da4d2545.png">


After:
<img width="392" alt="Screenshot 2023-03-30 at 16 09 15" src="https://user-images.githubusercontent.com/10082627/228895588-761bffb5-6d43-4bd8-be2b-a536a1e12b46.png">

<img width="1376" alt="Screenshot 2023-03-30 at 16 10 38" src="https://user-images.githubusercontent.com/10082627/228895805-43cfe3db-c500-4225-8dce-f697c908aca1.png">


<img width="684" alt="Screenshot 2023-03-30 at 17 49 52" src="https://user-images.githubusercontent.com/10082627/228895759-59b784c8-fdfa-401b-aa3f-9d67e53217dd.png">
<img width="626" alt="Screenshot 2023-03-30 at 17 50 14" src="https://user-images.githubusercontent.com/10082627/228895765-49e709c1-fe0b-4adc-a3e6-c15ef8222c95.png">



#### Release Note
```release-note
NONE
```
