### PR TITLE
MM-51970 - remove leftover css style causing double vertical scroll on lhs

### DIFF
--- a/webapp/channels/src/sass/layout/_sidebar-left.scss
+++ b/webapp/channels/src/sass/layout/_sidebar-left.scss
@@ -575,18 +575,6 @@ $sidebarOpacityAnimationDuration: 0.15s;
         }
     }
 
-    @media screen and (min-width: 768px) {
-        .SidebarNavContainer {
-            .scrollbar--view {
-                max-width: 240px;
-            }
-        }
-
-        #SidebarContainer .SidebarChannelGroup .SidebarChannelGroupHeader {
-            max-width: 240px;
-        }
-    }
-
     .SidebarCategory_newLabel {
         display: flex;
         width: 32px;
@@ -1027,6 +1015,7 @@ $sidebarOpacityAnimationDuration: 0.15s;
     /* Channels */
     .SidebarChannel {
         display: flex;
+        overflow: hidden;
         height: 32px;
 
         /* height required for transition animation */


### PR DESCRIPTION
#### Summary
This PR removes a leftover css style causing double vertical scroll on lhs.

Original PR that added the regression https://github.com/mattermost/mattermost-server/pull/22743/files#diff-d0500ece0484af3ff1e13165533525a6abc038f889de5261c37660f0d946b781L1024

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51970

#### Screenshots
Before:

https://user-images.githubusercontent.com/10082627/230389489-e9d08855-06ce-48f5-a1b2-446773fd87da.mov



After:


https://user-images.githubusercontent.com/10082627/230389562-21c93185-2cec-4cc1-8a7b-598bb3b812c0.mov



#### Release Note
```release-note
NONE
```
