### PR TITLE
MM-51562 Update package versions to 7.11.0

### DIFF
--- a/webapp/boards/package.json
+++ b/webapp/boards/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boards",
-	"version": "7.9.1",
+	"version": "7.11.0",
 	"private": true,
 	"description": "",
 	"scripts": {

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "7.9.1",
+  "version": "7.11.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react-dom": "1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -33,7 +33,7 @@
       }
     },
     "boards": {
-      "version": "7.9.1",
+      "version": "7.11.0",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.2",
         "@draft-js-plugins/emoji": "^4.6.0",
@@ -3403,7 +3403,7 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "7.9.1",
+      "version": "7.11.0",
       "dependencies": {
         "@floating-ui/react-dom": "1.0.0",
         "@floating-ui/react-dom-interactions": "0.10.3",
@@ -33282,7 +33282,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "7.9.0",
+      "version": "7.11.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "4.0.0"
@@ -33322,7 +33322,7 @@
     },
     "platform/components": {
       "name": "@mattermost/components",
-      "version": "7.4.0",
+      "version": "7.11.0",
       "devDependencies": {
         "@babel/cli": "^7.17.6",
         "@babel/core": "^7.17.7",
@@ -33746,7 +33746,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "7.9.0",
+      "version": "7.11.0",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"
@@ -33758,7 +33758,7 @@
       }
     },
     "playbooks": {
-      "version": "7.9.1",
+      "version": "7.11.0",
       "dependencies": {
         "@apollo/client": "3.7.3",
         "@floating-ui/react-dom-interactions": "0.6.3",

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "mattermost"
   ],
-  "homepage": "https://github.com/mattermost/mattermost-webapp/tree/master/packages/client#readme",
+  "homepage": "https://github.com/mattermost/mattermost-server/tree/master/webapp/platform/client#readme",
   "license": "MIT",
   "files": [
     "lib"
@@ -15,7 +15,7 @@
   "repository": {
     "type": "git",
     "url": "github:mattermost/mattermost-webapp",
-    "directory": "packages/client"
+    "directory": "webapp/platform/client"
   },
   "dependencies": {
     "form-data": "4.0.0"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "7.9.0",
+  "version": "7.11.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -14,7 +14,7 @@
   "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "github:mattermost/mattermost-webapp",
+    "url": "github:mattermost/mattermost-server",
     "directory": "webapp/platform/client"
   },
   "dependencies": {

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/components",
-  "version": "7.4.0",
+  "version": "7.11.0",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "styles": "dist/index.esm.css",

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "7.9.0",
+  "version": "7.11.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github:mattermost/mattermost-webapp",
+    "url": "github:mattermost/mattermost-server",
     "directory": "webapp/platform/types"
   },
   "peerDependencies": {

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "mattermost"
   ],
-  "homepage": "https://github.com/mattermost/mattermost-webapp/tree/master/packages/types#readme",
+  "homepage": "https://github.com/mattermost/mattermost-webapp/tree/master/webapp/platform/types#readme",
   "license": "MIT",
   "files": [
     "lib"
@@ -23,7 +23,7 @@
   "repository": {
     "type": "git",
     "url": "github:mattermost/mattermost-webapp",
-    "directory": "packages/types"
+    "directory": "webapp/platform/types"
   },
   "peerDependencies": {
     "typescript": "^4.3"

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "mattermost"
   ],
-  "homepage": "https://github.com/mattermost/mattermost-webapp/tree/master/webapp/platform/types#readme",
+  "homepage": "https://github.com/mattermost/mattermost-server/tree/master/webapp/platform/types#readme",
   "license": "MIT",
   "files": [
     "lib"

--- a/webapp/playbooks/package.json
+++ b/webapp/playbooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playbooks",
   "private": true,
-  "version": "7.9.1",
+  "version": "7.11.0",
   "dependencies": {
     "@apollo/client": "3.7.3",
     "@floating-ui/react-dom-interactions": "0.6.3",


### PR DESCRIPTION
#### Summary
I'm trying to do this early so that I don't have to make a change to the release branch after the release has been cut (see https://github.com/mattermost/mattermost-webapp/commit/3e848ac828834d3b2b145a54c9abbbdde243ad89).

The only ones of these that actually matter are the Client and Types packages since those are shipped on NPM, but we're going to just keep them all in sync for now

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51562

#### Release Note
```release-note
NONE
```
