### PR TITLE
make autolinked board ff false as default

### DIFF
--- a/model/feature_flags.go
+++ b/model/feature_flags.go
@@ -107,7 +107,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.ThreadsEverywhere = false
 	f.GlobalDrafts = true
 	f.WysiwygEditor = false
-	f.OnboardingAutoShowLinkedBoard = true
+	f.OnboardingAutoShowLinkedBoard = false
 	f.OnboardingTourTips = true
 }
 


### PR DESCRIPTION
#### Summary
Manual cherry-pick of the webapp side for https://github.com/mattermost/mattermost-server/pull/22714

#### Ticket Link
n/a

#### Related Pull Requests
- Monorepo: https://github.com/mattermost/mattermost-server/pull/22714
- Webapp: https://github.com/mattermost/mattermost-webapp/pull/12386

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
