### PR TITLE
[MM-52288] Cherry picking oauth postgres migration

### DIFF
--- a/db/migrations/migrations.list
+++ b/db/migrations/migrations.list
@@ -210,6 +210,8 @@ db/migrations/mysql/000104_upgrade_notifyadmin.down.sql
 db/migrations/mysql/000104_upgrade_notifyadmin.up.sql
 db/migrations/mysql/000105_remove_tokens.down.sql
 db/migrations/mysql/000105_remove_tokens.up.sql
+db/migrations/mysql/000108_remove_orphaned_oauth_preferences.down.sql
+db/migrations/mysql/000108_remove_orphaned_oauth_preferences.up.sql
 db/migrations/postgres/000001_create_teams.down.sql
 db/migrations/postgres/000001_create_teams.up.sql
 db/migrations/postgres/000002_create_team_members.down.sql
@@ -420,3 +422,5 @@ db/migrations/postgres/000104_upgrade_notifyadmin.down.sql
 db/migrations/postgres/000104_upgrade_notifyadmin.up.sql
 db/migrations/postgres/000105_remove_tokens.down.sql
 db/migrations/postgres/000105_remove_tokens.up.sql
+db/migrations/postgres/000108_remove_orphaned_oauth_preferences.down.sql
+db/migrations/postgres/000108_remove_orphaned_oauth_preferences.up.sql

--- a/db/migrations/mysql/000108_remove_orphaned_oauth_preferences.down.sql
+++ b/db/migrations/mysql/000108_remove_orphaned_oauth_preferences.down.sql
@@ -1,0 +1,1 @@
+-- Migration only applied to postgres

--- a/db/migrations/mysql/000108_remove_orphaned_oauth_preferences.up.sql
+++ b/db/migrations/mysql/000108_remove_orphaned_oauth_preferences.up.sql
@@ -1,0 +1,1 @@
+-- Migration only applied to postgres

--- a/db/migrations/postgres/000105_remove_tokens.up.sql
+++ b/db/migrations/postgres/000105_remove_tokens.up.sql
@@ -4,8 +4,7 @@ WITH oauthDelete AS (
 	DELETE FROM oauthaccessdata o
 	WHERE NOT EXISTS (
 		SELECT p.* FROM preferences p
-		WHERE o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app' 
-		and p.name IS NULL
+		WHERE o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
 	)
 	RETURNING o.token
 )

--- a/db/migrations/postgres/000108_remove_orphaned_oauth_preferences.down.sql
+++ b/db/migrations/postgres/000108_remove_orphaned_oauth_preferences.down.sql
@@ -1,0 +1,1 @@
+-- Skipping it because the forward migrations are destructive

--- a/db/migrations/postgres/000108_remove_orphaned_oauth_preferences.up.sql
+++ b/db/migrations/postgres/000108_remove_orphaned_oauth_preferences.up.sql
@@ -1,0 +1,33 @@
+DO $$
+DECLARE 
+    preferences_exist boolean := false;
+BEGIN
+    SELECT count(p.*) != 0 INTO preferences_exist FROM preferences p
+    WHERE (
+        (NOT EXISTS (
+            SELECT o.* FROM oauthaccessdata o
+            WHERE o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
+        ))
+        AND 
+        (NOT EXISTS (
+            SELECT oa.* FROM oauthauthdata oa
+            WHERE oa.clientid = p.name AND oa.userid = p.userid AND p.category = 'oauth_app'
+        ))
+    ) 
+    AND p.category = 'oauth_app';
+IF preferences_exist THEN
+    DELETE FROM preferences p
+    WHERE (
+        (NOT EXISTS (
+            SELECT o.* FROM oauthaccessdata o
+            WHERE o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
+        ))
+        AND 
+        (NOT EXISTS (
+            SELECT oa.* FROM oauthauthdata oa
+            WHERE oa.clientid = p.name AND oa.userid = p.userid AND p.category = 'oauth_app'
+        ))
+    ) 
+    AND p.category = 'oauth_app';
+END IF;
+END $$;


### PR DESCRIPTION
#### Summary
Cherry pick of https://github.com/mattermost/mattermost-server/pull/23036

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Fixing an issue caused by a migration

Query takes around 11ms on a PG 14 t3.medium RDS instance.
Locks on the preferences table will only be acquired if there are rows to delete. But the time taken is negligible.
```
