### PR TITLE
MM-51798: Fix Boards+Playbooks channel header RHS button styling 

### DIFF
--- a/e2e-tests/cypress/tests/integration/boards/channel_header_spec.ts
+++ b/e2e-tests/cypress/tests/integration/boards/channel_header_spec.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// ***************************************************************
+
+// Stage: @prod
+// Group: @boards
+
+describe('channels > channel header', {testIsolation: true}, () => {
+    let testTeam: {name: string};
+    let testUser: {username: string};
+
+    before(() => {
+        cy.apiInitSetup().then(({team, user}) => {
+            testTeam = team;
+            testUser = user;
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+        });
+    });
+
+    describe('App Bar enabled', () => {
+        it('webapp should hide the Boards channel header button', () => {
+            cy.apiAdminLogin();
+            cy.apiUpdateConfig({ExperimentalSettings: {EnableAppBar: true}});
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+
+            // # Navigate directly to a channel
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            // * Verify channel header button is not showing
+            cy.get('#channel-header').within(() => {
+                cy.get('[data-testid="boardsIcon"]').should('not.exist');
+            });
+        });
+    });
+
+    describe('App Bar disabled', () => {
+        beforeEach(() => {
+            cy.apiAdminLogin();
+            cy.apiUpdateConfig({ExperimentalSettings: {EnableAppBar: false}});
+
+            // # Login as testUser
+            cy.apiLogin(testUser);
+        });
+
+        it('webapp should show the Boards channel header button', () => {
+            // # Navigate directly to a channel
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            // * Verify channel header button is showing
+            cy.get('#channel-header').within(() => {
+                cy.get('#incidentIcon').should('exist');
+            });
+        });
+
+        it('tooltip text should show "Boards" for Boards channel header button', () => {
+            // # Navigate directly to a channel
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            // # Hover over the channel header icon
+            cy.get('#channel-header').within(() => {
+                cy.get('[data-testid="boardsIcon"]').trigger('mouseover');
+            });
+
+            // * Verify tooltip text
+            cy.get('#pluginTooltip').contains('Boards');
+        });
+
+        it('webapp should make the Boards channel header button active when opened', () => {
+            // # Navigate directly to a channel
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            cy.get('#channel-header').within(() => {
+                // # Click the channel header button
+                cy.get('[data-testid="boardsIcon"]').as('icon').click();
+
+                // * Verify channel header button is showing active className
+                cy.get('@icon').parent().
+                    should('have.class', 'channel-header__icon--active-inverted');
+            });
+        });
+    });
+});

--- a/e2e-tests/cypress/tests/integration/playbooks/channels/channel_header_spec.js
+++ b/e2e-tests/cypress/tests/integration/playbooks/channels/channel_header_spec.js
@@ -93,6 +93,20 @@ describe('channels > channel header', {testIsolation: true}, () => {
             // * Verify tooltip text
             cy.get('#pluginTooltip').contains('Playbooks');
         });
+
+        it('webapp should make the Playbook channel header button active when opened', () => {
+            // # Navigate directly to a non-playbook run channel
+            cy.visit(`/${testTeam.name}/channels/town-square`);
+
+            cy.get('#channel-header').within(() => {
+                // # Click the channel header button
+                cy.get('#incidentIcon').click();
+
+                // * Verify channel header button is showing active className
+                cy.get('#incidentIcon').parent().
+                    should('have.class', 'channel-header__icon--active-inverted');
+            });
+        });
     });
 
     describe('description text', () => {

--- a/webapp/boards/src/components/rhsChannelBoardsToggleIcon.tsx
+++ b/webapp/boards/src/components/rhsChannelBoardsToggleIcon.tsx
@@ -1,13 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useRef, ElementRef} from 'react'
+import React, {ElementRef, useRef} from 'react'
 
 import {useSelector} from 'react-redux'
 import {GlobalState} from '@mattermost/types/store'
 
 import FocalboardIcon from 'src/widgets/icons/logo'
-
 
 type Props = {
     boardsRhsId: string
@@ -18,8 +17,8 @@ type ViewsState = {views: {rhs: {isSidebarOpen: boolean, pluggableId: string}, r
 const RhsChannelBoardsToggleIcon = ({boardsRhsId}: Props) => {
     const iconRef = useRef<ElementRef<typeof FocalboardIcon>>(null)
     const isOpen = useSelector(({views: {rhs, rhsSuppressed}}: GlobalState & ViewsState) => (
-        rhs.isSidebarOpen && 
-        !rhsSuppressed && 
+        rhs.isSidebarOpen &&
+        !rhsSuppressed &&
         rhs.pluggableId === boardsRhsId
     ))
 

--- a/webapp/boards/src/components/rhsChannelBoardsToggleIcon.tsx
+++ b/webapp/boards/src/components/rhsChannelBoardsToggleIcon.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useRef, ElementRef} from 'react'
+
+import {useSelector} from 'react-redux'
+import {GlobalState} from '@mattermost/types/store'
+
+import FocalboardIcon from 'src/widgets/icons/logo'
+
+
+type Props = {
+    boardsRhsId: string
+}
+
+type ViewsState = {views: {rhs: {isSidebarOpen: boolean, pluggableId: string}, rhsSuppressed: boolean}}
+
+const RhsChannelBoardsToggleIcon = ({boardsRhsId}: Props) => {
+    const iconRef = useRef<ElementRef<typeof FocalboardIcon>>(null)
+    const isOpen = useSelector(({views: {rhs, rhsSuppressed}}: GlobalState & ViewsState) => (
+        rhs.isSidebarOpen && 
+        !rhsSuppressed && 
+        rhs.pluggableId === boardsRhsId
+    ))
+
+    // If it has been mounted, we know our parent is always a button.
+    const parent = iconRef?.current ? iconRef?.current?.parentNode as HTMLButtonElement : null
+    parent?.classList.toggle('channel-header__icon--active-inverted', isOpen)
+
+    return (
+        <FocalboardIcon
+            ref={iconRef}
+        />
+    )
+}
+
+export default RhsChannelBoardsToggleIcon

--- a/webapp/boards/src/index.tsx
+++ b/webapp/boards/src/index.tsx
@@ -367,9 +367,9 @@ export default class Plugin {
             this.rhsId = id
 
             this.channelHeaderButtonId = registry.registerChannelHeaderButtonAction(
-                () => <RhsChannelBoardsToggle boardsRhsId={id}/>, 
-                () => mmStore.dispatch(toggleRHSPlugin), 
-                'Boards', 
+                () => <RhsChannelBoardsToggle boardsRhsId={id}/>,
+                () => mmStore.dispatch(toggleRHSPlugin),
+                'Boards',
                 'Boards'
             )
 

--- a/webapp/boards/src/index.tsx
+++ b/webapp/boards/src/index.tsx
@@ -74,6 +74,7 @@ import './plugin.scss'
 import CreateBoardFromTemplate from 'src/components/createBoardFromTemplate'
 
 import CloudUpgradeNudge from './components/cloudUpgradeNudge/cloudUpgradeNudge'
+import RhsChannelBoardsToggle from './components/rhsChannelBoardsToggleIcon'
 
 function getSubpath(siteURL: string): string {
     const url = new URL(siteURL)
@@ -362,10 +363,15 @@ export default class Plugin {
                 </ErrorBoundary>
             )
 
-            const {rhsId, toggleRHSPlugin} = this.registry.registerRightHandSidebarComponent(component, title)
-            this.rhsId = rhsId
+            const {id, toggleRHSPlugin} = this.registry.registerRightHandSidebarComponent(component, title)
+            this.rhsId = id
 
-            this.channelHeaderButtonId = registry.registerChannelHeaderButtonAction(<FocalboardIcon/>, () => mmStore.dispatch(toggleRHSPlugin), 'Boards', 'Boards')
+            this.channelHeaderButtonId = registry.registerChannelHeaderButtonAction(
+                () => <RhsChannelBoardsToggle boardsRhsId={id}/>, 
+                () => mmStore.dispatch(toggleRHSPlugin), 
+                'Boards', 
+                'Boards'
+            )
 
             this.registry.registerProduct(
                 '/boards',

--- a/webapp/boards/src/widgets/icons/compassIcon.tsx
+++ b/webapp/boards/src/widgets/icons/compassIcon.tsx
@@ -8,13 +8,13 @@ type Props = {
     className?: string
 }
 
-export default React.forwardRef<HTMLElement, Props>(function CompassIcon(props, ref) {
+export default React.forwardRef<HTMLElement, Props>((props, ref) => {
     // All compass icon classes start with icon,
     // so not expecting that prefix in props.
     return (
-        <i 
+        <i
             {...props}
-            ref={ref} 
+            ref={ref}
             className={`CompassIcon icon-${props.icon}${props.className === undefined ? '' : ` ${props.className}`}`}
         />
     )

--- a/webapp/boards/src/widgets/icons/compassIcon.tsx
+++ b/webapp/boards/src/widgets/icons/compassIcon.tsx
@@ -8,14 +8,14 @@ type Props = {
     className?: string
 }
 
-export default React.forwardRef<HTMLElement, Props>((props, ref) => {
+export default React.forwardRef<HTMLElement, Props>(({icon, className, ...props}, ref) => {
     // All compass icon classes start with icon,
     // so not expecting that prefix in props.
     return (
         <i
             {...props}
             ref={ref}
-            className={`CompassIcon icon-${props.icon}${props.className === undefined ? '' : ` ${props.className}`}`}
+            className={`CompassIcon icon-${icon}${className === undefined ? '' : ` ${className}`}`}
         />
     )
 })

--- a/webapp/boards/src/widgets/icons/compassIcon.tsx
+++ b/webapp/boards/src/widgets/icons/compassIcon.tsx
@@ -8,10 +8,14 @@ type Props = {
     className?: string
 }
 
-export default function CompassIcon(props: Props): JSX.Element {
+export default React.forwardRef<HTMLElement, Props>(function CompassIcon(props, ref) {
     // All compass icon classes start with icon,
     // so not expecting that prefix in props.
     return (
-        <i className={`CompassIcon icon-${props.icon}${props.className === undefined ? '' : ` ${props.className}`}`}/>
+        <i 
+            {...props}
+            ref={ref} 
+            className={`CompassIcon icon-${props.icon}${props.className === undefined ? '' : ` ${props.className}`}`}
+        />
     )
-}
+})

--- a/webapp/boards/src/widgets/icons/logo.tsx
+++ b/webapp/boards/src/widgets/icons/logo.tsx
@@ -6,11 +6,13 @@ import React from 'react'
 import './logo.scss'
 import CompassIcon from './compassIcon'
 
-export default function LogoIcon(): JSX.Element {
+export default React.forwardRef<HTMLElement>(function LogoIcon(_, ref) {
     return (
         <CompassIcon
+            ref={ref}
+            data-testid='boardsIcon'
             icon='product-boards'
             className='boards-rhs-icon'
         />
     )
-}
+})

--- a/webapp/boards/src/widgets/icons/logo.tsx
+++ b/webapp/boards/src/widgets/icons/logo.tsx
@@ -6,7 +6,7 @@ import React from 'react'
 import './logo.scss'
 import CompassIcon from './compassIcon'
 
-export default React.forwardRef<HTMLElement>(function LogoIcon(_, ref) {
+export default React.forwardRef<HTMLElement>((_, ref) => {
     return (
         <CompassIcon
             ref={ref}

--- a/webapp/playbooks/src/components/assets/icons/playbooks_product_icon.tsx
+++ b/webapp/playbooks/src/components/assets/icons/playbooks_product_icon.tsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export type Ref = HTMLElement;
-
 interface Props {
     id?: string;
 }
@@ -14,7 +12,7 @@ const Icon = styled.i`
 	font-size: 22px;
 `;
 
-const PlaybooksProductIcon = React.forwardRef<Ref, Props>((props: Props, forwardedRef) => (
+const PlaybooksProductIcon = React.forwardRef<HTMLElement, Props>((props: Props, forwardedRef) => (
     <Icon
         id={props?.id}
         ref={forwardedRef}

--- a/webapp/playbooks/src/components/channel_header.tsx
+++ b/webapp/playbooks/src/components/channel_header.tsx
@@ -1,27 +1,21 @@
 // Copyright (c) 2017-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
 
-import React, {useRef} from 'react';
+import React, {ElementRef, useRef} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector} from 'react-redux';
 
-import PlaybooksProductIcon, {Ref as PlaybookRunIconRef} from 'src/components/assets/icons/playbooks_product_icon';
+import PlaybooksProductIcon from 'src/components/assets/icons/playbooks_product_icon';
 
 import {isPlaybookRunRHSOpen} from 'src/selectors';
 
 export const ChannelHeaderButton = () => {
-    const myRef = useRef<PlaybookRunIconRef>(null);
+    const myRef = useRef<ElementRef<typeof PlaybooksProductIcon>>(null);
     const isRHSOpen = useSelector(isPlaybookRunRHSOpen);
 
     // If it has been mounted, we know our parent is always a button.
     const parent = myRef?.current ? myRef?.current?.parentNode as HTMLButtonElement : null;
-    if (parent) {
-        if (isRHSOpen) {
-            parent.classList.add('channel-header__icon--active');
-        } else {
-            parent.classList.remove('channel-header__icon--active');
-        }
-    }
+    parent?.classList.toggle('channel-header__icon--active-inverted', isRHSOpen);
 
     return (
         <PlaybooksProductIcon


### PR DESCRIPTION
#### Summary
Fixes Boards and Playbooks channel header button styling to match Channel Info styling.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51798

#### Screenshots

|  before  |  after  |
|----|----|
| ![CleanShot 2023-05-03 at 14 33 20](https://user-images.githubusercontent.com/11724372/236026169-7d4b13c3-43f3-49de-ad13-aa8628ac190a.gif) | ![CleanShot 2023-05-03 at 14 30 52](https://user-images.githubusercontent.com/11724372/236025607-5a9ff386-5f9e-44b8-a6b5-d7024781ebf9.gif) |

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
