### PR TITLE
allow theme to be used

### DIFF
--- a/webapp/platform/components/src/compass/theme_provider/theme_provider.tsx
+++ b/webapp/platform/components/src/compass/theme_provider/theme_provider.tsx
@@ -12,9 +12,10 @@ import overrides from './overrides';
 
 type Props = {
     theme: Theme;
+    children?: React.ReactNode | React.ReactNode[];
 }
 
-const ThemeProvider = ({theme = THEMES.onyx}: Props) => {
+const ThemeProvider = ({theme = THEMES.onyx, children}: Props) => {
     const MUITheme = createMUIThemeFromMMTheme(theme);
     const combinedTheme = createTheme({
         ...MUITheme,
@@ -24,7 +25,9 @@ const ThemeProvider = ({theme = THEMES.onyx}: Props) => {
     return (
         <MUIThemeProvider
             theme={combinedTheme}
-        />
+        >
+            {children}
+        </MUIThemeProvider>
     );
 };
 


### PR DESCRIPTION
#### Summary
Wanted to sneak this PR in to all your other ongoing work on the new components library so I can make a [minimal usage](https://github.com/mattermost/mattermost-server/pull/23189/commits/d67bf7f6689c00105278db9d3a464489c9b78998) of the components library until I can fully convert the modal over to the new modal later. Not ideal, but I think its better than using a bad copy of the deprecated/removed @primary-button mixin. To do that, the provider will need to accept a children prop, which I think it is going to need regardless of my usage.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
