### PR TITLE
MM-52472: Use ubuntu-22.04 in the check-style step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the serialized files using 'make gen-serialized'"; exit 1; fi
   check-mattermost-vet:
     name: Check style
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-22.04
     defaults:
       run:
         working-directory: server


### PR DESCRIPTION
#### Summary
The `Check style` step probably does not need an overspec'd runner. This hopefully mitigates these long waiting times to get an available runner:
![image](https://user-images.githubusercontent.com/3924815/234335631-b6b9bdbf-aa59-473c-b9d7-7def2ba45937.png)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52472

#### Screenshots
--

#### Release Note
```release-note
NONE
```
