### PR TITLE
Bump libucrl gnutls to `7.64.0-4+deb10u6`

### DIFF
--- a/server/build/Dockerfile
+++ b/server/build/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
   libxext6=2:1.3.3-1+b2 \
   libxrender1=1:0.9.10-1 \
   libcairo2=1.16.0-4+deb10u1 \
-  libcurl3-gnutls=7.64.0-4+deb10u5 \
+  libcurl3-gnutls=7.64.0-4+deb10u6 \
   libglib2.0-0=2.58.3-2+deb10u3 \
   libgsf-1-common=1.14.45-1 \
   libgsf-1-114=1.14.45-1 \


### PR DESCRIPTION
#### Summary
The pin to previous version fails with not found.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5582

#### Release Note
```release-note
NONE
```
