### PR TITLE
Fix module version to v7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattermost/mattermost-server/v6
+module github.com/mattermost/mattermost-server/v7
 
 go 1.19
 


### PR DESCRIPTION
Updated `go.mod` module version to v7.

The PR fixes `go get` error::
```
$ go version
go version go1.20.2 linux/amd64

$ go get -u github.com/mattermost/mattermost-server@v7.10.0
go: github.com/mattermost/mattermost-server/v7@v7.10.0: go.mod has non-.../v7 module path "github.com/mattermost/mattermost-server/v6" (and .../v7/go.mod does not exist) at revision v7.10.0
```

```release-note
Updated go.mod module version to v7
```
