### PR TITLE
E2E: Enable skipped tests in playbooks

### DIFF
--- a/e2e-tests/cypress/package-lock.json
+++ b/e2e-tests/cypress/package-lock.json
@@ -12,7 +12,6 @@
         "@babel/eslint-parser": "7.19.1",
         "@babel/eslint-plugin": "7.19.1",
         "@cypress/request": "2.88.11",
-        "@cypress/skip-test": "2.6.1",
         "@mattermost/types": "7.4.0",
         "@testing-library/cypress": "9.0.0",
         "@types/async": "3.2.16",
@@ -2249,12 +2248,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/@cypress/skip-test": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.6.1.tgz",
-      "integrity": "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==",
-      "dev": true
     },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",
@@ -19061,12 +19054,6 @@
           "dev": true
         }
       }
-    },
-    "@cypress/skip-test": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.6.1.tgz",
-      "integrity": "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==",
-      "dev": true
     },
     "@cypress/xvfb": {
       "version": "1.2.4",

--- a/e2e-tests/cypress/package.json
+++ b/e2e-tests/cypress/package.json
@@ -3,7 +3,6 @@
     "@babel/eslint-parser": "7.19.1",
     "@babel/eslint-plugin": "7.19.1",
     "@cypress/request": "2.88.11",
-    "@cypress/skip-test": "2.6.1",
     "@mattermost/types": "7.4.0",
     "@testing-library/cypress": "9.0.0",
     "@types/async": "3.2.16",

--- a/e2e-tests/cypress/tests/integration/playbooks/channels/app_bar_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/channels/app_bar_spec.js
@@ -9,71 +9,45 @@
 // Stage: @prod
 // Group: @playbooks
 
-import {onlyOn} from '@cypress/skip-test';
-
 describe('channels > App Bar', {testIsolation: true}, () => {
     let testTeam;
     let testUser;
-    let testPlaybook;
-    let appBarEnabled;
 
     before(() => {
         cy.apiInitSetup().then(({team, user}) => {
             testTeam = team;
             testUser = user;
-
-            // # Login as testUser
-            cy.apiLogin(testUser);
-
-            // # Create a playbook
-            cy.apiCreateTestPlaybook({
-                teamId: testTeam.id,
-                title: 'Playbook',
-                userId: testUser.id,
-            }).then((playbook) => {
-                testPlaybook = playbook;
-
-                // # Start a playbook run
-                cy.apiRunPlaybook({
-                    teamId: testTeam.id,
-                    playbookId: testPlaybook.id,
-                    playbookRunName: 'Playbook Run',
-                    ownerUserId: testUser.id,
-                });
-            });
-
-            cy.apiGetConfig(true).then(({config}) => {
-                appBarEnabled = config.EnableAppBar === 'true';
-            });
         });
     });
 
     beforeEach(() => {
-        // # Size the viewport to show the RHS without covering posts.
-        cy.viewport('macbook-13');
-
-        // # Login as testUser
-        cy.apiLogin(testUser);
+        cy.apiAdminLogin();
     });
 
     describe('App Bar disabled', () => {
         it('should not show the Playbook App Bar icon', () => {
-            onlyOn(!appBarEnabled);
+            cy.apiUpdateConfig({ExperimentalSettings: {EnableAppBar: false}});
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
 
             // # Navigate directly to a non-playbook run channel
             cy.visit(`/${testTeam.name}/channels/town-square`);
 
             // * Verify App Bar icon is not showing
-            cy.get('#channel_view').within(() => {
-                cy.getPlaybooksAppBarIcon().should('not.exist');
-            });
+            cy.get('.app-bar').should('not.exist');
         });
     });
 
     describe('App Bar enabled', () => {
-        it('should show the Playbook App Bar icon', () => {
-            onlyOn(appBarEnabled);
+        beforeEach(() => {
+            cy.apiUpdateConfig({ExperimentalSettings: {EnableAppBar: true}});
 
+            // # Login as testUser
+            cy.apiLogin(testUser);
+        });
+
+        it('should show the Playbook App Bar icon', () => {
             // # Navigate directly to a non-playbook run channel
             cy.visit(`/${testTeam.name}/channels/town-square`);
 
@@ -82,8 +56,6 @@ describe('channels > App Bar', {testIsolation: true}, () => {
         });
 
         it('should show "Playbooks" tooltip for Playbook App Bar icon', () => {
-            onlyOn(appBarEnabled);
-
             // # Navigate directly to a non-playbook run channel
             cy.visit(`/${testTeam.name}/channels/town-square`);
 

--- a/e2e-tests/cypress/tests/integration/playbooks/channels/rhs/status_update_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/channels/rhs/status_update_spec.js
@@ -82,7 +82,7 @@ describe('channels > rhs > status update', {testIsolation: true}, () => {
             });
         });
 
-        it.skip('description link navigates to run overview', () => {
+        it('description link navigates to run overview', () => {
             // # Run the `/playbook update` slash command.
             cy.uiPostMessageQuickly('/playbook update');
 

--- a/e2e-tests/cypress/tests/integration/playbooks/lhs_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/lhs_spec.js
@@ -153,7 +153,7 @@ describe('lhs', {testIsolation: true}, () => {
             cy.findByTestId('dropdownmenu').should('be.visible');
         });
 
-        it.skip('can copy link', () => {
+        it('can copy link', () => {
             // # Visit the playbook run
             cy.visit(`/playbooks/runs/${playbookRun.id}`);
             stubClipboard().as('clipboard');
@@ -295,7 +295,7 @@ describe('lhs', {testIsolation: true}, () => {
             });
         });
 
-        it.skip('leave run, when on rdp of the same run', () => {
+        it('leave run, when on rdp of the same run', () => {
             // # Click on leave menu item
             getRunDropdownItemByText('Runs', playbookRun.name, 'Leave and unfollow run').click();
 

--- a/e2e-tests/cypress/tests/integration/playbooks/playbooks/edit_metrics_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/playbooks/edit_metrics_spec.js
@@ -290,7 +290,7 @@ describe('playbooks > edit_metrics', {testIsolation: true}, () => {
         });
 
         describe('delete metric', () => {
-            it.skip('verifies when clicking delete button; saved metrics have different confirmation text; deleted metrics are deleted', () => {
+            it('verifies when clicking delete button; saved metrics have different confirmation text; deleted metrics are deleted', () => {
                 // # Visit the selected playbook
                 cy.visit(`/playbooks/playbooks/${testPlaybook.id}`);
 

--- a/e2e-tests/cypress/tests/integration/playbooks/runs/permissions_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/runs/permissions_spec.js
@@ -160,9 +160,7 @@ describe('runs > permissions', {testIsolation: true}, () => {
         });
 
         describe('should be visible', () => {
-            // XXX: Skipping this test, since public playbooks currently have no members. This will
-            // likely change in the future, so keeping the skeleton.
-            it.skip('to playbook members', () => {
+            it('to playbook members', () => {
                 assertRunIsVisible(run, playbookMember);
             });
 
@@ -242,9 +240,7 @@ describe('runs > permissions', {testIsolation: true}, () => {
         });
 
         describe('should be visible', () => {
-            // XXX: Skipping this test, since public playbooks currently have no members. This will
-            // likely change in the future.
-            it.skip('to playbook members', () => {
+            it('to playbook members', () => {
                 assertRunIsVisible(run, playbookMember);
             });
 
@@ -332,10 +328,9 @@ describe('runs > permissions', {testIsolation: true}, () => {
                 assertRunIsVisible(run, runParticipant);
             });
 
-            // Skipping this test, since followers cannot follow a run with a private channel from
-            // a private playbook. (But leaving it for clarity in the code.)
-            it.skip('to run followers', () => {
-                assertRunIsVisible(run, runFollower);
+            // Followers cannot follow a run with a private channel from a private playbook
+            it('to run followers', () => {
+                assertRunIsNotVisible(run, runFollower);
             });
 
             it('to admins in the team', () => {
@@ -414,10 +409,9 @@ describe('runs > permissions', {testIsolation: true}, () => {
                 assertRunIsVisible(run, runParticipant);
             });
 
-            // Skipping this test, since followers cannot follow a run with a private channel from
-            // a private playbook. (But leaving it for clarity in the code.)
-            it.skip('to run followers', () => {
-                assertRunIsVisible(run, runFollower);
+            // Followers cannot follow a run with a private channel from a private playbook
+            it('to run followers', () => {
+                assertRunIsNotVisible(run, runFollower);
             });
 
             it('to admins in the team', () => {

--- a/e2e-tests/cypress/tests/integration/playbooks/runs/rdp_main_header_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/runs/rdp_main_header_spec.js
@@ -692,7 +692,7 @@ describe('runs > run details page > header', {testIsolation: true}, () => {
                     });
                 });
 
-                describe.skip('Join action disabled', () => {
+                describe('Join action disabled', () => {
                     beforeEach(() => {
                         cy.apiLogin(testUser);
 

--- a/e2e-tests/cypress/tests/integration/playbooks/runs/rdp_main_statusupdate_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/runs/rdp_main_statusupdate_spec.js
@@ -267,7 +267,7 @@ describe('runs > run details page > status update', {testIsolation: true}, () =>
             });
         });
 
-        it.skip('requests an update and confirm', () => {
+        it('requests an update and confirm', () => {
             // # Click on request update
             cy.findByTestId('run-statusupdate-section').
                 should('be.visible').
@@ -281,11 +281,11 @@ describe('runs > run details page > status update', {testIsolation: true}, () =>
                 cy.visit(`${testTeam.name}/channels/${playbookRunChannelName}`);
 
                 // * Assert that message has been sent
-                cy.getLastPost().contains(`${testUser.username} requested a status update for ${testPublicPlaybook.name}.`);
+                cy.getLastPost().contains(`${testViewerUser.username} requested a status update for ${testRun.name}.`);
             });
         });
 
-        it.skip('requests an update and cancel', () => {
+        it('requests an update and cancel', () => {
             // # Click request update
             cy.findByTestId('run-statusupdate-section').
                 should('be.visible').


### PR DESCRIPTION
#### Summary
- Enabled skipped tests in playbooks
- Removed `@cypress/skip-test` to prevent using it in the future

#### Ticket Link
none

#### Release Note
```release-note
NONE
```
