### PR TITLE
safer base64 generated values in settings

### DIFF
--- a/webapp/channels/src/components/admin_console/generated_setting.tsx
+++ b/webapp/channels/src/components/admin_console/generated_setting.tsx
@@ -38,7 +38,11 @@ export default class GeneratedSetting extends React.PureComponent<Props> {
     private regenerate = (e: React.MouseEvent) => {
         e.preventDefault();
 
-        this.props.onChange(this.props.id, crypto.randomBytes(256).toString('base64').substring(0, 32));
+        // Pure base64 implementation can contain characters that are not URL safe without additional
+        // encoding. Adopt a URL/Filename safer alphabet as noted in https://datatracker.ietf.org/doc/html/rfc4648#section-5
+        // where: 62 - (minus) , 63 _ (underscore)
+        const value = crypto.randomBytes(256).toString('base64').substring(0, 32);
+        this.props.onChange(this.props.id, value.replaceAll('+', '-').replaceAll('/', '_'));
     };
 
     public render() {


### PR DESCRIPTION
#### Summary
Generated values for settings are a random base64 string with a length of 32. Unfortunately, base64 has some accepted characters like `+` and `/` that don't behave correctly if we use them in a URL without the proper additional encoding.

Use instead this safe version of base64 https://datatracker.ietf.org/doc/html/rfc4648#section-5, where:
- `/` becomes `_`
- `+` becomes `-`

I checked other encodings like base32 or base58, but they required additional dependencies and this seemed good enough. 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-51923



#### Release Note
```release-note
Type-generated settings will be generated (only for future generations) with a URL-safe version of base64 encoding.
```
