### PR TITLE
Revert "Remove unnecessary blank imports (#23283)"

### DIFF
--- a/server/channels/imports/boards_imports.go
+++ b/server/channels/imports/boards_imports.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package imports
+
+import (
+	// Needed to ensure the init() method in the FocalBoard product is run.
+	_ "github.com/mattermost/mattermost-server/server/v8/boards/product"
+)

--- a/server/channels/imports/playbooks_imports.go
+++ b/server/channels/imports/playbooks_imports.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package imports
+
+import (
+	// Needed to ensure the init() method in the Playbooks product is run.
+	_ "github.com/mattermost/mattermost-server/server/v8/playbooks/product"
+)


### PR DESCRIPTION
#### Summary
This reverts commit 76ad948b805696c6cc192a39725ec37d60c3541f. Without it, it looks like neither playbooks nor boards starts up correctly. 

#### Ticket Link
None.

#### Release Note
```release-note
NONE
```
