### PR TITLE
open browse channels directly when user has no channel creation permissions

### DIFF
--- a/webapp/channels/src/components/sidebar/__snapshots__/add_channels_cta_button.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/__snapshots__/add_channels_cta_button.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`components/new_channel_modal should match snapshot 1`] = `
     aria-label="Add Channels Dropdown"
     className="SidebarChannelNavigator__addChannelsCtaLhsButton SidebarChannelNavigator__addChannelsCtaLhsButton--untouched"
     id="addChannelsCta"
+    onClick={[Function]}
   >
     <li
       aria-label="Add channels"
@@ -43,4 +44,24 @@ exports[`components/new_channel_modal should match snapshot 1`] = `
     </MenuGroup>
   </Menu>
 </MenuWrapper>
+`;
+
+exports[`components/new_channel_modal should match snapshot when user has only join channel permissions 1`] = `
+<button
+  aria-label="Add Channels Dropdown"
+  className="SidebarChannelNavigator__addChannelsCtaLhsButton SidebarChannelNavigator__addChannelsCtaLhsButton--untouched"
+  id="addChannelsCta"
+  onClick={[Function]}
+>
+  <li
+    aria-label="Add channels"
+  >
+    <i
+      className="icon-plus-box"
+    />
+    <span>
+      Add Channels
+    </span>
+  </li>
+</button>
 `;

--- a/webapp/channels/src/components/sidebar/add_channels_cta_button.tsx
+++ b/webapp/channels/src/components/sidebar/add_channels_cta_button.tsx
@@ -106,8 +106,28 @@ const AddChannelsCtaButton = (): JSX.Element | null => {
         );
     };
 
-    const trackOpen = (opened: boolean) => {
-        openAddChannelsCtaOpen(opened);
+    const addChannelsButton = (btnCallback?: () => void) => {
+        const handleClick = () => btnCallback?.();
+        return (
+            <button
+                className={buttonClass}
+                id={'addChannelsCta'}
+                aria-label={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.dropdownAriaLabel', defaultMessage: 'Add Channels Dropdown'})}
+                onClick={handleClick}
+            >
+                <li
+                    aria-label={intl.formatMessage({id: 'sidebar_left.sidebar_channel_navigator.addChannelsCta', defaultMessage: 'Add channels'})}
+                >
+                    <i className='icon-plus-box'/>
+                    <span>
+                        {intl.formatMessage({id: 'sidebar_left.addChannelsCta', defaultMessage: 'Add Channels'})}
+                    </span>
+                </li>
+            </button>
+        );
+    };
+
+    const storePreferencesAndTrackEvent = () => {
         trackEvent('ui', 'add_channels_cta_button_clicked');
         if (!touchedAddChannelsCtaButton) {
             dispatch(savePreferences(
@@ -122,26 +142,26 @@ const AddChannelsCtaButton = (): JSX.Element | null => {
         }
     };
 
+    const trackOpen = (opened: boolean) => {
+        openAddChannelsCtaOpen(opened);
+        storePreferencesAndTrackEvent();
+    };
+
+    if (!canCreateChannel) {
+        const browseChannelsAction = () => {
+            showMoreChannelsModal();
+            storePreferencesAndTrackEvent();
+        };
+        return addChannelsButton(browseChannelsAction);
+    }
+
     return (
         <MenuWrapper
             className='AddChannelsCtaDropdown'
             onToggle={trackOpen}
             open={isAddChannelCtaOpen}
         >
-            <button
-                className={buttonClass}
-                id={'addChannelsCta'}
-                aria-label={intl.formatMessage({id: 'sidebar_left.add_channel_dropdown.dropdownAriaLabel', defaultMessage: 'Add Channels Dropdown'})}
-            >
-                <li
-                    aria-label={intl.formatMessage({id: 'sidebar_left.sidebar_channel_navigator.addChannelsCta', defaultMessage: 'Add channels'})}
-                >
-                    <i className='icon-plus-box'/>
-                    <span>
-                        {intl.formatMessage({id: 'sidebar_left.addChannelsCta', defaultMessage: 'Add Channels'})}
-                    </span>
-                </li>
-            </button>
+            {addChannelsButton()}
             <Menu
                 id='AddChannelCtaDropdown'
                 ariaLabel={intl.formatMessage({id: 'sidebar_left.add_channel_cta_dropdown.dropdownAriaLabel', defaultMessage: 'Add Channels Dropdown'})}


### PR DESCRIPTION
#### Summary
This PR adds the necessary logic and tests to make sure that when a user has no permissions to create any kind of channel, the add channels cta button opens the browse channels modal directly once clicked

#### Ticket Link
n/a

#### Related PRs
https://github.com/mattermost/mattermost-server/pull/22743

#### Screenshots

User can not create channels:


https://user-images.githubusercontent.com/10082627/229211904-45078197-ca3a-4beb-87b8-b7bf0be87973.mov



User can create channels:


https://user-images.githubusercontent.com/10082627/229211929-1d0b5643-5dbd-49e0-a067-6f5f61fb8824.mov



#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
