### PR TITLE
[MM-50204] - Don't pass invalid prop to textarea by advanced text editor

### DIFF
--- a/webapp/channels/src/components/autosize_textarea.tsx
+++ b/webapp/channels/src/components/autosize_textarea.tsx
@@ -115,7 +115,6 @@ export class AutosizeTextarea extends React.PureComponent<Props> {
             placeholder,
             disabled,
             onInput,
-            onWidthChange,
 
             // TODO: The provided `id` is sometimes hard-coded and used to interface with the
             // component, e.g. `post_textbox`, so it can't be changed. This would ideally be
@@ -129,6 +128,8 @@ export class AutosizeTextarea extends React.PureComponent<Props> {
             rows: 0,
             height: 0,
         };
+
+        Reflect.deleteProperty(otherProps, 'onWidthChange');
 
         if (this.height <= 0) {
             // Set an initial number of rows so that the textarea doesn't appear too large when its first rendered

--- a/webapp/channels/src/components/autosize_textarea.tsx
+++ b/webapp/channels/src/components/autosize_textarea.tsx
@@ -115,6 +115,7 @@ export class AutosizeTextarea extends React.PureComponent<Props> {
             placeholder,
             disabled,
             onInput,
+            onWidthChange,
 
             // TODO: The provided `id` is sometimes hard-coded and used to interface with the
             // component, e.g. `post_textbox`, so it can't be changed. This would ideally be


### PR DESCRIPTION
#### Summary
We are getting an unknown-prop warning because we attempt to render a DOM element with a prop that is not recognized by React as a legal DOM attribute/property. Excluding this prop from the textarea props removed the warning.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50204

#### Release Note

```release-note
NONE
```
