### PR TITLE
[MM-52339] Top playbooks missing from insights

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/insights/insights_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/insights/insights_spec.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+// Stage: @prod
+
+describe('Insights', () => {
+    let teamA;
+
+    before(() => {
+        cy.shouldHaveFeatureFlag('InsightsEnabled', true);
+
+        cy.apiInitSetup().then(({team}) => {
+            teamA = team;
+        });
+    });
+    it('Check boards and playbooks load when plugins are disabled', () => {
+        cy.apiAdminLogin();
+
+        // # Ensure plugins for boards and playbooks are disabled
+        cy.apiUpdateConfig({
+            PluginSettings: {
+                PluginStates: {
+                    focalboard: {
+                        Enable: false,
+                    },
+                    playbooks: {
+                        Enable: false,
+                    },
+                },
+            },
+        });
+
+        // # Go to the Insights view
+        cy.visit(`/${teamA.name}/activity-and-insights`);
+
+        // * Check boards exists because product mode is enabled
+        cy.get('.top-boards-card').should('exist');
+
+        // * Check playbooks exists because product mode is enabled
+        cy.get('.top-playbooks-card').should('exist');
+    });
+});

--- a/webapp/channels/src/components/activity_and_insights/insights/insights.tsx
+++ b/webapp/channels/src/components/activity_and_insights/insights/insights.tsx
@@ -41,17 +41,26 @@ type SelectOption = {
 
 const Insights = () => {
     const dispatch = useDispatch();
-
-    // check if either of focalboard plugin or boards product is enabled
-    const focalboardPluginEnabled = useSelector((state: GlobalState) => state.plugins.plugins?.focalboard);
-    let focalboardProductEnabled = false;
     const products = useProducts();
+
+    // check if plugins or products are enabled for boards and playbooks
+    const focalboardPluginEnabled = useSelector((state: GlobalState) => state.plugins.plugins?.focalboard);
+    const playbooksPluginEnabled = useSelector((state: GlobalState) => state.plugins.plugins?.playbooks);
+
+    let focalboardProductEnabled = false;
+    let playbooksProductEnabled = false;
     if (products) {
-        focalboardProductEnabled = products.some((product) => product.pluginId === suitePluginIds.focalboard || product.pluginId === suitePluginIds.boards);
+        products.forEach((product) => {
+            if (product.pluginId === suitePluginIds.focalboard || product.pluginId === suitePluginIds.boards) {
+                focalboardProductEnabled = true;
+            } else if (product.pluginId === suitePluginIds.playbooks) {
+                playbooksProductEnabled = true;
+            }
+        });
     }
     const focalboardEnabled = focalboardPluginEnabled || focalboardProductEnabled;
+    const playbooksEnabled = playbooksPluginEnabled || playbooksProductEnabled;
 
-    const playbooksEnabled = useSelector((state: GlobalState) => state.plugins.plugins?.playbooks);
     const currentUserId = useSelector(getCurrentUserId);
     const currentTeamId = useSelector(getCurrentTeamId);
 


### PR DESCRIPTION
#### Summary
When playbooks was migrated to a plugin, we forgot to update insights to check for product mode

Side note: I don't think there is a way to disable product mode for boards/playbooks without just stopping them from running? Which means for our e2e tests we can't test the state where boards/playbooks are completely missing?

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52339

#### Screenshots
![Screenshot 2023-04-21 at 10 55 18 AM](https://user-images.githubusercontent.com/14115924/233667990-def6e8de-1ba5-47b5-879b-7e665c99218a.png)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
