### PR TITLE
Fix 7.10 merge issue from "Update slash command permission (#22468)"

### DIFF
--- a/api4/command_test.go
+++ b/api4/command_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mattermost/mattermost-server/v6/app/request"
 	"github.com/mattermost/mattermost-server/v6/model"
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
@@ -1068,6 +1069,7 @@ func TestExecuteCommandInTeamUserIsNotOn(t *testing.T) {
 
 func TestExecuteCommandReadOnly(t *testing.T) {
 	th := Setup(t).InitBasic()
+	ctx := request.EmptyContext(th.TestLogger)
 	defer th.TearDown()
 	client := th.Client
 
@@ -1125,6 +1127,7 @@ func TestExecuteCommandReadOnly(t *testing.T) {
 	th.App.SetPhase2PermissionsMigrationStatus(true)
 
 	_, appErr = th.App.PatchChannelModerationsForChannel(
+		ctx,
 		th.BasicChannel,
 		[]*model.ChannelModerationPatch{{
 			Name: &model.PermissionCreatePost.Id,


### PR DESCRIPTION
#### Summary

There was a merge issue in `command_test` when cherrypicking to `release-7.10` https://github.com/mattermost/mattermost-server/commit/160428329ad41bc11c94d462affbd2425376ae73

#### Release Note

```release-note
NONE
```
