### PR TITLE
MM-50577 Replaced makeCreateAriaLabelForPost with better memoized usePostAriaLabel

### DIFF
--- a/webapp/channels/src/components/post_view/post_aria_label_div.tsx
+++ b/webapp/channels/src/components/post_view/post_aria_label_div.tsx
@@ -1,36 +1,24 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useRef} from 'react';
-import {useSelector} from 'react-redux';
-import {useIntl} from 'react-intl';
+import React from 'react';
 
 import {Post} from '@mattermost/types/posts';
 
-import {GlobalState} from 'types/store';
-
-import {makeCreateAriaLabelForPost} from 'utils/post_utils';
+import {usePostAriaLabel} from 'utils/post_utils';
 
 export type Props = React.HTMLProps<HTMLDivElement> & {
-    labelPrefix?: string;
     post: Post;
 }
 
 const PostAriaLabelDiv = React.forwardRef((props: Props, ref: React.Ref<HTMLDivElement>) => {
     const {
         children,
-        labelPrefix,
         post,
         ...otherProps
     } = props;
 
-    const intl = useIntl();
-
-    const createAriaLabelForPost = useRef(makeCreateAriaLabelForPost());
-    let ariaLabel = useSelector<GlobalState, string>((state) => createAriaLabelForPost.current(state, post)(intl));
-    if (labelPrefix) {
-        ariaLabel = labelPrefix + ariaLabel;
-    }
+    const ariaLabel = usePostAriaLabel(post);
 
     return (
         <div

--- a/webapp/channels/src/components/post_view/post_list_virtualized/latest_post_reader.test.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/latest_post_reader.test.tsx
@@ -77,4 +77,18 @@ describe('LatestPostReader', () => {
         expect(span.prop('children')).toContain(author.username);
         expect(span.prop('children')).toContain('enero');
     });
+
+    test('should be able to handle an empty post array', () => {
+        const {mountOptions} = mockStore(baseState);
+
+        const props = {
+            ...baseProps,
+            postIds: [],
+        };
+
+        const wrapper = mount(<LatestPostReader {...props}/>, mountOptions);
+        const span = wrapper.childAt(0);
+
+        expect(span.prop('children')).toEqual('');
+    });
 });

--- a/webapp/channels/src/components/post_view/post_list_virtualized/latest_post_reader.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/latest_post_reader.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useMemo, useRef} from 'react';
-import {useIntl} from 'react-intl';
+import React, {useMemo} from 'react';
 import {useSelector} from 'react-redux';
 
 import {getPost} from 'mattermost-redux/selectors/entities/posts';
@@ -11,27 +10,18 @@ import {Post} from '@mattermost/types/posts';
 
 import {GlobalState} from 'types/store';
 
-import {getLatestPostId, makeCreateAriaLabelForPost} from 'utils/post_utils';
+import {getLatestPostId, usePostAriaLabel} from 'utils/post_utils';
 
 interface Props {
     postIds?: string[];
 }
 
 const LatestPostReader = (props: Props): JSX.Element => {
-    const intl = useIntl();
-
     const {postIds} = props;
     const latestPostId = useMemo(() => getLatestPostId(postIds || []), [postIds]);
     const latestPost = useSelector<GlobalState, Post>((state) => getPost(state, latestPostId));
 
-    const createAriaLabelForPost = useRef(makeCreateAriaLabelForPost());
-    const ariaLabel = useSelector<GlobalState, string>((state) => {
-        if (!latestPost) {
-            return '';
-        }
-
-        return createAriaLabelForPost.current(state, latestPost)(intl);
-    });
+    const ariaLabel = usePostAriaLabel(latestPost);
 
     return (
         <span

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -71,13 +71,13 @@ export function getReactionsForPosts(state: GlobalState): RelationOneToOne<Post,
 
 export function makeGetReactionsForPost(): (state: GlobalState, postId: Post['id']) => {
     [x: string]: Reaction;
-} | undefined | null {
+} | undefined {
     return createSelector('makeGetReactionsForPost', getReactionsForPosts, (state: GlobalState, postId: string) => postId, (reactions, postId) => {
         if (reactions[postId]) {
             return reactions[postId];
         }
 
-        return null;
+        return undefined;
     });
 }
 


### PR DESCRIPTION
#### Summary
Ported from https://github.com/mattermost/mattermost-webapp/pull/12233

`makeCreateAriaLabelForPost` is a bit weird because the value we're trying to calculate uses a bunch of data from a redux context and then it needs access to the `intl` object which is only available in the React context. It works okay, but the big problem that it has is that it wasn't memoized fully because it needed the `intl` object. This changes it to be memoized and also converts it into a hook so that I could use `useMemo` instead of our custom memoization stuff.

#### Ticket Link
MM-50577

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/12233

#### Release Note
```release-note
Improved performance of code used for post list screen reader support
```
