### PR TITLE
[GH-23058] UI Enhancement: use icons in Settings > Import submenu

### DIFF
--- a/webapp/boards/i18n/en.json
+++ b/webapp/boards/i18n/en.json
@@ -254,6 +254,7 @@
   "Sidebar.export-archive": "Export archive",
   "Sidebar.import": "Import",
   "Sidebar.import-archive": "Import archive",
+  "Sidebar.external-import-docs": "External import docs",
   "Sidebar.new-category.badge": "New",
   "Sidebar.new-category.drag-boards-cta": "Drag boards here...",
   "Sidebar.no-boards-in-category": "No boards inside",

--- a/webapp/boards/i18n/en.json
+++ b/webapp/boards/i18n/en.json
@@ -253,7 +253,7 @@
   "Sidebar.duplicate-board": "Duplicate board",
   "Sidebar.export-archive": "Export archive",
   "Sidebar.import": "Import",
-  "Sidebar.import-archive": "Import archive",
+  "Sidebar.import-archive": "Import archive file",
   "Sidebar.external-import-docs": "External import docs",
   "Sidebar.new-category.badge": "New",
   "Sidebar.new-category.drag-boards-cta": "Drag boards here...",

--- a/webapp/boards/i18n/en_AU.json
+++ b/webapp/boards/i18n/en_AU.json
@@ -257,6 +257,7 @@
   "Sidebar.export-archive": "Export archive",
   "Sidebar.import": "Import",
   "Sidebar.import-archive": "Import archive file",
+  "Sidebar.external-import-docs": "External import docs",
   "Sidebar.invite-users": "Invite users",
   "Sidebar.logout": "Log out",
   "Sidebar.new-category.badge": "New",

--- a/webapp/boards/i18n/en_AU.json
+++ b/webapp/boards/i18n/en_AU.json
@@ -256,7 +256,7 @@
   "Sidebar.duplicate-board": "Duplicate board",
   "Sidebar.export-archive": "Export archive",
   "Sidebar.import": "Import",
-  "Sidebar.import-archive": "Import archive",
+  "Sidebar.import-archive": "Import archive file",
   "Sidebar.invite-users": "Invite users",
   "Sidebar.logout": "Log out",
   "Sidebar.new-category.badge": "New",

--- a/webapp/boards/i18n/fr.json
+++ b/webapp/boards/i18n/fr.json
@@ -254,6 +254,7 @@
   "Sidebar.export-archive": "Exporter une archive",
   "Sidebar.import": "Importer",
   "Sidebar.import-archive": "Importer un fichier d'archive",
+  "Sidebar.external-import-docs": "Docs d'importation externe",
   "Sidebar.invite-users": "Inviter des utilisateurs",
   "Sidebar.logout": "Se déconnecter",
   "Sidebar.new-category.badge": "Nouveau",

--- a/webapp/boards/i18n/fr.json
+++ b/webapp/boards/i18n/fr.json
@@ -253,7 +253,7 @@
   "Sidebar.duplicate-board": "Dupliquer une carte",
   "Sidebar.export-archive": "Exporter une archive",
   "Sidebar.import": "Importer",
-  "Sidebar.import-archive": "Importer une archive",
+  "Sidebar.import-archive": "Importer un fichier d'archive",
   "Sidebar.invite-users": "Inviter des utilisateurs",
   "Sidebar.logout": "Se déconnecter",
   "Sidebar.new-category.badge": "Nouveau",

--- a/webapp/boards/i18n/it.json
+++ b/webapp/boards/i18n/it.json
@@ -218,7 +218,7 @@
   "Sidebar.duplicate-board": "Duplica bacheca",
   "Sidebar.export-archive": "Esporta archivio",
   "Sidebar.import": "Importa",
-  "Sidebar.import-archive": "Importa archivio",
+  "Sidebar.import-archive": "Importa file di archivio",
   "Sidebar.invite-users": "Invita utenti",
   "Sidebar.logout": "Logout",
   "Sidebar.no-boards-in-category": "Nessuna bacheca all'interno",

--- a/webapp/boards/i18n/it.json
+++ b/webapp/boards/i18n/it.json
@@ -219,6 +219,7 @@
   "Sidebar.export-archive": "Esporta archivio",
   "Sidebar.import": "Importa",
   "Sidebar.import-archive": "Importa file di archivio",
+  "Sidebar.external-import-docs": "Docs di importazione esterni",
   "Sidebar.invite-users": "Invita utenti",
   "Sidebar.logout": "Logout",
   "Sidebar.no-boards-in-category": "Nessuna bacheca all'interno",

--- a/webapp/boards/i18n/ja.json
+++ b/webapp/boards/i18n/ja.json
@@ -256,7 +256,7 @@
   "Sidebar.duplicate-board": "Boardを複製する",
   "Sidebar.export-archive": "エクスポート",
   "Sidebar.import": "インポート",
-  "Sidebar.import-archive": "インポート",
+  "Sidebar.import-archive": "アーカイブファイルをインポートする",
   "Sidebar.invite-users": "ユーザーを招待する",
   "Sidebar.logout": "ログアウト",
   "Sidebar.new-category.badge": "新規",

--- a/webapp/boards/i18n/ja.json
+++ b/webapp/boards/i18n/ja.json
@@ -257,6 +257,7 @@
   "Sidebar.export-archive": "エクスポート",
   "Sidebar.import": "インポート",
   "Sidebar.import-archive": "アーカイブファイルをインポートする",
+  "Sidebar.external-import-docs": "外部インポートドキュメント",
   "Sidebar.invite-users": "ユーザーを招待する",
   "Sidebar.logout": "ログアウト",
   "Sidebar.new-category.badge": "新規",

--- a/webapp/boards/i18n/kk.json
+++ b/webapp/boards/i18n/kk.json
@@ -134,7 +134,7 @@
   "Sidebar.changePassword": "Кілтсөзді өзгерту",
   "Sidebar.delete-board": "Тақтаны жою",
   "Sidebar.export-archive": "Мұрағатты экспорттау",
-  "Sidebar.import-archive": "Мұрағатты импорттау",
+  "Sidebar.import-archive": "Архив файлын импорттау",
   "Sidebar.invite-users": "Қолданушыларды шақыру",
   "Sidebar.logout": "Шығу",
   "Sidebar.random-icons": "Рандом икондар",

--- a/webapp/boards/i18n/lt.json
+++ b/webapp/boards/i18n/lt.json
@@ -254,6 +254,7 @@
   "Sidebar.export-archive": "Eksportuoti archyvą",
   "Sidebar.import": "Importuoti",
   "Sidebar.import-archive": "Importuoti archyvo failą",
+  "Sidebar.external-import-docs": "Išoriniai importo doks",
   "Sidebar.new-category.badge": "Naujas",
   "Sidebar.new-category.drag-boards-cta": "Vilkite lentas čia...",
   "Sidebar.no-boards-in-category": "Viduje nėra lentų",

--- a/webapp/boards/i18n/lt.json
+++ b/webapp/boards/i18n/lt.json
@@ -253,7 +253,7 @@
   "Sidebar.duplicate-board": "Pasikartojanti lenta",
   "Sidebar.export-archive": "Eksportuoti archyvą",
   "Sidebar.import": "Importuoti",
-  "Sidebar.import-archive": "Importuoti archyvą",
+  "Sidebar.import-archive": "Importuoti archyvo failą",
   "Sidebar.new-category.badge": "Naujas",
   "Sidebar.new-category.drag-boards-cta": "Vilkite lentas čia...",
   "Sidebar.no-boards-in-category": "Viduje nėra lentų",

--- a/webapp/boards/i18n/ml.json
+++ b/webapp/boards/i18n/ml.json
@@ -200,7 +200,7 @@
   "Sidebar.duplicate-board": "ഡ്യൂപ്ലിക്കേറ്റ് ബോർഡ്",
   "Sidebar.export-archive": "ആർക്കൈവ് എക്സ്പോർട്ട് ചെയ്യുക",
   "Sidebar.import": "ഇറക്കുമതി ചെയ്യുക",
-  "Sidebar.import-archive": "ആർക്കൈവ് ഇമ്പോർട്ട് ചെയ്യുക",
+  "Sidebar.import-archive": "ആർക്കൈവ് ഫയൽ ഇറക്കുമതി ചെയ്യുക",
   "Sidebar.invite-users": "ഉപയോക്താക്കളെ ക്ഷണിക്കുക",
   "Sidebar.logout": "ലോഗ്ഔട്ട്",
   "Sidebar.no-boards-in-category": "അകത്ത് ബോർഡുകളില്ല",

--- a/webapp/boards/i18n/nl.json
+++ b/webapp/boards/i18n/nl.json
@@ -257,6 +257,7 @@
   "Sidebar.export-archive": "Archief exporteren",
   "Sidebar.import": "Importeren",
   "Sidebar.import-archive": "Importeer archiefbestand",
+  "Sidebar.external-import-docs": "Externe importdocumenten",
   "Sidebar.invite-users": "Gebruikers uitnodigen",
   "Sidebar.logout": "Afmelden",
   "Sidebar.new-category.badge": "Nieuw",

--- a/webapp/boards/i18n/nl.json
+++ b/webapp/boards/i18n/nl.json
@@ -256,7 +256,7 @@
   "Sidebar.duplicate-board": "Board dupliceren",
   "Sidebar.export-archive": "Archief exporteren",
   "Sidebar.import": "Importeren",
-  "Sidebar.import-archive": "Archief importeren",
+  "Sidebar.import-archive": "Importeer archiefbestand",
   "Sidebar.invite-users": "Gebruikers uitnodigen",
   "Sidebar.logout": "Afmelden",
   "Sidebar.new-category.badge": "Nieuw",

--- a/webapp/boards/i18n/pl.json
+++ b/webapp/boards/i18n/pl.json
@@ -256,7 +256,7 @@
   "Sidebar.duplicate-board": "Duplikuj tablicę",
   "Sidebar.export-archive": "Eksportuj archiwum",
   "Sidebar.import": "Importuj",
-  "Sidebar.import-archive": "Importuj archiwum",
+  "Sidebar.import-archive": "Importuj plik archiwum",
   "Sidebar.invite-users": "Zaproś użytkowników",
   "Sidebar.logout": "Wyloguj się",
   "Sidebar.new-category.badge": "Nowy",

--- a/webapp/boards/i18n/pl.json
+++ b/webapp/boards/i18n/pl.json
@@ -257,6 +257,7 @@
   "Sidebar.export-archive": "Eksportuj archiwum",
   "Sidebar.import": "Importuj",
   "Sidebar.import-archive": "Importuj plik archiwum",
+  "Sidebar.external-import-docs": "Zewnętrzne dokumenty importowe",
   "Sidebar.invite-users": "Zaproś użytkowników",
   "Sidebar.logout": "Wyloguj się",
   "Sidebar.new-category.badge": "Nowy",

--- a/webapp/boards/i18n/ru.json
+++ b/webapp/boards/i18n/ru.json
@@ -257,6 +257,7 @@
   "Sidebar.export-archive": "Экспорт архива",
   "Sidebar.import": "Импорт",
   "Sidebar.import-archive": "Импортировать архивный файл",
+  "Sidebar.external-import-docs": "Внешние документы импорта",
   "Sidebar.invite-users": "Пригласить пользователей",
   "Sidebar.logout": "Выйти",
   "Sidebar.new-category.badge": "Новый",

--- a/webapp/boards/i18n/ru.json
+++ b/webapp/boards/i18n/ru.json
@@ -256,7 +256,7 @@
   "Sidebar.duplicate-board": "Дублировать доску",
   "Sidebar.export-archive": "Экспорт архива",
   "Sidebar.import": "Импорт",
-  "Sidebar.import-archive": "Импорт архива",
+  "Sidebar.import-archive": "Импортировать архивный файл",
   "Sidebar.invite-users": "Пригласить пользователей",
   "Sidebar.logout": "Выйти",
   "Sidebar.new-category.badge": "Новый",

--- a/webapp/boards/i18n/sk.json
+++ b/webapp/boards/i18n/sk.json
@@ -214,6 +214,7 @@
   "Sidebar.delete-board": "Odstrániť nástenku",
   "Sidebar.export-archive": "Export archívu",
   "Sidebar.import-archive": "Importovať archívny súbor",
+  "Sidebar.external-import-docs": "Externé importné doks",
   "Sidebar.invite-users": "Pozvať užívateľa",
   "Sidebar.logout": "Odhlásiť sa",
   "Sidebar.random-icons": "Náhodné ikony",

--- a/webapp/boards/i18n/sk.json
+++ b/webapp/boards/i18n/sk.json
@@ -213,7 +213,7 @@
   "Sidebar.changePassword": "Zmeniť heslo",
   "Sidebar.delete-board": "Odstrániť nástenku",
   "Sidebar.export-archive": "Export archívu",
-  "Sidebar.import-archive": "Import archívu",
+  "Sidebar.import-archive": "Importovať archívny súbor",
   "Sidebar.invite-users": "Pozvať užívateľa",
   "Sidebar.logout": "Odhlásiť sa",
   "Sidebar.random-icons": "Náhodné ikony",

--- a/webapp/boards/i18n/sv.json
+++ b/webapp/boards/i18n/sv.json
@@ -256,7 +256,7 @@
   "Sidebar.duplicate-board": "Duplicera Board",
   "Sidebar.export-archive": "Exportera arkiv",
   "Sidebar.import": "Importera",
-  "Sidebar.import-archive": "Importera arkiv",
+  "Sidebar.import-archive": "Importera arkivfil",
   "Sidebar.invite-users": "Bjud in användare",
   "Sidebar.logout": "Logga ut",
   "Sidebar.new-category.badge": "Ny",

--- a/webapp/boards/i18n/sv.json
+++ b/webapp/boards/i18n/sv.json
@@ -257,6 +257,7 @@
   "Sidebar.export-archive": "Exportera arkiv",
   "Sidebar.import": "Importera",
   "Sidebar.import-archive": "Importera arkivfil",
+  "Sidebar.external-import-docs": "Externa importdokument",
   "Sidebar.invite-users": "Bjud in användare",
   "Sidebar.logout": "Logga ut",
   "Sidebar.new-category.badge": "Ny",

--- a/webapp/boards/i18n/tr.json
+++ b/webapp/boards/i18n/tr.json
@@ -256,7 +256,7 @@
   "Sidebar.duplicate-board": "Panoyu kopyala",
   "Sidebar.export-archive": "Arşivi dışa aktar",
   "Sidebar.import": "İçe aktar",
-  "Sidebar.import-archive": "Arşivi içe aktar",
+  "Sidebar.import-archive": "Arşiv dosyası import et",
   "Sidebar.invite-users": "Kullanıcıları çağır",
   "Sidebar.logout": "Oturumu kapat",
   "Sidebar.new-category.badge": "Yeni",

--- a/webapp/boards/i18n/tr.json
+++ b/webapp/boards/i18n/tr.json
@@ -257,6 +257,7 @@
   "Sidebar.export-archive": "Arşivi dışa aktar",
   "Sidebar.import": "İçe aktar",
   "Sidebar.import-archive": "Arşiv dosyası import et",
+  "Sidebar.external-import-docs": "Harici ithalat belgeleri",
   "Sidebar.invite-users": "Kullanıcıları çağır",
   "Sidebar.logout": "Oturumu kapat",
   "Sidebar.new-category.badge": "Yeni",

--- a/webapp/boards/src/components/globalHeader/globalHeaderSettingsMenu.scss
+++ b/webapp/boards/src/components/globalHeader/globalHeaderSettingsMenu.scss
@@ -1,0 +1,10 @@
+.settings-menu-title__text {
+    color: rgba(63, 67, 80, 0.56);
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    line-height: 16px;
+    padding: 6px 20px;
+}

--- a/webapp/boards/src/components/globalHeader/globalHeaderSettingsMenu.tsx
+++ b/webapp/boards/src/components/globalHeader/globalHeaderSettingsMenu.tsx
@@ -14,6 +14,7 @@ import {IUser, UserConfigPatch} from 'src/user'
 import octoClient from 'src/octoClient'
 import {UserSettings} from 'src/userSettings'
 import SettingsIcon from 'src/widgets/icons/settings'
+import CompassIcon from 'src/widgets/icons/compassIcon'
 
 import {Constants} from 'src/constants'
 import TelemetryClient, {TelemetryActions, TelemetryCategory} from 'src/telemetry/telemetryClient'
@@ -50,12 +51,21 @@ const GlobalHeaderSettingsMenu = (props: Props) => {
                     >
                         <Menu.Text
                             id='import_archive'
-                            name={intl.formatMessage({id: 'Sidebar.import-archive', defaultMessage: 'Import archive'})}
+                            icon={
+                                <CompassIcon
+                                    icon='import'
+                                />
+                            }
+                            name={intl.formatMessage({id: 'Sidebar.import-archive', defaultMessage: 'Import archive file'})}
                             onClick={async () => {
                                 TelemetryClient.trackEvent(TelemetryCategory, TelemetryActions.ImportArchive)
                                 Archiver.importFullArchive()
                             }}
                         />
+                        <Menu.Separator/>
+                        <span className='settings-menu-title__text'>
+                            {intl.formatMessage({id: 'Sidebar.external-import-docs', defaultMessage: 'External import docs'})}
+                        </span>
                         {
                             Constants.imports.map((i) => (
                                 <Menu.Text


### PR DESCRIPTION
#### Summary

This PR enhances the UI for the import submenu in the main settings for boards. Add a separation in the submenu between import action and external links for docs to import from other 3rd party applications. Title the below section of the submenu as **External import docs** to signify external links to documentation.

- Change "Import archive" → "Import archive file"
- Add a separate between import action and external links
- Add "External import docs" as title for external links

#### Ticket Link

Fixes [GitHub issue #23058](https://github.com/mattermost/mattermost-server/issues/23058)

#### Screenshots

|  before  |  after  |
|----|----|
| ![](https://github.com/mattermost/mattermost-server/assets/11533007/76c9ce78-e3a1-4c26-840a-e422d0e50738) | ![](https://github.com/mattermost/mattermost-server/assets/11533007/2af762b1-17bc-4bde-8538-0a28870fc65d) |

#### Release Note
```
NONE
```