### PR TITLE
MM-52451: always show mark all threads as read button

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
+++ b/webapp/channels/src/components/threading/global_threads/thread_list/__snapshots__/thread_list.test.tsx.snap
@@ -52,7 +52,6 @@ exports[`components/threading/global_threads/thread_list should match snapshot 1
         >
           <Memo(Button)
             className="Button___large Button___icon"
-            disabled={false}
             id="threads-list__mark-all-as-read"
             marginTop={true}
             onClick={[Function]}

--- a/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.tsx
+++ b/webapp/channels/src/components/threading/global_threads/thread_list/thread_list.tsx
@@ -233,7 +233,6 @@ const ThreadList = ({
                         >
                             <Button
                                 id={'threads-list__mark-all-as-read'}
-                                disabled={!someUnread}
                                 className={'Button___large Button___icon'}
                                 onClick={handleOpenMarkAllAsReadModal}
                                 marginTop={true}


### PR DESCRIPTION
#### Summary

Enables the "Mark All Threads as Read" button even when you don't have unreads.
This is done as a temporary action to mitigate the phantom unread mentions pending issue.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52451


#### Release Note

```release-note
NONE
```
