### PR TITLE
MM-49937 Fix tappable area of modals on mobile

### DIFF
--- a/webapp/channels/src/sass/responsive/_mobile.scss
+++ b/webapp/channels/src/sass/responsive/_mobile.scss
@@ -1930,7 +1930,6 @@
 
             .modal-dialog {
                 max-width: 100%;
-                height: 100%;
                 margin: 0;
             }
 


### PR DESCRIPTION
#### Summary
Below a certain screen size, modals used to cover the whole screen, but when we changed that, we forgot to reduce the height of the `.modal-dialog` div to match that. Because it covered the whole screen, you couldn't tap below a modal to dismiss it since the tap wasn't considered "outside" the modal

#### Ticket Link
MM-49937

#### Screenshots
| before (>= 640px) | before (< 640px) | after (< 640px) |
-|-|-
![Screen Shot 2023-05-01 at 4 25 41 PM](https://user-images.githubusercontent.com/3277310/235524976-69e76917-efb8-484d-936d-0b6dc19847c2.png)|![Screen Shot 2023-05-01 at 4 25 50 PM](https://user-images.githubusercontent.com/3277310/235524982-991d4e4b-d773-464e-a17a-dc55c55c6fde.png)|![Screen Shot 2023-05-01 at 4 26 00 PM](https://user-images.githubusercontent.com/3277310/235524985-b1aead21-2166-4f9e-9f25-05e31c4facc0.png)

#### Release Note
```release-note
Fix modals not closing when clicking below them on certain screen sizes
```
