### PR TITLE
MM-11388 : Extend words that trigger mentions functionality to support phrases with spaces

### DIFF
--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -1264,6 +1264,14 @@ func (m *ExplicitMentions) checkForMention(word string, keywords map[string][]st
 
 	m.addGroupMention(word, groups)
 
+	// Check if the word contains a keyword.
+	for id, words := range keywords {
+		if strings.Contains(word, id) {
+			m.addMentions(words, mentionType)
+			return true
+		}
+	}
+
 	if ids, match := keywords[strings.ToLower(word)]; match {
 		m.addMentions(ids, mentionType)
 		return true
@@ -1305,7 +1313,7 @@ func (m *ExplicitMentions) processText(text string, keywords map[string][]string
 
 	for _, word := range strings.FieldsFunc(text, func(c rune) bool {
 		// Split on any whitespace or punctuation that can't be part of an at mention or emoji pattern
-		return !(c == ':' || c == '.' || c == '-' || c == '_' || c == '@' || unicode.IsLetter(c) || unicode.IsNumber(c))
+		return !(c == ':' || c == '.' || c == '-' || c == '_' || c == '@' || unicode.IsLetter(c) || unicode.IsSpace(c) || unicode.IsNumber(c))
 	}) {
 		// skip word with format ':word:' with an assumption that it is an emoji format only
 		if word[0] == ':' && word[len(word)-1] == ':' {

--- a/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
+++ b/webapp/channels/src/components/user_settings/notifications/user_settings_notifications.tsx
@@ -299,8 +299,8 @@ export default class NotificationsTab extends React.PureComponent<Props, State> 
         if (checked) {
             const text = this.customMentionsRef.current?.value || '';
 
-            // remove all spaces and split string into individual keys
-            this.setState({customKeys: text.replace(/ /g, ''), customKeysChecked: true});
+            // split string into individual keys
+            this.setState({customKeys: text, customKeysChecked: true});
         } else {
             this.setState({customKeys: '', customKeysChecked: false});
         }


### PR DESCRIPTION
#### Summary
Remove space formatting from words that trigger mentions.
Users may now use spaces in those custom words

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-server/issues/22205

Jira : https://mattermost.atlassian.net/browse/MM-11388

#### Screenshots
Steps to reproduce for QA : 

1. Add a word with space to words that trigger mentions 
2. Add another user and send that word with space
3. Navigate to another channel and wait for the notification to pop up

[screen-recorder-tue-may-02-2023-22-33-03.webm](https://user-images.githubusercontent.com/22036449/235791125-c0391c78-1e8b-468b-94c2-f37a48d12af1.webm)

#### Release Note

```release-note
Added the possibility to use spaces in words that trigger mentions
```
