### PR TITLE
Boards: Avoid panic in Boards file request handler when file not found.

### DIFF
--- a/server/boards/api/files.go
+++ b/server/boards/api/files.go
@@ -146,7 +146,7 @@ func (a *API) handleServeFile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		// if err is still not nil then it was not found via teams or workspace paths so we must
+		// if err is still not nil then it is an error other than `not found` so we must
 		// return the error to the requestor.  fileReader and Fileinfo are nil in this case.
 		a.errorResponse(w, r, err)
 	}

--- a/server/boards/api/files.go
+++ b/server/boards/api/files.go
@@ -145,6 +145,12 @@ func (a *API) handleServeFile(w http.ResponseWriter, r *http.Request) {
 		_ = a.app.MoveFile(board.ChannelID, board.TeamID, boardID, filename)
 	}
 
+	if err != nil {
+		// if err is still not nil then it was not found via teams or workspace paths so we must
+		// return the error to the requestor.  fileReader and Fileinfo are nil in this case.
+		a.errorResponse(w, r, err)
+	}
+
 	defer fileReader.Close()
 
 	mimeType := ""


### PR DESCRIPTION
#### Summary
This PR fixes a panic in the Boards Rest API for fetching files.  It panics if the `app.getFile` call returns an error other than `not found`.

The panic is caught and handled, but it is logged and thus is [reported by customers](https://community.mattermost.com/private-core/pl/pqnrooyqj3b9fcz7ktq46rkshr) as a crash.  It also returns the wrong error to the client.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51885

#### Release Note
```release-note
Fixes an innocuous panic in Boards Rest API when requesting files and a error other than `not found` is encountered.
```
