### PR TITLE
[MM-52788] webapp : Fix the "EBADENGINE" warnings on npm console

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -36,8 +36,8 @@
         "webpack-dev-server": "4.13.3"
       },
       "engines": {
-        "node": "16.10.0",
-        "npm": "7.24.0"
+        "node": "^16.10.0",
+        "npm": "^7.24.0"
       }
     },
     "boards": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -2,8 +2,8 @@
   "name": "@mattermost/webapp",
   "private": true,
   "engines": {
-    "node": "16.10.0",
-    "npm": "7.24.0"
+    "node": "^16.10.0",
+    "npm": "^7.24.0"
   },
   "scripts": {
     "postinstall": "node scripts/skip_integrity_check.js && npm run build --workspace=platform/types --workspace=platform/client --workspace=platform/components",


### PR DESCRIPTION
#### Summary
The terminal filled up with engines not compatible "EBADENGINE" warning because we had hard set the values of node and npm. We had to add "^" symbol indicating that the version range includes any minor or patch version updates that are backwards-compatible with the specified version in dependencies package.json. The actual update of node will be separate.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52788

#### Screenshots
|  before  |  after  |
|----|----|
| <img width="871" alt="image" src="https://github.com/mattermost/mattermost-server/assets/17708702/aa5b8e82-b83a-452f-91f8-58e225ae3f0b"> | <img width="871" alt="image" src="https://github.com/mattermost/mattermost-server/assets/17708702/46400a14-8025-4421-9224-e4e87f863004"> |





#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
