### PR TITLE
Let Boards/Product dev servers run on default ports

### DIFF
--- a/webapp/boards/webpack.config.js
+++ b/webapp/boards/webpack.config.js
@@ -189,17 +189,24 @@ config.plugins.push(new webpack.DefinePlugin({
 if (NPM_TARGET === 'start:product') {
     const url = new URL(process.env.MM_BOARDS_DEV_SERVER_URL ?? 'http://localhost:9006');
 
+    const protocol = url.protocol.substring(0, url.protocol.length - 1);
+    const hostname = url.hostname;
+    let port = url.port;
+    if (!port) {
+        port = protocol === 'https' ? '443' : '80';
+    }
+
     config.devServer = {
         server: {
-            type: url.protocol.substring(0, url.protocol.length - 1),
+            type: protocol,
             options: {
                 minVersion: process.env.MM_SERVICESETTINGS_TLSMINVER ?? 'TLSv1.2',
                 key: process.env.MM_SERVICESETTINGS_TLSKEYFILE,
                 cert: process.env.MM_SERVICESETTINGS_TLSCERTFILE,
             },
         },
-        host: url.hostname,
-        port: url.port,
+        host: hostname,
+        port,
         devMiddleware: {
             writeToDisk: false,
         },

--- a/webapp/playbooks/webpack.config.js
+++ b/webapp/playbooks/webpack.config.js
@@ -137,17 +137,24 @@ config.output = {
 if (NPM_TARGET === 'start:product') {
     const url = new URL(process.env.MM_PLAYBOOKS_DEV_SERVER_URL ?? 'http://localhost:9007');
 
+    const protocol = url.protocol.substring(0, url.protocol.length - 1);
+    const hostname = url.hostname;
+    let port = url.port;
+    if (!port) {
+        port = protocol === 'https' ? '443' : '80';
+    }
+
     config.devServer = {
         server: {
-            type: url.protocol.substring(0, url.protocol.length - 1),
+            type: protocol,
             options: {
                 minVersion: process.env.MM_SERVICESETTINGS_TLSMINVER ?? 'TLSv1.2',
                 key: process.env.MM_SERVICESETTINGS_TLSKEYFILE,
                 cert: process.env.MM_SERVICESETTINGS_TLSCERTFILE,
             },
         },
-        host: url.hostname,
-        port: url.port,
+        host: hostname,
+        port,
         devMiddleware: {
             writeToDisk: false,
         },


### PR DESCRIPTION
#### Summary
Node's `URL` sets its `port` field to the empty string when the URL is using a default port, even if you add `:443` to the end of an https URL, but Webpack Dev Server expects its `port` option to always have the actual number, so we have to do some extra negotiation to let the servers run on 80/443 for http and https respectively

#### Release Note
```release-note
NONE
```
