### PR TITLE
MM-52282 Remove ExperimentalSettings.PatchPluginsReactDOM

### DIFF
--- a/e2e-tests/playwright/support/server/default_config.ts
+++ b/e2e-tests/playwright/support/server/default_config.ts
@@ -530,7 +530,6 @@ const defaultServerConfig: AdminConfig = {
         EnableSharedChannels: false,
         EnableRemoteClusterService: false,
         EnableAppBar: false,
-        PatchPluginsReactDOM: false,
         DisableRefetchingOnBrowserFocus: false,
     },
     AnalyticsSettings: {

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -231,7 +231,6 @@ func (ch *Channels) initPlugins(c *request.Context, pluginDir, webappPluginDir s
 		NewDriverImpl(ch.srv),
 		pluginDir,
 		webappPluginDir,
-		*ch.cfgSvc.Config().ExperimentalSettings.PatchPluginsReactDOM,
 		ch.srv.Log(),
 		ch.srv.GetMetrics(),
 	)

--- a/server/model/config.go
+++ b/server/model/config.go
@@ -973,7 +973,6 @@ type ExperimentalSettings struct {
 	EnableSharedChannels            *bool   `access:"experimental_features"`
 	EnableRemoteClusterService      *bool   `access:"experimental_features"`
 	EnableAppBar                    *bool   `access:"experimental_features"`
-	PatchPluginsReactDOM            *bool   `access:"experimental_features"`
 	DisableRefetchingOnBrowserFocus *bool   `access:"experimental_features"`
 }
 
@@ -1008,10 +1007,6 @@ func (s *ExperimentalSettings) SetDefaults() {
 
 	if s.EnableAppBar == nil {
 		s.EnableAppBar = NewBool(false)
-	}
-
-	if s.PatchPluginsReactDOM == nil {
-		s.PatchPluginsReactDOM = NewBool(false)
 	}
 
 	if s.DisableRefetchingOnBrowserFocus == nil {

--- a/server/plugin/environment.go
+++ b/server/plugin/environment.go
@@ -4,12 +4,10 @@
 package plugin
 
 import (
-	"bytes"
 	"fmt"
 	"hash/fnv"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -59,7 +57,6 @@ type Environment struct {
 	dbDriver               Driver
 	pluginDir              string
 	webappPluginDir        string
-	patchReactDOM          bool
 	prepackagedPlugins     []*PrepackagedPlugin
 	prepackagedPluginsLock sync.RWMutex
 }
@@ -69,7 +66,6 @@ func NewEnvironment(
 	dbDriver Driver,
 	pluginDir string,
 	webappPluginDir string,
-	patchReactDOM bool,
 	logger *mlog.Logger,
 	metrics einterfaces.MetricsInterface,
 ) (*Environment, error) {
@@ -80,7 +76,6 @@ func NewEnvironment(
 		dbDriver:        dbDriver,
 		pluginDir:       pluginDir,
 		webappPluginDir: webappPluginDir,
-		patchReactDOM:   patchReactDOM,
 	}, nil
 }
 
@@ -488,17 +483,6 @@ func (env *Environment) UnpackWebappBundle(id string) (*model.Manifest, error) {
 		return nil, errors.Wrapf(err, "unable to read webapp bundle: %v", id)
 	}
 
-	if env.patchReactDOM {
-		newContents, changed := patchReactDOM(sourceBundleFileContents)
-		if changed {
-			sourceBundleFileContents = newContents
-			err = os.WriteFile(sourceBundleFilepath, sourceBundleFileContents, 0644)
-			if err != nil {
-				return nil, errors.Wrapf(err, "unable to overwrite webapp bundle: %v", id)
-			}
-		}
-	}
-
 	hash := fnv.New64a()
 	if _, err = hash.Write(sourceBundleFileContents); err != nil {
 		return nil, errors.Wrapf(err, "unable to generate hash for webapp bundle: %v", id)
@@ -513,52 +497,6 @@ func (env *Environment) UnpackWebappBundle(id string) (*model.Manifest, error) {
 	}
 
 	return manifest, nil
-}
-
-func patchReactDOM(initialBytes []byte) ([]byte, bool) {
-	if !bytes.Contains(initialBytes, []byte("react-dom.production.min.js")) {
-		return initialBytes, false
-	}
-
-	initial := string(initialBytes)
-	nameIndex := strings.Index(initial, "react-dom.production.min.js")
-
-	beginning := strings.LastIndex(initial[:nameIndex], "{")
-	var end int
-
-	argDefBeginning := strings.LastIndex(initial[:beginning], "function") + 9
-	argDefEnd := strings.LastIndex(initial[:beginning], ")") - 1
-	argsNames := strings.Split(initial[argDefBeginning:argDefEnd], ",")
-	if len(argsNames) != 3 {
-		return initialBytes, false
-	}
-
-	exportsArgName := strings.TrimSpace(argsNames[1])
-
-	numOpenBraces := 0
-	for i, c := range initial[beginning:] {
-		if end != 0 {
-			break
-		}
-		switch c {
-		case '}':
-			numOpenBraces--
-
-			if numOpenBraces == 0 {
-				end = beginning + i
-			}
-		case '{':
-			numOpenBraces++
-		}
-	}
-
-	beforePatch := initial[:end]
-	afterPatch := initial[end:]
-
-	patch := fmt.Sprintf("; Object.assign(%s, window.ReactDOM)", exportsArgName)
-
-	result := fmt.Sprintf("%s%s%s", beforePatch, patch, afterPatch)
-	return []byte(result), true
 }
 
 // HooksForPlugin returns the hooks API for the plugin with the given id.

--- a/webapp/channels/src/components/admin_console/admin_definition.jsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.jsx
@@ -6869,26 +6869,6 @@ const AdminDefinition = {
                     },
                     {
                         type: Constants.SettingsTypes.TYPE_BOOL,
-                        key: 'ExperimentalSettings.PatchPluginsReactDOM',
-                        label: t('admin.experimental.patchPluginsReactDOM.title'),
-                        label_default: 'Patch React DOM used by plugins:',
-                        help_text: t('admin.experimental.patchPluginsReactDOM.desc'),
-                        help_text_default: 'When true, client-side plugins will be patched to use the version of React DOM provided by the web app. This should only be enabled if plugins break after upgrading to Mattermost 7.6. The server must be restarted for this setting to take effect. See the <link>Important Upgrade Notes</link> for more information.',
-                        help_text_values: {
-                            link: (msg) => (
-                                <ExternalLink
-                                    location='admin_console'
-                                    href='https://docs.mattermost.com/upgrade/important-upgrade-notes.html'
-                                >
-                                    {msg}
-                                </ExternalLink>
-                            ),
-                        },
-                        isHidden: it.licensedForFeature('Cloud'),
-                        isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
-                    },
-                    {
-                        type: Constants.SettingsTypes.TYPE_BOOL,
                         key: 'ExperimentalSettings.DisableRefetchingOnBrowserFocus',
                         label: t('admin.experimental.disableRefetchingOnBrowserFocus.title'),
                         label_default: 'Disable data refetching on browser refocus:',

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -951,8 +951,6 @@
   "admin.experimental.linkMetadataTimeoutMilliseconds.desc": "The number of milliseconds to wait for metadata from a third-party link. Used with Post Metadata.",
   "admin.experimental.linkMetadataTimeoutMilliseconds.example": "E.g.: \"5000\"",
   "admin.experimental.linkMetadataTimeoutMilliseconds.title": "Link Metadata Timeout:",
-  "admin.experimental.patchPluginsReactDOM.desc": "When true, client-side plugins will be patched to use the version of React DOM provided by the web app. This should only be enabled if plugins break after upgrading to Mattermost 7.6. The server must be restarted for this setting to take effect. See the <link>Important Upgrade Notes</link> for more information.",
-  "admin.experimental.patchPluginsReactDOM.title": "Patch React DOM used by plugins:",
   "admin.experimental.samlSettingsLoginButtonBorderColor.desc": "Specify the color of the SAML login button border for white labeling purposes. Use a hex code with a #-sign before the code. This setting only applies to the mobile apps.",
   "admin.experimental.samlSettingsLoginButtonBorderColor.title": "SAML login Button Border Color:",
   "admin.experimental.samlSettingsLoginButtonColor.desc": "Specify the color of the SAML login button for white labeling purposes. Use a hex code with a #-sign before the code. This setting only applies to the mobile apps.",

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -728,7 +728,6 @@ export type ExperimentalSettings = {
     EnableSharedChannels: boolean;
     EnableRemoteClusterService: boolean;
     EnableAppBar: boolean;
-    PatchPluginsReactDOM: boolean;
     DisableRefetchingOnBrowserFocus: boolean;
 };
 


### PR DESCRIPTION
#### Summary
This setting was only temporary, and we'd planned to remove it in 8.0 since it was added

#### Ticket Link
MM-52282

#### Release Note
```release-note
Removed ExperimentalSettings.PatchPluginsReactDOM
```
