### PR TITLE
Do not shutdown DB handle from boards product

### DIFF
--- a/server/boards/integrationtests/clienttestlib.go
+++ b/server/boards/integrationtests/clienttestlib.go
@@ -388,6 +388,11 @@ func (th *TestHelper) TearDown() {
 		panic(err)
 	}
 
+	err = th.Server.Store().Shutdown()
+	if err != nil {
+		panic(err)
+	}
+
 	os.RemoveAll(th.Server.Config().FilesPath)
 
 	if err := os.Remove(th.Server.Config().DBConfigString); err == nil {

--- a/server/boards/server/server.go
+++ b/server/boards/server/server.go
@@ -355,7 +355,7 @@ func (s *Server) Shutdown() error {
 
 	defer s.logger.Info("Server.Shutdown")
 
-	return s.store.Shutdown()
+	return nil
 }
 
 func (s *Server) Config() *config.Configuration {


### PR DESCRIPTION
```
warn  [2023-04-12 09:16:55.397 +05:30] Failed to save status                         caller="platform/status.go:175" user_id=gt5aricnu7g7xkr4jstfybgmbc error="failed to upsert Status: sql: database is closed"
```

The DB handle is a global object that is finally closed
at a higher layer after all the necessary tasks are finished.
So closing it prematurely, in the boards shutdown phase
is not necessary and can cause failures as observed above.

To fix this, we just remove the shutdown method.

```release-note
NONE
```
