### PR TITLE
Cherrypick to 7.8 "Update slash command permission (#22468)"

### DIFF
--- a/api4/command.go
+++ b/api4/command.go
@@ -323,7 +323,14 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 	audit.AddEventParameterAuditable(auditRec, "command_args", &commandArgs)
 
-	// checks that user is a member of the specified channel, and that they have permission to use slash commands in it
+	// Checks that user is a member of the specified channel, and that they have permission to create a post in it.
+	if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), commandArgs.ChannelId, model.PermissionCreatePost) {
+		c.SetPermissionError(model.PermissionCreatePost)
+		return
+	}
+
+	// For compatibility reasons, PermissionUseSlashCommands is also checked.
+	// TODO: Remove in 8.0: https://mattermost.atlassian.net/browse/MM-51274
 	if !c.App.SessionHasPermissionToChannel(c.AppContext, *c.AppContext.Session(), commandArgs.ChannelId, model.PermissionUseSlashCommands) {
 		c.SetPermissionError(model.PermissionUseSlashCommands)
 		return
@@ -343,6 +350,13 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 		// if the slash command was used in a DM or GM, ensure that the user is a member of the specified team, so that
 		// they can't just execute slash commands against arbitrary teams
 		if c.AppContext.Session().GetTeamByTeamId(commandArgs.TeamId) == nil {
+			if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionCreatePost) {
+				c.SetPermissionError(model.PermissionCreatePost)
+				return
+			}
+
+			// For compatibility reasons, PermissionCreatePost is also checked.
+			// TODO: Remove in 8.0: https://mattermost.atlassian.net/browse/MM-51274
 			if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionUseSlashCommands) {
 				c.SetPermissionError(model.PermissionUseSlashCommands)
 				return

--- a/api4/command.go
+++ b/api4/command.go
@@ -355,7 +355,7 @@ func executeCommand(c *Context, w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			// For compatibility reasons, PermissionCreatePost is also checked.
+			// For compatibility reasons, PermissionUseSlashCommands is also checked.
 			// TODO: Remove in 8.0: https://mattermost.atlassian.net/browse/MM-51274
 			if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionUseSlashCommands) {
 				c.SetPermissionError(model.PermissionUseSlashCommands)

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -1065,3 +1065,78 @@ func TestExecuteCommandInTeamUserIsNotOn(t *testing.T) {
 	require.Error(t, err)
 	CheckForbiddenStatus(t, resp)
 }
+
+func TestExecuteCommandReadOnly(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+	client := th.Client
+
+	enableCommands := *th.App.Config().ServiceSettings.EnableCommands
+	allowedInternalConnections := *th.App.Config().ServiceSettings.AllowedUntrustedInternalConnections
+	defer func() {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.EnableCommands = &enableCommands })
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.ServiceSettings.AllowedUntrustedInternalConnections = &allowedInternalConnections
+		})
+	}()
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableCommands = true })
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost,127.0.0.1"
+	})
+
+	expectedCommandResponse := &model.CommandResponse{
+		Text:         "test post command response",
+		ResponseType: model.CommandResponseTypeInChannel,
+		Type:         "custom_test",
+		Props:        map[string]any{"someprop": "somevalue"},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		r.ParseForm()
+		require.Equal(t, th.BasicTeam.Name, r.FormValue("team_domain"))
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(expectedCommandResponse); err != nil {
+			th.TestLogger.Warn("Error while writing response", mlog.Err(err))
+		}
+	}))
+	defer ts.Close()
+
+	// create a slash command on that team
+	postCmd := &model.Command{
+		CreatorId: th.BasicUser.Id,
+		TeamId:    th.BasicTeam.Id,
+		URL:       ts.URL,
+		Method:    model.CommandMethodPost,
+		Trigger:   "postcommand",
+	}
+	_, appErr := th.App.CreateCommand(postCmd)
+	require.Nil(t, appErr, "failed to create post command")
+
+	// Confirm that the command works when the channel is not read only
+	_, resp, err := client.ExecuteCommandWithTeam(th.BasicChannel.Id, th.BasicChannel.TeamId, "/postcommand")
+	require.NoError(t, err)
+	CheckOKStatus(t, resp)
+
+	// Enable Enterprise features
+	th.App.Srv().SetLicense(model.NewTestLicense())
+
+	th.App.SetPhase2PermissionsMigrationStatus(true)
+
+	_, appErr = th.App.PatchChannelModerationsForChannel(
+		th.BasicChannel,
+		[]*model.ChannelModerationPatch{{
+			Name: &model.PermissionCreatePost.Id,
+			Roles: &model.ChannelModeratedRolesPatch{
+				Guests:  model.NewBool(false),
+				Members: model.NewBool(false),
+			},
+		}})
+	require.Nil(t, appErr)
+
+	// Confirm that the command fails when the channel is read only
+	_, resp, err = client.ExecuteCommandWithTeam(th.BasicChannel.Id, th.BasicChannel.TeamId, "/postcommand")
+	require.Error(t, err)
+	CheckForbiddenStatus(t, resp)
+}

--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
@@ -1068,6 +1069,7 @@ func TestExecuteCommandInTeamUserIsNotOn(t *testing.T) {
 
 func TestExecuteCommandReadOnly(t *testing.T) {
 	th := Setup(t).InitBasic()
+	ctx := request.EmptyContext(th.TestLogger)
 	defer th.TearDown()
 	client := th.Client
 
@@ -1125,6 +1127,7 @@ func TestExecuteCommandReadOnly(t *testing.T) {
 	th.App.SetPhase2PermissionsMigrationStatus(true)
 
 	_, appErr = th.App.PatchChannelModerationsForChannel(
+		ctx,
 		th.BasicChannel,
 		[]*model.ChannelModerationPatch{{
 			Name: &model.PermissionCreatePost.Id,

--- a/model/permission.go
+++ b/model/permission.go
@@ -21,6 +21,9 @@ type Permission struct {
 
 var PermissionInviteUser *Permission
 var PermissionAddUserToTeam *Permission
+
+// Deprecated: PermissionCreatePost should be used to determine if a slash command can be executed.
+// TODO: Remove in 8.0: https://mattermost.atlassian.net/browse/MM-51274
 var PermissionUseSlashCommands *Permission
 var PermissionManageSlashCommands *Permission
 var PermissionManageOthersSlashCommands *Permission


### PR DESCRIPTION
#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Cherrypick of #22468

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
