### PR TITLE
MM-51870 Fix /test url and json

### DIFF
--- a/server/channels/app/slashcommands/command_loadtest.go
+++ b/server/channels/app/slashcommands/command_loadtest.go
@@ -629,7 +629,7 @@ func (*LoadTestProvider) URLCommand(a *app.App, c request.CTX, args *model.Comma
 
 	// provide a shortcut to easily access tests stored in doc/developer/tests
 	if !strings.HasPrefix(url, "http") {
-		url = "https://raw.githubusercontent.com/mattermost/mattermost-server/master/tests/" + url
+		url = "https://raw.githubusercontent.com/mattermost/mattermost-server/master/server/tests/" + url
 
 		if path.Ext(url) == "" {
 			url += ".md"
@@ -683,7 +683,7 @@ func (*LoadTestProvider) JsonCommand(a *app.App, c request.CTX, args *model.Comm
 
 	// provide a shortcut to easily access tests stored in doc/developer/tests
 	if !strings.HasPrefix(url, "http") {
-		url = "https://raw.githubusercontent.com/mattermost/mattermost-server/master/tests/" + url
+		url = "https://raw.githubusercontent.com/mattermost/mattermost-server/master/server/tests/" + url
 
 		if path.Ext(url) == "" {
 			url += ".json"


### PR DESCRIPTION
#### Summary
Fixed /test url and json by pointing to new server path

Note: @amyblais This should be cherry-picked for April 13th Cloud release.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51870

#### Release Note
```release-note
NONE
```
