### PR TITLE
[MM-52975] server/docker-compose.yml: updates tp run HA in local after monorepo

### DIFF
--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -101,7 +101,7 @@ services:
     build:
       context: .
       dockerfile: ./build/Dockerfile.buildenv
-    working_dir: '/home/mattermost-server'
+    working_dir: '/home/mattermost-server/server'
     environment:
       - "MM_SQLSETTINGS_DRIVERNAME=postgres"
       - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable\u0026connect_timeout=10"
@@ -114,8 +114,7 @@ services:
     depends_on:
       - start_dependencies
     volumes:
-      - './server:/home/mattermost-server'
-      - './../../mattermost-webapp:/home/mattermost-webapp'
+      - './../:/home/mattermost-server'
       - './../../enterprise:/home/enterprise'
     restart: on-failure
     healthcheck:
@@ -138,7 +137,7 @@ services:
     build:
       context: .
       dockerfile: ./build/Dockerfile.buildenv
-    working_dir: '/home/mattermost-server'
+    working_dir: '/home/mattermost-server/server'
     environment:
       - "MM_SQLSETTINGS_DRIVERNAME=postgres"
       - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable\u0026connect_timeout=10"
@@ -151,8 +150,7 @@ services:
     depends_on:
       - leader
     volumes:
-      - './server:/home/mattermost-server'
-      - './../../mattermost-webapp:/home/mattermost-webapp'
+      - './../:/home/mattermost-server'
       - './../../enterprise:/home/enterprise'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://follower:8065/api/v4/system/ping"]
@@ -175,7 +173,7 @@ services:
     build:
       context: .
       dockerfile: ./build/Dockerfile.buildenv
-    working_dir: '/home/mattermost-server'
+    working_dir: '/home/mattermost-server/server'
     environment:
       - "MM_SQLSETTINGS_DRIVERNAME=postgres"
       - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable\u0026connect_timeout=10"
@@ -188,8 +186,7 @@ services:
     depends_on:
       - leader
     volumes:
-      - './server:/home/mattermost-server'
-      - './../../mattermost-webapp:/home/mattermost-webapp'
+      - './../:/home/mattermost-server'
       - './../../enterprise:/home/enterprise'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://follower2:8065/api/v4/system/ping"]


### PR DESCRIPTION

#### Summary
We need to update the docker compose files to make HA commands work.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-52975

#### Release Note

```release-note
NONE
```
