### PR TITLE
MM-51915-fix no more channels to join text

### DIFF
--- a/webapp/channels/src/i18n/de.json
+++ b/webapp/channels/src/i18n/de.json
@@ -4159,7 +4159,7 @@
   "more_channels.join": "Beitreten",
   "more_channels.joining": "Beitreten...",
   "more_channels.next": "Weiter",
-  "more_channels.noMore": "Keine weiteren Kanäle, denen beigetreten werden kann",
+  "more_channels.noMore": "Keine Ergebnisse für \"{text}\"",
   "more_channels.prev": "Zurück",
   "more_channels.show_archived_channels": "Anzeigen: Archivierte Kanäle",
   "more_channels.show_public_channels": "Anzeigen: Öffentliche Kanäle",

--- a/webapp/channels/src/i18n/de.json
+++ b/webapp/channels/src/i18n/de.json
@@ -4159,7 +4159,7 @@
   "more_channels.join": "Beitreten",
   "more_channels.joining": "Beitreten...",
   "more_channels.next": "Weiter",
-  "more_channels.noMore": "Keine Ergebnisse für \"{text}\"",
+  "more_channels.noMore": "Keine weiteren Kanäle, denen beigetreten werden kann",
   "more_channels.prev": "Zurück",
   "more_channels.show_archived_channels": "Anzeigen: Archivierte Kanäle",
   "more_channels.show_public_channels": "Anzeigen: Öffentliche Kanäle",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4167,7 +4167,7 @@
   "more_channels.join": "Join",
   "more_channels.joining": "Joining...",
   "more_channels.next": "Next",
-  "more_channels.noMore": "No results for \"{text}\"",
+  "more_channels.noMore": "No more channels to join",
   "more_channels.prev": "Previous",
   "more_channels.show_archived_channels": "Channel Type: Archived",
   "more_channels.show_public_channels": "Channel Type: Public",


### PR DESCRIPTION
#### Summary
when opening the browse channels modal there is an issue with English and German translations for the text "No more channels to join".

Original regression: https://github.com/mattermost/mattermost-webapp/pull/11262/files#diff-1a490f08504158838befaa816ee8d5c08dff9e694d5a568ce4b0a4398dcc563eR4170

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51915

#### Screenshots
Before:
<img width="850" alt="Screenshot 2023-04-04 at 14 06 25" src="https://user-images.githubusercontent.com/10082627/229786364-39d2769a-6fb9-4502-b681-d047c6344210.png">



After:
<img width="1228" alt="Screenshot 2023-04-04 at 14 01 33" src="https://user-images.githubusercontent.com/10082627/229785473-0bd9b6d1-d4ff-4d3c-a402-11bf12b94333.png">


#### Release Note
```release-note
NONE
```
