### PR TITLE
[MM-52228] Wrongly referenced API endpoint in cURL example in API reference

### DIFF
--- a/server/playbooks/server/api/api.yaml
+++ b/server/playbooks/server/api/api.yaml
@@ -584,7 +584,7 @@ paths:
       x-codeSamples:
         - lang: curl
           source: |
-            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/details' \
+            curl -X GET 'http://localhost:8065/plugins/playbooks/api/v0/runs/1igmynxs77ywmcbwbsujzktter/metadata' \
             -H 'Authorization: Bearer 9g64ig7q9pds8yjz8rsgd6e36e'
       responses:
         200:


### PR DESCRIPTION
#### Summary

Just a quick fix to modify a wrongly written cURL example for the `PlaybookRun` API reference

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52228

#### Release Note

* Modified the `details` endpoint with `metadata` in the API reference for [Get playbook run metadata](https://api.mattermost.com/#tag/PlaybookRuns/operation/getPlaybookRunMetadata)

