### PR TITLE
MM-52155 - Workspace Deletion Modal Style Issues

### DIFF
--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
@@ -12,6 +12,10 @@
         }
     }
 
+    &__Icon {
+        padding-top: 8px;
+    }
+
     &__Title {
         color: var(--sys-denim-center-channel-text);
         font-family: Metropolis;
@@ -22,10 +26,11 @@
 
     &__Usage {
         text-align: left;
+        color: var(--sys-center-channel-text);
 
         &-Highlighted {
             color: black;
-            font-weight: 700;
+            font-weight: bold;
         }
     }
 

--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
@@ -25,8 +25,8 @@
     }
 
     &__Usage {
-        text-align: left;
         color: var(--sys-center-channel-text);
+        text-align: left;
 
         &-Highlighted {
             color: black;

--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
@@ -25,7 +25,7 @@
     }
 
     &__Usage {
-        color: var(--center-channel-text);
+        color: var(--center-channel-color);
         text-align: left;
 
         &-Highlighted {
@@ -35,7 +35,7 @@
     }
 
     &__Warning {
-        color: var(--center-channel-text);
+        color: var(--center-channel-color);
         text-align: left;
     }
 

--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.scss
@@ -25,7 +25,7 @@
     }
 
     &__Usage {
-        color: var(--sys-center-channel-text);
+        color: var(--center-channel-text);
         text-align: left;
 
         &-Highlighted {
@@ -35,6 +35,7 @@
     }
 
     &__Warning {
+        color: var(--center-channel-text);
         text-align: left;
     }
 

--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.tsx
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.tsx
@@ -186,8 +186,8 @@ export default function DeleteWorkspaceModal(props: Props) {
             className='DeleteWorkspaceModal'
             onExited={handleClickCancel}
         >
-            <div>
-                <LaptopAlertSVG/>
+            <div className="DeleteWorkspaceModal__Icon">
+                <LaptopAlertSVG height={156}/>
             </div>
             <div className='DeleteWorkspaceModal__Title'>
                 <FormattedMessage

--- a/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.tsx
+++ b/webapp/channels/src/components/admin_console/billing/delete_workspace/delete_workspace_modal.tsx
@@ -186,7 +186,7 @@ export default function DeleteWorkspaceModal(props: Props) {
             className='DeleteWorkspaceModal'
             onExited={handleClickCancel}
         >
-            <div className="DeleteWorkspaceModal__Icon">
+            <div className='DeleteWorkspaceModal__Icon'>
                 <LaptopAlertSVG height={156}/>
             </div>
             <div className='DeleteWorkspaceModal__Title'>


### PR DESCRIPTION
#### Summary

There were some styling issues related to the Workspace Deletion modal:

1. The illustration (laptop image) should be 246 px width / 156 px height. Currently, it is 246px width / 182 px height (the default of the SVG): Set the SVG height property to `156px` (changing in CSS causes issues with overlapping, missing padding/margins, etc.)

3. The text colour should be center channel text colour (except for the bold text): Changed from `--sys-denim-center-channel-text` to `--center-channel-text`

4. The space above the illustration should be 48px (currently it appears to be 40px total with the modal’s padding and the existing padding on the illustration: Added 8px of padding above the SVG.

5. Bold text should be regular bold, not semibold: Seems to already be bold, but have applied styling to explicitly be bold

#### Ticket Link

[MM-52155](https://mattermost.atlassian.net/browse/MM-52155)

#### Screenshots

|  before  |  after  |
|----|----|
| ![image](https://user-images.githubusercontent.com/116016004/233454473-2fb3471c-fcf7-4494-a05f-e5d4492b4c9c.png) | ![image](https://user-images.githubusercontent.com/116016004/233473359-0cee04cc-8d82-413a-9f47-773972a21c8e.png) |

#### Release Note

```release-note
NONE
```


[MM-52155]: https://mattermost.atlassian.net/browse/MM-52155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ