### PR TITLE
MM-52439_MM-52439: New Marketplace icon on apps bar non-responsive when RHS open

### DIFF
--- a/webapp/channels/src/components/app_bar/app_bar.scss
+++ b/webapp/channels/src/components/app_bar/app_bar.scss
@@ -134,6 +134,7 @@ $app-bar-width: 48px;
     }
 
     &__bottom {
+        position: relative;
         display: flex;
         flex-flow: column;
         align-items: center;


### PR DESCRIPTION
#### Summary
Marketplace button in App bar is now responsive when RHS open

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52439

#### Screenshots
![Apr-25-2023 09-42-07](https://user-images.githubusercontent.com/79058848/234314378-f163eb1d-fd02-41f2-99ec-f617d0cd39c3.gif)

#### Release Note
```release-note
NONE
```
