### PR TITLE
Added missing types

### DIFF
--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -261,6 +261,8 @@ export type DataRetentionPolicy = {
     file_deletion_enabled: boolean;
     message_retention_cutoff: number;
     file_retention_cutoff: number;
+    boards_retention_cutoff: number;
+    boards_deletion_enabled: boolean;
 };
 
 export type ServiceSettings = {


### PR DESCRIPTION
#### Summary
API response for data retention was missing the boards components.

```
GET http://localhost:8065/api/v4/data_retention/policy
```

```json
{
    "message_deletion_enabled": true,
    "file_deletion_enabled": true,
    "boards_deletion_enabled": false,
    "message_retention_cutoff": 1649217600000,
    "file_retention_cutoff": 1649217600000,
    "boards_retention_cutoff": 0
}
```

#### Release Note

```release-note
NONE
```
