### PR TITLE
[MM-50219] Cherry picking oauth2 fix

### DIFF
--- a/app/oauth.go
+++ b/app/oauth.go
@@ -505,6 +505,10 @@ func (a *App) DeauthorizeOAuthAppForUser(userID, appID string) *model.AppError {
 		}
 	}
 
+	if err := a.Srv().Store().OAuth().RemoveAuthDataByClientId(appID, userID); err != nil {
+		return model.NewAppError("DeauthorizeOAuthAppForUser", "app.oauth.remove_auth_data_by_client_id.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
 	// Deauthorize the app
 	if err := a.Srv().Store().Preference().Delete(userID, model.PreferenceCategoryAuthorizedOAuthApp, appID); err != nil {
 		return model.NewAppError("DeauthorizeOAuthAppForUser", "app.preference.delete.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/db/migrations/migrations.list
+++ b/db/migrations/migrations.list
@@ -202,6 +202,8 @@ db/migrations/mysql/000100_add_draft_priority_column.down.sql
 db/migrations/mysql/000100_add_draft_priority_column.up.sql
 db/migrations/mysql/000101_create_true_up_review_history.down.sql
 db/migrations/mysql/000101_create_true_up_review_history.up.sql
+db/migrations/mysql/000105_remove_tokens.down.sql
+db/migrations/mysql/000105_remove_tokens.up.sql
 db/migrations/postgres/000001_create_teams.down.sql
 db/migrations/postgres/000001_create_teams.up.sql
 db/migrations/postgres/000002_create_team_members.down.sql
@@ -404,3 +406,5 @@ db/migrations/postgres/000100_add_draft_priority_column.down.sql
 db/migrations/postgres/000100_add_draft_priority_column.up.sql
 db/migrations/postgres/000101_create_true_up_review_history.down.sql
 db/migrations/postgres/000101_create_true_up_review_history.up.sql
+db/migrations/postgres/000105_remove_tokens.down.sql
+db/migrations/postgres/000105_remove_tokens.up.sql

--- a/db/migrations/mysql/000105_remove_tokens.down.sql
+++ b/db/migrations/mysql/000105_remove_tokens.down.sql
@@ -1,0 +1,1 @@
+-- Skipping it because the forward migrations are destructive

--- a/db/migrations/mysql/000105_remove_tokens.up.sql
+++ b/db/migrations/mysql/000105_remove_tokens.up.sql
@@ -1,0 +1,18 @@
+CREATE PROCEDURE Remove_Tokens_If_Exist ()
+BEGIN
+    DECLARE C INT;
+
+    SELECT COUNT(o.`Token`) INTO C from OAuthAccessData o 
+    LEFT JOIN Preferences p ON o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
+    INNER JOIN Sessions s ON o.token = s.token
+    WHERE p.name IS NULL;
+
+    IF(C > 0) THEN
+        DELETE o, s from OAuthAccessData o 
+        LEFT JOIN Preferences p ON o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
+        INNER JOIN Sessions s ON o.token = s.token
+        WHERE p.name IS NULL;
+    END IF;
+END;
+    CALL Remove_Tokens_If_Exist ();
+    DROP PROCEDURE IF EXISTS Remove_Tokens_If_Exist;

--- a/db/migrations/postgres/000105_remove_tokens.down.sql
+++ b/db/migrations/postgres/000105_remove_tokens.down.sql
@@ -1,0 +1,1 @@
+-- Skipping it because the forward migrations are destructive

--- a/db/migrations/postgres/000105_remove_tokens.up.sql
+++ b/db/migrations/postgres/000105_remove_tokens.up.sql
@@ -1,0 +1,21 @@
+DO $$
+DECLARE 
+    tokens_exist boolean := false;
+BEGIN
+	SELECT count(o.*) != 0 INTO tokens_exist FROM oauthaccessdata o
+	WHERE NOT EXISTS (
+		SELECT p.* FROM preferences p
+		WHERE o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
+	);
+	IF tokens_exist THEN
+		WITH oauthDelete AS (
+			DELETE FROM oauthaccessdata o
+			WHERE NOT EXISTS (
+				SELECT p.* FROM preferences p
+				WHERE o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
+			)
+			RETURNING o.token
+		)
+		DELETE FROM sessions s WHERE s.token in (select oauthDelete.token from oauthDelete);
+	END IF;
+END $$;

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5916,6 +5916,10 @@
     "translation": "Unable to remove the access token."
   },
   {
+    "id": "app.oauth.remove_auth_data_by_client_id.app_error",
+    "translation": "Unable to remove oauth data."
+  },
+  {
     "id": "app.oauth.save_app.existing.app_error",
     "translation": "Must call update for existing app."
   },

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -5537,6 +5537,24 @@ func (s *OpenTracingLayerOAuthStore) RemoveAuthData(code string) error {
 	return err
 }
 
+func (s *OpenTracingLayerOAuthStore) RemoveAuthDataByClientId(clientId string, userId string) error {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "OAuthStore.RemoveAuthDataByClientId")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	err := s.OAuthStore.RemoveAuthDataByClientId(clientId, userId)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return err
+}
+
 func (s *OpenTracingLayerOAuthStore) RemoveAuthDataByUserId(userId string) error {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "OAuthStore.RemoveAuthDataByUserId")

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -6277,6 +6277,27 @@ func (s *RetryLayerOAuthStore) RemoveAuthData(code string) error {
 
 }
 
+func (s *RetryLayerOAuthStore) RemoveAuthDataByClientId(clientId string, userId string) error {
+
+	tries := 0
+	for {
+		err := s.OAuthStore.RemoveAuthDataByClientId(clientId, userId)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerOAuthStore) RemoveAuthDataByUserId(userId string) error {
 
 	tries := 0

--- a/store/sqlstore/oauth_store.go
+++ b/store/sqlstore/oauth_store.go
@@ -261,6 +261,14 @@ func (as SqlOAuthStore) RemoveAuthData(code string) error {
 	return nil
 }
 
+func (as SqlOAuthStore) RemoveAuthDataByClientId(clientId string, userId string) error {
+	_, err := as.GetMasterX().Exec("DELETE FROM OAuthAuthData WHERE ClientId = ? and UserId = ?", clientId, userId)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete AuthData with clientId=%s and userId=%s", clientId, userId)
+	}
+	return nil
+}
+
 func (as SqlOAuthStore) RemoveAuthDataByUserId(userId string) error {
 	_, err := as.GetMasterX().Exec("DELETE FROM OAuthAuthData WHERE UserId = ?", userId)
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -564,6 +564,7 @@ type OAuthStore interface {
 	SaveAuthData(authData *model.AuthData) (*model.AuthData, error)
 	GetAuthData(code string) (*model.AuthData, error)
 	RemoveAuthData(code string) error
+	RemoveAuthDataByClientId(clientId string, userId string) error
 	RemoveAuthDataByUserId(userId string) error
 	PermanentDeleteAuthDataByUser(userID string) error
 	SaveAccessData(accessData *model.AccessData) (*model.AccessData, error)

--- a/store/storetest/mocks/OAuthStore.go
+++ b/store/storetest/mocks/OAuthStore.go
@@ -291,6 +291,20 @@ func (_m *OAuthStore) RemoveAuthData(code string) error {
 	return r0
 }
 
+// RemoveAuthDataByClientId provides a mock function with given fields: clientId, userId
+func (_m *OAuthStore) RemoveAuthDataByClientId(clientId string, userId string) error {
+	ret := _m.Called(clientId, userId)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(clientId, userId)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // RemoveAuthDataByUserId provides a mock function with given fields: userId
 func (_m *OAuthStore) RemoveAuthDataByUserId(userId string) error {
 	ret := _m.Called(userId)

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -5020,6 +5020,22 @@ func (s *TimerLayerOAuthStore) RemoveAuthData(code string) error {
 	return err
 }
 
+func (s *TimerLayerOAuthStore) RemoveAuthDataByClientId(clientId string, userId string) error {
+	start := time.Now()
+
+	err := s.OAuthStore.RemoveAuthDataByClientId(clientId, userId)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("OAuthStore.RemoveAuthDataByClientId", success, elapsed)
+	}
+	return err
+}
+
 func (s *TimerLayerOAuthStore) RemoveAuthDataByUserId(userId string) error {
 	start := time.Now()
 


### PR DESCRIPTION
#### Summary
Backporting fix from https://github.com/mattermost/mattermost-server/pull/22310 and the subsequent migration fix in https://github.com/mattermost/mattermost-server/pull/23036 for `postgres000105_remove_tokens.up.sql`.

As per our discussion in server platform I was asked to update the migrations for backports in order to avoid unnecessary table locks. I added some select statements in order to avoid running the `DELETE` queries if we don't need to.

**Migration timings on the large data dump:**
**MySQL@5.7.12:**
No data to delete:
`remove_tokens: migrated (0.0092s)`

Some data to delete:  
`remove_tokens: migrated (0.0172s)`

**Postgres@10:**
No data to delete:
`remove_tokens: migrated (0.0218s)`

Some data to delete:
`remove_tokens: migrated (0.0099s)` (This was faster for some reason?)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50219
https://mattermost.atlassian.net/browse/MM-50227

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
Backporting fix for oauth 2

Query times depend on if you have rows to delete or not. 
With no rows to delete:
 - MySQL@5.7.12: 9ms
 - Postgres@10: 21ms

4 rows:
 - MySQL@5.7.12: 17.2ms
 - Postgres@10: 9.9ms

Those times are based off the following table sizes:
 - Preferences: 2 million records
 - oauthaccessdata and sessions: 10 records

You can assess the number of impacted rows by running the following...

Postgres:
SELECT count(o.*) FROM oauthaccessdata o
WHERE NOT EXISTS (
	SELECT p.* FROM preferences p
	WHERE o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
);

MySQL:
SELECT COUNT(o.`Token`) from OAuthAccessData o 
LEFT JOIN Preferences p ON o.clientid = p.name AND o.userid = p.userid AND p.category = 'oauth_app'
INNER JOIN Sessions s ON o.token = s.token
WHERE p.name IS NULL;

Locks on the oauthaccessdata and sessions table will only be acquired if there are rows to delete.
```
