### PR TITLE
[MM-52492] Makefile: bump golangci-lint version

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -292,7 +292,7 @@ endif
 
 golangci-lint: ## Run golangci-lint on codebase
 	@# Keep the version in sync with the command in .circleci/config.yml
-	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+	$(GO) install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
 	@echo Running golangci-lint
 	$(GOBIN)/golangci-lint run ./...


### PR DESCRIPTION

#### Summary
The version `v1.50.1` seems to be broken as it's consuming more than hundred gb of ram. I was able to overcome it by upgrading the version.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52492

#### Screenshots

<img width="1072" alt="resim" src="https://user-images.githubusercontent.com/2153367/234587556-60ee7c46-7d39-47a4-8c44-4e9c682b3536.png">

#### Release Note

```release-note
NONE
```
