### PR TITLE
MM-51963 Fix how Webpack embeds i18n files in JS bundle

### DIFF
--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -80,7 +80,7 @@ var config = {
                 type: 'javascript/auto',
                 test: /\.json$/,
                 include: [
-                    path.resolve(__dirname, 'i18n'),
+                    path.resolve(__dirname, 'src/i18n'),
                 ],
                 exclude: [/en\.json$/],
                 use: [


### PR DESCRIPTION
#### Summary
The `include` line that I changed has been incorrect since we added the `src` folder as part of the monorepo migration. That caused Webpack to embed the translation files into the main JS bundle when they should be passed through the file-loader so that just a URL to the file is embedded into the main JS bundle.

The result of that change was that the i18n code was getting a JS object when importing from a translation file instead of the URL of that file which can be fetched separately

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51963

#### Release Note
```release-note
NONE
```
