### PR TITLE
Fixed image attachment e2e cypress test

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/messaging/image_attachment_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/image_attachment_spec.js
@@ -97,7 +97,7 @@ describe('Image attachment', () => {
         // # File thumbnail should have correct dimensions
         verifyFileThumbnail({
             filename,
-            actualImage: {height: 151, width: 955},
+            actualImage: {height: 144, width: 906},
         });
     });
 
@@ -117,7 +117,7 @@ describe('Image attachment', () => {
         // # File thumbnail should have correct dimensions
         verifyFileThumbnail({
             filename,
-            actualImage: {height: 151, width: 955},
+            actualImage: {height: 144, width: 906},
             clickPreview: () => cy.uiGetFileThumbnail(filename).click(),
         });
 


### PR DESCRIPTION
#### Summary
Fixes the failing tests in `image_attachmemt_spec.js`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52523

#### Release Note

```release-note
NONE
```
