### PR TITLE
[MM-52287] - Cloud Free should not show the ability to start a trial

### DIFF
--- a/webapp/channels/src/components/admin_console/billing/billing_summary/index.tsx
+++ b/webapp/channels/src/components/admin_console/billing/billing_summary/index.tsx
@@ -34,14 +34,14 @@ const BillingSummary = ({isFreeTrial, daysLeftOnTrial, onUpgradeMattermostCloud}
 
     const isPreTrial = subscription?.is_free_trial === 'false' && subscription?.trial_end_at === 0;
     const hasPriorTrial = useSelector(checkHadPriorTrial);
-    const showTryEnterprise = product?.sku === CloudProducts.STARTER && isPreTrial;
-    const showUpgradeProfessional = product?.sku === CloudProducts.STARTER && hasPriorTrial;
+    const isStarterPreTrial = product?.sku === CloudProducts.STARTER && isPreTrial;
+    const isStarterPostTrial = product?.sku === CloudProducts.STARTER && hasPriorTrial;
 
-    if (reverseTrial) {
+    if (isStarterPreTrial && reverseTrial) {
         body = <UpgradeToProfessionalCard/>;
-    } else if (showTryEnterprise) {
+    } else if (isStarterPreTrial) {
         body = tryEnterpriseCard;
-    } else if (showUpgradeProfessional) {
+    } else if (isStarterPostTrial) {
         body = <UpgradeToProfessionalCard/>;
     } else if (isFreeTrial) {
         body = freeTrial(onUpgradeMattermostCloud, daysLeftOnTrial);

--- a/webapp/channels/src/components/admin_console/billing/billing_summary/index.tsx
+++ b/webapp/channels/src/components/admin_console/billing/billing_summary/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import {useSelector} from 'react-redux';
 
 import {getSubscriptionProduct, checkHadPriorTrial, getCloudSubscription} from 'mattermost-redux/selectors/entities/cloud';
+import {cloudReverseTrial} from 'mattermost-redux/selectors/entities/preferences';
 
 import {CloudProducts} from 'utils/constants';
 
@@ -27,6 +28,7 @@ type BillingSummaryProps = {
 const BillingSummary = ({isFreeTrial, daysLeftOnTrial, onUpgradeMattermostCloud}: BillingSummaryProps) => {
     const subscription = useSelector(getCloudSubscription);
     const product = useSelector(getSubscriptionProduct);
+    const reverseTrial = useSelector(cloudReverseTrial);
 
     let body = noBillingHistory;
 
@@ -35,7 +37,9 @@ const BillingSummary = ({isFreeTrial, daysLeftOnTrial, onUpgradeMattermostCloud}
     const showTryEnterprise = product?.sku === CloudProducts.STARTER && isPreTrial;
     const showUpgradeProfessional = product?.sku === CloudProducts.STARTER && hasPriorTrial;
 
-    if (showTryEnterprise) {
+    if (reverseTrial) {
+        body = <UpgradeToProfessionalCard/>;
+    } else if (showTryEnterprise) {
         body = tryEnterpriseCard;
     } else if (showUpgradeProfessional) {
         body = <UpgradeToProfessionalCard/>;

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -300,6 +300,10 @@ export function deprecateCloudFree(state: GlobalState): boolean {
     return getFeatureFlagValue(state, 'DeprecateCloudFree') === 'true';
 }
 
+export function cloudReverseTrial(state: GlobalState): boolean {
+    return getFeatureFlagValue(state, 'CloudReverseTrial') === 'true';
+}
+
 export function appsSidebarCategoryEnabled(state: GlobalState): boolean {
     return getFeatureFlagValue(state, 'AppsSidebarCategory') === 'true';
 }


### PR DESCRIPTION
#### Summary
Before we reverse the current cloud flow, when workspaces are on starter and never done a trial, admins have the ability to start an enterprise trial. However, soon workspaces won't be able to request their own trials, and that means we need to take away this ability.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52287

#### Release Note

```release-note
NONE
```
