### PR TITLE
fix: Fix mmctl binary download script with the correct version

### DIFF
--- a/scripts/download_mmctl_release.sh
+++ b/scripts/download_mmctl_release.sh
@@ -15,13 +15,13 @@ fi
 
 BIN_PATH=${2:-bin}
 
-# strip whitespace
+## If pattern release-X.Y exist in branch name we parse the release branch and we fallback to masterx
 THIS_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [[ "$THIS_BRANCH" =~ 'release-'[0-9] ]];
-then
-  RELEASE_TO_DOWNLOAD=$(echo $THIS_BRANCH | grep -Eo 'release-([0-9](\.){0,1})\.([0-9](\.){0,1})')
+RELEASE_PATTERN='release-[0-9]+\.[0-9]+(\.[0-9]+)?'
+if [[ $THIS_BRANCH =~ $RELEASE_PATTERN ]]; then
+  RELEASE_TO_DOWNLOAD=$(echo $THIS_BRANCH | grep -Eo 'release-([0-9]+)?\.([0-9]+)?')
 else
-  RELEASE_TO_DOWNLOAD=master
+  RELEASE_TO_DOWNLOAD="master"
 fi
 
 echo "Downloading prepackaged binary: https://releases.mattermost.com/mmctl/$RELEASE_TO_DOWNLOAD";


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Related PR: https://github.com/mattermost/mattermost-server/pull/23488

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Screenshots
<!--
If the PR includes UI changes, include screenshots/GIFs.

For an easier comparison of UI changes a table (template below) can be used.

|  before  |  after  |
|----|----|
| <insert before screenshot here> | <insert after screenshot here> |

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
NONE
```
