### PR TITLE
bind to localhost:0 for tests

### DIFF
--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -177,7 +177,7 @@ func setupTestHelper(dbStore store.Store, searchEngine *searchengine.Broker, ent
 		*cfg.PasswordSettings.Symbol = false
 		*cfg.PasswordSettings.Number = false
 
-		*cfg.ServiceSettings.ListenAddress = ":0"
+		*cfg.ServiceSettings.ListenAddress = "localhost:0"
 	})
 	if err := th.Server.Start(); err != nil {
 		panic(err)

--- a/server/channels/app/app_test.go
+++ b/server/channels/app/app_test.go
@@ -22,7 +22,7 @@ func TestAppRace(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		a, err := New()
 		require.NoError(t, err)
-		a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })
+		a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = "localhost:0" })
 		serverErr := a.StartServer()
 		require.NoError(t, serverErr)
 		a.Srv().Shutdown()

--- a/server/channels/app/helper_test.go
+++ b/server/channels/app/helper_test.go
@@ -102,7 +102,7 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.MaxUsersPerTeam = 50 })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.RateLimitSettings.Enable = false })
 	prevListenAddress := *th.App.Config().ServiceSettings.ListenAddress
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = "localhost:0" })
 	serverErr := th.Server.Start()
 	if serverErr != nil {
 		panic(serverErr)

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -143,8 +143,8 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 	*memoryConfig.AnnouncementSettings.AdminNoticesEnabled = false
 	*memoryConfig.AnnouncementSettings.UserNoticesEnabled = false
 	*memoryConfig.MetricsSettings.Enable = true
-	*memoryConfig.ServiceSettings.ListenAddress = ":0"
-	*memoryConfig.MetricsSettings.ListenAddress = ":0"
+	*memoryConfig.ServiceSettings.ListenAddress = "localhost:0"
+	*memoryConfig.MetricsSettings.ListenAddress = "localhost:0"
 	configStore.Set(memoryConfig)
 
 	ps, err := New(ServiceConfig{

--- a/server/channels/app/platform/service_test.go
+++ b/server/channels/app/platform/service_test.go
@@ -112,7 +112,7 @@ func TestMetrics(t *testing.T) {
 
 		require.NotNil(t, th.Service.metrics)
 		metricsAddr := strings.Replace(th.Service.metrics.listenAddr, "[::]", "http://localhost", 1)
-		metricsAddr = strings.Replace(th.Service.metrics.listenAddr, "127.0.0.1", "http://localhost", 1)
+		metricsAddr = strings.Replace(metricsAddr, "127.0.0.1", "http://localhost", 1)
 
 		resp, err := http.Get(metricsAddr)
 		require.NoError(t, err)

--- a/server/channels/app/platform/service_test.go
+++ b/server/channels/app/platform/service_test.go
@@ -112,6 +112,7 @@ func TestMetrics(t *testing.T) {
 
 		require.NotNil(t, th.Service.metrics)
 		metricsAddr := strings.Replace(th.Service.metrics.listenAddr, "[::]", "http://localhost", 1)
+		metricsAddr = strings.Replace(th.Service.metrics.listenAddr, "127.0.0.1", "http://localhost", 1)
 
 		resp, err := http.Get(metricsAddr)
 		require.NoError(t, err)

--- a/server/channels/app/server_test.go
+++ b/server/channels/app/server_test.go
@@ -47,7 +47,7 @@ func newServerWithConfig(t *testing.T, f func(cfg *model.Config)) (*Server, erro
 
 func TestStartServerSuccess(t *testing.T) {
 	s, err := newServerWithConfig(t, func(cfg *model.Config) {
-		*cfg.ServiceSettings.ListenAddress = ":0"
+		*cfg.ServiceSettings.ListenAddress = "localhost:0"
 	})
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestStartServerPortUnavailable(t *testing.T) {
 	require.NoError(t, err)
 
 	// Listen on the next available port
-	listener, err := net.Listen("tcp", ":0")
+	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 
 	// Attempt to listen on the port used above.
@@ -104,7 +104,7 @@ func TestStartServerNoS3Bucket(t *testing.T) {
 		AmazonS3PathPrefix:      model.NewString(""),
 		AmazonS3SSL:             model.NewBool(false),
 	}
-	*cfg.ServiceSettings.ListenAddress = ":0"
+	*cfg.ServiceSettings.ListenAddress = "localhost:0"
 	_, _, err := store.Set(cfg)
 	require.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestStartServerTLSSuccess(t *testing.T) {
 	s, err := newServerWithConfig(t, func(cfg *model.Config) {
 		testDir, _ := fileutils.FindDir("tests")
 
-		*cfg.ServiceSettings.ListenAddress = ":0"
+		*cfg.ServiceSettings.ListenAddress = "localhost:0"
 		*cfg.ServiceSettings.ConnectionSecurity = "TLS"
 		*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
 		*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
@@ -185,7 +185,7 @@ func TestStartServerTLSVersion(t *testing.T) {
 	cfg := store.Get()
 	testDir, _ := fileutils.FindDir("tests")
 
-	*cfg.ServiceSettings.ListenAddress = ":0"
+	*cfg.ServiceSettings.ListenAddress = "localhost:0"
 	*cfg.ServiceSettings.ConnectionSecurity = "TLS"
 	*cfg.ServiceSettings.TLSMinVer = "1.2"
 	*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
@@ -229,7 +229,7 @@ func TestStartServerTLSOverwriteCipher(t *testing.T) {
 	s, err := newServerWithConfig(t, func(cfg *model.Config) {
 		testDir, _ := fileutils.FindDir("tests")
 
-		*cfg.ServiceSettings.ListenAddress = ":0"
+		*cfg.ServiceSettings.ListenAddress = "localhost:0"
 		*cfg.ServiceSettings.ConnectionSecurity = "TLS"
 		cfg.ServiceSettings.TLSOverwriteCiphers = []string{
 			"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
@@ -328,7 +328,7 @@ func TestPanicLog(t *testing.T) {
 
 	testDir, _ := fileutils.FindDir("tests")
 	s.platform.UpdateConfig(func(cfg *model.Config) {
-		*cfg.ServiceSettings.ListenAddress = ":0"
+		*cfg.ServiceSettings.ListenAddress = "localhost:0"
 		*cfg.ServiceSettings.ConnectionSecurity = "TLS"
 		*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
 		*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")
@@ -404,7 +404,7 @@ func TestSentry(t *testing.T) {
 		SentryDSN = dsn.String()
 
 		s, err := newServerWithConfig(t, func(cfg *model.Config) {
-			*cfg.ServiceSettings.ListenAddress = ":0"
+			*cfg.ServiceSettings.ListenAddress = "localhost:0"
 			*cfg.LogSettings.EnableSentry = false
 			*cfg.ServiceSettings.ConnectionSecurity = "TLS"
 			*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
@@ -448,7 +448,7 @@ func TestSentry(t *testing.T) {
 		SentryDSN = dsn.String()
 
 		s, err := newServerWithConfig(t, func(cfg *model.Config) {
-			*cfg.ServiceSettings.ListenAddress = ":0"
+			*cfg.ServiceSettings.ListenAddress = "localhost:0"
 			*cfg.ServiceSettings.ConnectionSecurity = "TLS"
 			*cfg.ServiceSettings.TLSKeyFile = path.Join(testDir, "tls_test_key.pem")
 			*cfg.ServiceSettings.TLSCertFile = path.Join(testDir, "tls_test_cert.pem")

--- a/server/channels/app/slashcommands/helper_test.go
+++ b/server/channels/app/slashcommands/helper_test.go
@@ -93,7 +93,7 @@ func setupTestHelper(dbStore store.Store, enterprise bool, includeCacheLayer boo
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.TeamSettings.MaxUsersPerTeam = 50 })
 	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.RateLimitSettings.Enable = false })
 	prevListenAddress := *th.App.Config().ServiceSettings.ListenAddress
-	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = "localhost:0" })
 	serverErr := th.Server.Start()
 	if serverErr != nil {
 		panic(serverErr)

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -107,7 +107,7 @@ func setupTestHelper(tb testing.TB, includeCacheLayer bool) *TestHelper {
 
 	a := app.New(app.ServerConnector(s.Channels()))
 	prevListenAddress := *s.Config().ServiceSettings.ListenAddress
-	a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = ":0" })
+	a.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.ListenAddress = "localhost:0" })
 	serverErr := s.Start()
 	if serverErr != nil {
 		panic(serverErr)

--- a/server/cmd/mattermost/commands/server_test.go
+++ b/server/cmd/mattermost/commands/server_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	unitTestListeningPort = ":0"
+	unitTestListeningPort = "localhost:0"
 )
 
 //nolint:golint,unused

--- a/server/playbooks/server/main_test.go
+++ b/server/playbooks/server/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -218,7 +219,7 @@ func (e *TestEnvironment) CreateClients() {
 	require.Nil(e.T, appErr)
 	e.RegularUserNotInTeam = notInTeam
 
-	siteURL := "http://localhost:9056"
+	siteURL := fmt.Sprintf("http://localhost:%v", e.A.Srv().ListenAddr.Port)
 
 	serverAdminClient := model.NewAPIv4Client(siteURL)
 	_, _, err := serverAdminClient.Login(admin.Email, userPassword)

--- a/server/playbooks/server/main_test.go
+++ b/server/playbooks/server/main_test.go
@@ -117,7 +117,7 @@ func Setup(t *testing.T) *TestEnvironment {
 	config := configStore.Get()
 	// Force plugins to be disabled since we are in product mode
 	config.PluginSettings.Enable = model.NewBool(false)
-	config.ServiceSettings.ListenAddress = model.NewString("localhost:9056")
+	config.ServiceSettings.ListenAddress = model.NewString("localhost:0")
 	config.TeamSettings.MaxUsersPerTeam = model.NewInt(10000)
 	config.LocalizationSettings.SetDefaults()
 	config.SqlSettings = *sqlSettings


### PR DESCRIPTION
#### Summary
When running unit tests, explicitly bind to `localhost:0` instead of just `:0` to avoid binding to all available interfaces and in turn avoid triggering firewall warnings on MacOS:

<img width="578" alt="image" src="https://user-images.githubusercontent.com/1023171/230111956-fb0a2376-7503-42c8-863f-b9478da903ab.png">

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
