### PR TITLE
MM-51912 - fix  not able to scroll in the LHS

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_list/__snapshots__/sidebar_list.test.tsx.snap
+++ b/webapp/channels/src/components/sidebar/sidebar_list/__snapshots__/sidebar_list.test.tsx.snap
@@ -54,7 +54,6 @@ exports[`SidebarList should match snapshot 1`] = `
       renderView={[Function]}
       style={
         Object {
-          "overflow": "initial",
           "position": "absolute",
         }
       }

--- a/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_list/sidebar_list.tsx
@@ -69,7 +69,7 @@ export function renderThumbVertical(props: any) {
     );
 }
 
-const scrollbarStyles: CSSProperties = {position: 'absolute', overflow: 'initial'};
+const scrollbarStyles: CSSProperties = {position: 'absolute'};
 
 type Props = {
     currentTeam: Team;

--- a/webapp/channels/src/sass/layout/_sidebar-left.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-left.scss
@@ -578,7 +578,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
     @media screen and (min-width: 768px) {
         .SidebarNavContainer {
             .scrollbar--view {
-                overflow: initial !important;
                 max-width: 240px;
             }
         }
@@ -754,7 +753,7 @@ $sidebarOpacityAnimationDuration: 0.15s;
     }
 
     .AddChannelsCtaDropdown .dropdown-menu {
-        min-width: 232px !important;
+        min-width: 210px !important;
         margin-left: 20px;
     }
 


### PR DESCRIPTION
#### Summary
While applying a fix for the add channels cta button a regression was introduced preventing the LHS banner to scroll-y. This PR removes that regression.

Regression cause: https://github.com/mattermost/mattermost-server/pull/22743/files#diff-d0500ece0484af3ff1e13165533525a6abc038f889de5261c37660f0d946b781R581

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51912

#### Screenshots

Before:

https://user-images.githubusercontent.com/10082627/229735692-9a8986f9-b8ae-4904-80fe-88d2b9d4dc58.mov



After:

https://user-images.githubusercontent.com/10082627/229735584-7e1bc539-ceb8-4bf5-a7e3-69eeccf24163.mov




#### Release Note
```release-note
NONE
```
