### PR TITLE
Make save_post_spec less affected by other E2E tests

### DIFF
--- a/e2e-tests/cypress/tests/support/ui/post.ts
+++ b/e2e-tests/cypress/tests/support/ui/post.ts
@@ -78,26 +78,28 @@ export function verifySavedPost(postId, message) {
     cy.findByText('Remove from Saved').scrollIntoView().should('be.visible');
     cy.get(`#CENTER_dropdown_${postId}`).should('be.visible').type('{esc}');
 
-    // * Check that the post is highlighted
-    cy.get(`#post_${postId}`).should('have.class', 'post--pinned-or-flagged');
+    cy.get('#postListContent').within(() => {
+        // * Check that the post is highlighted
+        cy.get(`#post_${postId}`).should('have.class', 'post--pinned-or-flagged');
 
-    // * Check that the post pre-header is visible
-    cy.get('div.post-pre-header').should('be.visible');
+        // * Check that the post pre-header is visible
+        cy.get('div.post-pre-header').should('be.visible');
 
-    // * Check that the post pre-header has the saved icon
-    cy.get('span.icon--post-pre-header').
-        should('be.visible').
-        within(() => {
-            cy.get('svg').should('have.attr', 'aria-label', 'Saved Icon');
-        });
+        // * Check that the post pre-header has the saved icon
+        cy.get('span.icon--post-pre-header').
+            should('be.visible').
+            within(() => {
+                cy.get('svg').should('have.attr', 'aria-label', 'Saved Icon');
+            });
 
-    // * Check that the post pre-header has the saved post link
-    cy.get('div.post-pre-header__text-container').
-        should('be.visible').
-        and('have.text', 'Saved').
-        within(() => {
-            cy.get('a').as('savedLink').should('be.visible');
-        });
+        // * Check that the post pre-header has the saved post link
+        cy.get('div.post-pre-header__text-container').
+            should('be.visible').
+            and('have.text', 'Saved').
+            within(() => {
+                cy.get('a').as('savedLink').should('be.visible');
+            });
+    });
 
     // * Check that the saved posts list is not open in RHS before clicking the link in the post pre-header
     cy.get('#searchContainer').should('not.exist');
@@ -112,7 +114,7 @@ export function verifySavedPost(postId, message) {
             and('have.text', 'Saved Posts');
 
         // * Check that the post pre-header is not shown for the saved message in RHS
-        cy.get('#search-items-container').within(() => {
+        cy.get(`#searchResult_${postId}`).within(() => {
             cy.get(`#rhsPostMessageText_${postId}`).contains(message);
             cy.get('div.post-pre-header').should('not.exist');
         });
@@ -137,19 +139,21 @@ export function verifyUnsavedPost(postId) {
     cy.findByText('Save').scrollIntoView().should('be.visible');
     cy.get(`#CENTER_dropdown_${postId}`).should('be.visible').type('{esc}');
 
-    // * Check that the post is highlighted
-    cy.get(`#post_${postId}`).should('not.have.class', 'post--pinned-or-flagged');
+    cy.get('#postListContent').within(() => {
+        // * Check that the post is not highlighted
+        cy.get(`#post_${postId}`).should('not.have.class', 'post--pinned-or-flagged');
 
-    // * Check that the post pre-header is visible
-    cy.get('div.post-pre-header').should('not.exist');
+        // * Check that the post pre-header is not visible
+        cy.get('div.post-pre-header').should('not.exist');
 
-    // * Check that the post pre-header has the saved icon
-    cy.get('span.icon--post-pre-header').
-        should('not.exist');
+        // * Check that the post pre-header does not have the saved icon
+        cy.get('span.icon--post-pre-header').
+            should('not.exist');
 
-    // * Check that the post pre-header has the saved post link
-    cy.get('div.post-pre-header__text-container').
-        should('not.exist');
+        // * Check that the post pre-header does not have the saved post link
+        cy.get('div.post-pre-header__text-container').
+            should('not.exist');
+    });
 
     // * Check that the saved posts list is not open in RHS before clicking the link in the post pre-header
     cy.get('#searchContainer').should('not.exist');


### PR DESCRIPTION
#### Summary
Some of the failures in https://github.com/mattermost/mattermost-server/pull/23510#issuecomment-1568335023 seem to be caused because these tests look for the existence of a `post-pre-header` in the search results, but depending on the order that the E2E tests run, you can sometimes have a pinned post in the search results which is actually supposed to show a `post-pre-header`. So, in this PR, I made some of these selectors narrower to ensure that other tests don't break these tests

#### Release Note
```release-note
NONE
```
