### PR TITLE
MM-51907 - Route True-Up Review Telemetry to CWS

### DIFF
--- a/model/client4.go
+++ b/model/client4.go
@@ -8803,3 +8803,17 @@ func (c *Client4) GetWorkTemplatesByCategory(category string) ([]*WorkTemplate, 
 	err = json.NewDecoder(r.Body).Decode(&templates)
 	return templates, BuildResponse(r), err
 }
+
+func (c *Client4) SubmitTrueUpReview(req map[string]any) (*Response, error) {
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return nil, NewAppError("SubmitTrueUpReview", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	r, err := c.DoAPIPostBytes(c.licenseRoute()+"/review", reqBytes)
+	if err != nil {
+		return BuildResponse(r), nil
+	}
+	defer closeBody(r)
+
+	return BuildResponse(r), nil
+}

--- a/plugin/api_timer_layer_generated.go
+++ b/plugin/api_timer_layer_generated.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 	timePkg "time"
 
-	"github.com/mattermost/mattermost-server/v6/server/channels/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/server/channels/einterfaces"
 )
 
 type apiTimerLayer struct {

--- a/plugin/hooks_timer_layer_generated.go
+++ b/plugin/hooks_timer_layer_generated.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 	timePkg "time"
 
-	"github.com/mattermost/mattermost-server/v6/server/channels/einterfaces"
 	"github.com/mattermost/mattermost-server/v6/model"
+	"github.com/mattermost/mattermost-server/v6/server/channels/einterfaces"
 )
 
 type hooksTimerLayer struct {

--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -359,7 +359,11 @@ func requestTrueUpReview(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.App.Srv().GetTelemetryService().SendTelemetry(model.TrueUpReviewTelemetryName, profileMap)
 	} else {
 		// Telemetry is disabled, submit true up review profile via CWS.
-		c.App.Cloud().SubmitTrueUpReview(profileMap)
+		err := c.App.Cloud().SubmitTrueUpReview(c.AppContext.Session().UserId, profileMap)
+		if err != nil {
+			c.SetJSONEncodingError(err)
+			return
+		}
 	}
 
 	// Update the review status to reflect the completion.

--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -351,19 +351,12 @@ func requestTrueUpReview(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Do not send true-up review data if the user has already requested one for the quarter.
-	// And only send a true-up review via as a one-time telemetry request if telemetry is disabled.
-	telemetryEnabled := c.App.Config().LogSettings.EnableDiagnostics
-	if telemetryEnabled != nil && *telemetryEnabled {
-		// Send telemetry data
-		c.App.Srv().GetTelemetryService().SendTelemetry(model.TrueUpReviewTelemetryName, profileMap)
-	} else {
-		// Telemetry is disabled, submit true up review profile via CWS.
-		err := c.App.Cloud().SubmitTrueUpReview(c.AppContext.Session().UserId, profileMap)
-		if err != nil {
-			c.SetJSONEncodingError(err)
-			return
-		}
+	// True-up is only enabled when telemetry is disabled. When telemetry is enabled, we already have all the data necessary
+	// for true-up reviews to be completed.
+	err = c.App.Cloud().SubmitTrueUpReview(c.AppContext.Session().UserId, profileMap)
+	if err != nil {
+		c.SetJSONEncodingError(err)
+		return
 	}
 
 	// Update the review status to reflect the completion.

--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -370,6 +370,7 @@ func requestTrueUpReview(c *Context, w http.ResponseWriter, r *http.Request) {
 	}{Content: encodedData}
 	response, _ := json.Marshal(responseContent)
 
+	w.WriteHeader(http.StatusOK)
 	w.Write(response)
 }
 

--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -351,12 +351,15 @@ func requestTrueUpReview(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// True-up is only enabled when telemetry is disabled. When telemetry is enabled, we already have all the data necessary
-	// for true-up reviews to be completed.
-	err = c.App.Cloud().SubmitTrueUpReview(c.AppContext.Session().UserId, profileMap)
-	if err != nil {
-		c.Err = model.NewAppError("requestTrueUpReview", "api.license.true_up_review.failed_to_submit", nil, err.Error(), http.StatusInternalServerError)
-		return
+	// True-up is only enabled when telemetry is disabled.
+	// When telemetry is enabled, we already have all the data necessary for true-up reviews to be completed.
+	telemetryEnabled := c.App.Config().LogSettings.EnableDiagnostics
+	if telemetryEnabled != nil && !*telemetryEnabled {
+		err = c.App.Cloud().SubmitTrueUpReview(c.AppContext.Session().UserId, profileMap)
+		if err != nil {
+			c.Err = model.NewAppError("requestTrueUpReview", "api.license.true_up_review.failed_to_submit", nil, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Update the review status to reflect the completion.

--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -355,7 +355,7 @@ func requestTrueUpReview(c *Context, w http.ResponseWriter, r *http.Request) {
 	// for true-up reviews to be completed.
 	err = c.App.Cloud().SubmitTrueUpReview(c.AppContext.Session().UserId, profileMap)
 	if err != nil {
-		c.SetJSONEncodingError(err)
+		c.Err = model.NewAppError("requestTrueUpReview", "api.license.true_up_review.failed_to_submit", nil, err.Error(), http.StatusInternalServerError)
 		return
 	}
 

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -521,6 +521,14 @@ func TestTrueUpReviewStatus(t *testing.T) {
 	th.App.Srv().SetLicense(model.NewTestLicense())
 
 	t.Run("returns 200 when status retrieved", func(t *testing.T) {
+		cloud := mocks.CloudInterface{}
+
+		cloudImpl := th.App.Srv().Cloud
+		defer func() {
+			th.App.Srv().Cloud = cloudImpl
+		}()
+		th.App.Srv().Cloud = &cloud
+
 		resp, err := th.SystemAdminClient.DoAPIGet("/license/review/status", "")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/server/channels/api4/license_test.go
+++ b/server/channels/api4/license_test.go
@@ -478,12 +478,11 @@ func TestRequestRenewalLink(t *testing.T) {
 }
 
 func TestRequestTrueUpReview(t *testing.T) {
-	th := Setup(t)
-	defer th.TearDown()
-
-	th.App.Srv().SetLicense(model.NewTestLicense())
-
 	t.Run("returns status 200 when telemetry data sent", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+		th.App.Srv().SetLicense(model.NewTestLicense())
+
 		th.Client.Login(th.SystemAdminUser.Email, th.SystemAdminUser.Password)
 
 		cloud := mocks.CloudInterface{}
@@ -502,6 +501,10 @@ func TestRequestTrueUpReview(t *testing.T) {
 	})
 
 	t.Run("returns 501 when ran by cloud user", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+		th.App.Srv().SetLicense(model.NewTestLicense())
+
 		th.App.Srv().SetLicense(model.NewTestLicense("cloud"))
 
 		resp, err := th.SystemAdminClient.DoAPIPost("/license/review", "")
@@ -512,12 +515,19 @@ func TestRequestTrueUpReview(t *testing.T) {
 	})
 
 	t.Run("returns 403 when user does not have permissions", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+		th.App.Srv().SetLicense(model.NewTestLicense())
+
 		resp, err := th.Client.DoAPIPost("/license/review", "")
 		require.Error(t, err)
 		require.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
 
 	t.Run("returns 400 when license is nil", func(t *testing.T) {
+		th := Setup(t).InitBasic()
+		defer th.TearDown()
+
 		th.App.Srv().SetLicense(nil)
 
 		resp, err := th.SystemAdminClient.DoAPIPost("/license/review", "")

--- a/server/channels/einterfaces/cloud.go
+++ b/server/channels/einterfaces/cloud.go
@@ -50,5 +50,5 @@ type CloudInterface interface {
 	SubscribeToNewsletter(userID string, req *model.SubscribeNewsletterRequest) error
 
 	// Used only for when a customer has telemetry disabled. In this scenario, true up review telemetry will be submitted via CWS.
-	SubmitTrueUpReview(trueUpReviewProfile map[string]any) error
+	SubmitTrueUpReview(userID string, trueUpReviewProfile map[string]any) error
 }

--- a/server/channels/einterfaces/cloud.go
+++ b/server/channels/einterfaces/cloud.go
@@ -48,4 +48,7 @@ type CloudInterface interface {
 
 	SelfServeDeleteWorkspace(userID string, deletionRequest *model.WorkspaceDeletionRequest) error
 	SubscribeToNewsletter(userID string, req *model.SubscribeNewsletterRequest) error
+
+	// Used only for when a customer has telemetry disabled. In this scenario, true up review telemetry will be submitted via CWS.
+	SubmitTrueUpReview(trueUpReviewProfile map[string]any) error
 }

--- a/server/channels/einterfaces/mocks/CloudInterface.go
+++ b/server/channels/einterfaces/mocks/CloudInterface.go
@@ -594,6 +594,20 @@ func (_m *CloudInterface) SelfServeDeleteWorkspace(userID string, deletionReques
 	return r0
 }
 
+// SubmitTrueUpReview provides a mock function with given fields: userID, trueUpReviewProfile
+func (_m *CloudInterface) SubmitTrueUpReview(userID string, trueUpReviewProfile map[string]interface{}) error {
+	ret := _m.Called(userID, trueUpReviewProfile)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, map[string]interface{}) error); ok {
+		r0 = rf(userID, trueUpReviewProfile)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SubscribeToNewsletter provides a mock function with given fields: userID, req
 func (_m *CloudInterface) SubscribeToNewsletter(userID string, req *model.SubscribeNewsletterRequest) error {
 	ret := _m.Called(userID, req)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -2090,6 +2090,10 @@
     "translation": "Could not create true up status record"
   },
   {
+    "id": "api.license.true_up_review.failed_to_submit",
+    "translation": "Failed to submit true up review profile to CWS."
+  },
+  {
     "id": "api.license.true_up_review.get_status_error",
     "translation": "Could not get true up status records"
   },

--- a/webapp/channels/src/components/analytics/true_up_review.tsx
+++ b/webapp/channels/src/components/analytics/true_up_review.tsx
@@ -223,10 +223,6 @@ const TrueUpReview: React.FC = () => {
         return null;
     }
 
-    if (telemetryEnabled) {
-        return null;
-    }
-
     pageVisited(TELEMETRY_CATEGORIES.TRUE_UP_REVIEW, 'pageview_true_up_review');
 
     return (

--- a/webapp/channels/src/components/analytics/true_up_review.tsx
+++ b/webapp/channels/src/components/analytics/true_up_review.tsx
@@ -223,6 +223,10 @@ const TrueUpReview: React.FC = () => {
         return null;
     }
 
+    if (telemetryEnabled) {
+        return null;
+    }
+
     pageVisited(TELEMETRY_CATEGORIES.TRUE_UP_REVIEW, 'pageview_true_up_review');
 
     return (


### PR DESCRIPTION
#### Summary

Adds alternative route for true up review submission via CWS in the case that telemetry is disabled on the server.

#### Ticket Link

[MM-51907](https://mattermost.atlassian.net/browse/MM-51907)

#### Test Plan

1. Ensure telemetry is ***DISABLED***.
2. Go to either `System Console > Site Statistics` or `System Console > Team Statistics`
3. Submit the true-up review by clicking the button in the true-up review panel.

To see the true-up review panels outside of true-up season, you should be able to modify records in the table `trueupreviewhistory` within Mattermost's database to a date within the next few days.

#### Related PRs

[CWS](https://github.com/mattermost/customer-web-server/pull/1163)
[Enterprise](https://github.com/mattermost/enterprise/pull/1417)

#### Release Note

```release-note
NONE
```


[MM-51907]: https://mattermost.atlassian.net/browse/MM-51907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ