### PR TITLE
MM-52419 - move preparing workspace onboarding behind usecaseonboarding ff for self-hosted

### DIFF
--- a/e2e-tests/playwright/support/server/default_config.ts
+++ b/e2e-tests/playwright/support/server/default_config.ts
@@ -664,6 +664,7 @@ const defaultServerConfig: AdminConfig = {
         BoardsFeatureFlags: '',
         BoardsDataRetention: false,
         NormalizeLdapDNs: false,
+        UseCaseOnboarding: false,
         GraphQL: false,
         InsightsEnabled: true,
         CommandPalette: false,

--- a/webapp/channels/src/actions/global_actions.tsx
+++ b/webapp/channels/src/actions/global_actions.tsx
@@ -13,7 +13,7 @@ import {logout, loadMe, loadMeREST} from 'mattermost-redux/actions/users';
 import {Preferences} from 'mattermost-redux/constants';
 import {getConfig, isPerformanceDebuggingEnabled} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId, getMyTeams, getTeam, getMyTeamMember, getTeamMemberships} from 'mattermost-redux/selectors/entities/teams';
-import {getBool, isCollapsedThreadsEnabled, isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getBool, getUseCaseOnboarding, isCollapsedThreadsEnabled, isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUser, getCurrentUserId, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentChannelStats, getCurrentChannelId, getMyChannelMember, getRedirectChannelNameForTeam, getChannelsNameMapInTeam, getAllDirectChannels, getChannelMessageCount} from 'mattermost-redux/selectors/entities/channels';
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
@@ -352,7 +352,7 @@ export async function redirectUserToDefaultTeam() {
     // Assume we need to load the user if they don't have any team memberships loaded or the user loaded
     let user = getCurrentUser(state);
     const shouldLoadUser = Utils.isEmptyObject(getTeamMemberships(state)) || !user;
-
+    const useCaseOnboarding = getUseCaseOnboarding(state);
     if (shouldLoadUser) {
         if (isGraphQLEnabled(state)) {
             await dispatch(loadMe());
@@ -375,7 +375,7 @@ export async function redirectUserToDefaultTeam() {
 
     let myTeams = getMyTeams(state);
     if (myTeams.length === 0) {
-        if (isUserFirstAdmin) {
+        if (isUserFirstAdmin && useCaseOnboarding) {
             getHistory().push('/preparing-workspace');
             return;
         }

--- a/webapp/channels/src/components/do_verify_email/do_verify_email.tsx
+++ b/webapp/channels/src/components/do_verify_email/do_verify_email.tsx
@@ -6,6 +6,7 @@ import {useIntl} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';
 import {useLocation, useHistory} from 'react-router-dom';
 
+import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import {trackEvent} from 'actions/telemetry_actions.jsx';
 
 import LaptopAlertSVG from 'components/common/svg_images_components/laptop_alert_svg';
@@ -14,6 +15,7 @@ import LoadingScreen from 'components/loading_screen';
 
 import {clearErrors, logError} from 'mattermost-redux/actions/errors';
 import {verifyUserEmail, getMe} from 'mattermost-redux/actions/users';
+import {getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {DispatchFunc} from 'mattermost-redux/types/actions';
 
@@ -38,6 +40,7 @@ const DoVerifyEmail = () => {
     const token = params.get('token') ?? '';
 
     const loggedIn = Boolean(useSelector(getCurrentUserId));
+    const useCaseOnboarding = useSelector(getUseCaseOnboarding);
 
     const [verifyStatus, setVerifyStatus] = useState(VerifyStatus.PENDING);
     const [serverError, setServerError] = useState('');
@@ -49,11 +52,15 @@ const DoVerifyEmail = () => {
 
     const handleRedirect = () => {
         if (loggedIn) {
-            // need info about whether admin or not,
-            // and whether admin has already completed
-            // first time onboarding. Instead of fetching and orchestrating that here,
-            // let the default root component handle it.
-            history.push('/');
+            if (useCaseOnboarding) {
+                // need info about whether admin or not,
+                // and whether admin has already completed
+                // first time onboarding. Instead of fetching and orchestrating that here,
+                // let the default root component handle it.
+                history.push('/');
+                return;
+            }
+            redirectUserToDefaultTeam();
             return;
         }
 

--- a/webapp/channels/src/components/global_header/center_controls/user_guide_dropdown/index.ts
+++ b/webapp/channels/src/components/global_header/center_controls/user_guide_dropdown/index.ts
@@ -8,6 +8,7 @@ import {withRouter} from 'react-router-dom';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {GenericAction} from 'mattermost-redux/types/actions';
 import {getCurrentRelativeTeamUrl} from 'mattermost-redux/selectors/entities/teams';
+import {getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
 import {isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 
 import {getUserGuideDropdownPluginMenuItems} from 'selectors/plugins';
@@ -31,6 +32,7 @@ function mapStateToProps(state: GlobalState) {
         teamUrl: getCurrentRelativeTeamUrl(state),
         pluginMenuItems: getUserGuideDropdownPluginMenuItems(state),
         isFirstAdmin: isFirstAdmin(state),
+        useCaseOnboarding: getUseCaseOnboarding(state),
     };
 }
 

--- a/webapp/channels/src/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.test.tsx
+++ b/webapp/channels/src/components/global_header/center_controls/user_guide_dropdown/user_guide_dropdown.test.tsx
@@ -34,6 +34,7 @@ describe('components/channel_header/components/UserGuideDropdown', () => {
         },
         pluginMenuItems: [],
         isFirstAdmin: false,
+        useCaseOnboarding: false,
     };
 
     test('should match snapshot', () => {

--- a/webapp/channels/src/components/login/login.tsx
+++ b/webapp/channels/src/components/login/login.tsx
@@ -13,7 +13,7 @@ import {UserProfile} from '@mattermost/types/users';
 
 import {Client4} from 'mattermost-redux/client';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
-import {isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getUseCaseOnboarding, isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getTeamByName, getMyTeamMember} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import {isSystemAdmin} from 'mattermost-redux/utils/user_utils';
@@ -104,6 +104,7 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
     const currentUser = useSelector(getCurrentUser);
     const experimentalPrimaryTeam = useSelector((state: GlobalState) => (ExperimentalPrimaryTeam ? getTeamByName(state, ExperimentalPrimaryTeam) : undefined));
     const experimentalPrimaryTeamMember = useSelector((state: GlobalState) => getMyTeamMember(state, experimentalPrimaryTeam?.id ?? ''));
+    const useCaseOnboarding = useSelector(getUseCaseOnboarding);
     const isCloud = useSelector(isCurrentLicenseCloud);
     const graphQLEnabled = useSelector(isGraphQLEnabled);
 
@@ -634,12 +635,14 @@ const Login = ({onCustomizeHeader}: LoginProps) => {
         } else if (experimentalPrimaryTeamMember.team_id) {
             // Only set experimental team if user is on that team
             history.push(`/${ExperimentalPrimaryTeam}`);
-        } else {
+        } else if (useCaseOnboarding) {
             // need info about whether admin or not,
             // and whether admin has already completed
             // first time onboarding. Instead of fetching and orchestrating that here,
             // let the default root component handle it.
             history.push('/');
+        } else {
+            redirectUserToDefaultTeam();
         }
     };
 

--- a/webapp/channels/src/components/preparing_workspace/preparing_workspace.tsx
+++ b/webapp/channels/src/components/preparing_workspace/preparing_workspace.tsx
@@ -11,6 +11,7 @@ import {General} from 'mattermost-redux/constants';
 import {getFirstAdminSetupComplete as getFirstAdminSetupCompleteAction} from 'mattermost-redux/actions/general';
 import {ActionResult} from 'mattermost-redux/types/actions';
 import {Team} from '@mattermost/types/teams';
+import {getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
 import {isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getCurrentTeam, getMyTeams} from 'mattermost-redux/selectors/entities/teams';
 import {getFirstAdminSetupComplete, getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
@@ -108,6 +109,7 @@ const PreparingWorkspace = (props: Props) => {
         defaultMessage: 'Something went wrong. Please try again.',
     });
     const isUserFirstAdmin = useSelector(isFirstAdmin);
+    const useCaseOnboarding = useSelector(getUseCaseOnboarding);
 
     const currentTeam = useSelector(getCurrentTeam);
     const myTeams = useSelector(getMyTeams);
@@ -288,7 +290,7 @@ const PreparingWorkspace = (props: Props) => {
     }, [submissionState]);
 
     const adminRevisitedPage = firstAdminSetupComplete && submissionState === SubmissionStates.Presubmit;
-    const shouldRedirect = !isUserFirstAdmin || adminRevisitedPage;
+    const shouldRedirect = !isUserFirstAdmin || adminRevisitedPage || !useCaseOnboarding;
 
     useEffect(() => {
         if (shouldRedirect) {

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -10,7 +10,7 @@ import classNames from 'classnames';
 import {Client4} from 'mattermost-redux/client';
 import {rudderAnalytics, RudderTelemetryHandler} from 'mattermost-redux/client/rudder';
 import {General} from 'mattermost-redux/constants';
-import {Theme} from 'mattermost-redux/selectors/entities/preferences';
+import {Theme, getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUser, isCurrentUserSystemAdmin, checkIsFirstAdmin} from 'mattermost-redux/selectors/entities/users';
 import {setUrl} from 'mattermost-redux/actions/general';
@@ -361,7 +361,9 @@ export default class Root extends React.PureComponent<Props, State> {
         }
 
         const myTeams = getMyTeams(storeState);
-        if (myTeams.length > 0) {
+        const useCaseOnboarding = getUseCaseOnboarding(storeState);
+
+        if (myTeams.length > 0 || !useCaseOnboarding) {
             GlobalActions.redirectUserToDefaultTeam();
             return;
         }

--- a/webapp/channels/src/components/root/root_redirect/index.ts
+++ b/webapp/channels/src/components/root/root_redirect/index.ts
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 
 import {getFirstAdminSetupComplete} from 'mattermost-redux/actions/general';
 import {getCurrentUserId, isCurrentUserSystemAdmin, isFirstAdmin} from 'mattermost-redux/selectors/entities/users';
+import {getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
 import {GenericAction} from 'mattermost-redux/types/actions';
 
 import {GlobalState} from 'types/store';
@@ -13,7 +14,11 @@ import {GlobalState} from 'types/store';
 import RootRedirect, {Props} from './root_redirect';
 
 function mapStateToProps(state: GlobalState) {
-    const isElegibleForFirstAdmingOnboarding = isCurrentUserSystemAdmin(state);
+    const useCaseOnboarding = getUseCaseOnboarding(state);
+    let isElegibleForFirstAdmingOnboarding = useCaseOnboarding;
+    if (isElegibleForFirstAdmingOnboarding) {
+        isElegibleForFirstAdmingOnboarding = isCurrentUserSystemAdmin(state);
+    }
     return {
         currentUserId: getCurrentUserId(state),
         isElegibleForFirstAdmingOnboarding,

--- a/webapp/channels/src/components/signup/signup.tsx
+++ b/webapp/channels/src/components/signup/signup.tsx
@@ -17,7 +17,7 @@ import {getTeamInviteInfo} from 'mattermost-redux/actions/teams';
 import {createUser, loadMe, loadMeREST} from 'mattermost-redux/actions/users';
 import {DispatchFunc} from 'mattermost-redux/types/actions';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
-import {isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
+import {getUseCaseOnboarding, isGraphQLEnabled} from 'mattermost-redux/selectors/entities/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 import {isEmail} from 'mattermost-redux/utils/helpers';
 
@@ -25,6 +25,7 @@ import {GlobalState} from 'types/store';
 
 import {getGlobalItem} from 'selectors/storage';
 
+import {redirectUserToDefaultTeam} from 'actions/global_actions';
 import {removeGlobalItem, setGlobalItem} from 'actions/storage';
 import {addUserToTeamFromInvite} from 'actions/team_actions';
 import {trackEvent} from 'actions/telemetry_actions.jsx';
@@ -103,6 +104,7 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
     } = config;
     const {IsLicensed, Cloud} = useSelector(getLicense);
     const loggedIn = Boolean(useSelector(getCurrentUserId));
+    const useCaseOnboarding = useSelector(getUseCaseOnboarding);
     const usedBefore = useSelector((state: GlobalState) => (!inviteId && !loggedIn && token ? getGlobalItem(state, token, null) : undefined));
     const graphQLEnabled = useSelector(isGraphQLEnabled);
 
@@ -308,7 +310,15 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
             } else if (inviteId) {
                 getInviteInfo(inviteId);
             } else if (loggedIn) {
-                history.push('/');
+                if (useCaseOnboarding) {
+                    // need info about whether admin or not,
+                    // and whether admin has already completed
+                    // first tiem onboarding. Instead of fetching and orchestrating that here,
+                    // let the default root component handle it.
+                    history.push('/');
+                } else {
+                    redirectUserToDefaultTeam();
+                }
             }
         }
 
@@ -451,12 +461,14 @@ const Signup = ({onCustomizeHeader}: SignupProps) => {
 
         if (redirectTo) {
             history.push(redirectTo);
-        } else {
+        } else if (useCaseOnboarding) {
             // need info about whether admin or not,
             // and whether admin has already completed
             // first tiem onboarding. Instead of fetching and orchestrating that here,
             // let the default root component handle it.
             history.push('/');
+        } else {
+            redirectUserToDefaultTeam();
         }
     };
 

--- a/webapp/channels/src/components/terms_of_service/index.ts
+++ b/webapp/channels/src/components/terms_of_service/index.ts
@@ -6,6 +6,7 @@ import {bindActionCreators, Dispatch, ActionCreatorsMapObject} from 'redux';
 
 import {getTermsOfService, updateMyTermsOfServiceStatus} from 'mattermost-redux/actions/users';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
+import {getUseCaseOnboarding} from 'mattermost-redux/selectors/entities/preferences';
 
 import {GlobalState} from '@mattermost/types/store';
 import {ActionFunc, GenericAction} from 'mattermost-redux/types/actions';
@@ -25,7 +26,9 @@ type Actions = {
 
 function mapStateToProps(state: GlobalState) {
     const config = getConfig(state);
+    const useCaseOnboarding = getUseCaseOnboarding(state);
     return {
+        useCaseOnboarding,
         termsEnabled: config.EnableCustomTermsOfService === 'true',
         emojiMap: getEmojiMap(state),
     };

--- a/webapp/channels/src/components/terms_of_service/terms_of_service.test.tsx
+++ b/webapp/channels/src/components/terms_of_service/terms_of_service.test.tsx
@@ -27,6 +27,7 @@ describe('components/terms_of_service/TermsOfService', () => {
         location: {search: ''},
         termsEnabled: true,
         emojiMap: {} as EmojiMap,
+        useCaseOnboarding: false,
     };
 
     test('should match snapshot', () => {

--- a/webapp/channels/src/components/terms_of_service/terms_of_service.tsx
+++ b/webapp/channels/src/components/terms_of_service/terms_of_service.tsx
@@ -38,6 +38,7 @@ export interface TermsOfServiceProps {
         ) => {data: UpdateMyTermsOfServiceStatusResponse};
     };
     emojiMap: EmojiMap;
+    useCaseOnboarding: boolean;
 }
 
 interface TermsOfServiceState {
@@ -110,12 +111,14 @@ export default class TermsOfService extends React.PureComponent<TermsOfServicePr
                 const redirectTo = query.get('redirect_to');
                 if (redirectTo && redirectTo.match(/^\/([^/]|$)/)) {
                     getHistory().push(redirectTo);
-                } else {
+                } else if (this.props.useCaseOnboarding) {
                     // need info about whether admin or not,
                     // and whether admin has already completed
                     // first time onboarding. Instead of fetching and orchestrating that here,
                     // let the default root component handle it.
                     getHistory().push('/');
+                } else {
+                    GlobalActions.redirectUserToDefaultTeam();
                 }
             },
         );

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -245,6 +245,14 @@ export function isCustomGroupsEnabled(state: GlobalState): boolean {
     return getConfig(state).EnableCustomGroups === 'true';
 }
 
+export function getUseCaseOnboarding(state: GlobalState): boolean {
+    const isCloud = getLicense(state)?.Cloud === 'true';
+    if (isCloud) {
+        return true;
+    }
+    return getFeatureFlagValue(state, 'UseCaseOnboarding') === 'true';
+}
+
 export function insightsAreEnabled(state: GlobalState): boolean {
     const isConfiguredForFeature = getConfig(state).InsightsEnabled === 'true';
     const featureIsEnabled = getFeatureFlagValue(state, 'InsightsEnabled') === 'true';


### PR DESCRIPTION
#### Summary
this PR makes sure to move preparing workspace onboarding flow behind UseSaseOnboarding Feature flag for self-hosted

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52419

#### Screenshots

https://user-images.githubusercontent.com/10082627/234054698-9760a94f-cf99-46a2-9942-5a24f27950f5.mov



#### Release Note
```release-note
NONE
```
