### PR TITLE
MM-50963 - enhance onboarding self-hosted telemetry

### DIFF
--- a/webapp/channels/src/components/preparing_workspace/organization.tsx
+++ b/webapp/channels/src/components/preparing_workspace/organization.tsx
@@ -38,8 +38,8 @@ type Props = PreparingWorkspacePageProps & {
     setInviteId: (inviteId: string) => void;
 }
 
-const reportValidationError = debounce(() => {
-    trackEvent('first_admin_setup', 'validate_organization_error');
+const reportValidationError = debounce((error: string) => {
+    trackEvent('first_admin_setup', 'admin_onboarding_organization_submit_fail', {error});
 }, 700, {leading: false});
 
 const Organization = (props: Props) => {
@@ -123,7 +123,7 @@ const Organization = (props: Props) => {
         }
 
         if (validation.error || teamApiError.current) {
-            reportValidationError();
+            reportValidationError(validation.error ? validation.error : teamApiError.current! as string);
             return;
         }
         props.next?.();

--- a/webapp/channels/src/components/preparing_workspace/plugins.tsx
+++ b/webapp/channels/src/components/preparing_workspace/plugins.tsx
@@ -31,6 +31,7 @@ type Props = PreparingWorkspacePageProps & {
     setOption: (option: keyof Form['plugins']) => void;
     className?: string;
     isSelfHosted: boolean;
+    handleVisitMarketPlaceClick: () => void;
 }
 const Plugins = (props: Props) => {
     const {formatMessage} = useIntl();
@@ -178,6 +179,7 @@ const Plugins = (props: Props) => {
                                             <ExternalLink
                                                 href='https://mattermost.com/marketplace/'
                                                 location='preparing_workspace_plugins'
+                                                onClick={props.handleVisitMarketPlaceClick}
                                             >
                                                 {chunks}
                                             </ExternalLink>

--- a/webapp/channels/src/components/preparing_workspace/preparing_workspace.tsx
+++ b/webapp/channels/src/components/preparing_workspace/preparing_workspace.tsx
@@ -267,6 +267,7 @@ const PreparingWorkspace = (props: Props) => {
         const goToChannels = () => {
             dispatch({type: GeneralTypes.SHOW_LAUNCHING_WORKSPACE, open: true});
             props.history.push(`/${team.name}/channels${Constants.DEFAULT_CHANNEL}`);
+            trackEvent('first_admin_setup', 'admin_setup_complete');
         };
 
         const sendFormEnd = Date.now();
@@ -460,6 +461,9 @@ const PreparingWorkspace = (props: Props) => {
                     show={shouldShowPage(WizardSteps.Plugins)}
                     transitionDirection={getTransitionDirection(WizardSteps.Plugins)}
                     className='child-page'
+                    handleVisitMarketPlaceClick={() => {
+                        trackEvent('first_admin_setup', 'click_visit_marketplace_link');
+                    }}
                 />
                 <InviteMembers
                     onPageView={onPageViews[WizardSteps.InviteMembers]}


### PR DESCRIPTION
#### Summary
This PR adds the enhancements to onboarding self-hosted telemetry. More details about the event ids findings were added to the JIRA ticket.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50963

#### Screenshots
<img width="688" alt="Screenshot 2023-04-20 at 17 14 10" src="https://user-images.githubusercontent.com/10082627/233433838-486a0ac9-773c-4b15-b0c7-a26bc7836677.png">
<img width="676" alt="Screenshot 2023-04-20 at 17 14 46" src="https://user-images.githubusercontent.com/10082627/233433844-49e48cdd-3697-4f23-b459-3ff61d00fa50.png">


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
