### PR TITLE
fix various copy/paste/typos

### DIFF
--- a/model/license.go
+++ b/model/license.go
@@ -442,7 +442,7 @@ func (lr *LicenseRecord) IsValid() *AppError {
 	}
 
 	if lr.Bytes == "" || len(lr.Bytes) > 10000 {
-		return NewAppError("LicenseRecord.IsValid", "model.license_record.is_valid.create_at.app_error", nil, "", http.StatusBadRequest)
+		return NewAppError("LicenseRecord.IsValid", "model.license_record.is_valid.bytes.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -120,7 +120,7 @@ func TestUploadLicenseFile(t *testing.T) {
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	})
 
-	t.Run("try to get gone through trial, with TE build", func(t *testing.T) {
+	t.Run("try to get one through trial, with TE build", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ExperimentalSettings.RestrictSystemAdmin = false })
 		th.App.Srv().Platform().SetLicenseManager(nil)
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9232,6 +9232,10 @@
     "translation": "Invalid job type."
   },
   {
+    "id": "model.license_record.is_valid.bytes.app_error",
+    "translation": "Invalid value for bytes when uploading a license."
+  },
+  {
     "id": "model.license_record.is_valid.create_at.app_error",
     "translation": "Invalid value for create_at when uploading a license."
   },


### PR DESCRIPTION
#### Summary
Fix two small issues, one of which made debugging a unit test failure harder due to the wrong copy/pasted error message.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
