### PR TITLE
MM-52438 Reorganize web app CI pipeline

### DIFF
--- a/.github/workflows/channels-ci.yml
+++ b/.github/workflows/channels-ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - mono-repo*
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains( github.ref , 'heads/ref/master') }}
@@ -12,37 +11,6 @@ defaults:
   run:
     shell: bash
 jobs:
-  check-lint:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: webapp
-    steps:
-      - name: ci/checkout-repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: ci/setup-node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        id: setup_node
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: 'webapp/package-lock.json'
-      # - uses: actions/cache@2b8105bdae4b746666ee225970c4a281bbd9d51f # v3.2.4
-      #   id: npm-cache
-      #   with:
-      #     path: |
-      #       '**/node_modules'
-      #       'e2e-tests/playwright/node_modules'
-      #       'e2e-tests/cypress/node_modules'
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
-      - name: ci/get-node-modules
-        # if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          make node_modules
-          # make channels/e2e-tests/playwright/node_modules
-      - name: ci/lint
-        run: |
-          npm run check
   check-i18n:
     runs-on: ubuntu-22.04
     defaults:
@@ -93,108 +61,3 @@ jobs:
         run: |
           npm run i18n-extract
           git --no-pager diff --exit-code i18n/en.json || (echo "Please run \"cd webapp/playbooks && npm run i18n-extract\" and commit the changes in webapp/playbooks/i18n/en.json." && exit 1)
-  check-types:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: webapp
-    steps:
-      - name: ci/checkout-repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: ci/setup-node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        id: setup_node
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: 'webapp/package-lock.json'
-      # - uses: actions/cache@2b8105bdae4b746666ee225970c4a281bbd9d51f # v3.2.4
-      #   id: npm-cache
-      #   with:
-      #     path: |
-      #       '**/node_modules'
-      #       'e2e-tests/playwright/node_modules'
-      #       'e2e-tests/cypress/node_modules'
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
-      - name: ci/get-node-modules
-        # if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          make node_modules
-          # make channels/e2e-tests/playwright/node_modules
-      - name: ci/lint
-        run: |
-          npm run check-types
-  test:
-    runs-on: ubuntu-22.04
-    needs: [check-types, check-i18n, check-lint]
-    permissions:
-      checks: write
-      pull-requests: write
-    defaults:
-      run:
-        working-directory: webapp
-    steps:
-      - name: ci/checkout-repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: ci/setup-node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        id: setup_node
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: 'webapp/package-lock.json'
-      # - uses: actions/cache@2b8105bdae4b746666ee225970c4a281bbd9d51f # v3.2.4
-      #   id: npm-cache
-      #   with:
-      #     path: |
-      #       '**/node_modules'
-      #       'e2e-tests/playwright/node_modules'
-      #       'e2e-tests/cypress/node_modules'
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
-      - name: ci/get-node-modules
-        # if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          make node_modules
-          # make channels/e2e-tests/playwright/node_modules
-      - name: ci/test
-        env:
-          NODE_OPTIONS: --max_old_space_size=5120
-        run: |
-          npm run test-ci --workspace=boards
-          npm run test-ci --workspace=channels
-          npm run test-ci --workspace=platform/client
-          npm run test-ci --workspace=playbooks
-  build:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: webapp
-    steps:
-      - name: ci/checkout-repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - name: ci/setup-node
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        id: setup_node
-        with:
-          node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: 'webapp/package-lock.json'
-      # - uses: actions/cache@2b8105bdae4b746666ee225970c4a281bbd9d51f # v3.2.4
-      #   id: npm-cache
-      #   with:
-      #     path: |
-      #       '**/node_modules'
-      #       'e2e-tests/playwright/node_modules'
-      #       'e2e-tests/cypress/node_modules'
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
-      - name: ci/get-node-modules
-        # if: steps.npm-cache.outputs.cache-hit != 'true'
-        run: |
-          make node_modules
-          # make channels/e2e-tests/playwright/node_modules
-      - name: ci/build
-        run: |
-          npm run build
-  # run-performance-bechmarks:
-  #   uses: ./.github/workflows/performance-benchmarks.yml
-  #   needs: build

--- a/.github/workflows/webapp-boards.yml
+++ b/.github/workflows/webapp-boards.yml
@@ -1,0 +1,22 @@
+name: Boards
+
+on:
+  pull_request:
+    paths:
+      - 'webapp/boards/**/*'
+      - 'webapp/platform/**/*'
+  push:
+    branches:
+      - master
+      - cloud
+      - release-*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains( github.ref , 'heads/ref/master') }}
+
+jobs:
+  web-app:
+    uses: ./.github/workflows/webapp-shared.yml
+    with:
+      workspace-argument: --workspace=boards

--- a/.github/workflows/webapp-channels.yml
+++ b/.github/workflows/webapp-channels.yml
@@ -1,0 +1,22 @@
+name: Channels
+
+on:
+  pull_request:
+    paths:
+      - 'webapp/channels/**/*'
+      - 'webapp/platform/**/*'
+  push:
+    branches:
+      - master
+      - cloud
+      - release-*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains( github.ref , 'heads/ref/master') }}
+
+jobs:
+  web-app:
+    uses: ./.github/workflows/webapp-shared.yml
+    with:
+      workspace-argument: --workspace=channels --workspace=platform/client --workspace=platform/components --workspace=platform/types --if-present

--- a/.github/workflows/webapp-playbooks.yml
+++ b/.github/workflows/webapp-playbooks.yml
@@ -1,0 +1,23 @@
+name: Playbooks
+
+on:
+  pull_request:
+    paths:
+      - 'webapp/channels/src/mattermost-redux/**/*'
+      - 'webapp/platform/**/*'
+      - 'webapp/playbooks/**/*'
+  push:
+    branches:
+      - master
+      - cloud
+      - release-*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains( github.ref , 'heads/ref/master') }}
+
+jobs:
+  web-app:
+    uses: ./.github/workflows/webapp-shared.yml
+    with:
+      workspace-argument: --workspace=playbooks

--- a/.github/workflows/webapp-shared.yml
+++ b/.github/workflows/webapp-shared.yml
@@ -1,0 +1,53 @@
+name: Shared Web App
+
+on:
+  workflow_call:
+    inputs:
+      workspace-argument:
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ci:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: webapp
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      - name: ci/setup-node
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        id: setup_node
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: 'webapp/package-lock.json'
+      - name: ci/get-node-modules
+        run: |
+          make node_modules
+      - name: ci/check-lint
+        id: check-lint
+        run: |
+          npm run check ${{ inputs.workspace-argument }}
+        continue-on-error: true
+      - name: ci/check-types
+        id: check-types
+        run: |
+          npm run check-types ${{ inputs.workspace-argument }}
+        continue-on-error: true
+      - name: ci/test
+        id: test
+        run: |
+          npm test ${{ inputs.workspace-argument }}
+        continue-on-error: true
+      - name: ci/check-for-failures
+        if: steps.check-lint.outcome != 'success' || steps.check-types.outcome != 'success' || steps.test.outcome != 'success'
+        run: exit 1
+      - name: ci/build
+        run: |
+          npm run build ${{ inputs.workspace-argument }}

--- a/.github/workflows/webapp-shared.yml
+++ b/.github/workflows/webapp-shared.yml
@@ -47,7 +47,18 @@ jobs:
         continue-on-error: true
       - name: ci/check-for-failures
         if: steps.check-lint.outcome != 'success' || steps.check-types.outcome != 'success' || steps.test.outcome != 'success'
-        run: exit 1
+        run: |
+          if [[ ${{ steps.check-lint.outcome }} != "success" ]]; then
+            echo "Linting failed. Check the output of the ci/check-lint step, run 'make check-style' or go to the Files changed tab in the pull request for more details."
+          fi
+          if [[ ${{ steps.check-types.outcome }} != "success" ]]; then
+            echo "Type checking failed. Check the output of the ci/check-types step or run 'make check-types' for more details."
+          fi
+          if [[ ${{ steps.test.outcome }} != "success" ]]; then
+            echo "Unit tests failed. Check the output of the ci/tests step or run 'make tests' for more details."
+          fi
+
+          exit 1
       - name: ci/build
         run: |
           npm run build ${{ inputs.workspace-argument }}

--- a/.github/workflows/webapp-shared.yml
+++ b/.github/workflows/webapp-shared.yml
@@ -7,10 +7,6 @@ on:
         required: true
         type: string
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   ci:
     runs-on: ubuntu-22.04
@@ -22,28 +18,23 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: ci/setup-node
         uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        id: setup_node
         with:
           node-version-file: ".nvmrc"
           cache: npm
           cache-dependency-path: 'webapp/package-lock.json'
       - name: ci/get-node-modules
-        run: |
-          make node_modules
+        run: make node_modules
       - name: ci/check-lint
         id: check-lint
-        run: |
-          npm run check ${{ inputs.workspace-argument }}
+        run: npm run check ${{ inputs.workspace-argument }}
         continue-on-error: true
       - name: ci/check-types
         id: check-types
-        run: |
-          npm run check-types ${{ inputs.workspace-argument }}
+        run: npm run check-types ${{ inputs.workspace-argument }}
         continue-on-error: true
       - name: ci/test
         id: test
-        run: |
-          npm test ${{ inputs.workspace-argument }}
+        run: npm test ${{ inputs.workspace-argument }}
         continue-on-error: true
       - name: ci/check-for-failures
         if: steps.check-lint.outcome != 'success' || steps.check-types.outcome != 'success' || steps.test.outcome != 'success'
@@ -60,5 +51,4 @@ jobs:
 
           exit 1
       - name: ci/build
-        run: |
-          npm run build ${{ inputs.workspace-argument }}
+        run: npm run build ${{ inputs.workspace-argument }}


### PR DESCRIPTION
#### Summary
As I discussed in [this spec](https://docs.google.com/document/d/1nLVVoFIGHhaP_PJCXQtt1Caj8jvDNksOoziRYB5FFrA/edit) and in Web Guild meeting a few weeks back, the goals of this reorganization are to have the web app's CI pipeline:
1. Only run when it's actually needed because the relevant code has changed
2. Limit the number of jobs and checks shown at the bottom of a GitHub PR to only those that are needed
3. Make those jobs and checks correspond more to the structure of the web app code rather than the type of check being done.

This PR itself will actually skip running the web app pipelines since it doesn't touch their code, so here's a couple demo PRs I set up to show different parts of the pipeline triggering and/or failing:
- https://github.com/mattermost/mattermost-server/pull/23094
- https://github.com/mattermost/mattermost-server/pull/23096

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52438

#### Release Note
```release-note
NONE
```
