### PR TITLE
Skip flaky "sidebar template close other" Boards test temporarily

### DIFF
--- a/webapp/boards/src/components/sidebar/sidebarCategory.test.tsx
+++ b/webapp/boards/src/components/sidebar/sidebarCategory.test.tsx
@@ -193,7 +193,10 @@ describe('components/sidebarCategory', () => {
         expect(mockTemplateClose).toBeCalled()
     })
 
-    test('sidebar template close other', async () => {
+    // TODO: Remove when fetch is mocked correctly
+    // https://mattermost.atlassian.net/browse/MM-52212
+    // eslint-disable-next-line no-only-tests/no-only-tests
+    test.skip('sidebar template close other', async () => {
         const mockStore = configureStore([])
         const store = mockStore(state)
 


### PR DESCRIPTION
#### Summary
Skips "sidebar template close other" test in the file "webapp/boards/src/components/sidebar/sidebarCategory.test.tsx" temporarily due to random test failures of "fetch not defined."

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
