### PR TITLE
Updates the check for the schema_migrations information

### DIFF
--- a/server/boards/services/store/sqlstore/schema_table_migration.go
+++ b/server/boards/services/store/sqlstore/schema_table_migration.go
@@ -126,7 +126,7 @@ func (s *SQLStore) isSchemaMigrationNeeded() (bool, error) {
 	case model.MysqlDBType:
 		query = query.Where(sq.Eq{"TABLE_SCHEMA": s.schemaName})
 	case model.PostgresDBType:
-		query = query.Where(sq.Eq{"TABLE_SCHEMA": "current_schema()"})
+		query = query.Where("table_schema = current_schema()")
 	}
 
 	rows, err := query.Query()


### PR DESCRIPTION
#### Summary
The old check was using `sq.Eq`, which replaces its values with strings, and for the case of `table_schema` we want to call a function.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52281

#### Release Note
```release-note
NONE
```
