### PR TITLE
MM-51911 - The Delete Workspace Button Opens the Modal in a New Tab

### DIFF
--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_cta.tsx
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_cta.tsx
@@ -80,17 +80,15 @@ export default function DeleteWorkspaceCTA() {
                         }}
                     />
                 </div>
-                <ExternalLink
-                    href=''
-                    location='delete_workspace_cta'
-                    className='cancelSubscriptionSection__contactUs'
+                <button
+                    className='btn cancelSubscriptionSection__contactUs'
                     onClick={handleOnClickDelete}
                 >
                     <FormattedMessage
                         id='admin.billing.subscription.deleteWorkspaceSection.delete'
                         defaultMessage='Delete Workspace'
                     />
-                </ExternalLink>
+                </button>
             </div>
         </div>
     );

--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_cta.tsx
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_cta.tsx
@@ -15,8 +15,6 @@ import {isCloudLicense} from 'utils/license_utils';
 
 import {getCloudSubscription, getSubscriptionProduct} from 'mattermost-redux/selectors/entities/cloud';
 
-import ExternalLink from 'components/external_link';
-
 import DeleteWorkspaceModal from './delete_workspace_modal';
 
 export default function DeleteWorkspaceCTA() {


### PR DESCRIPTION
#### Summary

Clicking the `Delete Worksapce` CTA opens a new tab, where the delete workspace modal is then opened.
The modal should open on the same tab.

#### Ticket Link

[MM-51911](https://mattermost.atlassian.net/browse/MM-51911)

#### Test Plan

Ensure you have a license for a workspace with the following conditions:
- Is subscribed to a cloud product
- Is on a free trial **OR**
- Is on a starter subscription **OR**
- Is on a monthly professional subscription

For clarity, these subscriptions may be deleted:
- Cloud-Starter.
- Cloud-Professional (monthly).
- Enterprise Free Trial.

1. Log in as an admin user
2. Go to the system console, and navigate to the `Billing > Subscription` page
3. Scroll to the bottom of the page and click the `Delete Workspace` button.
4. Notice the `Delete Workspace` modal opens in the same page, and that a new tab is not opened.

https://user-images.githubusercontent.com/116016004/229844499-60f3c44d-a7e3-4473-8943-98c01ed14194.mov

#### Release Note

```release-note
NONE
```


[MM-51911]: https://mattermost.atlassian.net/browse/MM-51911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ