### PR TITLE
Update supported Chrome version

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10037,7 +10037,7 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 110+"
+    "translation": "Version 112+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",


### PR DESCRIPTION
Desktop app v5.4 will include Electron v24.3.1, which includes Chrome version v112.