### PR TITLE
Make used of typed atomic.Pointer

### DIFF
--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -198,10 +198,7 @@ func (ps *PlatformService) regenerateClientConfig() {
 
 // AsymmetricSigningKey will return a private key that can be used for asymmetric signing.
 func (ps *PlatformService) AsymmetricSigningKey() *ecdsa.PrivateKey {
-	if key := ps.asymmetricSigningKey.Load(); key != nil {
-		return key.(*ecdsa.PrivateKey)
-	}
-	return nil
+	return ps.asymmetricSigningKey.Load()
 }
 
 // EnsureAsymmetricSigningKey ensures that an asymmetric signing key exists and future calls to

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -43,8 +43,7 @@ func (ps *PlatformService) SetLicenseManager(impl einterfaces.LicenseInterface) 
 }
 
 func (ps *PlatformService) License() *model.License {
-	license, _ := ps.licenseValue.Load().(*model.License)
-	return license
+	return ps.licenseValue.Load()
 }
 
 func (ps *PlatformService) LoadLicense() {
@@ -208,7 +207,7 @@ func (ps *PlatformService) SetLicense(license *model.License) bool {
 			if oldLicense == nil {
 				listener(nil, license)
 			} else {
-				listener(oldLicense.(*model.License), license)
+				listener(oldLicense, license)
 			}
 		}
 	}()
@@ -255,7 +254,7 @@ func (ps *PlatformService) ClientLicense() map[string]string {
 }
 
 func (ps *PlatformService) RemoveLicense() *model.AppError {
-	if license, _ := ps.licenseValue.Load().(*model.License); license == nil {
+	if license := ps.licenseValue.Load(); license == nil {
 		return nil
 	}
 

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -4,6 +4,7 @@
 package platform
 
 import (
+	"crypto/ecdsa"
 	"fmt"
 	"hash/maphash"
 	"net/http"
@@ -49,7 +50,7 @@ type PlatformService struct {
 	sessionCache  cache.Cache
 	sessionPool   sync.Pool
 
-	asymmetricSigningKey                   atomic.Value
+	asymmetricSigningKey                   atomic.Pointer[ecdsa.PrivateKey]
 	clientConfig                           atomic.Value
 	clientConfigHash                       atomic.Value
 	limitedClientConfig                    atomic.Value
@@ -67,7 +68,7 @@ type PlatformService struct {
 	featureFlagStop              chan struct{}
 	featureFlagStopped           chan struct{}
 
-	licenseValue       atomic.Value
+	licenseValue       atomic.Pointer[model.License]
 	clientLicenseValue atomic.Value
 	licenseListeners   map[string]func(*model.License, *model.License)
 	licenseManager     einterfaces.LicenseInterface

--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -108,7 +108,7 @@ type WebConn struct {
 	// leave that as an edge-case.
 	reuseCount   int
 	sessionToken atomic.Value
-	session      atomic.Value
+	session      atomic.Pointer[model.Session]
 	connectionID atomic.Value
 	endWritePump chan struct{}
 	pumpFinished chan struct{}
@@ -304,7 +304,7 @@ func areAllInactive(conns []*WebConn) bool {
 
 // GetSession returns the session of the connection.
 func (wc *WebConn) GetSession() *model.Session {
-	return wc.session.Load().(*model.Session)
+	return wc.session.Load()
 }
 
 // SetSession sets the session of the connection.

--- a/server/channels/app/platform/web_hub_test.go
+++ b/server/channels/app/platform/web_hub_test.go
@@ -484,9 +484,9 @@ func TestHubIsRegistered(t *testing.T) {
 	defer wc2.Close()
 	defer wc3.Close()
 
-	assert.True(t, th.Service.SessionIsRegistered(*wc1.session.Load().(*model.Session)))
-	assert.True(t, th.Service.SessionIsRegistered(*wc2.session.Load().(*model.Session)))
-	assert.True(t, th.Service.SessionIsRegistered(*wc3.session.Load().(*model.Session)))
+	assert.True(t, th.Service.SessionIsRegistered(*wc1.session.Load()))
+	assert.True(t, th.Service.SessionIsRegistered(*wc2.session.Load()))
+	assert.True(t, th.Service.SessionIsRegistered(*wc3.session.Load()))
 
 	session4, err := th.Service.CreateSession(&model.Session{
 		UserId: th.BasicUser2.Id,

--- a/server/channels/store/searchlayer/layer.go
+++ b/server/channels/store/searchlayer/layer.go
@@ -21,7 +21,7 @@ type SearchStore struct {
 	channel      *SearchChannelStore
 	post         *SearchPostStore
 	fileInfo     *SearchFileInfoStore
-	configValue  atomic.Value
+	configValue  atomic.Pointer[model.Config]
 }
 
 func NewSearchLayer(baseStore store.Store, searchEngine *searchengine.Broker, cfg *model.Config) *SearchStore {
@@ -44,7 +44,7 @@ func (s *SearchStore) UpdateConfig(cfg *model.Config) {
 }
 
 func (s *SearchStore) getConfig() *model.Config {
-	return s.configValue.Load().(*model.Config)
+	return s.configValue.Load()
 }
 
 func (s *SearchStore) Channel() store.ChannelStore {


### PR DESCRIPTION
#### Summary
`go1.19` added a typed [`atomic.Pointer`](https://pkg.go.dev/sync/atomic#Pointer). This PR makes use of this and covers some of the use of `atomic.Value` to a typed `atomic.Pointer`.

The remaining types used with an `atomic.Value` are `string` and `map`, which currently can't be typed without using a pointer.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```
