### PR TITLE
[MM-52425] - Remove leftover Start Trial CTAs

### DIFF
--- a/webapp/channels/src/components/invitation_modal/invite_as.tsx
+++ b/webapp/channels/src/components/invitation_modal/invite_as.tsx
@@ -14,6 +14,7 @@ import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/user
 import {getSubscriptionProduct, checkHadPriorTrial} from 'mattermost-redux/selectors/entities/cloud';
 import {DispatchFunc} from 'mattermost-redux/types/actions';
 import {getPrevTrialLicense} from 'mattermost-redux/actions/admin';
+import {deprecateCloudFree} from 'mattermost-redux/selectors/entities/preferences';
 
 import {closeModal, openModal} from 'actions/views/modals';
 
@@ -43,6 +44,7 @@ export type Props = {
 export default function InviteAs(props: Props) {
     const {formatMessage} = useIntl();
     const license = useSelector(getLicense);
+    const cloudFreeDeprecated = useSelector(deprecateCloudFree);
     const dispatch = useDispatch<DispatchFunc>();
 
     useEffect(() => {
@@ -193,7 +195,7 @@ export default function InviteAs(props: Props) {
                         },
                     ]}
                     isDisabled={guestDisabled}
-                    badge={badges}
+                    badge={cloudFreeDeprecated ? null : badges}
                 />
             </div>
         </div>

--- a/webapp/channels/src/components/learn_more_trial_modal/learn_more_trial_modal.tsx
+++ b/webapp/channels/src/components/learn_more_trial_modal/learn_more_trial_modal.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {useIntl} from 'react-intl';
+import {FormattedMessage, useIntl} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';
 
 import {trackEvent} from 'actions/telemetry_actions';
@@ -16,10 +16,12 @@ import MonitorImacLikeSVG from 'components/common/svg_images_components/monitor_
 import SystemRolesSVG from 'components/admin_console/feature_discovery/features/images/system_roles_svg';
 import CloudStartTrialButton from 'components/cloud_start_trial/cloud_start_trial_btn';
 import {BtnStyle} from 'components/common/carousel/carousel_button';
+import useOpenSalesLink from 'components/common/hooks/useOpenSalesLink';
 
 import {closeModal} from 'actions/views/modals';
 import {DispatchFunc} from 'mattermost-redux/types/actions';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
+import {deprecateCloudFree} from 'mattermost-redux/selectors/entities/preferences';
 
 import StartTrialBtn from './start_trial_btn';
 
@@ -43,8 +45,11 @@ const LearnMoreTrialModal = (
     const [embargoed, setEmbargoed] = useState(false);
     const dispatch = useDispatch<DispatchFunc>();
 
+    const [openSalesLink] = useOpenSalesLink();
+
     // Cloud conditions
     const license = useSelector(getLicense);
+    const cloudFreeDeprecated = useSelector(deprecateCloudFree);
     const isCloud = license?.Cloud === 'true';
 
     const handleEmbargoError = useCallback(() => {
@@ -78,6 +83,19 @@ const LearnMoreTrialModal = (
                 extraClass={'btn btn-primary start-cloud-trial-btn'}
             />
         );
+        if (cloudFreeDeprecated) {
+            startTrialBtn = (
+                <button
+                    onClick={openSalesLink}
+                    className='btn btn-primary start-cloud-trial-btn'
+                >
+                    <FormattedMessage
+                        id='learn_more_trial_modal.contact_sales'
+                        defaultMessage='Contact sales'
+                    />
+                </button>
+            );
+        }
     }
 
     const handleOnClose = useCallback(() => {

--- a/webapp/channels/src/components/learn_more_trial_modal/learn_more_trial_modal_step.tsx
+++ b/webapp/channels/src/components/learn_more_trial_modal/learn_more_trial_modal_step.tsx
@@ -2,10 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-
+import {useSelector} from 'react-redux';
 import {FormattedMessage} from 'react-intl';
 
 import TrialBenefitsModalStepMore from 'components/trial_benefits_modal/trial_benefits_modal_step_more';
+import {deprecateCloudFree} from 'mattermost-redux/selectors/entities/preferences';
 
 import './learn_more_trial_modal_step.scss';
 import {AboutLinks, LicenseLinks} from 'utils/constants';
@@ -35,6 +36,7 @@ const LearnMoreTrialModalStep = (
         buttonLabel,
         handleOnClose,
     }: LearnMoreTrialModalStepProps) => {
+    const cloudFreeDeprecated = useSelector(deprecateCloudFree);
     return (
         <div
             id={`learnMoreTrialModalStep-${id}`}
@@ -59,32 +61,36 @@ const LearnMoreTrialModalStep = (
                     telemetryId={'learn_more_trial_modal'}
                 />
             )}
-            <div className='disclaimer'>
-                <span>
-                    <FormattedMessage
-                        id='start_trial.modal.disclaimer'
-                        defaultMessage='By clicking “Start trial”, I agree to the <linkEvaluation>Mattermost Software and Services License Agreement</linkEvaluation>, <linkPrivacy>privacy policy</linkPrivacy> and receiving product emails.'
-                        values={{
-                            linkEvaluation: (msg: React.ReactNode) => (
-                                <ExternalLink
-                                    href={LicenseLinks.SOFTWARE_SERVICES_LICENSE_AGREEMENT}
-                                    location='learn_more_trial_modal_step'
-                                >
-                                    {msg}
-                                </ExternalLink>
-                            ),
-                            linkPrivacy: (msg: React.ReactNode) => (
-                                <ExternalLink
-                                    href={AboutLinks.PRIVACY_POLICY}
-                                    location='learn_more_trial_modal_step'
-                                >
-                                    {msg}
-                                </ExternalLink>
-                            ),
-                        }}
-                    />
-                </span>
-            </div>
+            {
+                cloudFreeDeprecated ? '' : (
+                    <div className='disclaimer'>
+                        <span>
+                            <FormattedMessage
+                                id='start_trial.modal.disclaimer'
+                                defaultMessage='By clicking “Start trial”, I agree to the <linkEvaluation>Mattermost Software and Services License Agreement</linkEvaluation>, <linkPrivacy>privacy policy</linkPrivacy> and receiving product emails.'
+                                values={{
+                                    linkEvaluation: (msg: React.ReactNode) => (
+                                        <ExternalLink
+                                            href={LicenseLinks.SOFTWARE_SERVICES_LICENSE_AGREEMENT}
+                                            location='learn_more_trial_modal_step'
+                                        >
+                                            {msg}
+                                        </ExternalLink>
+                                    ),
+                                    linkPrivacy: (msg: React.ReactNode) => (
+                                        <ExternalLink
+                                            href={AboutLinks.PRIVACY_POLICY}
+                                            location='learn_more_trial_modal_step'
+                                        >
+                                            {msg}
+                                        </ExternalLink>
+                                    ),
+                                }}
+                            />
+                        </span>
+                    </div>
+                )
+            }
             {bottomLeftMessage && (
                 <div className='bottom-text-left-message'>
                     {bottomLeftMessage}

--- a/webapp/channels/src/components/widgets/menu/menu_items/menu_cloud_trial.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_items/menu_cloud_trial.tsx
@@ -14,6 +14,7 @@ import {DispatchFunc} from 'mattermost-redux/types/actions';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {isCurrentUserSystemAdmin} from 'mattermost-redux/selectors/entities/users';
 import {getCloudSubscription, getSubscriptionProduct} from 'mattermost-redux/selectors/entities/cloud';
+import {deprecateCloudFree} from 'mattermost-redux/selectors/entities/preferences';
 
 import {openModal} from 'actions/views/modals';
 
@@ -32,6 +33,7 @@ const MenuCloudTrial = ({id}: Props): JSX.Element | null => {
     const subscription = useSelector(getCloudSubscription);
     const subscriptionProduct = useSelector(getSubscriptionProduct);
     const license = useSelector(getLicense);
+    const cloudFreeDeprecated = useSelector(deprecateCloudFree);
     const dispatch = useDispatch<DispatchFunc>();
 
     const isCloud = license?.Cloud === 'true';
@@ -109,7 +111,7 @@ const MenuCloudTrial = ({id}: Props): JSX.Element | null => {
     );
 
     // menu option displayed when the workspace is not running any trial
-    const noFreeTrialContent = noPriorTrial ? (
+    let noFreeTrialContent = noPriorTrial ? (
         <FormattedMessage
             id='menu.cloudFree.priorTrial.tryEnterprise'
             defaultMessage='Interested in a limitless plan with high-security features? <openModalLink>Try Enterprise free for 30 days</openModalLink>'
@@ -144,6 +146,27 @@ const MenuCloudTrial = ({id}: Props): JSX.Element | null => {
             }
         />
     );
+
+    if (cloudFreeDeprecated) {
+        noFreeTrialContent = (
+            <FormattedMessage
+                id='menu.cloudFree.postTrial.tryEnterprise'
+                defaultMessage='Interested in a limitless plan with high-security features? <openModalLink>See plans</openModalLink>'
+                values={
+                    {
+                        openModalLink: (msg: string) => (
+                            <a
+                                className='open-see-plans-modal style-link'
+                                onClick={() => openPricingModal({trackingLocation: 'menu_cloud_trial'})}
+                            >
+                                {msg}
+                            </a>
+                        ),
+                    }
+                }
+            />
+        );
+    }
 
     return (
         <li

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4037,7 +4037,7 @@
   "learn_more_about_trial.modal.useSsoDescription": "Sign on quickly and easily with our SSO feature that works with OpenID, SAML, Google, and O365.",
   "learn_more_about_trial.modal.useSsoTitle": "Use SSO (with OpenID, SAML, Google, O365)",
   "learn_more_trial_modal_step.learnMoreAboutFeature": "Learn more about this feature.",
-  "learn_more_trial_modal.contact_sales": "Contact sales",
+  "learn_more_trial_modal.contact_sales": "Contact Sales",
   "learn_more_trial_modal.pretitle": "With Enterprise, you can...",
   "leave_private_channel_modal.leave": "Yes, leave channel",
   "leave_private_channel_modal.message": "Are you sure you wish to leave the private channel {channel}? You must be re-invited in order to re-join this channel in the future.",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4037,6 +4037,7 @@
   "learn_more_about_trial.modal.useSsoDescription": "Sign on quickly and easily with our SSO feature that works with OpenID, SAML, Google, and O365.",
   "learn_more_about_trial.modal.useSsoTitle": "Use SSO (with OpenID, SAML, Google, O365)",
   "learn_more_trial_modal_step.learnMoreAboutFeature": "Learn more about this feature.",
+  "learn_more_trial_modal.contact_sales": "Contact sales",
   "learn_more_trial_modal.pretitle": "With Enterprise, you can...",
   "leave_private_channel_modal.leave": "Yes, leave channel",
   "leave_private_channel_modal.message": "Are you sure you wish to leave the private channel {channel}? You must be re-invited in order to re-join this channel in the future.",


### PR DESCRIPTION
#### Summary
With the `cloudFreeDeprecated` feature flag on, there should be no mentions of "Start trial" in the webapp

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52425

#### Screenshots
<img width="1792" alt="Screenshot 2023-04-25 at 10 30 05" src="https://user-images.githubusercontent.com/28563179/234218279-a9572c24-effa-476b-aeef-42d800d6a406.png">

<img width="1792" alt="Screenshot 2023-04-25 at 10 47 51" src="https://user-images.githubusercontent.com/28563179/234218302-53e816ba-0477-44ad-aa86-1461b764dddf.png">

<img width="1792" alt="Screenshot 2023-04-25 at 11 08 04" src="https://user-images.githubusercontent.com/28563179/234218311-ca3ce513-0ca1-4409-b2a0-033e4c091068.png">


#### Release Note

```release-note
NONE
```
