### PR TITLE
MM-52940: Turn on GraphQL by default

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -47,7 +47,6 @@ ifeq ($(BUILD_NUMBER),)
 endif
 
 ifeq ($(BUILD_NUMBER),dev)
-	export MM_FEATUREFLAGS_GRAPHQL = true
 	GOTAGS += "testlicensekey"
 endif
 

--- a/server/channels/api4/apitestlib.go
+++ b/server/channels/api4/apitestlib.go
@@ -812,16 +812,12 @@ func (th *TestHelper) CreateDmChannel(user *model.User) *model.Channel {
 
 func (th *TestHelper) LoginBasic() {
 	th.LoginBasicWithClient(th.Client)
-	if os.Getenv("MM_FEATUREFLAGS_GRAPHQL") == "true" {
-		th.LoginBasicWithGraphQL()
-	}
+	th.LoginBasicWithGraphQL()
 }
 
 func (th *TestHelper) LoginBasic2() {
 	th.LoginBasic2WithClient(th.Client)
-	if os.Getenv("MM_FEATUREFLAGS_GRAPHQL") == "true" {
-		th.LoginBasicWithGraphQL()
-	}
+	th.LoginBasicWithGraphQL()
 }
 
 func (th *TestHelper) LoginTeamAdmin() {

--- a/server/channels/api4/graphql_test.go
+++ b/server/channels/api4/graphql_test.go
@@ -4,7 +4,6 @@
 package api4
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -12,9 +11,6 @@ import (
 )
 
 func TestGraphQLPayload(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
-
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 

--- a/server/channels/api4/resolver_channel_member_test.go
+++ b/server/channels/api4/resolver_channel_member_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,8 +14,6 @@ import (
 )
 
 func TestGraphQLChannelMembers(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 

--- a/server/channels/api4/resolver_channel_test.go
+++ b/server/channels/api4/resolver_channel_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,8 +14,6 @@ import (
 )
 
 func TestGraphQLChannels(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
@@ -386,8 +383,6 @@ func TestGraphQLChannels(t *testing.T) {
 }
 
 func TestGetPrettyDNForUsers(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
 	t.Run("nickname_full_name", func(t *testing.T) {
 		users := []*model.User{
 			{

--- a/server/channels/api4/resolver_sidebar_categories_test.go
+++ b/server/channels/api4/resolver_sidebar_categories_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"encoding/json"
-	"os"
 	"sort"
 	"testing"
 
@@ -16,8 +15,6 @@ import (
 )
 
 func TestGraphQLSidebarCategories(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 

--- a/server/channels/api4/resolver_team_member_test.go
+++ b/server/channels/api4/resolver_team_member_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"encoding/json"
-	"os"
 	"sort"
 	"testing"
 
@@ -16,8 +15,6 @@ import (
 )
 
 func TestGraphQLTeamMembers(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
@@ -292,9 +289,6 @@ func TestGraphQLTeamMembers(t *testing.T) {
 }
 
 func TestGraphQLTeamMembersAsGuest(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
-
 	th := Setup(t)
 
 	id := model.NewId()

--- a/server/channels/api4/resolver_test.go
+++ b/server/channels/api4/resolver_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,9 +14,6 @@ import (
 )
 
 func TestGraphQLConfig(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
-
 	th := Setup(t)
 	th.LoginBasicWithGraphQL()
 	defer th.TearDown()
@@ -46,9 +42,6 @@ func TestGraphQLConfig(t *testing.T) {
 }
 
 func TestGraphQLLicense(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
-
 	th := Setup(t)
 	th.LoginBasicWithGraphQL()
 	defer th.TearDown()
@@ -77,9 +70,6 @@ func TestGraphQLLicense(t *testing.T) {
 }
 
 func TestGraphQLChannelsLeft(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
-
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 
@@ -146,9 +136,6 @@ func TestGraphQLChannelsLeft(t *testing.T) {
 }
 
 func TestGraphQLRolesLoader(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
-
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 

--- a/server/channels/api4/resolver_user_test.go
+++ b/server/channels/api4/resolver_user_test.go
@@ -5,7 +5,6 @@ package api4
 
 import (
 	"encoding/json"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -17,9 +16,6 @@ import (
 )
 
 func TestGraphQLUser(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_GRAPHQL", "true")
-	defer os.Unsetenv("MM_FEATUREFLAGS_GRAPHQL")
-
 	th := Setup(t).InitBasic()
 	defer th.TearDown()
 

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3517,7 +3517,7 @@ func TestAttachDeviceId(t *testing.T) {
 
 				sessions, appErr := th.App.GetSessions(th.BasicUser.Id)
 				require.Nil(t, appErr)
-				assert.Equal(t, deviceId, sessions[0].DeviceId, "Missing device Id")
+				assert.Equal(t, deviceId, sessions[len(sessions)-1].DeviceId, "Missing device Id")
 			})
 		}
 	})

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -94,7 +94,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.BoardsDataRetention = false
 	f.NormalizeLdapDNs = false
 	f.UseCaseOnboarding = true
-	f.GraphQL = false
+	f.GraphQL = true
 	f.InsightsEnabled = true
 	f.CommandPalette = false
 	f.CallsEnabled = true


### PR DESCRIPTION
```release-note
The GraphQL backend is turned on by default from now on.
In case there are any issues, it can be turned off by
setting the environment variable MM_FEATUREFLAGS_GRAPHQL to off.
```

https://mattermost.atlassian.net/browse/MM-52940
