### PR TITLE
Cherrypick of #22559

### DIFF
--- a/api4/user.go
+++ b/api4/user.go
@@ -2993,6 +2993,10 @@ func getThreadForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetPermissionError(model.PermissionEditOtherUsers)
 		return
 	}
+	if !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), c.Params.ThreadId, model.PermissionReadChannel) {
+		c.SetPermissionError(model.PermissionReadChannel)
+		return
+	}
 	extendedStr := r.URL.Query().Get("extended")
 	extended, _ := strconv.ParseBool(extendedStr)
 
@@ -3021,6 +3025,10 @@ func getThreadsForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	if !c.App.SessionHasPermissionToUser(*c.AppContext.Session(), c.Params.UserId) {
 		c.SetPermissionError(model.PermissionEditOtherUsers)
+		return
+	}
+	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionViewTeam) {
+		c.SetPermissionError(model.PermissionViewTeam)
 		return
 	}
 
@@ -3100,6 +3108,10 @@ func updateReadStateThreadByUser(c *Context, w http.ResponseWriter, r *http.Requ
 		c.SetPermissionError(model.PermissionEditOtherUsers)
 		return
 	}
+	if !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), c.Params.ThreadId, model.PermissionReadChannel) {
+		c.SetPermissionError(model.PermissionReadChannel)
+		return
+	}
 
 	thread, err := c.App.UpdateThreadReadForUser(c.AppContext.Session().Id, c.Params.UserId, c.Params.TeamId, c.Params.ThreadId, c.Params.Timestamp)
 	if err != nil {
@@ -3166,6 +3178,10 @@ func unfollowThreadByUser(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.SetPermissionError(model.PermissionEditOtherUsers)
 		return
 	}
+	if !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), c.Params.ThreadId, model.PermissionReadChannel) {
+		c.SetPermissionError(model.PermissionReadChannel)
+		return
+	}
 
 	if !c.App.SessionHasPermissionToChannelByPost(*c.AppContext.Session(), c.Params.ThreadId, model.PermissionReadChannel) {
 		c.SetPermissionError(model.PermissionReadChannel)
@@ -3228,6 +3244,10 @@ func updateReadStateAllThreadsByUser(c *Context, w http.ResponseWriter, r *http.
 
 	if !c.App.SessionHasPermissionToUser(*c.AppContext.Session(), c.Params.UserId) {
 		c.SetPermissionError(model.PermissionEditOtherUsers)
+		return
+	}
+	if !c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), c.Params.TeamId, model.PermissionViewTeam) {
+		c.SetPermissionError(model.PermissionViewTeam)
 		return
 	}
 

--- a/api4/user_test.go
+++ b/api4/user_test.go
@@ -6061,6 +6061,15 @@ func TestGetThreadsForUser(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uss.TotalUnreadThreads, int64(2))
 	})
+
+	t.Run("should error when not a team member", func(t *testing.T) {
+		th.UnlinkUserFromTeam(th.BasicUser, th.BasicTeam)
+		defer th.LinkUserToTeam(th.BasicUser, th.BasicTeam)
+
+		_, resp, err := th.Client.GetUserThreads(th.BasicUser.Id, th.BasicTeam.Id, model.GetUserThreadsOpts{})
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
 }
 
 func TestThreadSocketEvents(t *testing.T) {
@@ -6556,30 +6565,81 @@ func TestSingleThreadGet(t *testing.T) {
 	})
 
 	client := th.Client
+<<<<<<< HEAD:api4/user_test.go
 	defer th.App.Srv().Store.Post().PermanentDeleteByUser(th.BasicUser.Id)
 	defer th.App.Srv().Store.Post().PermanentDeleteByUser(th.SystemAdminUser.Id)
+=======
+>>>>>>> a24111f9bd (MM-45009: Delete ThreadMemberships from "left" channels (#22559)):server/channels/api4/user_test.go
 
-	// create a post by regular user
-	rpost, _ := postAndCheck(t, client, &model.Post{ChannelId: th.BasicChannel.Id, Message: "testMsg"})
-	// reply with another
-	postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel.Id, Message: "testReply", RootId: rpost.Id})
+	t.Run("get single thread", func(t *testing.T) {
+		defer th.App.Srv().Store().Post().PermanentDeleteByUser(th.BasicUser.Id)
+		defer th.App.Srv().Store().Post().PermanentDeleteByUser(th.SystemAdminUser.Id)
 
+<<<<<<< HEAD:api4/user_test.go
 	// create another thread to check that we are not returning it by mistake
 	rpost2, _ := postAndCheck(t, client, &model.Post{ChannelId: th.BasicChannel2.Id, Message: "testMsg2"})
 	postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel2.Id, Message: "testReply", RootId: rpost2.Id})
+=======
+		// create a post by regular user
+		rpost, _ := postAndCheck(t, client, &model.Post{ChannelId: th.BasicChannel.Id, Message: "testMsg"})
+		// reply with another
+		postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel.Id, Message: "testReply", RootId: rpost.Id})
 
-	// regular user should have two threads with 3 replies total
-	threads, _ := checkThreadListReplies(t, th, th.Client, th.BasicUser.Id, 2, 2, nil)
+		// create another thread to check that we are not returning it by mistake
+		rpost2, _ := postAndCheck(t, client, &model.Post{
+			ChannelId: th.BasicChannel2.Id,
+			Message:   "testMsg2",
+			Metadata: &model.PostMetadata{
+				Priority: &model.PostPriority{
+					Priority: model.NewString(model.PostPriorityUrgent),
+				},
+			},
+		})
+		postAndCheck(t, th.SystemAdminClient, &model.Post{ChannelId: th.BasicChannel2.Id, Message: "testReply", RootId: rpost2.Id})
+>>>>>>> a24111f9bd (MM-45009: Delete ThreadMemberships from "left" channels (#22559)):server/channels/api4/user_test.go
 
-	tr, _, err := th.Client.GetUserThread(th.BasicUser.Id, th.BasicTeam.Id, threads.Threads[0].PostId, false)
-	require.NoError(t, err)
-	require.NotNil(t, tr)
-	require.Equal(t, threads.Threads[0].PostId, tr.PostId)
-	require.Empty(t, tr.Participants[0].Username)
+		// regular user should have two threads with 3 replies total
+		threads, _ := checkThreadListReplies(t, th, th.Client, th.BasicUser.Id, 2, 2, nil)
 
+		tr, _, err := th.Client.GetUserThread(th.BasicUser.Id, th.BasicTeam.Id, threads.Threads[0].PostId, false)
+		require.NoError(t, err)
+		require.NotNil(t, tr)
+		require.Equal(t, threads.Threads[0].PostId, tr.PostId)
+		require.Empty(t, tr.Participants[0].Username)
+
+<<<<<<< HEAD:api4/user_test.go
 	tr, _, err = th.Client.GetUserThread(th.BasicUser.Id, th.BasicTeam.Id, threads.Threads[0].PostId, true)
 	require.NoError(t, err)
 	require.NotEmpty(t, tr.Participants[0].Username)
+=======
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.PostPriority = false
+		})
+
+		tr, _, err = th.Client.GetUserThread(th.BasicUser.Id, th.BasicTeam.Id, threads.Threads[0].PostId, true)
+		require.NoError(t, err)
+		require.NotEmpty(t, tr.Participants[0].Username)
+		require.Equal(t, false, tr.IsUrgent)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.PostPriority = true
+			cfg.FeatureFlags.PostPriority = true
+		})
+
+		tr, _, err = th.Client.GetUserThread(th.BasicUser.Id, th.BasicTeam.Id, threads.Threads[0].PostId, true)
+		require.NoError(t, err)
+		require.Equal(t, true, tr.IsUrgent)
+	})
+
+	t.Run("should error when not a team member", func(t *testing.T) {
+		th.UnlinkUserFromTeam(th.BasicUser, th.BasicTeam)
+		defer th.LinkUserToTeam(th.BasicUser, th.BasicTeam)
+
+		_, resp, err := th.Client.GetUserThread(th.BasicUser.Id, th.BasicTeam.Id, model.NewId(), false)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+>>>>>>> a24111f9bd (MM-45009: Delete ThreadMemberships from "left" channels (#22559)):server/channels/api4/user_test.go
 }
 
 func TestMaintainUnreadMentionsInThread(t *testing.T) {
@@ -6752,6 +6812,23 @@ func TestReadThreads(t *testing.T) {
 		CheckOKStatus(t, resp)
 
 		checkThreadListReplies(t, th, th.Client, th.BasicUser.Id, 1, 1, nil)
+	})
+
+	t.Run("should error when not a team member", func(t *testing.T) {
+		th.UnlinkUserFromTeam(th.BasicUser, th.BasicTeam)
+		defer th.LinkUserToTeam(th.BasicUser, th.BasicTeam)
+
+		_, resp, err := th.Client.UpdateThreadReadForUser(th.BasicUser.Id, th.BasicTeam.Id, model.NewId(), model.GetMillis())
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		_, resp, err = th.Client.SetThreadUnreadByPostId(th.BasicUser.Id, th.BasicTeam.Id, model.NewId(), model.NewId())
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		resp, err = th.Client.UpdateThreadsReadForUser(th.BasicUser.Id, th.BasicTeam.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
 	})
 }
 

--- a/app/channel.go
+++ b/app/channel.go
@@ -2431,6 +2431,9 @@ func (a *App) removeUserFromChannel(c *request.Context, userIDToRemove string, r
 	if err := a.Srv().Store.ChannelMemberHistory().LogLeaveEvent(userIDToRemove, channel.Id, model.GetMillis()); err != nil {
 		return model.NewAppError("removeUserFromChannel", "app.channel_member_history.log_leave_event.internal_error", nil, err.Error(), http.StatusInternalServerError)
 	}
+	if err := a.Srv().Store().Thread().DeleteMembershipsForChannel(userIDToRemove, channel.Id); err != nil {
+		return model.NewAppError("removeUserFromChannel", model.NoTranslation, nil, "failed to delete threadmemberships upon leaving channel", http.StatusInternalServerError).Wrap(err)
+	}
 
 	if isGuest {
 		currentMembers, err := a.GetChannelMembersForUser(channel.TeamId, userIDToRemove)

--- a/app/channel_test.go
+++ b/app/channel_test.go
@@ -583,6 +583,85 @@ func TestLeaveDefaultChannel(t *testing.T) {
 		_, err = th.App.GetChannelMember(context.Background(), townSquare.Id, guest.Id)
 		assert.NotNil(t, err)
 	})
+
+	t.Run("Trying to leave the default channel should not delete thread memberships", func(t *testing.T) {
+		post := &model.Post{
+			ChannelId: townSquare.Id,
+			Message:   "root post",
+			UserId:    th.BasicUser.Id,
+		}
+		rpost, err := th.App.CreatePost(th.Context, post, th.BasicChannel, false, true)
+		require.Nil(t, err)
+
+		reply := &model.Post{
+			ChannelId: townSquare.Id,
+			Message:   "reply post",
+			UserId:    th.BasicUser.Id,
+			RootId:    rpost.Id,
+		}
+		_, err = th.App.CreatePost(th.Context, reply, th.BasicChannel, false, true)
+		require.Nil(t, err)
+
+		threads, err := th.App.GetThreadsForUser(th.BasicUser.Id, townSquare.TeamId, model.GetUserThreadsOpts{})
+		require.Nil(t, err)
+		require.Len(t, threads.Threads, 1)
+
+		err = th.App.LeaveChannel(th.Context, townSquare.Id, th.BasicUser.Id)
+		assert.NotNil(t, err, "It should fail to remove a regular user from the default channel")
+		assert.Equal(t, err.Id, "api.channel.remove.default.app_error")
+
+		threads, err = th.App.GetThreadsForUser(th.BasicUser.Id, townSquare.TeamId, model.GetUserThreadsOpts{})
+		require.Nil(t, err)
+		require.Len(t, threads.Threads, 1)
+	})
+}
+
+func TestLeaveChannel(t *testing.T) {
+	th := Setup(t).InitBasic()
+	defer th.TearDown()
+
+	createThread := func(channel *model.Channel) (rpost *model.Post) {
+		t.Helper()
+		post := &model.Post{
+			ChannelId: channel.Id,
+			Message:   "root post",
+			UserId:    th.BasicUser.Id,
+		}
+
+		rpost, err := th.App.CreatePost(th.Context, post, th.BasicChannel, false, true)
+		require.Nil(t, err)
+
+		reply := &model.Post{
+			ChannelId: channel.Id,
+			Message:   "reply post",
+			UserId:    th.BasicUser.Id,
+			RootId:    rpost.Id,
+		}
+		_, err = th.App.CreatePost(th.Context, reply, th.BasicChannel, false, true)
+		require.Nil(t, err)
+
+		return rpost
+	}
+
+	t.Run("thread memberships are deleted", func(t *testing.T) {
+		createThread(th.BasicChannel)
+		channel2 := th.createChannel(th.Context, th.BasicTeam, model.ChannelTypeOpen)
+		createThread(channel2)
+
+		threads, err := th.App.GetThreadsForUser(th.BasicUser.Id, th.BasicChannel.TeamId, model.GetUserThreadsOpts{})
+		require.Nil(t, err)
+		require.Len(t, threads.Threads, 2)
+
+		err = th.App.LeaveChannel(th.Context, th.BasicChannel.Id, th.BasicUser.Id)
+		require.Nil(t, err)
+
+		_, err = th.App.GetChannelMember(th.Context, th.BasicChannel.Id, th.BasicUser.Id)
+		require.NotNil(t, err, "It should remove channel membership")
+
+		threads, err = th.App.GetThreadsForUser(th.BasicUser.Id, th.BasicChannel.TeamId, model.GetUserThreadsOpts{})
+		require.Nil(t, err)
+		require.Len(t, threads.Threads, 1)
+	})
 }
 
 func TestLeaveLastChannel(t *testing.T) {

--- a/db/migrations/migrations.list
+++ b/db/migrations/migrations.list
@@ -182,6 +182,8 @@ db/migrations/mysql/000095_remove_posts_parentid.down.sql
 db/migrations/mysql/000095_remove_posts_parentid.up.sql
 db/migrations/mysql/000105_remove_tokens.down.sql
 db/migrations/mysql/000105_remove_tokens.up.sql
+db/migrations/mysql/000107_threadmemberships_cleanup.down.sql
+db/migrations/mysql/000107_threadmemberships_cleanup.up.sql
 db/migrations/postgres/000001_create_teams.down.sql
 db/migrations/postgres/000001_create_teams.up.sql
 db/migrations/postgres/000002_create_team_members.down.sql
@@ -364,3 +366,5 @@ db/migrations/postgres/000095_remove_posts_parentid.down.sql
 db/migrations/postgres/000095_remove_posts_parentid.up.sql
 db/migrations/postgres/000105_remove_tokens.down.sql
 db/migrations/postgres/000105_remove_tokens.up.sql
+db/migrations/postgres/000107_threadmemberships_cleanup.down.sql
+db/migrations/postgres/000107_threadmemberships_cleanup.up.sql

--- a/db/migrations/mysql/000107_threadmemberships_cleanup.down.sql
+++ b/db/migrations/mysql/000107_threadmemberships_cleanup.down.sql
@@ -1,0 +1,1 @@
+-- Skipping it because the forward migrations are destructive

--- a/db/migrations/mysql/000107_threadmemberships_cleanup.up.sql
+++ b/db/migrations/mysql/000107_threadmemberships_cleanup.up.sql
@@ -1,0 +1,5 @@
+DELETE FROM
+    tm USING ThreadMemberships AS tm
+    JOIN Threads ON Threads.PostId = tm.PostId
+WHERE
+    (tm.UserId, Threads.ChannelId) NOT IN (SELECT UserId, ChannelId FROM ChannelMembers);

--- a/db/migrations/postgres/000107_threadmemberships_cleanup.down.sql
+++ b/db/migrations/postgres/000107_threadmemberships_cleanup.down.sql
@@ -1,0 +1,1 @@
+-- Skipping it because the forward migrations are destructive

--- a/db/migrations/postgres/000107_threadmemberships_cleanup.up.sql
+++ b/db/migrations/postgres/000107_threadmemberships_cleanup.up.sql
@@ -1,0 +1,12 @@
+DELETE FROM threadmemberships WHERE (postid, userid) IN (
+    SELECT
+        threadmemberships.postid,
+        threadmemberships.userid
+    FROM
+        threadmemberships
+        JOIN threads ON threads.postid = threadmemberships.postid
+        LEFT JOIN channelmembers ON channelmembers.userid = threadmemberships.userid
+            AND threads.channelid = channelmembers.channelid
+    WHERE
+        channelmembers.channelid IS NULL
+);

--- a/store/opentracinglayer/opentracinglayer.go
+++ b/store/opentracinglayer/opentracinglayer.go
@@ -9520,6 +9520,24 @@ func (s *OpenTracingLayerThreadStore) DeleteMembershipForUser(userId string, pos
 	return err
 }
 
+func (s *OpenTracingLayerThreadStore) DeleteMembershipsForChannel(userID string, channelID string) error {
+	origCtx := s.Root.Store.Context()
+	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ThreadStore.DeleteMembershipsForChannel")
+	s.Root.Store.SetContext(newCtx)
+	defer func() {
+		s.Root.Store.SetContext(origCtx)
+	}()
+
+	defer span.Finish()
+	err := s.ThreadStore.DeleteMembershipsForChannel(userID, channelID)
+	if err != nil {
+		span.LogFields(spanlog.Error(err))
+		ext.Error.Set(span, true)
+	}
+
+	return err
+}
+
 func (s *OpenTracingLayerThreadStore) DeleteOrphanedRows(limit int) (int64, error) {
 	origCtx := s.Root.Store.Context()
 	span, newCtx := tracing.StartSpanWithParentByContext(s.Root.Store.Context(), "ThreadStore.DeleteOrphanedRows")

--- a/store/retrylayer/retrylayer.go
+++ b/store/retrylayer/retrylayer.go
@@ -10877,6 +10877,27 @@ func (s *RetryLayerThreadStore) DeleteMembershipForUser(userId string, postID st
 
 }
 
+func (s *RetryLayerThreadStore) DeleteMembershipsForChannel(userID string, channelID string) error {
+
+	tries := 0
+	for {
+		err := s.ThreadStore.DeleteMembershipsForChannel(userID, channelID)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerThreadStore) DeleteOrphanedRows(limit int) (int64, error) {
 
 	tries := 0

--- a/store/sqlstore/thread_store.go
+++ b/store/sqlstore/thread_store.go
@@ -649,6 +649,28 @@ func (s *SqlThreadStore) UpdateMembership(membership *model.ThreadMembership) (*
 	return s.updateMembership(s.GetMasterX(), membership)
 }
 
+func (s *SqlThreadStore) DeleteMembershipsForChannel(userID, channelID string) error {
+	subQuery := s.getSubQueryBuilder().
+		Select("1").
+		From("Threads").
+		Where(sq.And{
+			sq.Expr("Threads.PostId = ThreadMemberships.PostId"),
+			sq.Eq{"Threads.ChannelId": channelID},
+		})
+
+	query := s.getQueryBuilder().
+		Delete("ThreadMemberships").
+		Where(sq.Eq{"UserId": userID}).
+		Where(sq.Expr("EXISTS (?)", subQuery))
+
+	_, err := s.GetMasterX().ExecBuilder(query)
+	if err != nil {
+		return errors.Wrapf(err, "failed to remove thread memberships with userid=%s channelid=%s", userID, channelID)
+	}
+
+	return nil
+}
+
 func (s *SqlThreadStore) updateMembership(ex sqlxExecutor, membership *model.ThreadMembership) (*model.ThreadMembership, error) {
 	query := s.getQueryBuilder().
 		Update("ThreadMemberships").
@@ -673,7 +695,14 @@ func (s *SqlThreadStore) GetMembershipsForUser(userId, teamId string) ([]*model.
 	memberships := []*model.ThreadMembership{}
 
 	query := s.getQueryBuilder().
-		Select("ThreadMemberships.*").
+		Select(
+			"ThreadMemberships.PostId",
+			"ThreadMemberships.UserId",
+			"ThreadMemberships.Following",
+			"ThreadMemberships.LastUpdated",
+			"ThreadMemberships.LastViewed",
+			"ThreadMemberships.UnreadMentions",
+		).
 		Join("Threads ON Threads.PostId = ThreadMemberships.PostId").
 		Join("Channels ON Threads.ChannelId = Channels.Id").
 		From("ThreadMemberships").
@@ -694,7 +723,14 @@ func (s *SqlThreadStore) GetMembershipForUser(userId, postId string) (*model.Thr
 func (s *SqlThreadStore) getMembershipForUser(ex sqlxExecutor, userId, postId string) (*model.ThreadMembership, error) {
 	var membership model.ThreadMembership
 	query := s.getQueryBuilder().
-		Select("*").
+		Select(
+			"PostId",
+			"UserId",
+			"Following",
+			"LastUpdated",
+			"LastViewed",
+			"UnreadMentions",
+		).
 		From("ThreadMemberships").
 		Where(sq.And{
 			sq.Eq{"PostId": postId},

--- a/store/store.go
+++ b/store/store.go
@@ -331,6 +331,7 @@ type ThreadStore interface {
 	PermanentDeleteBatchThreadMembershipsForRetentionPolicies(now, globalPolicyEndTime, limit int64, cursor model.RetentionPolicyCursor) (int64, model.RetentionPolicyCursor, error)
 	DeleteOrphanedRows(limit int) (deleted int64, err error)
 	GetThreadUnreadReplyCount(threadMembership *model.ThreadMembership) (int64, error)
+	DeleteMembershipsForChannel(userID, channelID string) error
 
 	// Insights - threads
 	GetTopThreadsForTeamSince(teamID string, userID string, since int64, offset int, limit int) (*model.TopThreadList, error)

--- a/store/storetest/mocks/ThreadStore.go
+++ b/store/storetest/mocks/ThreadStore.go
@@ -29,6 +29,20 @@ func (_m *ThreadStore) DeleteMembershipForUser(userId string, postID string) err
 	return r0
 }
 
+// DeleteMembershipsForChannel provides a mock function with given fields: userID, channelID
+func (_m *ThreadStore) DeleteMembershipsForChannel(userID string, channelID string) error {
+	ret := _m.Called(userID, channelID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(userID, channelID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteOrphanedRows provides a mock function with given fields: limit
 func (_m *ThreadStore) DeleteOrphanedRows(limit int) (int64, error) {
 	ret := _m.Called(limit)

--- a/store/timerlayer/timerlayer.go
+++ b/store/timerlayer/timerlayer.go
@@ -8567,6 +8567,22 @@ func (s *TimerLayerThreadStore) DeleteMembershipForUser(userId string, postID st
 	return err
 }
 
+func (s *TimerLayerThreadStore) DeleteMembershipsForChannel(userID string, channelID string) error {
+	start := time.Now()
+
+	err := s.ThreadStore.DeleteMembershipsForChannel(userID, channelID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ThreadStore.DeleteMembershipsForChannel", success, elapsed)
+	}
+	return err
+}
+
 func (s *TimerLayerThreadStore) DeleteOrphanedRows(limit int) (int64, error) {
 	start := time.Now()
 


### PR DESCRIPTION
Cherrypick of #22559

#### Release Note

```release-note
Fixed a bug where a user would still see threads, in threads view, of channels they have left.
Migration execution time in MySQL: Query OK, 2766769 rows affected (4 min 47.57 sec)
Migration execution time in PostgreSQL: Execution time: 58.11 sec, DELETE 2766690
```