### PR TITLE
Remove unnecessary blank imports (round 2)

### DIFF
--- a/server/channels/imports/boards_imports.go
+++ b/server/channels/imports/boards_imports.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-
-package imports
-
-import (
-	// Needed to ensure the init() method in the FocalBoard product is run.
-	_ "github.com/mattermost/mattermost-server/server/v8/boards/product"
-)

--- a/server/channels/imports/playbooks_imports.go
+++ b/server/channels/imports/playbooks_imports.go
@@ -1,9 +1,0 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
-// See LICENSE.txt for license information.
-
-package imports
-
-import (
-	// Needed to ensure the init() method in the Playbooks product is run.
-	_ "github.com/mattermost/mattermost-server/server/v8/playbooks/product"
-)

--- a/server/cmd/mattermost/main.go
+++ b/server/cmd/mattermost/main.go
@@ -14,6 +14,10 @@ import (
 
 	// Enterprise Imports
 	_ "github.com/mattermost/mattermost-server/server/v8/channels/imports"
+
+	// Blank imports for each product to register themselves
+	_ "github.com/mattermost/mattermost-server/server/v8/boards/product"
+	_ "github.com/mattermost/mattermost-server/server/v8/playbooks/product"
 )
 
 func main() {


### PR DESCRIPTION
I mistakenly assumed that those packages are naturally imported.

And also atleast one test would have broken.

None of them are true. :)

So we just import it again at a better place

This reverts commit 30a053314b9611cc5dbe2d47a5d31bc7828165fc.

```release-note
NONE
```
