### PR TITLE
[MM-52152] Expose license SkuShortName to all users

### DIFF
--- a/server/channels/app/license_test.go
+++ b/server/channels/app/license_test.go
@@ -71,8 +71,6 @@ func TestGetSanitizedClientLicense(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = m["SkuName"]
 	assert.False(t, ok)
-	_, ok = m["SkuShortName"]
-	assert.False(t, ok)
 }
 
 func TestGenerateRenewalToken(t *testing.T) {

--- a/server/channels/app/platform/license_test.go
+++ b/server/channels/app/platform/license_test.go
@@ -71,8 +71,6 @@ func TestGetSanitizedClientLicense(t *testing.T) {
 	assert.False(t, ok)
 	_, ok = m["SkuName"]
 	assert.False(t, ok)
-	_, ok = m["SkuShortName"]
-	assert.False(t, ok)
 }
 
 func TestGenerateRenewalToken(t *testing.T) {

--- a/server/channels/utils/license.go
+++ b/server/channels/utils/license.go
@@ -210,7 +210,6 @@ func GetSanitizedClientLicense(l map[string]string) map[string]string {
 	delete(sanitizedLicense, "StartsAt")
 	delete(sanitizedLicense, "ExpiresAt")
 	delete(sanitizedLicense, "SkuName")
-	delete(sanitizedLicense, "SkuShortName")
 
 	return sanitizedLicense
 }


### PR DESCRIPTION
#### Summary
So far, only people with enough permission to read license details would have access to this information. After discussions with the security team and approval from Joram, we decided to expose the `SkuShortName` when any user retrieves the license info.

A huge benefit for us is to be able to easily control if a user can access a feature or not in the webapp.

Fixes MM-52152


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52152

#### Release Note
```release-note
NONE
```
