### PR TITLE
playbooks/server: Avoid using main package

### DIFF
--- a/server/playbooks/server/api_actions_test.go
+++ b/server/playbooks/server/api_actions_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/api_bot_test.go
+++ b/server/playbooks/server/api_bot_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"encoding/json"

--- a/server/playbooks/server/api_general_test.go
+++ b/server/playbooks/server/api_general_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"net/http"

--- a/server/playbooks/server/api_graphql_playbooks_test.go
+++ b/server/playbooks/server/api_graphql_playbooks_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/api_graphql_runs_test.go
+++ b/server/playbooks/server/api_graphql_runs_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/api_playbooks_test.go
+++ b/server/playbooks/server/api_playbooks_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/api_runs_test.go
+++ b/server/playbooks/server/api_runs_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/api_settings_test.go
+++ b/server/playbooks/server/api_settings_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/api_stats_test.go
+++ b/server/playbooks/server/api_stats_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/api_telemetry_test.go
+++ b/server/playbooks/server/api_telemetry_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"

--- a/server/playbooks/server/main_test.go
+++ b/server/playbooks/server/main_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-package main
+package server
 
 import (
 	"context"


### PR DESCRIPTION
The main package was used unnecessarily without a main function.
```release-note
NONE
```
