### PR TITLE
[E2E]: Fix issue with MM-T2927_1 Should show all available statuses with their icons

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/menus/status_dropdown_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/menus/status_dropdown_spec.js
@@ -15,7 +15,7 @@ import theme from '../../../fixtures/theme.json';
 
 describe('Status dropdown menu', () => {
     const statusTestCases = [
-        {text: 'Online', className: 'icon-check', profileClassName: 'icon-check-circle'},
+        {text: 'Online', className: 'icon-check-circle', profileClassName: 'icon-check-circle'},
         {text: 'Away', className: 'icon-clock'},
         {text: 'Do Not Disturb', className: 'icon-minus-circle'},
         {text: 'Offline', className: 'icon-circle-outline'},


### PR DESCRIPTION
#### Summary
Fix issue with MM-T2927_1 Should show all available statuses with their icons caused by https://github.com/mattermost/mattermost-server/pull/22941

#### Ticket Link
  Fixes https://mattermost.atlassian.net/browse/MM-52647


#### Screenshots
NA

#### Release Note
```release-note
NONE
```
