### PR TITLE
Bump Gitlab Postgres image version to v11

### DIFF
--- a/server/build/gitlab-dc.postgres.yml
+++ b/server/build/gitlab-dc.postgres.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   postgres:
-    image: ${CI_REGISTRY}/mattermost/ci/images/postgres:10-1
+    image: ${CI_REGISTRY}/mattermost/ci/images/postgres:11-1
     restart: always
     environment:
       POSTGRES_USER: mmuser


### PR DESCRIPTION
#### Summary

Bumping the postgres image on Gitlab, which we are trying to release with https://git.internal.mattermost.com/mattermost/ci/images/postgres/-/merge_requests/2

This should prevent the MM server from failing to start on some e2e pipelines (e.g. Calls) that use this image.

#### Release Note

```release-note
NONE
```
