### PR TITLE
[MM-MM-52695] webapp/channels : Change plain import of PropsFromRedux to "import type" for certain files

### DIFF
--- a/webapp/channels/src/components/post_edit_history/edited_post_item/edited_post_item.tsx
+++ b/webapp/channels/src/components/post_edit_history/edited_post_item/edited_post_item.tsx
@@ -29,7 +29,7 @@ import InfoToast from 'components/info_toast/info_toast';
 
 import RestorePostModal from '../restore_post_modal';
 
-import {PropsFromRedux} from '.';
+import type {PropsFromRedux} from './index';
 
 const DATE_RANGES = [
     RelativeRanges.TODAY_TITLE_CASE,

--- a/webapp/channels/src/components/post_edit_history/post_edit_history.tsx
+++ b/webapp/channels/src/components/post_edit_history/post_edit_history.tsx
@@ -11,7 +11,7 @@ import LoadingScreen from 'components/loading_screen';
 
 import EditedPostItem from './edited_post_item';
 
-import {PropsFromRedux} from '.';
+import type {PropsFromRedux} from './index';
 
 const renderView = (props: Record<string, unknown>): JSX.Element => (
     <div

--- a/webapp/channels/src/components/post_reminder_custom_time_picker_modal/post_reminder_custom_time_picker_modal.tsx
+++ b/webapp/channels/src/components/post_reminder_custom_time_picker_modal/post_reminder_custom_time_picker_modal.tsx
@@ -15,7 +15,7 @@ import {getCurrentMomentForTimezone} from 'utils/timezone';
 
 import Constants from 'utils/constants';
 
-import {PropsFromRedux} from './index';
+import type {PropsFromRedux} from './index';
 
 import './post_reminder_custom_time_picker_modal.scss';
 


### PR DESCRIPTION
#### Summary
A while ago, we introduced the PropsFromRedux pattern, which was mostly used in class-based components or functional components if hooks were not used for selectors and dispatch. However, we discussed that it is recommended to import the type PropsFromRedux back to the component file from its index file with the type to avoid any cyclic import bugs.

```js 
import type {PropsFromRedux} from './index'; ✔️ 
```
#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52695

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
