### PR TITLE
Avoid calling the user count query in future if we get a count > 0

### DIFF
--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -39,6 +39,8 @@ type ServiceConfig struct {
 // ensure the config wrapper implements `product.ConfigService`
 var _ product.ConfigService = (*PlatformService)(nil)
 
+var fetchUserCount = true
+
 func (ps *PlatformService) Config() *model.Config {
 	return ps.configStore.Get()
 }
@@ -326,12 +328,18 @@ func (ps *PlatformService) LimitedClientConfig() map[string]string {
 }
 
 func (ps *PlatformService) IsFirstUserAccount() bool {
-	count, err := ps.Store.User().Count(model.UserCountOptions{IncludeDeleted: true})
-	if err != nil {
-		return false
+	if fetchUserCount {
+		count, err := ps.Store.User().Count(model.UserCountOptions{IncludeDeleted: true})
+		if err != nil {
+			return false
+		}
+		// Avoid calling the user count query in future if we get a count > 0
+		if count > 0 {
+			fetchUserCount = false
+		}
 	}
 
-	return count <= 0
+	return fetchUserCount
 }
 
 func (ps *PlatformService) MaxPostSize() int {

--- a/server/channels/app/platform/config_test.go
+++ b/server/channels/app/platform/config_test.go
@@ -124,6 +124,9 @@ func TestIsFirstUserAccount(t *testing.T) {
 		{"success multiple users - no store call", 42, nil, false, false},
 	}
 
+	// create a session, this should not affect IsFirstUserAccount
+	th.Service.sessionCache.Set("mock_session", 1)
+
 	for _, te := range tests {
 		t.Run(te.name, func(t *testing.T) {
 			*userStoreMock = smocks.UserStore{}

--- a/server/channels/app/platform/config_test.go
+++ b/server/channels/app/platform/config_test.go
@@ -109,37 +109,30 @@ func TestIsFirstUserAccount(t *testing.T) {
 	storeMock.On("User").Return(userStoreMock)
 
 	type test struct {
-		name   string
-		count  int64
-		err    error
-		result bool
+		name            string
+		count           int64
+		err             error
+		result          bool
+		shouldCallStore bool
 	}
 
 	tests := []test{
-		{"success no users", 0, nil, true},
-		{"success one user", 1, nil, false},
-		{"success multiple users", 42, nil, false},
-		{"success negative users", -100, nil, true},
-		{"failed request", 0, errors.New("error"), false},
+		{"failed request", 0, errors.New("error"), false, true},
+		{"success negative users", -100, nil, true, true},
+		{"success no users", 0, nil, true, true},
+		{"success one user", 1, nil, false, true},
+		{"success multiple users - no store call", 42, nil, false, false},
 	}
 
 	for _, te := range tests {
 		t.Run(te.name, func(t *testing.T) {
 			*userStoreMock = smocks.UserStore{}
 
-			userStoreMock.On("Count", model.UserCountOptions{IncludeDeleted: true}).Return(te.count, te.err)
-			require.Equal(t, te.result, th.Service.IsFirstUserAccount())
-		})
-	}
-
-	// create a session, this should not affect IsFirstUserAccount
-	th.Service.sessionCache.Set("mock_session", 1)
-
-	for _, te := range tests {
-		t.Run(te.name+" with session", func(t *testing.T) {
-			*userStoreMock = smocks.UserStore{}
-
-			userStoreMock.On("Count", model.UserCountOptions{IncludeDeleted: true}).Return(te.count, te.err)
+			userStoreMock.On("Count", model.UserCountOptions{IncludeDeleted: true}).Return(te.count, te.err).RunFn = func(args mock.Arguments) {
+				if !te.shouldCallStore {
+					assert.Fail(t, "should not have called the store")
+				}
+			}
 			require.Equal(t, te.result, th.Service.IsFirstUserAccount())
 		})
 	}

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -49,10 +49,11 @@ type PlatformService struct {
 	sessionCache  cache.Cache
 	sessionPool   sync.Pool
 
-	asymmetricSigningKey atomic.Value
-	clientConfig         atomic.Value
-	clientConfigHash     atomic.Value
-	limitedClientConfig  atomic.Value
+	asymmetricSigningKey                   atomic.Value
+	clientConfig                           atomic.Value
+	clientConfigHash                       atomic.Value
+	limitedClientConfig                    atomic.Value
+	fetchUserCountForFirstUserAccountCheck atomic.Bool
 
 	logger              *mlog.Logger
 	notificationsLogger *mlog.Logger
@@ -125,6 +126,9 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 		licenseListeners:          map[string]func(*model.License, *model.License){},
 		additionalClusterHandlers: map[model.ClusterEvent]einterfaces.ClusterMessageHandler{},
 	}
+
+	// Assume the first user account has not been created yet. A call to the DB will later check if this is really the case.
+	ps.fetchUserCountForFirstUserAccountCheck.Store(true)
 
 	// Step 1: Cache provider.
 	// At the moment we only have this implementation


### PR DESCRIPTION
#### Summary
This change should fix an issue where we are unnecessarily getting the total user count for every license request. We only need to know that they have at least 1 user. This var gets reset on server restart

#### Ticket Link

#### Screenshots


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates).
* API additions—new endpoint, new response fields, or newly accepted request parameters.
* Database changes (any).
* Schema migration changes. Use the [Schema Migration Template](https://docs.google.com/document/d/18lD7N32oyMtYjFrJKwsNv8yn6Fe5QtF-eMm8nn0O8tk/edit?usp=sharing) as a starting point to capture these details as release notes. 
* Websocket additions or changes.
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating).
* New features and improvements, including behavioral changes, UI changes, and CLI changes.
* Bug fixes and fixes of previous known issues.
* Deprecation warnings, breaking changes, or compatibility notes.

If no release notes are required, write NONE. Use past-tense. Newlines are stripped.

Examples:

```
Added new API endpoints POST /api/v4/foo, GET api/v4/foo, and GET api/v4/foo/:foo_id.
```

```
Added a new config setting ServiceSettings.FooBar. Added a new column Foo to the Users table.
```

```
NONE
```
-->
```release-note
fix an issue where we are unnecessarily getting the total user count for every license request. We only need to know that they have at least 1 user
```
