### PR TITLE
[MM-52574] Add back PermissionUseSlashCommands

### DIFF
--- a/server/public/model/permission.go
+++ b/server/public/model/permission.go
@@ -21,6 +21,10 @@ type Permission struct {
 
 var PermissionInviteUser *Permission
 var PermissionAddUserToTeam *Permission
+
+// Deprecated: PermissionUseSlashCommands is not longer used. It's only kept for backwards compatibility.
+// See https://mattermost.atlassian.net/browse/MM-52574 for more details.
+var PermissionUseSlashCommands *Permission
 var PermissionManageSlashCommands *Permission
 var PermissionManageOthersSlashCommands *Permission
 var PermissionCreatePublicChannel *Permission
@@ -388,6 +392,12 @@ func initializePermissions() {
 		"authentication.permissions.add_user_to_team.name",
 		"authentication.permissions.add_user_to_team.description",
 		PermissionScopeTeam,
+	}
+	PermissionUseSlashCommands = &Permission{
+		"use_slash_commands",
+		"authentication.permissions.team_use_slash_commands.name",
+		"authentication.permissions.team_use_slash_commands.description",
+		PermissionScopeChannel,
 	}
 	PermissionManageSlashCommands = &Permission{
 		"manage_slash_commands",
@@ -2308,6 +2318,7 @@ func initializePermissions() {
 	}
 
 	ChannelScopedPermissions := []*Permission{
+		PermissionUseSlashCommands,
 		PermissionManagePublicChannelMembers,
 		PermissionManagePrivateChannelMembers,
 		PermissionManageChannelRoles,


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-server/pull/22819 introduce a regression, that causes server which import the load-test DB dump to fail on startup.

As part of the migrations that happen on every server start, all roles [get fetched from the store](https://github.com/mattermost/mattermost-server/blob/cfa5be4d3e0da608d0f0cb3cacc5925ce2a864b3/server/channels/app/permissions_migrations.go#L1140-L11449). These roles do contain the legacy permission `use_slash_commands`, as it's still in the DB.

Later, the roles [get saved in the DB](https://github.com/mattermost/mattermost-server/blob/cfa5be4d3e0da608d0f0cb3cacc5925ce2a864b3/server/channels/app/permissions_migrations.go#L231) again (which in most cases is a no-op). As part of that, [it's checked if the permissions of the role are known](https://github.com/mattermost/mattermost-server/blob/cfa5be4d3e0da608d0f0cb3cacc5925ce2a864b3/server/public/model/role.go#L697-L703). This check fails for `use_slash_commands`, as the permission does not longer exist in the code.

This PR adds the permission back, therefore fixing the role check.

I did test the changes against the load-test DB dump and can confirm the server starts without an issue.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52574

#### Release Note
```release-note
NONE
```
