### PR TITLE
MM-52216: Re-fix for release-7.1

### DIFF
--- a/web/context.go
+++ b/web/context.go
@@ -93,7 +93,7 @@ func (c *Context) LogErrorByCode(err *model.AppError) {
 	fields := []mlog.Field{
 		mlog.String("err_where", err.Where),
 		mlog.Int("http_code", err.StatusCode),
-		mlog.String("err_details", err.DetailedError),
+		mlog.String("err_details", err.Error()),
 	}
 	switch {
 	case (code >= http.StatusBadRequest && code < http.StatusInternalServerError) ||


### PR DESCRIPTION
We were logging directly the DetailedError field in 7.1 branch.
We fix that to log err.Error() which is how it is in master.

https://mattermost.atlassian.net/browse/MM-52216

```release-note
NONE
```
