### PR TITLE
[MM-52493] workflows/artifacts.yml: do not upload build artifacts for branches

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -27,11 +27,9 @@ jobs:
           path: server/dist
       - name: cd/Upload artifacts to S3
         env:
-          BRANCH_NAME: ${{ github.event.workflow_run.head_branch }}
           REPO_NAME: ${{ github.event.repository.name }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          aws s3 cp server/dist/ s3://pr-builds.mattermost.com/$REPO_NAME/$BRANCH_NAME/ --acl public-read --cache-control "no-cache" --recursive --no-progress
           aws s3 cp server/dist/ s3://pr-builds.mattermost.com/$REPO_NAME/commit/$COMMIT_SHA/ --acl public-read --cache-control "no-cache" --recursive --no-progress
 
   build-docker:


### PR DESCRIPTION

#### Summary
The build artifacts with branch names are no longer required as there are no other builds needs to be built for other repositories such as mattermost-webapp.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52493


#### Release Note

```release-note
NONE
```
