### PR TITLE
MM-52544 Fix missing reply bar mention highlight

### DIFF
--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -1122,11 +1122,12 @@
     &.post--comment {
         .post__body {
             padding-left: 7px;
-            border-left: 4px solid $gray;
+            border-left: 4px solid rgba(var(--center-channel-color-rgb), 0.2);
+        }
 
-            &.mention-comment {
-                border-color: $yellow;
-                border-left: 4px solid $yellow;
+        &.mention-comment {
+            .post__body {
+                border-left: 4px solid var(--mention-highlight-bg);
             }
         }
 

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -406,7 +406,6 @@ export function applyTheme(theme: Theme) {
         changeCss('body', 'scrollbar-arrow-color:' + theme.centerChannelColor);
         changeCss('.app__body .post-create__container .post-create-body .btn-file svg, .app__body .post.post--compact .post-image__column .post-image__details svg, .app__body .modal .about-modal .about-modal__logo svg, .app__body .status svg, .app__body .edit-post__actions .icon svg', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .post-list__new-messages-below', 'background:' + changeColor(theme.centerChannelColor, 0.5));
-        changeCss('.app__body .post.post--comment .post__body', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('@media(min-width: 768px){.app__body .post.post--compact.same--root.post--comment .post__content', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .post.post--comment.current--user .post__body', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .emoji-picker', 'color:' + theme.centerChannelColor);
@@ -467,7 +466,6 @@ export function applyTheme(theme: Theme) {
 
     if (theme.mentionHighlightBg) {
         changeCss('.app__body .search-highlight', 'background:' + theme.mentionHighlightBg);
-        changeCss('.app__body .post.post--comment .post__body.mention-comment', 'border-color:' + theme.mentionHighlightBg);
         changeCss('.app__body .post.post--highlight', 'background:' + changeOpacity(theme.mentionHighlightBg, 0.5));
     }
 


### PR DESCRIPTION
#### Summary
During the big refactor of the post, we moved around some CSS rules that were meant to turn the bar to the left of replies to the user's mention colour when they were mentioned by that thread due to their Reply Mentions setting. This fixes that by rearranging the CSS, and I also took the chance to move that to being coloured with CSS variables

#### Ticket Link
MM-52544

#### Screenshots
<details>

Light theme, reply mentions disabled:

![Screen Shot 2023-05-29 at 4 53 46 PM](https://github.com/mattermost/mattermost-server/assets/3277310/e00ce0d5-e968-4918-b95c-b294fef57212)

Dark theme, reply mentions enabled:

![Screen Shot 2023-05-29 at 4 53 36 PM](https://github.com/mattermost/mattermost-server/assets/3277310/08909188-2705-43c9-a1a8-709d17f58268)

Light theme, reply mentions enabled:

![Screen Shot 2023-05-29 at 5 02 57 PM](https://github.com/mattermost/mattermost-server/assets/3277310/c58aedbe-bded-4f67-9d3b-6b9a264dbe76)

</details>

#### Release Note
```release-note
Fixed reply bar not being highlighted when a user is mentioned by a reply because of their Reply Notifications setting
```
