### PR TITLE
[MM-26398] Remove deprecated model.CommandArgs.Session

### DIFF
--- a/model/command_args.go
+++ b/model/command_args.go
@@ -19,9 +19,6 @@ type CommandArgs struct {
 	T               i18n.TranslateFunc `json:"-"`
 	UserMentions    UserMentionMap     `json:"-"`
 	ChannelMentions ChannelMentionMap  `json:"-"`
-
-	// DO NOT USE Session field is deprecated. MM-26398
-	Session Session `json:"-"`
 }
 
 func (o *CommandArgs) Auditable() map[string]interface{} {

--- a/server/channels/api4/command.go
+++ b/server/channels/api4/command.go
@@ -353,7 +353,6 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	commandArgs.UserId = c.AppContext.Session().UserId
 	commandArgs.T = c.AppContext.T
 	commandArgs.SiteURL = c.GetSiteURLHeader()
-	commandArgs.Session = *c.AppContext.Session()
 
 	response, err := c.App.ExecuteCommand(c.AppContext, &commandArgs)
 	if err != nil {
@@ -424,7 +423,6 @@ func listCommandAutocompleteSuggestions(c *Context, w http.ResponseWriter, r *ht
 		RootId:    query.Get("root_id"),
 		UserId:    c.AppContext.Session().UserId,
 		T:         c.AppContext.T,
-		Session:   *c.AppContext.Session(),
 		SiteURL:   c.GetSiteURLHeader(),
 		Command:   userInput,
 	}


### PR DESCRIPTION
#### Summary
This PR removes the session from `model.CommandArgs`. Plugins should use the RPC API directly to modify the server state or create custom session using the same API.

For more context, please see https://github.com/mattermost/mattermost-server/pull/14880#discussion_r443693131.

To my knowledge, no plugin uses this field.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-26398

#### Release Note
```release-note
Remove the deprecated model.CommandArgs.Session 
```
