### PR TITLE
[MM-52659] server/release: use the manifest file from bin directory

### DIFF
--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -134,8 +134,8 @@ else
 endif
 	cp ../NOTICE.txt $(DIST_PATH)
 	cp ../README.md $(DIST_PATH)
-	if [ -f ../manifest.txt ]; then \
-		cp ../manifest.txt $(DIST_PATH); \
+	if [ -f bin/manifest.txt ]; then \
+		cp bin/manifest.txt $(DIST_PATH); \
 	fi
 
 	@# Import Mattermost plugin public key


### PR DESCRIPTION

#### Summary
It seems like we are searching for the manifest file in the wrong path in release.mk file:

```
if [ -f ../manifest.txt ]; then \
	cp ../manifest.txt $(DIST_PATH); \
fi
```

This was working before because we were keeping the manifest.txt file in the project root. The project root is changed, but on the other hand we already copy the manifest file in bin directory. I think it should remain with the binaries in bin hence I think we should look for that file instead.

The current release pipelines are blocked because of this. So we need to cherry pick this into `release-v7.11` branch as well.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52659


#### Release Note

```release-note
NONE
```
