### PR TITLE
Deprecate Toolkit CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
-/plugin/ @mattermost/integrations
 /.github/workflows/channels-ci.yml @mattermost/web-platform
 /webapp/package.json @mattermost/web-platform
 /webapp/channels/package.json @mattermost/web-platform

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
+/plugin/ @mattermost/integrations
 /.github/workflows/channels-ci.yml @mattermost/web-platform
 /webapp/package.json @mattermost/web-platform
 /webapp/channels/package.json @mattermost/web-platform

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,3 @@
-/plugin/ @mattermost/toolkit
-
 /.github/workflows/channels-ci.yml @mattermost/web-platform
 /webapp/package.json @mattermost/web-platform
 /webapp/channels/package.json @mattermost/web-platform


### PR DESCRIPTION
#### Summary
Proposing we deprecate Toolkit's ownership of `/plugin` via CODEOWNERS.

#### Ticket Link
None.

#### Screenshots
```release-note
NONE
```
