### PR TITLE
[MM-51997] Fix potential errors when accessing calls store

### DIFF
--- a/webapp/channels/src/components/profile_popover/index.ts
+++ b/webapp/channels/src/components/profile_popover/index.ts
@@ -50,12 +50,12 @@ function getDefaultChannelId(state: GlobalState) {
     return selectedPost.exists ? selectedPost.channel_id : getCurrentChannelId(state);
 }
 
-function checkUserInCall(state: GlobalState, userId: string) {
+export function checkUserInCall(state: GlobalState, userId: string) {
     let isUserInCall = false;
 
     const calls = getCalls(state);
     Object.keys(calls).forEach((channelId) => {
-        const usersInCall = calls[channelId];
+        const usersInCall = calls[channelId] || [];
 
         for (const user of usersInCall) {
             if (user.id === userId) {

--- a/webapp/channels/src/components/profile_popover/profile_popover.test.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover.test.tsx
@@ -9,6 +9,7 @@ import {General} from 'mattermost-redux/constants';
 import {CustomStatusDuration} from '@mattermost/types/users';
 
 import ProfilePopover from 'components/profile_popover/profile_popover';
+import {checkUserInCall} from 'components/profile_popover';
 
 import Pluggable from 'plugins/pluggable';
 
@@ -282,5 +283,54 @@ describe('components/ProfilePopover', () => {
         );
         expect(wrapper.find('ProfilePopoverCallButton').exists()).toBe(true);
         expect(wrapper).toMatchSnapshot();
+    });
+});
+
+describe('checkUserInCall', () => {
+    test('missing state', () => {
+        expect(checkUserInCall({
+            'plugins-com.mattermost.calls': {},
+        }, 'userA')).toBe(false);
+    });
+
+    test('call state missing', () => {
+        expect(checkUserInCall({
+            'plugins-com.mattermost.calls': {
+                voiceConnectedProfiles: {
+                    channelID: null,
+                },
+            },
+        }, 'userA')).toBe(false);
+    });
+
+    test('user not in call', () => {
+        expect(checkUserInCall({
+            'plugins-com.mattermost.calls': {
+                voiceConnectedProfiles: {
+                    channelID: [
+                        {
+                            id: 'userB',
+                        },
+                    ],
+                },
+            },
+        }, 'userA')).toBe(false);
+    });
+
+    test('user in call', () => {
+        expect(checkUserInCall({
+            'plugins-com.mattermost.calls': {
+                voiceConnectedProfiles: {
+                    channelID: [
+                        {
+                            id: 'userB',
+                        },
+                        {
+                            id: 'userA',
+                        },
+                    ],
+                },
+            },
+        }, 'userA')).toBe(true);
     });
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/common.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/common.ts
@@ -74,7 +74,7 @@ export function getUsers(state: GlobalState): IDMappedObjects<UserProfile> {
 export function getCalls(state: GlobalState): Record<string, UserProfile[]> {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    return state[CALLS_PLUGIN].voiceConnectedProfiles;
+    return state[CALLS_PLUGIN].voiceConnectedProfiles || {};
 }
 
 export function getCallsConfig(state: GlobalState): CallsConfig {


### PR DESCRIPTION
#### Summary

I am still unsure how to reproduce this but either way we shouldn't be crashing so I am adding some minor defensive code.

@tanmay-des Looking at the logic here I think it may need some review from a UX perspective. A couple of things I noticed:

- We disable the call button if the other user is in a call. This doesn't seem right to me since nothing is blocking the current user from starting a call in the other's DM.
- Also the user could be in a call in a channel that we don't have access to in which case we would never know, so the above check is not that useful.
- We also disable the call button if the current user is in a call. This makes a little more sense although, again we should likely support switching to another call rather than preventing the user from starting one.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51997

#### Release Note

```
Fixed a potential crash when opening the user profile popover.
```
