### PR TITLE
Fix duplicate keys in CombinedSystemMessage component

### DIFF
--- a/webapp/channels/src/components/post_view/combined_system_message/combined_system_message.tsx
+++ b/webapp/channels/src/components/post_view/combined_system_message/combined_system_message.tsx
@@ -322,14 +322,15 @@ export class CombinedSystemMessage extends React.PureComponent<Props> {
         );
     }
 
-    renderMessage(postType: string, userIds: string[], actorId?: string): JSX.Element {
+    renderMessage(index: number, postType: string, userIds: string[], actorId?: string): JSX.Element {
         return (
-            <React.Fragment key={postType + actorId}>
+            <React.Fragment key={index}>
                 {this.renderFormattedMessage(postType, userIds, actorId)}
                 <br/>
             </React.Fragment>
         );
     }
+
     render(): JSX.Element {
         const {
             currentUserId,
@@ -337,7 +338,8 @@ export class CombinedSystemMessage extends React.PureComponent<Props> {
         } = this.props;
 
         const content = [];
-        for (const message of messageData) {
+        for (let i = 0; i < messageData.length; i++) {
+            const message = messageData[i];
             const {
                 postType,
                 actorId,
@@ -356,7 +358,7 @@ export class CombinedSystemMessage extends React.PureComponent<Props> {
                 }
             }
 
-            content.push(this.renderMessage(postType, userIds, actorId));
+            content.push(this.renderMessage(i, postType, userIds, actorId));
         }
 
         return (


### PR DESCRIPTION
#### Summary
When the combined join/leave message component was changed recently, it became possible for multiple lines in that post to have the same actor, post type, and user ID, so the key we were using for them became non-unique. 

While it's usually a bad practice to use an index as a key, there's no truly unique identifier for these items, so we have to use that. That list of combined messages also isn't likely to be reordered often, so we're not really helping React's reconciliation process with a better key either

#### Release Note
```release-note
NONE
```
