### PR TITLE
Bump JS package versions to 8.0.0

### DIFF
--- a/webapp/boards/package.json
+++ b/webapp/boards/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "boards",
-	"version": "7.11.0",
+	"version": "8.0.0",
 	"private": true,
 	"description": "",
 	"scripts": {

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -3,7 +3,7 @@
   "browser": {
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
-  "version": "7.11.0",
+  "version": "8.0.0",
   "private": true,
   "dependencies": {
     "@floating-ui/react-dom": "1.0.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -41,7 +41,7 @@
       }
     },
     "boards": {
-      "version": "7.11.0",
+      "version": "8.0.0",
       "dependencies": {
         "@draft-js-plugins/editor": "^4.1.2",
         "@draft-js-plugins/emoji": "^4.6.0",
@@ -3378,7 +3378,7 @@
     },
     "channels": {
       "name": "mattermost-webapp",
-      "version": "7.11.0",
+      "version": "8.0.0",
       "dependencies": {
         "@floating-ui/react-dom": "1.0.0",
         "@floating-ui/react-dom-interactions": "0.10.3",
@@ -33236,7 +33236,7 @@
     },
     "platform/client": {
       "name": "@mattermost/client",
-      "version": "7.11.0",
+      "version": "8.0.0",
       "license": "MIT",
       "dependencies": {
         "form-data": "^4.0.0"
@@ -33253,7 +33253,7 @@
     },
     "platform/components": {
       "name": "@mattermost/components",
-      "version": "7.11.0",
+      "version": "8.0.0",
       "dependencies": {
         "color-blend": "4.0.0"
       },
@@ -33787,7 +33787,7 @@
     },
     "platform/types": {
       "name": "@mattermost/types",
-      "version": "7.11.0",
+      "version": "8.0.0",
       "license": "MIT",
       "peerDependencies": {
         "typescript": "^4.3"
@@ -33799,7 +33799,7 @@
       }
     },
     "playbooks": {
-      "version": "7.11.0",
+      "version": "8.0.0",
       "dependencies": {
         "@apollo/client": "3.7.3",
         "@floating-ui/react-dom-interactions": "0.6.3",

--- a/webapp/platform/client/package.json
+++ b/webapp/platform/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/client",
-  "version": "7.11.0",
+  "version": "8.0.0",
   "description": "JavaScript/TypeScript client for Mattermost",
   "keywords": [
     "mattermost"

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mattermost/components",
-  "version": "7.11.0",
+  "version": "8.0.0",
+  "private": true,
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "styles": "dist/index.esm.css",

--- a/webapp/platform/types/package.json
+++ b/webapp/platform/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mattermost/types",
-  "version": "7.11.0",
+  "version": "8.0.0",
   "description": "Shared type definitions used by the Mattermost web app",
   "keywords": [
     "mattermost"

--- a/webapp/playbooks/package.json
+++ b/webapp/playbooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playbooks",
   "private": true,
-  "version": "7.11.0",
+  "version": "8.0.0",
   "dependencies": {
     "@apollo/client": "3.7.3",
     "@floating-ui/react-dom-interactions": "0.6.3",


### PR DESCRIPTION
#### Summary
I'm doing this ahead of time so that I won't need to do it after the release branch gets cut. These version numbers only matter once we go to publish the non-private packages to NPM

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52599

#### Release Note
```release-note
NONE
```
